### PR TITLE
bug: Build the typescript before testing

### DIFF
--- a/components/build/typescript.mk
+++ b/components/build/typescript.mk
@@ -12,7 +12,7 @@ build: install
 
 build_release: build
 
-test: install 
+test: install build
 	npm run test
 
 run: start

--- a/components/si-graphql-api/src/schema/generator.ts
+++ b/components/si-graphql-api/src/schema/generator.ts
@@ -232,6 +232,7 @@ export class SchemaGenerator {
         for (const thisHint of hint["has_many"]) {
           gt.field(thisHint["to"], {
             type: thisHint["type"],
+            // @ts-ignore - we know, this isn't strongly typed
             args: { input: arg({ type: thisHint["inputType"] }) },
             async resolve(
               obj,


### PR DESCRIPTION
This builds the typescript projects before testing, and adds a
typescript ignore line to si-graphql-api for when we automatically
generate things.