### PR TITLE
feat: edit sessions can be canceled

### DIFF
--- a/components/si-sdf/src/data.rs
+++ b/components/si-sdf/src/data.rs
@@ -177,6 +177,15 @@ pub async fn create_indexes(db: &Db) -> DataResult<()> {
     create_index(
         &db,
         format!(
+            "CREATE INDEX `idx_si_changeset_changesetid_si_changeset_editsessionid` on `{bucket}`(siChangeSet.changeSetId, siChangeSet.editSessionId)",
+            bucket = db.bucket_name
+        ),
+    )
+    .await?;
+
+    create_index(
+        &db,
+        format!(
             "CREATE INDEX `idx_id` on `{bucket}`(id)",
             bucket = db.bucket_name
         ),

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -414,6 +414,7 @@ pub fn change_sets(
     change_set_create(db.clone(), nats.clone())
         .or(change_set_patch(db.clone(), nats.clone()))
         .or(edit_session_create(db.clone(), nats.clone()))
+        .or(edit_session_patch(db.clone(), nats.clone()))
 }
 
 pub fn change_set_create(
@@ -453,6 +454,19 @@ pub fn edit_session_create(
         .and(warp::header::<String>("authorization"))
         .and(warp::body::json::<models::edit_session::CreateRequest>())
         .and_then(handlers::edit_sessions::create)
+}
+
+pub fn edit_session_patch(
+    db: Db,
+    nats: Connection,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("changeSets" / String / "editSessions" / String)
+        .and(warp::patch())
+        .and(with_db(db))
+        .and(with_nats(nats))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<models::edit_session::PatchRequest>())
+        .and_then(handlers::edit_sessions::patch)
 }
 
 // changeSetParticipants

--- a/components/si-sdf/src/handlers/edit_sessions.rs
+++ b/components/si-sdf/src/handlers/edit_sessions.rs
@@ -1,7 +1,10 @@
 use crate::data::{Connection, Db};
 
 use crate::handlers::{authenticate, authorize, HandlerError};
-use crate::models::edit_session::{CreateReply, CreateRequest, EditSession};
+use crate::models::edit_session::{
+    CreateReply, CreateRequest, EditSession, PatchReply, PatchRequest,
+};
+use crate::models::get_model;
 
 pub async fn create(
     change_set_id: String,
@@ -34,5 +37,37 @@ pub async fn create(
     .map_err(HandlerError::from)?;
 
     let reply = CreateReply { item: edit_session };
+    Ok(warp::reply::json(&reply))
+}
+
+pub async fn patch(
+    change_set_id: String,
+    edit_session_id: String,
+    db: Db,
+    nats: Connection,
+    token: String,
+    request: PatchRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let claim = authenticate(&db, &token).await?;
+    authorize(
+        &db,
+        &claim.user_id,
+        &claim.billing_account_id,
+        "editSession",
+        "patch",
+    )
+    .await?;
+
+    let edit_session: EditSession = get_model(&db, &edit_session_id, &claim.billing_account_id)
+        .await
+        .map_err(HandlerError::from)?;
+    match request {
+        PatchRequest::Cancel(_) => edit_session
+            .cancel(&db, &nats)
+            .await
+            .map_err(HandlerError::from)?,
+    }
+
+    let reply = PatchReply::Cancel(edit_session);
     Ok(warp::reply::json(&reply))
 }

--- a/components/si-sdf/src/models/change_set.rs
+++ b/components/si-sdf/src/models/change_set.rs
@@ -253,10 +253,7 @@ impl ChangeSet {
             }
         }
 
-        //// Calculate the final entities properties
-        tracing::warn!(?last_type_name, "what is the last type name");
         if last_type_name.is_some() && last_type_name.unwrap() == "entity" {
-            tracing::warn!("why aren't you getting here");
             let mut last_entity = seen_map.get_mut(&last_id.unwrap()).unwrap();
             calculate_properties(&mut last_entity).await?;
         }
@@ -272,6 +269,10 @@ impl ChangeSet {
                         .pointer_mut("/head")
                         .ok_or(ChangeSetError::MissingHead)?;
                     *head = serde_json::Value::Bool(false);
+                    let base = obj
+                        .pointer_mut("/base")
+                        .ok_or(ChangeSetError::MissingHead)?;
+                    *base = serde_json::Value::Bool(false);
                     let change_set_id = obj
                         .pointer_mut("/siChangeSet/changeSetId")
                         .ok_or(ChangeSetError::IdMissing)?;
@@ -293,6 +294,10 @@ impl ChangeSet {
                         .pointer_mut("/head")
                         .ok_or(ChangeSetError::MissingHead)?;
                     *head = serde_json::Value::Bool(true);
+                    let base = obj
+                        .pointer_mut("/base")
+                        .ok_or(ChangeSetError::MissingHead)?;
+                    *base = serde_json::Value::Bool(false);
                 }
                 upsert_model(db, nats, id, obj).await?;
                 {
@@ -300,6 +305,10 @@ impl ChangeSet {
                         .pointer_mut("/head")
                         .ok_or(ChangeSetError::MissingHead)?;
                     *head = serde_json::Value::Bool(false);
+                    let base = obj
+                        .pointer_mut("/base")
+                        .ok_or(ChangeSetError::MissingHead)?;
+                    *base = serde_json::Value::Bool(false);
                     let change_set_id = obj
                         .pointer_mut("/siChangeSet/changeSetId")
                         .ok_or(ChangeSetError::IdMissing)?;

--- a/components/si-sdf/src/models/edit_session.rs
+++ b/components/si-sdf/src/models/edit_session.rs
@@ -1,8 +1,12 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::data::{Connection, Db};
-use crate::models::{insert_model, ModelError, SiStorable, SiStorableError};
+use crate::data::{Connection, DataError, Db};
+use crate::models::{
+    insert_model, publish_model, ChangeSet, ChangeSetError, ModelError, SiStorable, SiStorableError,
+};
+
+use std::collections::HashMap;
 
 #[derive(Error, Debug)]
 pub enum EditSessionError {
@@ -10,9 +14,25 @@ pub enum EditSessionError {
     SiStorable(#[from] SiStorableError),
     #[error("error in core model functions: {0}")]
     Model(#[from] ModelError),
+    #[error("data error: {0}")]
+    Data(#[from] DataError),
+    #[error("changeSet error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
 }
 
 pub type EditSessionResult<T> = Result<T, EditSessionError>;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum PatchRequest {
+    Cancel(bool),
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum PatchReply {
+    Cancel(EditSession),
+}
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -71,5 +91,55 @@ impl EditSession {
         };
         insert_model(db, nats, &edit_session.id, &edit_session).await?;
         Ok(edit_session)
+    }
+
+    pub async fn cancel(&self, db: &Db, nats: &Connection) -> EditSessionResult<()> {
+        let query = format!(
+            "UPDATE `{bucket}`
+                SET siOp.skip = true
+                WHERE siChangeSet.changeSetId = $change_set_id 
+                  AND siChangeSet.editSessionId = $edit_session_id
+            RETURNING `{bucket}`.*",
+            bucket = db.bucket_name,
+        );
+        let mut named_params: HashMap<String, serde_json::Value> = HashMap::new();
+        named_params.insert(
+            "change_set_id".into(),
+            serde_json::json![&self.change_set_id],
+        );
+        named_params.insert("edit_session_id".into(), serde_json::json![&self.id]);
+        let query_results: Vec<serde_json::Value> = db.query(query, Some(named_params)).await?;
+        for item in query_results.iter() {
+            publish_model(nats, item).await?;
+        }
+        let query = format!(
+            "UPDATE `{bucket}`
+                SET siStorable.deleted = true
+                WHERE siChangeSet.changeSetId = $change_set_id 
+                  AND siChangeSet.editSessionId = $edit_session_id
+                  AND base = true
+            RETURNING `{bucket}`.*",
+            bucket = db.bucket_name,
+        );
+        let mut named_params: HashMap<String, serde_json::Value> = HashMap::new();
+        named_params.insert(
+            "change_set_id".into(),
+            serde_json::json![&self.change_set_id],
+        );
+        named_params.insert("edit_session_id".into(), serde_json::json![&self.id]);
+        let query_results: Vec<serde_json::Value> = db.query(query, Some(named_params)).await?;
+        for item in query_results.iter() {
+            publish_model(nats, item).await?;
+        }
+        let mut change_set = ChangeSet::get(
+            db,
+            &self.change_set_id,
+            &self.si_storable.billing_account_id,
+        )
+        .await?;
+        change_set.execute(db, nats, true).await?;
+
+        tracing::info!(?query_results, "cancel edit session");
+        Ok(())
     }
 }

--- a/components/si-web-app/src/api/sdf/model/editSession.ts
+++ b/components/si-web-app/src/api/sdf/model/editSession.ts
@@ -12,6 +12,14 @@ import { Query, Comparison } from "@/api/sdf/model/query";
 import store from "@/store";
 import _ from "lodash";
 
+export interface IEditSessionPatchRequest {
+  cancel?: boolean;
+}
+
+export interface IEditSessionPatchReply {
+  cancel?: IEditSession;
+}
+
 export interface IEditSession {
   id: string;
   name: string;
@@ -128,6 +136,22 @@ export class EditSession implements IEditSession {
       items,
       totalCount,
     };
+  }
+
+  async cancel(): Promise<void> {
+    let request: IEditSessionPatchRequest = {
+      cancel: true,
+    };
+    let reply: IEditSessionPatchReply = await sdf.patch(
+      `changeSets/${this.changeSetId}/editSessions/${this.id}`,
+      request,
+    );
+    if (reply.cancel) {
+      console.log("you have been canceled");
+      return;
+    } else {
+      throw new Error("incorrect response to patch call");
+    }
   }
 
   async save(): Promise<void> {

--- a/components/si-web-app/src/api/sdf/model/entity.ts
+++ b/components/si-web-app/src/api/sdf/model/entity.ts
@@ -45,6 +45,7 @@ export interface IEntity {
   };
   nodeId: string;
   head: boolean;
+  base: boolean;
   siStorable: ISiStorable;
   siChangeSet: ISiChangeSet;
 }
@@ -60,6 +61,7 @@ export class Entity implements IEntity {
   properties: IEntity["properties"];
   nodeId: IEntity["nodeId"];
   head: IEntity["head"];
+  base: IEntity["base"];
   siStorable: IEntity["siStorable"];
   siChangeSet: IEntity["siChangeSet"];
 
@@ -74,6 +76,7 @@ export class Entity implements IEntity {
     this.properties = args.properties;
     this.nodeId = args.nodeId;
     this.head = args.head;
+    this.base = args.base;
     this.siStorable = args.siStorable;
     this.siChangeSet = args.siChangeSet;
   }
@@ -322,7 +325,9 @@ export class Entity implements IEntity {
     if (this.head) {
       await db.headEntities.put(this);
     } else {
-      await db.projectionEntities.put(this);
+      if (!this.base) {
+        await db.projectionEntities.put(this);
+      }
     }
     this.dispatch();
   }

--- a/components/si-web-app/src/components/views/application/ApplicationDetails.vue
+++ b/components/si-web-app/src/components/views/application/ApplicationDetails.vue
@@ -390,8 +390,7 @@ export default Vue.extend({
       }
     },
     async cancelEditSession() {
-      // TODO: Add edit session revert - going to be a lot easier
-      //       after we add the rest of the logic.
+      await this.$store.dispatch("editor/editSessionCancel");
       await this.$store.dispatch("editor/setEditSession", { id: undefined });
       await this.$store.dispatch("editor/modeSwitch");
     },

--- a/components/si-web-app/src/store/modules/editor.ts
+++ b/components/si-web-app/src/store/modules/editor.ts
@@ -655,6 +655,13 @@ export const editor: Module<EditorStore, RootStore> = {
       commit("system", system);
       await dispatch("context");
     },
+    async editSessionCancel({ state }) {
+      let editSession = state.editSession;
+      if (editSession) {
+        console.log("I am canceling the crap out of this session");
+        await editSession.cancel();
+      }
+    },
     async editSessionCreate({ commit, rootGetters, state }) {
       let workspace = rootGetters["workspace/current"];
       let organization = rootGetters["organization/current"];


### PR DESCRIPTION
This commit adds canceling edit sessions, which closes [ch470].

Any operations taken during the edit session will be reverted (skipped)
if the edit session is canceled. New nodes added in the edit session
will be deleted, edits made to objects won't be applied. Deleted nodes
will not be deleted.

It's clever! It's fun! It works like Alex thinks it should.

Love,
Adam and Fletcher

![](https://media2.giphy.com/media/3o7WIJtl6kcvpq7A9W/200.gif?cid=5a38a5a2ybrly367mjivs30roi5xahb59qhmg1eklzjft867&rid=200.gif)
