### PR TITLE
bug(si-registry): fix race awaiting child process

### DIFF
--- a/components/si-registry/lib/codegen/fs.js
+++ b/components/si-registry/lib/codegen/fs.js
@@ -83,12 +83,12 @@ function _writeCode() {
             codeOutput = code;
 
             if (!_fs["default"].existsSync(codeFilename)) {
-              _context2.next = 55;
+              _context2.next = 56;
               break;
             }
 
             if (!codeFilename.endsWith(".rs")) {
-              _context2.next = 48;
+              _context2.next = 49;
               break;
             }
 
@@ -96,109 +96,112 @@ function _writeCode() {
             rustfmtChild = _child_process["default"].spawn("rustfmt", ["--emit", "stdout"], {
               stdio: ["pipe", "pipe", "pipe"]
             });
-            (0, _stringio.streamWrite)(rustfmtChild.stdin, code);
-            (0, _stringio.streamEnd)(rustfmtChild.stdin);
+            (0, _stringio.onExit)(rustfmtChild);
+            _context2.next = 13;
+            return (0, _stringio.streamWrite)(rustfmtChild.stdin, code);
+
+          case 13:
+            _context2.next = 15;
+            return (0, _stringio.streamEnd)(rustfmtChild.stdin);
+
+          case 15:
             codeOutput = "";
             _iteratorNormalCompletion = true;
             _didIteratorError = false;
-            _context2.prev = 15;
+            _context2.prev = 18;
             _iterator = (0, _asyncIterator2["default"])((0, _stringio.chunksToLinesAsync)(rustfmtChild.stdout));
 
-          case 17:
-            _context2.next = 19;
+          case 20:
+            _context2.next = 22;
             return _iterator.next();
 
-          case 19:
+          case 22:
             _step = _context2.sent;
             _iteratorNormalCompletion = _step.done;
-            _context2.next = 23;
+            _context2.next = 26;
             return _step.value;
 
-          case 23:
+          case 26:
             _value = _context2.sent;
 
             if (_iteratorNormalCompletion) {
-              _context2.next = 30;
+              _context2.next = 33;
               break;
             }
 
             line = _value;
             codeOutput += line;
 
-          case 27:
-            _iteratorNormalCompletion = true;
-            _context2.next = 17;
-            break;
-
           case 30:
-            _context2.next = 36;
+            _iteratorNormalCompletion = true;
+            _context2.next = 20;
             break;
 
-          case 32:
-            _context2.prev = 32;
-            _context2.t0 = _context2["catch"](15);
+          case 33:
+            _context2.next = 39;
+            break;
+
+          case 35:
+            _context2.prev = 35;
+            _context2.t0 = _context2["catch"](18);
             _didIteratorError = true;
             _iteratorError = _context2.t0;
 
-          case 36:
-            _context2.prev = 36;
-            _context2.prev = 37;
+          case 39:
+            _context2.prev = 39;
+            _context2.prev = 40;
 
             if (!(!_iteratorNormalCompletion && _iterator["return"] != null)) {
-              _context2.next = 41;
+              _context2.next = 44;
               break;
             }
 
-            _context2.next = 41;
+            _context2.next = 44;
             return _iterator["return"]();
 
-          case 41:
-            _context2.prev = 41;
+          case 44:
+            _context2.prev = 44;
 
             if (!_didIteratorError) {
-              _context2.next = 44;
+              _context2.next = 47;
               break;
             }
 
             throw _iteratorError;
 
-          case 44:
-            return _context2.finish(41);
-
-          case 45:
-            return _context2.finish(36);
-
-          case 46:
-            _context2.next = 48;
-            return (0, _stringio.onExit)(rustfmtChild);
+          case 47:
+            return _context2.finish(44);
 
           case 48:
+            return _context2.finish(39);
+
+          case 49:
             codeHash = _xxhash["default"].hash64(Buffer.from(codeOutput), 1234, "base64");
-            _context2.next = 51;
+            _context2.next = 52;
             return _fs["default"].promises.readFile(codeFilename);
 
-          case 51:
+          case 52:
             existingCode = _context2.sent;
             existingCodeHash = _xxhash["default"].hash64(existingCode, 1234, "base64");
 
             if (!(codeHash == existingCodeHash)) {
-              _context2.next = 55;
+              _context2.next = 56;
               break;
             }
 
             return _context2.abrupt("return");
 
-          case 55:
-            _context2.next = 57;
+          case 56:
+            _context2.next = 58;
             return _fs["default"].promises.writeFile(codeFilename, codeOutput);
 
-          case 57:
+          case 58:
           case "end":
             return _context2.stop();
         }
       }
