### PR TITLE
refactor(kubernetes): extract common agent/apply impl

### DIFF
--- a/components/si-kubernetes/src/agent.rs
+++ b/components/si-kubernetes/src/agent.rs
@@ -1,1 +1,56 @@
+use crate::kubectl::KubectlCommand;
+use si_cea::agent::utility::spawn_command::{spawn_command_with_stdin, CaptureOutput};
+use si_cea::{CeaError, CeaResult, EntityEvent, MqttClient};
+use std::env;
+
 pub mod aws_eks_kubernetes_deployment;
+
+// TODO(fnichol): this should be entity/workspace/upstream info and not hardcoded
+const NAMESPACE_VAR: &str = "KUBERNETES_NAMESPACE";
+const NAMESPACE_DEFAULT: &str = "si";
+
+#[macro_export]
+macro_rules! yaml_bytes {
+    (
+        $entity_event:expr $(,)?
+    ) => {
+        $crate::yaml_bytes!($entity_event, kubernetes_object_yaml)
+    };
+    (
+        $entity_event:expr, $property:ident $(,)?
+    ) => {
+        $entity_event
+            .input_entity()?
+            .properties()?
+            .$property
+            .as_ref()
+            .ok_or_else(|| si_data::required_field_err(stringify!($property)))?
+            .clone()
+    };
+}
+
+pub async fn agent_apply(
+    mqtt_client: &MqttClient,
+    entity_event: &mut impl EntityEvent,
+    stdin_bytes: impl AsRef<[u8]>,
+) -> CeaResult<()> {
+    let cmd = KubectlCommand::new(namespace())
+        .apply()
+        .map_err(|err| CeaError::ActionError(err.to_string()))?;
+
+    spawn_command_with_stdin(
+        mqtt_client,
+        cmd,
+        entity_event,
+        CaptureOutput::None,
+        Some(stdin_bytes),
+    )
+    .await?
+    .success()?;
+
+    Ok(())
+}
+
+fn namespace() -> String {
+    env::var(NAMESPACE_VAR).unwrap_or_else(|_| NAMESPACE_DEFAULT.to_string())
+}

--- a/components/si-kubernetes/src/agent/aws_eks_kubernetes_deployment.rs
+++ b/components/si-kubernetes/src/agent/aws_eks_kubernetes_deployment.rs
@@ -1,16 +1,11 @@
+use crate::agent::agent_apply;
 use crate::gen::agent::{
     AwsEksKubernetesKubernetesDeploymentDispatchFunctions,
     AwsEksKubernetesKubernetesDeploymentDispatcher,
 };
-use crate::kubectl::KubectlCommand;
 use crate::model::KubernetesDeploymentEntityEvent;
+use crate::yaml_bytes;
 use si_cea::agent::dispatch::prelude::*;
-use si_cea::agent::utility::spawn_command::{spawn_command_with_stdin, CaptureOutput};
-use std::env;
-
-// TODO(fnichol): this should be entity/workspace/upstream info and not hardcoded
-const NAMESPACE_VAR: &str = "KUBERNETES_NAMESPACE";
-const NAMESPACE_DEFAULT: &str = "si";
 
 #[derive(Clone)]
 pub struct AwsEksKubernetesKubernetesDeploymentDispatchFunctionsImpl;
@@ -25,33 +20,9 @@ impl AwsEksKubernetesKubernetesDeploymentDispatchFunctions
         mqtt_client: &MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> CeaResult<()> {
-        async {
-            let cmd = KubectlCommand::new(namespace())
-                .apply()
-                .map_err(|err| CeaError::ActionError(err.to_string()))?;
-
-            let stdin = entity_event
-                .input_entity()?
-                .properties()?
-                .kubernetes_object_yaml
-                .as_ref()
-                .ok_or_else(|| si_data::required_field_err("kubernetes_object_yaml"))?
-                .clone();
-
-            spawn_command_with_stdin(
-                mqtt_client,
-                cmd,
-                entity_event,
-                CaptureOutput::None,
-                Some(stdin),
-            )
-            .await?
-            .success()?;
-
-            Ok(())
-        }
-        .instrument(debug_span!("apply"))
-        .await
+        async { agent_apply(mqtt_client, entity_event, yaml_bytes!(entity_event)).await }
+            .instrument(debug_span!("apply"))
+            .await
     }
 
     async fn create(
@@ -93,8 +64,4 @@ pub fn dispatcher() -> AwsEksKubernetesKubernetesDeploymentDispatcher<
     AwsEksKubernetesKubernetesDeploymentDispatcher::<
         AwsEksKubernetesKubernetesDeploymentDispatchFunctionsImpl,
     >::new()
-}
-
-fn namespace() -> String {
-    env::var(NAMESPACE_VAR).unwrap_or_else(|_| NAMESPACE_DEFAULT.to_string())
 }


### PR DESCRIPTION
This extracted code will be consumed by a future `KubernetesService`
agent implementation. As these entities will both share a property
called `kubernetes_object_yaml` but are distinct types, this couldn't be
"hardcoded" into `agent_apply` and so the `stdin` extraction is left as
a macro which optionally takes a property field to override what is
expected to be a reasonably shared default.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>