### PR TITLE
chore(data): add `required_field_err` helper function

### DIFF
--- a/components/si-data/src/error.rs
+++ b/components/si-data/src/error.rs
@@ -81,3 +81,7 @@ impl From<DataError> for tonic::Status {
         }
     }
 }
+
+pub fn required_field_err(field: impl Into<String>) -> DataError {
+    DataError::RequiredField(field.into())
+}

--- a/components/si-data/src/lib.rs
+++ b/components/si-data/src/lib.rs
@@ -14,7 +14,7 @@ pub mod query;
 pub mod storable;
 
 pub use db::{Db, ListResult};
-pub use error::{DataError, Result};
+pub use error::{required_field_err, DataError, Result};
 pub use migrateable::Migrateable;
 pub use query::{
     DataQuery, DataQueryBooleanTerm, DataQueryItems, DataQueryItemsExpression,


### PR DESCRIPTION
This change adds a convenience function to create and populate a
`si_data::error::DataError::RequiredField` which can be used when
implementing agent dispatch traits and possibly even for code
generation.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>