### PR TITLE
feat: Adding Monaco as the editor for code

### DIFF
--- a/components/si-web-app/package-lock.json
+++ b/components/si-web-app/package-lock.json
@@ -4740,8 +4740,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
       "version": "9.0.0",
@@ -7513,8 +7512,7 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -11253,7 +11251,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -11264,7 +11261,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -12540,6 +12536,19 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "monaco-editor": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
+      "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
+    },
+    "monaco-editor-webpack-plugin": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.9.0.tgz",
+      "integrity": "sha512-tOiiToc94E1sb50BgZ8q8WK/bxus77SRrwCqIpAB5er3cpX78SULbEBY4YPOB8kDolOzKRt30WIHG/D6gz69Ww==",
+      "requires": {
+        "loader-utils": "^1.2.3"
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/components/si-web-app/package.json
+++ b/components/si-web-app/package.json
@@ -43,6 +43,8 @@
     "js-cookie": "^2.2.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
+    "monaco-editor": "^0.20.0",
+    "monaco-editor-webpack-plugin": "^1.9.0",
     "si-registry": "file:../si-registry",
     "tailwindcss": "^1.4.6",
     "unique-names-generator": "^4.2.0",

--- a/components/si-web-app/src/components/ui/Monaco.vue
+++ b/components/si-web-app/src/components/ui/Monaco.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="flex flex-col" style="height: 90%">
+    <div class="w-full h-full">
+      <div id="monaco-mount" class="h-full"></div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { mapState, mapGetters } from "vuex";
+import * as monaco from "monaco-editor";
+
+import { Node } from "@/store/modules/node";
+
+interface Data {
+  editor: monaco.editor.IEditor | undefined;
+}
+
+export default Vue.extend({
+  name: "Monaco",
+  data(): Data {
+    return {
+      editor: undefined,
+    };
+  },
+  computed: {
+    ...mapGetters({
+      codeProperty: "node/codeProperty",
+    }),
+    ...mapState({
+      selectedNode: (state: any): any => state.node.current,
+    }),
+    fieldValue: {
+      set(value: any) {
+        console.log("setting the new value", {
+          value,
+          codePropertyPath: this.codeProperty.path,
+        });
+        this.$store.dispatch("node/setFieldValue", {
+          path: this.codeProperty.path,
+          value,
+        });
+      },
+      get(): string {
+        if (this.codeProperty) {
+          return this.$store.getters["node/getFieldValue"](
+            this.codeProperty.path,
+          );
+        } else {
+          return "# No Code!";
+        }
+      },
+    },
+  },
+  methods: {
+    updateModel(): void {
+      if (this.editor) {
+        let existingModel = monaco.editor.getModel(this.selectedNode.id);
+        if (!existingModel) {
+          const newModel = monaco.editor.createModel(
+            this.fieldValue,
+            "yaml",
+            this.selectedNode.id,
+          );
+          this.editor.setModel(newModel);
+        } else {
+          existingModel.setValue(this.fieldValue);
+          this.editor.setModel(existingModel);
+        }
+      }
+    },
+  },
+  mounted() {
+    const mountPoint = document.getElementById("monaco-mount");
+    if (mountPoint) {
+      let editor = monaco.editor.create(mountPoint, {
+        theme: "vs-dark",
+        automaticLayout: true,
+        language: "yaml",
+        scrollBeyondLastLine: false,
+      });
+      const vx = this;
+      editor.onDidBlurEditorText(function() {
+        const model = editor.getModel();
+        if (model) {
+          let value = model.getValue();
+          vx.fieldValue = value;
+        }
+      });
+      this.editor = editor;
+      this.updateModel();
+    } else {
+      console.log("failed to mount monaco, element not found");
+    }
+  },
+  watch: {
+    selectedNode(currentValue: Node) {
+      this.updateModel();
+    },
+  },
+});
+</script>

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/index.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="property-panel" class="w-full property-editor-bg-color">
+  <div ref="property-panel" class="w-full h-full property-editor-bg-color">
     <div
       id="property-panel-menu"
       class="flex flex-row flex-no-wrap content-between justify-between w-full bg-black"
@@ -13,7 +13,10 @@
           <filter-icon size="1.1x" />
         </button>
 
-        <button class="px-4 py-2 text-white focus:outline-none">
+        <button
+          class="px-4 py-2 text-white focus:outline-none"
+          @click="toggleCodeEditor"
+        >
           <code-icon size="1.1x" />
         </button>
       </div>
@@ -29,7 +32,8 @@
       </div>
     </div>
 
-    <PropertyList />
+    <Monaco v-if="codeEditor" />
+    <PropertyList v-else />
   </div>
 </template>
 
@@ -42,6 +46,7 @@ import {
   SearchIcon,
   CodeIcon,
 } from "vue-feather-icons";
+import Monaco from "@/components/ui/Monaco.vue";
 
 import PropertyList from "./PropertyList.vue";
 
@@ -55,8 +60,17 @@ export default Vue.extend({
     SearchIcon,
     CodeIcon,
     PropertyList,
+    Monaco,
+  },
+  data() {
+    return {
+      codeEditor: false,
+    };
   },
   methods: {
+    toggleCodeEditor(): void {
+      this.codeEditor = !this.codeEditor;
+    },
     maximizePanel(): void {
       this.$emit("maximizePanelMsg", {
         panel: {

--- a/components/si-web-app/src/store/modules/entity.ts
+++ b/components/si-web-app/src/store/modules/entity.ts
@@ -85,6 +85,7 @@ interface UpdateEntityPayload {
     displayName?: string;
     [field: string]: any;
   };
+  code?: boolean;
   hypotheticalState?: {
     path: string[];
     value: any;
@@ -1174,8 +1175,15 @@ export const entity: Module<EntityStore, RootStore> = {
       const changeSetId = rootGetters["changeSet/current"].id;
       variables.changeSetId = changeSetId;
       variables.workspaceId = workspaceId;
-      if (variables.update.properties?.kubernetesObjectYaml != undefined) {
-        delete variables.update.properties.kubernetesObjectYaml;
+
+      if (payload.code) {
+        if (variables.update.properties?.kubernetesObject != undefined) {
+          delete variables.update.properties.kubernetesObject;
+        }
+      } else {
+        if (variables.update.properties?.kubernetesObjectYaml != undefined) {
+          delete variables.update.properties.kubernetesObjectYaml;
+        }
       }
 
       const result = await graphqlMutation({

--- a/components/si-web-app/src/store/modules/node.ts
+++ b/components/si-web-app/src/store/modules/node.ts
@@ -58,7 +58,7 @@ interface NodeConstructor {
 // sockets: Socket[]; -- alex tmp --
 // connections: NodeConnection[]; -- alex tmp --
 
-interface Node extends GqlNode {
+export interface Node extends GqlNode {
   stack: any[];
   display: Record<string, any>;
 }
@@ -177,6 +177,15 @@ export const node: Module<NodeStore, RootStore> = {
     mouseTrackSelection: null,
   },
   getters: {
+    codeProperty(_state, getters): undefined | RegistryProperty {
+      const propertiesList: RegistryProperty[] = getters["propertiesList"];
+      for (const prop of propertiesList) {
+        if (prop.kind == "code") {
+          return prop;
+        }
+      }
+      return undefined;
+    },
     // For the current node, produce the diff between the base state and the current state
     diffCurrent(state, _getters, rootState, _rootGetters): DiffResult {
       const currentNode: Node | null = state.current;

--- a/components/si-web-app/vue.config.js
+++ b/components/si-web-app/vue.config.js
@@ -1,5 +1,12 @@
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
+
 module.exports = {
   configureWebpack: {
+    plugins: [
+      new MonacoWebpackPlugin({
+        languages: ["yaml"],
+      }),
+    ],
     resolve: {
       symlinks: false,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
This resolves [ch87]. A user can:

* View the YAML representation of their k8s object
* Edit the YAML representaiton of their k8s object
* Changes are persisted, regardless of the representation
* Users can swap in and out of code view

![](https://media3.giphy.com/media/FltCW7GUbF5iE/giphy.gif?cid=5a38a5a2xawtiami9obz9uino89j1ed4tjai52l2c55cl0ty&rid=giphy.gif)
