### PR TITLE
feat(si-graphql,si-web-app): Add components

### DIFF
--- a/components/si-graphql/package-lock.json
+++ b/components/si-graphql/package-lock.json
@@ -26,6 +26,56 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -35,6 +85,489 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@graphql-codegen/cli": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-1.6.1.tgz",
+      "integrity": "sha512-zdqNknXROqBCRSIl03y4pw+GbTp7viOl9gcsikr4kgS4IZj4FOdEQqXWW+1L882Ex5Emp05h4m5TqfaJj/uylQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "7.5.5",
+        "@graphql-codegen/core": "1.6.1",
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "@types/debounce": "1.2.0",
+        "@types/is-glob": "4.0.1",
+        "@types/mkdirp": "0.5.2",
+        "@types/valid-url": "1.0.2",
+        "babel-types": "7.0.0-beta.3",
+        "chalk": "2.4.2",
+        "change-case": "3.1.0",
+        "chokidar": "3.0.2",
+        "commander": "3.0.0",
+        "common-tags": "1.8.0",
+        "debounce": "1.2.0",
+        "detect-indent": "6.0.0",
+        "glob": "7.1.4",
+        "graphql-config": "2.2.1",
+        "graphql-import": "0.7.1",
+        "graphql-tag-pluck": "0.8.4",
+        "graphql-toolkit": "0.5.10",
+        "graphql-tools": "4.0.5",
+        "indent-string": "4.0.0",
+        "inquirer": "6.5.1",
+        "is-glob": "4.0.1",
+        "is-valid-path": "0.1.1",
+        "js-yaml": "3.13.1",
+        "json-to-pretty-yaml": "1.2.2",
+        "listr": "0.14.3",
+        "listr-update-renderer": "0.5.0",
+        "log-symbols": "3.0.0",
+        "log-update": "3.2.0",
+        "mkdirp": "0.5.1",
+        "prettier": "1.18.2",
+        "request": "2.88.0",
+        "ts-log": "2.1.4",
+        "tslib": "1.10.0",
+        "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "anymatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
+          "integrity": "sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
+          "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^3.0.1",
+            "braces": "^3.0.2",
+            "fsevents": "^2.0.6",
+            "glob-parent": "^5.0.0",
+            "is-binary-path": "^2.1.0",
+            "is-glob": "^4.0.1",
+            "normalize-path": "^3.0.0",
+            "readdirp": "^3.1.1"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "commander": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.0.tgz",
+          "integrity": "sha512-pl3QrGOBa9RZaslQiqnnKX2J068wcQw7j9AIaBQ9/JEp5RY6je4jKTImg0Bd+rpoONSe7GUFSgkxLeo17m3Pow==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+          "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+          "dev": true,
+          "optional": true
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "graphql-toolkit": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/graphql-toolkit/-/graphql-toolkit-0.5.10.tgz",
+          "integrity": "sha512-mMHNezD9oT0IlM/vkZd/aeoIKtXqKnZq3ipJIMcHZPmMDPcZEf7BMzbB8naKWSWPaB1Iskg426DrfzQDUgU25A==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/graphql-tools": "4.0.6",
+            "@types/glob": "7.1.1",
+            "aggregate-error": "3.0.0",
+            "asyncro": "^3.0.0",
+            "cross-fetch": "^3.0.4",
+            "deepmerge": "4.0.0",
+            "globby": "10.0.1",
+            "graphql-import": "0.7.1",
+            "is-glob": "4.0.1",
+            "is-valid-path": "0.1.1",
+            "lodash": "4.17.15",
+            "tslib": "^1.9.3",
+            "valid-url": "1.0.9"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "readdirp": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
+          "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "@graphql-codegen/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-kNRdOeL/966qOE7ObeWOkiYOV2By4xm/fUPPucbAkf1i5hjkNPPzKLk8Dr0TUzeO7MQHg9Y6MVuFHpuKQMVX7Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "graphql-toolkit": "0.5.10",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "graphql-toolkit": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/graphql-toolkit/-/graphql-toolkit-0.5.10.tgz",
+          "integrity": "sha512-mMHNezD9oT0IlM/vkZd/aeoIKtXqKnZq3ipJIMcHZPmMDPcZEf7BMzbB8naKWSWPaB1Iskg426DrfzQDUgU25A==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/graphql-tools": "4.0.6",
+            "@types/glob": "7.1.1",
+            "aggregate-error": "3.0.0",
+            "asyncro": "^3.0.0",
+            "cross-fetch": "^3.0.4",
+            "deepmerge": "4.0.0",
+            "globby": "10.0.1",
+            "graphql-import": "0.7.1",
+            "is-glob": "4.0.1",
+            "is-valid-path": "0.1.1",
+            "lodash": "4.17.15",
+            "tslib": "^1.9.3",
+            "valid-url": "1.0.9"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/introspection": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/introspection/-/introspection-1.6.1.tgz",
+      "integrity": "sha512-2BZMEXinHwBsR7eMwsxLuYQrPaKqK0tjQiPYkn2o7nIiapji2JO8hZ8tDvLOyYWjVW/b1cPmIhzO1tlV/yLdhA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/plugin-helpers": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.6.1.tgz",
+      "integrity": "sha512-rgmt3wIXEgv1vCMN43ZPB51b1FuxmQ07CEv1WIFDakZ8cvVNq/c/uZ1mVWt4es1cK5l0QlnJFiZMYv5cor9nSQ==",
+      "dev": true,
+      "requires": {
+        "change-case": "3.1.0",
+        "common-tags": "1.8.0",
+        "import-from": "3.0.0",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/typescript": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-1.6.1.tgz",
+      "integrity": "sha512-+hQ4VA5ortF284LurkK18s0r0eJ9ywt14263WpnwaAiREook3v+pJYMEL5ClLkYinpGw1pUHJX22qrpq+sPQHA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "@graphql-codegen/visitor-plugin-common": "1.6.1",
+        "auto-bind": "2.0.0",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/typescript-resolvers": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-1.6.1.tgz",
+      "integrity": "sha512-JE9KkYZoxoCYelqttrIWkfIwkgCXPh5Wnjyd/nOIp/gX3H12cj+S4CcEmn1OAxjLxc01Qv38BPeVsu++Zr02lQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "@graphql-codegen/typescript": "1.6.1",
+        "@graphql-codegen/visitor-plugin-common": "1.6.1",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/visitor-plugin-common": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.6.1.tgz",
+      "integrity": "sha512-ioBkvipLE12ZH1nMERrwMOPWgsnNgnDPTzSSabQlzyalPOvjyPDHbqwJlB7WQw5rVjDXI4yXiPRsidgY5IlPRw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.6.1",
+        "auto-bind": "2.0.0",
+        "dependency-graph": "0.8.0",
+        "graphql-tag": "2.10.1",
+        "tslib": "1.10.0"
       }
     },
     "@graphql-modules/core": {
@@ -67,6 +600,32 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",
+      "integrity": "sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.1",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
+      "integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz",
+      "integrity": "sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.1",
+        "fastq": "^1.6.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -123,6 +682,15 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "@types/accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
@@ -172,6 +740,12 @@
       "requires": {
         "@types/express": "*"
       }
+    },
+    "@types/debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
+      "dev": true
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -250,6 +824,12 @@
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.0.tgz",
       "integrity": "sha512-8CBLG8RmxSvoY07FE6M/QpvJ7J5KzeKqF8eWN7Dq6Ks+lBTQae8Roc2G81lUu2Kw5Ju1gymOuvgyUsussbjAaA=="
     },
