### PR TITLE
feat(kubernetes): add `KubectlCommand` interface with k8s

### DIFF
--- a/components/si-kubernetes/examples/kubectl-apply.rs
+++ b/components/si-kubernetes/examples/kubectl-apply.rs
@@ -1,0 +1,25 @@
+use si_kubernetes::kubectl::KubectlCommand;
+use std::{env, io, process};
+
+const NAMESPACE_VAR: &str = "NAMESPACE";
+const NAMESPACE_DEFAULT: &str = "si";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    process::exit(
+        KubectlCommand::new(namespace())
+            .apply()?
+            .status()
+            .await?
+            .code()
+            .ok_or(io_other_err("terminated by signal"))?,
+    )
+}
+
+fn namespace() -> String {
+    env::var(NAMESPACE_VAR).unwrap_or_else(|_| NAMESPACE_DEFAULT.to_string())
+}
+
+fn io_other_err(cause: impl AsRef<str>) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, cause.as_ref())
+}

--- a/components/si-kubernetes/examples/kubectl-get-deployment-last-applied.rs
+++ b/components/si-kubernetes/examples/kubectl-get-deployment-last-applied.rs
@@ -1,0 +1,32 @@
+use si_kubernetes::kubectl::KubectlCommand;
+use std::{env, io, process};
+
+const NAMESPACE_VAR: &str = "NAMESPACE";
+const NAMESPACE_DEFAULT: &str = "si";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    process::exit(
+        KubectlCommand::new(namespace())
+            .get_deployment_last_applied(arg1()?)?
+            .status()
+            .await?
+            .code()
+            .ok_or(io_other_err("terminated by signal"))?,
+    )
+}
+
+fn namespace() -> String {
+    env::var(NAMESPACE_VAR).unwrap_or_else(|_| NAMESPACE_DEFAULT.to_string())
+}
+
+fn io_other_err(cause: impl AsRef<str>) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, cause.as_ref())
+}
+
+fn arg1() -> Result<String, io::Error> {
+    env::args().skip(1).next().ok_or(io_other_err(format!(
+        "usage: {} <NAME>",
+        env::args().next().unwrap_or("<PROGRAM>".to_string())
+    )))
+}

--- a/components/si-kubernetes/examples/kubectl-get-deployments.rs
+++ b/components/si-kubernetes/examples/kubectl-get-deployments.rs
@@ -1,0 +1,25 @@
+use si_kubernetes::kubectl::KubectlCommand;
+use std::{env, io, process};
+
+const NAMESPACE_VAR: &str = "NAMESPACE";
+const NAMESPACE_DEFAULT: &str = "si";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    process::exit(
+        KubectlCommand::new(namespace())
+            .get_deployments()?
+            .status()
+            .await?
+            .code()
+            .ok_or(io_other_err("terminated by signal"))?,
+    )
+}
+
+fn namespace() -> String {
+    env::var(NAMESPACE_VAR).unwrap_or_else(|_| NAMESPACE_DEFAULT.to_string())
+}
+
+fn io_other_err(cause: impl AsRef<str>) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, cause.as_ref())
+}

--- a/components/si-kubernetes/src/kubectl.rs
+++ b/components/si-kubernetes/src/kubectl.rs
@@ -1,0 +1,65 @@
+use std::env;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+const KUBECTL_COMMAND: &str = "kubectl";
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("could not find command on PATH: {0}")]
+    CommandNotFound(&'static str),
+    #[error("environment variable error: {0}")]
+    EnvVarError(#[from] env::VarError),
+}
+
+pub struct KubectlCommand {
+    namespace: String,
+}
+
+impl KubectlCommand {
+    pub fn new(namespace: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn apply(&mut self) -> Result<Command> {
+        let mut cmd = self.cmd()?;
+        cmd.arg("apply").arg("-f").arg("-");
+
+        Ok(cmd)
+    }
+
+    pub fn get_deployments(&mut self) -> Result<Command> {
+        let mut cmd = self.cmd()?;
+        cmd.arg("get").arg("deployments.apps");
+
+        Ok(cmd)
+    }
+
+    pub fn get_deployment_last_applied(&mut self, name: impl AsRef<str>) -> Result<Command> {
+        let mut cmd = self.cmd()?;
+        cmd.arg("apply")
+            .arg("view-last-applied")
+            .arg(format!("deployment.apps/{}", name.as_ref()))
+            .arg("--output=yaml");
+
+        Ok(cmd)
+    }
+
+    fn cmd(&self) -> Result<Command> {
+        let mut cmd = Command::new(kubectl_binary()?);
+        cmd.arg(format!("--namespace={}", &self.namespace));
+
+        Ok(cmd)
+    }
+}
+
+fn kubectl_binary() -> Result<PathBuf> {
+    env::split_paths(&env::var("PATH")?)
+        .map(|path| path.join(KUBECTL_COMMAND))
+        .find(|candidate| candidate.is_file())
+        .ok_or(Error::CommandNotFound(KUBECTL_COMMAND))
+}

--- a/components/si-kubernetes/src/lib.rs
+++ b/components/si-kubernetes/src/lib.rs
@@ -4,4 +4,5 @@ pub mod protobuf {
 
 pub mod agent;
 pub mod gen;
+pub mod kubectl;
 pub mod model;


### PR DESCRIPTION
This change adds a `KubectlCommand` type to the system which wraps an
async `Command` type. Currently the following methods are supported:

* `apply`: calls `kubectl apply` and takes its input on `stdin`
* `get_deployments`: lists all deployments in a namespace
* `get_deployment_last_applied`: calls `kubectl apply view-last-applied`
  to get the contents of the last applied template

This type heavily uses the `kubectl` command which must be present on
the prcesses `$PATH` and will return an error if the command cannot be
found.

Finally, to better directly try and test `KubectlCommand` 3 crate
examples are included to exercise these methods. The `kubectl-apply`
example will expect a deployment YAML to be provided on stdin so it can
be run with:

```console
$ cd components/si-kubernetes
$ cargo run --example kubectl-apply <nginx-deployment
```

Note that for the examples, a namespace of `si` will be used, which
should already be present.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>