### PR TITLE
bug: remove squash from base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ container//base: clean
 		-t si-base:latest \
 		-t si-base:$(RELEASE) \
 		-t docker.pkg.github.com/systeminit/si/si-base:latest \
-		--squash .
+		.
 
 release//base: container//base
 	docker push docker.pkg.github.com/systeminit/si/si-base:latest


### PR DESCRIPTION
This removes the squash option from building the base image, so that you don't need to have experimental docker features enabled. This sucks because squashing would have given better results - but, whatever. Life goes on.

![tenor-134139929](https://user-images.githubusercontent.com/4304/71837884-52160f00-306c-11ea-8533-7680557d5de7.gif)
