### PR TITLE
chore(cea): add `spawn_command_with_stdin` function

### DIFF
--- a/components/si-cea/src/agent/dispatch.rs
+++ b/components/si-cea/src/agent/dispatch.rs
@@ -7,8 +7,9 @@ use std::collections::HashMap;
 pub mod prelude {
     pub use super::IntegrationActions;
     pub use crate::agent::mqtt::MqttClient;
+    pub use crate::entity::Entity as _;
     pub use crate::entity_event::EntityEvent as _;
-    pub use crate::error::CeaResult;
+    pub use crate::error::{CeaError, CeaResult};
     pub use async_trait::async_trait;
     pub use tracing::debug_span;
     pub use tracing_futures::Instrument as _;

--- a/components/si-cea/src/agent/server.rs
+++ b/components/si-cea/src/agent/server.rs
@@ -104,7 +104,14 @@ impl<
                         warn!(?err, "missing input entity on event");
                         return;
                     }
+                    if let Err(err) = entity_event.init_output_entity() {
+                        warn!(?err, "cannot initialize output entity");
+                        return;
+                    }
                     debug!(?entity_event, "dispatch");
+
+                    // TODO: fix
+                    // Setup tracing *outside* the dispatch function call
 
                     match dispatch.dispatch(&mqtt_client, &mut entity_event).await {
                         Ok(()) => {


### PR DESCRIPTION
This change adds a new function to the `spawn_command` module called
`spawn_command_with_stdin` which will accept bytes to be fed to a
spawned process' stdin stream. The `spawn_command` function continues to
operate as before.

Additionally, several ergonomic updates were added to help when
consuming this library:

* Add the `si_cea::Entity` trait and `si_cea::CeaError` error type to
  the `si_cea::agent::dispath::prelude`
* Automatically prepare the `EntityEvent`'s `output_entity_event` field
  before calling the dispatch function, thus ensuring that the output
  field is always correctly set
* Add an `into_output` method on `CommandResult` to consume the `stdout`
  and `stderr` results when captured output was requested, thus saving
  needless cloning

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>