### PR TITLE
feat(core): add `Application` & `System` component & entity

### DIFF
--- a/components/si-core/src/agent.rs
+++ b/components/si-core/src/agent.rs
@@ -1,1 +1,3 @@
+pub mod global_core_application;
 pub mod global_core_service;
+pub mod global_core_system;

--- a/components/si-core/src/agent/global_core_application.rs
+++ b/components/si-core/src/agent/global_core_application.rs
@@ -1,0 +1,38 @@
+use crate::gen::agent::{GlobalCoreApplicationDispatchFunctions, GlobalCoreApplicationDispatcher};
+use crate::model::ApplicationEntityEvent;
+use si_cea::agent::dispatch::prelude::*;
+
+#[derive(Clone)]
+pub struct GlobalCoreApplicationDispatchFunctionsImpl;
+
+#[async_trait]
+impl GlobalCoreApplicationDispatchFunctions for GlobalCoreApplicationDispatchFunctionsImpl {
+    type EntityEvent = ApplicationEntityEvent;
+
+    async fn create(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }.instrument(debug_span!("create")).await
+    }
+
+    async fn edit_phantom(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }
+            .instrument(debug_span!("edit_phantom"))
+            .await
+    }
+
+    async fn sync(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }.instrument(debug_span!("sync")).await
+    }
+}
+
+pub fn dispatcher() -> GlobalCoreApplicationDispatcher<GlobalCoreApplicationDispatchFunctionsImpl> {
+    GlobalCoreApplicationDispatcher::<GlobalCoreApplicationDispatchFunctionsImpl>::new()
+}

--- a/components/si-core/src/agent/global_core_service.rs
+++ b/components/si-core/src/agent/global_core_service.rs
@@ -45,6 +45,7 @@ impl GlobalCoreServiceDispatchFunctions for GlobalCoreServiceDispatchFunctionsIm
     ) -> CeaResult<()> {
         async { Ok(()) }.instrument(debug_span!("deploy")).await
     }
+
     async fn sync(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-core/src/agent/global_core_system.rs
+++ b/components/si-core/src/agent/global_core_system.rs
@@ -1,0 +1,38 @@
+use crate::gen::agent::{GlobalCoreSystemDispatchFunctions, GlobalCoreSystemDispatcher};
+use crate::model::SystemEntityEvent;
+use si_cea::agent::dispatch::prelude::*;
+
+#[derive(Clone)]
+pub struct GlobalCoreSystemDispatchFunctionsImpl;
+
+#[async_trait]
+impl GlobalCoreSystemDispatchFunctions for GlobalCoreSystemDispatchFunctionsImpl {
+    type EntityEvent = SystemEntityEvent;
+
+    async fn create(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }.instrument(debug_span!("create")).await
+    }
+
+    async fn edit_phantom(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }
+            .instrument(debug_span!("edit_phantom"))
+            .await
+    }
+
+    async fn sync(
+        _mqtt_client: &MqttClient,
+        _entity_event: &mut Self::EntityEvent,
+    ) -> CeaResult<()> {
+        async { Ok(()) }.instrument(debug_span!("sync")).await
+    }
+}
+
+pub fn dispatcher() -> GlobalCoreSystemDispatcher<GlobalCoreSystemDispatchFunctionsImpl> {
+    GlobalCoreSystemDispatcher::<GlobalCoreSystemDispatchFunctionsImpl>::new()
+}

--- a/components/si-core/src/bin/server.rs
+++ b/components/si-core/src/bin/server.rs
@@ -3,7 +3,7 @@ use opentelemetry::{api::Provider, sdk};
 use si_cea::binary::server::prelude::*;
 use si_core::agent::global_core_service;
 use si_core::gen::service::{Server, Service};
-use si_core::model::ServiceEntityEvent;
+use si_core::model::{ApplicationEntityEvent, ServiceEntityEvent, SystemEntityEvent};
 use tracing_opentelemetry::layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{self, fmt, EnvFilter, Registry};
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         .with(opentelemetry_layer);
 
     tracing::subscriber::set_global_default(subscriber)
-        .context("cannot set the global tracing defalt")?;
+        .context("cannot set the global tracing default")?;
 
     let server_name = "core";
 
@@ -64,6 +64,34 @@ async fn main() -> anyhow::Result<()> {
     let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings)?;
     tokio::spawn(async move { agent_server.run().await });
 
+    // TODO(fnichol): We need to add an envelope to the payload before activating this code,
+    // otherwise both Deployments and Services will be consumed by both Agents
+    //
+    println!(
+        "*** (NOT YET) Spawning the {} Agent Server ***",
+        ApplicationEntityEvent::type_name()
+    );
+    // let mut agent_dispatcher = Dispatcher::default();
+    // agent_dispatcher
+    //     .add(&db, global_core_application::dispatcher())
+    //     .await?;
+    // let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings);
+    // tokio::spawn(async move { agent_server.run().await });
+
+    // TODO(fnichol): We need to add an envelope to the payload before activating this code,
+    // otherwise both Deployments and Services will be consumed by both Agents
+    //
+    println!(
+        "*** (NOT YET) Spawning the {} Agent Server ***",
+        SystemEntityEvent::type_name()
+    );
+    // let mut agent_dispatcher = Dispatcher::default();
+    // agent_dispatcher
+    //     .add(&db, global_core_system::dispatcher())
+    //     .await?;
+    // let mut agent_server = AgentServer::new(server_name, agent_dispatcher, &settings);
+    // tokio::spawn(async move { agent_server.run().await });
+
     println!(
         "*** Spawning the {} Agent Finalizer ***",
         ServiceEntityEvent::type_name()
@@ -71,6 +99,34 @@ async fn main() -> anyhow::Result<()> {
     let mut finalizer =
         AgentFinalizer::new(db.clone(), ServiceEntityEvent::type_name(), &settings)?;
     tokio::spawn(async move { finalizer.run::<ServiceEntityEvent>().await });
+
+    // TODO(fnichol): We need to add an envelope to the payload before activating this code,
+    // otherwise both Deployments and Services will be consumed by both Finalizers
+    //
+    println!(
+        "*** (NOT YET) Spawning the {} Agent Finalizer ***",
+        ApplicationEntityEvent::type_name()
+    );
+    // let mut finalizer = AgentFinalizer::new(
+    //     db.clone(),
+    //     ApplicationEntityEvent::type_name(),
+    //     &settings,
+    // );
+    // tokio::spawn(async move { finalizer.run::<ApplicationEntityEvent>().await });
+
+    // TODO(fnichol): We need to add an envelope to the payload before activating this code,
+    // otherwise both Deployments and Services will be consumed by both Finalizers
+    //
+    println!(
+        "*** (NOT YET) Spawning the {} Agent Finalizer ***",
+        SystemEntityEvent::type_name()
+    );
+    // let mut finalizer = AgentFinalizer::new(
+    //     db.clone(),
+    //     SystemEntityEvent::type_name(),
+    //     &settings,
+    // );
+    // tokio::spawn(async move { finalizer.run::<SystemEntityEvent>().await });
 
     let addr = format!("0.0.0.0:{}", settings.service.port)
         .parse()

--- a/components/si-core/src/gen/agent/global_core_application.rs
+++ b/components/si-core/src/gen/agent/global_core_application.rs
@@ -1,0 +1,82 @@
+use si_cea::EntityEvent;
+
+#[derive(Clone)]
+pub struct GlobalCoreApplicationDispatcher<T: GlobalCoreApplicationDispatchFunctions> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: GlobalCoreApplicationDispatchFunctions> GlobalCoreApplicationDispatcher<T> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<T: GlobalCoreApplicationDispatchFunctions> si_cea::agent::dispatch::IntegrationActions
+    for GlobalCoreApplicationDispatcher<T>
+{
+    fn integration_actions(&self) -> &'static [&'static str] {
+        &["create", "edit_phantom", "sync"]
+    }
+}
+
+impl<T: GlobalCoreApplicationDispatchFunctions> si_cea::agent::dispatch::IntegrationAndServiceName
+    for GlobalCoreApplicationDispatcher<T>
+{
+    fn integration_name() -> &'static str {
+        "global"
+    }
+
+    fn integration_service_name() -> &'static str {
+        "core"
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: GlobalCoreApplicationDispatchFunctions + Sync> si_cea::agent::dispatch::Dispatch
+    for GlobalCoreApplicationDispatcher<T>
+{
+    type EntityEvent = T::EntityEvent;
+
+    async fn dispatch(
+        &self,
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()> {
+        match entity_event.action_name()? {
+            "create" => T::create(mqtt_client, entity_event).await,
+            "edit_phantom" => T::edit_phantom(mqtt_client, entity_event).await,
+            "sync" => T::sync(mqtt_client, entity_event).await,
+            invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
+                entity_event.integration_service_id()?.to_string(),
+                invalid.to_string(),
+            )),
+        }
+    }
+}
+
+impl<T: GlobalCoreApplicationDispatchFunctions + Sync + Send + Clone>
+    si_cea::agent::dispatch::IntegrationDispatch for GlobalCoreApplicationDispatcher<T>
+{
+}
+
+#[async_trait::async_trait]
+pub trait GlobalCoreApplicationDispatchFunctions {
+    type EntityEvent: si_cea::EntityEvent + Send;
+
+    async fn create(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+
+    async fn edit_phantom(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+
+    async fn sync(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+}

--- a/components/si-core/src/gen/agent/global_core_system.rs
+++ b/components/si-core/src/gen/agent/global_core_system.rs
@@ -1,0 +1,82 @@
+use si_cea::EntityEvent;
+
+#[derive(Clone)]
+pub struct GlobalCoreSystemDispatcher<T: GlobalCoreSystemDispatchFunctions> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: GlobalCoreSystemDispatchFunctions> GlobalCoreSystemDispatcher<T> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<T: GlobalCoreSystemDispatchFunctions> si_cea::agent::dispatch::IntegrationActions
+    for GlobalCoreSystemDispatcher<T>
+{
+    fn integration_actions(&self) -> &'static [&'static str] {
+        &["create", "edit_phantom", "sync"]
+    }
+}
+
+impl<T: GlobalCoreSystemDispatchFunctions> si_cea::agent::dispatch::IntegrationAndServiceName
+    for GlobalCoreSystemDispatcher<T>
+{
+    fn integration_name() -> &'static str {
+        "global"
+    }
+
+    fn integration_service_name() -> &'static str {
+        "core"
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: GlobalCoreSystemDispatchFunctions + Sync> si_cea::agent::dispatch::Dispatch
+    for GlobalCoreSystemDispatcher<T>
+{
+    type EntityEvent = T::EntityEvent;
+
+    async fn dispatch(
+        &self,
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()> {
+        match entity_event.action_name()? {
+            "create" => T::create(mqtt_client, entity_event).await,
+            "edit_phantom" => T::edit_phantom(mqtt_client, entity_event).await,
+            "sync" => T::sync(mqtt_client, entity_event).await,
+            invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
+                entity_event.integration_service_id()?.to_string(),
+                invalid.to_string(),
+            )),
+        }
+    }
+}
+
+impl<T: GlobalCoreSystemDispatchFunctions + Sync + Send + Clone>
+    si_cea::agent::dispatch::IntegrationDispatch for GlobalCoreSystemDispatcher<T>
+{
+}
+
+#[async_trait::async_trait]
+pub trait GlobalCoreSystemDispatchFunctions {
+    type EntityEvent: si_cea::EntityEvent + Send;
+
+    async fn create(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+
+    async fn edit_phantom(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+
+    async fn sync(
+        mqtt_client: &si_cea::MqttClient,
+        entity_event: &mut Self::EntityEvent,
+    ) -> si_cea::CeaResult<()>;
+}

--- a/components/si-core/src/gen/agent/mod.rs
+++ b/components/si-core/src/gen/agent/mod.rs
@@ -1,6 +1,12 @@
 // Auto-generated code!
 // No touchy!
 
+pub mod global_core_application;
 pub mod global_core_service;
+pub mod global_core_system;
 
+pub use global_core_application::{
+    GlobalCoreApplicationDispatchFunctions, GlobalCoreApplicationDispatcher,
+};
 pub use global_core_service::{GlobalCoreServiceDispatchFunctions, GlobalCoreServiceDispatcher};
+pub use global_core_system::{GlobalCoreSystemDispatchFunctions, GlobalCoreSystemDispatcher};

--- a/components/si-core/src/gen/model/application_component.rs
+++ b/components/si-core/src/gen/model/application_component.rs
@@ -1,0 +1,468 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::ApplicationComponent {
+    pub fn new(
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        si_properties: Option<si_cea::protobuf::ComponentSiProperties>,
+    ) -> si_data::Result<crate::protobuf::ApplicationComponent> {
+        let mut si_storable = si_data::protobuf::DataStorable::default();
+        si_storable.add_to_tenant_ids("global");
+        si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::ValidationError("siProperties".into()))?;
+        let integration_id = si_properties
+            .as_ref()
+            .unwrap()
+            .integration_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.integrationId".into())
+            })?;
+        si_storable.add_to_tenant_ids(integration_id);
+        let integration_service_id = si_properties
+            .as_ref()
+            .unwrap()
+            .integration_service_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.integrationServiceId".into())
+            })?;
+        si_storable.add_to_tenant_ids(integration_service_id);
+
+        let mut result: crate::protobuf::ApplicationComponent = Default::default();
+        result.name = name;
+        result.display_name = display_name;
+        result.description = description;
+        result.constraints = constraints;
+        result.si_properties = si_properties;
+        result.si_storable = Some(si_storable);
+
+        Ok(result)
+    }
+
+    pub async fn create(
+        db: &si_data::Db,
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        si_properties: Option<si_cea::protobuf::ComponentSiProperties>,
+    ) -> si_data::Result<crate::protobuf::ApplicationComponent> {
+        let mut result = crate::protobuf::ApplicationComponent::new(
+            name,
+            display_name,
+            description,
+            constraints,
+            si_properties,
+        )?;
+        db.validate_and_insert_as_new(&mut result).await?;
+
+        Ok(result)
+    }
+
+    pub async fn get(
+        db: &si_data::Db,
+        id: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationComponent> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationComponent> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::ApplicationComponentListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::ApplicationComponent>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+
+    pub async fn pick_by_expressions(
+        db: &si_data::Db,
+        items: Vec<si_data::DataQueryItems>,
+        boolean_term: si_data::DataQueryBooleanTerm,
+    ) -> si_data::Result<Self> {
+        let query = si_data::DataQuery {
+            items,
+            boolean_term: boolean_term as i32,
+            ..Default::default()
+        };
+
+        let mut check_result: si_data::ListResult<Self> =
+            db.list(&Some(query), 1, "", 0, "global", "").await?;
+        if check_result.len() == 1 {
+            return Ok(check_result.items.pop().unwrap());
+        } else {
+            return Err(si_data::DataError::PickComponent(
+                "a match was not found".to_string(),
+            ));
+        }
+    }
+
+    pub async fn pick_by_string_field<F, V>(
+        db: &si_data::Db,
+        field: F,
+        value: V,
+    ) -> si_data::Result<Option<Self>>
+    where
+        F: Into<String> + Send,
+        V: Into<String> + Send,
+    {
+        let value = value.into();
+        let field = field.into();
+
+        if value != "" {
+            let query = si_data::DataQuery::generate_for_string(
+                field.clone(),
+                si_data::DataQueryItemsExpressionComparison::Equals,
+                value.clone(),
+            );
+            let mut check_result: si_data::ListResult<Self> =
+                db.list(&Some(query), 1, "", 0, "global", "").await?;
+            if check_result.len() == 1 {
+                return Ok(Some(check_result.items.pop().unwrap()));
+            } else {
+                return Err(si_data::DataError::PickComponent(format!(
+                    "{}={} must match exactly, and was not found",
+                    field, value
+                )));
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn pick_by_component_name(
+        db: &si_data::Db,
+        req: &crate::protobuf::ApplicationComponentConstraints,
+    ) -> si_data::Result<Option<(crate::protobuf::ApplicationComponentConstraints, Self)>> {
+        match &req.component_name {
+            Some(name) => match Self::pick_by_string_field(db, "name", name).await? {
+                Some(component) => Ok(Some((
+                    crate::protobuf::ApplicationComponentConstraints::default(),
+                    component,
+                ))),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub async fn pick_by_component_display_name(
+        db: &si_data::Db,
+        req: &crate::protobuf::ApplicationComponentConstraints,
+    ) -> si_data::Result<Option<(crate::protobuf::ApplicationComponentConstraints, Self)>> {
+        match &req.component_display_name {
+            Some(display_name) => {
+                match Self::pick_by_string_field(db, "displayName", display_name).await? {
+                    Some(component) => Ok(Some((
+                        crate::protobuf::ApplicationComponentConstraints::default(),
+                        component,
+                    ))),
+                    None => Ok(None),
+                }
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl si_data::Storable for crate::protobuf::ApplicationComponent {
+    fn type_name() -> &'static str {
+        "application_component"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .natural_key
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        let natural_key = format!(
+            "{}:{}:{}",
+            self.tenant_ids()?
+                .first()
+                .ok_or_else(|| si_data::DataError::MissingTenantIds)?,
+            Self::type_name(),
+            self.name
+                .as_ref()
+                .ok_or_else(|| si_data::DataError::RequiredField("name".to_string()))?,
+        );
+
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.natural_key = Some(natural_key);
+
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required name value".into(),
+            ));
+        }
+        if self.display_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required display_name value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.description.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required description value".into(),
+            ));
+        }
+        if self.constraints.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required constraints value".into(),
+            ));
+        }
+        if self.si_properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_properties value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        let integration_id = match &self.si_properties {
+            Some(cip) => cip
+                .integration_id
+                .as_ref()
+                .map(String::as_ref)
+                .unwrap_or("No integration_id found for referential integrity check"),
+            None => "No integration_id found for referential integrity check",
+        };
+        let integration_service_id = match &self.si_properties {
+            Some(cip) => cip
+                .integration_service_id
+                .as_ref()
+                .map(String::as_ref)
+                .unwrap_or("No integration_service_id found for referential integrity check"),
+            None => "No integration_service_id found for referential integrity check",
+        };
+        vec![
+            si_data::Reference::HasOne("integration_id", integration_id),
+            si_data::Reference::HasOne("integration_service_id", integration_service_id),
+        ]
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "name",
+            "displayName",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "description",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+            "siStorable.naturalKey",
+        ]
+    }
+}
+
+impl si_data::Migrateable for crate::protobuf::ApplicationComponent {
+    fn get_version(&self) -> i32 {
+        match self.si_properties.as_ref().map(|p| p.version) {
+            Some(v) => v.unwrap_or(0),
+            None => 0,
+        }
+    }
+}