+    "@types/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-k3RS5HyBPu4h+5hTmIEfPB2rl5P3LnGdQEZrV2b9OWTJVtsUQ2VBcedqYKGqxvZqle5UALUXdSfVA8nf3HfyWQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -288,6 +868,12 @@
         "@types/koa": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.137",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
+      "integrity": "sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==",
+      "dev": true
+    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
@@ -302,6 +888,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "12.6.8",
@@ -336,6 +931,12 @@
       "requires": {
         "source-map": "^0.6.1"
       }
+    },
+    "@types/valid-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.2.tgz",
+      "integrity": "sha1-YPpDXOJL/VuhB7jSqAeWrq86j0U=",
+      "dev": true
     },
     "@types/webpack": {
       "version": "4.32.0",
@@ -700,6 +1301,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -1117,6 +1724,12 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "auto-bind": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-2.0.0.tgz",
+      "integrity": "sha512-rvRBv0/O7iriUMqSzTDhAfyAD1vVnElAEruo5rMSFeYLA0iKDEzLPSJiwMnL86+IPpTlhfOIAzjoKZ9TaySYdA==",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1184,6 +1797,17 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "babel-types": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "backo2": {
@@ -1539,6 +2163,16 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -1565,6 +2199,32 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "chardet": {
@@ -1697,6 +2357,59 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -1774,6 +2487,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1829,6 +2548,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2011,10 +2740,22 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
       "dev": true
     },
     "debug": {
@@ -2127,6 +2868,12 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "dependency-graph": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.0.tgz",
+      "integrity": "sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==",
+      "dev": true
+    },
     "deprecated-decorator": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
@@ -2151,6 +2898,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+      "dev": true
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -2182,6 +2935,15 @@
         "randombytes": "^2.0.0"
       }
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2196,6 +2958,15 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -2250,6 +3021,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.0",
@@ -2812,6 +3589,65 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.1",
+        "@nodelib/fs.walk": "^1.2.1",
+        "glob-parent": "^5.0.0",
+        "is-glob": "^4.0.1",
+        "merge2": "^1.2.3",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2822,6 +3658,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -3972,6 +4817,18 @@
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
       "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
     },
