### PR TITLE
feat(si-web-app): Allow actions on nodes

### DIFF
--- a/components/si-cea/src/entity_event.rs
+++ b/components/si-cea/src/entity_event.rs
@@ -87,6 +87,7 @@ pub trait EntityEvent:
     fn new(
         user_id: impl Into<String>,
         action_name: impl Into<String>,
+        change_set_id: impl Into<String>,
         entity: &Self::Entity,
     ) -> DataResult<Self> {
         let create_time: DateTime<Utc> = Utc::now();
@@ -105,10 +106,7 @@ pub trait EntityEvent:
         entity_event.set_integration_id(entity.integration_id()?);
         entity_event.set_integration_service_id(entity.integration_service_id()?);
         entity_event.set_component_id(entity.component_id()?);
-        // This can probably become an unwrap once we're all the
-        // way finished, and know we won't be going back to the
-        // old world without changesets.
-        entity_event.set_change_set_id(entity.change_set_id()?.unwrap_or(""));
+        entity_event.set_change_set_id(change_set_id.into());
         entity_event.set_entity_id(entity.id()?);
 
         Ok(entity_event)
@@ -118,9 +116,10 @@ pub trait EntityEvent:
         db: &Db,
         user_id: &str,
         action_name: &str,
+        change_set_id: &str,
         entity: &Self::Entity,
     ) -> DataResult<Self> {
-        let mut entity_event = Self::new(user_id, action_name, entity)?;
+        let mut entity_event = Self::new(user_id, action_name, change_set_id, entity)?;
 
         db.validate_and_insert_as_new(&mut entity_event).await?;
 
@@ -131,10 +130,11 @@ pub trait EntityEvent:
         db: &Db,
         user_id: &str,
         action_name: &str,
+        change_set_id: &str,
         entity: &Self::Entity,
         previous_entity: Self::Entity,
     ) -> DataResult<Self> {
-        let mut entity_event = Self::new(user_id, action_name, entity)?;
+        let mut entity_event = Self::new(user_id, action_name, change_set_id, entity)?;
         entity_event.set_previous_entity(previous_entity);
 
         db.validate_and_insert_as_new(&mut entity_event).await?;

--- a/components/si-core/src/agent/global_core_application.rs
+++ b/components/si-core/src/agent/global_core_application.rs
@@ -16,15 +16,6 @@ impl GlobalCoreApplicationDispatchFunctions for GlobalCoreApplicationDispatchFun
         async { Ok(()) }.instrument(debug_span!("create")).await
     }
 
-    async fn edit_phantom(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_phantom"))
-            .await
-    }
-
     async fn sync(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-core/src/agent/global_core_service.rs
+++ b/components/si-core/src/agent/global_core_service.rs
@@ -16,29 +16,6 @@ impl GlobalCoreServiceDispatchFunctions for GlobalCoreServiceDispatchFunctionsIm
         async { Ok(()) }.instrument(debug_span!("create")).await
     }
 
-    async fn edit_image(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }.instrument(debug_span!("edit_image")).await
-    }
-
-    async fn edit_port(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }.instrument(debug_span!("edit_port")).await
-    }
-
-    async fn edit_replicas(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_replicas"))
-            .await
-    }
-
     async fn deploy(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-core/src/agent/global_core_system.rs
+++ b/components/si-core/src/agent/global_core_system.rs
@@ -16,15 +16,6 @@ impl GlobalCoreSystemDispatchFunctions for GlobalCoreSystemDispatchFunctionsImpl
         async { Ok(()) }.instrument(debug_span!("create")).await
     }
 
-    async fn edit_phantom(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_phantom"))
-            .await
-    }
-
     async fn sync(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-core/src/gen/agent/global_core_application.rs
+++ b/components/si-core/src/gen/agent/global_core_application.rs
@@ -17,7 +17,7 @@ impl<T: GlobalCoreApplicationDispatchFunctions> si_cea::agent::dispatch::Integra
     for GlobalCoreApplicationDispatcher<T>
 {
     fn integration_actions(&self) -> &'static [&'static str] {
-        &["create", "edit_phantom", "sync"]
+        &["create", "sync"]
     }
 }
 