-    }, _callee2, null, [[15, 32, 36, 46], [37,, 41, 45]]);
+    }, _callee2, null, [[18, 35, 39, 49], [40,, 44, 48]]);
   }));
   return _writeCode.apply(this, arguments);
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9jb2RlZ2VuL2ZzLnRzIl0sIm5hbWVzIjpbIm1ha2VQYXRoIiwicGF0aFBhcnQiLCJhYnNvbHV0ZVBhdGhOYW1lIiwicGF0aCIsInJlc29sdmUiLCJmcyIsImV4aXN0c1N5bmMiLCJwcm9taXNlcyIsIm1rZGlyIiwicmVjdXJzaXZlIiwid3JpdGVDb2RlIiwiZmlsZW5hbWUiLCJjb2RlIiwicGF0aG5hbWUiLCJkaXJuYW1lIiwiYmFzZW5hbWUiLCJjcmVhdGVkUGF0aCIsImNvZGVGaWxlbmFtZSIsImpvaW4iLCJjb2RlT3V0cHV0IiwiZW5kc1dpdGgiLCJydXN0Zm10Q2hpbGQiLCJjaGlsZFByb2Nlc3MiLCJzcGF3biIsInN0ZGlvIiwic3RkaW4iLCJzdGRvdXQiLCJsaW5lIiwiY29kZUhhc2giLCJYWEhhc2giLCJoYXNoNjQiLCJCdWZmZXIiLCJmcm9tIiwicmVhZEZpbGUiLCJleGlzdGluZ0NvZGUiLCJleGlzdGluZ0NvZGVIYXNoIiwid3JpdGVGaWxlIl0sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7Ozs7Ozs7O0FBQUE7O0FBTUE7O0FBQ0E7O0FBQ0E7O0FBQ0E7O1NBRXNCQSxROzs7Ozs0RkFBZixpQkFBd0JDLFFBQXhCO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUNDQyxZQUFBQSxnQkFERCxHQUNvQkMsaUJBQUtDLE9BQUwsQ0FBYUgsUUFBYixDQURwQjs7QUFBQSxnQkFFQUksZUFBR0MsVUFBSCxDQUFjSixnQkFBZCxDQUZBO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUEsbUJBR0dHLGVBQUdFLFFBQUgsQ0FBWUMsS0FBWixDQUFrQk4sZ0JBQWxCLEVBQW9DO0FBQUVPLGNBQUFBLFNBQVMsRUFBRTtBQUFiLGFBQXBDLENBSEg7O0FBQUE7QUFBQSw2Q0FLRVAsZ0JBTEY7O0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsRzs7OztTQVFlUSxTOzs7Ozs2RkFBZixrQkFBeUJDLFFBQXpCLEVBQTJDQyxJQUEzQztBQUFBOztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQ0NDLFlBQUFBLFFBREQsR0FDWVYsaUJBQUtXLE9BQUwsQ0FBYUgsUUFBYixDQURaO0FBRUNJLFlBQUFBLFFBRkQsR0FFWVosaUJBQUtZLFFBQUwsQ0FBY0osUUFBZCxDQUZaO0FBQUE7QUFBQSxtQkFHcUJYLFFBQVEsQ0FBQ2EsUUFBRCxDQUg3Qjs7QUFBQTtBQUdDRyxZQUFBQSxXQUhEO0FBSUNDLFlBQUFBLFlBSkQsR0FJZ0JkLGlCQUFLZSxJQUFMLENBQVVGLFdBQVYsRUFBdUJELFFBQXZCLENBSmhCO0FBS0RJLFlBQUFBLFVBTEMsR0FLWVAsSUFMWjs7QUFBQSxpQkFNRFAsZUFBR0MsVUFBSCxDQUFjVyxZQUFkLENBTkM7QUFBQTtBQUFBO0FBQUE7O0FBQUEsaUJBT0NBLFlBQVksQ0FBQ0csUUFBYixDQUFzQixLQUF0QixDQVBEO0FBQUE7QUFBQTtBQUFBOztBQVFEO0FBQ01DLFlBQUFBLFlBVEwsR0FTb0JDLDBCQUFhQyxLQUFiLENBQW1CLFNBQW5CLEVBQThCLENBQUMsUUFBRCxFQUFXLFFBQVgsQ0FBOUIsRUFBb0Q7QUFDdkVDLGNBQUFBLEtBQUssRUFBRSxDQUFDLE1BQUQsRUFBUyxNQUFULEVBQWlCLE1BQWpCO0FBRGdFLGFBQXBELENBVHBCO0FBWUQsdUNBQVlILFlBQVksQ0FBQ0ksS0FBekIsRUFBZ0NiLElBQWhDO0FBQ0EscUNBQVVTLFlBQVksQ0FBQ0ksS0FBdkI7QUFDQU4sWUFBQUEsVUFBVSxHQUFHLEVBQWI7QUFkQztBQUFBO0FBQUE7QUFBQSx3REFld0Isa0NBQW1CRSxZQUFZLENBQUNLLE1BQWhDLENBZnhCOztBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUE7O0FBQUE7QUFBQTtBQUFBO0FBQUE7O0FBZWdCQyxZQUFBQSxJQWZoQjtBQWdCQ1IsWUFBQUEsVUFBVSxJQUFJUSxJQUFkOztBQWhCRDtBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7O0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7O0FBQUE7QUFBQTtBQUFBO0FBQUE7O0FBQUE7QUFBQTs7QUFBQTtBQUFBOztBQUFBO0FBQUE7QUFBQTtBQUFBOztBQUFBOztBQUFBO0FBQUE7O0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUEsbUJBa0JLLHNCQUFPTixZQUFQLENBbEJMOztBQUFBO0FBb0JHTyxZQUFBQSxRQXBCSCxHQW9CY0MsbUJBQU9DLE1BQVAsQ0FBY0MsTUFBTSxDQUFDQyxJQUFQLENBQVliLFVBQVosQ0FBZCxFQUF1QyxJQUF2QyxFQUE2QyxRQUE3QyxDQXBCZDtBQUFBO0FBQUEsbUJBcUJ3QmQsZUFBR0UsUUFBSCxDQUFZMEIsUUFBWixDQUFxQmhCLFlBQXJCLENBckJ4Qjs7QUFBQTtBQXFCR2lCLFlBQUFBLFlBckJIO0FBc0JHQyxZQUFBQSxnQkF0QkgsR0FzQnNCTixtQkFBT0MsTUFBUCxDQUFjSSxZQUFkLEVBQTRCLElBQTVCLEVBQWtDLFFBQWxDLENBdEJ0Qjs7QUFBQSxrQkF1QkNOLFFBQVEsSUFBSU8sZ0JBdkJiO0FBQUE7QUFBQTtBQUFBOztBQUFBOztBQUFBO0FBQUE7QUFBQSxtQkEyQkM5QixlQUFHRSxRQUFILENBQVk2QixTQUFaLENBQXNCbkIsWUFBdEIsRUFBb0NFLFVBQXBDLENBM0JEOztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLEciLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQge1xuICBvbkV4aXQsXG4gIGNodW5rc1RvTGluZXNBc3luYyxcbiAgc3RyZWFtV3JpdGUsXG4gIHN0cmVhbUVuZCxcbn0gZnJvbSBcIkByYXVzY2htYS9zdHJpbmdpb1wiO1xuaW1wb3J0IGNoaWxkUHJvY2VzcyBmcm9tIFwiY2hpbGRfcHJvY2Vzc1wiO1xuaW1wb3J0IGZzIGZyb20gXCJmc1wiO1xuaW1wb3J0IHBhdGggZnJvbSBcInBhdGhcIjtcbmltcG9ydCBYWEhhc2ggZnJvbSBcInh4aGFzaFwiO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gbWFrZVBhdGgocGF0aFBhcnQ6IHN0cmluZyk6IFByb21pc2U8c3RyaW5nPiB7XG4gIGNvbnN0IGFic29sdXRlUGF0aE5hbWUgPSBwYXRoLnJlc29sdmUocGF0aFBhcnQpO1xuICBpZiAoIWZzLmV4aXN0c1N5bmMoYWJzb2x1dGVQYXRoTmFtZSkpIHtcbiAgICBhd2FpdCBmcy5wcm9taXNlcy5ta2RpcihhYnNvbHV0ZVBhdGhOYW1lLCB7IHJlY3Vyc2l2ZTogdHJ1ZSB9KTtcbiAgfVxuICByZXR1cm4gYWJzb2x1dGVQYXRoTmFtZTtcbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHdyaXRlQ29kZShmaWxlbmFtZTogc3RyaW5nLCBjb2RlOiBzdHJpbmcpOiBQcm9taXNlPHZvaWQ+IHtcbiAgY29uc3QgcGF0aG5hbWUgPSBwYXRoLmRpcm5hbWUoZmlsZW5hbWUpO1xuICBjb25zdCBiYXNlbmFtZSA9IHBhdGguYmFzZW5hbWUoZmlsZW5hbWUpO1xuICBjb25zdCBjcmVhdGVkUGF0aCA9IGF3YWl0IG1ha2VQYXRoKHBhdGhuYW1lKTtcbiAgY29uc3QgY29kZUZpbGVuYW1lID0gcGF0aC5qb2luKGNyZWF0ZWRQYXRoLCBiYXNlbmFtZSk7XG4gIGxldCBjb2RlT3V0cHV0ID0gY29kZTtcbiAgaWYgKGZzLmV4aXN0c1N5bmMoY29kZUZpbGVuYW1lKSkge1xuICAgIGlmIChjb2RlRmlsZW5hbWUuZW5kc1dpdGgoXCIucnNcIikpIHtcbiAgICAgIC8vIEB0cy1pZ25vcmUgLSB3ZSBrbm93IHdoYXQgdGhpcyBpcywgcmlnaHQ/IDswXG4gICAgICBjb25zdCBydXN0Zm10Q2hpbGQgPSBjaGlsZFByb2Nlc3Muc3Bhd24oXCJydXN0Zm10XCIsIFtcIi0tZW1pdFwiLCBcInN0ZG91dFwiXSwge1xuICAgICAgICBzdGRpbzogW1wicGlwZVwiLCBcInBpcGVcIiwgXCJwaXBlXCJdLFxuICAgICAgfSk7XG4gICAgICBzdHJlYW1Xcml0ZShydXN0Zm10Q2hpbGQuc3RkaW4sIGNvZGUpO1xuICAgICAgc3RyZWFtRW5kKHJ1c3RmbXRDaGlsZC5zdGRpbik7XG4gICAgICBjb2RlT3V0cHV0ID0gXCJcIjtcbiAgICAgIGZvciBhd2FpdCAoY29uc3QgbGluZSBvZiBjaHVua3NUb0xpbmVzQXN5bmMocnVzdGZtdENoaWxkLnN0ZG91dCkpIHtcbiAgICAgICAgY29kZU91dHB1dCArPSBsaW5lO1xuICAgICAgfVxuICAgICAgYXdhaXQgb25FeGl0KHJ1c3RmbXRDaGlsZCk7XG4gICAgfVxuICAgIGNvbnN0IGNvZGVIYXNoID0gWFhIYXNoLmhhc2g2NChCdWZmZXIuZnJvbShjb2RlT3V0cHV0KSwgMTIzNCwgXCJiYXNlNjRcIik7XG4gICAgY29uc3QgZXhpc3RpbmdDb2RlID0gYXdhaXQgZnMucHJvbWlzZXMucmVhZEZpbGUoY29kZUZpbGVuYW1lKTtcbiAgICBjb25zdCBleGlzdGluZ0NvZGVIYXNoID0gWFhIYXNoLmhhc2g2NChleGlzdGluZ0NvZGUsIDEyMzQsIFwiYmFzZTY0XCIpO1xuICAgIGlmIChjb2RlSGFzaCA9PSBleGlzdGluZ0NvZGVIYXNoKSB7XG4gICAgICByZXR1cm47XG4gICAgfVxuICB9XG4gIGF3YWl0IGZzLnByb21pc2VzLndyaXRlRmlsZShjb2RlRmlsZW5hbWUsIGNvZGVPdXRwdXQpO1xufVxuIl19
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9jb2RlZ2VuL2ZzLnRzIl0sIm5hbWVzIjpbIm1ha2VQYXRoIiwicGF0aFBhcnQiLCJhYnNvbHV0ZVBhdGhOYW1lIiwicGF0aCIsInJlc29sdmUiLCJmcyIsImV4aXN0c1N5bmMiLCJwcm9taXNlcyIsIm1rZGlyIiwicmVjdXJzaXZlIiwid3JpdGVDb2RlIiwiZmlsZW5hbWUiLCJjb2RlIiwicGF0aG5hbWUiLCJkaXJuYW1lIiwiYmFzZW5hbWUiLCJjcmVhdGVkUGF0aCIsImNvZGVGaWxlbmFtZSIsImpvaW4iLCJjb2RlT3V0cHV0IiwiZW5kc1dpdGgiLCJydXN0Zm10Q2hpbGQiLCJjaGlsZFByb2Nlc3MiLCJzcGF3biIsInN0ZGlvIiwic3RkaW4iLCJzdGRvdXQiLCJsaW5lIiwiY29kZUhhc2giLCJYWEhhc2giLCJoYXNoNjQiLCJCdWZmZXIiLCJmcm9tIiwicmVhZEZpbGUiLCJleGlzdGluZ0NvZGUiLCJleGlzdGluZ0NvZGVIYXNoIiwid3JpdGVGaWxlIl0sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7Ozs7Ozs7O0FBQUE7O0FBTUE7O0FBQ0E7O0FBQ0E7O0FBQ0E7O1NBRXNCQSxROzs7Ozs0RkFBZixpQkFBd0JDLFFBQXhCO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUNDQyxZQUFBQSxnQkFERCxHQUNvQkMsaUJBQUtDLE9BQUwsQ0FBYUgsUUFBYixDQURwQjs7QUFBQSxnQkFFQUksZUFBR0MsVUFBSCxDQUFjSixnQkFBZCxDQUZBO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUEsbUJBR0dHLGVBQUdFLFFBQUgsQ0FBWUMsS0FBWixDQUFrQk4sZ0JBQWxCLEVBQW9DO0FBQUVPLGNBQUFBLFNBQVMsRUFBRTtBQUFiLGFBQXBDLENBSEg7O0FBQUE7QUFBQSw2Q0FLRVAsZ0JBTEY7O0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsRzs7OztTQVFlUSxTOzs7Ozs2RkFBZixrQkFBeUJDLFFBQXpCLEVBQTJDQyxJQUEzQztBQUFBOztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQ0NDLFlBQUFBLFFBREQsR0FDWVYsaUJBQUtXLE9BQUwsQ0FBYUgsUUFBYixDQURaO0FBRUNJLFlBQUFBLFFBRkQsR0FFWVosaUJBQUtZLFFBQUwsQ0FBY0osUUFBZCxDQUZaO0FBQUE7QUFBQSxtQkFHcUJYLFFBQVEsQ0FBQ2EsUUFBRCxDQUg3Qjs7QUFBQTtBQUdDRyxZQUFBQSxXQUhEO0FBSUNDLFlBQUFBLFlBSkQsR0FJZ0JkLGlCQUFLZSxJQUFMLENBQVVGLFdBQVYsRUFBdUJELFFBQXZCLENBSmhCO0FBS0RJLFlBQUFBLFVBTEMsR0FLWVAsSUFMWjs7QUFBQSxpQkFNRFAsZUFBR0MsVUFBSCxDQUFjVyxZQUFkLENBTkM7QUFBQTtBQUFBO0FBQUE7O0FBQUEsaUJBT0NBLFlBQVksQ0FBQ0csUUFBYixDQUFzQixLQUF0QixDQVBEO0FBQUE7QUFBQTtBQUFBOztBQVFEO0FBQ01DLFlBQUFBLFlBVEwsR0FTb0JDLDBCQUFhQyxLQUFiLENBQW1CLFNBQW5CLEVBQThCLENBQUMsUUFBRCxFQUFXLFFBQVgsQ0FBOUIsRUFBb0Q7QUFDdkVDLGNBQUFBLEtBQUssRUFBRSxDQUFDLE1BQUQsRUFBUyxNQUFULEVBQWlCLE1BQWpCO0FBRGdFLGFBQXBELENBVHBCO0FBWUQsa0NBQU9ILFlBQVA7QUFaQztBQUFBLG1CQWFLLDJCQUFZQSxZQUFZLENBQUNJLEtBQXpCLEVBQWdDYixJQUFoQyxDQWJMOztBQUFBO0FBQUE7QUFBQSxtQkFjSyx5QkFBVVMsWUFBWSxDQUFDSSxLQUF2QixDQWRMOztBQUFBO0FBZUROLFlBQUFBLFVBQVUsR0FBRyxFQUFiO0FBZkM7QUFBQTtBQUFBO0FBQUEsd0RBZ0J3QixrQ0FBbUJFLFlBQVksQ0FBQ0ssTUFBaEMsQ0FoQnhCOztBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUE7O0FBQUE7QUFBQTtBQUFBO0FBQUE7O0FBZ0JnQkMsWUFBQUEsSUFoQmhCO0FBaUJDUixZQUFBQSxVQUFVLElBQUlRLElBQWQ7O0FBakJEO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBOztBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBO0FBQUE7QUFBQTs7QUFBQTtBQUFBOztBQUFBO0FBQUE7O0FBQUE7QUFBQTtBQUFBO0FBQUE7O0FBQUE7O0FBQUE7QUFBQTs7QUFBQTtBQUFBOztBQUFBO0FBb0JHQyxZQUFBQSxRQXBCSCxHQW9CY0MsbUJBQU9DLE1BQVAsQ0FBY0MsTUFBTSxDQUFDQyxJQUFQLENBQVliLFVBQVosQ0FBZCxFQUF1QyxJQUF2QyxFQUE2QyxRQUE3QyxDQXBCZDtBQUFBO0FBQUEsbUJBcUJ3QmQsZUFBR0UsUUFBSCxDQUFZMEIsUUFBWixDQUFxQmhCLFlBQXJCLENBckJ4Qjs7QUFBQTtBQXFCR2lCLFlBQUFBLFlBckJIO0FBc0JHQyxZQUFBQSxnQkF0QkgsR0FzQnNCTixtQkFBT0MsTUFBUCxDQUFjSSxZQUFkLEVBQTRCLElBQTVCLEVBQWtDLFFBQWxDLENBdEJ0Qjs7QUFBQSxrQkF1QkNOLFFBQVEsSUFBSU8sZ0JBdkJiO0FBQUE7QUFBQTtBQUFBOztBQUFBOztBQUFBO0FBQUE7QUFBQSxtQkEyQkM5QixlQUFHRSxRQUFILENBQVk2QixTQUFaLENBQXNCbkIsWUFBdEIsRUFBb0NFLFVBQXBDLENBM0JEOztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLEciLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQge1xuICBvbkV4aXQsXG4gIGNodW5rc1RvTGluZXNBc3luYyxcbiAgc3RyZWFtV3JpdGUsXG4gIHN0cmVhbUVuZCxcbn0gZnJvbSBcIkByYXVzY2htYS9zdHJpbmdpb1wiO1xuaW1wb3J0IGNoaWxkUHJvY2VzcyBmcm9tIFwiY2hpbGRfcHJvY2Vzc1wiO1xuaW1wb3J0IGZzIGZyb20gXCJmc1wiO1xuaW1wb3J0IHBhdGggZnJvbSBcInBhdGhcIjtcbmltcG9ydCBYWEhhc2ggZnJvbSBcInh4aGFzaFwiO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gbWFrZVBhdGgocGF0aFBhcnQ6IHN0cmluZyk6IFByb21pc2U8c3RyaW5nPiB7XG4gIGNvbnN0IGFic29sdXRlUGF0aE5hbWUgPSBwYXRoLnJlc29sdmUocGF0aFBhcnQpO1xuICBpZiAoIWZzLmV4aXN0c1N5bmMoYWJzb2x1dGVQYXRoTmFtZSkpIHtcbiAgICBhd2FpdCBmcy5wcm9taXNlcy5ta2RpcihhYnNvbHV0ZVBhdGhOYW1lLCB7IHJlY3Vyc2l2ZTogdHJ1ZSB9KTtcbiAgfVxuICByZXR1cm4gYWJzb2x1dGVQYXRoTmFtZTtcbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHdyaXRlQ29kZShmaWxlbmFtZTogc3RyaW5nLCBjb2RlOiBzdHJpbmcpOiBQcm9taXNlPHZvaWQ+IHtcbiAgY29uc3QgcGF0aG5hbWUgPSBwYXRoLmRpcm5hbWUoZmlsZW5hbWUpO1xuICBjb25zdCBiYXNlbmFtZSA9IHBhdGguYmFzZW5hbWUoZmlsZW5hbWUpO1xuICBjb25zdCBjcmVhdGVkUGF0aCA9IGF3YWl0IG1ha2VQYXRoKHBhdGhuYW1lKTtcbiAgY29uc3QgY29kZUZpbGVuYW1lID0gcGF0aC5qb2luKGNyZWF0ZWRQYXRoLCBiYXNlbmFtZSk7XG4gIGxldCBjb2RlT3V0cHV0ID0gY29kZTtcbiAgaWYgKGZzLmV4aXN0c1N5bmMoY29kZUZpbGVuYW1lKSkge1xuICAgIGlmIChjb2RlRmlsZW5hbWUuZW5kc1dpdGgoXCIucnNcIikpIHtcbiAgICAgIC8vIEB0cy1pZ25vcmUgLSB3ZSBrbm93IHdoYXQgdGhpcyBpcywgcmlnaHQ/IDswXG4gICAgICBjb25zdCBydXN0Zm10Q2hpbGQgPSBjaGlsZFByb2Nlc3Muc3Bhd24oXCJydXN0Zm10XCIsIFtcIi0tZW1pdFwiLCBcInN0ZG91dFwiXSwge1xuICAgICAgICBzdGRpbzogW1wicGlwZVwiLCBcInBpcGVcIiwgXCJwaXBlXCJdLFxuICAgICAgfSk7XG4gICAgICBvbkV4aXQocnVzdGZtdENoaWxkKTtcbiAgICAgIGF3YWl0IHN0cmVhbVdyaXRlKHJ1c3RmbXRDaGlsZC5zdGRpbiwgY29kZSk7XG4gICAgICBhd2FpdCBzdHJlYW1FbmQocnVzdGZtdENoaWxkLnN0ZGluKTtcbiAgICAgIGNvZGVPdXRwdXQgPSBcIlwiO1xuICAgICAgZm9yIGF3YWl0IChjb25zdCBsaW5lIG9mIGNodW5rc1RvTGluZXNBc3luYyhydXN0Zm10Q2hpbGQuc3Rkb3V0KSkge1xuICAgICAgICBjb2RlT3V0cHV0ICs9IGxpbmU7XG4gICAgICB9XG4gICAgfVxuICAgIGNvbnN0IGNvZGVIYXNoID0gWFhIYXNoLmhhc2g2NChCdWZmZXIuZnJvbShjb2RlT3V0cHV0KSwgMTIzNCwgXCJiYXNlNjRcIik7XG4gICAgY29uc3QgZXhpc3RpbmdDb2RlID0gYXdhaXQgZnMucHJvbWlzZXMucmVhZEZpbGUoY29kZUZpbGVuYW1lKTtcbiAgICBjb25zdCBleGlzdGluZ0NvZGVIYXNoID0gWFhIYXNoLmhhc2g2NChleGlzdGluZ0NvZGUsIDEyMzQsIFwiYmFzZTY0XCIpO1xuICAgIGlmIChjb2RlSGFzaCA9PSBleGlzdGluZ0NvZGVIYXNoKSB7XG4gICAgICByZXR1cm47XG4gICAgfVxuICB9XG4gIGF3YWl0IGZzLnByb21pc2VzLndyaXRlRmlsZShjb2RlRmlsZW5hbWUsIGNvZGVPdXRwdXQpO1xufVxuIl19

