### PR TITLE
bug: fix the save loop [ch453]

### DIFF
--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropBool.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropBool.vue
@@ -24,6 +24,8 @@
         type="checkbox"
         :aria-label="entityProperty.name"
         v-model="fieldValue"
+        @focus="storeStartingValue"
+        @blur="saveIfModified"
       />
       <ValidationWidget :value="fieldValue" :entityProperty="entityProperty" />
     </div>
@@ -51,20 +53,6 @@ export default PropMixin.extend({
       editorMode: (state: any): RootStore["editor"]["mode"] =>
         state.editor.mode,
     }),
-    fieldValue: {
-      get(): string {
-        return this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-      },
-      async set(value: any) {
-        debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value,
-        });
-      },
-    },
   },
 });
 </script>

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropEnum.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropEnum.vue
@@ -22,6 +22,8 @@
         :aria-label="entityProperty.name"
         v-bind:class="inputClasses"
         v-model="fieldValue"
+        @focus="storeStartingValue"
+        @blur="saveIfModified"
       >
         <option
           v-for="option in entityProperty.prop.variants"
@@ -55,20 +57,6 @@ export default PropMixin.extend({
       editorMode: (state: any): RootStore["editor"]["mode"] =>
         state.editor.mode,
     }),
-    fieldValue: {
-      get(): string {
-        return this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-      },
-      async set(value: any) {
-        debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value,
-        });
-      },
-    },
   },
 });
 </script>

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropNumber.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropNumber.vue
@@ -24,6 +24,8 @@
         :aria-label="entityProperty.name"
         v-model="fieldValue"
         placeholder="number"
+        @focus="storeStartingValue"
+        @blur="saveIfModified"
       />
       <ValidationWidget :value="fieldValue" :entityProperty="entityProperty" />
     </div>
@@ -54,24 +56,6 @@ export default PropMixin.extend({
       editorMode: (state: any): RootStore["editor"]["mode"] =>
         state.editor.mode,
     }),
-    fieldValue: {
-      get(): string {
-        return this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-      },
-      async set(value: any) {
-        // @ts-ignore - we know you're a number
-        if (this.entityProperty.prop.numberKind == "int32") {
-          value = parseInt(value);
-        }
-        debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value,
-        });
-      },
-    },
   },
 });
 </script>

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropRepeated.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropRepeated.vue
@@ -17,12 +17,12 @@
     <div>
       <div class="flex flex-col text-gray-400">
         <div
-          class="flex flex-row pl-2 ml-16 mr-12 items-center"
+          class="flex flex-row items-center pl-2 ml-16 mr-12"
           v-for="(repeatedEntry, index) in fieldValue"
           :key="index"
           v-show="showPath(entityProperty, index)"
         >
-          <div class="repeated-border border rounded-sm mb-2 w-full">
+          <div class="w-full mb-2 border rounded-sm repeated-border">
             <div
               class="text-white"
               v-for="ep in propertiesList(entityProperty, index)"
@@ -93,7 +93,7 @@
         </div>
         <div>
           <div
-            class="flex align-middle justify-center text-gray-500"
+            class="flex justify-center text-gray-500 align-middle"
             v-if="editorMode == 'edit'"
           >
             <button
@@ -129,6 +129,7 @@ import PropNumber from "./PropNumber.vue";
 import PropEnum from "./PropEnum.vue";
 import PropMap from "./PropMap.vue";
 import PropSelect from "./PropSelect.vue";
+import PropMixin from "./PropMixin";
 
 // This component only works with repeated objects! When we need it to work with
 // repeated fields of other types, we're going to have to extend it. For now,
@@ -137,7 +138,7 @@ interface Data {
   collapsedPaths: (string | number)[][];
 }
 