+    "graphql-tag-pluck": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/graphql-tag-pluck/-/graphql-tag-pluck-0.8.4.tgz",
+      "integrity": "sha512-weT9fZPILIOkdW26ZkkiGf2OGvSfHQZBudYxkxnNoiLU+9RH+I0THE95iAvzMWbtKVmoBovLF/qQyK4ay/D7Bw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "source-map-support": "^0.5.12"
+      }
+    },
     "graphql-toolkit": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/graphql-toolkit/-/graphql-toolkit-0.5.0.tgz",
@@ -4119,6 +4976,16 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4214,6 +5081,23 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
       }
     },
     "import-lazy": {
@@ -4467,6 +5351,15 @@
         }
       }
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -4496,6 +5389,15 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -4590,6 +5492,15 @@
         "unc-path-regex": "^0.1.2"
       }
     },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
+    },
     "is-valid-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
@@ -4655,6 +5566,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4681,6 +5598,16 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+      "dev": true,
+      "requires": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      }
     },
     "json5": {
       "version": "1.0.1",
@@ -4864,6 +5791,156 @@
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
       "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg=="
     },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "log-update": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+          "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "cli-cursor": "^2.0.0",
+            "wrap-ansi": "^3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -4952,10 +6029,45 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "log-update": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.2.0.tgz",
+      "integrity": "sha512-KJ6zAPIHWo7Xg1jYror6IUDFJBq1bQ4Bi4wAEp2y/0ScjBBVi/g0thr0sUVhuvuXauWzczt7T2QHghPDNnKBuw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
+      }
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -5106,6 +6218,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge2": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -5348,6 +6466,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -5842,6 +6969,15 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5885,6 +7021,16 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -5895,6 +7041,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -5947,6 +7102,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -6352,10 +7513,22 @@
         "rc": "^1.0.1"
       }
     },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "remove-trailing-spaces": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.7.tgz",
+      "integrity": "sha512-wjM17CJ2kk0SgoGyJ7ZMzRRCuTq+V8YhMwpZ5XEWX0uaked2OUq6utvHXGNBQrfkUzUUABFMyxlKn+85hMv4dg==",
       "dev": true
     },
     "repeat-element": {
@@ -6490,6 +7663,12 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -6516,6 +7695,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -6610,6 +7795,16 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "serialize-javascript": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
@@ -6693,6 +7888,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -6702,6 +7903,15 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {
@@ -7062,6 +8272,16 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -7196,6 +8416,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7209,6 +8439,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
@@ -7278,6 +8514,12 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "ts-invariant": {
       "version": "0.4.4",
@@ -7350,6 +8592,12 @@
           }
         }
       }
+    },
+    "ts-log": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
+      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ==",
+      "dev": true
     },
     "ts-node": {
       "version": "8.3.0",
@@ -7443,6 +8691,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -7586,6 +8840,21 @@
         "latest-version": "^3.0.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.1"
       }
     },
     "uri-js": {
@@ -7998,9 +9267,9 @@
       }
     },
     "yn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "zen-observable": {

--- a/components/si-graphql/package.json
+++ b/components/si-graphql/package.json
@@ -12,6 +12,7 @@
   "keywords": [],
   "author": "System Initiative, Inc.",
   "devDependencies": {
+    "@types/lodash": "^4.14.137",
     "@types/webpack-env": "^1.14.0",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
@@ -50,6 +51,7 @@
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.6.0",
     "knex": "^0.19.1",
+    "lodash": "^4.17.15",
     "objection": "^1.6.9",
     "sqlite3": "^4.0.9"
   }

--- a/components/si-graphql/src/app.modules.ts
+++ b/components/si-graphql/src/app.modules.ts
@@ -1,0 +1,27 @@
+import { GraphQLModule } from "@graphql-modules/core";
+import { HelloWorld } from "@modules/hello-world";
+import { Users } from "@modules/users";
+import { Workspaces } from "@modules/workspaces";
+import { Integrations } from "@modules/integrations";
+import { Components } from "@modules/components";
+import { Servers } from "@modules/servers";
+
+export interface GqlRoot {
+  [key: string]: any; //eslint-disable-line
+}
+
+export interface GqlArgs {
+  [key: string]: any; //eslint-disable-line
+}
+
+export interface GqlContext {
+  [key: string]: any; //eslint-disable-line
+}
+
+export interface GqlInfo {
+  [key: string]: any; //eslint-disable-line
+}
+
+export const AppModule = new GraphQLModule({
+  imports: [HelloWorld, Users, Workspaces, Integrations, Components, Servers],
+});

