### PR TITLE
feat: deleting applications and components

### DIFF
--- a/components/si-web-app/src/components/views/editor/EditorSchematicPanel/index.vue
+++ b/components/si-web-app/src/components/views/editor/EditorSchematicPanel/index.vue
@@ -1,12 +1,12 @@
 <template>
-  <div ref="schematic-panel" class="flex flex-col h-full w-full">
+  <div ref="schematic-panel" class="flex flex-col w-full h-full">
     <div
       id="schematic-panel-menu"
-      class="flex flex-row justify-between flex-no-wrap content-between bg-black w-full"
+      class="flex flex-row flex-no-wrap content-between justify-between w-full bg-black"
     >
       <div class="flex flex-row justify-start mx-3">
         <button
-          class="text-white px-4 py-2 focus:outline-none"
+          class="px-4 py-2 text-white focus:outline-none"
           @click="createNode()"
           type="button"
         >
@@ -14,7 +14,7 @@
         </button>
         <div class="text-black">
           <select
-            class="bg-gray-800 border text-gray-400 my-2 text-xs leading-tight focus:outline-none"
+            class="my-2 text-xs leading-tight text-gray-400 bg-gray-800 border focus:outline-none"
             v-model="selectedEntityType"
           >
             <option
@@ -27,7 +27,7 @@
           </select>
         </div>
         <button
-          class="text-white px-4 py-2 focus:outline-none"
+          class="px-4 py-2 text-white focus:outline-none"
           @click="sendAction()"
           type="button"
         >
@@ -35,7 +35,7 @@
         </button>
         <div class="text-black">
           <select
-            class="bg-gray-800 border text-gray-400 my-2 text-xs leading-tight focus:outline-none"
+            class="my-2 text-xs leading-tight text-gray-400 bg-gray-800 border focus:outline-none"
             v-model="selectedAction"
           >
             <option key="delete" value="delete">
@@ -50,7 +50,7 @@
 
       <div class="mx-3">
         <button
-          class="text-white px-4 py-2 focus:outline-none"
+          class="px-4 py-2 text-white focus:outline-none"
           @click="maximizePanel()"
           type="button"
         >
@@ -74,6 +74,7 @@ import _ from "lodash";
 import { mapState } from "vuex";
 import { RootStore } from "@/store";
 import { camelCase } from "change-case";
+import { NodeNodeKind } from "@/graphql-types";
 
 interface Data {
   selectedEntityType: string;
@@ -107,7 +108,7 @@ export default Vue.extend({
     },
     async createNode(): Promise<void> {
       await this.$store.dispatch("node/create", {
-        nodeType: "Entity",
+        nodeType: NodeNodeKind.Entity,
         typeName: this.selectedEntityType,
       });
     },

--- a/components/si-web-app/src/store/modules/edge.ts
+++ b/components/si-web-app/src/store/modules/edge.ts
@@ -35,6 +35,29 @@ export const edge: Module<EdgeStore, RootStore> = {
   },
   getters: {
     // prettier-ignore
+    allRelatedNodes: (state) => (startingNodeId: string): string[] => {
+      const relatedNodes = [startingNodeId];
+      for (const nodeId of relatedNodes) {
+        const relatedEdges = _.filter(state.edges, (edge) => {
+          if (edge.tailVertex?.id == nodeId) {
+            return true;
+          } else {
+            return false;
+          }
+        });
+        for (const relatedEdge of relatedEdges) {
+          if (relatedEdge.headVertex?.id) {
+            if (!_.find(relatedNodes, relatedEdge.headVertex?.id)) {
+              relatedNodes.push(relatedEdge.headVertex?.id);
+            }
+          }
+        }
+      }
+      // Remove the starting node
+      relatedNodes.shift();
+      return relatedNodes;
+    },
+    // prettier-ignore
     filter: (state) => (filter: any): EdgeStore["edges"] => {
       return _.filter(state.edges, filter);
     },

--- a/components/si-web-app/src/store/modules/entity.ts
+++ b/components/si-web-app/src/store/modules/entity.ts
@@ -6,8 +6,8 @@ import { registry, Props, PropMethod, PropLink, PropObject } from "si-registry";
 import { generateName } from "@/api/names";
 import { graphqlQuery, graphqlMutation } from "@/api/apollo";
 import { RootStore } from "@/store";
-import { NodeType, Item } from "./node";
-import { ServiceEntity, Edge } from "@/graphql-types";
+import { Item } from "./node";
+import { ServiceEntity, Edge, NodeNodeKind } from "@/graphql-types";
 
 interface EntityMeta {
   workspaceId: string;
@@ -528,7 +528,7 @@ export const entity: Module<EntityStore, RootStore> = {
       let node = {
         entityId: entity.siStorable?.itemId,
         name: entity.name,
-        nodeType: "Entity",
+        nodeType: NodeNodeKind.Entity,
         object: entity,
       };
       await dispatch(
@@ -617,7 +617,7 @@ export const entity: Module<EntityStore, RootStore> = {
       let node = {
         entityId: entityId,
         name: entity.name,
-        nodeType: "Entity",
+        nodeType: NodeNodeKind.Entity,
         object: entity,
       };
       await dispatch(
@@ -665,7 +665,7 @@ export const entity: Module<EntityStore, RootStore> = {
             {
               entityId: entity.siStorable.itemId,
               name: entity.name,
-              nodeType: NodeType.Entity,
+              nodeType: NodeNodeKind.Entity,
               object: entity,
             },
           ],
@@ -693,14 +693,14 @@ export const entity: Module<EntityStore, RootStore> = {
         node = {
           entityId: entity.siStorable.itemId,
           name: entity.name,
-          nodeType: NodeType.Entity,
+          nodeType: NodeNodeKind.Entity,
           object: entity,
         };
       } else {
         node = {
           entityId: entity.id,
           name: entity.name,
-          nodeType: NodeType.Entity,
+          nodeType: NodeNodeKind.Entity,
           object: entity,
         };
       }
@@ -798,14 +798,14 @@ export const entity: Module<EntityStore, RootStore> = {
           return {
             entityId: entity.siStorable.itemId,
             name: entity.name,
-            nodeType: NodeType.Entity,
+            nodeType: NodeNodeKind.Entity,
             object: entity,
           };
         } else {
           return {
             entityId: entity.id,
             name: entity.name,
-            nodeType: NodeType.Entity,
+            nodeType: NodeNodeKind.Entity,
             object: entity,
           };
         }


### PR DESCRIPTION
You can now delete applications and components from the schematic panel.

* If a node has been saved, then the node is marked deleted.
* If a node has been created in a change set, but that changeset has
  never been executed, then the node is removed from the schematic panel
  (but still exists in the worksapce)
* Delete cascades to all nodes related to the delted node. (Eventually,
  this will need to be smart about not deleting things that have more
  than one inbound edge - but lets wait for that problem, yes?)