### PR TITLE
fix(transport): use a `$share` topic, not a `$shared` topic

### DIFF
--- a/components/si-transport/src/metadata.rs
+++ b/components/si-transport/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use std::{fmt, str::FromStr};
 use typed_builder::TypedBuilder;
 
-const SHARED: &str = "$shared";
+const SHARED: &str = "$share";
 const CMD: &str = "cmd";
 const DT: &str = "dt";
 const AGENT: &str = "agent";
@@ -534,7 +534,7 @@ impl fmt::Display for AgentDataTopic {
             data.as_ref().map(String::as_str).unwrap_or("+"),
         ];
         if self.shared {
-            parts.insert(0, "$shared");
+            parts.insert(0, SHARED);
         }
 
         f.write_str(&parts.join("/"))


### PR DESCRIPTION
This is a straight up bug fix where a "shared" topic subscription should
be prefixed with `$share/`, but in referring to shared topics, the
literal `$shared/` topic prefix was added instead. And I think that's
probably the better choice, but that choice is not up to me, so I bow to
smarter people than myself.

![tenor-212913980](https://user-images.githubusercontent.com/261548/89818794-9b00db00-db07-11ea-9feb-561d7621b571.gif)
