### PR TITLE
Fix CORS and add default / route

### DIFF
--- a/components/si-graphql/package.json
+++ b/components/si-graphql/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@graphql-modules/core": "^0.7.9",
+    "@types/express": "^4.17.0",
     "apollo-server": "^2.8.1",
     "apollo-server-express": "^2.8.1",
     "cors": "^2.8.5",

--- a/components/si-graphql/src/server.ts
+++ b/components/si-graphql/src/server.ts
@@ -39,8 +39,24 @@ const server = new ApolloServer({
 });
 
 const app = express();
-app.use(cors);
+app.use(cors());
+app.options("*", cors());
 app.use(checkJwt);
 server.applyMiddleware({ app });
+
+app.get("/", function(req, res, _next): void {
+  res.send(`
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>System Initiative GraphQL API</title>
+</head>
+<body>
+<h1>The System Initiative GraphQL API</h1>
+</body>
+</html>
+`);
+});
 
 export default app;


### PR DESCRIPTION
This commit fixes a dumb bug made late at night, which passed an object
rather than constructing what the middleware was.

It also adds a default route on '/', which returns 200 OK, which means
that we won't be disabled in the AWS load balancer for being unhealthy.