@@ -46,7 +46,6 @@ impl<T: GlobalCoreApplicationDispatchFunctions + Sync> si_cea::agent::dispatch::
     ) -> si_cea::CeaResult<()> {
         match entity_event.action_name()? {
             "create" => T::create(mqtt_client, entity_event).await,
-            "edit_phantom" => T::edit_phantom(mqtt_client, entity_event).await,
             "sync" => T::sync(mqtt_client, entity_event).await,
             invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
                 entity_event.integration_service_id()?.to_string(),
@@ -66,11 +65,6 @@ pub trait GlobalCoreApplicationDispatchFunctions {
     type EntityEvent: si_cea::EntityEvent + Send;
 
     async fn create(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_phantom(
         mqtt_client: &si_cea::MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> si_cea::CeaResult<()>;

--- a/components/si-core/src/gen/agent/global_core_service.rs
+++ b/components/si-core/src/gen/agent/global_core_service.rs
@@ -17,14 +17,7 @@ impl<T: GlobalCoreServiceDispatchFunctions> si_cea::agent::dispatch::Integration
     for GlobalCoreServiceDispatcher<T>
 {
     fn integration_actions(&self) -> &'static [&'static str] {
-        &[
-            "create",
-            "deploy",
-            "edit_image",
-            "edit_port",
-            "edit_replicas",
-            "sync",
-        ]
+        &["create", "deploy", "sync"]
     }
 }
 
@@ -54,9 +47,6 @@ impl<T: GlobalCoreServiceDispatchFunctions + Sync> si_cea::agent::dispatch::Disp
         match entity_event.action_name()? {
             "create" => T::create(mqtt_client, entity_event).await,
             "deploy" => T::deploy(mqtt_client, entity_event).await,
-            "edit_image" => T::edit_image(mqtt_client, entity_event).await,
-            "edit_port" => T::edit_port(mqtt_client, entity_event).await,
-            "edit_replicas" => T::edit_replicas(mqtt_client, entity_event).await,
             "sync" => T::sync(mqtt_client, entity_event).await,
             invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
                 entity_event.integration_service_id()?.to_string(),
@@ -81,21 +71,6 @@ pub trait GlobalCoreServiceDispatchFunctions {
     ) -> si_cea::CeaResult<()>;
 
     async fn deploy(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_image(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_port(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_replicas(
         mqtt_client: &si_cea::MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> si_cea::CeaResult<()>;

--- a/components/si-core/src/gen/agent/global_core_system.rs
+++ b/components/si-core/src/gen/agent/global_core_system.rs
@@ -17,7 +17,7 @@ impl<T: GlobalCoreSystemDispatchFunctions> si_cea::agent::dispatch::IntegrationA
     for GlobalCoreSystemDispatcher<T>
 {
     fn integration_actions(&self) -> &'static [&'static str] {
-        &["create", "edit_phantom", "sync"]
+        &["create", "sync"]
     }
 }
 
@@ -46,7 +46,6 @@ impl<T: GlobalCoreSystemDispatchFunctions + Sync> si_cea::agent::dispatch::Dispa
     ) -> si_cea::CeaResult<()> {
         match entity_event.action_name()? {
             "create" => T::create(mqtt_client, entity_event).await,
-            "edit_phantom" => T::edit_phantom(mqtt_client, entity_event).await,
             "sync" => T::sync(mqtt_client, entity_event).await,
             invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
                 entity_event.integration_service_id()?.to_string(),
@@ -66,11 +65,6 @@ pub trait GlobalCoreSystemDispatchFunctions {
     type EntityEvent: si_cea::EntityEvent + Send;
 
     async fn create(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_phantom(
         mqtt_client: &si_cea::MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> si_cea::CeaResult<()>;

--- a/components/si-core/src/gen/model/application_entity.rs
+++ b/components/si-core/src/gen/model/application_entity.rs
@@ -141,14 +141,6 @@ impl crate::protobuf::ApplicationEntity {
         Ok(result)
     }
 
-    pub fn edit_phantom(&mut self, property: bool) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.phantom = Some(property);
-
-        Ok(())
-    }
-
     pub async fn delete(
         &mut self,
         db: &si_data::Db,

--- a/components/si-core/src/gen/model/application_entity_event.rs
+++ b/components/si-core/src/gen/model/application_entity_event.rs
@@ -62,7 +62,7 @@ impl si_cea::EntityEvent for crate::protobuf::ApplicationEntityEvent {
     type Entity = crate::protobuf::ApplicationEntity;
 
     fn action_names() -> &'static [&'static str] {
-        &["create", "edit_phantom", "sync"]
+        &["create", "sync"]
     }
 
     fn action_name(&self) -> si_data::Result<&str> {

--- a/components/si-core/src/gen/model/service_entity.rs
+++ b/components/si-core/src/gen/model/service_entity.rs
@@ -141,30 +141,6 @@ impl crate::protobuf::ServiceEntity {
         Ok(result)
     }
 
-    pub fn edit_image(&mut self, property: String) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.image = Some(property);
-
-        Ok(())
-    }
-
-    pub fn edit_port(&mut self, property: u32) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.port = Some(property);
-
-        Ok(())
-    }
-
-    pub fn edit_replicas(&mut self, property: u32) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.replicas = Some(property);
-
-        Ok(())
-    }
-
     pub async fn delete(
         &mut self,
         db: &si_data::Db,

--- a/components/si-core/src/gen/model/service_entity_event.rs
+++ b/components/si-core/src/gen/model/service_entity_event.rs
@@ -62,14 +62,7 @@ impl si_cea::EntityEvent for crate::protobuf::ServiceEntityEvent {
     type Entity = crate::protobuf::ServiceEntity;
 
     fn action_names() -> &'static [&'static str] {
-        &[
-            "create",
-            "deploy",
-            "edit_image",
-            "edit_port",
-            "edit_replicas",
-            "sync",
-        ]
+        &["create", "deploy", "sync"]
     }
 
     fn action_name(&self) -> si_data::Result<&str> {

--- a/components/si-core/src/gen/model/system_entity.rs
+++ b/components/si-core/src/gen/model/system_entity.rs
@@ -138,14 +138,6 @@ impl crate::protobuf::SystemEntity {
         Ok(result)
     }
 
-    pub fn edit_phantom(&mut self, property: bool) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.phantom = Some(property);
-
-        Ok(())
-    }
-
     pub async fn delete(
         &mut self,
         db: &si_data::Db,

--- a/components/si-core/src/gen/model/system_entity_event.rs
+++ b/components/si-core/src/gen/model/system_entity_event.rs
@@ -62,7 +62,7 @@ impl si_cea::EntityEvent for crate::protobuf::SystemEntityEvent {
     type Entity = crate::protobuf::SystemEntity;
 
     fn action_names() -> &'static [&'static str] {
-        &["create", "edit_phantom", "sync"]
+        &["create", "sync"]
     }
 
     fn action_name(&self) -> si_data::Result<&str> {

--- a/components/si-core/src/gen/service.rs
+++ b/components/si-core/src/gen/service.rs
@@ -558,91 +558,6 @@ impl crate::protobuf::core_server::Core for Service {
         .await
     }
 
-    async fn application_entity_phantom_edit(
-        &self,
-        request: tonic::Request<crate::protobuf::ApplicationEntityPhantomEditRequest>,
-    ) -> std::result::Result<
-        tonic::Response<crate::protobuf::ApplicationEntityPhantomEditReply>,
-        tonic::Status,
-    > {
-        let span_context =
-            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
-        let span = tracing::span!(
-            tracing::Level::INFO,
-            "core.application_entity_phantom_edit",
-            metadata.content_type = tracing::field::Empty,
-            authenticated = tracing::field::Empty,
-            userId = tracing::field::Empty,
-            billingAccountId = tracing::field::Empty,
-            http.user_agent = tracing::field::Empty,
-        );
-        span.set_parent(&span_context);
-
-        {
-            let metadata = request.metadata();
-            if let Some(raw_value) = metadata.get("authenticated") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("authenticated", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("userid") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("userId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("billingAccountId") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("billingAccountId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("user-agent") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("http.user_agent", &tracing::field::display(value));
-            }
-        }
-
-        async {
-            use si_cea::{Entity, EntityEvent};
-
-            let auth = si_account::authorize::authnz(
-                &self.db,
-                &request,
-                "application_entity_phantom_edit",
-            )
-            .await?;
-
-            let inner = request.into_inner();
-            let id = inner
-                .id
-                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
-            let property = inner
-                .property
-                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
-
-            let mut entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
-            let previous_entity = entity.clone();
-
-            entity.set_entity_state_transition();
-            entity.edit_phantom(property)?;
-            entity.save(&self.db).await?;
-
-            let entity_event =
-                crate::protobuf::ApplicationEntityEvent::create_with_previous_entity(
-                    &self.db,
-                    auth.user_id(),
-                    "edit_phantom",
-                    &entity,
-                    previous_entity,
-                )
-                .await?;
-
-            Ok(tonic::Response::new(
-                crate::protobuf::ApplicationEntityPhantomEditReply {
-                    item: Some(entity_event),
-                },
-            ))
-        }
-        .instrument(span)
-        .await
-    }
-
     async fn application_entity_sync(
         &self,
         request: tonic::Request<crate::protobuf::ApplicationEntitySyncRequest>,
@@ -693,12 +608,16 @@ impl crate::protobuf::core_server::Core for Service {
             let id = inner
                 .id
                 .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let change_set_id = inner
+                .change_set_id
+                .ok_or_else(|| si_data::DataError::RequiredField("changeSetId".to_string()))?;
 
             let entity = crate::protobuf::ApplicationEntity::get(&self.db, &id).await?;
             let entity_event = crate::protobuf::ApplicationEntityEvent::create(
                 &self.db,
                 auth.user_id(),
                 "sync",
+                &change_set_id,
                 &entity,
             )
             .await?;
@@ -1295,12 +1214,16 @@ impl crate::protobuf::core_server::Core for Service {
             let id = inner
                 .id
                 .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let change_set_id = inner
+                .change_set_id
+                .ok_or_else(|| si_data::DataError::RequiredField("changeSetId".to_string()))?;
 
             let entity = crate::protobuf::ServiceEntity::get(&self.db, &id).await?;
             let entity_event = crate::protobuf::ServiceEntityEvent::create(
                 &self.db,
                 auth.user_id(),
                 "deploy",
+                &change_set_id,
                 &entity,
             )
             .await?;
@@ -1371,87 +1294,6 @@ impl crate::protobuf::core_server::Core for Service {
         .await
     }
 
-    async fn service_entity_image_edit(
-        &self,
-        request: tonic::Request<crate::protobuf::ServiceEntityImageEditRequest>,
-    ) -> std::result::Result<
-        tonic::Response<crate::protobuf::ServiceEntityImageEditReply>,
-        tonic::Status,
-    > {
-        let span_context =
-            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
-        let span = tracing::span!(
-            tracing::Level::INFO,
-            "core.service_entity_image_edit",
-            metadata.content_type = tracing::field::Empty,
-            authenticated = tracing::field::Empty,
-            userId = tracing::field::Empty,
-            billingAccountId = tracing::field::Empty,
-            http.user_agent = tracing::field::Empty,
-        );
-        span.set_parent(&span_context);
-
-        {
-            let metadata = request.metadata();
-            if let Some(raw_value) = metadata.get("authenticated") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("authenticated", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("userid") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("userId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("billingAccountId") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("billingAccountId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("user-agent") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("http.user_agent", &tracing::field::display(value));
-            }
-        }
-
-        async {
-            use si_cea::{Entity, EntityEvent};
-
-            let auth =
-                si_account::authorize::authnz(&self.db, &request, "service_entity_image_edit")
-                    .await?;
-
-            let inner = request.into_inner();
-            let id = inner
-                .id
-                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
-            let property = inner
-                .property
-                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
-
-            let mut entity = crate::protobuf::ServiceEntity::get(&self.db, &id).await?;
-            let previous_entity = entity.clone();
-
-            entity.set_entity_state_transition();
-            entity.edit_image(property)?;
-            entity.save(&self.db).await?;
-
-            let entity_event = crate::protobuf::ServiceEntityEvent::create_with_previous_entity(
-                &self.db,
-                auth.user_id(),
-                "edit_image",
-                &entity,
-                previous_entity,
-            )
-            .await?;
-
-            Ok(tonic::Response::new(
-                crate::protobuf::ServiceEntityImageEditReply {
-                    item: Some(entity_event),
-                },
-            ))
-        }
-        .instrument(span)
-        .await
-    }
-
     async fn service_entity_list(
         &self,
         request: tonic::Request<crate::protobuf::ServiceEntityListRequest>,
@@ -1514,168 +1356,6 @@ impl crate::protobuf::core_server::Core for Service {
         .await
     }
 
-    async fn service_entity_port_edit(
-        &self,
-        request: tonic::Request<crate::protobuf::ServiceEntityPortEditRequest>,
-    ) -> std::result::Result<
-        tonic::Response<crate::protobuf::ServiceEntityPortEditReply>,
-        tonic::Status,
-    > {
-        let span_context =
-            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
-        let span = tracing::span!(
-            tracing::Level::INFO,
-            "core.service_entity_port_edit",
-            metadata.content_type = tracing::field::Empty,
-            authenticated = tracing::field::Empty,
-            userId = tracing::field::Empty,
-            billingAccountId = tracing::field::Empty,
-            http.user_agent = tracing::field::Empty,
-        );
-        span.set_parent(&span_context);
-
-        {
-            let metadata = request.metadata();
-            if let Some(raw_value) = metadata.get("authenticated") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("authenticated", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("userid") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("userId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("billingAccountId") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("billingAccountId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("user-agent") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("http.user_agent", &tracing::field::display(value));
-            }
-        }
-
-        async {
-            use si_cea::{Entity, EntityEvent};
-
-            let auth =
-                si_account::authorize::authnz(&self.db, &request, "service_entity_port_edit")
-                    .await?;
-
-            let inner = request.into_inner();
-            let id = inner
-                .id
-                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
-            let property = inner
-                .property
-                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
-
-            let mut entity = crate::protobuf::ServiceEntity::get(&self.db, &id).await?;
-            let previous_entity = entity.clone();
-
-            entity.set_entity_state_transition();
-            entity.edit_port(property)?;
-            entity.save(&self.db).await?;
-
-            let entity_event = crate::protobuf::ServiceEntityEvent::create_with_previous_entity(
-                &self.db,
-                auth.user_id(),
-                "edit_port",
-                &entity,
-                previous_entity,
-            )
-            .await?;
-
-            Ok(tonic::Response::new(
-                crate::protobuf::ServiceEntityPortEditReply {
-                    item: Some(entity_event),
-                },
-            ))
-        }
-        .instrument(span)
-        .await
-    }
-
-    async fn service_entity_replicas_edit(
-        &self,
-        request: tonic::Request<crate::protobuf::ServiceEntityReplicasEditRequest>,
-    ) -> std::result::Result<
-        tonic::Response<crate::protobuf::ServiceEntityReplicasEditReply>,
-        tonic::Status,
-    > {
-        let span_context =
-            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
-        let span = tracing::span!(
-            tracing::Level::INFO,
-            "core.service_entity_replicas_edit",
-            metadata.content_type = tracing::field::Empty,
-            authenticated = tracing::field::Empty,
-            userId = tracing::field::Empty,
-            billingAccountId = tracing::field::Empty,
-            http.user_agent = tracing::field::Empty,
-        );
-        span.set_parent(&span_context);
-
-        {
-            let metadata = request.metadata();
-            if let Some(raw_value) = metadata.get("authenticated") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("authenticated", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("userid") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("userId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("billingAccountId") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("billingAccountId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("user-agent") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("http.user_agent", &tracing::field::display(value));
-            }
-        }
-
-        async {
-            use si_cea::{Entity, EntityEvent};
-
-            let auth =
-                si_account::authorize::authnz(&self.db, &request, "service_entity_replicas_edit")
-                    .await?;
-
-            let inner = request.into_inner();
-            let id = inner
-                .id
-                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
-            let property = inner
-                .property
-                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
-
-            let mut entity = crate::protobuf::ServiceEntity::get(&self.db, &id).await?;
-            let previous_entity = entity.clone();
-
-            entity.set_entity_state_transition();
-            entity.edit_replicas(property)?;
-            entity.save(&self.db).await?;
-
-            let entity_event = crate::protobuf::ServiceEntityEvent::create_with_previous_entity(
-                &self.db,
-                auth.user_id(),
-                "edit_replicas",
-                &entity,
-                previous_entity,
-            )
-            .await?;
-
-            Ok(tonic::Response::new(
-                crate::protobuf::ServiceEntityReplicasEditReply {
-                    item: Some(entity_event),
-                },
-            ))
-        }
-        .instrument(span)
-        .await
-    }
-
     async fn service_entity_sync(
         &self,
         request: tonic::Request<crate::protobuf::ServiceEntitySyncRequest>,
@@ -1724,12 +1404,16 @@ impl crate::protobuf::core_server::Core for Service {
             let id = inner
                 .id
                 .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let change_set_id = inner
+                .change_set_id
+                .ok_or_else(|| si_data::DataError::RequiredField("changeSetId".to_string()))?;
 
             let entity = crate::protobuf::ServiceEntity::get(&self.db, &id).await?;
             let entity_event = crate::protobuf::ServiceEntityEvent::create(
                 &self.db,
                 auth.user_id(),
                 "sync",
+                &change_set_id,
                 &entity,
             )
             .await?;
@@ -2388,87 +2072,6 @@ impl crate::protobuf::core_server::Core for Service {
         .await
     }
 
-    async fn system_entity_phantom_edit(
-        &self,
-        request: tonic::Request<crate::protobuf::SystemEntityPhantomEditRequest>,
-    ) -> std::result::Result<
-        tonic::Response<crate::protobuf::SystemEntityPhantomEditReply>,
-        tonic::Status,
-    > {
-        let span_context =
-            opentelemetry::api::TraceContextPropagator::new().extract(request.metadata());
-        let span = tracing::span!(
-            tracing::Level::INFO,
-            "core.system_entity_phantom_edit",
-            metadata.content_type = tracing::field::Empty,
-            authenticated = tracing::field::Empty,
-            userId = tracing::field::Empty,
-            billingAccountId = tracing::field::Empty,
-            http.user_agent = tracing::field::Empty,
-        );
-        span.set_parent(&span_context);
-
-        {
-            let metadata = request.metadata();
-            if let Some(raw_value) = metadata.get("authenticated") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("authenticated", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("userid") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("userId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("billingAccountId") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("billingAccountId", &tracing::field::display(value));
-            }
-            if let Some(raw_value) = metadata.get("user-agent") {
-                let value = raw_value.to_str().unwrap_or("unserializable");
-                span.record("http.user_agent", &tracing::field::display(value));
-            }
-        }
-
-        async {
-            use si_cea::{Entity, EntityEvent};
-
-            let auth =
-                si_account::authorize::authnz(&self.db, &request, "system_entity_phantom_edit")
-                    .await?;
-
-            let inner = request.into_inner();
-            let id = inner
-                .id
-                .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
-            let property = inner
-                .property
-                .ok_or_else(|| si_data::DataError::RequiredField("property".to_string()))?;
-
-            let mut entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
-            let previous_entity = entity.clone();
-
-            entity.set_entity_state_transition();
-            entity.edit_phantom(property)?;
-            entity.save(&self.db).await?;
-
-            let entity_event = crate::protobuf::SystemEntityEvent::create_with_previous_entity(
-                &self.db,
-                auth.user_id(),
-                "edit_phantom",
-                &entity,
-                previous_entity,
-            )
-            .await?;
-
-            Ok(tonic::Response::new(
-                crate::protobuf::SystemEntityPhantomEditReply {
-                    item: Some(entity_event),
-                },
-            ))
-        }
-        .instrument(span)
-        .await
-    }
-
     async fn system_entity_sync(
         &self,
         request: tonic::Request<crate::protobuf::SystemEntitySyncRequest>,
@@ -2517,12 +2120,16 @@ impl crate::protobuf::core_server::Core for Service {
             let id = inner
                 .id
                 .ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+            let change_set_id = inner
+                .change_set_id
+                .ok_or_else(|| si_data::DataError::RequiredField("changeSetId".to_string()))?;
 
             let entity = crate::protobuf::SystemEntity::get(&self.db, &id).await?;
             let entity_event = crate::protobuf::SystemEntityEvent::create(
                 &self.db,
                 auth.user_id(),
                 "sync",
+                &change_set_id,
                 &entity,
             )
             .await?;

--- a/components/si-graphql-api/fullstack-schema.graphql
+++ b/components/si-graphql-api/fullstack-schema.graphql
@@ -303,21 +303,6 @@ input ApplicationEntityListRequest {
   scopeByTenantId: String
 }
 
-"""Edit Phantom Property Reply"""
-type ApplicationEntityPhantomEditReply {
-  """Entity Event"""
-  item: ApplicationEntityEvent
-}
-
-"""Edit Phantom Property Request"""
-input ApplicationEntityPhantomEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Phantom Data property value"""
-  property: Boolean
-}
-
 type ApplicationEntityProperties {
   """Phantom Data"""
   phantom: Boolean
@@ -336,6 +321,9 @@ type ApplicationEntitySyncReply {
 
 """Sync State Request"""
 input ApplicationEntitySyncRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -1536,6 +1524,9 @@ type KubernetesDeploymentEntityApplyReply {
 
 """Apply Request"""
 input KubernetesDeploymentEntityApplyRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -1686,40 +1677,6 @@ input KubernetesDeploymentEntityGetRequest {
   id: ID
 }
 
-"""
-Edit kubernetesDeploymentEntityPropertiesKubernetesObject Property Reply
-"""
-type KubernetesDeploymentEntityKubernetesObjectEditReply {
-  """Entity Event"""
-  item: KubernetesDeploymentEntityEvent
-}
-
-"""
-Edit kubernetesDeploymentEntityPropertiesKubernetesObject Property Request
-"""
-input KubernetesDeploymentEntityKubernetesObjectEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Kubernetes Object property value"""
-  property: KubernetesDeploymentEntityPropertiesKubernetesObjectRequest
-}
-
-"""Edit KubernetesObjectYaml Property Reply"""
-type KubernetesDeploymentEntityKubernetesObjectYamlEditReply {
-  """Entity Event"""
-  item: KubernetesDeploymentEntityEvent
-}
-
-"""Edit KubernetesObjectYaml Property Request"""
-input KubernetesDeploymentEntityKubernetesObjectYamlEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Kubernetes Object YAML property value"""
-  property: String
-}
-
 """List Kubernetes Deployment Object Entity Reply"""
 type KubernetesDeploymentEntityListReply {
   """Items"""
@@ -1827,6 +1784,9 @@ type KubernetesDeploymentEntitySyncReply {
 
 """Sync State Request"""
 input KubernetesDeploymentEntitySyncRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -2232,38 +2192,6 @@ input KubernetesServiceEntityGetRequest {
   id: ID
 }
 
-"""Edit kubernetesServiceEntityPropertiesKubernetesObject Property Reply"""
-type KubernetesServiceEntityKubernetesObjectEditReply {
-  """Entity Event"""
-  item: KubernetesServiceEntityEvent
-}
-
-"""
-Edit kubernetesServiceEntityPropertiesKubernetesObject Property Request
-"""
-input KubernetesServiceEntityKubernetesObjectEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Kubernetes Object property value"""
-  property: KubernetesServiceEntityPropertiesKubernetesObjectRequest
-}
-
-"""Edit KubernetesObjectYaml Property Reply"""
-type KubernetesServiceEntityKubernetesObjectYamlEditReply {
-  """Entity Event"""
-  item: KubernetesServiceEntityEvent
-}
-
-"""Edit KubernetesObjectYaml Property Request"""
-input KubernetesServiceEntityKubernetesObjectYamlEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Kubernetes Object YAML property value"""
-  property: String
-}
-
 """List Kubernetes Service Object Entity Reply"""
 type KubernetesServiceEntityListReply {
   """Items"""
@@ -2509,6 +2437,9 @@ type KubernetesServiceEntitySyncReply {
 
 """Sync State Request"""
 input KubernetesServiceEntitySyncRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -2620,7 +2551,6 @@ input MatchLabelsRequest {
 type Mutation {
   applicationEntityCreate(input: ApplicationEntityCreateRequest): ApplicationEntityCreateReply
   applicationEntityDelete(input: ApplicationEntityDeleteRequest): ApplicationEntityDeleteReply
-  applicationEntityPhantomEdit(input: ApplicationEntityPhantomEditRequest): ApplicationEntityPhantomEditReply
   applicationEntitySync(input: ApplicationEntitySyncRequest): ApplicationEntitySyncReply
   applicationEntityUpdate(input: ApplicationEntityUpdateRequest): ApplicationEntityUpdateReply
   billingAccountSignup(input: BillingAccountSignupRequest): BillingAccountSignupReply
@@ -2630,28 +2560,20 @@ type Mutation {
   kubernetesDeploymentEntityApply(input: KubernetesDeploymentEntityApplyRequest): KubernetesDeploymentEntityApplyReply
   kubernetesDeploymentEntityCreate(input: KubernetesDeploymentEntityCreateRequest): KubernetesDeploymentEntityCreateReply
   kubernetesDeploymentEntityDelete(input: KubernetesDeploymentEntityDeleteRequest): KubernetesDeploymentEntityDeleteReply
-  kubernetesDeploymentEntityKubernetesObjectEdit(input: KubernetesDeploymentEntityKubernetesObjectEditRequest): KubernetesDeploymentEntityKubernetesObjectEditReply
-  kubernetesDeploymentEntityKubernetesObjectYamlEdit(input: KubernetesDeploymentEntityKubernetesObjectYamlEditRequest): KubernetesDeploymentEntityKubernetesObjectYamlEditReply
   kubernetesDeploymentEntitySync(input: KubernetesDeploymentEntitySyncRequest): KubernetesDeploymentEntitySyncReply
   kubernetesDeploymentEntityUpdate(input: KubernetesDeploymentEntityUpdateRequest): KubernetesDeploymentEntityUpdateReply
   kubernetesServiceEntityCreate(input: KubernetesServiceEntityCreateRequest): KubernetesServiceEntityCreateReply
   kubernetesServiceEntityDelete(input: KubernetesServiceEntityDeleteRequest): KubernetesServiceEntityDeleteReply
-  kubernetesServiceEntityKubernetesObjectEdit(input: KubernetesServiceEntityKubernetesObjectEditRequest): KubernetesServiceEntityKubernetesObjectEditReply
-  kubernetesServiceEntityKubernetesObjectYamlEdit(input: KubernetesServiceEntityKubernetesObjectYamlEditRequest): KubernetesServiceEntityKubernetesObjectYamlEditReply
   kubernetesServiceEntitySync(input: KubernetesServiceEntitySyncRequest): KubernetesServiceEntitySyncReply
   kubernetesServiceEntityUpdate(input: KubernetesServiceEntityUpdateRequest): KubernetesServiceEntityUpdateReply
   organizationCreate(input: OrganizationCreateRequest): OrganizationCreateReply
   serviceEntityCreate(input: ServiceEntityCreateRequest): ServiceEntityCreateReply
   serviceEntityDelete(input: ServiceEntityDeleteRequest): ServiceEntityDeleteReply
   serviceEntityDeploy(input: ServiceEntityDeployRequest): ServiceEntityDeployReply
-  serviceEntityImageEdit(input: ServiceEntityImageEditRequest): ServiceEntityImageEditReply
-  serviceEntityPortEdit(input: ServiceEntityPortEditRequest): ServiceEntityPortEditReply
-  serviceEntityReplicasEdit(input: ServiceEntityReplicasEditRequest): ServiceEntityReplicasEditReply
   serviceEntitySync(input: ServiceEntitySyncRequest): ServiceEntitySyncReply
   serviceEntityUpdate(input: ServiceEntityUpdateRequest): ServiceEntityUpdateReply
   systemEntityCreate(input: SystemEntityCreateRequest): SystemEntityCreateReply
   systemEntityDelete(input: SystemEntityDeleteRequest): SystemEntityDeleteReply
-  systemEntityPhantomEdit(input: SystemEntityPhantomEditRequest): SystemEntityPhantomEditReply
   systemEntitySync(input: SystemEntitySyncRequest): SystemEntitySyncReply
   systemEntityUpdate(input: SystemEntityUpdateRequest): SystemEntityUpdateReply
   userCreate(input: UserCreateRequest): UserCreateReply
@@ -3001,6 +2923,9 @@ type ServiceEntityDeployReply {
 
 """Deploy Request"""
 input ServiceEntityDeployRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -3100,21 +3025,6 @@ input ServiceEntityGetRequest {
   id: ID
 }
 
-"""Edit Image Property Reply"""
-type ServiceEntityImageEditReply {
-  """Entity Event"""
-  item: ServiceEntityEvent
-}
-
-"""Edit Image Property Request"""
-input ServiceEntityImageEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Container Image property value"""
-  property: String
-}
-
 """List Service Entity Reply"""
 type ServiceEntityListReply {
   """Items"""
@@ -3148,21 +3058,6 @@ input ServiceEntityListRequest {
   scopeByTenantId: String
 }
 
-"""Edit Port Property Reply"""
-type ServiceEntityPortEditReply {
-  """Entity Event"""
-  item: ServiceEntityEvent
-}
-
-"""Edit Port Property Request"""
-input ServiceEntityPortEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Container Port property value"""
-  property: String
-}
-
 type ServiceEntityProperties {
   """Container Image"""
   image: String
@@ -3185,21 +3080,6 @@ input ServiceEntityPropertiesRequest {
   replicas: String
 }
 
-"""Edit Replicas Property Reply"""
-type ServiceEntityReplicasEditReply {
-  """Entity Event"""
-  item: ServiceEntityEvent
-}
-
-"""Edit Replicas Property Request"""
-input ServiceEntityReplicasEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Replicas property value"""
-  property: String
-}
-
 """Sync State Reply"""
 type ServiceEntitySyncReply {
   """Entity Event"""
@@ -3208,6 +3088,9 @@ type ServiceEntitySyncReply {
 
 """Sync State Request"""
 input ServiceEntitySyncRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }
@@ -3545,21 +3428,6 @@ input SystemEntityListRequest {
   scopeByTenantId: String
 }
 
-"""Edit Phantom Property Reply"""
-type SystemEntityPhantomEditReply {
-  """Entity Event"""
-  item: SystemEntityEvent
-}
-
-"""Edit Phantom Property Request"""
-input SystemEntityPhantomEditRequest {
-  """Entity ID"""
-  id: ID
-
-  """The Phantom Data property value"""
-  property: Boolean
-}
-
 type SystemEntityProperties {
   """Phantom Data"""
   phantom: Boolean
@@ -3578,6 +3446,9 @@ type SystemEntitySyncReply {
 
 """Sync State Request"""
 input SystemEntitySyncRequest {
+  """Change Set ID"""
+  changeSetId: String
+
   """Entity ID"""
   id: ID
 }

--- a/components/si-graphql-api/fullstack-typegen.ts
+++ b/components/si-graphql-api/fullstack-typegen.ts
@@ -64,14 +64,11 @@ export interface NexusGenInputs {
     query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
     scopeByTenantId?: string | null; // String
   }
-  ApplicationEntityPhantomEditRequest: { // input type
-    id?: string | null; // ID
-    property?: boolean | null; // Boolean
-  }
   ApplicationEntityPropertiesRequest: { // input type
     phantom?: boolean | null; // Boolean
   }
   ApplicationEntitySyncRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   ApplicationEntityUpdateRequest: { // input type
@@ -240,6 +237,7 @@ export interface NexusGenInputs {
     constraints?: NexusGenInputs['KubernetesDeploymentComponentConstraintsRequest'] | null; // KubernetesDeploymentComponentConstraintsRequest
   }
   KubernetesDeploymentEntityApplyRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   KubernetesDeploymentEntityCreateRequest: { // input type
@@ -266,14 +264,6 @@ export interface NexusGenInputs {
   KubernetesDeploymentEntityGetRequest: { // input type
     id?: string | null; // ID
   }
-  KubernetesDeploymentEntityKubernetesObjectEditRequest: { // input type
-    id?: string | null; // ID
-    property?: NexusGenInputs['KubernetesDeploymentEntityPropertiesKubernetesObjectRequest'] | null; // KubernetesDeploymentEntityPropertiesKubernetesObjectRequest
-  }
-  KubernetesDeploymentEntityKubernetesObjectYamlEditRequest: { // input type
-    id?: string | null; // ID
-    property?: string | null; // String
-  }
   KubernetesDeploymentEntityListRequest: { // input type
     orderBy?: string | null; // String
     orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
@@ -298,6 +288,7 @@ export interface NexusGenInputs {
     kubernetesObjectYaml?: string | null; // String
   }
   KubernetesDeploymentEntitySyncRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   KubernetesDeploymentEntityUpdateRequest: { // input type
@@ -375,14 +366,6 @@ export interface NexusGenInputs {
   KubernetesServiceEntityGetRequest: { // input type
     id?: string | null; // ID
   }
-  KubernetesServiceEntityKubernetesObjectEditRequest: { // input type
-    id?: string | null; // ID
-    property?: NexusGenInputs['KubernetesServiceEntityPropertiesKubernetesObjectRequest'] | null; // KubernetesServiceEntityPropertiesKubernetesObjectRequest
-  }
-  KubernetesServiceEntityKubernetesObjectYamlEditRequest: { // input type
-    id?: string | null; // ID
-    property?: string | null; // String
-  }
   KubernetesServiceEntityListRequest: { // input type
     orderBy?: string | null; // String
     orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
@@ -429,6 +412,7 @@ export interface NexusGenInputs {
     kubernetesObjectYaml?: string | null; // String
   }
   KubernetesServiceEntitySyncRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   KubernetesServiceEntityUpdateRequest: { // input type
@@ -509,6 +493,7 @@ export interface NexusGenInputs {
     id?: string | null; // ID
   }
   ServiceEntityDeployRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   ServiceEntityEventListRequest: { // input type
@@ -522,10 +507,6 @@ export interface NexusGenInputs {
   ServiceEntityGetRequest: { // input type
     id?: string | null; // ID
   }
-  ServiceEntityImageEditRequest: { // input type
-    id?: string | null; // ID
-    property?: string | null; // String
-  }
   ServiceEntityListRequest: { // input type
     orderBy?: string | null; // String
     orderByDirection?: NexusGenEnums['DataPageTokenOrderByDirection'] | null; // DataPageTokenOrderByDirection
@@ -534,20 +515,13 @@ export interface NexusGenInputs {
     query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
     scopeByTenantId?: string | null; // String
   }
-  ServiceEntityPortEditRequest: { // input type
-    id?: string | null; // ID
-    property?: string | null; // String
-  }
   ServiceEntityPropertiesRequest: { // input type
     image?: string | null; // String
     port?: string | null; // String
     replicas?: string | null; // String
   }
-  ServiceEntityReplicasEditRequest: { // input type
-    id?: string | null; // ID
-    property?: string | null; // String
-  }
   ServiceEntitySyncRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   ServiceEntityUpdateRequest: { // input type
@@ -611,14 +585,11 @@ export interface NexusGenInputs {
     query?: NexusGenInputs['DataQueryRequest'] | null; // DataQueryRequest
     scopeByTenantId?: string | null; // String
   }
-  SystemEntityPhantomEditRequest: { // input type
-    id?: string | null; // ID
-    property?: boolean | null; // Boolean
-  }
   SystemEntityPropertiesRequest: { // input type
     phantom?: boolean | null; // Boolean
   }
   SystemEntitySyncRequest: { // input type
+    changeSetId?: string | null; // String
     id?: string | null; // ID
   }
   SystemEntityUpdateRequest: { // input type
@@ -771,9 +742,6 @@ export interface NexusGenRootTypes {
     items?: NexusGenRootTypes['ApplicationEntity'][] | null; // [ApplicationEntity!]
     nextPageToken?: string | null; // String
     totalCount?: string | null; // String
-  }
-  ApplicationEntityPhantomEditReply: { // root type
-    item?: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
   }
   ApplicationEntityProperties: { // root type
     phantom?: boolean | null; // Boolean
@@ -1096,12 +1064,6 @@ export interface NexusGenRootTypes {
   KubernetesDeploymentEntityGetReply: { // root type
     item?: NexusGenRootTypes['KubernetesDeploymentEntity'] | null; // KubernetesDeploymentEntity
   }
-  KubernetesDeploymentEntityKubernetesObjectEditReply: { // root type
-    item?: NexusGenRootTypes['KubernetesDeploymentEntityEvent'] | null; // KubernetesDeploymentEntityEvent
-  }
-  KubernetesDeploymentEntityKubernetesObjectYamlEditReply: { // root type
-    item?: NexusGenRootTypes['KubernetesDeploymentEntityEvent'] | null; // KubernetesDeploymentEntityEvent
-  }
   KubernetesDeploymentEntityListReply: { // root type
     items?: NexusGenRootTypes['KubernetesDeploymentEntity'][] | null; // [KubernetesDeploymentEntity!]
     nextPageToken?: string | null; // String
@@ -1218,12 +1180,6 @@ export interface NexusGenRootTypes {
   }
   KubernetesServiceEntityGetReply: { // root type
     item?: NexusGenRootTypes['KubernetesServiceEntity'] | null; // KubernetesServiceEntity
-  }
-  KubernetesServiceEntityKubernetesObjectEditReply: { // root type
-    item?: NexusGenRootTypes['KubernetesServiceEntityEvent'] | null; // KubernetesServiceEntityEvent
-  }
-  KubernetesServiceEntityKubernetesObjectYamlEditReply: { // root type
-    item?: NexusGenRootTypes['KubernetesServiceEntityEvent'] | null; // KubernetesServiceEntityEvent
   }
   KubernetesServiceEntityListReply: { // root type
     items?: NexusGenRootTypes['KubernetesServiceEntity'][] | null; // [KubernetesServiceEntity!]
@@ -1385,24 +1341,15 @@ export interface NexusGenRootTypes {
   ServiceEntityGetReply: { // root type
     item?: NexusGenRootTypes['ServiceEntity'] | null; // ServiceEntity
   }
-  ServiceEntityImageEditReply: { // root type
-    item?: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
-  }
   ServiceEntityListReply: { // root type
     items?: NexusGenRootTypes['ServiceEntity'][] | null; // [ServiceEntity!]
     nextPageToken?: string | null; // String
     totalCount?: string | null; // String
   }
-  ServiceEntityPortEditReply: { // root type
-    item?: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
-  }
   ServiceEntityProperties: { // root type
     image?: string | null; // String
     port?: string | null; // String
     replicas?: string | null; // String
-  }
-  ServiceEntityReplicasEditReply: { // root type
-    item?: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
   }
   ServiceEntitySyncReply: { // root type
     item?: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
@@ -1483,9 +1430,6 @@ export interface NexusGenRootTypes {
     nextPageToken?: string | null; // String
     totalCount?: string | null; // String
   }
-  SystemEntityPhantomEditReply: { // root type
-    item?: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
-  }
   SystemEntityProperties: { // root type
     phantom?: boolean | null; // Boolean
   }
@@ -1564,7 +1508,6 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   ApplicationEntityEventListRequest: NexusGenInputs['ApplicationEntityEventListRequest'];
   ApplicationEntityGetRequest: NexusGenInputs['ApplicationEntityGetRequest'];
   ApplicationEntityListRequest: NexusGenInputs['ApplicationEntityListRequest'];
-  ApplicationEntityPhantomEditRequest: NexusGenInputs['ApplicationEntityPhantomEditRequest'];
   ApplicationEntityPropertiesRequest: NexusGenInputs['ApplicationEntityPropertiesRequest'];
   ApplicationEntitySyncRequest: NexusGenInputs['ApplicationEntitySyncRequest'];
   ApplicationEntityUpdateRequest: NexusGenInputs['ApplicationEntityUpdateRequest'];
@@ -1604,8 +1547,6 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   KubernetesDeploymentEntityDeleteRequest: NexusGenInputs['KubernetesDeploymentEntityDeleteRequest'];
   KubernetesDeploymentEntityEventListRequest: NexusGenInputs['KubernetesDeploymentEntityEventListRequest'];
   KubernetesDeploymentEntityGetRequest: NexusGenInputs['KubernetesDeploymentEntityGetRequest'];
-  KubernetesDeploymentEntityKubernetesObjectEditRequest: NexusGenInputs['KubernetesDeploymentEntityKubernetesObjectEditRequest'];
-  KubernetesDeploymentEntityKubernetesObjectYamlEditRequest: NexusGenInputs['KubernetesDeploymentEntityKubernetesObjectYamlEditRequest'];
   KubernetesDeploymentEntityListRequest: NexusGenInputs['KubernetesDeploymentEntityListRequest'];
   KubernetesDeploymentEntityPropertiesKubernetesObjectRequest: NexusGenInputs['KubernetesDeploymentEntityPropertiesKubernetesObjectRequest'];
   KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest: NexusGenInputs['KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest'];
@@ -1627,8 +1568,6 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   KubernetesServiceEntityDeleteRequest: NexusGenInputs['KubernetesServiceEntityDeleteRequest'];
   KubernetesServiceEntityEventListRequest: NexusGenInputs['KubernetesServiceEntityEventListRequest'];
   KubernetesServiceEntityGetRequest: NexusGenInputs['KubernetesServiceEntityGetRequest'];
-  KubernetesServiceEntityKubernetesObjectEditRequest: NexusGenInputs['KubernetesServiceEntityKubernetesObjectEditRequest'];
-  KubernetesServiceEntityKubernetesObjectYamlEditRequest: NexusGenInputs['KubernetesServiceEntityKubernetesObjectYamlEditRequest'];
   KubernetesServiceEntityListRequest: NexusGenInputs['KubernetesServiceEntityListRequest'];
   KubernetesServiceEntityPropertiesKubernetesObjectRequest: NexusGenInputs['KubernetesServiceEntityPropertiesKubernetesObjectRequest'];
   KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest: NexusGenInputs['KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest'];
@@ -1655,11 +1594,8 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   ServiceEntityDeployRequest: NexusGenInputs['ServiceEntityDeployRequest'];
   ServiceEntityEventListRequest: NexusGenInputs['ServiceEntityEventListRequest'];
   ServiceEntityGetRequest: NexusGenInputs['ServiceEntityGetRequest'];
-  ServiceEntityImageEditRequest: NexusGenInputs['ServiceEntityImageEditRequest'];
   ServiceEntityListRequest: NexusGenInputs['ServiceEntityListRequest'];
-  ServiceEntityPortEditRequest: NexusGenInputs['ServiceEntityPortEditRequest'];
   ServiceEntityPropertiesRequest: NexusGenInputs['ServiceEntityPropertiesRequest'];
-  ServiceEntityReplicasEditRequest: NexusGenInputs['ServiceEntityReplicasEditRequest'];
   ServiceEntitySyncRequest: NexusGenInputs['ServiceEntitySyncRequest'];
   ServiceEntityUpdateRequest: NexusGenInputs['ServiceEntityUpdateRequest'];
   ServiceEntityUpdateRequestUpdateRequest: NexusGenInputs['ServiceEntityUpdateRequestUpdateRequest'];
@@ -1672,7 +1608,6 @@ export interface NexusGenAllTypes extends NexusGenRootTypes {
   SystemEntityEventListRequest: NexusGenInputs['SystemEntityEventListRequest'];
   SystemEntityGetRequest: NexusGenInputs['SystemEntityGetRequest'];
   SystemEntityListRequest: NexusGenInputs['SystemEntityListRequest'];
-  SystemEntityPhantomEditRequest: NexusGenInputs['SystemEntityPhantomEditRequest'];
   SystemEntityPropertiesRequest: NexusGenInputs['SystemEntityPropertiesRequest'];
   SystemEntitySyncRequest: NexusGenInputs['SystemEntitySyncRequest'];
   SystemEntityUpdateRequest: NexusGenInputs['SystemEntityUpdateRequest'];
@@ -1776,9 +1711,6 @@ export interface NexusGenFieldTypes {
     items: NexusGenRootTypes['ApplicationEntity'][] | null; // [ApplicationEntity!]
     nextPageToken: string | null; // String
     totalCount: string | null; // String
-  }
-  ApplicationEntityPhantomEditReply: { // field return type
-    item: NexusGenRootTypes['ApplicationEntityEvent'] | null; // ApplicationEntityEvent
   }
   ApplicationEntityProperties: { // field return type
     phantom: boolean | null; // Boolean
@@ -2134,12 +2066,6 @@ export interface NexusGenFieldTypes {
   KubernetesDeploymentEntityGetReply: { // field return type
     item: NexusGenRootTypes['KubernetesDeploymentEntity'] | null; // KubernetesDeploymentEntity
   }
-  KubernetesDeploymentEntityKubernetesObjectEditReply: { // field return type
-    item: NexusGenRootTypes['KubernetesDeploymentEntityEvent'] | null; // KubernetesDeploymentEntityEvent
-  }
-  KubernetesDeploymentEntityKubernetesObjectYamlEditReply: { // field return type
-    item: NexusGenRootTypes['KubernetesDeploymentEntityEvent'] | null; // KubernetesDeploymentEntityEvent
-  }
   KubernetesDeploymentEntityListReply: { // field return type
     items: NexusGenRootTypes['KubernetesDeploymentEntity'][] | null; // [KubernetesDeploymentEntity!]
     nextPageToken: string | null; // String
@@ -2260,12 +2186,6 @@ export interface NexusGenFieldTypes {
   KubernetesServiceEntityGetReply: { // field return type
     item: NexusGenRootTypes['KubernetesServiceEntity'] | null; // KubernetesServiceEntity
   }
-  KubernetesServiceEntityKubernetesObjectEditReply: { // field return type
-    item: NexusGenRootTypes['KubernetesServiceEntityEvent'] | null; // KubernetesServiceEntityEvent
-  }
-  KubernetesServiceEntityKubernetesObjectYamlEditReply: { // field return type
-    item: NexusGenRootTypes['KubernetesServiceEntityEvent'] | null; // KubernetesServiceEntityEvent
-  }
   KubernetesServiceEntityListReply: { // field return type
     items: NexusGenRootTypes['KubernetesServiceEntity'][] | null; // [KubernetesServiceEntity!]
     nextPageToken: string | null; // String
@@ -2333,7 +2253,6 @@ export interface NexusGenFieldTypes {
   Mutation: { // field return type
     applicationEntityCreate: NexusGenRootTypes['ApplicationEntityCreateReply'] | null; // ApplicationEntityCreateReply
     applicationEntityDelete: NexusGenRootTypes['ApplicationEntityDeleteReply'] | null; // ApplicationEntityDeleteReply
-    applicationEntityPhantomEdit: NexusGenRootTypes['ApplicationEntityPhantomEditReply'] | null; // ApplicationEntityPhantomEditReply
     applicationEntitySync: NexusGenRootTypes['ApplicationEntitySyncReply'] | null; // ApplicationEntitySyncReply
     applicationEntityUpdate: NexusGenRootTypes['ApplicationEntityUpdateReply'] | null; // ApplicationEntityUpdateReply
     billingAccountSignup: NexusGenRootTypes['BillingAccountSignupReply'] | null; // BillingAccountSignupReply
@@ -2343,28 +2262,20 @@ export interface NexusGenFieldTypes {
     kubernetesDeploymentEntityApply: NexusGenRootTypes['KubernetesDeploymentEntityApplyReply'] | null; // KubernetesDeploymentEntityApplyReply
     kubernetesDeploymentEntityCreate: NexusGenRootTypes['KubernetesDeploymentEntityCreateReply'] | null; // KubernetesDeploymentEntityCreateReply
     kubernetesDeploymentEntityDelete: NexusGenRootTypes['KubernetesDeploymentEntityDeleteReply'] | null; // KubernetesDeploymentEntityDeleteReply
-    kubernetesDeploymentEntityKubernetesObjectEdit: NexusGenRootTypes['KubernetesDeploymentEntityKubernetesObjectEditReply'] | null; // KubernetesDeploymentEntityKubernetesObjectEditReply
-    kubernetesDeploymentEntityKubernetesObjectYamlEdit: NexusGenRootTypes['KubernetesDeploymentEntityKubernetesObjectYamlEditReply'] | null; // KubernetesDeploymentEntityKubernetesObjectYamlEditReply
     kubernetesDeploymentEntitySync: NexusGenRootTypes['KubernetesDeploymentEntitySyncReply'] | null; // KubernetesDeploymentEntitySyncReply
     kubernetesDeploymentEntityUpdate: NexusGenRootTypes['KubernetesDeploymentEntityUpdateReply'] | null; // KubernetesDeploymentEntityUpdateReply
     kubernetesServiceEntityCreate: NexusGenRootTypes['KubernetesServiceEntityCreateReply'] | null; // KubernetesServiceEntityCreateReply
     kubernetesServiceEntityDelete: NexusGenRootTypes['KubernetesServiceEntityDeleteReply'] | null; // KubernetesServiceEntityDeleteReply
-    kubernetesServiceEntityKubernetesObjectEdit: NexusGenRootTypes['KubernetesServiceEntityKubernetesObjectEditReply'] | null; // KubernetesServiceEntityKubernetesObjectEditReply
-    kubernetesServiceEntityKubernetesObjectYamlEdit: NexusGenRootTypes['KubernetesServiceEntityKubernetesObjectYamlEditReply'] | null; // KubernetesServiceEntityKubernetesObjectYamlEditReply
     kubernetesServiceEntitySync: NexusGenRootTypes['KubernetesServiceEntitySyncReply'] | null; // KubernetesServiceEntitySyncReply
     kubernetesServiceEntityUpdate: NexusGenRootTypes['KubernetesServiceEntityUpdateReply'] | null; // KubernetesServiceEntityUpdateReply
     organizationCreate: NexusGenRootTypes['OrganizationCreateReply'] | null; // OrganizationCreateReply
     serviceEntityCreate: NexusGenRootTypes['ServiceEntityCreateReply'] | null; // ServiceEntityCreateReply
     serviceEntityDelete: NexusGenRootTypes['ServiceEntityDeleteReply'] | null; // ServiceEntityDeleteReply
     serviceEntityDeploy: NexusGenRootTypes['ServiceEntityDeployReply'] | null; // ServiceEntityDeployReply
-    serviceEntityImageEdit: NexusGenRootTypes['ServiceEntityImageEditReply'] | null; // ServiceEntityImageEditReply
-    serviceEntityPortEdit: NexusGenRootTypes['ServiceEntityPortEditReply'] | null; // ServiceEntityPortEditReply
-    serviceEntityReplicasEdit: NexusGenRootTypes['ServiceEntityReplicasEditReply'] | null; // ServiceEntityReplicasEditReply
     serviceEntitySync: NexusGenRootTypes['ServiceEntitySyncReply'] | null; // ServiceEntitySyncReply
     serviceEntityUpdate: NexusGenRootTypes['ServiceEntityUpdateReply'] | null; // ServiceEntityUpdateReply
     systemEntityCreate: NexusGenRootTypes['SystemEntityCreateReply'] | null; // SystemEntityCreateReply
     systemEntityDelete: NexusGenRootTypes['SystemEntityDeleteReply'] | null; // SystemEntityDeleteReply
-    systemEntityPhantomEdit: NexusGenRootTypes['SystemEntityPhantomEditReply'] | null; // SystemEntityPhantomEditReply
     systemEntitySync: NexusGenRootTypes['SystemEntitySyncReply'] | null; // SystemEntitySyncReply
     systemEntityUpdate: NexusGenRootTypes['SystemEntityUpdateReply'] | null; // SystemEntityUpdateReply
     userCreate: NexusGenRootTypes['UserCreateReply'] | null; // UserCreateReply
@@ -2523,24 +2434,15 @@ export interface NexusGenFieldTypes {
   ServiceEntityGetReply: { // field return type
     item: NexusGenRootTypes['ServiceEntity'] | null; // ServiceEntity
   }
-  ServiceEntityImageEditReply: { // field return type
-    item: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
-  }
   ServiceEntityListReply: { // field return type
     items: NexusGenRootTypes['ServiceEntity'][] | null; // [ServiceEntity!]
     nextPageToken: string | null; // String
     totalCount: string | null; // String
   }
-  ServiceEntityPortEditReply: { // field return type
-    item: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
-  }
   ServiceEntityProperties: { // field return type
     image: string | null; // String
     port: string | null; // String
     replicas: string | null; // String
-  }
-  ServiceEntityReplicasEditReply: { // field return type
-    item: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
   }
   ServiceEntitySyncReply: { // field return type
     item: NexusGenRootTypes['ServiceEntityEvent'] | null; // ServiceEntityEvent
@@ -2620,9 +2522,6 @@ export interface NexusGenFieldTypes {
     items: NexusGenRootTypes['SystemEntity'][] | null; // [SystemEntity!]
     nextPageToken: string | null; // String
     totalCount: string | null; // String
-  }
-  SystemEntityPhantomEditReply: { // field return type
-    item: NexusGenRootTypes['SystemEntityEvent'] | null; // SystemEntityEvent
   }
   SystemEntityProperties: { // field return type
     phantom: boolean | null; // Boolean
@@ -2735,9 +2634,6 @@ export interface NexusGenArgTypes {
     applicationEntityDelete: { // args
       input?: NexusGenInputs['ApplicationEntityDeleteRequest'] | null; // ApplicationEntityDeleteRequest
     }
-    applicationEntityPhantomEdit: { // args
-      input?: NexusGenInputs['ApplicationEntityPhantomEditRequest'] | null; // ApplicationEntityPhantomEditRequest
-    }
     applicationEntitySync: { // args
       input?: NexusGenInputs['ApplicationEntitySyncRequest'] | null; // ApplicationEntitySyncRequest
     }
@@ -2765,12 +2661,6 @@ export interface NexusGenArgTypes {
     kubernetesDeploymentEntityDelete: { // args
       input?: NexusGenInputs['KubernetesDeploymentEntityDeleteRequest'] | null; // KubernetesDeploymentEntityDeleteRequest
     }
-    kubernetesDeploymentEntityKubernetesObjectEdit: { // args
-      input?: NexusGenInputs['KubernetesDeploymentEntityKubernetesObjectEditRequest'] | null; // KubernetesDeploymentEntityKubernetesObjectEditRequest
-    }
-    kubernetesDeploymentEntityKubernetesObjectYamlEdit: { // args
-      input?: NexusGenInputs['KubernetesDeploymentEntityKubernetesObjectYamlEditRequest'] | null; // KubernetesDeploymentEntityKubernetesObjectYamlEditRequest
-    }
     kubernetesDeploymentEntitySync: { // args
       input?: NexusGenInputs['KubernetesDeploymentEntitySyncRequest'] | null; // KubernetesDeploymentEntitySyncRequest
     }
@@ -2782,12 +2672,6 @@ export interface NexusGenArgTypes {
     }
     kubernetesServiceEntityDelete: { // args
       input?: NexusGenInputs['KubernetesServiceEntityDeleteRequest'] | null; // KubernetesServiceEntityDeleteRequest
-    }
-    kubernetesServiceEntityKubernetesObjectEdit: { // args
-      input?: NexusGenInputs['KubernetesServiceEntityKubernetesObjectEditRequest'] | null; // KubernetesServiceEntityKubernetesObjectEditRequest
-    }
-    kubernetesServiceEntityKubernetesObjectYamlEdit: { // args
-      input?: NexusGenInputs['KubernetesServiceEntityKubernetesObjectYamlEditRequest'] | null; // KubernetesServiceEntityKubernetesObjectYamlEditRequest
     }
     kubernetesServiceEntitySync: { // args
       input?: NexusGenInputs['KubernetesServiceEntitySyncRequest'] | null; // KubernetesServiceEntitySyncRequest
@@ -2807,15 +2691,6 @@ export interface NexusGenArgTypes {
     serviceEntityDeploy: { // args
       input?: NexusGenInputs['ServiceEntityDeployRequest'] | null; // ServiceEntityDeployRequest
     }
-    serviceEntityImageEdit: { // args
-      input?: NexusGenInputs['ServiceEntityImageEditRequest'] | null; // ServiceEntityImageEditRequest
-    }
-    serviceEntityPortEdit: { // args
-      input?: NexusGenInputs['ServiceEntityPortEditRequest'] | null; // ServiceEntityPortEditRequest
-    }
-    serviceEntityReplicasEdit: { // args
-      input?: NexusGenInputs['ServiceEntityReplicasEditRequest'] | null; // ServiceEntityReplicasEditRequest
-    }
     serviceEntitySync: { // args
       input?: NexusGenInputs['ServiceEntitySyncRequest'] | null; // ServiceEntitySyncRequest
     }
@@ -2827,9 +2702,6 @@ export interface NexusGenArgTypes {
     }
     systemEntityDelete: { // args
       input?: NexusGenInputs['SystemEntityDeleteRequest'] | null; // SystemEntityDeleteRequest
-    }
-    systemEntityPhantomEdit: { // args
-      input?: NexusGenInputs['SystemEntityPhantomEditRequest'] | null; // SystemEntityPhantomEditRequest
     }
     systemEntitySync: { // args
       input?: NexusGenInputs['SystemEntitySyncRequest'] | null; // SystemEntitySyncRequest
@@ -3013,9 +2885,9 @@ export interface NexusGenAbstractResolveReturnTypes {
 
 export interface NexusGenInheritedFields {}
 
-export type NexusGenObjectNames = "ApplicationComponent" | "ApplicationComponentConstraints" | "ApplicationComponentGetReply" | "ApplicationComponentListReply" | "ApplicationComponentPickReply" | "ApplicationEntity" | "ApplicationEntityCreateReply" | "ApplicationEntityDeleteReply" | "ApplicationEntityEvent" | "ApplicationEntityEventListReply" | "ApplicationEntityGetReply" | "ApplicationEntityListReply" | "ApplicationEntityPhantomEditReply" | "ApplicationEntityProperties" | "ApplicationEntitySyncReply" | "ApplicationEntityUpdateReply" | "BillingAccount" | "BillingAccountAssociations" | "BillingAccountGetReply" | "BillingAccountListReply" | "BillingAccountSignupReply" | "Capability" | "ChangeSet" | "ChangeSetAssociations" | "ChangeSetCreateReply" | "ChangeSetExecuteReply" | "ChangeSetGetReply" | "ChangeSetListReply" | "ChangeSetSiProperties" | "ComponentSiProperties" | "DataPageToken" | "DataQuery" | "DataQueryItems" | "DataQueryItemsExpression" | "DataStorable" | "EntityEventSiProperties" | "EntitySiProperties" | "Group" | "GroupCreateReply" | "GroupGetReply" | "GroupListReply" | "GroupSiProperties" | "Integration" | "IntegrationAssociations" | "IntegrationGetReply" | "IntegrationInstance" | "IntegrationInstanceAssociations" | "IntegrationInstanceGetReply" | "IntegrationInstanceListReply" | "IntegrationInstanceOptionValues" | "IntegrationInstanceSiProperties" | "IntegrationListReply" | "IntegrationOptions" | "IntegrationService" | "IntegrationServiceAssociations" | "IntegrationServiceGetReply" | "IntegrationServiceSiProperties" | "IntegrationSiProperties" | "Item" | "ItemAssociations" | "ItemGetReply" | "ItemListReply" | "ItemSiProperties" | "KubernetesContainer" | "KubernetesContainerPort" | "KubernetesDeploymentComponent" | "KubernetesDeploymentComponentConstraints" | "KubernetesDeploymentComponentGetReply" | "KubernetesDeploymentComponentListReply" | "KubernetesDeploymentComponentPickReply" | "KubernetesDeploymentEntity" | "KubernetesDeploymentEntityApplyReply" | "KubernetesDeploymentEntityAssociations" | "KubernetesDeploymentEntityCreateReply" | "KubernetesDeploymentEntityDeleteReply" | "KubernetesDeploymentEntityEvent" | "KubernetesDeploymentEntityEventListReply" | "KubernetesDeploymentEntityGetReply" | "KubernetesDeploymentEntityKubernetesObjectEditReply" | "KubernetesDeploymentEntityKubernetesObjectYamlEditReply" | "KubernetesDeploymentEntityListReply" | "KubernetesDeploymentEntityProperties" | "KubernetesDeploymentEntityPropertiesKubernetesObject" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpec" | "KubernetesDeploymentEntitySyncReply" | "KubernetesDeploymentEntityUpdateReply" | "KubernetesLoadBalancerStatus" | "KubernetesLoadBalancerStatusIngress" | "KubernetesMetadata" | "KubernetesPodSpec" | "KubernetesPodTemplateSpec" | "KubernetesSelector" | "KubernetesServiceComponent" | "KubernetesServiceComponentConstraints" | "KubernetesServiceComponentGetReply" | "KubernetesServiceComponentListReply" | "KubernetesServiceComponentPickReply" | "KubernetesServiceEntity" | "KubernetesServiceEntityAssociations" | "KubernetesServiceEntityCreateReply" | "KubernetesServiceEntityDeleteReply" | "KubernetesServiceEntityEvent" | "KubernetesServiceEntityEventListReply" | "KubernetesServiceEntityGetReply" | "KubernetesServiceEntityKubernetesObjectEditReply" | "KubernetesServiceEntityKubernetesObjectYamlEditReply" | "KubernetesServiceEntityListReply" | "KubernetesServiceEntityProperties" | "KubernetesServiceEntityPropertiesKubernetesObject" | "KubernetesServiceEntityPropertiesKubernetesObjectSpec" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfig" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIp" | "KubernetesServiceEntityPropertiesKubernetesObjectStatus" | "KubernetesServiceEntitySyncReply" | "KubernetesServiceEntityUpdateReply" | "KubernetesServicePort" | "Labels" | "MatchLabels" | "Mutation" | "Organization" | "OrganizationAssociations" | "OrganizationCreateReply" | "OrganizationGetReply" | "OrganizationListReply" | "OrganizationSiProperties" | "Query" | "ServiceComponent" | "ServiceComponentConstraints" | "ServiceComponentGetReply" | "ServiceComponentListReply" | "ServiceComponentPickReply" | "ServiceEntity" | "ServiceEntityAssociations" | "ServiceEntityCreateReply" | "ServiceEntityDeleteReply" | "ServiceEntityDeployReply" | "ServiceEntityEvent" | "ServiceEntityEventListReply" | "ServiceEntityGetReply" | "ServiceEntityImageEditReply" | "ServiceEntityListReply" | "ServiceEntityPortEditReply" | "ServiceEntityProperties" | "ServiceEntityReplicasEditReply" | "ServiceEntitySyncReply" | "ServiceEntityUpdateReply" | "SystemComponent" | "SystemComponentConstraints" | "SystemComponentGetReply" | "SystemComponentListReply" | "SystemComponentPickReply" | "SystemEntity" | "SystemEntityCreateReply" | "SystemEntityDeleteReply" | "SystemEntityEvent" | "SystemEntityEventListReply" | "SystemEntityGetReply" | "SystemEntityListReply" | "SystemEntityPhantomEditReply" | "SystemEntityProperties" | "SystemEntitySyncReply" | "SystemEntityUpdateReply" | "User" | "UserAssociations" | "UserCreateReply" | "UserGetReply" | "UserListReply" | "UserLoginReply" | "UserSiProperties" | "Workspace" | "WorkspaceAssociations" | "WorkspaceCreateReply" | "WorkspaceGetReply" | "WorkspaceListReply" | "WorkspaceSiProperties";
+export type NexusGenObjectNames = "ApplicationComponent" | "ApplicationComponentConstraints" | "ApplicationComponentGetReply" | "ApplicationComponentListReply" | "ApplicationComponentPickReply" | "ApplicationEntity" | "ApplicationEntityCreateReply" | "ApplicationEntityDeleteReply" | "ApplicationEntityEvent" | "ApplicationEntityEventListReply" | "ApplicationEntityGetReply" | "ApplicationEntityListReply" | "ApplicationEntityProperties" | "ApplicationEntitySyncReply" | "ApplicationEntityUpdateReply" | "BillingAccount" | "BillingAccountAssociations" | "BillingAccountGetReply" | "BillingAccountListReply" | "BillingAccountSignupReply" | "Capability" | "ChangeSet" | "ChangeSetAssociations" | "ChangeSetCreateReply" | "ChangeSetExecuteReply" | "ChangeSetGetReply" | "ChangeSetListReply" | "ChangeSetSiProperties" | "ComponentSiProperties" | "DataPageToken" | "DataQuery" | "DataQueryItems" | "DataQueryItemsExpression" | "DataStorable" | "EntityEventSiProperties" | "EntitySiProperties" | "Group" | "GroupCreateReply" | "GroupGetReply" | "GroupListReply" | "GroupSiProperties" | "Integration" | "IntegrationAssociations" | "IntegrationGetReply" | "IntegrationInstance" | "IntegrationInstanceAssociations" | "IntegrationInstanceGetReply" | "IntegrationInstanceListReply" | "IntegrationInstanceOptionValues" | "IntegrationInstanceSiProperties" | "IntegrationListReply" | "IntegrationOptions" | "IntegrationService" | "IntegrationServiceAssociations" | "IntegrationServiceGetReply" | "IntegrationServiceSiProperties" | "IntegrationSiProperties" | "Item" | "ItemAssociations" | "ItemGetReply" | "ItemListReply" | "ItemSiProperties" | "KubernetesContainer" | "KubernetesContainerPort" | "KubernetesDeploymentComponent" | "KubernetesDeploymentComponentConstraints" | "KubernetesDeploymentComponentGetReply" | "KubernetesDeploymentComponentListReply" | "KubernetesDeploymentComponentPickReply" | "KubernetesDeploymentEntity" | "KubernetesDeploymentEntityApplyReply" | "KubernetesDeploymentEntityAssociations" | "KubernetesDeploymentEntityCreateReply" | "KubernetesDeploymentEntityDeleteReply" | "KubernetesDeploymentEntityEvent" | "KubernetesDeploymentEntityEventListReply" | "KubernetesDeploymentEntityGetReply" | "KubernetesDeploymentEntityListReply" | "KubernetesDeploymentEntityProperties" | "KubernetesDeploymentEntityPropertiesKubernetesObject" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpec" | "KubernetesDeploymentEntitySyncReply" | "KubernetesDeploymentEntityUpdateReply" | "KubernetesLoadBalancerStatus" | "KubernetesLoadBalancerStatusIngress" | "KubernetesMetadata" | "KubernetesPodSpec" | "KubernetesPodTemplateSpec" | "KubernetesSelector" | "KubernetesServiceComponent" | "KubernetesServiceComponentConstraints" | "KubernetesServiceComponentGetReply" | "KubernetesServiceComponentListReply" | "KubernetesServiceComponentPickReply" | "KubernetesServiceEntity" | "KubernetesServiceEntityAssociations" | "KubernetesServiceEntityCreateReply" | "KubernetesServiceEntityDeleteReply" | "KubernetesServiceEntityEvent" | "KubernetesServiceEntityEventListReply" | "KubernetesServiceEntityGetReply" | "KubernetesServiceEntityListReply" | "KubernetesServiceEntityProperties" | "KubernetesServiceEntityPropertiesKubernetesObject" | "KubernetesServiceEntityPropertiesKubernetesObjectSpec" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfig" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIp" | "KubernetesServiceEntityPropertiesKubernetesObjectStatus" | "KubernetesServiceEntitySyncReply" | "KubernetesServiceEntityUpdateReply" | "KubernetesServicePort" | "Labels" | "MatchLabels" | "Mutation" | "Organization" | "OrganizationAssociations" | "OrganizationCreateReply" | "OrganizationGetReply" | "OrganizationListReply" | "OrganizationSiProperties" | "Query" | "ServiceComponent" | "ServiceComponentConstraints" | "ServiceComponentGetReply" | "ServiceComponentListReply" | "ServiceComponentPickReply" | "ServiceEntity" | "ServiceEntityAssociations" | "ServiceEntityCreateReply" | "ServiceEntityDeleteReply" | "ServiceEntityDeployReply" | "ServiceEntityEvent" | "ServiceEntityEventListReply" | "ServiceEntityGetReply" | "ServiceEntityListReply" | "ServiceEntityProperties" | "ServiceEntitySyncReply" | "ServiceEntityUpdateReply" | "SystemComponent" | "SystemComponentConstraints" | "SystemComponentGetReply" | "SystemComponentListReply" | "SystemComponentPickReply" | "SystemEntity" | "SystemEntityCreateReply" | "SystemEntityDeleteReply" | "SystemEntityEvent" | "SystemEntityEventListReply" | "SystemEntityGetReply" | "SystemEntityListReply" | "SystemEntityProperties" | "SystemEntitySyncReply" | "SystemEntityUpdateReply" | "User" | "UserAssociations" | "UserCreateReply" | "UserGetReply" | "UserListReply" | "UserLoginReply" | "UserSiProperties" | "Workspace" | "WorkspaceAssociations" | "WorkspaceCreateReply" | "WorkspaceGetReply" | "WorkspaceListReply" | "WorkspaceSiProperties";
 
-export type NexusGenInputNames = "ApplicationComponentConstraintsRequest" | "ApplicationComponentGetRequest" | "ApplicationComponentListRequest" | "ApplicationComponentPickRequest" | "ApplicationEntityCreateRequest" | "ApplicationEntityDeleteRequest" | "ApplicationEntityEventListRequest" | "ApplicationEntityGetRequest" | "ApplicationEntityListRequest" | "ApplicationEntityPhantomEditRequest" | "ApplicationEntityPropertiesRequest" | "ApplicationEntitySyncRequest" | "ApplicationEntityUpdateRequest" | "ApplicationEntityUpdateRequestUpdateRequest" | "BillingAccountGetRequest" | "BillingAccountListRequest" | "BillingAccountSignupRequest" | "BillingAccountSignupRequestBillingAccountRequest" | "BillingAccountSignupRequestUserRequest" | "CapabilityRequest" | "ChangeSetCreateRequest" | "ChangeSetExecuteRequest" | "ChangeSetGetRequest" | "ChangeSetListRequest" | "DataQueryItemsExpressionRequest" | "DataQueryItemsRequest" | "DataQueryRequest" | "GroupCreateRequest" | "GroupGetRequest" | "GroupListRequest" | "GroupSiPropertiesRequest" | "IntegrationGetRequest" | "IntegrationInstanceGetRequest" | "IntegrationInstanceListRequest" | "IntegrationListRequest" | "IntegrationServiceGetRequest" | "ItemGetRequest" | "ItemListRequest" | "KubernetesContainerPortRequest" | "KubernetesContainerRequest" | "KubernetesDeploymentComponentConstraintsRequest" | "KubernetesDeploymentComponentGetRequest" | "KubernetesDeploymentComponentListRequest" | "KubernetesDeploymentComponentPickRequest" | "KubernetesDeploymentEntityApplyRequest" | "KubernetesDeploymentEntityCreateRequest" | "KubernetesDeploymentEntityDeleteRequest" | "KubernetesDeploymentEntityEventListRequest" | "KubernetesDeploymentEntityGetRequest" | "KubernetesDeploymentEntityKubernetesObjectEditRequest" | "KubernetesDeploymentEntityKubernetesObjectYamlEditRequest" | "KubernetesDeploymentEntityListRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesDeploymentEntityPropertiesRequest" | "KubernetesDeploymentEntitySyncRequest" | "KubernetesDeploymentEntityUpdateRequest" | "KubernetesDeploymentEntityUpdateRequestUpdateRequest" | "KubernetesLoadBalancerStatusIngressRequest" | "KubernetesLoadBalancerStatusRequest" | "KubernetesMetadataRequest" | "KubernetesPodSpecRequest" | "KubernetesPodTemplateSpecRequest" | "KubernetesSelectorRequest" | "KubernetesServiceComponentConstraintsRequest" | "KubernetesServiceComponentGetRequest" | "KubernetesServiceComponentListRequest" | "KubernetesServiceComponentPickRequest" | "KubernetesServiceEntityCreateRequest" | "KubernetesServiceEntityDeleteRequest" | "KubernetesServiceEntityEventListRequest" | "KubernetesServiceEntityGetRequest" | "KubernetesServiceEntityKubernetesObjectEditRequest" | "KubernetesServiceEntityKubernetesObjectYamlEditRequest" | "KubernetesServiceEntityListRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIpRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectStatusRequest" | "KubernetesServiceEntityPropertiesRequest" | "KubernetesServiceEntitySyncRequest" | "KubernetesServiceEntityUpdateRequest" | "KubernetesServiceEntityUpdateRequestUpdateRequest" | "KubernetesServicePortRequest" | "LabelsRequest" | "MatchLabelsRequest" | "OrganizationCreateRequest" | "OrganizationGetRequest" | "OrganizationListRequest" | "OrganizationSiPropertiesRequest" | "ServiceComponentConstraintsRequest" | "ServiceComponentGetRequest" | "ServiceComponentListRequest" | "ServiceComponentPickRequest" | "ServiceEntityCreateRequest" | "ServiceEntityDeleteRequest" | "ServiceEntityDeployRequest" | "ServiceEntityEventListRequest" | "ServiceEntityGetRequest" | "ServiceEntityImageEditRequest" | "ServiceEntityListRequest" | "ServiceEntityPortEditRequest" | "ServiceEntityPropertiesRequest" | "ServiceEntityReplicasEditRequest" | "ServiceEntitySyncRequest" | "ServiceEntityUpdateRequest" | "ServiceEntityUpdateRequestUpdateRequest" | "SystemComponentConstraintsRequest" | "SystemComponentGetRequest" | "SystemComponentListRequest" | "SystemComponentPickRequest" | "SystemEntityCreateRequest" | "SystemEntityDeleteRequest" | "SystemEntityEventListRequest" | "SystemEntityGetRequest" | "SystemEntityListRequest" | "SystemEntityPhantomEditRequest" | "SystemEntityPropertiesRequest" | "SystemEntitySyncRequest" | "SystemEntityUpdateRequest" | "SystemEntityUpdateRequestUpdateRequest" | "UserCreateRequest" | "UserGetRequest" | "UserListRequest" | "UserLoginRequest" | "UserSiPropertiesRequest" | "WorkspaceCreateRequest" | "WorkspaceGetRequest" | "WorkspaceListRequest" | "WorkspaceSiPropertiesRequest";
+export type NexusGenInputNames = "ApplicationComponentConstraintsRequest" | "ApplicationComponentGetRequest" | "ApplicationComponentListRequest" | "ApplicationComponentPickRequest" | "ApplicationEntityCreateRequest" | "ApplicationEntityDeleteRequest" | "ApplicationEntityEventListRequest" | "ApplicationEntityGetRequest" | "ApplicationEntityListRequest" | "ApplicationEntityPropertiesRequest" | "ApplicationEntitySyncRequest" | "ApplicationEntityUpdateRequest" | "ApplicationEntityUpdateRequestUpdateRequest" | "BillingAccountGetRequest" | "BillingAccountListRequest" | "BillingAccountSignupRequest" | "BillingAccountSignupRequestBillingAccountRequest" | "BillingAccountSignupRequestUserRequest" | "CapabilityRequest" | "ChangeSetCreateRequest" | "ChangeSetExecuteRequest" | "ChangeSetGetRequest" | "ChangeSetListRequest" | "DataQueryItemsExpressionRequest" | "DataQueryItemsRequest" | "DataQueryRequest" | "GroupCreateRequest" | "GroupGetRequest" | "GroupListRequest" | "GroupSiPropertiesRequest" | "IntegrationGetRequest" | "IntegrationInstanceGetRequest" | "IntegrationInstanceListRequest" | "IntegrationListRequest" | "IntegrationServiceGetRequest" | "ItemGetRequest" | "ItemListRequest" | "KubernetesContainerPortRequest" | "KubernetesContainerRequest" | "KubernetesDeploymentComponentConstraintsRequest" | "KubernetesDeploymentComponentGetRequest" | "KubernetesDeploymentComponentListRequest" | "KubernetesDeploymentComponentPickRequest" | "KubernetesDeploymentEntityApplyRequest" | "KubernetesDeploymentEntityCreateRequest" | "KubernetesDeploymentEntityDeleteRequest" | "KubernetesDeploymentEntityEventListRequest" | "KubernetesDeploymentEntityGetRequest" | "KubernetesDeploymentEntityListRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectRequest" | "KubernetesDeploymentEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesDeploymentEntityPropertiesRequest" | "KubernetesDeploymentEntitySyncRequest" | "KubernetesDeploymentEntityUpdateRequest" | "KubernetesDeploymentEntityUpdateRequestUpdateRequest" | "KubernetesLoadBalancerStatusIngressRequest" | "KubernetesLoadBalancerStatusRequest" | "KubernetesMetadataRequest" | "KubernetesPodSpecRequest" | "KubernetesPodTemplateSpecRequest" | "KubernetesSelectorRequest" | "KubernetesServiceComponentConstraintsRequest" | "KubernetesServiceComponentGetRequest" | "KubernetesServiceComponentListRequest" | "KubernetesServiceComponentPickRequest" | "KubernetesServiceEntityCreateRequest" | "KubernetesServiceEntityDeleteRequest" | "KubernetesServiceEntityEventListRequest" | "KubernetesServiceEntityGetRequest" | "KubernetesServiceEntityListRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigClientIpRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinityConfigRequest" | "KubernetesServiceEntityPropertiesKubernetesObjectStatusRequest" | "KubernetesServiceEntityPropertiesRequest" | "KubernetesServiceEntitySyncRequest" | "KubernetesServiceEntityUpdateRequest" | "KubernetesServiceEntityUpdateRequestUpdateRequest" | "KubernetesServicePortRequest" | "LabelsRequest" | "MatchLabelsRequest" | "OrganizationCreateRequest" | "OrganizationGetRequest" | "OrganizationListRequest" | "OrganizationSiPropertiesRequest" | "ServiceComponentConstraintsRequest" | "ServiceComponentGetRequest" | "ServiceComponentListRequest" | "ServiceComponentPickRequest" | "ServiceEntityCreateRequest" | "ServiceEntityDeleteRequest" | "ServiceEntityDeployRequest" | "ServiceEntityEventListRequest" | "ServiceEntityGetRequest" | "ServiceEntityListRequest" | "ServiceEntityPropertiesRequest" | "ServiceEntitySyncRequest" | "ServiceEntityUpdateRequest" | "ServiceEntityUpdateRequestUpdateRequest" | "SystemComponentConstraintsRequest" | "SystemComponentGetRequest" | "SystemComponentListRequest" | "SystemComponentPickRequest" | "SystemEntityCreateRequest" | "SystemEntityDeleteRequest" | "SystemEntityEventListRequest" | "SystemEntityGetRequest" | "SystemEntityListRequest" | "SystemEntityPropertiesRequest" | "SystemEntitySyncRequest" | "SystemEntityUpdateRequest" | "SystemEntityUpdateRequestUpdateRequest" | "UserCreateRequest" | "UserGetRequest" | "UserListRequest" | "UserLoginRequest" | "UserSiPropertiesRequest" | "WorkspaceCreateRequest" | "WorkspaceGetRequest" | "WorkspaceListRequest" | "WorkspaceSiPropertiesRequest";
 
 export type NexusGenEnumNames = "ChangeSetStatus" | "DataPageTokenOrderByDirection" | "DataQueryBooleanTerm" | "DataQueryItemsExpressionComparison" | "DataQueryItemsExpressionFieldType" | "DataStorableChangeSetEventType" | "EntitySiPropertiesEntityState" | "IntegrationOptionsOptionType" | "KubernetesDeploymentComponentConstraintsKubernetesVersion" | "KubernetesServiceComponentConstraintsKubernetesVersion" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecExternalTrafficPolicy" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecIpFamily" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecSessionAffinity" | "KubernetesServiceEntityPropertiesKubernetesObjectSpecType" | "KubernetesServicePortProtocol";
 

--- a/components/si-kubernetes/src/agent/aws_eks_kubernetes_deployment.rs
+++ b/components/si-kubernetes/src/agent/aws_eks_kubernetes_deployment.rs
@@ -32,24 +32,6 @@ impl AwsEksKubernetesKubernetesDeploymentDispatchFunctions
         async { Ok(()) }.instrument(debug_span!("create")).await
     }
 
-    async fn edit_kubernetes_object(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_kubernetes_object"))
-            .await
-    }
-
-    async fn edit_kubernetes_object_yaml(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_kubernetes_object_yaml"))
-            .await
-    }
-
     async fn sync(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-kubernetes/src/agent/aws_eks_kubernetes_service.rs
+++ b/components/si-kubernetes/src/agent/aws_eks_kubernetes_service.rs
@@ -20,24 +20,6 @@ impl AwsEksKubernetesKubernetesServiceDispatchFunctions
         async { Ok(()) }.instrument(debug_span!("create")).await
     }
 
-    async fn edit_kubernetes_object(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_kubernetes_object"))
-            .await
-    }
-
-    async fn edit_kubernetes_object_yaml(
-        _mqtt_client: &MqttClient,
-        _entity_event: &mut Self::EntityEvent,
-    ) -> CeaResult<()> {
-        async { Ok(()) }
-            .instrument(debug_span!("edit_kubernetes_object_yaml"))
-            .await
-    }
-
     async fn sync(
         _mqtt_client: &MqttClient,
         _entity_event: &mut Self::EntityEvent,

--- a/components/si-kubernetes/src/gen/agent/aws_eks_kubernetes_kubernetes_deployment.rs
+++ b/components/si-kubernetes/src/gen/agent/aws_eks_kubernetes_kubernetes_deployment.rs
@@ -22,13 +22,7 @@ impl<T: AwsEksKubernetesKubernetesDeploymentDispatchFunctions>
     for AwsEksKubernetesKubernetesDeploymentDispatcher<T>
 {
     fn integration_actions(&self) -> &'static [&'static str] {
-        &[
-            "create",
-            "apply",
-            "edit_kubernetes_object",
-            "edit_kubernetes_object_yaml",
-            "sync",
-        ]
+        &["create", "apply", "sync"]
     }
 }
 
@@ -59,10 +53,6 @@ impl<T: AwsEksKubernetesKubernetesDeploymentDispatchFunctions + Sync>
         match entity_event.action_name()? {
             "create" => T::create(mqtt_client, entity_event).await,
             "apply" => T::apply(mqtt_client, entity_event).await,
-            "edit_kubernetes_object" => T::edit_kubernetes_object(mqtt_client, entity_event).await,
-            "edit_kubernetes_object_yaml" => {
-                T::edit_kubernetes_object_yaml(mqtt_client, entity_event).await
-            }
             "sync" => T::sync(mqtt_client, entity_event).await,
             invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
                 entity_event.integration_service_id()?.to_string(),
@@ -88,16 +78,6 @@ pub trait AwsEksKubernetesKubernetesDeploymentDispatchFunctions {
     ) -> si_cea::CeaResult<()>;
 
     async fn apply(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_kubernetes_object(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_kubernetes_object_yaml(
         mqtt_client: &si_cea::MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> si_cea::CeaResult<()>;

--- a/components/si-kubernetes/src/gen/agent/aws_eks_kubernetes_kubernetes_service.rs
+++ b/components/si-kubernetes/src/gen/agent/aws_eks_kubernetes_kubernetes_service.rs
@@ -21,12 +21,7 @@ impl<T: AwsEksKubernetesKubernetesServiceDispatchFunctions>
     si_cea::agent::dispatch::IntegrationActions for AwsEksKubernetesKubernetesServiceDispatcher<T>
 {
     fn integration_actions(&self) -> &'static [&'static str] {
-        &[
-            "create",
-            "edit_kubernetes_object",
-            "edit_kubernetes_object_yaml",
-            "sync",
-        ]
+        &["create", "sync"]
     }
 }
 
@@ -56,10 +51,6 @@ impl<T: AwsEksKubernetesKubernetesServiceDispatchFunctions + Sync> si_cea::agent
     ) -> si_cea::CeaResult<()> {
         match entity_event.action_name()? {
             "create" => T::create(mqtt_client, entity_event).await,
-            "edit_kubernetes_object" => T::edit_kubernetes_object(mqtt_client, entity_event).await,
-            "edit_kubernetes_object_yaml" => {
-                T::edit_kubernetes_object_yaml(mqtt_client, entity_event).await
-            }
             "sync" => T::sync(mqtt_client, entity_event).await,
             invalid => Err(si_cea::CeaError::DispatchFunctionMissing(
                 entity_event.integration_service_id()?.to_string(),
@@ -80,16 +71,6 @@ pub trait AwsEksKubernetesKubernetesServiceDispatchFunctions {
     type EntityEvent: si_cea::EntityEvent + Send;
 
     async fn create(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_kubernetes_object(
-        mqtt_client: &si_cea::MqttClient,
-        entity_event: &mut Self::EntityEvent,
-    ) -> si_cea::CeaResult<()>;
-
-    async fn edit_kubernetes_object_yaml(
         mqtt_client: &si_cea::MqttClient,
         entity_event: &mut Self::EntityEvent,
     ) -> si_cea::CeaResult<()>;

--- a/components/si-kubernetes/src/gen/model/kubernetes_deployment_entity.rs
+++ b/components/si-kubernetes/src/gen/model/kubernetes_deployment_entity.rs
@@ -57,34 +57,6 @@ impl crate::protobuf::KubernetesDeploymentEntity {
         result.si_properties = si_properties;
         result.si_storable = Some(si_storable);
 
-        use si_cea::Entity;
-
-        match (
-            result.properties()?.kubernetes_object.as_ref(),
-            result.properties()?.kubernetes_object_yaml.as_ref(),
-        ) {
-            (Some(_), None) => {
-                result.update_kubernetes_object_yaml_from_kubernetes_object()?;
-            }
-            (None, Some(_)) => {
-                result.update_kubernetes_object_from_kubernetes_object_yaml()?;
-            }
-            (Some(_), Some(_)) => {
-                return Err(si_data::DataError::MultipleEithersProvided2(
-                    "kubernetes_object".to_string(),
-                    "kubernetes_object_yaml".to_string(),
-                )
-                .into());
-            }
-            (None, None) => {
-                return Err(si_data::DataError::NeitherEithersProvided2(
-                    "kubernetes_object".to_string(),
-                    "kubernetes_object_yaml".to_string(),
-                )
-                .into());
-            }
-        }
-
         Ok(result)
     }
 
@@ -167,49 +139,6 @@ impl crate::protobuf::KubernetesDeploymentEntity {
             }
         };
         Ok(result)
-    }
-
-    pub fn edit_kubernetes_object(
-        &mut self,
-        property: crate::protobuf::KubernetesDeploymentEntityPropertiesKubernetesObject,
-    ) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.kubernetes_object = Some(property);
-        self.update_kubernetes_object_yaml_from_kubernetes_object()?;
-
-        Ok(())
-    }
-
-    pub fn edit_kubernetes_object_yaml(&mut self, property: String) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.kubernetes_object_yaml = Some(property);
-        self.update_kubernetes_object_from_kubernetes_object_yaml()?;
-
-        Ok(())
-    }
-
-    fn update_kubernetes_object_yaml_from_kubernetes_object(&mut self) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-        use std::convert::TryInto;
-
-        if let Some(ref kubernetes_object) = self.properties()?.kubernetes_object {
-            self.properties_mut()?.kubernetes_object_yaml = Some(kubernetes_object.try_into()?);
-        }
-
-        Ok(())
-    }
-
-    fn update_kubernetes_object_from_kubernetes_object_yaml(&mut self) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-        use std::convert::TryInto;
-
-        if let Some(ref kubernetes_object_yaml) = self.properties()?.kubernetes_object_yaml {
-            self.properties_mut()?.kubernetes_object = Some(kubernetes_object_yaml.try_into()?);
-        }
-
-        Ok(())
     }
 
     pub async fn delete(
@@ -632,27 +561,5 @@ impl si_data::Storable for crate::protobuf::KubernetesDeploymentEntity {
 
     fn order_by_fields() -> Vec<&'static str> {
         vec!["siStorable.naturalKey", "id", "name", "displayName", "siStorable.naturalKey", "dataStorable.viewContext", "dataStorable.changeSetId", "dataStorable.itemId", "dataStorable.changeSetEntryCount", "dataStorable.changeSetEventType", "dataStorable.changeSetExecuted", "dataStorable.deleted", "description", "siStorable.naturalKey", "entitySiProperties.entityState", "siStorable.naturalKey", "siStorable.naturalKey", "properties.kubernetesObject.apiVersion", "properties.kubernetesObject.kind", "siStorable.naturalKey", "properties.kubernetesObject.kubernetesMetadata.name", "properties.kubernetesObject.kubernetesMetadata.labels", "siStorable.naturalKey", "properties.kubernetesObject.spec.replicas", "siStorable.naturalKey", "properties.kubernetesObject.spec.kubernetesSelector.matchLabels", "siStorable.naturalKey", "siStorable.naturalKey", "properties.kubernetesObject.spec.kubernetesPodTemplateSpec.kubernetesMetadata.name", "properties.kubernetesObject.spec.kubernetesPodTemplateSpec.kubernetesMetadata.labels", "siStorable.naturalKey", "siStorable.naturalKey", "properties.kubernetesObject.spec.kubernetesPodTemplateSpec.kubernetesPodSpec.kubernetesContainer.name", "properties.kubernetesObject.spec.kubernetesPodTemplateSpec.kubernetesPodSpec.kubernetesContainer.image", "siStorable.naturalKey", "properties.kubernetesObject.spec.kubernetesPodTemplateSpec.kubernetesPodSpec.kubernetesContainer.kubernetesContainerPort.containerPort", "properties.kubernetesObjectYaml", "siStorable.naturalKey", "constraints.componentName", "constraints.componentDisplayName", "constraints.kubernetesVersion", "siStorable.naturalKey", "constraints.componentName", "constraints.componentDisplayName", "constraints.kubernetesVersion"]
-    }
-}
-
-impl std::convert::TryFrom<&crate::protobuf::KubernetesDeploymentEntityPropertiesKubernetesObject>
-    for String
-{
-    type Error = si_cea::CeaError;
-
-    fn try_from(
-        value: &crate::protobuf::KubernetesDeploymentEntityPropertiesKubernetesObject,
-    ) -> std::result::Result<Self, Self::Error> {
-        Ok(serde_yaml::to_string(value)?)
-    }
-}
-
-impl std::convert::TryFrom<&String>
-    for crate::protobuf::KubernetesDeploymentEntityPropertiesKubernetesObject
-{
-    type Error = si_cea::CeaError;
-
-    fn try_from(value: &String) -> std::result::Result<Self, Self::Error> {
-        Ok(serde_yaml::from_str(value)?)
     }
 }

--- a/components/si-kubernetes/src/gen/model/kubernetes_deployment_entity_event.rs
+++ b/components/si-kubernetes/src/gen/model/kubernetes_deployment_entity_event.rs
@@ -63,13 +63,7 @@ impl si_cea::EntityEvent for crate::protobuf::KubernetesDeploymentEntityEvent {
     type Entity = crate::protobuf::KubernetesDeploymentEntity;
 
     fn action_names() -> &'static [&'static str] {
-        &[
-            "create",
-            "apply",
-            "edit_kubernetes_object",
-            "edit_kubernetes_object_yaml",
-            "sync",
-        ]
+        &["create", "apply", "sync"]
     }
 
     fn action_name(&self) -> si_data::Result<&str> {

--- a/components/si-kubernetes/src/gen/model/kubernetes_service_entity.rs
+++ b/components/si-kubernetes/src/gen/model/kubernetes_service_entity.rs
@@ -57,34 +57,6 @@ impl crate::protobuf::KubernetesServiceEntity {
         result.si_properties = si_properties;
         result.si_storable = Some(si_storable);
 
-        use si_cea::Entity;
-
-        match (
-            result.properties()?.kubernetes_object.as_ref(),
-            result.properties()?.kubernetes_object_yaml.as_ref(),
-        ) {
-            (Some(_), None) => {
-                result.update_kubernetes_object_yaml_from_kubernetes_object()?;
-            }
-            (None, Some(_)) => {
-                result.update_kubernetes_object_from_kubernetes_object_yaml()?;
-            }
-            (Some(_), Some(_)) => {
-                return Err(si_data::DataError::MultipleEithersProvided2(
-                    "kubernetes_object".to_string(),
-                    "kubernetes_object_yaml".to_string(),
-                )
-                .into());
-            }
-            (None, None) => {
-                return Err(si_data::DataError::NeitherEithersProvided2(
-                    "kubernetes_object".to_string(),
-                    "kubernetes_object_yaml".to_string(),
-                )
-                .into());
-            }
-        }
-
         Ok(result)
     }
 
@@ -167,49 +139,6 @@ impl crate::protobuf::KubernetesServiceEntity {
             }
         };
         Ok(result)
-    }
-
-    pub fn edit_kubernetes_object(
-        &mut self,
-        property: crate::protobuf::KubernetesServiceEntityPropertiesKubernetesObject,
-    ) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.kubernetes_object = Some(property);
-        self.update_kubernetes_object_yaml_from_kubernetes_object()?;
-
-        Ok(())
-    }
-
-    pub fn edit_kubernetes_object_yaml(&mut self, property: String) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-
-        self.properties_mut()?.kubernetes_object_yaml = Some(property);
-        self.update_kubernetes_object_from_kubernetes_object_yaml()?;
-
-        Ok(())
-    }
-
-    fn update_kubernetes_object_yaml_from_kubernetes_object(&mut self) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-        use std::convert::TryInto;
-
-        if let Some(ref kubernetes_object) = self.properties()?.kubernetes_object {
-            self.properties_mut()?.kubernetes_object_yaml = Some(kubernetes_object.try_into()?);
-        }
-
-        Ok(())
-    }
-
-    fn update_kubernetes_object_from_kubernetes_object_yaml(&mut self) -> si_cea::CeaResult<()> {
-        use si_cea::Entity;
-        use std::convert::TryInto;
-
-        if let Some(ref kubernetes_object_yaml) = self.properties()?.kubernetes_object_yaml {
-            self.properties_mut()?.kubernetes_object = Some(kubernetes_object_yaml.try_into()?);
-        }
-
-        Ok(())
     }
 
     pub async fn delete(
@@ -694,27 +623,5 @@ impl si_data::Storable for crate::protobuf::KubernetesServiceEntity {
             "constraints.componentDisplayName",
             "constraints.kubernetesVersion",
         ]
-    }
-}
-
-impl std::convert::TryFrom<&crate::protobuf::KubernetesServiceEntityPropertiesKubernetesObject>
-    for String
-{
-    type Error = si_cea::CeaError;
-
-    fn try_from(
-        value: &crate::protobuf::KubernetesServiceEntityPropertiesKubernetesObject,
-    ) -> std::result::Result<Self, Self::Error> {
-        Ok(serde_yaml::to_string(value)?)
-    }
-}
-
-impl std::convert::TryFrom<&String>
-    for crate::protobuf::KubernetesServiceEntityPropertiesKubernetesObject
-{
-    type Error = si_cea::CeaError;
-
-    fn try_from(value: &String) -> std::result::Result<Self, Self::Error> {
-        Ok(serde_yaml::from_str(value)?)
     }
 }

--- a/components/si-kubernetes/src/gen/model/kubernetes_service_entity_event.rs
+++ b/components/si-kubernetes/src/gen/model/kubernetes_service_entity_event.rs
@@ -62,12 +62,7 @@ impl si_cea::EntityEvent for crate::protobuf::KubernetesServiceEntityEvent {
     type Entity = crate::protobuf::KubernetesServiceEntity;
 
     fn action_names() -> &'static [&'static str] {
-        &[
-            "create",
-            "edit_kubernetes_object",
-            "edit_kubernetes_object_yaml",
-            "sync",
-        ]
+        &["create", "sync"]
     }
 
     fn action_name(&self) -> si_data::Result<&str> {

--- a/components/si-registry/proto/si.core.proto
+++ b/components/si-registry/proto/si.core.proto
@@ -19,7 +19,6 @@ service Core {
   rpc ApplicationEntityDelete(ApplicationEntityDeleteRequest) returns (ApplicationEntityDeleteReply);
   rpc ApplicationEntityUpdate(ApplicationEntityUpdateRequest) returns (ApplicationEntityUpdateReply);
   rpc ApplicationEntitySync(ApplicationEntitySyncRequest) returns (ApplicationEntitySyncReply);
-  rpc ApplicationEntityPhantomEdit(ApplicationEntityPhantomEditRequest) returns (ApplicationEntityPhantomEditReply);
   rpc ApplicationEntityEventList(ApplicationEntityEventListRequest) returns (ApplicationEntityEventListReply);
   rpc ServiceComponentGet(ServiceComponentGetRequest) returns (ServiceComponentGetReply);
   rpc ServiceComponentList(ServiceComponentListRequest) returns (ServiceComponentListReply);
@@ -31,9 +30,6 @@ service Core {
   rpc ServiceEntityDelete(ServiceEntityDeleteRequest) returns (ServiceEntityDeleteReply);
   rpc ServiceEntityUpdate(ServiceEntityUpdateRequest) returns (ServiceEntityUpdateReply);
   rpc ServiceEntitySync(ServiceEntitySyncRequest) returns (ServiceEntitySyncReply);
-  rpc ServiceEntityImageEdit(ServiceEntityImageEditRequest) returns (ServiceEntityImageEditReply);
-  rpc ServiceEntityPortEdit(ServiceEntityPortEditRequest) returns (ServiceEntityPortEditReply);
-  rpc ServiceEntityReplicasEdit(ServiceEntityReplicasEditRequest) returns (ServiceEntityReplicasEditReply);
   rpc ServiceEntityDeploy(ServiceEntityDeployRequest) returns (ServiceEntityDeployReply);
   rpc ServiceEntityEventList(ServiceEntityEventListRequest) returns (ServiceEntityEventListReply);
   rpc SystemComponentGet(SystemComponentGetRequest) returns (SystemComponentGetReply);
@@ -46,7 +42,6 @@ service Core {
   rpc SystemEntityDelete(SystemEntityDeleteRequest) returns (SystemEntityDeleteReply);
   rpc SystemEntityUpdate(SystemEntityUpdateRequest) returns (SystemEntityUpdateReply);
   rpc SystemEntitySync(SystemEntitySyncRequest) returns (SystemEntitySyncReply);
-  rpc SystemEntityPhantomEdit(SystemEntityPhantomEditRequest) returns (SystemEntityPhantomEditReply);
   rpc SystemEntityEventList(SystemEntityEventListRequest) returns (SystemEntityEventListReply);
 }
 message ApplicationComponentConstraints {
@@ -166,15 +161,9 @@ message ApplicationEntityUpdateReply {
 }
 message ApplicationEntitySyncRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message ApplicationEntitySyncReply {
-  si.core.ApplicationEntityEvent item = 1;
-}
-message ApplicationEntityPhantomEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.BoolValue property = 1001;
-}
-message ApplicationEntityPhantomEditReply {
   si.core.ApplicationEntityEvent item = 1;
 }
 message ApplicationEntityEvent {
@@ -327,33 +316,14 @@ message ServiceEntityUpdateReply {
 }
 message ServiceEntitySyncRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message ServiceEntitySyncReply {
   si.core.ServiceEntityEvent item = 1;
 }
-message ServiceEntityImageEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.StringValue property = 1001;
-}
-message ServiceEntityImageEditReply {
-  si.core.ServiceEntityEvent item = 1;
-}
-message ServiceEntityPortEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.UInt32Value property = 1001;
-}
-message ServiceEntityPortEditReply {
-  si.core.ServiceEntityEvent item = 1;
-}
-message ServiceEntityReplicasEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.UInt32Value property = 1001;
-}
-message ServiceEntityReplicasEditReply {
-  si.core.ServiceEntityEvent item = 1;
-}
 message ServiceEntityDeployRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message ServiceEntityDeployReply {
   si.core.ServiceEntityEvent item = 1;
@@ -506,15 +476,9 @@ message SystemEntityUpdateReply {
 }
 message SystemEntitySyncRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message SystemEntitySyncReply {
-  si.core.SystemEntityEvent item = 1;
-}
-message SystemEntityPhantomEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.BoolValue property = 1001;
-}
-message SystemEntityPhantomEditReply {
   si.core.SystemEntityEvent item = 1;
 }
 message SystemEntityEvent {

--- a/components/si-registry/proto/si.kubernetes.proto
+++ b/components/si-registry/proto/si.kubernetes.proto
@@ -19,8 +19,6 @@ service Kubernetes {
   rpc KubernetesDeploymentEntityDelete(KubernetesDeploymentEntityDeleteRequest) returns (KubernetesDeploymentEntityDeleteReply);
   rpc KubernetesDeploymentEntityUpdate(KubernetesDeploymentEntityUpdateRequest) returns (KubernetesDeploymentEntityUpdateReply);
   rpc KubernetesDeploymentEntitySync(KubernetesDeploymentEntitySyncRequest) returns (KubernetesDeploymentEntitySyncReply);
-  rpc KubernetesDeploymentEntityKubernetesObjectEdit(KubernetesDeploymentEntityKubernetesObjectEditRequest) returns (KubernetesDeploymentEntityKubernetesObjectEditReply);
-  rpc KubernetesDeploymentEntityKubernetesObjectYamlEdit(KubernetesDeploymentEntityKubernetesObjectYamlEditRequest) returns (KubernetesDeploymentEntityKubernetesObjectYamlEditReply);
   rpc KubernetesDeploymentEntityApply(KubernetesDeploymentEntityApplyRequest) returns (KubernetesDeploymentEntityApplyReply);
   rpc KubernetesDeploymentEntityEventList(KubernetesDeploymentEntityEventListRequest) returns (KubernetesDeploymentEntityEventListReply);
   rpc KubernetesServiceComponentGet(KubernetesServiceComponentGetRequest) returns (KubernetesServiceComponentGetReply);
@@ -33,8 +31,6 @@ service Kubernetes {
   rpc KubernetesServiceEntityDelete(KubernetesServiceEntityDeleteRequest) returns (KubernetesServiceEntityDeleteReply);
   rpc KubernetesServiceEntityUpdate(KubernetesServiceEntityUpdateRequest) returns (KubernetesServiceEntityUpdateReply);
   rpc KubernetesServiceEntitySync(KubernetesServiceEntitySyncRequest) returns (KubernetesServiceEntitySyncReply);
-  rpc KubernetesServiceEntityKubernetesObjectEdit(KubernetesServiceEntityKubernetesObjectEditRequest) returns (KubernetesServiceEntityKubernetesObjectEditReply);
-  rpc KubernetesServiceEntityKubernetesObjectYamlEdit(KubernetesServiceEntityKubernetesObjectYamlEditRequest) returns (KubernetesServiceEntityKubernetesObjectYamlEditReply);
   rpc KubernetesServiceEntityEventList(KubernetesServiceEntityEventListRequest) returns (KubernetesServiceEntityEventListReply);
 }
 message KubernetesMetadata {
@@ -206,26 +202,14 @@ message KubernetesDeploymentEntityUpdateReply {
 }
 message KubernetesDeploymentEntitySyncRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message KubernetesDeploymentEntitySyncReply {
   si.kubernetes.KubernetesDeploymentEntityEvent item = 1;
 }
-message KubernetesDeploymentEntityKubernetesObjectEditRequest {
-  google.protobuf.StringValue id = 1;
-  si.kubernetes.KubernetesDeploymentEntityPropertiesKubernetesObject property = 1001;
-}
-message KubernetesDeploymentEntityKubernetesObjectEditReply {
-  si.kubernetes.KubernetesDeploymentEntityEvent item = 1;
-}
-message KubernetesDeploymentEntityKubernetesObjectYamlEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.StringValue property = 1001;
-}
-message KubernetesDeploymentEntityKubernetesObjectYamlEditReply {
-  si.kubernetes.KubernetesDeploymentEntityEvent item = 1;
-}
 message KubernetesDeploymentEntityApplyRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message KubernetesDeploymentEntityApplyReply {
   si.kubernetes.KubernetesDeploymentEntityEvent item = 1;
@@ -442,22 +426,9 @@ message KubernetesServiceEntityUpdateReply {
 }
 message KubernetesServiceEntitySyncRequest {
   google.protobuf.StringValue id = 1;
+  google.protobuf.StringValue change_set_id = 2;
 }
 message KubernetesServiceEntitySyncReply {
-  si.kubernetes.KubernetesServiceEntityEvent item = 1;
-}
-message KubernetesServiceEntityKubernetesObjectEditRequest {
-  google.protobuf.StringValue id = 1;
-  si.kubernetes.KubernetesServiceEntityPropertiesKubernetesObject property = 1001;
-}
-message KubernetesServiceEntityKubernetesObjectEditReply {
-  si.kubernetes.KubernetesServiceEntityEvent item = 1;
-}
-message KubernetesServiceEntityKubernetesObjectYamlEditRequest {
-  google.protobuf.StringValue id = 1;
-  google.protobuf.StringValue property = 1001;
-}
-message KubernetesServiceEntityKubernetesObjectYamlEditReply {
   si.kubernetes.KubernetesServiceEntityEvent item = 1;
 }
 message KubernetesServiceEntityEvent {

--- a/components/si-registry/src/attrList.ts
+++ b/components/si-registry/src/attrList.ts
@@ -9,9 +9,7 @@ import { PropBool } from "./prop/bool";
 import { PropLink } from "./prop/link";
 import { PropPassword } from "./prop/password";
 
-import { pascalCase, camelCase } from "change-case";
-
-import { registry } from "./registry";
+import { pascalCase } from "change-case";
 
 export type Props =
   | PropText
@@ -201,31 +199,34 @@ export class AttrList {
     this.addProp(p, addArgs);
   }
 
-  autoCreateEditAction(p: Props): void {
-    const notAllowedKinds = ["method", "action"];
-    if (notAllowedKinds.includes(p.kind())) {
-      return;
-    }
-    const systemObject = registry.get(p.componentTypeName);
-
-    systemObject.methods.addAction({
-      name: `${camelCase(p.name)}Edit`,
-      label: `Edit ${camelCase(p.parentName)}${pascalCase(p.name)} Property`,
-      options(pa: PropAction) {
-        pa.universal = true;
-        pa.mutation = true;
-        pa.request.properties.addLink({
-          name: "property",
-          label: `The ${p.label} property value`,
-          options(pl: PropLink) {
-            pl.lookup = {
-              typeName: p.componentTypeName,
-              names: ["properties", p.name],
-            };
-          },
-        });
-      },
-    });
+  autoCreateEditAction(_p: Props): void {
+    //We went another way, and no longer need to auto create edits.
+    //
+    //I'm leaving this code here, just in case we decide to change our minds.
+    //
+    //const notAllowedKinds = ["method", "action"];
+    //if (notAllowedKinds.includes(p.kind())) {
+    //  return;
+    //}
+    //const systemObject = registry.get(p.componentTypeName);
+    //systemObject.methods.addAction({
+    //  name: `${camelCase(p.name)}Edit`,
+    //  label: `Edit ${camelCase(p.parentName)}${pascalCase(p.name)} Property`,
+    //  options(pa: PropAction) {
+    //    pa.universal = true;
+    //    pa.mutation = true;
+    //    pa.request.properties.addLink({
+    //      name: "property",
+    //      label: `The ${p.label} property value`,
+    //      options(pl: PropLink) {
+    //        pl.lookup = {
+    //          typeName: p.componentTypeName,
+    //          names: ["properties", p.name],
+    //        };
+    //      },
+    //    });
+    //  },
+    //});
   }
 }
 
@@ -366,6 +367,14 @@ export class PropAction extends PropMethod {
     this.request.properties.addText({
       name: "id",
       label: "Entity ID",
+      options(p) {
+        p.universal = true;
+        p.required = true;
+      },
+    });
+    this.request.properties.addText({
+      name: "changeSetId",
+      label: "Change Set ID",
       options(p) {
         p.universal = true;
         p.required = true;

--- a/components/si-registry/src/codegen/rust/implServiceEntityAction.rs.ejs
+++ b/components/si-registry/src/codegen/rust/implServiceEntityAction.rs.ejs
@@ -4,12 +4,14 @@ let auth = <%- fmt.implServiceAuth(propMethod) %>;
 
 let inner = request.into_inner();
 let id = inner.id.ok_or_else(|| si_data::DataError::RequiredField("id".to_string()))?;
+let change_set_id = inner.change_set_id.ok_or_else(|| si_data::DataError::RequiredField("changeSetId".to_string()))?;
 
 let entity = <%- fmt.structName() %>::get(&self.db, &id).await?;
 let entity_event = <%- fmt.entityEventName() %>::create(
     &self.db,
     auth.user_id(),
     "<%- fmt.rustFieldNameForProp(propMethod) %>",
+    &change_set_id,
     &entity
 ).await?;
 

--- a/components/si-registry/src/registry.ts
+++ b/components/si-registry/src/registry.ts
@@ -8,7 +8,7 @@ import {
   ComponentAndEntityObject,
   ComponentAndEntityObjectConstructor,
 } from "./systemComponent";
-import { Props } from "./attrList";
+import { Props, PropAction } from "./attrList";
 import { camelCase } from "change-case";
 
 export interface PropLookup {
@@ -111,6 +111,21 @@ export class Registry {
     for (const object of this.objects) {
       if (object instanceof EntityObject) {
         results.push(object);
+      }
+    }
+    return results;
+  }
+
+  listActions(): { [key: string]: string[] } {
+    const results: { [key: string]: string[] } = {};
+    for (const entity of this.objects) {
+      results[entity.typeName] = [];
+      if (entity instanceof EntityObject) {
+        for (const attr of entity.methods.attrs) {
+          if (attr instanceof PropAction) {
+            results[entity.typeName].push(attr.name);
+          }
+        }
       }
     }
     return results;

--- a/components/si-web-app/src/components/views/system/SystemDetails.vue
+++ b/components/si-web-app/src/components/views/system/SystemDetails.vue
@@ -11,7 +11,7 @@
       </div>
       <span class="text-white">
         Mode: {{ mode }} System: {{ systemName }} Change Set Status:
-        {{ changeSet.status }} Change Sets:
+        <span v-if="changeSet">{{ changeSet.status }}</span> Change Sets:
         <select
           label="Change Sets"
           aria-label="Change Sets"
@@ -65,6 +65,25 @@
           </template>
         </button>
       </div>
+      <div v-if="changeSet">
+        <div class="h-10 overflow-auto">
+          <ol>
+            <li
+              class="text-gray-500"
+              v-for="entry in changeSet.associations.changeSetEntries.items"
+              :key="entry.id"
+            >
+              <template v-if="entry.siStorable.changeSetEventType == 'ACTION'">
+                {{ entry.siStorable.changeSetEventType }}:
+                {{ entry.siStorable.itemId }}
+              </template>
+              <template v-else>
+                {{ entry.siStorable.changeSetEventType }}: {{ entry.name }}
+              </template>
+            </li>
+          </ol>
+        </div>
+      </div>
     </div>
 
     <div id="system-editor" class="flex h-full w-full overflow-hidden">
@@ -105,14 +124,18 @@ export default {
   computed: {
     selectedChangeSetId: {
       get() {
-        return this.changeSet.id;
+        if (this.changeSet) {
+          return this.changeSet.id;
+        } else {
+          return "";
+        }
       },
       async set(value) {
         await this.$store.commit("changeSet/setCurrentById", value);
       },
     },
     ...mapState({
-      changeSet: state => state.changeSet.current || {},
+      changeSet: state => state.changeSet.current,
       changeSets: state => state.changeSet.changeSets,
       mode: state => state.editor.mode,
       isSaving: state => state.editor.isSaving,

--- a/components/si-web-app/src/store/modules/entity.ts
+++ b/components/si-web-app/src/store/modules/entity.ts
@@ -129,6 +129,7 @@ export const entity: Module<EntityStore, RootStore> = {
         },
         { root: true },
       );
+      await dispatch("changeSet/get", { changeSetId }, { root: true });
     },
     async create(
       { commit, dispatch, rootGetters },
@@ -190,6 +191,7 @@ export const entity: Module<EntityStore, RootStore> = {
         },
         { root: true },
       );
+      await dispatch("changeSet/get", { changeSetId }, { root: true });
     },
     async delete(
       { commit, getters, rootGetters, rootState, dispatch },
@@ -226,6 +228,7 @@ export const entity: Module<EntityStore, RootStore> = {
         },
         { root: true },
       );
+      await dispatch("changeSet/get", { changeSetId }, { root: true });
     },
 
     async get(


### PR DESCRIPTION
This commit enables actions to be taken on nodes in the web application,
though a context menu in the schematic panel.

* All actions on an entity are automatically included, and the menu is
  context sensitive.
* It also includes global actions, like "delete".
* It removes the "_edit" actions which were automatically created for
  every top level field. In the new model, this is no longer neccesary,
  and is handled by a single universal update method.
* It adds visibility into the list of changes that are in the changeSet,
  through a very janky div. But it makes it so you can at least see what
  is batched up in the changeset. We need to eventually make the
  entityEvent data be more visible!

![image](https://user-images.githubusercontent.com/4304/87724937-31441a00-c771-11ea-9a6c-6edff96abb4d.png)
