### PR TITLE
bug: fixed the stutter in property editing

### DIFF
--- a/components/si-web-app/src/store/modules/node.ts
+++ b/components/si-web-app/src/store/modules/node.ts
@@ -135,7 +135,7 @@ export const debouncedSetFieldValue = _.debounce(async function({
     map,
   });
 },
-100);
+1000);
 
 export const debouncedSetPosition = _.debounce(async function({
   store,

--- a/components/si-web-app/src/store/plugins/persistEdits.ts
+++ b/components/si-web-app/src/store/plugins/persistEdits.ts
@@ -46,7 +46,7 @@ export function persistEdits(store: Store<RootStore>): void {
             store.commit("editor/setEditSaveError", err);
           }
           store.commit("editor/setIsSaving", false);
-        }, 500);
+        }, 2000);
       }
       store.commit("editor/setEditSaveError", undefined);
       store.commit("editor/setIsSaving", true);


### PR DESCRIPTION
We had a stutter! I fixed it. No more stuttering. Not that there is
anything wrong with a stutter in general, but not when you're editing
text maybe.