--- a/components/si-core/src/gen/model/application_entity.rs
+++ b/components/si-core/src/gen/model/application_entity.rs
@@ -1,0 +1,596 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::ApplicationEntity {
+    pub fn new(
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        implicit_constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        properties: Option<crate::protobuf::ApplicationEntityProperties>,
+        si_properties: Option<si_cea::protobuf::EntitySiProperties>,
+        change_set_id: Option<String>,
+    ) -> si_cea::CeaResult<crate::protobuf::ApplicationEntity> {
+        let mut si_storable = si_data::protobuf::DataStorable::default();
+        si_storable.change_set_id = change_set_id;
+        si_storable.change_set_event_type =
+            si_data::protobuf::DataStorableChangeSetEventType::Create as i32;
+        si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::ValidationError("siProperties".into()))?;
+        let billing_account_id = si_properties
+            .as_ref()
+            .unwrap()
+            .billing_account_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.billingAccountId".into())
+            })?;
+        si_storable.add_to_tenant_ids(billing_account_id);
+        let organization_id = si_properties
+            .as_ref()
+            .unwrap()
+            .organization_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.organizationId".into())
+            })?;
+        si_storable.add_to_tenant_ids(organization_id);
+        let workspace_id = si_properties
+            .as_ref()
+            .unwrap()
+            .workspace_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.workspaceId".into())
+            })?;
+        si_storable.add_to_tenant_ids(workspace_id);
+
+        let mut result: crate::protobuf::ApplicationEntity = Default::default();
+        result.name = name;
+        result.display_name = display_name;
+        result.description = description;
+        result.constraints = constraints;
+        result.implicit_constraints = implicit_constraints;
+        result.properties = properties;
+        result.si_properties = si_properties;
+        result.si_storable = Some(si_storable);
+
+        Ok(result)
+    }
+
+    pub async fn create(
+        db: &si_data::Db,
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        implicit_constraints: Option<crate::protobuf::ApplicationComponentConstraints>,
+        properties: Option<crate::protobuf::ApplicationEntityProperties>,
+        si_properties: Option<si_cea::protobuf::EntitySiProperties>,
+        change_set_id: Option<String>,
+    ) -> si_cea::CeaResult<crate::protobuf::ApplicationEntity> {
+        let mut result = crate::protobuf::ApplicationEntity::new(
+            name,
+            display_name,
+            description,
+            constraints,
+            implicit_constraints,
+            properties,
+            si_properties,
+            change_set_id,
+        )?;
+        db.validate_and_insert_as_new(&mut result).await?;
+
+        Ok(result)
+    }
+
+    pub async fn get(
+        db: &si_data::Db,
+        id: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationEntity> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationEntity> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::ApplicationEntityListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::ApplicationEntity>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+
+    pub fn edit_phantom(&mut self, property: bool) -> si_cea::CeaResult<()> {
+        use si_cea::Entity;
+
+        self.properties_mut()?.phantom = Some(property);
+
+        Ok(())
+    }
+
+    pub async fn delete(
+        &mut self,
+        db: &si_data::Db,
+        change_set_id: Option<String>,
+    ) -> si_data::Result<()> {
+        let item_id = self.id.as_ref().map(|change_set_enabled_id| {
+            let split_result: Vec<&str> = change_set_enabled_id.split(":").collect();
+            let item_id = if split_result.len() == 2 {
+                format!("{}:{}", split_result[0], split_result[1])
+            } else {
+                format!("{}:{}", split_result[3], split_result[4])
+            };
+            item_id
+        });
+        self.si_storable.as_mut().map(|si_storable| {
+            si_storable.change_set_id = change_set_id;
+            si_storable.deleted = Some(true);
+            si_storable.set_change_set_event_type(si_data::DataStorableChangeSetEventType::Delete);
+            si_storable.item_id = item_id;
+            si_storable.change_set_executed = Some(false);
+            si_storable
+        });
+
+        db.delete(self).await?;
+        Ok(())
+    }
+
+    pub async fn update(
+        &mut self,
+        db: &si_data::Db,
+        change_set_id: Option<String>,
+        update: Option<crate::protobuf::ApplicationEntityUpdateRequestUpdate>,
+    ) -> si_data::Result<()> {
+        let item_id = self.id.as_ref().map(|change_set_enabled_id| {
+            let split_result: Vec<&str> = change_set_enabled_id.split(":").collect();
+            let item_id = if split_result.len() == 2 {
+                format!("{}:{}", split_result[0], split_result[1])
+            } else {
+                format!("{}:{}", split_result[3], split_result[4])
+            };
+            item_id
+        });
+        self.si_storable.as_mut().map(|si_storable| {
+            si_storable.change_set_id = change_set_id;
+            si_storable.deleted = Some(false);
+            si_storable.set_change_set_event_type(si_data::DataStorableChangeSetEventType::Update);
+            si_storable.item_id = item_id;
+            si_storable.change_set_executed = Some(false);
+            si_storable
+        });
+
+        if update.is_some() {
+            let real_update = update.unwrap();
+            if real_update.description.is_some() {
+                self.description = real_update.description;
+            }
+            if real_update.properties.is_some() {
+                self.properties = real_update.properties;
+            }
+            if real_update.name.is_some() {
+                self.name = real_update.name;
+            }
+        }
+
+        db.update(self).await?;
+        Ok(())
+    }
+}
+
+impl si_cea::Entity for crate::protobuf::ApplicationEntity {
+    type EntityProperties = crate::protobuf::ApplicationEntityProperties;
+
+    fn entity_state(&self) -> si_data::Result<si_cea::EntitySiPropertiesEntityState> {
+        Ok(self
+            .si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .entity_state())
+    }
+
+    fn set_entity_state(&mut self, state: si_cea::EntitySiPropertiesEntityState) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.set_entity_state(state);
+    }
+
+    fn properties(&self) -> si_data::Result<&Self::EntityProperties> {
+        self.properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("properties".to_string()))
+    }
+
+    fn properties_mut(&mut self) -> si_data::Result<&mut Self::EntityProperties> {
+        self.properties
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("properties".to_string()))
+    }
+
+    fn integration_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_id".to_string()))
+    }
+
+    fn set_integration_id(&mut self, integration_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_id = Some(integration_id.into());
+    }
+
+    fn integration_service_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_service_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_service_id".to_string()))
+    }
+
+    fn set_integration_service_id(&mut self, integration_service_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_service_id = Some(integration_service_id.into());
+    }
+
+    fn component_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .component_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("component_id".to_string()))
+    }
+
+    fn set_component_id(&mut self, component_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.component_id = Some(component_id.into());
+    }
+
+    fn workspace_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .workspace_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("workspace_id".to_string()))
+    }
+
+    fn set_workspace_id(&mut self, workspace_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.workspace_id = Some(workspace_id.into());
+    }
+
+    fn organization_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .organization_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("organization_id".to_string()))
+    }
+
+    fn set_organization_id(&mut self, organization_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.organization_id = Some(organization_id.into());
+    }
+
+    fn billing_account_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .billing_account_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("billing_account_id".to_string()))
+    }
+
+    fn set_billing_account_id(&mut self, billing_account_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.billing_account_id = Some(billing_account_id.into());
+    }
+}
+
+impl si_data::Storable for crate::protobuf::ApplicationEntity {
+    fn type_name() -> &'static str {
+        "application_entity"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(None)
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationEntity.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required name value".into(),
+            ));
+        }
+        if self.display_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required display_name value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.description.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required description value".into(),
+            ));
+        }
+        if self.si_properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_properties value".into(),
+            ));
+        }
+        if self.properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required properties value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        Vec::new()
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "name",
+            "displayName",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "description",
+            "siStorable.naturalKey",
+            "entitySiProperties.entityState",
+            "siStorable.naturalKey",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+        ]
+    }
+}

--- a/components/si-core/src/gen/model/application_entity_event.rs
+++ b/components/si-core/src/gen/model/application_entity_event.rs
@@ -1,0 +1,547 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::ApplicationEntityEvent {
+    pub async fn get(
+        db: &si_data::Db,
+        id: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationEntityEvent> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::ApplicationEntityEvent> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::ApplicationEntityEventListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::ApplicationEntityEvent>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+}
+
+impl si_cea::EntityEvent for crate::protobuf::ApplicationEntityEvent {
+    type Entity = crate::protobuf::ApplicationEntity;
+
+    fn action_names() -> &'static [&'static str] {
+        &["create", "edit_phantom", "sync"]
+    }
+
+    fn action_name(&self) -> si_data::Result<&str> {
+        self.action_name
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("action_name".to_string()))
+    }
+
+    fn set_action_name(&mut self, action_name: impl Into<String>) {
+        self.action_name = Some(action_name.into());
+    }
+
+    fn create_time(&self) -> si_data::Result<&str> {
+        self.create_time
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("create_time".to_string()))
+    }
+
+    fn set_create_time(&mut self, create_time: impl Into<String>) {
+        self.create_time = Some(create_time.into());
+    }
+
+    fn updated_time(&self) -> Option<&str> {
+        self.updated_time.as_ref().map(String::as_str)
+    }
+
+    fn set_updated_time(&mut self, updated_time: impl Into<String>) {
+        self.updated_time = Some(updated_time.into());
+    }
+
+    fn final_time(&self) -> Option<&str> {
+        self.final_time.as_ref().map(String::as_str)
+    }
+
+    fn set_final_time(&mut self, final_time: impl Into<String>) {
+        self.final_time = Some(final_time.into());
+    }
+
+    fn success(&self) -> Option<bool> {
+        self.success
+    }
+
+    fn set_success(&mut self, success: bool) {
+        self.success = Some(success);
+    }
+
+    fn finalized(&self) -> Option<bool> {
+        self.finalized
+    }
+
+    fn set_finalized(&mut self, finalized: bool) {
+        self.finalized = Some(finalized);
+    }
+
+    fn user_id(&self) -> si_data::Result<&str> {
+        self.user_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("user_id".to_string()))
+    }
+
+    fn set_user_id(&mut self, user_id: impl Into<String>) {
+        self.user_id = Some(user_id.into());
+    }
+
+    fn output_lines(&self) -> &[String] {
+        &self.output_lines
+    }
+
+    fn add_to_output_lines(&mut self, line: impl Into<String>) {
+        self.output_lines.push(line.into());
+    }
+
+    fn error_lines(&self) -> &[String] {
+        self.error_lines.as_ref()
+    }
+
+    fn add_to_error_lines(&mut self, line: impl Into<String>) {
+        self.error_lines.push(line.into());
+    }
+
+    fn error_message(&self) -> Option<&str> {
+        self.error_message.as_ref().map(String::as_str)
+    }
+
+    fn set_error_message(&mut self, error_message: impl Into<String>) {
+        self.error_message = Some(error_message.into());
+    }
+
+    fn previous_entity(&self) -> Option<&Self::Entity> {
+        self.previous_entity.as_ref()
+    }
+
+    fn set_previous_entity(&mut self, previous_entity: Self::Entity) {
+        self.previous_entity = Some(previous_entity);
+    }
+
+    fn input_entity(&self) -> si_data::Result<&Self::Entity> {
+        self.input_entity
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("input_entity".to_string()))
+    }
+
+    fn set_input_entity(&mut self, input_entity: Self::Entity) {
+        self.input_entity = Some(input_entity);
+    }
+
+    fn output_entity(&self) -> Option<&Self::Entity> {
+        self.output_entity.as_ref()
+    }
+
+    fn set_output_entity(&mut self, output_entity: Self::Entity) {
+        self.output_entity = Some(output_entity);
+    }
+
+    fn mut_output_entity(&mut self) -> si_data::Result<&mut Self::Entity> {
+        if self.output_entity.is_none() {
+            self.init_output_entity()?;
+        }
+
+        Ok(self
+            .output_entity
+            .as_mut()
+            .expect("output_entity has been set or initialized"))
+    }
+
+    fn billing_account_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .billing_account_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("billing_account_id".to_string()))
+    }
+
+    fn set_billing_account_id(&mut self, billing_account_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.billing_account_id = Some(billing_account_id.into());
+    }
+
+    fn organization_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .organization_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("organization_id".to_string()))
+    }
+
+    fn set_organization_id(&mut self, organization_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.organization_id = Some(organization_id.into());
+    }
+
+    fn workspace_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .workspace_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("workspace_id".to_string()))
+    }
+
+    fn set_workspace_id(&mut self, workspace_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.workspace_id = Some(workspace_id.into());
+    }
+
+    fn integration_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_id".to_string()))
+    }
+
+    fn set_integration_id(&mut self, integration_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_id = Some(integration_id.into());
+    }
+
+    fn integration_service_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_service_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_service_id".to_string()))
+    }
+
+    fn set_integration_service_id(&mut self, integration_service_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_service_id = Some(integration_service_id.into());
+    }
+
+    fn component_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .component_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("component_id".to_string()))
+    }
+
+    fn set_component_id(&mut self, component_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.component_id = Some(component_id.into());
+    }
+
+    fn entity_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .entity_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("entity_id".to_string()))
+    }
+
+    fn set_entity_id(&mut self, entity_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.entity_id = Some(entity_id.into());
+    }
+
+    fn set_change_set_id(&mut self, change_set_id: impl Into<String>) {
+        self.si_storable.as_mut().map(|storable| {
+            storable.change_set_id = Some(change_set_id.into());
+            storable.change_set_event_type =
+                si_data::protobuf::DataStorableChangeSetEventType::Action as i32;
+        });
+    }
+}
+
+impl si_data::Storable for crate::protobuf::ApplicationEntityEvent {
+    fn type_name() -> &'static str {
+        "application_entity_event"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(None)
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::ApplicationEntityEvent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.action_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required action_name value".into(),
+            ));
+        }
+        if self.input_entity.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required input_entity value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        Vec::new()
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "actionName",
+            "createTime",
+            "updatedTime",
+            "finalTime",
+            "success",
+            "finalized",
+            "userId",
+            "outputLines",
+            "errorLines",
+            "errorMessage",
+        ]
+    }
+}

--- a/components/si-core/src/gen/model/mod.rs
+++ b/components/si-core/src/gen/model/mod.rs
@@ -1,6 +1,12 @@
 // Auto-generated code!
 // No touchy!
 
+pub mod application_component;
+pub mod application_entity;
+pub mod application_entity_event;
 pub mod service_component;
 pub mod service_entity;
 pub mod service_entity_event;
+pub mod system_component;
+pub mod system_entity;
+pub mod system_entity_event;

--- a/components/si-core/src/gen/model/system_component.rs
+++ b/components/si-core/src/gen/model/system_component.rs
@@ -1,0 +1,468 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::SystemComponent {
+    pub fn new(
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        si_properties: Option<si_cea::protobuf::ComponentSiProperties>,
+    ) -> si_data::Result<crate::protobuf::SystemComponent> {
+        let mut si_storable = si_data::protobuf::DataStorable::default();
+        si_storable.add_to_tenant_ids("global");
+        si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::ValidationError("siProperties".into()))?;
+        let integration_id = si_properties
+            .as_ref()
+            .unwrap()
+            .integration_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.integrationId".into())
+            })?;
+        si_storable.add_to_tenant_ids(integration_id);
+        let integration_service_id = si_properties
+            .as_ref()
+            .unwrap()
+            .integration_service_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.integrationServiceId".into())
+            })?;
+        si_storable.add_to_tenant_ids(integration_service_id);
+
+        let mut result: crate::protobuf::SystemComponent = Default::default();
+        result.name = name;
+        result.display_name = display_name;
+        result.description = description;
+        result.constraints = constraints;
+        result.si_properties = si_properties;
+        result.si_storable = Some(si_storable);
+
+        Ok(result)
+    }
+
+    pub async fn create(
+        db: &si_data::Db,
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        si_properties: Option<si_cea::protobuf::ComponentSiProperties>,
+    ) -> si_data::Result<crate::protobuf::SystemComponent> {
+        let mut result = crate::protobuf::SystemComponent::new(
+            name,
+            display_name,
+            description,
+            constraints,
+            si_properties,
+        )?;
+        db.validate_and_insert_as_new(&mut result).await?;
+
+        Ok(result)
+    }
+
+    pub async fn get(
+        db: &si_data::Db,
+        id: &str,
+    ) -> si_data::Result<crate::protobuf::SystemComponent> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::SystemComponent> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::SystemComponentListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::SystemComponent>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+
+    pub async fn pick_by_expressions(
+        db: &si_data::Db,
+        items: Vec<si_data::DataQueryItems>,
+        boolean_term: si_data::DataQueryBooleanTerm,
+    ) -> si_data::Result<Self> {
+        let query = si_data::DataQuery {
+            items,
+            boolean_term: boolean_term as i32,
+            ..Default::default()
+        };
+
+        let mut check_result: si_data::ListResult<Self> =
+            db.list(&Some(query), 1, "", 0, "global", "").await?;
+        if check_result.len() == 1 {
+            return Ok(check_result.items.pop().unwrap());
+        } else {
+            return Err(si_data::DataError::PickComponent(
+                "a match was not found".to_string(),
+            ));
+        }
+    }
+
+    pub async fn pick_by_string_field<F, V>(
+        db: &si_data::Db,
+        field: F,
+        value: V,
+    ) -> si_data::Result<Option<Self>>
+    where
+        F: Into<String> + Send,
+        V: Into<String> + Send,
+    {
+        let value = value.into();
+        let field = field.into();
+
+        if value != "" {
+            let query = si_data::DataQuery::generate_for_string(
+                field.clone(),
+                si_data::DataQueryItemsExpressionComparison::Equals,
+                value.clone(),
+            );
+            let mut check_result: si_data::ListResult<Self> =
+                db.list(&Some(query), 1, "", 0, "global", "").await?;
+            if check_result.len() == 1 {
+                return Ok(Some(check_result.items.pop().unwrap()));
+            } else {
+                return Err(si_data::DataError::PickComponent(format!(
+                    "{}={} must match exactly, and was not found",
+                    field, value
+                )));
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn pick_by_component_name(
+        db: &si_data::Db,
+        req: &crate::protobuf::SystemComponentConstraints,
+    ) -> si_data::Result<Option<(crate::protobuf::SystemComponentConstraints, Self)>> {
+        match &req.component_name {
+            Some(name) => match Self::pick_by_string_field(db, "name", name).await? {
+                Some(component) => Ok(Some((
+                    crate::protobuf::SystemComponentConstraints::default(),
+                    component,
+                ))),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub async fn pick_by_component_display_name(
+        db: &si_data::Db,
+        req: &crate::protobuf::SystemComponentConstraints,
+    ) -> si_data::Result<Option<(crate::protobuf::SystemComponentConstraints, Self)>> {
+        match &req.component_display_name {
+            Some(display_name) => {
+                match Self::pick_by_string_field(db, "displayName", display_name).await? {
+                    Some(component) => Ok(Some((
+                        crate::protobuf::SystemComponentConstraints::default(),
+                        component,
+                    ))),
+                    None => Ok(None),
+                }
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl si_data::Storable for crate::protobuf::SystemComponent {
+    fn type_name() -> &'static str {
+        "system_component"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .natural_key
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        let natural_key = format!(
+            "{}:{}:{}",
+            self.tenant_ids()?
+                .first()
+                .ok_or_else(|| si_data::DataError::MissingTenantIds)?,
+            Self::type_name(),
+            self.name
+                .as_ref()
+                .ok_or_else(|| si_data::DataError::RequiredField("name".to_string()))?,
+        );
+
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.natural_key = Some(natural_key);
+
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemComponent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required name value".into(),
+            ));
+        }
+        if self.display_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required display_name value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.description.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required description value".into(),
+            ));
+        }
+        if self.constraints.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required constraints value".into(),
+            ));
+        }
+        if self.si_properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_properties value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        let integration_id = match &self.si_properties {
+            Some(cip) => cip
+                .integration_id
+                .as_ref()
+                .map(String::as_ref)
+                .unwrap_or("No integration_id found for referential integrity check"),
+            None => "No integration_id found for referential integrity check",
+        };
+        let integration_service_id = match &self.si_properties {
+            Some(cip) => cip
+                .integration_service_id
+                .as_ref()
+                .map(String::as_ref)
+                .unwrap_or("No integration_service_id found for referential integrity check"),
+            None => "No integration_service_id found for referential integrity check",
+        };
+        vec![
+            si_data::Reference::HasOne("integration_id", integration_id),
+            si_data::Reference::HasOne("integration_service_id", integration_service_id),
+        ]
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "name",
+            "displayName",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "description",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+            "siStorable.naturalKey",
+        ]
+    }
+}
+
+impl si_data::Migrateable for crate::protobuf::SystemComponent {
+    fn get_version(&self) -> i32 {
+        match self.si_properties.as_ref().map(|p| p.version) {
+            Some(v) => v.unwrap_or(0),
+            None => 0,
+        }
+    }
+}

