### PR TITLE
bug: persist the store locally for faster loading

### DIFF
--- a/components/si-web-app/package-lock.json
+++ b/components/si-web-app/package-lock.json
@@ -9939,6 +9939,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "immutable": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
@@ -10992,6 +10997,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -11265,6 +11278,14 @@
             "minimist": "^1.2.0"
           }
         }
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {

--- a/components/si-web-app/package.json
+++ b/components/si-web-app/package.json
@@ -42,6 +42,7 @@
     "joi": "^17.2.0",
     "js-cookie": "^2.2.1",
     "jsonwebtoken": "^8.5.1",
+    "localforage": "^1.9.0",
     "lodash": "^4.17.15",
     "monaco-editor": "^0.20.0",
     "monaco-editor-webpack-plugin": "^1.9.0",

--- a/components/si-web-app/src/pages/LoadingPage.vue
+++ b/components/si-web-app/src/pages/LoadingPage.vue
@@ -69,7 +69,7 @@ export default Vue.extend({
       loaded: (state: any) => state.loader.loading,
     }),
   },
-  mounted(): void {
+  async mounted(): Promise<void> {
     // @ts-ignore
     const handle = setInterval(() => {
       this.getQuote();

--- a/components/si-web-app/src/pages/WorkspacePage/WorkspaceNav.vue
+++ b/components/si-web-app/src/pages/WorkspacePage/WorkspaceNav.vue
@@ -170,14 +170,24 @@
       <line x1="5" y1="0" x2="95" y2="0" stroke="#313639" />
     </svg>
 
-    <div class="flex items-center justify-end w-full h-12 color-grey-medium">
-      <div class="flex self-center mr-8">
-        <div class="self-center flex-1 text-center">
-          <user-icon
-            size="1.2x"
-            class="text-center cursor-pointer color-grey-light"
-            @click="onLogout"
-          />
+    <div class="flex items-center w-full h-12 justify-left color-grey-medium">
+      <div class="flex self-center ml-8">
+        <RefreshCwIcon
+          size="1.2x"
+          class="text-center cursor-pointer color-grey-light"
+          @click="clearLogout"
+        />
+      </div>
+
+      <div class="flex justify-end w-full">
+        <div class="flex self-center mr-8">
+          <div class="self-center flex-1 text-center">
+            <user-icon
+              size="1.2x"
+              class="text-center cursor-pointer color-grey-light"
+              @click="onLogout"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -196,9 +206,12 @@ import {
   LayersIcon,
   BookOpenIcon,
   GridIcon,
+  RefreshCwIcon,
 } from "vue-feather-icons";
 
 import SysinitIcon from "@/components/icons/SysinitIcon.vue";
+
+import localforage from "localforage";
 
 export default {
   name: "WorkspaceNav",
@@ -214,6 +227,7 @@ export default {
     LayersIcon,
     BookOpenIcon,
     GridIcon,
+    RefreshCwIcon,
   },
   props: {
     organizationId: {
@@ -230,10 +244,18 @@ export default {
     };
   },
   methods: {
-    // @ts-ignore
-    async onLogout(event) {
+    async onLogout(event: any) {
       console.log("logout clicked");
       await this.$store.dispatch("user/logout");
+      this.$router.push({ name: "signin" });
+    },
+    async clearLogout(event: any) {
+      console.log("clear logout clicked");
+      await this.$store.dispatch("user/logout");
+      await localforage.dropInstance({
+        name: "si-store",
+        storeName: "vuex",
+      });
       this.$router.push({ name: "signin" });
     },
   },

--- a/components/si-web-app/src/store/index.ts
+++ b/components/si-web-app/src/store/index.ts
@@ -1,7 +1,8 @@
 import Vue from "vue";
-import Vuex from "vuex";
+import Vuex, { Payload } from "vuex";
 import { Store } from "vuex";
-//import VuexPersistence from "vuex-persist";
+import localforage from "localforage";
+import VuexPersistence from "vuex-persist";
 //import Cookies from "js-cookie";
 import { editor, EditorStore } from "./modules/editor";
 import { application, ApplicationStore } from "./modules/application";
@@ -21,6 +22,19 @@ import { loader, LoaderStore } from "./modules/loader";
 Vue.use(Vuex);
 
 const debug = process.env.NODE_ENV !== "production";
+
+const localForage = localforage.createInstance({
+  driver: localforage.INDEXEDDB,
+  name: "si-store",
+  storeName: "vuex",
+  description: "the vuex state, stored",
+});
+
+// @ts-ignore types?
+const vuexPersist = new VuexPersistence<any>({
+  storage: localForage,
+  asyncStorage: true,
+});
 
 //const vuexCookie = new VuexPersistence({
 //  restoreState: (key, _storage) => Cookies.getJSON(key),
@@ -72,7 +86,7 @@ const store: Store<RootStore> = new Vuex.Store({
     loader,
   },
   strict: debug,
-  plugins: [persistEdits, persistNodes],
+  plugins: [persistEdits, persistNodes, vuexPersist.plugin],
 });
 
 export default store;

--- a/components/si-web-app/src/store/modules/loader.ts
+++ b/components/si-web-app/src/store/modules/loader.ts
@@ -29,24 +29,27 @@ export const loader: Module<LoaderStore, RootStore> = {
     },
   },
   actions: {
-    async load({ commit, dispatch, rootState }): Promise<void> {
-      commit("loading", true);
-      await dispatch("workspace/load", {}, { root: true });
-      await dispatch(
-        "billingAccount/get",
-        {
-          billingAccountId: rootState.user.auth.profile?.billingAccount?.id,
-        },
-        { root: true },
-      );
-      await dispatch("system/load", {}, { root: true });
-      await dispatch("node/load", {}, { root: true });
-      await dispatch("edge/load", {}, { root: true });
-      await dispatch("changeSet/load", {}, { root: true });
-      await dispatch("entity/load", {}, { root: true });
-      await dispatch("eventLog/load", {}, { root: true });
-      commit("loading", false);
-      commit("loaded", true);
+    async load({ state, commit, dispatch, rootState }): Promise<void> {
+      console.log("why?", { state, rootState });
+      if (!state.loaded) {
+        commit("loading", true);
+        await dispatch("workspace/load", {}, { root: true });
+        await dispatch(
+          "billingAccount/get",
+          {
+            billingAccountId: rootState.user.auth.profile?.billingAccount?.id,
+          },
+          { root: true },
+        );
+        await dispatch("system/load", {}, { root: true });
+        await dispatch("node/load", {}, { root: true });
+        await dispatch("edge/load", {}, { root: true });
+        await dispatch("changeSet/load", {}, { root: true });
+        await dispatch("entity/load", {}, { root: true });
+        await dispatch("eventLog/load", {}, { root: true });
+        commit("loading", false);
+        commit("loaded", true);
+      }
     },
   },
 };

--- a/components/si-web-app/src/store/modules/user.ts
+++ b/components/si-web-app/src/store/modules/user.ts
@@ -175,7 +175,6 @@ export const user: Module<UserStore, any> = {
     async logout({ commit }): Promise<void> {
       commit("profile", undefined);
       commit("loggedIn", false);
-      commit("loader/loaded", false, { root: true });
       await onLogout();
       localStorage.removeItem("profile");
     },


### PR DESCRIPTION
This is a partial solution - it stores the data in the browsers
IndexedDB every time the Vuex store is mutated. The result is that we
get the full application state all the time, no matter what.

That means reloading is really fast, because all your application state
is stored on disk. Yay!

The bad part: it will only work for a single user - if mutations happen
outside your web browser, all bets are off.

The medium part: I added a "refresh" logout button down near the user
icon. If you click it, the indexeddb will be dropped, and you will be
logged out. If you then shift-refresh the browser, you will be starting
again from scratch.

Eventually, this behavior needs to be completely thought out -
essentially, vuex is great (reactive state! central!) and also not so
great (double persisting to the API!). I think it's all fine for now,
but as soon as we have multiple users, we will want to extend this
functionality.

Love,
Adam