### PR TITLE
chore: start containers in tmux environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ ifdef TMUX
 else
 	@ echo "*** Starting new tmux session ***"
 	@ tmux -2 new-session -d -s si
+	@ tmux send-keys "make dev_deps" C-m
 	@ echo "tmux attach -t si"
 endif
 
@@ -134,6 +135,6 @@ force_clean:
 	sudo rm -rf ./target
 
 dev_deps:
-	./components/couchbase/run.sh; exit 0
-	./components/jaeger/run.sh; exit 0
-	./components/vernemq/run.sh; exit 0
+	./components/couchbase/run.sh || docker start db; exit 0
+	./components/vernemq/run.sh || docker start vernemq; exit 0
+	./components/opentelemetry-collector/run.sh || docker start otelcol; exit 0


### PR DESCRIPTION
When you run `make tmux`, we will now also run (or start) the required
dev environment containers (couchbase, vernemq, and open telemetry
collector).