--- a/components/si-core/src/gen/model/system_entity.rs
+++ b/components/si-core/src/gen/model/system_entity.rs
@@ -1,0 +1,593 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::SystemEntity {
+    pub fn new(
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        implicit_constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        properties: Option<crate::protobuf::SystemEntityProperties>,
+        si_properties: Option<si_cea::protobuf::EntitySiProperties>,
+        change_set_id: Option<String>,
+    ) -> si_cea::CeaResult<crate::protobuf::SystemEntity> {
+        let mut si_storable = si_data::protobuf::DataStorable::default();
+        si_storable.change_set_id = change_set_id;
+        si_storable.change_set_event_type =
+            si_data::protobuf::DataStorableChangeSetEventType::Create as i32;
+        si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::ValidationError("siProperties".into()))?;
+        let billing_account_id = si_properties
+            .as_ref()
+            .unwrap()
+            .billing_account_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.billingAccountId".into())
+            })?;
+        si_storable.add_to_tenant_ids(billing_account_id);
+        let organization_id = si_properties
+            .as_ref()
+            .unwrap()
+            .organization_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.organizationId".into())
+            })?;
+        si_storable.add_to_tenant_ids(organization_id);
+        let workspace_id = si_properties
+            .as_ref()
+            .unwrap()
+            .workspace_id
+            .as_ref()
+            .ok_or_else(|| {
+                si_data::DataError::ValidationError("siProperties.workspaceId".into())
+            })?;
+        si_storable.add_to_tenant_ids(workspace_id);
+
+        let mut result: crate::protobuf::SystemEntity = Default::default();
+        result.name = name;
+        result.display_name = display_name;
+        result.description = description;
+        result.constraints = constraints;
+        result.implicit_constraints = implicit_constraints;
+        result.properties = properties;
+        result.si_properties = si_properties;
+        result.si_storable = Some(si_storable);
+
+        Ok(result)
+    }
+
+    pub async fn create(
+        db: &si_data::Db,
+        name: Option<String>,
+        display_name: Option<String>,
+        description: Option<String>,
+        constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        implicit_constraints: Option<crate::protobuf::SystemComponentConstraints>,
+        properties: Option<crate::protobuf::SystemEntityProperties>,
+        si_properties: Option<si_cea::protobuf::EntitySiProperties>,
+        change_set_id: Option<String>,
+    ) -> si_cea::CeaResult<crate::protobuf::SystemEntity> {
+        let mut result = crate::protobuf::SystemEntity::new(
+            name,
+            display_name,
+            description,
+            constraints,
+            implicit_constraints,
+            properties,
+            si_properties,
+            change_set_id,
+        )?;
+        db.validate_and_insert_as_new(&mut result).await?;
+
+        Ok(result)
+    }
+
+    pub async fn get(db: &si_data::Db, id: &str) -> si_data::Result<crate::protobuf::SystemEntity> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::SystemEntity> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::SystemEntityListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::SystemEntity>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+
+    pub fn edit_phantom(&mut self, property: bool) -> si_cea::CeaResult<()> {
+        use si_cea::Entity;
+
+        self.properties_mut()?.phantom = Some(property);
+
+        Ok(())
+    }
+
+    pub async fn delete(
+        &mut self,
+        db: &si_data::Db,
+        change_set_id: Option<String>,
+    ) -> si_data::Result<()> {
+        let item_id = self.id.as_ref().map(|change_set_enabled_id| {
+            let split_result: Vec<&str> = change_set_enabled_id.split(":").collect();
+            let item_id = if split_result.len() == 2 {
+                format!("{}:{}", split_result[0], split_result[1])
+            } else {
+                format!("{}:{}", split_result[3], split_result[4])
+            };
+            item_id
+        });
+        self.si_storable.as_mut().map(|si_storable| {
+            si_storable.change_set_id = change_set_id;
+            si_storable.deleted = Some(true);
+            si_storable.set_change_set_event_type(si_data::DataStorableChangeSetEventType::Delete);
+            si_storable.item_id = item_id;
+            si_storable.change_set_executed = Some(false);
+            si_storable
+        });
+
+        db.delete(self).await?;
+        Ok(())
+    }
+
+    pub async fn update(
+        &mut self,
+        db: &si_data::Db,
+        change_set_id: Option<String>,
+        update: Option<crate::protobuf::SystemEntityUpdateRequestUpdate>,
+    ) -> si_data::Result<()> {
+        let item_id = self.id.as_ref().map(|change_set_enabled_id| {
+            let split_result: Vec<&str> = change_set_enabled_id.split(":").collect();
+            let item_id = if split_result.len() == 2 {
+                format!("{}:{}", split_result[0], split_result[1])
+            } else {
+                format!("{}:{}", split_result[3], split_result[4])
+            };
+            item_id
+        });
+        self.si_storable.as_mut().map(|si_storable| {
+            si_storable.change_set_id = change_set_id;
+            si_storable.deleted = Some(false);
+            si_storable.set_change_set_event_type(si_data::DataStorableChangeSetEventType::Update);
+            si_storable.item_id = item_id;
+            si_storable.change_set_executed = Some(false);
+            si_storable
+        });
+
+        if update.is_some() {
+            let real_update = update.unwrap();
+            if real_update.description.is_some() {
+                self.description = real_update.description;
+            }
+            if real_update.properties.is_some() {
+                self.properties = real_update.properties;
+            }
+            if real_update.name.is_some() {
+                self.name = real_update.name;
+            }
+        }
+
+        db.update(self).await?;
+        Ok(())
+    }
+}
+
+impl si_cea::Entity for crate::protobuf::SystemEntity {
+    type EntityProperties = crate::protobuf::SystemEntityProperties;
+
+    fn entity_state(&self) -> si_data::Result<si_cea::EntitySiPropertiesEntityState> {
+        Ok(self
+            .si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .entity_state())
+    }
+
+    fn set_entity_state(&mut self, state: si_cea::EntitySiPropertiesEntityState) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.set_entity_state(state);
+    }
+
+    fn properties(&self) -> si_data::Result<&Self::EntityProperties> {
+        self.properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("properties".to_string()))
+    }
+
+    fn properties_mut(&mut self) -> si_data::Result<&mut Self::EntityProperties> {
+        self.properties
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("properties".to_string()))
+    }
+
+    fn integration_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_id".to_string()))
+    }
+
+    fn set_integration_id(&mut self, integration_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_id = Some(integration_id.into());
+    }
+
+    fn integration_service_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_service_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_service_id".to_string()))
+    }
+
+    fn set_integration_service_id(&mut self, integration_service_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_service_id = Some(integration_service_id.into());
+    }
+
+    fn component_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .component_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("component_id".to_string()))
+    }
+
+    fn set_component_id(&mut self, component_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.component_id = Some(component_id.into());
+    }
+
+    fn workspace_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .workspace_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("workspace_id".to_string()))
+    }
+
+    fn set_workspace_id(&mut self, workspace_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.workspace_id = Some(workspace_id.into());
+    }
+
+    fn organization_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .organization_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("organization_id".to_string()))
+    }
+
+    fn set_organization_id(&mut self, organization_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.organization_id = Some(organization_id.into());
+    }
+
+    fn billing_account_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .billing_account_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("billing_account_id".to_string()))
+    }
+
+    fn set_billing_account_id(&mut self, billing_account_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_properties \
+                has been set or initialized",
+        );
+        si_properties.billing_account_id = Some(billing_account_id.into());
+    }
+}
+
+impl si_data::Storable for crate::protobuf::SystemEntity {
+    fn type_name() -> &'static str {
+        "system_entity"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(None)
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemEntity.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required name value".into(),
+            ));
+        }
+        if self.display_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required display_name value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.description.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required description value".into(),
+            ));
+        }
+        if self.si_properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_properties value".into(),
+            ));
+        }
+        if self.properties.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required properties value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        Vec::new()
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "name",
+            "displayName",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "description",
+            "siStorable.naturalKey",
+            "entitySiProperties.entityState",
+            "siStorable.naturalKey",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+            "siStorable.naturalKey",
+            "constraints.componentName",
+            "constraints.componentDisplayName",
+        ]
+    }
+}

