### PR TITLE
bug(si-web-app): Switch the graphql API on environment

### DIFF
--- a/components/si-web-app/src/main.ts
+++ b/components/si-web-app/src/main.ts
@@ -13,10 +13,15 @@ import AuthService from "@/auth/authService";
 
 Vue.config.productionTip = false;
 
+let graphqlUrl = "https://localhost:4000/graphql";
+if (process.env.NODE_ENV === "production") {
+  graphqlUrl = "https://graphql.systeminit.com/graphql";
+}
+
 // HTTP connection to the API
 const httpLink = createHttpLink({
   // You should use an absolute URL here
-  uri: "http://localhost:4000/graphql",
+  uri: graphqlUrl,
 });
 
 // Cache implementation


### PR DESCRIPTION
This makes it so the graphql API is set to the global deployment when it is being run in production.