-export default Vue.extend({
+export default PropMixin.extend({
   name: "PropRepeated",
   props: {
     entityProperty: Object as () => RegistryProperty,
@@ -170,11 +171,13 @@ export default Vue.extend({
       let current = _.cloneDeep(this.fieldValue);
       current.push({});
       this.fieldValue = current;
+      this.saveIfModified();
     },
     removeFromList(index: number): void {
       let current = _.cloneDeep(this.fieldValue);
       current.splice(index, 1);
       this.fieldValue = current;
+      this.saveIfModified();
     },
     showPath(prop: RegistryProperty, index: number): boolean {
       let propPath = _.cloneDeep(prop.path);
@@ -264,25 +267,6 @@ export default Vue.extend({
         // 'is-primary': this.isOpen,
         // 'is-dark': !this.isOpen
       };
-    },
-    fieldValue: {
-      get(): any[] {
-        let objectValues = this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-        if (objectValues == undefined) {
-          return [];
-        } else {
-          return _.cloneDeep(objectValues);
-        }
-      },
-      async set(value: any) {
-        await debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value: value,
-        });
-      },
     },
   },
 });

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropSelect.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropSelect.vue
@@ -32,6 +32,8 @@
             :value="option.value"
             v-bind:class="inputClasses"
             v-model="fieldValue"
+            @focus="storeStartingValue"
+            @blur="saveIfModified"
           />
           <label
             class="pl-2 text-sm leading-tight text-white input-label"
@@ -48,6 +50,8 @@
           v-bind:class="inputClasses"
           :aria-label="entityProperty.name"
           v-model="fieldValue"
+          @focus="storeStartingValue"
+          @blur="saveIfModified"
         >
           <option
             v-for="option in this.options"
@@ -106,29 +110,29 @@ export default PropMixin.extend({
         return this.entityProperty.prop.options;
       }
     },
-    fieldValue: {
-      get(): string | string[] {
-        let value = this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-        if (this.entityProperty.repeated) {
-          if (value) {
-            return value;
-          } else {
-            return [];
-          }
-        } else {
-          return value;
-        }
-      },
-      async set(value: any) {
-        debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value,
-        });
-      },
-    },
+    //fieldValue: {
+    //  get(): string | string[] {
+    //    let value = this.$store.getters["node/getFieldValue"](
+    //      this.entityProperty.path,
+    //    );
+    //    if (this.entityProperty.repeated) {
+    //      if (value) {
+    //        return value;
+    //      } else {
+    //        return [];
+    //      }
+    //    } else {
+    //      return value;
+    //    }
+    //  },
+    //  async set(value: any) {
+    //    debouncedSetFieldValue({
+    //      store: this.$store,
+    //      path: this.entityProperty.path,
+    //      value,
+    //    });
+    //  },
+    //},
   },
 });
 </script>

--- a/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropText.vue
+++ b/components/si-web-app/src/components/views/editor/EditorPropertyPanel/PropText.vue
@@ -22,6 +22,8 @@
         :aria-label="entityProperty.name"
         v-model="fieldValue"
         placeholder="text"
+        @focus="storeStartingValue"
+        @blur="saveIfModified"
       />
       <ValidationWidget :value="fieldValue" :entityProperty="entityProperty" />
     </div>
@@ -39,6 +41,10 @@ import { RegistryProperty, debouncedSetFieldValue } from "@/store/modules/node";
 import PropMixin from "./PropMixin";
 import ValidationWidget from "@/components/ui/ValidationWidget.vue";
 
+interface Data {
+  originalValue: any;
+}
+
 export default PropMixin.extend({
   name: "PropText",
   components: {
@@ -49,20 +55,6 @@ export default PropMixin.extend({
       editorMode: (state: any): RootStore["editor"]["mode"] =>
         state.editor.mode,
     }),
-    fieldValue: {
-      get(): string {
-        return this.$store.getters["node/getFieldValue"](
-          this.entityProperty.path,
-        );
-      },
-      async set(value: any) {
-        debouncedSetFieldValue({
-          store: this.$store,
-          path: this.entityProperty.path,
-          value,
-        });
-      },
-    },
   },
 });
 </script>


### PR DESCRIPTION
This fixes the save flow [ch453], at least for now. Maps still have a
bug with their data being lost on entry, and if you don't want for the
save, you can loose some data on adding to a repeated object.

I have plans to fix both bugs, but it means a bigger refactor of the
whole flow, which really needs a new service (which is also on the
board).

For now, you should be good to edit fields as fast as you can type.