--- a/components/si-registry/src/codegen/fs.ts
+++ b/components/si-registry/src/codegen/fs.ts
@@ -29,13 +29,13 @@ export async function writeCode(filename: string, code: string): Promise<void> {
       const rustfmtChild = childProcess.spawn("rustfmt", ["--emit", "stdout"], {
         stdio: ["pipe", "pipe", "pipe"],
       });
-      streamWrite(rustfmtChild.stdin, code);
-      streamEnd(rustfmtChild.stdin);
+      onExit(rustfmtChild);
+      await streamWrite(rustfmtChild.stdin, code);
+      await streamEnd(rustfmtChild.stdin);
       codeOutput = "";
       for await (const line of chunksToLinesAsync(rustfmtChild.stdout)) {
         codeOutput += line;
       }
-      await onExit(rustfmtChild);
     }
     const codeHash = XXHash.hash64(Buffer.from(codeOutput), 1234, "base64");
     const existingCode = await fs.promises.readFile(codeFilename);


### PR DESCRIPTION
This fixes a race condition on awaiting a spawned child process. Rather
than `await onExit`, we should set the `onExit` callback first, and then
simply ignore the resolution of the promise. That way we will listen for
the signal from the children, even if they exit (and perhaps get
reaped?) before we get a chance to set the signal handler.

Good times, OS X!