### PR TITLE
feat: allow for debugging events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,5 +136,5 @@ force_clean:
 
 dev_deps:
 	./components/couchbase/run.sh || docker start db; exit 0
-	./components/vernemq/run.sh || docker start vernemq; exit 0
+	./components/vernemq/run.sh || docker start mqtt; exit 0
 	./components/opentelemetry-collector/run.sh || docker start otelcol; exit 0

--- a/components/si-web-app/src/components/common/EventBar.vue
+++ b/components/si-web-app/src/components/common/EventBar.vue
@@ -13,23 +13,271 @@
       </div>
 
       <div class="flex-col h-40 overflow-y-auto event-list">
-        <div class="items-center w-full h-3 text-xs event-list-row" />
+        <div class="w-full text-xs event-list-row">
+          <div
+            v-for="(eventLog, index) of eventLogs"
+            :key="index"
+            class="flex flex-col text-xs text-gray-400 event-list-row"
+          >
+            <div
+              class="flex flex-row items-center"
+              @click="toggleEventExpansion(eventLog.id)"
+            >
+              <div class="ml-8">
+                <ChevronDownIcon
+                  size="1.0x"
+                  v-if="isEventExpanded(eventLog.id)"
+                />
+                <ChevronRightIcon size="1.0x" v-else />
+              </div>
+              <div class="ml-2">
+                <span class="text-gray-500">
+                  {{ eventLog.level }}
+                </span>
+                <span class="text-gray-600">
+                  {{ eventLog.timestamp }}
+                </span>
+                <span class="text-gray-400">
+                  {{ eventLog.message }}
+                </span>
+              </div>
+            </div>
+            <div class="ml-16 mr-10" v-if="isEventExpanded(eventLog.id)">
+              <div v-if="eventLog.payload.kind == 'entity'" class="flex-col">
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      name:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      type:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.siStorable.typeName }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    event:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.name }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                v-else-if="eventLog.payload.kind == 'change_set'"
+                class="flex-col"
+              >
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      name:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      type:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.siStorable.typeName }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    event:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.name }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                v-else-if="
+                  eventLog.payload.kind == 'change_set_entry' &&
+                    eventLog.payload.data.actionName
+                "
+                class="flex-col"
+              >
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>action:</div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.actionName }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      type:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.siStorable.typeName }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    event:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    entity name:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.inputEntity.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    entity type:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{
+                        eventLog.payload.data.inputEntity.siStorable.typeName
+                      }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    success:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.success }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    stdout:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      <pre>{{
+                        eventLog.payload.data.outputLines.join("\n")
+                      }}</pre>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    stderr:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      <pre>{{
+                        eventLog.payload.data.errorLines.join("\n")
+                      }}</pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                v-else-if="eventLog.payload.kind == 'change_set_entry'"
+                class="flex-col"
+              >
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      action:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      edited
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    <div>
+                      type:
+                    </div>
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.siStorable.typeName }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    event:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    entity name:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.name }}
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-row w-full">
+                  <div class="flex justify-end w-1/12 mr-2 text-white">
+                    entity type:
+                  </div>
+                  <div class="flex justify-start w-11/12">
+                    <div>
+                      {{ eventLog.payload.data.siStorable.typeName }}
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-        <div
-          v-for="eventLog in eventLogs"
-          :key="eventLog.id"
-          class="flex items-center h-5 text-xs text-gray-400 event-list-row"
-        >
-          <div class="ml-8">
-            <span class="text-gray-500">
-              {{ eventLog.level }}
-            </span>
-            <span class="text-gray-600">
-              {{ eventLog.timestamp }}
-            </span>
-            <span class="text-gray-400">
-              {{ eventLog.message }}
-            </span>
+              <div v-else>
+                {{ eventLog.payload.kind }}
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -61,14 +309,23 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { MaximizeIcon, MinimizeIcon } from "vue-feather-icons";
+import {
+  MaximizeIcon,
+  MinimizeIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+} from "vue-feather-icons";
 import { mapState, mapGetters } from "vuex";
 import { camelCase } from "change-case";
 import { RootStore } from "@/store";
