### PR TITLE
fix(transport): fix `Display` impl for `AgentData` header & topic

### DIFF
--- a/components/si-core/src/bin/server.rs
+++ b/components/si-core/src/bin/server.rs
@@ -52,6 +52,7 @@ async fn spawn_finalized_listener(
     transport_server_uri: impl Into<String>,
     db: Db,
 ) -> anyhow::Result<()> {
+    println!("*** Spawning the FinalizedListener ***");
     let mut listener_builder = FinalizedListener::builder(server_name, transport_server_uri, db);
     listener_builder.finalizer(application_entity_event::finalizer()?);
     listener_builder.finalizer(edge_entity_event::finalizer()?);

--- a/components/si-transport/src/metadata.rs
+++ b/components/si-transport/src/metadata.rs
@@ -210,7 +210,7 @@ impl fmt::Display for AgentDataHeader {
         let data = self.data.to_string();
 
         let parts = vec![
-            CMD,
+            DT,
             AGENT,
             self.agent_id.as_ref(),
             self.agent_installation_id.as_ref(),
@@ -502,7 +502,7 @@ impl fmt::Display for AgentDataTopic {
         let data = self.data.as_ref().map(|c| c.to_string());
 
         let mut parts = vec![
-            CMD,
+            DT,
             AGENT,
             self.agent_id.as_ref().map(String::as_str).unwrap_or("+"),
             self.agent_installation_id


### PR DESCRIPTION
An agent data topic is a "data" topic, rather than a "command" topic,
where a data topic subscription would be something like:

```
$shared/dt/agent/+/+/+/+/+/+/+/application_entity_event/+/finalize
```

vs a command topic subscription which looks like:

```
$shared/cmd/agent/+/+/+/+/+/+/+/application_entity_event/+/execute
```

It turns out that `AgentDataHeader` & `AgentDataTopic` had an incorrect
formatting, where `cmd` was being inserted, where `dt` was expected. The
complementary `FromStr` impl was correctly parsing the data topics and
headers and therefore would error out if a data header or topic was
serialized to a `String`, then deserialized back.

Interestingly, this was discovered when booting `si-core` and
`si-kubernetes`, both of which spawn a `FinalizedListener`, which
subscribe to data topics (rather than command topics). The code that
spawns this subsystem would unconditionally fail on setup, which I
suspect lead to an honest-to-god segfault/core dump. I'm still a bit
baffled as to why, as the setup code should be taking place in the main
thread of execution, before `tokio::spawn(listener.run())` is run,
but...it's gone now?

Anyway, this was a bug regardless and a good lesson to add unit tests to
this part of our codebase. I ignored my instincts here in the interests
of finishing this work out and it may make good sense to add a few tests
in the next few weeks to shore up the basic behaviors in si-transport.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>