--- a/components/si-graphql/src/datalayer/serverComponents.ts
+++ b/components/si-graphql/src/datalayer/serverComponents.ts
@@ -1,0 +1,102 @@
+import { Integration } from "@/datalayer/integration";
+
+export interface ServerCpu {
+  id: string;
+  name: string;
+  cores: number;
+  baseFreqMHz: number;
+  allCoreTurboFreqMHz: number;
+  singleCoreTurboFreqMHz: number;
+}
+
+export interface ServerComponent {
+  id: string;
+  name: string;
+  description: string;
+  rawDataJson: string;
+  integration: Integration;
+  cpu: ServerCpu;
+  memoryGIB: number;
+  nodeType: string;
+  __typename: string;
+}
+
+export async function serverComponentData(): Promise<ServerComponent[]> {
+  let aws = await Integration.query().findById(1);
+  let gcp = await Integration.query().findById(3);
+  let serverComponentData: ServerComponent[] = [
+    {
+      id: "1",
+      name: "m5.large",
+      description: "AWS EC2 m5.large",
+      rawDataJson: "{}",
+      integration: aws,
+      nodeType: "Server",
+      cpu: {
+        id: "1",
+        name: "Intel Xeon 8175",
+        cores: 2,
+        baseFreqMHz: 3100,
+        allCoreTurboFreqMHz: 3100,
+        singleCoreTurboFreqMHz: 3100,
+      },
+      memoryGIB: 8,
+      __typename: "ServerComponent",
+    },
+    {
+      id: "2",
+      name: "m5.xlarge",
+      description: "AWS EC2 m5.xlarge",
+      rawDataJson: "{}",
+      integration: aws,
+      nodeType: "Server",
+      memoryGIB: 16,
+      cpu: {
+        id: "1",
+        name: "Intel Xeon 8175",
+        cores: 4,
+        baseFreqMHz: 3100,
+        allCoreTurboFreqMHz: 3100,
+        singleCoreTurboFreqMHz: 3100,
+      },
+      __typename: "ServerComponent",
+    },
+    {
+      id: "3",
+      name: "n1-standard-1",
+      description: "GCP n1-standard-1",
+      rawDataJson: "{}",
+      integration: gcp,
+      nodeType: "Server",
+      memoryGIB: 16,
+      cpu: {
+        id: "2",
+        name: "Intel Xeon Scalable Processor (Skylake)",
+        cores: 4,
+        baseFreqMHz: 2000,
+        allCoreTurboFreqMHz: 2700,
+        singleCoreTurboFreqMHz: 3500,
+      },
+      __typename: "ServerComponent",
+    },
+    {
+      id: "4",
+      name: "n1-standard-1",
+      description: "GCP n1-standard-1",
+      rawDataJson: "{}",
+      integration: gcp,
+      nodeType: "Server",
+      memoryGIB: 16,
+      cpu: {
+        id: "3",
+        name: "Intel Xeon E7 (Broadwell E7)",
+        cores: 4,
+        baseFreqMHz: 2200,
+        allCoreTurboFreqMHz: 2800,
+        singleCoreTurboFreqMHz: 3800,
+      },
+      __typename: "ServerComponent",
+    },
+  ];
+  return serverComponentData;
+}

--- a/components/si-graphql/src/graphql.d.ts
+++ b/components/si-graphql/src/graphql.d.ts
@@ -1,7 +1,7 @@
 // graphql.d.ts file