+import { EventLog } from "@/graphql-types";
 
 interface Data {
   expanded: boolean;
   interval: number | null | undefined;
+  eventExpanded: {
+    [key: string]: boolean;
+  };
 }
 
 export default Vue.extend({
@@ -76,16 +333,34 @@ export default Vue.extend({
   components: {
     MaximizeIcon,
     MinimizeIcon,
+    ChevronRightIcon,
+    ChevronDownIcon,
   },
   data(): Data {
     return {
       expanded: false,
       interval: null,
+      eventExpanded: {},
     };
   },
   methods: {
     toggleExpand() {
       this.expanded = !this.expanded;
+    },
+    isEventExpanded(eventLogId: string): boolean {
+      if (this.eventExpanded[eventLogId]) {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    toggleEventExpansion(eventLogId: string): void {
+      if (this.eventExpanded[eventLogId]) {
+        Vue.set(this.eventExpanded, eventLogId, false);
+      } else {
+        Vue.set(this.eventExpanded, eventLogId, true);
+      }
+      console.log("toggling", { eventExpanded: this.eventExpanded });
     },
   },
   computed: {
@@ -93,8 +368,13 @@ export default Vue.extend({
       eventLogLatest: "eventLog/latest",
     }),
     ...mapState({
-      eventLogs: (state: any): RootStore["eventLog"]["eventLogs"] =>
-        state.eventLog.eventLogs,
+      eventLogs: (state: any): RootStore["eventLog"]["eventLogs"] => {
+        if (state.eventLog.eventLogs.length > 40) {
+          return state.eventLog.eventLogs.slice(0, 40);
+        } else {
+          return state.eventLog.eventLogs;
+        }
+      },
     }),
   },
   mounted(): void {

--- a/components/si-web-app/src/store/modules/eventLog.ts
+++ b/components/si-web-app/src/store/modules/eventLog.ts
@@ -20,8 +20,14 @@ export const eventLog: Module<EventLogStore, RootStore> = {
   },
   mutations: {
     add(state, payload: AddMutation) {
+      const fullEventLogs = payload.eventLogs.map(eventLog => {
+        if (eventLog.payload?.data) {
+          eventLog.payload.data = JSON.parse(eventLog.payload.data);
+        }
+        return eventLog;
+      });
       state.eventLogs = _.orderBy(
-        _.unionBy(payload.eventLogs, state.eventLogs, "id"),
+        _.unionBy(fullEventLogs, state.eventLogs, "id"),
         ["timestamp"],
         ["desc"],
       );
@@ -40,11 +46,11 @@ export const eventLog: Module<EventLogStore, RootStore> = {
     add({ commit }, payload: AddMutation) {
       commit("add", payload);
     },
-    async load({ commit }): Promise<void> {
+    async load({ commit, state }): Promise<void> {
       const eventLogs: EventLog[] = await graphqlQueryListAll({
         typeName: "eventLog",
       });
-      if (eventLogs.length > 0) {
+      if (eventLogs.length > 0 && eventLogs.length > state.eventLogs.length) {
         commit("add", { eventLogs });
       }
     },


### PR DESCRIPTION
This commit allows for (basic) debugging of events. The Event Bar now
has clickable chevrons for each line, which when expanded show more
information about the event.

It also now includes an event for when an EntityEvent is finalized, so
we can get the log messages. Its messy and wasteful, but its going to
work.

It doesn't stream the event logs as the event is firing - this should be
fine for now, as the events we are firing just don't take very long.
Instead, it shows you the final results, with the output inline.

![](https://media0.giphy.com/media/QVmwvXrFlCbzsd2F9O/giphy.gif?cid=5a38a5a2325mrq7r2cylifrqbuwfrcnnh6mzbsf5fztska4r&rid=giphy.gif)
