### PR TITLE
build(dev): in dev mode, run Rust services with `RUST_LOG=info`

### DIFF
--- a/components/build/rust.mk
+++ b/components/build/rust.mk
@@ -3,6 +3,7 @@ include $(CURDIR)/../build/docker.mk
 RELEASE := $(shell date +%Y%m%d%H%M%S)
 WATCH_PATHS ?= .
 WATCH_TASK ?= run
+RUST_LOG ?= info
 
 .PHONY: build build_release test run start release container
 
@@ -21,7 +22,7 @@ run:
 start: run
 
 watch:
-	cargo watch $(foreach path,$(WATCH_PATHS),-w $(path)) -x $(WATCH_TASK)
+	env RUST_LOG=$(RUST_LOG) cargo watch $(foreach path,$(WATCH_PATHS),-w $(path)) -x $(WATCH_TASK)
 
 test_container:
 	docker run -t --network=host --volume=$(CURDIR)/../../:/src docker.pkg.github.com/systeminit/si/si-base:latest /bin/bash -c "cd / && if [[ ! -d /src/target ]]; then tar zxf /build-cache/cargo-cache.tgz; fi && if [[ ! -d /src/components/si-web-ui/node_modules ]]; then tar zxf /build-cache/npm-cache.tgz; fi && . /root/.cargo/env && cd /src/components/$(COMPONENT) && make test"


### PR DESCRIPTION
We might want to raise or lower this threshold, but now a developer
should be able to see and track `WARN` and `ERROR` level events for each
service.

![tenor-62213753](https://user-images.githubusercontent.com/261548/90095069-d7416080-dcec-11ea-9d54-1ef51f1a30f2.gif)
