### PR TITLE
chore(registry): remove unused tracing import & inline debug macro

### DIFF
--- a/components/si-account/src/gen/service.rs
+++ b/components/si-account/src/gen/service.rs
@@ -2,7 +2,6 @@
 // No-Touchy!
 
 use opentelemetry::api::propagation::text_propagator::HttpTextFormat;
-use tracing::{debug, info};
 use tracing_futures::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -2033,7 +2032,7 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         match raw_value.to_str() {
             Ok(value) => Some(value),
             Err(_e) => {
-                debug!("Cannot extract header for trace parent, not a string");
+                tracing::debug!("Cannot extract header for trace parent, not a string");
                 None
             }
         }
@@ -2043,8 +2042,8 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         let value = match tonic::metadata::MetadataValue::from_str(&raw_value) {
             Ok(value) => value,
             Err(_e) => {
-                debug!("Cannot insert header for trace parent, not a string");
-                debug!("Inserting the empty string");
+                tracing::debug!("Cannot insert header for trace parent, not a string");
+                tracing::debug!("Inserting the empty string");
                 tonic::metadata::MetadataValue::from_str("").unwrap()
             }
         };

--- a/components/si-kubernetes/src/gen/service.rs
+++ b/components/si-kubernetes/src/gen/service.rs
@@ -2,7 +2,6 @@
 // No-Touchy!
 
 use opentelemetry::api::propagation::text_propagator::HttpTextFormat;
-use tracing::{debug, info};
 use tracing_futures::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -915,7 +914,7 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         match raw_value.to_str() {
             Ok(value) => Some(value),
             Err(_e) => {
-                debug!("Cannot extract header for trace parent, not a string");
+                tracing::debug!("Cannot extract header for trace parent, not a string");
                 None
             }
         }
@@ -925,8 +924,8 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         let value = match tonic::metadata::MetadataValue::from_str(&raw_value) {
             Ok(value) => value,
             Err(_e) => {
-                debug!("Cannot insert header for trace parent, not a string");
-                debug!("Inserting the empty string");
+                tracing::debug!("Cannot insert header for trace parent, not a string");
+                tracing::debug!("Inserting the empty string");
                 tonic::metadata::MetadataValue::from_str("").unwrap()
             }
         };

--- a/components/si-registry/src/codegen/rust/service.rs.ejs
+++ b/components/si-registry/src/codegen/rust/service.rs.ejs
@@ -1,7 +1,6 @@
 // Auto-generated rust code!
 // No-Touchy!
 
-use tracing::{debug, info};
 use tracing_futures::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use opentelemetry::api::propagation::text_propagator::HttpTextFormat;
@@ -42,7 +41,7 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         match raw_value.to_str() {
             Ok(value) => Some(value),
             Err(_e) => {
-                debug!("Cannot extract header for trace parent, not a string");
+                tracing::debug!("Cannot extract header for trace parent, not a string");
                 None
             }
         }
@@ -52,8 +51,8 @@ impl<'a> opentelemetry::api::propagation::Carrier for TonicMetaWrapper<'a> {
         let value = match tonic::metadata::MetadataValue::from_str(&raw_value) {
             Ok(value) => value,
             Err(_e) => {
-                debug!("Cannot insert header for trace parent, not a string");
-                debug!("Inserting the empty string");
+                tracing::debug!("Cannot insert header for trace parent, not a string");
+                tracing::debug!("Inserting the empty string");
                 tonic::metadata::MetadataValue::from_str("").unwrap()
             }
         };


### PR DESCRIPTION
There was one now-unused import (`tracing::info`) now that a tracing
span is better auto-generated. This is now removed, dropping a
compilation warning.

Additionally, to be more in line with the rest of the code generation
strategy, the `tracing::debug!` macro is now fully qualified and
"inlined" where needed.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>