--- a/components/si-core/src/gen/model/system_entity_event.rs
+++ b/components/si-core/src/gen/model/system_entity_event.rs
@@ -1,0 +1,547 @@
+// Auth-generated code!
+// No touchy!
+
+impl crate::protobuf::SystemEntityEvent {
+    pub async fn get(
+        db: &si_data::Db,
+        id: &str,
+    ) -> si_data::Result<crate::protobuf::SystemEntityEvent> {
+        let obj = db.get(id).await?;
+        Ok(obj)
+    }
+
+    pub async fn get_by_natural_key(
+        db: &si_data::Db,
+        natural_key: &str,
+    ) -> si_data::Result<crate::protobuf::SystemEntityEvent> {
+        let obj = db.lookup_by_natural_key(natural_key).await?;
+        Ok(obj)
+    }
+
+    pub async fn save(&self, db: &si_data::Db) -> si_data::Result<()> {
+        db.upsert(self).await?;
+        Ok(())
+    }
+
+    pub async fn list(
+        db: &si_data::Db,
+        list_request: crate::protobuf::SystemEntityEventListRequest,
+    ) -> si_data::Result<si_data::ListResult<crate::protobuf::SystemEntityEvent>> {
+        let result = match list_request.page_token {
+            Some(token) => db.list_by_page_token(token).await?,
+            None => {
+                let page_size = match list_request.page_size {
+                    Some(page_size) => page_size,
+                    None => 10,
+                };
+                let order_by = match list_request.order_by {
+                    Some(order_by) => order_by,
+                    // The empty string is the signal for a default, thanks protobuf history
+                    None => "".to_string(),
+                };
+                let contained_within = match list_request.scope_by_tenant_id {
+                    Some(contained_within) => contained_within,
+                    None => return Err(si_data::DataError::MissingScopeByTenantId),
+                };
+                db.list(
+                    &list_request.query,
+                    page_size,
+                    order_by,
+                    list_request.order_by_direction,
+                    contained_within,
+                    "",
+                )
+                .await?
+            }
+        };
+        Ok(result)
+    }
+}
+
+impl si_cea::EntityEvent for crate::protobuf::SystemEntityEvent {
+    type Entity = crate::protobuf::SystemEntity;
+
+    fn action_names() -> &'static [&'static str] {
+        &["create", "edit_phantom", "sync"]
+    }
+
+    fn action_name(&self) -> si_data::Result<&str> {
+        self.action_name
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("action_name".to_string()))
+    }
+
+    fn set_action_name(&mut self, action_name: impl Into<String>) {
+        self.action_name = Some(action_name.into());
+    }
+
+    fn create_time(&self) -> si_data::Result<&str> {
+        self.create_time
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("create_time".to_string()))
+    }
+
+    fn set_create_time(&mut self, create_time: impl Into<String>) {
+        self.create_time = Some(create_time.into());
+    }
+
+    fn updated_time(&self) -> Option<&str> {
+        self.updated_time.as_ref().map(String::as_str)
+    }
+
+    fn set_updated_time(&mut self, updated_time: impl Into<String>) {
+        self.updated_time = Some(updated_time.into());
+    }
+
+    fn final_time(&self) -> Option<&str> {
+        self.final_time.as_ref().map(String::as_str)
+    }
+
+    fn set_final_time(&mut self, final_time: impl Into<String>) {
+        self.final_time = Some(final_time.into());
+    }
+
+    fn success(&self) -> Option<bool> {
+        self.success
+    }
+
+    fn set_success(&mut self, success: bool) {
+        self.success = Some(success);
+    }
+
+    fn finalized(&self) -> Option<bool> {
+        self.finalized
+    }
+
+    fn set_finalized(&mut self, finalized: bool) {
+        self.finalized = Some(finalized);
+    }
+
+    fn user_id(&self) -> si_data::Result<&str> {
+        self.user_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("user_id".to_string()))
+    }
+
+    fn set_user_id(&mut self, user_id: impl Into<String>) {
+        self.user_id = Some(user_id.into());
+    }
+
+    fn output_lines(&self) -> &[String] {
+        &self.output_lines
+    }
+
+    fn add_to_output_lines(&mut self, line: impl Into<String>) {
+        self.output_lines.push(line.into());
+    }
+
+    fn error_lines(&self) -> &[String] {
+        self.error_lines.as_ref()
+    }
+
+    fn add_to_error_lines(&mut self, line: impl Into<String>) {
+        self.error_lines.push(line.into());
+    }
+
+    fn error_message(&self) -> Option<&str> {
+        self.error_message.as_ref().map(String::as_str)
+    }
+
+    fn set_error_message(&mut self, error_message: impl Into<String>) {
+        self.error_message = Some(error_message.into());
+    }
+
+    fn previous_entity(&self) -> Option<&Self::Entity> {
+        self.previous_entity.as_ref()
+    }
+
+    fn set_previous_entity(&mut self, previous_entity: Self::Entity) {
+        self.previous_entity = Some(previous_entity);
+    }
+
+    fn input_entity(&self) -> si_data::Result<&Self::Entity> {
+        self.input_entity
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("input_entity".to_string()))
+    }
+
+    fn set_input_entity(&mut self, input_entity: Self::Entity) {
+        self.input_entity = Some(input_entity);
+    }
+
+    fn output_entity(&self) -> Option<&Self::Entity> {
+        self.output_entity.as_ref()
+    }
+
+    fn set_output_entity(&mut self, output_entity: Self::Entity) {
+        self.output_entity = Some(output_entity);
+    }
+
+    fn mut_output_entity(&mut self) -> si_data::Result<&mut Self::Entity> {
+        if self.output_entity.is_none() {
+            self.init_output_entity()?;
+        }
+
+        Ok(self
+            .output_entity
+            .as_mut()
+            .expect("output_entity has been set or initialized"))
+    }
+
+    fn billing_account_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .billing_account_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("billing_account_id".to_string()))
+    }
+
+    fn set_billing_account_id(&mut self, billing_account_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.billing_account_id = Some(billing_account_id.into());
+    }
+
+    fn organization_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .organization_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("organization_id".to_string()))
+    }
+
+    fn set_organization_id(&mut self, organization_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.organization_id = Some(organization_id.into());
+    }
+
+    fn workspace_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .workspace_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("workspace_id".to_string()))
+    }
+
+    fn set_workspace_id(&mut self, workspace_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.workspace_id = Some(workspace_id.into());
+    }
+
+    fn integration_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_id".to_string()))
+    }
+
+    fn set_integration_id(&mut self, integration_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_id = Some(integration_id.into());
+    }
+
+    fn integration_service_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .integration_service_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("integration_service_id".to_string()))
+    }
+
+    fn set_integration_service_id(&mut self, integration_service_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.integration_service_id = Some(integration_service_id.into());
+    }
+
+    fn component_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .component_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("component_id".to_string()))
+    }
+
+    fn set_component_id(&mut self, component_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.component_id = Some(component_id.into());
+    }
+
+    fn entity_id(&self) -> si_data::Result<&str> {
+        self.si_properties
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_properties".to_string()))?
+            .entity_id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("entity_id".to_string()))
+    }
+
+    fn set_entity_id(&mut self, entity_id: impl Into<String>) {
+        if self.si_properties.is_none() {
+            self.si_properties = Some(Default::default());
+        }
+
+        let si_properties = self.si_properties.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_properties \
+                has been set or initialized",
+        );
+        si_properties.entity_id = Some(entity_id.into());
+    }
+
+    fn set_change_set_id(&mut self, change_set_id: impl Into<String>) {
+        self.si_storable.as_mut().map(|storable| {
+            storable.change_set_id = Some(change_set_id.into());
+            storable.change_set_event_type =
+                si_data::protobuf::DataStorableChangeSetEventType::Action as i32;
+        });
+    }
+}
+
+impl si_data::Storable for crate::protobuf::SystemEntityEvent {
+    fn type_name() -> &'static str {
+        "system_entity_event"
+    }
+
+    fn set_type_name(&mut self) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.type_name = Some(Self::type_name().to_string());
+    }
+
+    fn id(&self) -> si_data::Result<&str> {
+        self.id
+            .as_ref()
+            .map(String::as_str)
+            .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))
+    }
+
+    fn set_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
+    fn change_set_id(&self) -> si_data::Result<Option<&str>> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_id
+            .as_ref()
+            .map(String::as_str))
+    }
+
+    fn set_change_set_entry_count(&mut self, entry_count: u64) -> si_data::Result<()> {
+        self.si_storable
+            .as_mut()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .change_set_entry_count
+            .replace(entry_count);
+        Ok(())
+    }
+
+    // How this should work:
+    //
+    //  * Do we have an ID?
+    //      * Are we in a change set?
+    //          * Update the order
+    //          * Set the new ID
+    //      * keep the current ID
+    //  * We don't have an ID
+    //      * Generate a new real object id
+    //          * Set the item ID to it
+    //      * Make the change-set id, and set that as the real one.
+    //
+    // This needs to possibly error now!
+    fn generate_id(&mut self) {
+        if let Ok(_current_id) = self.id() {
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let real_id = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.item_id.as_ref())
+                    .flatten()
+                    .expect("must have a real item_id");
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            }
+        } else {
+            let real_id = format!("{}:{}", Self::type_name(), si_data::uuid_string(),);
+            self.si_storable
+                .as_mut()
+                .map(|si_storable| si_storable.item_id = Some(real_id.clone()));
+            if let Some(change_set_id) = self
+                .si_storable
+                .as_ref()
+                .map(|si_storable| si_storable.change_set_id.as_ref())
+                .flatten()
+            {
+                let change_set_entry_count = self
+                    .si_storable
+                    .as_ref()
+                    .map(|si_storable| si_storable.change_set_entry_count.as_ref())
+                    .flatten()
+                    .expect("must have a change_set_entry_count");
+                let new_id = format!("{}:{}:{}", change_set_id, change_set_entry_count, real_id);
+                self.set_id(new_id);
+            } else {
+                self.set_id(real_id);
+            }
+        }
+    }
+
+    fn natural_key(&self) -> si_data::Result<Option<&str>> {
+        Ok(None)
+    }
+
+    fn set_natural_key(&mut self) -> si_data::Result<()> {
+        Ok(())
+    }
+
+    fn tenant_ids(&self) -> si_data::Result<&[String]> {
+        Ok(self
+            .si_storable
+            .as_ref()
+            .ok_or_else(|| si_data::DataError::RequiredField("si_storable".to_string()))?
+            .tenant_ids
+            .as_slice())
+    }
+
+    fn add_to_tenant_ids(&mut self, id: impl Into<String>) {
+        if self.si_storable.is_none() {
+            self.si_storable = Some(Default::default());
+        }
+
+        let si_storable = self.si_storable.as_mut().expect(
+            "crate::protobuf::SystemEntityEvent.si_storable \
+                has been set or initialized",
+        );
+        si_storable.tenant_ids.push(id.into());
+    }
+
+    fn validate(&self) -> si_data::error::Result<()> {
+        if self.id.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required id value".into(),
+            ));
+        }
+        if self.si_storable.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required si_storable value".into(),
+            ));
+        }
+        if self.action_name.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required action_name value".into(),
+            ));
+        }
+        if self.input_entity.is_none() {
+            return Err(si_data::DataError::ValidationError(
+                "missing required input_entity value".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn referential_fields(&self) -> Vec<si_data::Reference> {
+        Vec::new()
+    }
+
+    fn order_by_fields() -> Vec<&'static str> {
+        vec![
+            "siStorable.naturalKey",
+            "id",
+            "siStorable.naturalKey",
+            "dataStorable.viewContext",
+            "dataStorable.changeSetId",
+            "dataStorable.itemId",
+            "dataStorable.changeSetEntryCount",
+            "dataStorable.changeSetEventType",
+            "dataStorable.changeSetExecuted",
+            "dataStorable.deleted",
+            "actionName",
+            "createTime",
+            "updatedTime",
+            "finalTime",
+            "success",
+            "finalized",
+            "userId",
+            "outputLines",
+            "errorLines",
+            "errorMessage",
+        ]
+    }
+}

--- a/components/si-core/src/gen/service.rs
+++ b/components/si-core/src/gen/service.rs
@@ -19,7 +19,9 @@ impl Service {
     }
 
     pub async fn migrate(&self) -> si_data::Result<()> {
+        crate::protobuf::ApplicationComponent::migrate(&self.db).await?;
         crate::protobuf::ServiceComponent::migrate(&self.db).await?;
+        crate::protobuf::SystemComponent::migrate(&self.db).await?;
 
         Ok(())
     }
@@ -27,6 +29,817 @@ impl Service {
 
 #[tonic::async_trait]
 impl crate::protobuf::core_server::Core for Service {
+    async fn application_component_create(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationComponentCreateRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationComponentCreateReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_component_create",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_component_create")
+                .await?;
+
+            let inner = request.into_inner();
+            let name = inner.name;
+            let display_name = inner.display_name;
+            let description = inner.description;
+            let constraints = inner.constraints;
+            let si_properties = inner.si_properties;
+
+            let output = crate::protobuf::ApplicationComponent::create(
+                &self.db,
+                name,
+                display_name,
+                description,
+                constraints,
+                si_properties,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationComponentCreateReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_component_get(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationComponentGetRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationComponentGetReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_component_get",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_component_get").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let output = crate::protobuf::ApplicationComponent::get(&self.db, &id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationComponentGetReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_component_list(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationComponentListRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationComponentListReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_component_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "application_component_list")
+                    .await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(String::from("global"));
+            }
+
+            let output = crate::protobuf::ApplicationComponent::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationComponentListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_component_pick(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationComponentPickRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationComponentPickReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_component_pick",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_component_pick").await?;
+
+            let inner = request.into_inner();
+            let constraints = inner.constraints;
+
+            let (implicit_constraints, component) =
+                crate::protobuf::ApplicationComponent::pick(&self.db, constraints).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationComponentPickReply {
+                    implicit_constraints: Some(implicit_constraints),
+                    component: Some(component),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_create(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityCreateRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityCreateReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_create",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_entity_create").await?;
+
+            let inner = request.into_inner();
+            let name = inner.name;
+            let display_name = inner.display_name;
+            let description = inner.description;
+            let workspace_id = inner.workspace_id;
+            let change_set_id = inner.change_set_id;
+            let properties = inner.properties;
+            let constraints = inner.constraints;
+
+            let workspace_id = workspace_id.ok_or_else(|| {
+                si_data::DataError::ValidationError(
+                    "missing required workspace_id value".to_string(),
+                )
+            })?;
+
+            let workspace = si_account::Workspace::get(&self.db, &workspace_id).await?;
+
+            let (implicit_constraints, component) =
+                crate::protobuf::ApplicationComponent::pick(&self.db, constraints.clone()).await?;
+
+            let si_properties = si_cea::EntitySiProperties::new(
+                &workspace,
+                component
+                    .id
+                    .as_ref()
+                    .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?,
+                component.si_properties.as_ref().ok_or_else(|| {
+                    si_data::DataError::RequiredField("si_properties".to_string())
+                })?,
+            )?;
+
+            let entity = crate::protobuf::ApplicationEntity::create(
+                &self.db,
+                name,
+                display_name,
+                description,
+                constraints,
+                Some(implicit_constraints),
+                properties,
+                Some(si_properties),
+                change_set_id,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityCreateReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_delete(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityDeleteRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityDeleteReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_delete",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_entity_delete").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let mut entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
+
+            entity.delete(&self.db, inner.change_set_id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityDeleteReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_get(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityGetRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityGetReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_get",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_entity_get").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let output = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityGetReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_list(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityListRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityListReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth = si_account::authorize::authnz(&self.db, &request, "application_entity_list")
+                .await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(auth.billing_account_id().into());
+            }
+
+            let output = crate::protobuf::ApplicationEntity::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_phantom_edit(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityPhantomEditRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityPhantomEditReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_phantom_edit",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            use si_cea::{Entity, EntityEvent};
+
+            let auth = si_account::authorize::authnz(
+                &self.db,
+                &request,
+                "application_entity_phantom_edit",
+            )
+            .await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let property = inner
+                .property
+                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
+
+            let mut entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
+            let previous_entity = entity.clone();
+
+            entity.set_entity_state_transition();
+            entity.edit_phantom(property)?;
+            entity.save(&self.db).await?;
+
+            let entity_event =
+                crate::protobuf::ApplicationEntityEvent::create_with_previous_entity(
+                    &self.db,
+                    auth.user_id(),
+                    "edit_phantom",
+                    &entity,
+                    previous_entity,
+                )
+                .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityPhantomEditReply {
+                    item: Some(entity_event),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_sync(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntitySyncRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntitySyncReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_sync",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            use si_cea::EntityEvent;
+
+            let auth = si_account::authorize::authnz(&self.db, &request, "application_entity_sync")
+                .await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
+            let entity_event = crate::protobuf::ApplicationEntityEvent::create(
+                &self.db,
+                auth.user_id(),
+                "sync",
+                &entity,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntitySyncReply {
+                    item: Some(entity_event),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_update(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityUpdateRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityUpdateReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_update",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "application_entity_update").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let mut entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
+
+            entity
+                .update(&self.db, inner.change_set_id, inner.update)
+                .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityUpdateReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn application_entity_event_list(
+        &self,
+        request: tonic::Request<crate::protobuf::ApplicationEntityEventListRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::ApplicationEntityEventListReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.application_entity_event_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "application_entity_event_list")
+                    .await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(auth.billing_account_id().into());
+            }
+
+            let output = crate::protobuf::ApplicationEntityEvent::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::ApplicationEntityEventListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
     async fn service_component_create(
         &self,
         request: tonic::Request<crate::protobuf::ServiceComponentCreateRequest>,
@@ -1048,6 +1861,797 @@ impl crate::protobuf::core_server::Core for Service {
 
             Ok(tonic::Response::new(
                 crate::protobuf::ServiceEntityEventListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_component_create(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemComponentCreateRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::SystemComponentCreateReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_component_create",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_component_create").await?;
+
+            let inner = request.into_inner();
+            let name = inner.name;
+            let display_name = inner.display_name;
+            let description = inner.description;
+            let constraints = inner.constraints;
+            let si_properties = inner.si_properties;
+
+            let output = crate::protobuf::SystemComponent::create(
+                &self.db,
+                name,
+                display_name,
+                description,
+                constraints,
+                si_properties,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemComponentCreateReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_component_get(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemComponentGetRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemComponentGetReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_component_get",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_component_get").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let output = crate::protobuf::SystemComponent::get(&self.db, &id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemComponentGetReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_component_list(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemComponentListRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::SystemComponentListReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_component_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "system_component_list").await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(String::from("global"));
+            }
+
+            let output = crate::protobuf::SystemComponent::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemComponentListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_component_pick(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemComponentPickRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::SystemComponentPickReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_component_pick",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_component_pick").await?;
+
+            let inner = request.into_inner();
+            let constraints = inner.constraints;
+
+            let (implicit_constraints, component) =
+                crate::protobuf::SystemComponent::pick(&self.db, constraints).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemComponentPickReply {
+                    implicit_constraints: Some(implicit_constraints),
+                    component: Some(component),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_create(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityCreateRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntityCreateReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_create",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_entity_create").await?;
+
+            let inner = request.into_inner();
+            let name = inner.name;
+            let display_name = inner.display_name;
+            let description = inner.description;
+            let workspace_id = inner.workspace_id;
+            let change_set_id = inner.change_set_id;
+            let properties = inner.properties;
+            let constraints = inner.constraints;
+
+            let workspace_id = workspace_id.ok_or_else(|| {
+                si_data::DataError::ValidationError(
+                    "missing required workspace_id value".to_string(),
+                )
+            })?;
+
+            let workspace = si_account::Workspace::get(&self.db, &workspace_id).await?;
+
+            let (implicit_constraints, component) =
+                crate::protobuf::SystemComponent::pick(&self.db, constraints.clone()).await?;
+
+            let si_properties = si_cea::EntitySiProperties::new(
+                &workspace,
+                component
+                    .id
+                    .as_ref()
+                    .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?,
+                component.si_properties.as_ref().ok_or_else(|| {
+                    si_data::DataError::RequiredField("si_properties".to_string())
+                })?,
+            )?;
+
+            let entity = crate::protobuf::SystemEntity::create(
+                &self.db,
+                name,
+                display_name,
+                description,
+                constraints,
+                Some(implicit_constraints),
+                properties,
+                Some(si_properties),
+                change_set_id,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityCreateReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_delete(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityDeleteRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntityDeleteReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_delete",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_entity_delete").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let mut entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
+
+            entity.delete(&self.db, inner.change_set_id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityDeleteReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_get(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityGetRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntityGetReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_get",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_entity_get").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let output = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityGetReply { item: Some(output) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_list(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityListRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntityListReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "system_entity_list").await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(auth.billing_account_id().into());
+            }
+
+            let output = crate::protobuf::SystemEntity::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityListReply {
+                    items: output.items,
+                    total_count: Some(output.total_count),
+                    next_page_token: Some(output.page_token),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_phantom_edit(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityPhantomEditRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::SystemEntityPhantomEditReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_phantom_edit",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            use si_cea::{Entity, EntityEvent};
+
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "system_entity_phantom_edit")
+                    .await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let property = inner
+                .property
+                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
+
+            let mut entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
+            let previous_entity = entity.clone();
+
+            entity.set_entity_state_transition();
+            entity.edit_phantom(property)?;
+            entity.save(&self.db).await?;
+
+            let entity_event = crate::protobuf::SystemEntityEvent::create_with_previous_entity(
+                &self.db,
+                auth.user_id(),
+                "edit_phantom",
+                &entity,
+                previous_entity,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityPhantomEditReply {
+                    item: Some(entity_event),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_sync(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntitySyncRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntitySyncReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_sync",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            use si_cea::EntityEvent;
+
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "system_entity_sync").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
+            let entity_event = crate::protobuf::SystemEntityEvent::create(
+                &self.db,
+                auth.user_id(),
+                "sync",
+                &entity,
+            )
+            .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntitySyncReply {
+                    item: Some(entity_event),
+                },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_update(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityUpdateRequest>,
+    ) -> std::result::Result<tonic::Response<crate::protobuf::SystemEntityUpdateReply>, tonic::Status>
+    {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_update",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            si_account::authorize::authnz(&self.db, &request, "system_entity_update").await?;
+
+            let inner = request.into_inner();
+            let id = inner
+                .id
+                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+
+            let mut entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
+
+            entity
+                .update(&self.db, inner.change_set_id, inner.update)
+                .await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityUpdateReply { item: Some(entity) },
+            ))
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn system_entity_event_list(
+        &self,
+        request: tonic::Request<crate::protobuf::SystemEntityEventListRequest>,
+    ) -> std::result::Result<
+        tonic::Response<crate::protobuf::SystemEntityEventListReply>,
+        tonic::Status,
+    > {
+        let span_context =
+            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
+        let span = tracing::span!(
+            tracing::Level::INFO,
+            "core.system_entity_event_list",
+            metadata.content_type = tracing::field::Empty,
+            authenticated = tracing::field::Empty,
+            userId = tracing::field::Empty,
+            billingAccountId = tracing::field::Empty,
+            http.user_agent = tracing::field::Empty,
+        );
+        span.set_parent(&span_context);
+
+        {
+            let metadata = request.metadata();
+            if let Some(raw_value) = metadata.get("authenticated") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("authenticated", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("userid") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("userId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("billingAccountId") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("billingAccountId", &tracing::field::display(value));
+            }
+            if let Some(raw_value) = metadata.get("user-agent") {
+                let value = raw_value.to_str().unwrap_or("unserializable");
+                span.record("http.user_agent", &tracing::field::display(value));
+            }
+        }
+
+        async {
+            #[allow(unused_variables)]
+            let auth =
+                si_account::authorize::authnz(&self.db, &request, "system_entity_event_list")
+                    .await?;
+
+            let mut inner = request.into_inner();
+            if inner.scope_by_tenant_id.is_none() {
+                inner.scope_by_tenant_id = Some(auth.billing_account_id().into());
+            }
+
+            let output = crate::protobuf::SystemEntityEvent::list(&self.db, inner).await?;
+
+            Ok(tonic::Response::new(
+                crate::protobuf::SystemEntityEventListReply {
                     items: output.items,
                     total_count: Some(output.total_count),
                     next_page_token: Some(output.page_token),

--- a/components/si-core/src/model.rs
+++ b/components/si-core/src/model.rs
@@ -1,5 +1,9 @@
+pub mod application_component;
 pub mod service_component;
+pub mod system_component;
 
-pub use crate::protobuf::ServiceEntity;
-pub use crate::protobuf::ServiceEntityEvent;
+pub use crate::protobuf::{ApplicationEntity, ServiceEntity, SystemEntity};
+pub use crate::protobuf::{ApplicationEntityEvent, ServiceEntityEvent, SystemEntityEvent};
+pub use application_component::ApplicationComponent;
 pub use service_component::ServiceComponent;
+pub use system_component::SystemComponent;

--- a/components/si-core/src/model/application_component.rs
+++ b/components/si-core/src/model/application_component.rs
@@ -1,0 +1,93 @@
+use crate::protobuf::ApplicationComponentConstraints;
+use si_cea::component::prelude::*;
+
+type Constraints = ApplicationComponentConstraints;
+
+pub use crate::protobuf::ApplicationComponent;
+
+impl ApplicationComponent {
+    pub async fn pick(db: &Db, constraints: Option<Constraints>) -> CeaResult<(Constraints, Self)> {
+        let span = tracing_pick_span!("application", &constraints);
+        async {
+            let span = Span::current();
+            match constraints {
+                None => {
+                    let implicit_constraints = Constraints::default();
+
+                    span.record(
+                        "pick.implicit_constraints",
+                        &field::debug(&implicit_constraints),
+                    );
+
+                    let query_items = Vec::new();
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+
+                    Ok((implicit_constraints, component))
+                }
+                Some(constraints) => {
+                    span.record("pick.constraints", &field::debug(&constraints));
+
+                    if let Some(found) = Self::pick_by_component_name(db, &constraints).await? {
+                        span.record("pick.component", &field::debug(&found));
+                        return Ok(found);
+                    }
+                    if let Some(found) =
+                        Self::pick_by_component_display_name(db, &constraints).await?
+                    {
+                        span.record("pick.component", &field::debug(&found));
+                        return Ok(found);
+                    }
+
+                    let implicit_constraints = Constraints::default();
+                    let query_items = Vec::new();
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+                    span.record("pick.component", &field::debug(&component));
+
+                    Ok((implicit_constraints, component))
+                }
+            }
+        }
+        .instrument(span)
+        .await
+    }
+
+    pub async fn migrate(db: &Db) -> DataResult<()> {
+        let global_integration: Integration = db
+            .lookup_by_natural_key("global:integration:global")
+            .await?;
+
+        let global_core_integration_service_id =
+            format!("{}:integration_service:core", global_integration.id()?);
+
+        let global_core_integration_service: IntegrationService = db
+            .lookup_by_natural_key(global_core_integration_service_id)
+            .await?;
+
+        let name = "Application".to_string();
+        let mut c = Self {
+            name: Some(name.clone()),
+            display_name: Some(name.clone()),
+            description: Some(name.clone()),
+            constraints: Some(Constraints::default()),
+            si_properties: Some(si_cea::protobuf::ComponentSiProperties {
+                version: Some(1),
+                integration_id: global_integration.id.clone(),
+                integration_service_id: global_core_integration_service.id.clone(),
+            }),
+            ..Default::default()
+        };
+        c.add_to_tenant_ids("global".to_string());
+        c.add_to_tenant_ids(global_integration.id()?.to_string());
+        c.add_to_tenant_ids(global_core_integration_service.id()?.to_string());
+
+        db.migrate(&mut c).await?;
+
+        Ok(())
+    }
+}

--- a/components/si-core/src/model/system_component.rs
+++ b/components/si-core/src/model/system_component.rs
@@ -1,0 +1,93 @@
+use crate::protobuf::SystemComponentConstraints;
+use si_cea::component::prelude::*;
+
+type Constraints = SystemComponentConstraints;
+
+pub use crate::protobuf::SystemComponent;
+
+impl SystemComponent {
+    pub async fn pick(db: &Db, constraints: Option<Constraints>) -> CeaResult<(Constraints, Self)> {
+        let span = tracing_pick_span!("system", &constraints);
+        async {
+            let span = Span::current();
+            match constraints {
+                None => {
+                    let implicit_constraints = Constraints::default();
+
+                    span.record(
+                        "pick.implicit_constraints",
+                        &field::debug(&implicit_constraints),
+                    );
+
+                    let query_items = Vec::new();
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+
+                    Ok((implicit_constraints, component))
+                }
+                Some(constraints) => {
+                    span.record("pick.constraints", &field::debug(&constraints));
+
+                    if let Some(found) = Self::pick_by_component_name(db, &constraints).await? {
+                        span.record("pick.component", &field::debug(&found));
+                        return Ok(found);
+                    }
+                    if let Some(found) =
+                        Self::pick_by_component_display_name(db, &constraints).await?
+                    {
+                        span.record("pick.component", &field::debug(&found));
+                        return Ok(found);
+                    }
+
+                    let implicit_constraints = Constraints::default();
+                    let query_items = Vec::new();
+
+                    let component =
+                        Self::pick_by_expressions(db, query_items, DataQueryBooleanTerm::And)
+                            .await?;
+                    span.record("pick.component", &field::debug(&component));
+
+                    Ok((implicit_constraints, component))
+                }
+            }
+        }
+        .instrument(span)
+        .await
+    }
+
+    pub async fn migrate(db: &Db) -> DataResult<()> {
+        let global_integration: Integration = db
+            .lookup_by_natural_key("global:integration:global")
+            .await?;
+
+        let global_core_integration_service_id =
+            format!("{}:integration_service:core", global_integration.id()?);
+
+        let global_core_integration_service: IntegrationService = db
+            .lookup_by_natural_key(global_core_integration_service_id)
+            .await?;
+
+        let name = "System".to_string();
+        let mut c = Self {
+            name: Some(name.clone()),
+            display_name: Some(name.clone()),
+            description: Some(name.clone()),
+            constraints: Some(Constraints::default()),
+            si_properties: Some(si_cea::protobuf::ComponentSiProperties {
+                version: Some(1),
+                integration_id: global_integration.id.clone(),
+                integration_service_id: global_core_integration_service.id.clone(),
+            }),
+            ..Default::default()
+        };
+        c.add_to_tenant_ids("global".to_string());
+        c.add_to_tenant_ids(global_integration.id()?.to_string());
+        c.add_to_tenant_ids(global_core_integration_service.id()?.to_string());
+
+        db.migrate(&mut c).await?;
+
+        Ok(())
+    }
+}

--- a/components/si-graphql-api/fullstack-schema.graphql
+++ b/components/si-graphql-api/fullstack-schema.graphql
@@ -2,6 +2,376 @@
 ### Do not make changes to this file directly
 
 
+type ApplicationComponent {
+  """Component Constraints"""
+  constraints: ApplicationComponentConstraints
+
+  """Component Description"""
+  description: String
+
+  """A System Initiative Application Component Display Name"""
+  displayName: String
+
+  """A System Initiative Application Component ID"""
+  id: ID
+
+  """A System Initiative Application Component Name"""
+  name: String
+
+  """SI Properties"""
+  siProperties: ComponentSiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+}
+
+type ApplicationComponentConstraints {
+  """Component Display Name"""
+  componentDisplayName: String
+
+  """Component Name"""
+  componentName: String
+}
+
+input ApplicationComponentConstraintsRequest {
+  """Component Display Name"""
+  componentDisplayName: String
+
+  """Component Name"""
+  componentName: String
+}
+
+"""Get a A System Initiative Application Component Reply"""
+type ApplicationComponentGetReply {
+  """A System Initiative Application Component Item"""
+  item: ApplicationComponent
+}
+
+"""Get a A System Initiative Application Component Request"""
+input ApplicationComponentGetRequest {
+  """A System Initiative Application Component ID"""
+  id: ID!
+}
+
+"""List A System Initiative Application Component Reply"""
+type ApplicationComponentListReply {
+  """Items"""
+  items: [ApplicationComponent!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative Application Component Request"""
+input ApplicationComponentListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Pick Component Reply"""
+type ApplicationComponentPickReply {
+  """Chosen Component"""
+  component: ApplicationComponent
+
+  """Implicit Constraints"""
+  implicitConstraints: ApplicationComponentConstraints
+}
+
+"""Pick Component Request"""
+input ApplicationComponentPickRequest {
+  """Constraints"""
+  constraints: ApplicationComponentConstraintsRequest
+}
+
+type ApplicationEntity {
+  """Constraints"""
+  constraints: ApplicationComponentConstraints
+
+  """Entity Description"""
+  description: String
+
+  """A System Initiative Application Entity Display Name"""
+  displayName: String
+
+  """A System Initiative Application Entity ID"""
+  id: ID
+
+  """Implicit Constraints"""
+  implicitConstraints: ApplicationComponentConstraints
+
+  """A System Initiative Application Entity Name"""
+  name: String
+
+  """Properties"""
+  properties: ApplicationEntityProperties
+
+  """SI Properties"""
+  siProperties: EntitySiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+}
+
+"""Create Entity Reply"""
+type ApplicationEntityCreateReply {
+  """applicationEntity Item"""
+  item: ApplicationEntity
+}
+
+"""Create Entity Request"""
+input ApplicationEntityCreateRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """Constraints"""
+  constraints: ApplicationComponentConstraintsRequest
+
+  """Description"""
+  description: String!
+
+  """Display Name"""
+  displayName: String!
+
+  """Name"""
+  name: String!
+
+  """Properties"""
+  properties: ApplicationEntityPropertiesRequest
+
+  """Workspace ID"""
+  workspaceId: String!
+}
+
+"""Delete Entity Reply"""
+type ApplicationEntityDeleteReply {
+  """application Item"""
+  item: ApplicationEntity
+}
+
+"""Delete Entity Request"""
+input ApplicationEntityDeleteRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """applicationEntity ID"""
+  id: ID!
+}
+
+type ApplicationEntityEvent {
+  """Action Name"""
+  actionName: String
+
+  """Creation Time"""
+  createTime: String
+
+  """Error Lines"""
+  errorLines: [String!]
+
+  """Error Message"""
+  errorMessage: String
+
+  """Finalized"""
+  finalized: Boolean
+
+  """Final Time"""
+  finalTime: String
+
+  """A System Initiative Application EntityEvent ID"""
+  id: ID
+
+  """Input Entity"""
+  inputEntity: ApplicationEntity
+
+  """Output Entity"""
+  outputEntity: ApplicationEntity
+
+  """Output Lines"""
+  outputLines: [String!]
+
+  """Previous Entity"""
+  previousEntity: ApplicationEntity
+
+  """SI Properties"""
+  siProperties: EntityEventSiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+
+  """success"""
+  success: Boolean
+
+  """Updated Time"""
+  updatedTime: String
+
+  """User ID"""
+  userId: String
+}
+
+"""List A System Initiative Application EntityEvent Reply"""
+type ApplicationEntityEventListReply {
+  """Items"""
+  items: [ApplicationEntityEvent!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative Application EntityEvent Request"""
+input ApplicationEntityEventListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Get a A System Initiative Application Entity Reply"""
+type ApplicationEntityGetReply {
+  """A System Initiative Application Entity Item"""
+  item: ApplicationEntity
+}
+
+"""Get a A System Initiative Application Entity Request"""
+input ApplicationEntityGetRequest {
+  """A System Initiative Application Entity ID"""
+  id: ID!
+}
+
+"""List A System Initiative Application Entity Reply"""
+type ApplicationEntityListReply {
+  """Items"""
+  items: [ApplicationEntity!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative Application Entity Request"""
+input ApplicationEntityListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Edit Phantom Property Reply"""
+type ApplicationEntityPhantomEditReply {
+  """Entity Event"""
+  item: ApplicationEntityEvent
+}
+
+"""Edit Phantom Property Request"""
+input ApplicationEntityPhantomEditRequest {
+  """Entity ID"""
+  id: ID!
+
+  """The Phantom Data property value"""
+  property: Boolean
+}
+
+type ApplicationEntityProperties {
+  """Phantom Data"""
+  phantom: Boolean
+}
+
+input ApplicationEntityPropertiesRequest {
+  """Phantom Data"""
+  phantom: Boolean
+}
+
+"""Sync State Reply"""
+type ApplicationEntitySyncReply {
+  """Entity Event"""
+  item: ApplicationEntityEvent
+}
+
+"""Sync State Request"""
+input ApplicationEntitySyncRequest {
+  """Entity ID"""
+  id: ID!
+}
+
+"""Update an Entity Reply"""
+type ApplicationEntityUpdateReply {
+  """application Item"""
+  item: ApplicationEntity
+}
+
+"""Update an Entity Request"""
+input ApplicationEntityUpdateRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """applicationEntity ID"""
+  id: ID!
+
+  """application Item Update"""
+  update: ApplicationEntityUpdateRequestUpdateRequest
+}
+
+input ApplicationEntityUpdateRequestUpdateRequest {
+  """description"""
+  description: String
+
+  """displayName"""
+  displayName: String
+
+  """name"""
+  name: String
+
+  """properties"""
+  properties: ApplicationEntityPropertiesRequest
+}
+
 type BillingAccount {
   associations: BillingAccountAssociations
 
@@ -2248,6 +2618,11 @@ input MatchLabelsRequest {
 }
 
 type Mutation {
+  applicationEntityCreate(input: ApplicationEntityCreateRequest): ApplicationEntityCreateReply
+  applicationEntityDelete(input: ApplicationEntityDeleteRequest): ApplicationEntityDeleteReply
+  applicationEntityPhantomEdit(input: ApplicationEntityPhantomEditRequest): ApplicationEntityPhantomEditReply
+  applicationEntitySync(input: ApplicationEntitySyncRequest): ApplicationEntitySyncReply
+  applicationEntityUpdate(input: ApplicationEntityUpdateRequest): ApplicationEntityUpdateReply
   billingAccountSignup(input: BillingAccountSignupRequest): BillingAccountSignupReply
   changeSetCreate(input: ChangeSetCreateRequest): ChangeSetCreateReply
   changeSetExecute(input: ChangeSetExecuteRequest): ChangeSetExecuteReply
@@ -2274,6 +2649,11 @@ type Mutation {
   serviceEntityReplicasEdit(input: ServiceEntityReplicasEditRequest): ServiceEntityReplicasEditReply
   serviceEntitySync(input: ServiceEntitySyncRequest): ServiceEntitySyncReply
   serviceEntityUpdate(input: ServiceEntityUpdateRequest): ServiceEntityUpdateReply
+  systemEntityCreate(input: SystemEntityCreateRequest): SystemEntityCreateReply
+  systemEntityDelete(input: SystemEntityDeleteRequest): SystemEntityDeleteReply
+  systemEntityPhantomEdit(input: SystemEntityPhantomEditRequest): SystemEntityPhantomEditReply
+  systemEntitySync(input: SystemEntitySyncRequest): SystemEntitySyncReply
+  systemEntityUpdate(input: SystemEntityUpdateRequest): SystemEntityUpdateReply
   userCreate(input: UserCreateRequest): UserCreateReply
   workspaceCreate(input: WorkspaceCreateRequest): WorkspaceCreateReply
 }
@@ -2380,6 +2760,12 @@ input OrganizationSiPropertiesRequest {
 }
 
 type Query {
+  applicationComponentGet(input: ApplicationComponentGetRequest): ApplicationComponentGetReply
+  applicationComponentList(input: ApplicationComponentListRequest): ApplicationComponentListReply
+  applicationComponentPick(input: ApplicationComponentPickRequest): ApplicationComponentPickReply
+  applicationEntityEventList(input: ApplicationEntityEventListRequest): ApplicationEntityEventListReply
+  applicationEntityGet(input: ApplicationEntityGetRequest): ApplicationEntityGetReply
+  applicationEntityList(input: ApplicationEntityListRequest): ApplicationEntityListReply
   billingAccountGet(input: BillingAccountGetRequest): BillingAccountGetReply
   billingAccountList(input: BillingAccountListRequest): BillingAccountListReply
   changeSetGet(input: ChangeSetGetRequest): ChangeSetGetReply
@@ -2413,6 +2799,12 @@ type Query {
   serviceEntityEventList(input: ServiceEntityEventListRequest): ServiceEntityEventListReply
   serviceEntityGet(input: ServiceEntityGetRequest): ServiceEntityGetReply
   serviceEntityList(input: ServiceEntityListRequest): ServiceEntityListReply
+  systemComponentGet(input: SystemComponentGetRequest): SystemComponentGetReply
+  systemComponentList(input: SystemComponentListRequest): SystemComponentListReply
+  systemComponentPick(input: SystemComponentPickRequest): SystemComponentPickReply
+  systemEntityEventList(input: SystemEntityEventListRequest): SystemEntityEventListReply
+  systemEntityGet(input: SystemEntityGetRequest): SystemEntityGetReply
+  systemEntityList(input: SystemEntityListRequest): SystemEntityListReply
   userGet(input: UserGetRequest): UserGetReply
   userList(input: UserListRequest): UserListReply
   userLogin(input: UserLoginRequest): UserLoginReply
@@ -2850,6 +3242,376 @@ input ServiceEntityUpdateRequestUpdateRequest {
 
   """properties"""
   properties: ServiceEntityPropertiesRequest
+}
+
+type SystemComponent {
+  """Component Constraints"""
+  constraints: SystemComponentConstraints
+
+  """Component Description"""
+  description: String
+
+  """A System Initiative System Component Display Name"""
+  displayName: String
+
+  """A System Initiative System Component ID"""
+  id: ID
+
+  """A System Initiative System Component Name"""
+  name: String
+
+  """SI Properties"""
+  siProperties: ComponentSiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+}
+
+type SystemComponentConstraints {
+  """Component Display Name"""
+  componentDisplayName: String
+
+  """Component Name"""
+  componentName: String
+}
+
+input SystemComponentConstraintsRequest {
+  """Component Display Name"""
+  componentDisplayName: String
+
+  """Component Name"""
+  componentName: String
+}
+
+"""Get a A System Initiative System Component Reply"""
+type SystemComponentGetReply {
+  """A System Initiative System Component Item"""
+  item: SystemComponent
+}
+
+"""Get a A System Initiative System Component Request"""
+input SystemComponentGetRequest {
+  """A System Initiative System Component ID"""
+  id: ID!
+}
+
+"""List A System Initiative System Component Reply"""
+type SystemComponentListReply {
+  """Items"""
+  items: [SystemComponent!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative System Component Request"""
+input SystemComponentListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Pick Component Reply"""
+type SystemComponentPickReply {
+  """Chosen Component"""
+  component: SystemComponent
+
+  """Implicit Constraints"""
+  implicitConstraints: SystemComponentConstraints
+}
+
+"""Pick Component Request"""
+input SystemComponentPickRequest {
+  """Constraints"""
+  constraints: SystemComponentConstraintsRequest
+}
+
+type SystemEntity {
+  """Constraints"""
+  constraints: SystemComponentConstraints
+
+  """Entity Description"""
+  description: String
+
+  """A System Initiative System Entity Display Name"""
+  displayName: String
+
+  """A System Initiative System Entity ID"""
+  id: ID
+
+  """Implicit Constraints"""
+  implicitConstraints: SystemComponentConstraints
+
+  """A System Initiative System Entity Name"""
+  name: String
+
+  """Properties"""
+  properties: SystemEntityProperties
+
+  """SI Properties"""
+  siProperties: EntitySiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+}
+
+"""Create Entity Reply"""
+type SystemEntityCreateReply {
+  """systemEntity Item"""
+  item: SystemEntity
+}
+
+"""Create Entity Request"""
+input SystemEntityCreateRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """Constraints"""
+  constraints: SystemComponentConstraintsRequest
+
+  """Description"""
+  description: String!
+
+  """Display Name"""
+  displayName: String!
+
+  """Name"""
+  name: String!
+
+  """Properties"""
+  properties: SystemEntityPropertiesRequest
+
+  """Workspace ID"""
+  workspaceId: String!
+}
+
+"""Delete Entity Reply"""
+type SystemEntityDeleteReply {
+  """system Item"""
+  item: SystemEntity
+}
+
+"""Delete Entity Request"""
+input SystemEntityDeleteRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """systemEntity ID"""
+  id: ID!
+}
+
+type SystemEntityEvent {
+  """Action Name"""
+  actionName: String
+
+  """Creation Time"""
+  createTime: String
+
+  """Error Lines"""
+  errorLines: [String!]
+
+  """Error Message"""
+  errorMessage: String
+
+  """Finalized"""
+  finalized: Boolean
+
+  """Final Time"""
+  finalTime: String
+
+  """A System Initiative System EntityEvent ID"""
+  id: ID
+
+  """Input Entity"""
+  inputEntity: SystemEntity
+
+  """Output Entity"""
+  outputEntity: SystemEntity
+
+  """Output Lines"""
+  outputLines: [String!]
+
+  """Previous Entity"""
+  previousEntity: SystemEntity
+
+  """SI Properties"""
+  siProperties: EntityEventSiProperties
+
+  """SI Storable"""
+  siStorable: DataStorable
+
+  """success"""
+  success: Boolean
+
+  """Updated Time"""
+  updatedTime: String
+
+  """User ID"""
+  userId: String
+}
+
+"""List A System Initiative System EntityEvent Reply"""
+type SystemEntityEventListReply {
+  """Items"""
+  items: [SystemEntityEvent!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative System EntityEvent Request"""
+input SystemEntityEventListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Get a A System Initiative System Entity Reply"""
+type SystemEntityGetReply {
+  """A System Initiative System Entity Item"""
+  item: SystemEntity
+}
+
+"""Get a A System Initiative System Entity Request"""
+input SystemEntityGetRequest {
+  """A System Initiative System Entity ID"""
+  id: ID!
+}
+
+"""List A System Initiative System Entity Reply"""
+type SystemEntityListReply {
+  """Items"""
+  items: [SystemEntity!]
+
+  """Next Page Token"""
+  nextPageToken: String
+
+  """Total Count"""
+  totalCount: String
+}
+
+"""List A System Initiative System Entity Request"""
+input SystemEntityListRequest {
+  """Order By"""
+  orderBy: String
+
+  """Order By Direction"""
+  orderByDirection: DataPageTokenOrderByDirection
+
+  """Page Size"""
+  pageSize: String
+
+  """Page Token"""
+  pageToken: String
+
+  """Query"""
+  query: DataQueryRequest
+
+  """Scope By Tenant ID"""
+  scopeByTenantId: String
+}
+
+"""Edit Phantom Property Reply"""
+type SystemEntityPhantomEditReply {
+  """Entity Event"""
+  item: SystemEntityEvent
+}
+
+"""Edit Phantom Property Request"""
+input SystemEntityPhantomEditRequest {
+  """Entity ID"""
+  id: ID!
+
+  """The Phantom Data property value"""
+  property: Boolean
+}
+
+type SystemEntityProperties {
+  """Phantom Data"""
+  phantom: Boolean
+}
+
+input SystemEntityPropertiesRequest {
+  """Phantom Data"""
+  phantom: Boolean
+}
+
+"""Sync State Reply"""
+type SystemEntitySyncReply {
+  """Entity Event"""
+  item: SystemEntityEvent
+}
+
+"""Sync State Request"""
+input SystemEntitySyncRequest {
+  """Entity ID"""
+  id: ID!
+}
+
+"""Update an Entity Reply"""
+type SystemEntityUpdateReply {
+  """system Item"""
+  item: SystemEntity
+}
+
+"""Update an Entity Request"""
+input SystemEntityUpdateRequest {
+  """Change Set ID"""
+  changeSetId: String!
+
+  """systemEntity ID"""
+  id: ID!
+
+  """system Item Update"""
+  update: SystemEntityUpdateRequestUpdateRequest
+}
+
+input SystemEntityUpdateRequestUpdateRequest {
+  """description"""
+  description: String
+
+  """displayName"""
+  displayName: String
+
+  """name"""
+  name: String
+
+  """properties"""
+  properties: SystemEntityPropertiesRequest
 }
 
 type User {

--- a/components/si-graphql-api/fullstack-typegen.ts
+++ b/components/si-graphql-api/fullstack-typegen.ts
@@ -14,6 +14,77 @@ declare global {
 }
 
 export interface NexusGenInputs {
+  ApplicationComponentConstraintsRequest: { // input type
+    componentDisplayName?: string | null; // String
+    componentName?: string | null; // String
+  }
+  ApplicationComponentGetRequest: { // input type
+    id: string; // ID!
+  }
+  ApplicationComponentListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  ApplicationComponentPickRequest: { // input type
+    constraints?: NexusGenInputs['ApplicationComponentConstraintsRequest'] | null; // ApplicationComponentConstraintsRequest
+  }
+  ApplicationEntityCreateRequest: { // input type
+    changeSetId: string; // String!
+    constraints?: NexusGenInputs['ApplicationComponentConstraintsRequest'] | null; // ApplicationComponentConstraintsRequest
+    description: string; // String!
+    displayName: string; // String!
+    name: string; // String!
+    properties?: NexusGenInputs['ApplicationEntityPropertiesRequest'] | null; // ApplicationEntityPropertiesRequest
+    workspaceId: string; // String!
+  }
+  ApplicationEntityDeleteRequest: { // input type
+    changeSetId: string; // String!
+    id: string; // ID!
+  }
+  ApplicationEntityEventListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  ApplicationEntityGetRequest: { // input type
+    id: string; // ID!
+  }
+  ApplicationEntityListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  ApplicationEntityPhantomEditRequest: { // input type
+    id: string; // ID!
+    property?: boolean | null; // Boolean
+  }
+  ApplicationEntityPropertiesRequest: { // input type
+    phantom?: boolean | null; // Boolean
+  }
+  ApplicationEntitySyncRequest: { // input type
+    id: string; // ID!
+  }
+  ApplicationEntityUpdateRequest: { // input type
+    changeSetId: string; // String!
+    id: string; // ID!
+    update?: NexusGenInputs['ApplicationEntityUpdateRequestUpdateRequest'] | null; // ApplicationEntityUpdateRequestUpdateRequest
+  }
+  ApplicationEntityUpdateRequestUpdateRequest: { // input type
+    description?: string | null; // String
+    displayName?: string | null; // String
+    name?: string | null; // String
+    properties?: NexusGenInputs['ApplicationEntityPropertiesRequest'] | null; // ApplicationEntityPropertiesRequest
+  }
   BillingAccountGetRequest: { // input type
     id: string; // ID!
   }
@@ -490,6 +561,77 @@ export interface NexusGenInputs {
     name?: string | null; // String
     properties?: NexusGenInputs['ServiceEntityPropertiesRequest'] | null; // ServiceEntityPropertiesRequest
   }
+  SystemComponentConstraintsRequest: { // input type
+    componentDisplayName?: string | null; // String
+    componentName?: string | null; // String
+  }
+  SystemComponentGetRequest: { // input type
+    id: string; // ID!
+  }
+  SystemComponentListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  SystemComponentPickRequest: { // input type
+    constraints?: NexusGenInputs['SystemComponentConstraintsRequest'] | null; // SystemComponentConstraintsRequest
+  }
+  SystemEntityCreateRequest: { // input type
+    changeSetId: string; // String!
+    constraints?: NexusGenInputs['SystemComponentConstraintsRequest'] | null; // SystemComponentConstraintsRequest
+    description: string; // String!
+    displayName: string; // String!
+    name: string; // String!
+    properties?: NexusGenInputs['SystemEntityPropertiesRequest'] | null; // SystemEntityPropertiesRequest
+    workspaceId: string; // String!
+  }
+  SystemEntityDeleteRequest: { // input type
+    changeSetId: string; // String!
+    id: string; // ID!
+  }
+  SystemEntityEventListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  SystemEntityGetRequest: { // input type
+    id: string; // ID!
+  }
+  SystemEntityListRequest: { // input type
+    orderBy?: string | null; // String
+    orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
+    pageSize?: string | null; // String
+    pageToken?: string | null; // String
+    query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
+    scopeByTenantId?: string | null; // String
+  }
+  SystemEntityPhantomEditRequest: { // input type
+    id: string; // ID!
+    property?: boolean | null; // Boolean
+  }
+  SystemEntityPropertiesRequest: { // input type
+    phantom?: boolean | null; // Boolean
+  }
+  SystemEntitySyncRequest: { // input type
+    id: string; // ID!
+  }
+  SystemEntityUpdateRequest: { // input type
+    changeSetId: string; // String!
+    id: string; // ID!
+    update?: NexusGenInputs['SystemEntityUpdateRequestUpdateRequest'] | null; // SystemEntityUpdateRequestUpdateRequest
+  }
+  SystemEntityUpdateRequestUpdateRequest: { // input type
+    description?: string | null; // String
+    displayName?: string | null; // String
+    name?: string | null; // String
+    properties?: NexusGenInputs['SystemEntityPropertiesRequest'] | null; // SystemEntityPropertiesRequest
+  }
   UserCreateRequest: { // input type
     displayName: string; // String!
     email: string; // String!
@@ -557,6 +699,91 @@ export interface NexusGenEnums {
 }
 
 export interface NexusGenRootTypes {
+  ApplicationComponent: { // root type
+    constraints?: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    description?: string | null; // String
+    displayName?: string | null; // String
+    id?: string | null; // ID
+    name?: string | null; // String
+    siProperties?: NexusGenRootTypes['ComponentSiProperties'] | null; // ComponentSiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  ApplicationComponentConstraints: { // root type
+    componentDisplayName?: string | null; // String
+    componentName?: string | null; // String
+  }
+  ApplicationComponentGetReply: { // root type
+    item?: NexusGenRootTypes['ApplicationComponent'] | null; // ApplicationComponent
+  }
+  ApplicationComponentListReply: { // root type
+    items?: NexusGenRootTypes['ApplicationComponent'][] | null; // [ApplicationComponent!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  ApplicationComponentPickReply: { // root type
+    component?: NexusGenRootTypes['ApplicationComponent'] | null; // ApplicationComponent
+    implicitConstraints?: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+  }
+  ApplicationEntity: { // root type
+    constraints?: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    description?: string | null; // String
+    displayName?: string | null; // String
+    id?: string | null; // ID
+    implicitConstraints?: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    name?: string | null; // String
+    properties?: NexusGenRootTypes['ApplicationEntityProperties'] | null; // ApplicationEntityProperties
+    siProperties?: NexusGenRootTypes['EntitySiProperties'] | null; // EntitySiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  ApplicationEntityCreateReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityDeleteReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityEvent: { // root type
+    actionName?: string | null; // String
+    createTime?: string | null; // String
+    errorLines?: string[] | null; // [String!]
+    errorMessage?: string | null; // String
+    finalized?: boolean | null; // Boolean
+    finalTime?: string | null; // String
+    id?: string | null; // ID
+    inputEntity?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    outputEntity?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    outputLines?: string[] | null; // [String!]
+    previousEntity?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    siProperties?: NexusGenRootTypes['EntityEventSiProperties'] | null; // EntityEventSiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+    success?: boolean | null; // Boolean
+    updatedTime?: string | null; // String
+    userId?: string | null; // String
+  }
+  ApplicationEntityEventListReply: { // root type
+    items?: NexusGenRootTypes['ApplicationEntityEvent'][] | null; // [ApplicationEntityEvent!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  ApplicationEntityGetReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityListReply: { // root type
+    items?: NexusGenRootTypes['ApplicationEntity'][] | null; // [ApplicationEntity!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  ApplicationEntityPhantomEditReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
+  }
+  ApplicationEntityProperties: { // root type
+    phantom?: boolean | null; // Boolean
+  }
+  ApplicationEntitySyncReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
+  }
+  ApplicationEntityUpdateReply: { // root type
+    item?: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
   BillingAccount: { // root type
     displayName?: string | null; // String
     id?: string | null; // ID
@@ -1183,6 +1410,91 @@ export interface NexusGenRootTypes {
   ServiceEntityUpdateReply: { // root type
     item?: NexusGenRootTypes['ServiceEntity'] | null; // ServiceEntity
   }
+  SystemComponent: { // root type
+    constraints?: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    description?: string | null; // String
+    displayName?: string | null; // String
+    id?: string | null; // ID
+    name?: string | null; // String
+    siProperties?: NexusGenRootTypes['ComponentSiProperties'] | null; // ComponentSiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  SystemComponentConstraints: { // root type
+    componentDisplayName?: string | null; // String
+    componentName?: string | null; // String
+  }
+  SystemComponentGetReply: { // root type
+    item?: NexusGenRootTypes['SystemComponent'] | null; // SystemComponent
+  }
+  SystemComponentListReply: { // root type
+    items?: NexusGenRootTypes['SystemComponent'][] | null; // [SystemComponent!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  SystemComponentPickReply: { // root type
+    component?: NexusGenRootTypes['SystemComponent'] | null; // SystemComponent
+    implicitConstraints?: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+  }
+  SystemEntity: { // root type
+    constraints?: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    description?: string | null; // String
+    displayName?: string | null; // String
+    id?: string | null; // ID
+    implicitConstraints?: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    name?: string | null; // String
+    properties?: NexusGenRootTypes['SystemEntityProperties'] | null; // SystemEntityProperties
+    siProperties?: NexusGenRootTypes['EntitySiProperties'] | null; // EntitySiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  SystemEntityCreateReply: { // root type
+    item?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityDeleteReply: { // root type
+    item?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityEvent: { // root type
+    actionName?: string | null; // String
+    createTime?: string | null; // String
+    errorLines?: string[] | null; // [String!]
+    errorMessage?: string | null; // String
+    finalized?: boolean | null; // Boolean
+    finalTime?: string | null; // String
+    id?: string | null; // ID
+    inputEntity?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    outputEntity?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    outputLines?: string[] | null; // [String!]
+    previousEntity?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    siProperties?: NexusGenRootTypes['EntityEventSiProperties'] | null; // EntityEventSiProperties
+    siStorable?: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+    success?: boolean | null; // Boolean
+    updatedTime?: string | null; // String
+    userId?: string | null; // String
+  }
+  SystemEntityEventListReply: { // root type
+    items?: NexusGenRootTypes['SystemEntityEvent'][] | null; // [SystemEntityEvent!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  SystemEntityGetReply: { // root type
+    item?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityListReply: { // root type
+    items?: NexusGenRootTypes['SystemEntity'][] | null; // [SystemEntity!]
+    nextPageToken?: string | null; // String
+    totalCount?: string | null; // String
+  }
+  SystemEntityPhantomEditReply: { // root type
+    item?: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
+  }
+  SystemEntityProperties: { // root type
+    phantom?: boolean | null; // Boolean
+  }
+  SystemEntitySyncReply: { // root type
+    item?: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
+  }
+  SystemEntityUpdateReply: { // root type
+    item?: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
   User: { // root type
     capabilities?: NexusGenRootTypes['Capability'] | null; // Capability
     displayName?: string | null; // String
@@ -1243,6 +1555,20 @@ export interface NexusGenRootTypes {
 }
 
 export interface NexusGenAllTypes extends NexusGenRootTypes {
+  ApplicationComponentConstraintsRequest: NexusGenInputs['ApplicationComponentConstraintsRequest'];
+  ApplicationComponentGetRequest: NexusGenInputs['ApplicationComponentGetRequest'];
+  ApplicationComponentListRequest: NexusGenInputs['ApplicationComponentListRequest'];
+  ApplicationComponentPickRequest: NexusGenInputs['ApplicationComponentPickRequest'];
+  ApplicationEntityCreateRequest: NexusGenInputs['ApplicationEntityCreateRequest'];
+  ApplicationEntityDeleteRequest: NexusGenInputs['ApplicationEntityDeleteRequest'];
+  ApplicationEntityEventListRequest: NexusGenInputs['ApplicationEntityEventListRequest'];
+  ApplicationEntityGetRequest: NexusGenInputs['ApplicationEntityGetRequest'];
+  ApplicationEntityListRequest: NexusGenInputs['ApplicationEntityListRequest'];
+  ApplicationEntityPhantomEditRequest: NexusGenInputs['ApplicationEntityPhantomEditRequest'];
+  ApplicationEntityPropertiesRequest: NexusGenInputs['ApplicationEntityPropertiesRequest'];
+  ApplicationEntitySyncRequest: NexusGenInputs['ApplicationEntitySyncRequest'];
+  ApplicationEntityUpdateRequest: NexusGenInputs['ApplicationEntityUpdateRequest'];
+  ApplicationEntityUpdateRequestUpdateRequest: NexusGenInputs['ApplicationEntityUpdateRequestUpdateRequest'];
   BillingAccountGetRequest: NexusGenInputs['BillingAccountGetRequest'];
   BillingAccountListRequest: NexusGenInputs['BillingAccountListRequest'];
   BillingAccountSignupRequest: NexusGenInputs['BillingAccountSignupRequest'];
@@ -1337,6 +1663,20 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   ServiceEntitySyncRequest: NexusGenInputs['ServiceEntitySyncRequest'];
   ServiceEntityUpdateRequest: NexusGenInputs['ServiceEntityUpdateRequest'];
   ServiceEntityUpdateRequestUpdateRequest: NexusGenInputs['ServiceEntityUpdateRequestUpdateRequest'];
+  SystemComponentConstraintsRequest: NexusGenInputs['SystemComponentConstraintsRequest'];
+  SystemComponentGetRequest: NexusGenInputs['SystemComponentGetRequest'];
+  SystemComponentListRequest: NexusGenInputs['SystemComponentListRequest'];
+  SystemComponentPickRequest: NexusGenInputs['SystemComponentPickRequest'];
+  SystemEntityCreateRequest: NexusGenInputs['SystemEntityCreateRequest'];
+  SystemEntityDeleteRequest: NexusGenInputs['SystemEntityDeleteRequest'];
+  SystemEntityEventListRequest: NexusGenInputs['SystemEntityEventListRequest'];
+  SystemEntityGetRequest: NexusGenInputs['SystemEntityGetRequest'];
+  SystemEntityListRequest: NexusGenInputs['SystemEntityListRequest'];
+  SystemEntityPhantomEditRequest: NexusGenInputs['SystemEntityPhantomEditRequest'];
+  SystemEntityPropertiesRequest: NexusGenInputs['SystemEntityPropertiesRequest'];
+  SystemEntitySyncRequest: NexusGenInputs['SystemEntitySyncRequest'];
+  SystemEntityUpdateRequest: NexusGenInputs['SystemEntityUpdateRequest'];
+  SystemEntityUpdateRequestUpdateRequest: NexusGenInputs['SystemEntityUpdateRequestUpdateRequest'];
   UserCreateRequest: NexusGenInputs['UserCreateRequest'];
   UserGetRequest: NexusGenInputs['UserGetRequest'];
   UserListRequest: NexusGenInputs['UserListRequest'];
@@ -1364,6 +1704,91 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
 }
 
 export interface NexusGenFieldTypes {
+  ApplicationComponent: { // field return type
+    constraints: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    description: string | null; // String
+    displayName: string | null; // String
+    id: string | null; // ID
+    name: string | null; // String
+    siProperties: NexusGenRootTypes['ComponentSiProperties'] | null; // ComponentSiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  ApplicationComponentConstraints: { // field return type
+    componentDisplayName: string | null; // String
+    componentName: string | null; // String
+  }
+  ApplicationComponentGetReply: { // field return type
+    item: NexusGenRootTypes['ApplicationComponent'] | null; // ApplicationComponent
+  }
+  ApplicationComponentListReply: { // field return type
+    items: NexusGenRootTypes['ApplicationComponent'][] | null; // [ApplicationComponent!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  ApplicationComponentPickReply: { // field return type
+    component: NexusGenRootTypes['ApplicationComponent'] | null; // ApplicationComponent
+    implicitConstraints: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+  }
+  ApplicationEntity: { // field return type
+    constraints: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    description: string | null; // String
+    displayName: string | null; // String
+    id: string | null; // ID
+    implicitConstraints: NexusGenRootTypes['ApplicationComponentConstraints'] | null; // ApplicationComponentConstraints
+    name: string | null; // String
+    properties: NexusGenRootTypes['ApplicationEntityProperties'] | null; // ApplicationEntityProperties
+    siProperties: NexusGenRootTypes['EntitySiProperties'] | null; // EntitySiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  ApplicationEntityCreateReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityDeleteReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityEvent: { // field return type
+    actionName: string | null; // String
+    createTime: string | null; // String
+    errorLines: string[] | null; // [String!]
+    errorMessage: string | null; // String
+    finalized: boolean | null; // Boolean
+    finalTime: string | null; // String
+    id: string | null; // ID
+    inputEntity: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    outputEntity: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    outputLines: string[] | null; // [String!]
+    previousEntity: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+    siProperties: NexusGenRootTypes['EntityEventSiProperties'] | null; // EntityEventSiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+    success: boolean | null; // Boolean
+    updatedTime: string | null; // String
+    userId: string | null; // String
+  }
+  ApplicationEntityEventListReply: { // field return type
+    items: NexusGenRootTypes['ApplicationEntityEvent'][] | null; // [ApplicationEntityEvent!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  ApplicationEntityGetReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
+  ApplicationEntityListReply: { // field return type
+    items: NexusGenRootTypes['ApplicationEntity'][] | null; // [ApplicationEntity!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  ApplicationEntityPhantomEditReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
+  }
+  ApplicationEntityProperties: { // field return type
+    phantom: boolean | null; // Boolean
+  }
+  ApplicationEntitySyncReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
+  }
+  ApplicationEntityUpdateReply: { // field return type
+    item: NexusGenRootTypes['ApplicationEntity'] | null; // ApplicationEntity
+  }
   BillingAccount: { // field return type
     associations: NexusGenRootTypes['BillingAccountAssociations'] | null; // BillingAccountAssociations
     displayName: string | null; // String
@@ -1906,6 +2331,11 @@ export interface NexusGenFieldTypes {
     value: string | null; // String
   }
   Mutation: { // field return type
+    applicationEntityCreate: NexusGenRootTypes['ApplicationEntityCreateReply'] | null; // ApplicationEntityCreateReply
+    applicationEntityDelete: NexusGenRootTypes['ApplicationEntityDeleteReply'] | null; // ApplicationEntityDeleteReply
+    applicationEntityPhantomEdit: NexusGenRootTypes['ApplicationEntityPhantomEditReply'] | null; // ApplicationEntityPhantomEditReply
+    applicationEntitySync: NexusGenRootTypes['ApplicationEntitySyncReply'] | null; // ApplicationEntitySyncReply
+    applicationEntityUpdate: NexusGenRootTypes['ApplicationEntityUpdateReply'] | null; // ApplicationEntityUpdateReply
     billingAccountSignup: NexusGenRootTypes['BillingAccountSignupReply'] | null; // BillingAccountSignupReply
     changeSetCreate: NexusGenRootTypes['ChangeSetCreateReply'] | null; // ChangeSetCreateReply
     changeSetExecute: NexusGenRootTypes['ChangeSetExecuteReply'] | null; // ChangeSetExecuteReply
@@ -1932,6 +2362,11 @@ export interface NexusGenFieldTypes {
     serviceEntityReplicasEdit: NexusGenRootTypes['ServiceEntityReplicasEditReply'] | null; // ServiceEntityReplicasEditReply
     serviceEntitySync: NexusGenRootTypes['ServiceEntitySyncReply'] | null; // ServiceEntitySyncReply
     serviceEntityUpdate: NexusGenRootTypes['ServiceEntityUpdateReply'] | null; // ServiceEntityUpdateReply
+    systemEntityCreate: NexusGenRootTypes['SystemEntityCreateReply'] | null; // SystemEntityCreateReply
+    systemEntityDelete: NexusGenRootTypes['SystemEntityDeleteReply'] | null; // SystemEntityDeleteReply
+    systemEntityPhantomEdit: NexusGenRootTypes['SystemEntityPhantomEditReply'] | null; // SystemEntityPhantomEditReply
+    systemEntitySync: NexusGenRootTypes['SystemEntitySyncReply'] | null; // SystemEntitySyncReply
+    systemEntityUpdate: NexusGenRootTypes['SystemEntityUpdateReply'] | null; // SystemEntityUpdateReply
     userCreate: NexusGenRootTypes['UserCreateReply'] | null; // UserCreateReply
     workspaceCreate: NexusGenRootTypes['WorkspaceCreateReply'] | null; // WorkspaceCreateReply
   }
@@ -1962,6 +2397,12 @@ export interface NexusGenFieldTypes {
     billingAccountId: string | null; // String
   }
   Query: { // field return type
+    applicationComponentGet: NexusGenRootTypes['ApplicationComponentGetReply'] | null; // ApplicationComponentGetReply
+    applicationComponentList: NexusGenRootTypes['ApplicationComponentListReply'] | null; // ApplicationComponentListReply
+    applicationComponentPick: NexusGenRootTypes['ApplicationComponentPickReply'] | null; // ApplicationComponentPickReply
+    applicationEntityEventList: NexusGenRootTypes['ApplicationEntityEventListReply'] | null; // ApplicationEntityEventListReply
+    applicationEntityGet: NexusGenRootTypes['ApplicationEntityGetReply'] | null; // ApplicationEntityGetReply
+    applicationEntityList: NexusGenRootTypes['ApplicationEntityListReply'] | null; // ApplicationEntityListReply
     billingAccountGet: NexusGenRootTypes['BillingAccountGetReply'] | null; // BillingAccountGetReply
     billingAccountList: NexusGenRootTypes['BillingAccountListReply'] | null; // BillingAccountListReply
     changeSetGet: NexusGenRootTypes['ChangeSetGetReply'] | null; // ChangeSetGetReply
@@ -1995,6 +2436,12 @@ export interface NexusGenFieldTypes {
     serviceEntityEventList: NexusGenRootTypes['ServiceEntityEventListReply'] | null; // ServiceEntityEventListReply
     serviceEntityGet: NexusGenRootTypes['ServiceEntityGetReply'] | null; // ServiceEntityGetReply
     serviceEntityList: NexusGenRootTypes['ServiceEntityListReply'] | null; // ServiceEntityListReply
+    systemComponentGet: NexusGenRootTypes['SystemComponentGetReply'] | null; // SystemComponentGetReply
+    systemComponentList: NexusGenRootTypes['SystemComponentListReply'] | null; // SystemComponentListReply
+    systemComponentPick: NexusGenRootTypes['SystemComponentPickReply'] | null; // SystemComponentPickReply
+    systemEntityEventList: NexusGenRootTypes['SystemEntityEventListReply'] | null; // SystemEntityEventListReply
+    systemEntityGet: NexusGenRootTypes['SystemEntityGetReply'] | null; // SystemEntityGetReply
+    systemEntityList: NexusGenRootTypes['SystemEntityListReply'] | null; // SystemEntityListReply
     userGet: NexusGenRootTypes['UserGetReply'] | null; // UserGetReply
     userList: NexusGenRootTypes['UserListReply'] | null; // UserListReply
     userLogin: NexusGenRootTypes['UserLoginReply'] | null; // UserLoginReply
@@ -2101,6 +2548,91 @@ export interface NexusGenFieldTypes {
   ServiceEntityUpdateReply: { // field return type
     item: NexusGenRootTypes['ServiceEntity'] | null; // ServiceEntity
   }
+  SystemComponent: { // field return type
+    constraints: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    description: string | null; // String
+    displayName: string | null; // String
+    id: string | null; // ID
+    name: string | null; // String
+    siProperties: NexusGenRootTypes['ComponentSiProperties'] | null; // ComponentSiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  SystemComponentConstraints: { // field return type
+    componentDisplayName: string | null; // String
+    componentName: string | null; // String
+  }
+  SystemComponentGetReply: { // field return type
+    item: NexusGenRootTypes['SystemComponent'] | null; // SystemComponent
+  }
+  SystemComponentListReply: { // field return type
+    items: NexusGenRootTypes['SystemComponent'][] | null; // [SystemComponent!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  SystemComponentPickReply: { // field return type
+    component: NexusGenRootTypes['SystemComponent'] | null; // SystemComponent
+    implicitConstraints: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+  }
+  SystemEntity: { // field return type
+    constraints: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    description: string | null; // String
+    displayName: string | null; // String
+    id: string | null; // ID
+    implicitConstraints: NexusGenRootTypes['SystemComponentConstraints'] | null; // SystemComponentConstraints
+    name: string | null; // String
+    properties: NexusGenRootTypes['SystemEntityProperties'] | null; // SystemEntityProperties
+    siProperties: NexusGenRootTypes['EntitySiProperties'] | null; // EntitySiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+  }
+  SystemEntityCreateReply: { // field return type
+    item: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityDeleteReply: { // field return type
+    item: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityEvent: { // field return type
+    actionName: string | null; // String
+    createTime: string | null; // String
+    errorLines: string[] | null; // [String!]
+    errorMessage: string | null; // String
+    finalized: boolean | null; // Boolean
+    finalTime: string | null; // String
+    id: string | null; // ID
+    inputEntity: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    outputEntity: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    outputLines: string[] | null; // [String!]
+    previousEntity: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+    siProperties: NexusGenRootTypes['EntityEventSiProperties'] | null; // EntityEventSiProperties
+    siStorable: NexusGenRootTypes['DataStorable'] | null; // DataStorable
+    success: boolean | null; // Boolean
+    updatedTime: string | null; // String
+    userId: string | null; // String
+  }
+  SystemEntityEventListReply: { // field return type
+    items: NexusGenRootTypes['SystemEntityEvent'][] | null; // [SystemEntityEvent!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  SystemEntityGetReply: { // field return type
+    item: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
+  SystemEntityListReply: { // field return type
+    items: NexusGenRootTypes['SystemEntity'][] | null; // [SystemEntity!]
+    nextPageToken: string | null; // String
+    totalCount: string | null; // String
+  }
+  SystemEntityPhantomEditReply: { // field return type
+    item: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
+  }
+  SystemEntityProperties: { // field return type
+    phantom: boolean | null; // Boolean
+  }
+  SystemEntitySyncReply: { // field return type
+    item: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
+  }
+  SystemEntityUpdateReply: { // field return type
+    item: NexusGenRootTypes['SystemEntity'] | null; // SystemEntity
+  }
   User: { // field return type
     associations: NexusGenRootTypes['UserAssociations'] | null; // UserAssociations
     capabilities: NexusGenRootTypes['Capability'] | null; // Capability
@@ -2197,6 +2729,21 @@ export interface NexusGenArgTypes {
     }
   }
   Mutation: {
+    applicationEntityCreate: { // args
+      input?: NexusGenInputs['ApplicationEntityCreateRequest'] | null; // ApplicationEntityCreateRequest
+    }
+    applicationEntityDelete: { // args
+      input?: NexusGenInputs['ApplicationEntityDeleteRequest'] | null; // ApplicationEntityDeleteRequest
+    }
+    applicationEntityPhantomEdit: { // args
+      input?: NexusGenInputs['ApplicationEntityPhantomEditRequest'] | null; // ApplicationEntityPhantomEditRequest
+    }
+    applicationEntitySync: { // args
+      input?: NexusGenInputs['ApplicationEntitySyncRequest'] | null; // ApplicationEntitySyncRequest
+    }
+    applicationEntityUpdate: { // args
+      input?: NexusGenInputs['ApplicationEntityUpdateRequest'] | null; // ApplicationEntityUpdateRequest
+    }
     billingAccountSignup: { // args
       input?: NexusGenInputs['BillingAccountSignupRequest'] | null; // BillingAccountSignupRequest
     }
@@ -2275,6 +2822,21 @@ export interface NexusGenArgTypes {
     serviceEntityUpdate: { // args
       input?: NexusGenInputs['ServiceEntityUpdateRequest'] | null; // ServiceEntityUpdateRequest
     }
+    systemEntityCreate: { // args
+      input?: NexusGenInputs['SystemEntityCreateRequest'] | null; // SystemEntityCreateRequest
+    }
+    systemEntityDelete: { // args
+      input?: NexusGenInputs['SystemEntityDeleteRequest'] | null; // SystemEntityDeleteRequest
+    }
+    systemEntityPhantomEdit: { // args
+      input?: NexusGenInputs['SystemEntityPhantomEditRequest'] | null; // SystemEntityPhantomEditRequest
+    }
+    systemEntitySync: { // args
+      input?: NexusGenInputs['SystemEntitySyncRequest'] | null; // SystemEntitySyncRequest
+    }
+    systemEntityUpdate: { // args
+      input?: NexusGenInputs['SystemEntityUpdateRequest'] | null; // SystemEntityUpdateRequest
+    }
     userCreate: { // args
       input?: NexusGenInputs['UserCreateRequest'] | null; // UserCreateRequest
     }
@@ -2288,6 +2850,24 @@ export interface NexusGenArgTypes {
     }
   }
   Query: {
+    applicationComponentGet: { // args
+      input?: NexusGenInputs['ApplicationComponentGetRequest'] | null; // ApplicationComponentGetRequest
+    }
+    applicationComponentList: { // args
+      input?: NexusGenInputs['ApplicationComponentListRequest'] | null; // ApplicationComponentListRequest
+    }
+    applicationComponentPick: { // args
+      input?: NexusGenInputs['ApplicationComponentPickRequest'] | null; // ApplicationComponentPickRequest
+    }
+    applicationEntityEventList: { // args
+      input?: NexusGenInputs['ApplicationEntityEventListRequest'] | null; // ApplicationEntityEventListRequest
+    }
+    applicationEntityGet: { // args
+      input?: NexusGenInputs['ApplicationEntityGetRequest'] | null; // ApplicationEntityGetRequest
+    }
+    applicationEntityList: { // args
+      input?: NexusGenInputs['ApplicationEntityListRequest'] | null; // ApplicationEntityListRequest
+    }
     billingAccountGet: { // args
       input?: NexusGenInputs['BillingAccountGetRequest'] | null; // BillingAccountGetRequest
     }
@@ -2387,6 +2967,24 @@ export interface NexusGenArgTypes {
     serviceEntityList: { // args
       input?: NexusGenInputs['ServiceEntityListRequest'] | null; // ServiceEntityListRequest
     }
+    systemComponentGet: { // args
+      input?: NexusGenInputs['SystemComponentGetRequest'] | null; // SystemComponentGetRequest
+    }
+    systemComponentList: { // args
+      input?: NexusGenInputs['SystemComponentListRequest'] | null; // SystemComponentListRequest
+    }
+    systemComponentPick: { // args
+      input?: NexusGenInputs['SystemComponentPickRequest'] | null; // SystemComponentPickRequest
+    }
+    systemEntityEventList: { // args
+      input?: NexusGenInputs['SystemEntityEventListRequest'] | null; // SystemEntityEventListRequest
+    }
+    systemEntityGet: { // args
+      input?: NexusGenInputs['SystemEntityGetRequest'] | null; // SystemEntityGetRequest
+    }
+    systemEntityList: { // args
+      input?: NexusGenInputs['SystemEntityListRequest'] | null; // SystemEntityListRequest
+    }
     userGet: { // args
       input?: NexusGenInputs['UserGetRequest'] | null; // UserGetRequest
     }
@@ -2415,9 +3013,9 @@ export interface NexusGenAbstractResolveReturnTypes {
 
 export interface NexusGenInheritedFields {}
 
-export type NexusGenObjectNames = "BillingAccount" | "BillingAccountAssociations" | "BillingAccountGetReply" | "BillingAccountListReply" | "BillingAccountSignupReply" | "Capability" | "ChangeSet" | "ChangeSetAssociations" | "ChangeSetCreateReply" | "ChangeSetExecuteReply" | "ChangeSetGetReply" | "ChangeSetListReply" | "ChangeSetSiProperties" | "ComponentSiProperties" | "DataPageToken" | "DataQuery" | "DataQueryItems" | "DataQueryItemsExpression" | "DataStorable" | "EntityEventSiProperties" | "EntitySiProperties" | "Group" | "GroupCreateReply" | "GroupGetReply" | "GroupListReply" | "GroupSiProperties" | "Integration" | "IntegrationAssociations" | "IntegrationGetReply" | "IntegrationInstance" | "IntegrationInstanceAssociations" | "IntegrationInstanceGetReply" | "IntegrationInstanceListReply" | "IntegrationInstanceOptionValues" | "IntegrationInstanceSiProperties" | "IntegrationListReply" | "IntegrationOptions" | "IntegrationService" | "IntegrationServiceAssociations" | "IntegrationServiceGetReply" | "IntegrationServiceSiProperties" | "IntegrationSiProperties" | "Item" | "ItemAssociations" | "ItemGetReply" | "ItemListReply" | "ItemSiProperties" | "KubernetesContainer" | "KubernetesContainerPort" | "KubernetesDeploymentComponent" | "KubernetesDeploymentComponentConstraints" | "KubernetesDeploymentComponentGetReply" | "KubernetesDeploymentComponentListReply" | "KubernetesDeploymentComponentPickReply" | "KubernetesDeploymentEntity" | "KubernetesDeploymentEntityApplyReply" | "KubernetesDeploymentEntityAssociations" | "KubernetesDeploymentEntityCreateReply" | "KubernetesDeploymentEntityDeleteReply" | "KubernetesDeploymentEntityEvent" | "KubernetesDeploymentEntityEventListReply" | "KubernetesDeploymentEntityGetReply" | "KubernetesDeploymentEntityKubernetesObjectEditReply" | "KubernetesDeploymentEntityKubernetesObjectYamlEditReply" | "KubernetesDeploymentEntityListReply" | "KubernetesDeploymentEntityProperties" | "KubernetesDeploymentEntityPropertiesKubernetesObject" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpec" | "KubernetesDeploymentEntitySyncReply" | "KubernetesDeploymentEntityUpdateReply" | "KubernetesLoadBalancerStatus" | "KubernetesLoadBalancerStatusIngress" | "KubernetesMetadata" | "KubernetesPodSpec" | "KubernetesPodTemplateSpec" | "KubernetesSelector" | "KubernetesServiceComponent" | "KubernetesServiceComponentConstraints" | "KubernetesServiceComponentGetReply" | "KubernetesServiceComponentListReply" | "KubernetesServiceComponentPickReply" | "KubernetesServiceEntity" | "KubernetesServiceEntityAssociations" | "KubernetesServiceEntityCreateReply" | "KubernetesServiceEntityDeleteReply" | "KubernetesServiceEntityEvent" | "KubernetesServiceEntityEventListReply" | "KubernetesServiceEntityGetReply" | "KubernetesServiceEntityKubernetesObjectEditReply" | "KubernetesServiceEntityKubernetesObjectYamlEditReply" | "KubernetesServiceEntityListReply" | "KubernetesServiceEntityProperties" | "KubernetesServiceEntityPropertiesKubernetesObject" | "KubernetesServiceEntityPropertiesKubernetesObjectSpec" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfig" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIp" | "KubernetesServiceEntityPropertiesKubernetesObjectStatus" | "KubernetesServiceEntitySyncReply" | "KubernetesServiceEntityUpdateReply" | "KubernetesServicePort" | "Labels" | "MatchLabels" | "Mutation" | "Organization" | "OrganizationAssociations" | "OrganizationCreateReply" | "OrganizationGetReply" | "OrganizationListReply" | "OrganizationSiProperties" | "Query" | "ServiceComponent" | "ServiceComponentConstraints" | "ServiceComponentGetReply" | "ServiceComponentListReply" | "ServiceComponentPickReply" | "ServiceEntity" | "ServiceEntityAssociations" | "ServiceEntityCreateReply" | "ServiceEntityDeleteReply" | "ServiceEntityDeployReply" | "ServiceEntityEvent" | "ServiceEntityEventListReply" | "ServiceEntityGetReply" | "ServiceEntityImageEditReply" | "ServiceEntityListReply" | "ServiceEntityPortEditReply" | "ServiceEntityProperties" | "ServiceEntityReplicasEditReply" | "ServiceEntitySyncReply" | "ServiceEntityUpdateReply" | "User" | "UserAssociations" | "UserCreateReply" | "UserGetReply" | "UserListReply" | "UserLoginReply" | "UserSiProperties" | "Workspace" | "WorkspaceAssociations" | "WorkspaceCreateReply" | "WorkspaceGetReply" | "WorkspaceListReply" | "WorkspaceSiProperties";
+export type NexusGenObjectNames = "ApplicationComponent" | "ApplicationComponentConstraints" | "ApplicationComponentGetReply" | "ApplicationComponentListReply" | "ApplicationComponentPickReply" | "ApplicationEntity" | "ApplicationEntityCreateReply" | "ApplicationEntityDeleteReply" | "ApplicationEntityEvent" | "ApplicationEntityEventListReply" | "ApplicationEntityGetReply" | "ApplicationEntityListReply" | "ApplicationEntityPhantomEditReply" | "ApplicationEntityProperties" | "ApplicationEntitySyncReply" | "ApplicationEntityUpdateReply" | "BillingAccount" | "BillingAccountAssociations" | "BillingAccountGetReply" | "BillingAccountListReply" | "BillingAccountSignupReply" | "Capability" | "ChangeSet" | "ChangeSetAssociations" | "ChangeSetCreateReply" | "ChangeSetExecuteReply" | "ChangeSetGetReply" | "ChangeSetListReply" | "ChangeSetSiProperties" | "ComponentSiProperties" | "DataPageToken" | "DataQuery" | "DataQueryItems" | "DataQueryItemsExpression" | "DataStorable" | "EntityEventSiProperties" | "EntitySiProperties" | "Group" | "GroupCreateReply" | "GroupGetReply" | "GroupListReply" | "GroupSiProperties" | "Integration" | "IntegrationAssociations" | "IntegrationGetReply" | "IntegrationInstance" | "IntegrationInstanceAssociations" | "IntegrationInstanceGetReply" | "IntegrationInstanceListReply" | "IntegrationInstanceOptionValues" | "IntegrationInstanceSiProperties" | "IntegrationListReply" | "IntegrationOptions" | "IntegrationService" | "IntegrationServiceAssociations" | "IntegrationServiceGetReply" | "IntegrationServiceSiProperties" | "IntegrationSiProperties" | "Item" | "ItemAssociations" | "ItemGetReply" | "ItemListReply" | "ItemSiProperties" | "KubernetesContainer" | "KubernetesContainerPort" | "KubernetesDeploymentComponent" | "KubernetesDeploymentComponentConstraints" | "KubernetesDeploymentComponentGetReply" | "KubernetesDeploymentComponentListReply" | "KubernetesDeploymentComponentPickReply" | "KubernetesDeploymentEntity" | "KubernetesDeploymentEntityApplyReply" | "KubernetesDeploymentEntityAssociations" | "KubernetesDeploymentEntityCreateReply" | "KubernetesDeploymentEntityDeleteReply" | "KubernetesDeploymentEntityEvent" | "KubernetesDeploymentEntityEventListReply" | "KubernetesDeploymentEntityGetReply" | "KubernetesDeploymentEntityKubernetesObjectEditReply" | "KubernetesDeploymentEntityKubernetesObjectYamlEditReply" | "KubernetesDeploymentEntityListReply" | "KubernetesDeploymentEntityProperties" | "KubernetesDeploymentEntityPropertiesKubernetesObject" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpec" | "KubernetesDeploymentEntitySyncReply" | "KubernetesDeploymentEntityUpdateReply" | "KubernetesLoadBalancerStatus" | "KubernetesLoadBalancerStatusIngress" | "KubernetesMetadata" | "KubernetesPodSpec" | "KubernetesPodTemplateSpec" | "KubernetesSelector" | "KubernetesServiceComponent" | "KubernetesServiceComponentConstraints" | "KubernetesServiceComponentGetReply" | "KubernetesServiceComponentListReply" | "KubernetesServiceComponentPickReply" | "KubernetesServiceEntity" | "KubernetesServiceEntityAssociations" | "KubernetesServiceEntityCreateReply" | "KubernetesServiceEntityDeleteReply" | "KubernetesServiceEntityEvent" | "KubernetesServiceEntityEventListReply" | "KubernetesServiceEntityGetReply" | "KubernetesServiceEntityKubernetesObjectEditReply" | "KubernetesServiceEntityKubernetesObjectYamlEditReply" | "KubernetesServiceEntityListReply" | "KubernetesServiceEntityProperties" | "KubernetesServiceEntityPropertiesKubernetesObject" | "KubernetesServiceEntityPropertiesKubernetesObjectSpec" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfig" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIp" | "KubernetesServiceEntityPropertiesKubernetesObjectStatus" | "KubernetesServiceEntitySyncReply" | "KubernetesServiceEntityUpdateReply" | "KubernetesServicePort" | "Labels" | "MatchLabels" | "Mutation" | "Organization" | "OrganizationAssociations" | "OrganizationCreateReply" | "OrganizationGetReply" | "OrganizationListReply" | "OrganizationSiProperties" | "Query" | "ServiceComponent" | "ServiceComponentConstraints" | "ServiceComponentGetReply" | "ServiceComponentListReply" | "ServiceComponentPickReply" | "ServiceEntity" | "ServiceEntityAssociations" | "ServiceEntityCreateReply" | "ServiceEntityDeleteReply" | "ServiceEntityDeployReply" | "ServiceEntityEvent" | "ServiceEntityEventListReply" | "ServiceEntityGetReply" | "ServiceEntityImageEditReply" | "ServiceEntityListReply" | "ServiceEntityPortEditReply" | "ServiceEntityProperties" | "ServiceEntityReplicasEditReply" | "ServiceEntitySyncReply" | "ServiceEntityUpdateReply" | "SystemComponent" | "SystemComponentConstraints" | "SystemComponentGetReply" | "SystemComponentListReply" | "SystemComponentPickReply" | "SystemEntity" | "SystemEntityCreateReply" | "SystemEntityDeleteReply" | "SystemEntityEvent" | "SystemEntityEventListReply" | "SystemEntityGetReply" | "SystemEntityListReply" | "SystemEntityPhantomEditReply" | "SystemEntityProperties" | "SystemEntitySyncReply" | "SystemEntityUpdateReply" | "User" | "UserAssociations" | "UserCreateReply" | "UserGetReply" | "UserListReply" | "UserLoginReply" | "UserSiProperties" | "Workspace" | "WorkspaceAssociations" | "WorkspaceCreateReply" | "WorkspaceGetReply" | "WorkspaceListReply" | "WorkspaceSiProperties";
 
-export type NexusGenInputNames = "BillingAccountGetRequest" | "BillingAccountListRequest" | "BillingAccountSignupRequest" | "BillingAccountSignupRequestBillingAccountRequest" | "BillingAccountSignupRequestUserRequest" | "CapabilityRequest" | "ChangeSetCreateRequest" | "ChangeSetExecuteRequest" | "ChangeSetGetRequest" | "ChangeSetListRequest" | "DataQueryItemsExpressionRequest" | "DataQueryItemsRequest" | "DataQueryRequest" | "GroupCreateRequest" | "GroupGetRequest" | "GroupListRequest" | "GroupSiPropertiesRequest" | "IntegrationGetRequest" | "IntegrationInstanceGetRequest" | "IntegrationInstanceListRequest" | "IntegrationListRequest" | "IntegrationServiceGetRequest" | "ItemGetRequest" | "ItemListRequest" | "KubernetesContainerPortRequest" | "KubernetesContainerRequest" | "KubernetesDeploymentComponentConstraintsRequest" | "KubernetesDeploymentComponentGetRequest" | "KubernetesDeploymentComponentListRequest" | "KubernetesDeploymentComponentPickRequest" | "KubernetesDeploymentEntityApplyRequest" | "KubernetesDeploymentEntityCreateRequest" | "KubernetesDeploymentEntityDeleteRequest" | "KubernetesDeploymentEntityEventListRequest" | "KubernetesDeploymentEntityGetRequest" | "KubernetesDeploymentEntityKubernetesObjectEditRequest" | "KubernetesDeploymentEntityKubernetesObjectYamlEditRequest" | "KubernetesDeploymentEntityListRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesDeploymentEntityPropertiesRequest" | "KubernetesDeploymentEntitySyncRequest" | "KubernetesDeploymentEntityUpdateRequest" | "KubernetesDeploymentEntityUpdateRequestUpdateRequest" | "KubernetesLoadBalancerStatusIngressRequest" | "KubernetesLoadBalancerStatusRequest" | "KubernetesMetadataRequest" | "KubernetesPodSpecRequest" | "KubernetesPodTemplateSpecRequest" | "KubernetesSelectorRequest" | "KubernetesServiceComponentConstraintsRequest" | "KubernetesServiceComponentGetRequest" | "KubernetesServiceComponentListRequest" | "KubernetesServiceComponentPickRequest" | "KubernetesServiceEntityCreateRequest" | "KubernetesServiceEntityDeleteRequest" | "KubernetesServiceEntityEventListRequest" | "KubernetesServiceEntityGetRequest" | "KubernetesServiceEntityKubernetesObjectEditRequest" | "KubernetesServiceEntityKubernetesObjectYamlEditRequest" | "KubernetesServiceEntityListRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIpRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectStatusRequest" | "KubernetesServiceEntityPropertiesRequest" | "KubernetesServiceEntitySyncRequest" | "KubernetesServiceEntityUpdateRequest" | "KubernetesServiceEntityUpdateRequestUpdateRequest" | "KubernetesServicePortRequest" | "LabelsRequest" | "MatchLabelsRequest" | "OrganizationCreateRequest" | "OrganizationGetRequest" | "OrganizationListRequest" | "OrganizationSiPropertiesRequest" | "ServiceComponentConstraintsRequest" | "ServiceComponentGetRequest" | "ServiceComponentListRequest" | "ServiceComponentPickRequest" | "ServiceEntityCreateRequest" | "ServiceEntityDeleteRequest" | "ServiceEntityDeployRequest" | "ServiceEntityEventListRequest" | "ServiceEntityGetRequest" | "ServiceEntityImageEditRequest" | "ServiceEntityListRequest" | "ServiceEntityPortEditRequest" | "ServiceEntityPropertiesRequest" | "ServiceEntityReplicasEditRequest" | "ServiceEntitySyncRequest" | "ServiceEntityUpdateRequest" | "ServiceEntityUpdateRequestUpdateRequest" | "UserCreateRequest" | "UserGetRequest" | "UserListRequest" | "UserLoginRequest" | "UserSiPropertiesRequest" | "WorkspaceCreateRequest" | "WorkspaceGetRequest" | "WorkspaceListRequest" | "WorkspaceSiPropertiesRequest";
+export type NexusGenInputNames = "ApplicationComponentConstraintsRequest" | "ApplicationComponentGetRequest" | "ApplicationComponentListRequest" | "ApplicationComponentPickRequest" | "ApplicationEntityCreateRequest" | "ApplicationEntityDeleteRequest" | "ApplicationEntityEventListRequest" | "ApplicationEntityGetRequest" | "ApplicationEntityListRequest" | "ApplicationEntityPhantomEditRequest" | "ApplicationEntityPropertiesRequest" | "ApplicationEntitySyncRequest" | "ApplicationEntityUpdateRequest" | "ApplicationEntityUpdateRequestUpdateRequest" | "BillingAccountGetRequest" | "BillingAccountListRequest" | "BillingAccountSignupRequest" | "BillingAccountSignupRequestBillingAccountRequest" | "BillingAccountSignupRequestUserRequest" | "CapabilityRequest" | "ChangeSetCreateRequest" | "ChangeSetExecuteRequest" | "ChangeSetGetRequest" | "ChangeSetListRequest" | "DataQueryItemsExpressionRequest" | "DataQueryItemsRequest" | "DataQueryRequest" | "GroupCreateRequest" | "GroupGetRequest" | "GroupListRequest" | "GroupSiPropertiesRequest" | "IntegrationGetRequest" | "IntegrationInstanceGetRequest" | "IntegrationInstanceListRequest" | "IntegrationListRequest" | "IntegrationServiceGetRequest" | "ItemGetRequest" | "ItemListRequest" | "KubernetesContainerPortRequest" | "KubernetesContainerRequest" | "KubernetesDeploymentComponentConstraintsRequest" | "KubernetesDeploymentComponentGetRequest" | "KubernetesDeploymentComponentListRequest" | "KubernetesDeploymentComponentPickRequest" | "KubernetesDeploymentEntityApplyRequest" | "KubernetesDeploymentEntityCreateRequest" | "KubernetesDeploymentEntityDeleteRequest" | "KubernetesDeploymentEntityEventListRequest" | "KubernetesDeploymentEntityGetRequest" | "KubernetesDeploymentEntityKubernetesObjectEditRequest" | "KubernetesDeploymentEntityKubernetesObjectYamlEditRequest" | "KubernetesDeploymentEntityListRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesDeploymentEntityPropertiesRequest" | "KubernetesDeploymentEntitySyncRequest" | "KubernetesDeploymentEntityUpdateRequest" | "KubernetesDeploymentEntityUpdateRequestUpdateRequest" | "KubernetesLoadBalancerStatusIngressRequest" | "KubernetesLoadBalancerStatusRequest" | "KubernetesMetadataRequest" | "KubernetesPodSpecRequest" | "KubernetesPodTemplateSpecRequest" | "KubernetesSelectorRequest" | "KubernetesServiceComponentConstraintsRequest" | "KubernetesServiceComponentGetRequest" | "KubernetesServiceComponentListRequest" | "KubernetesServiceComponentPickRequest" | "KubernetesServiceEntityCreateRequest" | "KubernetesServiceEntityDeleteRequest" | "KubernetesServiceEntityEventListRequest" | "KubernetesServiceEntityGetRequest" | "KubernetesServiceEntityKubernetesObjectEditRequest" | "KubernetesServiceEntityKubernetesObjectYamlEditRequest" | "KubernetesServiceEntityListRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIpRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectStatusRequest" | "KubernetesServiceEntityPropertiesRequest" | "KubernetesServiceEntitySyncRequest" | "KubernetesServiceEntityUpdateRequest" | "KubernetesServiceEntityUpdateRequestUpdateRequest" | "KubernetesServicePortRequest" | "LabelsRequest" | "MatchLabelsRequest" | "OrganizationCreateRequest" | "OrganizationGetRequest" | "OrganizationListRequest" | "OrganizationSiPropertiesRequest" | "ServiceComponentConstraintsRequest" | "ServiceComponentGetRequest" | "ServiceComponentListRequest" | "ServiceComponentPickRequest" | "ServiceEntityCreateRequest" | "ServiceEntityDeleteRequest" | "ServiceEntityDeployRequest" | "ServiceEntityEventListRequest" | "ServiceEntityGetRequest" | "ServiceEntityImageEditRequest" | "ServiceEntityListRequest" | "ServiceEntityPortEditRequest" | "ServiceEntityPropertiesRequest" | "ServiceEntityReplicasEditRequest" | "ServiceEntitySyncRequest" | "ServiceEntityUpdateRequest" | "ServiceEntityUpdateRequestUpdateRequest" | "SystemComponentConstraintsRequest" | "SystemComponentGetRequest" | "SystemComponentListRequest" | "SystemComponentPickRequest" | "SystemEntityCreateRequest" | "SystemEntityDeleteRequest" | "SystemEntityEventListRequest" | "SystemEntityGetRequest" | "SystemEntityListRequest" | "SystemEntityPhantomEditRequest" | "SystemEntityPropertiesRequest" | "SystemEntitySyncRequest" | "SystemEntityUpdateRequest" | "SystemEntityUpdateRequestUpdateRequest" | "UserCreateRequest" | "UserGetRequest" | "UserListRequest" | "UserLoginRequest" | "UserSiPropertiesRequest" | "WorkspaceCreateRequest" | "WorkspaceGetRequest" | "WorkspaceListRequest" | "WorkspaceSiPropertiesRequest";
 
 export type NexusGenEnumNames = "ChangeSetStatus" | "DataPageTokenOrderByDirection" | "DataQueryBooleanTerm" | "DataQueryItemsExpressionComparison" | "DataQueryItemsExpressionFieldType" | "DataStorableChangeSetEventType" | "EntitySiPropertiesEntityState" | "IntegrationOptionsOptionType" | "KubernetesDeploymentComponentConstraintsKubernetesVersion" | "KubernetesServiceComponentConstraintsKubernetesVersion" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecExternalTrafficPolicy" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecIpFamily" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinity" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecType" | "KubernetesServicePortProtocol";
 

--- a/components/si-kubernetes/src/bin/server.rs
+++ b/components/si-kubernetes/src/bin/server.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
         .with(opentelemetry_layer);
 
     tracing::subscriber::set_global_default(subscriber)
-        .context("cannot set the global tracing defalt")?;
+        .context("cannot set the global tracing default")?;
 
     let server_name = "kubernetes";
 

--- a/components/si-registry/proto/si.core.proto
+++ b/components/si-registry/proto/si.core.proto
@@ -9,6 +9,18 @@ import "google/protobuf/wrappers.proto";
 import "si-registry/proto/si.data.proto";
 import "si-registry/proto/si.cea.proto";
 service Core {
+  rpc ApplicationComponentGet(ApplicationComponentGetRequest) returns (ApplicationComponentGetReply);
+  rpc ApplicationComponentList(ApplicationComponentListRequest) returns (ApplicationComponentListReply);
+  rpc ApplicationComponentCreate(ApplicationComponentCreateRequest) returns (ApplicationComponentCreateReply);
+  rpc ApplicationComponentPick(ApplicationComponentPickRequest) returns (ApplicationComponentPickReply);
+  rpc ApplicationEntityGet(ApplicationEntityGetRequest) returns (ApplicationEntityGetReply);
+  rpc ApplicationEntityList(ApplicationEntityListRequest) returns (ApplicationEntityListReply);
+  rpc ApplicationEntityCreate(ApplicationEntityCreateRequest) returns (ApplicationEntityCreateReply);
+  rpc ApplicationEntityDelete(ApplicationEntityDeleteRequest) returns (ApplicationEntityDeleteReply);
+  rpc ApplicationEntityUpdate(ApplicationEntityUpdateRequest) returns (ApplicationEntityUpdateReply);
+  rpc ApplicationEntitySync(ApplicationEntitySyncRequest) returns (ApplicationEntitySyncReply);
+  rpc ApplicationEntityPhantomEdit(ApplicationEntityPhantomEditRequest) returns (ApplicationEntityPhantomEditReply);
+  rpc ApplicationEntityEventList(ApplicationEntityEventListRequest) returns (ApplicationEntityEventListReply);
   rpc ServiceComponentGet(ServiceComponentGetRequest) returns (ServiceComponentGetReply);
   rpc ServiceComponentList(ServiceComponentListRequest) returns (ServiceComponentListReply);
   rpc ServiceComponentCreate(ServiceComponentCreateRequest) returns (ServiceComponentCreateReply);
@@ -24,6 +36,177 @@ service Core {
   rpc ServiceEntityReplicasEdit(ServiceEntityReplicasEditRequest) returns (ServiceEntityReplicasEditReply);
   rpc ServiceEntityDeploy(ServiceEntityDeployRequest) returns (ServiceEntityDeployReply);
   rpc ServiceEntityEventList(ServiceEntityEventListRequest) returns (ServiceEntityEventListReply);
+  rpc SystemComponentGet(SystemComponentGetRequest) returns (SystemComponentGetReply);
+  rpc SystemComponentList(SystemComponentListRequest) returns (SystemComponentListReply);
+  rpc SystemComponentCreate(SystemComponentCreateRequest) returns (SystemComponentCreateReply);
+  rpc SystemComponentPick(SystemComponentPickRequest) returns (SystemComponentPickReply);
+  rpc SystemEntityGet(SystemEntityGetRequest) returns (SystemEntityGetReply);
+  rpc SystemEntityList(SystemEntityListRequest) returns (SystemEntityListReply);
+  rpc SystemEntityCreate(SystemEntityCreateRequest) returns (SystemEntityCreateReply);
+  rpc SystemEntityDelete(SystemEntityDeleteRequest) returns (SystemEntityDeleteReply);
+  rpc SystemEntityUpdate(SystemEntityUpdateRequest) returns (SystemEntityUpdateReply);
+  rpc SystemEntitySync(SystemEntitySyncRequest) returns (SystemEntitySyncReply);
+  rpc SystemEntityPhantomEdit(SystemEntityPhantomEditRequest) returns (SystemEntityPhantomEditReply);
+  rpc SystemEntityEventList(SystemEntityEventListRequest) returns (SystemEntityEventListReply);
+}
+message ApplicationComponentConstraints {
+  google.protobuf.StringValue component_name = 1;
+  google.protobuf.StringValue component_display_name = 2;
+}
+message ApplicationComponent {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue name = 2;
+  google.protobuf.StringValue display_name = 3;
+  si.data.DataStorable si_storable = 4;
+  google.protobuf.StringValue description = 5;
+  si.core.ApplicationComponentConstraints constraints = 6;
+  si.cea.ComponentSiProperties si_properties = 7;
+}
+message ApplicationComponentGetRequest {
+  google.protobuf.StringValue id = 1001;
+}
+message ApplicationComponentGetReply {
+  si.core.ApplicationComponent item = 1001;
+}
+message ApplicationComponentListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message ApplicationComponentListReply {
+  repeated si.core.ApplicationComponent items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
+}
+message ApplicationComponentCreateRequest {
+  google.protobuf.StringValue name = 1001;
+  google.protobuf.StringValue display_name = 1002;
+  google.protobuf.StringValue description = 1003;
+  si.core.ApplicationComponentConstraints constraints = 1;
+  si.cea.ComponentSiProperties si_properties = 1004;
+}
+message ApplicationComponentCreateReply {
+  si.core.ApplicationComponent item = 1;
+}
+message ApplicationComponentPickRequest {
+  si.core.ApplicationComponentConstraints constraints = 1;
+}
+message ApplicationComponentPickReply {
+  si.core.ApplicationComponentConstraints implicit_constraints = 1;
+  si.core.ApplicationComponent component = 2;
+}
+message ApplicationEntityProperties {
+  google.protobuf.BoolValue phantom = 1001;
+}
+message ApplicationEntity {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue name = 2;
+  google.protobuf.StringValue display_name = 3;
+  si.data.DataStorable si_storable = 4;
+  google.protobuf.StringValue description = 5;
+  si.cea.EntitySiProperties si_properties = 6;
+  si.core.ApplicationEntityProperties properties = 7;
+  si.core.ApplicationComponentConstraints constraints = 8;
+  si.core.ApplicationComponentConstraints implicit_constraints = 9;
+}
+message ApplicationEntityGetRequest {
+  google.protobuf.StringValue id = 1001;
+}
+message ApplicationEntityGetReply {
+  si.core.ApplicationEntity item = 1001;
+}
+message ApplicationEntityListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message ApplicationEntityListReply {
+  repeated si.core.ApplicationEntity items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
+}
+message ApplicationEntityCreateRequest {
+  google.protobuf.StringValue name = 1;
+  google.protobuf.StringValue display_name = 2;
+  google.protobuf.StringValue description = 3;
+  google.protobuf.StringValue workspace_id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+  si.core.ApplicationEntityProperties properties = 4;
+  si.core.ApplicationComponentConstraints constraints = 5;
+}
+message ApplicationEntityCreateReply {
+  si.core.ApplicationEntity item = 1;
+}
+message ApplicationEntityDeleteRequest {
+  google.protobuf.StringValue id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+}
+message ApplicationEntityDeleteReply {
+  si.core.ApplicationEntity item = 1001;
+}
+message ApplicationEntityUpdateRequestUpdate {
+  google.protobuf.StringValue name = 1001;
+  google.protobuf.StringValue display_name = 1002;
+  google.protobuf.StringValue description = 1003;
+  si.core.ApplicationEntityProperties properties = 1004;
+}
+message ApplicationEntityUpdateRequest {
+  google.protobuf.StringValue id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+  si.core.ApplicationEntityUpdateRequestUpdate update = 1003;
+}
+message ApplicationEntityUpdateReply {
+  si.core.ApplicationEntity item = 1001;
+}
+message ApplicationEntitySyncRequest {
+  google.protobuf.StringValue id = 1;
+}
+message ApplicationEntitySyncReply {
+  si.core.ApplicationEntityEvent item = 1;
+}
+message ApplicationEntityPhantomEditRequest {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.BoolValue property = 1001;
+}
+message ApplicationEntityPhantomEditReply {
+  si.core.ApplicationEntityEvent item = 1;
+}
+message ApplicationEntityEvent {
+  google.protobuf.StringValue id = 1;
+  si.data.DataStorable si_storable = 2;
+  google.protobuf.StringValue action_name = 3;
+  google.protobuf.StringValue create_time = 4;
+  google.protobuf.StringValue updated_time = 5;
+  google.protobuf.StringValue final_time = 6;
+  google.protobuf.BoolValue success = 7;
+  google.protobuf.BoolValue finalized = 8;
+  google.protobuf.StringValue user_id = 9;
+  repeated google.protobuf.StringValue output_lines = 10;
+  repeated google.protobuf.StringValue error_lines = 11;
+  google.protobuf.StringValue error_message = 12;
+  si.core.ApplicationEntity previous_entity = 13;
+  si.core.ApplicationEntity input_entity = 14;
+  si.core.ApplicationEntity output_entity = 15;
+  si.cea.EntityEventSiProperties si_properties = 16;
+}
+message ApplicationEntityEventListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message ApplicationEntityEventListReply {
+  repeated si.core.ApplicationEntityEvent items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
 }
 message ServiceComponentConstraints {
   google.protobuf.StringValue component_name = 1;
@@ -203,6 +386,165 @@ message ServiceEntityEventListRequest {
 }
 message ServiceEntityEventListReply {
   repeated si.core.ServiceEntityEvent items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
+}
+message SystemComponentConstraints {
+  google.protobuf.StringValue component_name = 1;
+  google.protobuf.StringValue component_display_name = 2;
+}
+message SystemComponent {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue name = 2;
+  google.protobuf.StringValue display_name = 3;
+  si.data.DataStorable si_storable = 4;
+  google.protobuf.StringValue description = 5;
+  si.core.SystemComponentConstraints constraints = 6;
+  si.cea.ComponentSiProperties si_properties = 7;
+}
+message SystemComponentGetRequest {
+  google.protobuf.StringValue id = 1001;
+}
+message SystemComponentGetReply {
+  si.core.SystemComponent item = 1001;
+}
+message SystemComponentListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message SystemComponentListReply {
+  repeated si.core.SystemComponent items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
+}
+message SystemComponentCreateRequest {
+  google.protobuf.StringValue name = 1001;
+  google.protobuf.StringValue display_name = 1002;
+  google.protobuf.StringValue description = 1003;
+  si.core.SystemComponentConstraints constraints = 1;
+  si.cea.ComponentSiProperties si_properties = 1004;
+}
+message SystemComponentCreateReply {
+  si.core.SystemComponent item = 1;
+}
+message SystemComponentPickRequest {
+  si.core.SystemComponentConstraints constraints = 1;
+}
+message SystemComponentPickReply {
+  si.core.SystemComponentConstraints implicit_constraints = 1;
+  si.core.SystemComponent component = 2;
+}
+message SystemEntityProperties {
+  google.protobuf.BoolValue phantom = 1001;
+}
+message SystemEntity {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue name = 2;
+  google.protobuf.StringValue display_name = 3;
+  si.data.DataStorable si_storable = 4;
+  google.protobuf.StringValue description = 5;
+  si.cea.EntitySiProperties si_properties = 6;
+  si.core.SystemEntityProperties properties = 7;
+  si.core.SystemComponentConstraints constraints = 8;
+  si.core.SystemComponentConstraints implicit_constraints = 9;
+}
+message SystemEntityGetRequest {
+  google.protobuf.StringValue id = 1001;
+}
+message SystemEntityGetReply {
+  si.core.SystemEntity item = 1001;
+}
+message SystemEntityListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message SystemEntityListReply {
+  repeated si.core.SystemEntity items = 1;
+  google.protobuf.UInt32Value total_count = 2;
+  google.protobuf.StringValue next_page_token = 3;
+}
+message SystemEntityCreateRequest {
+  google.protobuf.StringValue name = 1;
+  google.protobuf.StringValue display_name = 2;
+  google.protobuf.StringValue description = 3;
+  google.protobuf.StringValue workspace_id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+  si.core.SystemEntityProperties properties = 4;
+  si.core.SystemComponentConstraints constraints = 5;
+}
+message SystemEntityCreateReply {
+  si.core.SystemEntity item = 1;
+}
+message SystemEntityDeleteRequest {
+  google.protobuf.StringValue id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+}
+message SystemEntityDeleteReply {
+  si.core.SystemEntity item = 1001;
+}
+message SystemEntityUpdateRequestUpdate {
+  google.protobuf.StringValue name = 1001;
+  google.protobuf.StringValue display_name = 1002;
+  google.protobuf.StringValue description = 1003;
+  si.core.SystemEntityProperties properties = 1004;
+}
+message SystemEntityUpdateRequest {
+  google.protobuf.StringValue id = 1001;
+  google.protobuf.StringValue change_set_id = 1002;
+  si.core.SystemEntityUpdateRequestUpdate update = 1003;
+}
+message SystemEntityUpdateReply {
+  si.core.SystemEntity item = 1001;
+}
+message SystemEntitySyncRequest {
+  google.protobuf.StringValue id = 1;
+}
+message SystemEntitySyncReply {
+  si.core.SystemEntityEvent item = 1;
+}
+message SystemEntityPhantomEditRequest {
+  google.protobuf.StringValue id = 1;
+  google.protobuf.BoolValue property = 1001;
+}
+message SystemEntityPhantomEditReply {
+  si.core.SystemEntityEvent item = 1;
+}
+message SystemEntityEvent {
+  google.protobuf.StringValue id = 1;
+  si.data.DataStorable si_storable = 2;
+  google.protobuf.StringValue action_name = 3;
+  google.protobuf.StringValue create_time = 4;
+  google.protobuf.StringValue updated_time = 5;
+  google.protobuf.StringValue final_time = 6;
+  google.protobuf.BoolValue success = 7;
+  google.protobuf.BoolValue finalized = 8;
+  google.protobuf.StringValue user_id = 9;
+  repeated google.protobuf.StringValue output_lines = 10;
+  repeated google.protobuf.StringValue error_lines = 11;
+  google.protobuf.StringValue error_message = 12;
+  si.core.SystemEntity previous_entity = 13;
+  si.core.SystemEntity input_entity = 14;
+  si.core.SystemEntity output_entity = 15;
+  si.cea.EntityEventSiProperties si_properties = 16;
+}
+message SystemEntityEventListRequest {
+  si.data.DataQuery query = 1;
+  google.protobuf.UInt32Value page_size = 2;
+  google.protobuf.StringValue order_by = 3;
+  si.data.DataPageTokenOrderByDirection order_by_direction = 4;
+  google.protobuf.StringValue page_token = 5;
+  google.protobuf.StringValue scope_by_tenant_id = 6;
+}
+message SystemEntityEventListReply {
+  repeated si.core.SystemEntityEvent items = 1;
   google.protobuf.UInt32Value total_count = 2;
   google.protobuf.StringValue next_page_token = 3;
 }

--- a/components/si-registry/src/components/si-core/application.ts
+++ b/components/si-registry/src/components/si-core/application.ts
@@ -1,0 +1,27 @@
+import { PropBool } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "application",
+  displayTypeName: "A System Initiative Application",
+  siPathName: "si-core",
+  serviceName: "core",
+  options(c) {
+    c.entity.integrationServices.push({
+      integrationName: "global",
+      integrationServiceName: "core",
+    });
+
+    // Properties
+    // TODO(fnichol): we don't have properties, but GraphQL will not accept an empty
+    // *Properties type so... phantom data for now?
+    c.properties.addBool({
+      name: "phantom",
+      label: "Phantom Data",
+      options(p: PropBool) {
+        p.hidden = true;
+        p.baseDefaultValue = true;
+      },
+    });
+  },
+});

--- a/components/si-registry/src/components/si-core/service.ts
+++ b/components/si-registry/src/components/si-core/service.ts
@@ -1,6 +1,5 @@
-import { PropAction, PropText } from "../../components/prelude";
+import { PropAction, PropNumber, PropText } from "../../components/prelude";
 import { registry } from "../../registry";
-import { PropNumber } from "@/prop/number";
 
 registry.componentAndEntity({
   typeName: "service",

--- a/components/si-registry/src/components/si-core/system.ts
+++ b/components/si-registry/src/components/si-core/system.ts
@@ -1,0 +1,27 @@
+import { PropBool } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "system",
+  displayTypeName: "A System Initiative System",
+  siPathName: "si-core",
+  serviceName: "core",
+  options(c) {
+    c.entity.integrationServices.push({
+      integrationName: "global",
+      integrationServiceName: "core",
+    });
+
+    // Properties
+    // TODO(fnichol): we don't have properties, but GraphQL will not accept an empty
+    // *Properties type so... phantom data for now?
+    c.properties.addBool({
+      name: "phantom",
+      label: "Phantom Data",
+      options(p: PropBool) {
+        p.hidden = true;
+        p.baseDefaultValue = true;
+      },
+    });
+  },
+});

--- a/components/si-registry/src/loader.ts
+++ b/components/si-registry/src/loader.ts
@@ -21,7 +21,9 @@ import "./components/si-account/integrationInstance";
 import "./components/si-account/changeSet";
 import "./components/si-account/item";
 
+import "./components/si-core/application";
 import "./components/si-core/service";
+import "./components/si-core/system";
 
 import "./components/si-kubernetes/kubernetes";
 import "./components/si-kubernetes/deployment";


### PR DESCRIPTION
This is a first pass at our Application and System concepts which are
fairly property and constraint-free at the moment. Right now they are
more important as objects in the system that can be referenced. We'll
see if these should be modeled as Components/Entities or something more
lightweight going forward.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>