### PR TITLE
chore(mqtt): Upgrade to unreleased paho-mqtt 0.8 on Git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,10 +623,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
+dependencies = [
+ "futures-core-preview",
+ "futures-sink-preview",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-core-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
 name = "futures-cpupool"
@@ -650,10 +666,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-executor-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
+dependencies = [
+ "futures-core-preview",
+ "futures-util-preview",
+ "num_cpus",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-io-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 
 [[package]]
 name = "futures-macro"
@@ -668,10 +701,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
+dependencies = [
+ "futures-channel-preview",
+ "futures-core-preview",
+ "futures-executor-preview",
+ "futures-io-preview",
+ "futures-sink-preview",
+ "futures-util-preview",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+
+[[package]]
+name = "futures-sink-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
 name = "futures-task"
@@ -684,11 +737,12 @@ dependencies = [
 
 [[package]]
 name = "futures-timer"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5cedfe9b6dc756220782cc1ba5bcb1fa091cdcba155e40d3556159c3db58043"
+checksum = "8f9eb554aa23143abc64ec4d0016f038caf53bb7cbc3d91490835c54edc96550"
 dependencies = [
- "futures 0.1.29",
+ "futures-preview",
+ "pin-utils",
 ]
 
 [[package]]
@@ -709,6 +763,21 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
+name = "futures-util-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
+dependencies = [
+ "futures-channel-preview",
+ "futures-core-preview",
+ "futures-io-preview",
+ "futures-sink-preview",
+ "memchr",
+ "pin-utils",
  "slab",
 ]
 
@@ -1313,17 +1382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,24 +1500,21 @@ dependencies = [
 
 [[package]]
 name = "paho-mqtt"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4115ddef47704b582e5d03a760e2b8cca0c3d456c060cd382d10dad1807612de"
+version = "0.8.0"
+source = "git+https://github.com/eclipse/paho.mqtt.rust#47eb3eaee53a9e5f3687f9120b20d15a22a7bb9f"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.3.5",
  "futures-timer",
  "libc",
  "log",
- "num-derive",
- "num-traits 0.2.12",
  "paho-mqtt-sys",
+ "thiserror",
 ]
 
 [[package]]
 name = "paho-mqtt-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26f81abbcaf3ef810b6e7fb4f34ed5c0de590e64b268a20392cc2eb24fb78de"
+version = "0.4.0"
+source = "git+https://github.com/eclipse/paho.mqtt.rust#47eb3eaee53a9e5f3687f9120b20d15a22a7bb9f"
 dependencies = [
  "cmake",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ members = [
   "vendor/couchbase-rs/couchbase",
   "vendor/couchbase-rs/couchbase-sys",
 ]
+
+[patch.crates-io]
+# Pending release of `paho-mqtt` 0.8.0 and `paho-mqtt-sys` 0.4.0 which
+# resolves: https://github.com/eclipse/paho.mqtt.rust/issues/75
+paho-mqtt = { git = "https://github.com/eclipse/paho.mqtt.rust" }

--- a/components/si-account/Cargo.toml
+++ b/components/si-account/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 couchbase = { path = "../../vendor/couchbase-rs/couchbase" }
-futures = { version = "0.3", features = ["alloc", "compat"] }
+futures = { version = "0.3", features = ["alloc"] }
 opentelemetry = { version = "0.6", features = ["tonic"] }
 opentelemetry-jaeger = "0.5"
-paho-mqtt = "0.7"
+paho-mqtt = "0.8"
 prost = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/components/si-cea/Cargo.toml
+++ b/components/si-cea/Cargo.toml
@@ -9,8 +9,8 @@ async-trait = "0.1"
 bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 dyn-clone = "1.0.1"
-futures = { version = "0.3", features = ["alloc", "compat"] }
-paho-mqtt = "0.7"
+futures = { version = "0.3", features = ["alloc"] }
+paho-mqtt = "0.8"
 prost = "0.6"
 prost-derive = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/components/si-cea/src/agent/finalizer.rs
+++ b/components/si-cea/src/agent/finalizer.rs
@@ -1,10 +1,9 @@
 use crate::entity_event::EntityEvent;
-use crate::{CeaResult, MqttClient};
-use futures::compat::{Future01CompatExt, Stream01CompatExt};
+use crate::{agent::mqtt::PersistenceType, CeaResult, MqttClient};
 use futures::StreamExt;
 use si_data::{uuid_string, Db};
 use si_settings::Settings;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 #[derive(Debug, Clone)]
 pub struct AgentFinalizer {
@@ -18,21 +17,21 @@ impl AgentFinalizer {
         db: Db,
         entity_event_type_name: impl Into<String>,
         settings: &Settings,
-    ) -> AgentFinalizer {
+    ) -> CeaResult<AgentFinalizer> {
         let entity_event_name = entity_event_type_name.into();
         let client_id = format!("agent_finalizer:{}:{}", entity_event_name, uuid_string());
 
         let mqtt = MqttClient::new()
-            .server_uri(settings.vernemq_server_uri().as_ref())
-            .client_id(client_id.as_ref())
-            .persistence(false)
-            .finalize();
+            .server_uri(settings.vernemq_server_uri())
+            .client_id(client_id)
+            .persistence(PersistenceType::None)
+            .create_client()?;
 
-        AgentFinalizer {
+        Ok(AgentFinalizer {
             mqtt,
             db,
             entity_event_type_name: entity_event_name,
-        }
+        })
     }
 
     fn subscribe_topics(&self) -> (Vec<String>, Vec<i32>) {
@@ -56,21 +55,23 @@ impl AgentFinalizer {
 
     pub async fn run<T: EntityEvent + 'static>(&mut self) -> CeaResult<()> {
         // Whats the right value? Who knows? God only knows. Ask the Beach Boys.
-        let mut rx = self.mqtt.get_stream(1000).compat();
+        let mut rx = self.mqtt.get_stream(1000);
         println!("Finalizer connecting to the MQTT server...");
-        let (server_uri, ver, session_present) = self
+        let response = self
             .mqtt
             .default_connect()
             .await?
             .connect_response()
             .expect("should contain a connection response");
+        let server_uri = response.server_uri;
+        let ver = response.mqtt_version;
+        let session_present = response.session_present;
         // Make the connection to the broker
         println!("Connected to: '{}' with MQTT version {}", server_uri, ver);
         if !session_present {
             let (subscribe_channels, subscribe_qos) = self.subscribe_topics();
             self.mqtt
                 .subscribe(&subscribe_channels[0], subscribe_qos[0])
-                .compat()
                 .await?;
         }
 
@@ -79,15 +80,13 @@ impl AgentFinalizer {
         println!("Waiting for messages...");
         while let Some(stream_msg) = rx.next().await {
             let msg = match stream_msg {
-                Ok(maybe_msg) => match maybe_msg {
-                    Some(msg) => msg,
-                    None => {
-                        debug!("you don't have a message, eh?");
-                        continue;
+                Some(msg) => msg,
+                None => {
+                    info!("lost connection to mqtt, attempting to reconnect");
+                    while let Err(err) = self.mqtt.reconnect().await {
+                        warn!(?err, "error reconnecting to MQTT");
+                        tokio::time::delay_for(std::time::Duration::from_millis(1000)).await;
                     }
-                },
-                Err(_) => {
-                    debug!("whats up?");
                     continue;
                 }
             };

--- a/components/si-cea/src/entity_event.rs
+++ b/components/si-cea/src/entity_event.rs
@@ -2,7 +2,6 @@ use crate::entity::{Entity, EntitySiPropertiesEntityState};
 use crate::{CeaError, CeaResult, MqttClient};
 use async_trait::async_trait;
 use chrono::prelude::{DateTime, Utc};
-use futures::compat::Future01CompatExt;
 use paho_mqtt as mqtt;
 use prost::Message;
 use serde::de::DeserializeOwned;
@@ -228,12 +227,12 @@ pub trait EntityEvent:
         //};
         if finalized.unwrap_or(false) {
             let msg = mqtt::Message::new(self.result_topic()?, payload.clone(), 0);
-            mqtt_client.publish(msg).compat().await?;
+            mqtt_client.publish(msg).await?;
             let msg = mqtt::Message::new(self.finalized_topic()?, payload, 2);
-            mqtt_client.publish(msg).compat().await?;
+            mqtt_client.publish(msg).await?;
         } else {
             let msg = mqtt::Message::new(self.result_topic()?, payload, 0);
-            mqtt_client.publish(msg).compat().await?;
+            mqtt_client.publish(msg).await?;
         }
         Ok(())
     }

--- a/components/si-cea/src/error.rs
+++ b/components/si-cea/src/error.rs
@@ -73,7 +73,7 @@ pub enum CeaError {
 
     // MQTT
     #[error("mqtt failed: {0}")]
-    Mqtt(#[from] mqtt::errors::MqttError),
+    Mqtt(#[from] mqtt::Error),
 
     // Prost
     #[error("prost failed to encode: {0}")]

--- a/components/si-core/src/bin/server.rs
+++ b/components/si-core/src/bin/server.rs
@@ -61,14 +61,15 @@ async fn main() -> anyhow::Result<()> {
     agent_dispatcher
         .add(&db, global_core_service::dispatcher())
         .await?;
-    let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings);
+    let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings)?;
     tokio::spawn(async move { agent_server.run().await });
 
     println!(
         "*** Spawning the {} Agent Finalizer ***",
         ServiceEntityEvent::type_name()
     );
-    let mut finalizer = AgentFinalizer::new(db.clone(), ServiceEntityEvent::type_name(), &settings);
+    let mut finalizer =
+        AgentFinalizer::new(db.clone(), ServiceEntityEvent::type_name(), &settings)?;
     tokio::spawn(async move { finalizer.run::<ServiceEntityEvent>().await });
 
     let addr = format!("0.0.0.0:{}", settings.service.port)

--- a/components/si-kubernetes/src/bin/server.rs
+++ b/components/si-kubernetes/src/bin/server.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     agent_dispatcher
         .add(&db, aws_eks_kubernetes_deployment::dispatcher())
         .await?;
-    let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings);
+    let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings)?;
     tokio::spawn(async move { agent_server.run().await });
 
     // TODO(fnichol): We need to add an envelope to the payload before activating this code,
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
         db.clone(),
         KubernetesDeploymentEntityEvent::type_name(),
         &settings,
-    );
+    )?;
     tokio::spawn(async move { finalizer.run::<KubernetesDeploymentEntityEvent>().await });
 
     // TODO(fnichol): We need to add an envelope to the payload before activating this code,


### PR DESCRIPTION
This is an early upgrade of `paho-mqtt` and `paho-mqtt-sys` to the
unreleased versions of `0.8.0` and `0.4.0` respectively. The initial
motivation for this is to support proper building of `paho-mqtt-sys`
with the default `ssl` feature on macOS (which is currently broken on
version `0.3.0`). However, the current version of these crates have
upgraded away from `futures` `0.1.x` which means there's a lot less
`.compat()` calls in the codebase, yay!

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>