### PR TITLE
refactor(cea): extract common imports & tracing setup

### DIFF
--- a/components/si-cea/src/component.rs
+++ b/components/si-cea/src/component.rs
@@ -18,9 +18,31 @@ pub mod codegen_prelude {
 pub mod prelude {
     pub use crate::component::Component;
     pub use crate::error::CeaResult;
+    pub use crate::tracing_pick_span;
     pub use si_account::{Integration, IntegrationService};
-    pub use si_data::Storable;
-    pub use si_data::{Db, Result as DataResult};
+    pub use si_data::{
+        DataQueryBooleanTerm, DataQueryItems, DataQueryItemsExpressionComparison, Db,
+        Result as DataResult, Storable,
+    };
+    pub use tracing::{self, debug, field, Span};
+    pub use tracing_futures::Instrument as _;
+}
+
+#[macro_export]
+macro_rules! tracing_pick_span {
+    (
+        $name:expr, $raw_constraints:expr $(,)?
+    ) => {
+        tracing::span!(
+            tracing::Level::DEBUG,
+            concat!($name, "_pick"),
+            pick.raw_constraints = tracing::field::debug($raw_constraints),
+            pick.implicit_constraints = tracing::field::Empty,
+            pick.constraints = tracing::field::Empty,
+            pick.component_name = tracing::field::display(concat!($name, "_component")),
+            pick.component = tracing::field::Empty,
+        )
+    };
 }
 
 #[async_trait]

--- a/components/si-kubernetes/src/model/kubernetes_deployment_component.rs
+++ b/components/si-kubernetes/src/model/kubernetes_deployment_component.rs
@@ -3,96 +3,88 @@ use crate::protobuf::{
     KubernetesDeploymentComponentConstraintsKubernetesVersion,
 };
 use si_cea::component::prelude::*;
-use std::fmt;
-use std::str::FromStr;
-
-use tracing::{self, debug, span, Level};
-use tracing_futures::Instrument as _;
-
-pub use crate::protobuf::KubernetesDeploymentComponent;
 
 type Constraints = KubernetesDeploymentComponentConstraints;
 type KubernetesVersion = KubernetesDeploymentComponentConstraintsKubernetesVersion;
+
+pub use crate::protobuf::KubernetesDeploymentComponent;
 
 impl KubernetesDeploymentComponent {
     pub async fn pick(
         db: &Db,
         raw_constraints: Option<Constraints>,
     ) -> CeaResult<(Constraints, Self)> {
-        let span = span!(
-            Level::DEBUG,
-            "kubernetes_deployment_pick",
-            pick.raw_constraints = tracing::field::debug(&raw_constraints),
-            pick.implicit_constraints = tracing::field::Empty,
-            pick.constraints = tracing::field::Empty,
-            pick.component_name = tracing::field::display("kubernetes_deployment_component"),
-            pick.component = tracing::field::Empty,
-        );
+        let span = tracing_pick_span!("kubernetes_deployment", &raw_constraints);
         async {
             let span = tracing::Span::current();
-            if raw_constraints.is_none() {
-                let mut implicit_constraints = Constraints::default();
-                implicit_constraints.set_kubernetes_version(KubernetesVersion::V115);
+            match raw_constraints {
+                None => {
+                    let mut implicit_constraints = Constraints::default();
+                    implicit_constraints.set_kubernetes_version(KubernetesVersion::default_value());
 
-                span.record(
-                    "pick.implict_constraints",
-                    &tracing::field::debug(&implicit_constraints),
-                );
-
-                let mut query_items = Vec::new();
-                query_items.push(si_data::DataQueryItems::generate_expression_for_int(
-                    "constraints.kubernetesVersion",
-                    si_data::DataQueryItemsExpressionComparison::Equals,
-                    (KubernetesVersion::V115 as i32).to_string(),
-                ));
-
-                let component =
-                    Self::pick_by_expressions(db, query_items, si_data::DataQueryBooleanTerm::And)
-                        .await?;
-
-                span.record("pick.component", &tracing::field::debug(&component));
-
-                return Ok((implicit_constraints, component));
-            }
-            let constraints = raw_constraints.unwrap();
-            span.record("pick.constraints", &tracing::field::debug(&constraints));
-
-            if let Some(found) = Self::pick_by_component_name(db, &constraints).await? {
-                span.record("pick.component", &tracing::field::debug(&found));
-                return Ok(found);
-            }
-            if let Some(found) = Self::pick_by_component_display_name(db, &constraints).await? {
-                span.record("pick.component", &tracing::field::debug(&found));
-                return Ok(found);
-            }
-
-            let mut implicit_constraints = Constraints::default();
-            let mut query_items = Vec::new();
-
-            let kubernetes_version = match constraints.kubernetes_version() {
-                KubernetesVersion::Unknown => {
-                    let default = KubernetesVersion::default();
-                    implicit_constraints.set_kubernetes_version(default);
                     span.record(
-                        "pick.implicit_constraints",
-                        &tracing::field::debug(&implicit_constraints),
+                        "pick.implict_constraints",
+                        &field::debug(&implicit_constraints),
                     );
-                    default
+
+                    let mut query_items = Vec::new();
+                    query_items.push(DataQueryItems::generate_expression_for_int(
+                        "constraints.kubernetesVersion",
+                        DataQueryItemsExpressionComparison::Equals,
+                        KubernetesVersion::default_value().to_i32_string(),
+                    ));
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+
+                    span.record("pick.component", &field::debug(&component));
+
+                    Ok((implicit_constraints, component))
                 }
-                value => value,
-            };
-            query_items.push(si_data::DataQueryItems::generate_expression_for_int(
-                "constraints.kubernetesVersion",
-                si_data::DataQueryItemsExpressionComparison::Equals,
-                (kubernetes_version as i32).to_string(),
-            ));
+                Some(constraints) => {
+                    span.record("pick.constraints", &tracing::field::debug(&constraints));
 
-            let component =
-                Self::pick_by_expressions(db, query_items, si_data::DataQueryBooleanTerm::And)
-                    .await?;
-            span.record("pick.component", &tracing::field::debug(&component));
+                    if let Some(found) = Self::pick_by_component_name(db, &constraints).await? {
+                        span.record("pick.component", &tracing::field::debug(&found));
+                        return Ok(found);
+                    }
+                    if let Some(found) =
+                        Self::pick_by_component_display_name(db, &constraints).await?
+                    {
+                        span.record("pick.component", &tracing::field::debug(&found));
+                        return Ok(found);
+                    }
 
-            Ok((implicit_constraints, component))
+                    let mut implicit_constraints = Constraints::default();
+                    let mut query_items = Vec::new();
+
+                    let kubernetes_version = match constraints.kubernetes_version() {
+                        KubernetesVersion::Unknown => {
+                            let default = KubernetesVersion::default_value();
+                            implicit_constraints.set_kubernetes_version(default);
+                            span.record(
+                                "pick.implicit_constraints",
+                                &tracing::field::debug(&implicit_constraints),
+                            );
+                            default
+                        }
+                        value => value,
+                    };
+                    query_items.push(si_data::DataQueryItems::generate_expression_for_int(
+                        "constraints.kubernetesVersion",
+                        DataQueryItemsExpressionComparison::Equals,
+                        kubernetes_version.to_i32_string(),
+                    ));
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+                    span.record("pick.component", &tracing::field::debug(&component));
+
+                    Ok((implicit_constraints, component))
+                }
+            }
         }
         .instrument(span)
         .await
@@ -153,25 +145,29 @@ impl KubernetesDeploymentComponent {
 }
 
 // TODO(fnichol) Code gen this
-impl KubernetesVersion {
+impl KubernetesDeploymentComponentConstraintsKubernetesVersion {
     pub fn iterator() -> impl Iterator<Item = Self> {
         [Self::V112, Self::V113, Self::V114, Self::V115]
             .iter()
             .copied()
     }
 
-    fn default() -> Self {
+    fn default_value() -> Self {
         Self::V115
+    }
+
+    fn to_i32_string(&self) -> String {
+        (*self as i32).to_string()
     }
 }
 
 // TODO(fnichol) Code gen this
 #[derive(thiserror::Error, Debug)]
-#[error("invalid KubernetesVersion value: {0}")]
+#[error("invalid KubernetesDeploymentComponentConstraintsKubernetesVersion value: {0}")]
 pub struct InvalidKubernetesVersionError(String);
 
 // TODO(fnichol) Code gen this
-impl FromStr for KubernetesVersion {
+impl std::str::FromStr for KubernetesDeploymentComponentConstraintsKubernetesVersion {
     type Err = InvalidKubernetesVersionError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -187,31 +183,14 @@ impl FromStr for KubernetesVersion {
 }
 
 // TODO(fnichol) Code gen this
-impl fmt::Display for KubernetesVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for KubernetesDeploymentComponentConstraintsKubernetesVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let msg = match self {
             Self::Unknown => "<UNKNOWN>",
             Self::V112 => "v1.12",
             Self::V113 => "v1.13",
             Self::V114 => "v1.14",
             Self::V115 => "v1.15",
-        };
-        write!(f, "{}", msg)
-    }
-}
-
-enum Field {
-    DisplayName,
-    KubernetesVersion,
-    Name,
-}
-
-impl fmt::Display for Field {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg = match self {
-            Self::DisplayName => "displayName",
-            Self::KubernetesVersion => "kubernetesVersion",
-            Self::Name => "name",
         };
         write!(f, "{}", msg)
     }


### PR DESCRIPTION
This change extracts some common `use` imports from the
`KubernetesDeployment` component code into the common cea crate.
Additionally, a new macro is provided in cea called `tracing_pick_span`
which sets up a tracing span suitable for all Component `pick` method
implementations.

Several other refactorings are included here:

* Refactor `KubernetesDeployment`'s `pick` function to be based off a
  primary `match` expression
* Add `to_i32_string` method on `KubernetesVersion`
* Update `default` function on `KubernetesVersion` to `default_value` as
  the Prost generated code already implements the `Default` trait and
  sets that default to the zero value, `Unknown`. The intent of
  `default_value` is to provide the semantic default value for a given
  enum
* Fully qualify all types in code that may be code generated in future
  work
* Remove `Field` enum type as it is no longer used

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>