-declare module '*.graphql' {
-    import {DocumentNode} from 'graphql';
+declare module "*.graphql" {
+  import { DocumentNode } from "graphql";
 
-    const value: DocumentNode;
-    export = value;
+  const value: DocumentNode;
+  export = value;
 }

--- a/components/si-graphql/src/modules/auth.ts
+++ b/components/si-graphql/src/modules/auth.ts
@@ -1,8 +1,9 @@
 import { AuthenticationError } from "apollo-server";
 
 import { User } from "@/datalayer/user";
+import { GqlInfo } from "@/app.modules";
 
-export async function checkAuthentication(info): Promise<User> {
+export async function checkAuthentication(info: GqlInfo): Promise<User> {
   if (info.session.req.user === undefined) {
     throw new AuthenticationError("must authenticate");
   }

--- a/components/si-graphql/src/modules/components/index.ts
+++ b/components/si-graphql/src/modules/components/index.ts
@@ -1,0 +1,13 @@
+import { GraphQLModule } from "@graphql-modules/core";
+
+import typeDefs from "./schema.graphql";
+import { getComponents } from "./queries";
+
+export const Components = new GraphQLModule({
+  typeDefs,
+  resolvers: {
+    Query: {
+      getComponents,
+    },
+  },
+});

--- a/components/si-graphql/src/modules/components/queries.ts
+++ b/components/si-graphql/src/modules/components/queries.ts
@@ -1,0 +1,85 @@
+import { UserInputError } from "apollo-server";
+import hasIn from "lodash/hasIn";
+import filter from "lodash/filter";
+
+import { checkAuthentication } from "@/modules/auth";
+import { ServerComponent } from "@/datalayer/serverComponents";
+import { Integration } from "@/datalayer/integration";
+import { GqlRoot, GqlContext, GqlInfo } from "@/app.modules";
+import { getServerComponents } from "@/modules/servers/queries";
+import { User } from "@/datalayer/user";
+import { Workspace } from "@/datalayer/workspace";
+import { IntegrationInstance } from "@/datalayer/integration";
+
+export interface Component {
+  id: string;
+  name: string;
+  description: string;
+  rawDataJson: string;
+  integration: Integration;
+  memoryGIB: number;
+  nodeType: string;
+}
+
+export interface GetComponentsInput {
+  where?: {
+    integration?: string;
+    workspace?: string;
+  };
+}
+
+export async function getComponents(
+  obj: GqlRoot,
+  args: GetComponentsInput,
+  context: GqlContext,
+  info: GqlInfo,
+): Promise<Component[]> {
+  await checkAuthentication(info);
+  let data: Component[] = [];
+  let serverData: ServerComponent[] = await getServerComponents(
+    obj,
+    args,
+    context,
+    info,
+  );
+  data = data.concat(serverData);
+  return data;
+}
+
+export async function filterComponents<T extends Component>(
+  data: T[],
+  args: GetComponentsInput,
+  user: User,
+): Promise<T[]> {
+  // Limit by Workspace
+  if (hasIn(args, "where.workspace")) {
+    let workspace: Workspace[] = await user
+      .$relatedQuery("workspaces")
+      .where("id", args.where.workspace);
+    if (workspace.length == 0) {
+      throw new UserInputError("Workspace is not associated with the user", {
+        invalidArgs: ["workspace"],
+      });
+    }
+    let integrationInstances: IntegrationInstance[] = await workspace[0]
+      .$relatedQuery("integrationInstances")
+      .eager("integration");
+    let result = filter(data, (o: T): boolean => {
+      for (let x = 0; x < integrationInstances.length; x++) {
+        if (integrationInstances[x].integration.id == o.integration.id) {
+          return true;
+        }
+      }
+      return false;
+    });
+    return result;
+    // Limit by Integration
+  } else if (hasIn(args, "where.integration")) {
+    let result = filter(data, (o: T): boolean => {
+      return `${o.integration.id}` == args.where.integration;
+    });
+    return result;
+  } else {
+    return data;
+  }
+}

--- a/components/si-graphql/src/modules/components/schema.graphql
+++ b/components/si-graphql/src/modules/components/schema.graphql
@@ -1,0 +1,24 @@
+interface Component {
+  "The ID"
+  id: ID!
+  "The Name of the Component"
+  name: String!
+  "Description of the element"
+  description: String!
+  "Raw data for the component"
+  rawDataJson: String!
+  "The integration that backs the component"
+  integration: Integration!
+  "The kind of node created by this component type"
+  nodeType: String!
+}
+
+input GetComponentsInput {
+  integration: String,
+  workspace: String,
+}
+
+extend type Query {
+  "Get a list of all known components"
+  getComponents(where: GetComponentsInput): [Component]!
+}

--- a/components/si-graphql/src/modules/servers/index.ts
+++ b/components/si-graphql/src/modules/servers/index.ts
@@ -1,0 +1,14 @@
+import { GraphQLModule } from "@graphql-modules/core";
+
+import typeDefs from "./schema.graphql";
+import { getServerComponents } from "./queries";
+
+export const Servers = new GraphQLModule({
+  typeDefs,
+  resolvers: {
+    Query: {
+      getServerComponents,
+    },
+  },
+});
+

--- a/components/si-graphql/src/modules/servers/queries.ts
+++ b/components/si-graphql/src/modules/servers/queries.ts
@@ -1,0 +1,53 @@
+import { checkAuthentication } from "@/modules/auth";
+import {
+  ServerComponent,
+  serverComponentData,
+} from "@/datalayer/serverComponents";
+import { GqlRoot, GqlContext, GqlInfo } from "@/app.modules";
+import {
+  GetComponentsInput,
+  filterComponents,
+} from "@/modules/components/queries";
+
+export async function getServerComponents(
+  _obj: GqlRoot,
+  args: GetComponentsInput,
+  _context: GqlContext,
+  info: GqlInfo,
+): Promise<ServerComponent[]> {
+  let user = await checkAuthentication(info);
+  let data: ServerComponent[] = await serverComponentData();
+  return filterComponents(data, args, user);
+
+  // Limit by Workspace
+  //if (hasIn(args, "where.workspace")) {
+  //  let workspace: Workspace[] = await user
+  //    .$relatedQuery("workspaces")
+  //    .where("id", args.where.workspace);
+  //  if (workspace.length == 0) {
+  //    throw new UserInputError("Workspace is not associated with the user", {
+  //      invalidArgs: ["workspace"],
+  //    });
+  //  }
+  //  let integrationInstances: IntegrationInstance[] = await workspace[0]
+  //    .$relatedQuery("integrationInstances")
+  //    .eager("integration");
+  //  let result = filter(data, (o: ServerComponent): boolean => {
+  //    for (let x = 0; x < integrationInstances.length; x++) {
+  //      if (integrationInstances[x].integration.id == o.integration.id) {
+  //        return true;
+  //      }
+  //    }
+  //    return false;
+  //  });
+  //  return result;
+  //  // Limit by Integration
+  //} else if (hasIn(args, "where.integration")) {
+  //  let result = filter(data, (o: ServerComponent): boolean => {
+  //    return `${o.integration.id}` == args.where.integration;
+  //  });
+  //  return result;
+  //} else {
+  //  return data;
+  //}
+}

--- a/components/si-graphql/src/modules/servers/schema.graphql
+++ b/components/si-graphql/src/modules/servers/schema.graphql
@@ -1,0 +1,62 @@
+"A list of acceptable actions"
+enum ServerComponentAction {
+  Start
+  Stop
+  Restart
+  Destroy
+  Create
+  Console
+}
+
+"A list of states for a component"
+enum ServerComponentState {
+  Running
+  Stopped
+  Destroyed
+  Creating
+  Unknown
+}
+
+"CPU data for the server component"
+type ServerCpu {
+  id: ID!
+  name: String!
+  cores: Int!
+  baseFreqMHz: Int!
+  allCoreTurboFreqMHz: Int!
+  singleCoreTurboFreqMHz: Int!
+}
+
+type ServerComponent implements Component {
+  "The ID"
+  id: ID!
+  "The Name of the Component"
+  name: String!
+  "Description of the element"
+  description: String!
+  "Raw data for the component"
+  rawDataJson: String!
+  "The integration that backs the component"
+  integration: Integration!
+  "The type of node created by this component type"
+  nodeType: String!
+  "The CPU options"
+  cpu: ServerCpu!
+  "The amount of memory"
+  memoryGIB: Int!
+}
+
+type Server {
+  id: ID!
+  internalIntegrationKey: String!
+  name: String!
+  description: String
+  componentType: ServerComponent
+  state: ServerComponentState
+  rawDataJson: String!
+}
+
+extend type Query {
+  "Get Server Components enabled for this user"
+  getServerComponents(where: GetComponentsInput): [ServerComponent]!
+}

--- a/components/si-graphql/src/modules/workspaces/fields.ts
+++ b/components/si-graphql/src/modules/workspaces/fields.ts
@@ -3,24 +3,24 @@ import { User } from "@/datalayer/user";
 
 // Workspace Fields
 
-export async function creator(workspace): Promise<User> {
+export async function creator(workspace: Workspace): Promise<User> {
   let creator = await workspace.$relatedQuery("creator");
   return creator;
 }
 
-export async function members(workspace): Promise<User[]> {
+export async function members(workspace: Workspace): Promise<User[]> {
   let members = await workspace.$relatedQuery("members");
   return members;
 }
 
 // User Fields
 
-export async function createdWorkspaces(user): Promise<Workspace[]> {
-  let workspaces = await user.$relatedQuery("createdWorkspaces");
+export async function createdWorkspaces(user: Workspace): Promise<Workspace[]> {
+  let workspaces: Workspace[] = await user.$relatedQuery("createdWorkspaces");
   return workspaces;
 }
 
-export async function workspaces(user): Promise<Workspace[]> {
-  let workspaces = await user.$relatedQuery("workspaces");
+export async function workspaces(user: User): Promise<Workspace[]> {
+  let workspaces: Workspace[] = await user.$relatedQuery("workspaces");
   return workspaces;
 }

--- a/components/si-graphql/src/server.ts
+++ b/components/si-graphql/src/server.ts
@@ -4,10 +4,7 @@ import jwt from "express-jwt";
 import jwksRsa from "jwks-rsa";
 import cors from "cors";
 
-import { HelloWorld } from "@modules/hello-world";
-import { Users } from "@modules/users";
-import { Workspaces } from "@modules/workspaces";
-import { Integrations } from "@modules/integrations";
+import { AppModule } from "@/app.modules";
 import { environment } from "@/environment";
 
 // Authentication middleware. When used, the
@@ -33,7 +30,7 @@ const checkJwt = jwt({
 
 const server = new ApolloServer({
   context: (session): typeof session => session,
-  modules: [HelloWorld, Users, Workspaces, Integrations],
+  modules: [AppModule],
   introspection: environment.apollo.introspection,
   playground: environment.apollo.playground,
 });
@@ -44,7 +41,7 @@ app.options("*", cors());
 app.use(checkJwt);
 server.applyMiddleware({ app });
 
-app.get("/", function(req, res, _next): void {
+app.get("/", function(_req, res, _next): void {
   res.send(`
 <!DOCTYPE html>
 <html lang="en">

--- a/components/si-web-app/package.json
+++ b/components/si-web-app/package.json
@@ -6,7 +6,8 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "start": "vue-cli-service serve"
   },
   "dependencies": {
     "alight": "^0.14.1",

--- a/components/si-web-app/src/components/ComponentTable.vue
+++ b/components/si-web-app/src/components/ComponentTable.vue
@@ -1,0 +1,80 @@
+<template>
+  <v-card>
+    <v-card-title>
+      Components
+      <div class="flex-grow-1"></div>
+      <v-text-field
+        v-model="search"
+        append-icon="search"
+        label="Search"
+        single-line
+        hide-details
+      ></v-text-field>
+    </v-card-title>
+    <v-data-table
+      :headers="headers"
+      :items="getComponents"
+      :search="search"
+      :expanded.sync="expanded"
+      show-expand
+    >
+      <template v-slot:expanded-item="props">
+        <td
+          :colspan="props.headers.length"
+          v-if="props.item.nodeType == 'Server'"
+        >
+          <ul>
+            <li>CPU: {{ props.item.cpu.name }}</li>
+            <li>Cores: {{ props.item.cpu.cores }}</li>
+            <li>Base Frequency: {{ props.item.cpu.baseFreqMHz }} MHz</li>
+            <li>
+              All Core Turbo Frequency:
+              {{ props.item.cpu.allCoreTurboFreqMHz }} MHz
+            </li>
+            <li>
+              Single Core Turbo Frequency:
+              {{ props.item.cpu.singleCoreTurboFreqMHz }} MHz
+            </li>
+            <li>Memory {{ props.item.memoryGIB }} GIB</li>
+          </ul>
+        </td>
+      </template>
+    </v-data-table>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+import getComponents from "@/graphql/queries/getComponents.graphql";
+
+export default Vue.extend({
+  name: "ComponentTable",
+  apollo: {
+    getComponents: {
+      query: getComponents,
+      variables() {
+        return {
+          integrationId: this.integrationId,
+          workspaceId: this.workspaceId,
+        };
+      },
+    },
+  },
+  data() {
+    return {
+      expanded: [],
+      search: "",
+      headers: [
+        { text: "Name", align: "left", value: "name" },
+        { text: "Description", value: "description" },
+        { text: "Node Type", value: "nodeType" },
+      ],
+    };
+  },
+  props: {
+    integrationId: String,
+    workspaceId: String,
+  },
+});
+</script>

--- a/components/si-web-app/src/components/IntegrationFull.vue
+++ b/components/si-web-app/src/components/IntegrationFull.vue
@@ -64,6 +64,9 @@
                   :initialEnabled="isWorkspaceEnabled(workspace)"
                 />
               </v-list>
+              <ComponentTable
+                :integrationId="getIntegrationInstanceById.integration.id"
+              ></ComponentTable>
             </v-card-text>
           </v-card>
         </v-col>
@@ -76,6 +79,7 @@
 import Vue from "vue";
 
 import IntegrationToggle from "@/components/IntegrationToggle.vue";
+import ComponentTable from "@/components/ComponentTable.vue";
 
 import getWorkspacesWithIntegrationInstances from "@/graphql/queries/getWorkspacesWithIntegrationInstances.graphql";
 import getIntegrationInstances from "@/graphql/queries/getIntegrationInstances.graphql";
@@ -155,6 +159,7 @@ export default Vue.extend({
   },
   components: {
     IntegrationToggle,
+    ComponentTable,
   },
 });
 </script>

--- a/components/si-web-app/src/components/IntegrationToggle.vue
+++ b/components/si-web-app/src/components/IntegrationToggle.vue
@@ -3,7 +3,10 @@
     <v-list-item-action>
       <v-switch @click.stop="toggleIntegration()" v-model="enabled"></v-switch>
     </v-list-item-action>
-    <v-list-item-title>{{ title }}</v-list-item-title>
+    <v-list-item-title v-if="integrationName">
+      {{ integrationName }}: {{ title }}
+    </v-list-item-title>
+    <v-list-item-title v-else>{{ title }}</v-list-item-title>
   </v-list-item>
 </template>
 
@@ -52,6 +55,7 @@ export default Vue.extend({
     workspaceId: String,
     initialEnabled: Boolean,
     title: String,
+    integrationName: String,
   },
 });
 </script>

--- a/components/si-web-app/src/components/WorkspaceFull.vue
+++ b/components/si-web-app/src/components/WorkspaceFull.vue
@@ -40,6 +40,9 @@
             <v-divider />
             <v-card-text>
               {{ getWorkspaceById.description }}
+
+              <ComponentTable :workspaceId="workspace_id"></ComponentTable>
+
               <v-divider />
               <div v-if="getIntegrationInstances.length != 0">
                 <h3>Enable/Disable Integrations</h3>
@@ -50,6 +53,7 @@
                     :integrationInstanceId="integrationInstance.id"
                     :workspaceId="getWorkspaceById.id"
                     :title="integrationInstance.name"
+                    :integrationName="integrationInstance.integration.name"
                     :initialEnabled="
                       isIntegrationInstanceEnabled(integrationInstance)
                     "
@@ -70,6 +74,7 @@
 <script lang="ts">
 import Vue from "vue";
 
+import ComponentTable from "@/components/ComponentTable.vue";
 import IntegrationToggle from "@/components/IntegrationToggle.vue";
 
 import getIntegrationInstances from "@/graphql/queries/getIntegrationInstances.graphql";
@@ -146,6 +151,7 @@ export default Vue.extend({
   },
   components: {
     IntegrationToggle,
+    ComponentTable,
   },
 });
 </script>

--- a/components/si-web-app/src/graphql/fragments/ComponentDefault.graphql
+++ b/components/si-web-app/src/graphql/fragments/ComponentDefault.graphql
@@ -1,0 +1,12 @@
+fragment ComponentDefault on Component {
+  id
+  name
+  description
+  rawDataJson
+  integration {
+    id
+    name
+    description
+  }
+  nodeType
+}

--- a/components/si-web-app/src/graphql/fragments/ServerComponentDefault.graphql
+++ b/components/si-web-app/src/graphql/fragments/ServerComponentDefault.graphql
@@ -1,0 +1,7 @@
+#import "../fragments/ComponentDefault.graphql"
+#import "../fragments/ServerComponentUnique.graphql"
+
+fragment ServerComponentDefault on ServerComponent {
+  ... ComponentDefault
+  ... ServerComponentUnique
+}

--- a/components/si-web-app/src/graphql/fragments/ServerComponentUnique.graphql
+++ b/components/si-web-app/src/graphql/fragments/ServerComponentUnique.graphql
@@ -1,0 +1,11 @@
+fragment ServerComponentUnique on ServerComponent {
+  cpu {
+    id
+    name
+    cores
+    baseFreqMHz
+    allCoreTurboFreqMHz
+    singleCoreTurboFreqMHz
+  }
+  memoryGIB
+}

--- a/components/si-web-app/src/graphql/queries/getComponents.graphql
+++ b/components/si-web-app/src/graphql/queries/getComponents.graphql
@@ -1,0 +1,11 @@
+#import "../fragments/ComponentDefault.graphql"
+#import "../fragments/ServerComponentUnique.graphql"
+
+query getComponents($integrationId: String, $workspaceId: String) {
+  getComponents(where: { integration: $integrationId, workspace: $workspaceId }) {
+    ... ComponentDefault
+    ... on ServerComponent {
+      ...ServerComponentUnique
+    }
+  }
+}

--- a/designs/system-graph/dsl.js
+++ b/designs/system-graph/dsl.js
@@ -1,8 +1,5 @@
-
 // Assuming you had some kind of catalog of things that already exist
 let os = si.operatingSystem.lookup("Ubuntu", { version: "18.04" });
-os.update(); // Sorry, nothign to update
-
 let network = si.network.lookup("10.0.0.0/4");
 let service = si.service.lookup("si-graphql");
 let server = si.compute.lookup(integration: "AWS", instanceType: "x1.large") // << 

--- a/designs/system-graph/high-level-language.md
+++ b/designs/system-graph/high-level-language.md
@@ -37,7 +37,6 @@ A component
 * instanceType
 * cpu
 * memory
-* gpu
 * currentState (started/stopped/restarting/destroyed/created..)
 
 #### Implementations


### PR DESCRIPTION
This adds components to the system. Components are "created" when an
integration is added to the system; so for example, the AWS integration
would create Server, Network, etc. components.

This commit includes a generic interface for querying for lists of
components, or specific components - this should make it (relatively)
easy to create new Components.

The Web UI now includes a data table showing the components that are
available in a given workspace, and on a given integration. This is an
early example of how we can use the same data to populate the nodes
themselves when we get there.

Next up is adding prototypes for all the different types of Components;
this commit only includes the 'Server' component.

Various refactorings and types are also included in this commit. Of
particular note is the shift to having all the graphql modules included
in a single global `app.modules`, which reflects the current best
practice in graphql modules land.

![tenor-27576227](https://user-images.githubusercontent.com/4304/63477003-fe49b700-c437-11e9-9fb0-a46ffe5e2795.gif)
