### PR TITLE
chore(vernemq): update VerneMQ container to official upstream

### DIFF
--- a/components/vernemq/run.sh
+++ b/components/vernemq/run.sh
@@ -1,3 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-docker run -e "DOCKER_VERNEMQ_ACCEPT_EULA=yes" -e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" -p 1883:1883 -p 8081:8080 --name vernemq -d erlio/docker-vernemq
+VERSION=1.10.4.1-alpine
+
+docker run \
+  --env "DOCKER_VERNEMQ_ACCEPT_EULA=yes" \
+  --env "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" \
+  --env "DOCKER_VERNEMQ_LISTENER__TCP__ALLOWED_PROTOCOL_VERSIONS=3,4,131,5" \
+  --publish 1883:1883 \
+  --name mqtt \
+  --detach \
+  "vernemq/vernemq:$VERSION"


### PR DESCRIPTION
This change swaps our VerneMQ image to `vernemq/vernemq` which appears
to be actively maintained by the upstream company and project. This also
includes tags for versioned releases, and so the deployed version of
VerneMQ is currently controlled via a `VERSION` variable in the `run.sh`
script.

Most importantly, the MQTT v5 protocol is explicitly enabled, as we're
starting to use features from this protocol version.

![tenor-137268104](https://user-images.githubusercontent.com/261548/89818341-d18a2600-db06-11ea-977e-ac7278d17866.gif)
