### PR TITLE
feat: services visualization and deployment button

### DIFF
--- a/components/si-registry/src/components/si-core/application.ts
+++ b/components/si-registry/src/components/si-core/application.ts
@@ -1,5 +1,11 @@
 import { PropBool, PropText, PropSelect } from "../../components/prelude";
 import { registry } from "../../registry";
+import {
+  ActionRequest,
+  ActionReply,
+  ResourceHealth,
+  ResourceStatus,
+} from "../../veritech/intelligence";
 
 registry.componentAndEntity({
   typeName: "application",
@@ -20,5 +26,25 @@ registry.componentAndEntity({
         p.repeated = true;
       },
     });
+
+    c.entity.intelligence.actions = {
+      async deploy(request: ActionRequest): Promise<ActionReply> {
+        const actions: ActionReply["actions"] = [];
+        for (const child of request.entities.successors) {
+          if (child.objectType == "service") {
+            actions.push({ action: "deploy", entityId: child.id });
+          }
+        }
+        const reply: ActionReply = {
+          resource: {
+            state: { edward: "van halen" },
+            health: ResourceHealth.Ok,
+            status: ResourceStatus.Created,
+          },
+          actions,
+        };
+        return reply;
+      },
+    };
   },
 });

--- a/components/si-registry/src/components/si-core/service.ts
+++ b/components/si-registry/src/components/si-core/service.ts
@@ -4,6 +4,12 @@ import {
   PropText,
   PropSelect,
 } from "../../components/prelude";
+import {
+  ActionRequest,
+  ActionReply,
+  ResourceHealth,
+  ResourceStatus,
+} from "../../veritech/intelligence";
 import { registry } from "../../registry";
 
 registry.componentAndEntity({
@@ -70,5 +76,28 @@ registry.componentAndEntity({
         p.mutation = true;
       },
     });
+
+    c.entity.intelligence.actions = {
+      async deploy(request: ActionRequest): Promise<ActionReply> {
+        const actions: ActionReply["actions"] = [];
+        for (const child of request.entities.successors) {
+          if (child.objectType == "service") {
+            actions.push({ action: "deploy", nodeId: child.nodeId });
+          }
+        }
+        const reply: ActionReply = {
+          resource: {
+            state: {
+              alex: "van halen",
+              deployedBy: request.entities.predecessors.map(p => p.name),
+            },
+            health: ResourceHealth.Ok,
+            status: ResourceStatus.Created,
+          },
+          actions,
+        };
+        return reply;
+      },
+    };
   },
 });

--- a/components/si-registry/src/veritech/intelligence.ts
+++ b/components/si-registry/src/veritech/intelligence.ts
@@ -257,7 +257,7 @@ export interface ActionReply {
   resource: ResourceUpdate;
   actions: {
     action: string;
-    nodeId: string;
+    entityId: string;
   }[];
 }
 

--- a/components/si-sdf/src/handlers/nodes.rs
+++ b/components/si-sdf/src/handlers/nodes.rs
@@ -177,11 +177,11 @@ pub async fn object_patch(
         }
         OpRequest::EntityAction(op_request) => {
             OpEntityAction::new(
-                &db,
-                &nats,
-                &entity_id,
-                &op_request.action,
-                &op_request.system_id,
+                db.clone(),
+                nats.clone(),
+                entity_id,
+                op_request.action,
+                op_request.system_id,
                 claim.billing_account_id,
                 request.organization_id,
                 request.workspace_id,

--- a/components/si-sdf/src/models/ops.rs
+++ b/components/si-sdf/src/models/ops.rs
@@ -55,7 +55,7 @@ pub struct OpReply {
 
 pub type OpResult<T> = Result<T, OpError>;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SiOp {
     skip: bool,

--- a/components/si-sdf/src/models/si_change_set.rs
+++ b/components/si-sdf/src/models/si_change_set.rs
@@ -18,7 +18,7 @@ pub enum SiChangeSetError {
 
 pub type SiChangeSetResult<T> = Result<T, SiChangeSetError>;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum SiChangeSetEvent {
     Create,
     Delete,
@@ -27,7 +27,7 @@ pub enum SiChangeSetEvent {
     Projection,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SiChangeSet {
     pub change_set_id: String,

--- a/components/si-sdf/src/models/si_storable.rs
+++ b/components/si-sdf/src/models/si_storable.rs
@@ -12,7 +12,7 @@ pub enum SiStorableError {
 
 pub type SiStorableResult<T> = Result<T, SiStorableError>;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SiStorable {
     pub type_name: String,

--- a/components/si-web-app/src/api/sdf/model/resource.ts
+++ b/components/si-web-app/src/api/sdf/model/resource.ts
@@ -82,6 +82,7 @@ export class Resource implements IResource {
 
   async dispatch(): Promise<void> {
     await store.dispatch("editor/fromResource", this);
+    await store.dispatch("application/fromResource", this);
   }
 
   static async restore(): Promise<void> {

--- a/components/si-web-app/src/components/ui/Button2.vue
+++ b/components/si-web-app/src/components/ui/Button2.vue
@@ -11,6 +11,7 @@
         <XIcon :size="iconSize" v-else-if="icon == 'cancel'" />
         <RefreshCcwIcon :size="iconSize" v-else-if="icon == 'refresh'" />
         <EditIcon :size="iconSize" v-else-if="icon == 'edit'" />
+        <UploadCloudIcon :size="iconSize" v-else-if="icon == 'deploy'" />
       </div>
       <div class="ml-1 font-normal" v-if="label">
         {{ label }}
@@ -28,12 +29,13 @@ import {
   SaveIcon,
   XIcon,
   EditIcon,
+  UploadCloudIcon,
 } from "vue-feather-icons";
 
 interface ButtonProps {
   kind: "standard" | "save" | "cancel";
   label: null | string;
-  icon: null | "play" | "save" | "cancel" | "refresh" | "edit";
+  icon: null | "play" | "save" | "cancel" | "refresh" | "edit" | "deploy";
   size: "xs" | "sm" | "base" | "lg";
   disabled: boolean;
 }
@@ -46,6 +48,7 @@ export default Vue.extend({
     XIcon,
     RefreshCcwIcon,
     EditIcon,
+    UploadCloudIcon,
   },
   props: {
     kind: {

--- a/components/si-web-app/src/components/views/editor/EditorSchematicPanel/index.vue
+++ b/components/si-web-app/src/components/views/editor/EditorSchematicPanel/index.vue
@@ -119,7 +119,9 @@ export default Vue.extend({
       });
     },
     async sendAction(): Promise<void> {
-      await this.$store.dispatch("editor/sendAction", this.selectedAction);
+      await this.$store.dispatch("editor/sendAction", {
+        action: this.selectedAction,
+      });
     },
   },
   computed: {

--- a/components/si-web-app/src/components/visualization/SystemsVisualization.vue
+++ b/components/si-web-app/src/components/visualization/SystemsVisualization.vue
@@ -5,8 +5,8 @@
     </div>
     <div class="flex pl-1 mt-1">
       <div v-for="system in systems" class="mr-1" :key="system.id">
-        <SquareChart
-          rgbColor="115, 76, 118"
+        <SystemChart
+          :system="system"
           :data-cy="'systems-visualization-' + system.name"
         />
       </div>
@@ -19,12 +19,12 @@ import Vue from "vue";
 import { mapState } from "vuex";
 
 import { RootStore } from "@/store";
-import SquareChart from "@/components/visualization/charts/SquareChart.vue";
+import SystemChart from "@/components/visualization/charts/SystemChart.vue";
 
 export default Vue.extend({
   name: "SystemsVisualization",
   components: {
-    SquareChart,
+    SystemChart,
   },
   props: {
     applicationId: String,

--- a/components/si-web-app/src/components/visualization/charts/SquareChart.vue
+++ b/components/si-web-app/src/components/visualization/charts/SquareChart.vue
@@ -1,13 +1,89 @@
 <template>
-  <svg :width="width" :height="height">
-    <rect :width="width" :height="height" :style="style" />
-  </svg>
+  <Tooltip>
+    <svg :width="width" :height="height">
+      <rect :width="width" :height="height" :style="entityStyle" />
+      <rect :width="width / 3" :height="height" :style="statusStyle" />
+      <rect
+        :width="width / 3"
+        :height="height"
+        :x="(width / 3) * 2"
+        :style="healthStyle"
+      />
+    </svg>
+    <template v-slot:tooltip>
+      <div class="flex flex-col text-gray-400">
+        <div class="text-sm">
+          {{ service.name }}
+        </div>
+        <div class="flex flex-col ml-2 text-xs">
+          <div class="flex">
+            <div class="pr-2">
+              Target
+            </div>
+            <div>
+              {{ deploymentTarget }}
+            </div>
+          </div>
+
+          <div class="flex">
+            <div class="pr-2">
+              Status
+            </div>
+            <div :style="statusTooltip">
+              {{ resource.status }}
+            </div>
+          </div>
+          <div class="flex">
+            <div class="pr-2">
+              Health
+            </div>
+            <div :style="healthTooltip">
+              {{ resource.health }}
+            </div>
+          </div>
+          <div class="flex">
+            <div class="pr-2">
+              Time
+            </div>
+            <div>
+              {{ resource.timestamp }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </Tooltip>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from "vue";
+import { mapState } from "vuex";
+import _ from "lodash";
+
+import { Entity } from "@/api/sdf/model/entity";
+import {
+  Resource,
+  ResourceStatus,
+  ResourceHealth,
+} from "@/api/sdf/model/resource";
+import { RootStore } from "@/store";
+import Tooltip from "@/components/ui/Tooltip.vue";
+
+export default Vue.extend({
   name: "SquareChart",
+  components: {
+    Tooltip,
+  },
   props: {
+    service: {
+      type: Object as () => Entity,
+    },
+    inEditor: {
+      type: String,
+    },
+    applicationId: {
+      type: String,
+    },
     width: {
       type: Number,
       default: 14,
@@ -21,10 +97,105 @@ export default {
       default: "0,0,255",
     },
   },
-  computed: {
-    style() {
-      return "fill:rgb(" + this.rgbColor + ")";
+  methods: {
+    statusCore(tooltip?: boolean): string {
+      let styleName = "fill";
+      if (tooltip) {
+        styleName = "color";
+      }
+      let resource = this.resource;
+      let createdColor = "0,176,90,1"; // (green)
+      let failedColor = "116,42,42,1"; // (dark red)
+      let pendingColor = "160,174,192,1"; // (gray)
+      let deletedColor = "26,32,44,1"; // (black)
+      let programmersSuckColor = "254,178,227,1"; // (yucky pink)
+
+      let color;
+      if (!resource) {
+        color = programmersSuckColor;
+      } else if (resource.status == ResourceStatus.Created) {
+        color = createdColor;
+      } else if (resource.status == ResourceStatus.Failed) {
+        color = failedColor;
+      } else if (resource.status == ResourceStatus.Pending) {
+        color = pendingColor;
+      } else if (resource.status == ResourceStatus.Deleted) {
+        color = deletedColor;
+      } else {
+        // What about in progress colors? lets stay pink! yummy
+        color = programmersSuckColor;
+      }
+      return `${styleName}:rgba(${color})`;
+    },
+    healthCore(tooltip?: boolean): string {
+      let styleName = "fill";
+      if (tooltip) {
+        styleName = "color";
+      }
+      let resource = this.resource;
+      let okColor = "0,176,90,1"; // (green)
+      let warningColor = "168,107,2,1"; // (green)
+      let errorColor = "116,42,42,1"; // (dark red)
+      let unknownColor = "160,174,192,1"; // (gray)
+      let programmersSuckColor = "254,178,227,1"; // (yucky pink)
+
+      let color;
+      if (!resource) {
+        color = programmersSuckColor;
+      } else if (resource.health == ResourceHealth.Ok) {
+        color = okColor;
+      } else if (resource.health == ResourceHealth.Warning) {
+        color = warningColor;
+      } else if (resource.health == ResourceHealth.Error) {
+        color = errorColor;
+      } else if (resource.health == ResourceHealth.Unknown) {
+        color = unknownColor;
+      } else {
+        color = programmersSuckColor;
+      }
+      return `${styleName}:rgba(${color})`;
     },
   },
-};
+  computed: {
+    resource(): Resource | undefined {
+      if (this.inEditor == "true") {
+        return _.find(this.$store.state.editor.resources, [
+          "nodeId",
+          this.service.nodeId,
+        ]);
+      } else {
+        let results = _.find(
+          this.$store.state.application.resources[this.applicationId],
+          ["nodeId", this.service.nodeId],
+        );
+        return results;
+      }
+    },
+    deploymentTarget(): string {
+      let deploymentTarget = "unknown";
+      if (this.service.properties["__baseline"]) {
+        if (this.service.properties["__baseline"].deploymentTarget) {
+          deploymentTarget = this.service.properties["__baseline"]
+            .deploymentTarget;
+        }
+      }
+      return deploymentTarget;
+    },
+    entityStyle(): string {
+      return "fill:rgba(78,141,171,1)";
+    },
+    statusStyle(): string {
+      return this.statusCore();
+    },
+    statusTooltip(): string {
+      return this.healthCore(true);
+    },
+    healthStyle(): string {
+      return this.healthCore();
+    },
+    healthTooltip(): string {
+      return this.healthCore(true);
+    },
+  },
+});
 </script>

--- a/components/si-web-app/src/components/visualization/charts/SystemChart.vue
+++ b/components/si-web-app/src/components/visualization/charts/SystemChart.vue
@@ -1,0 +1,59 @@
+<template>
+  <Tooltip>
+    <svg :width="width" :height="height">
+      <rect :width="width" :height="height" :style="entityStyle" />
+    </svg>
+    <template v-slot:tooltip>
+      <div class="flex flex-col text-gray-400">
+        <div class="text-sm">
+          {{ system.name }}
+        </div>
+      </div>
+    </template>
+  </Tooltip>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { mapState } from "vuex";
+import _ from "lodash";
+
+import { Entity } from "@/api/sdf/model/entity";
+import {
+  Resource,
+  ResourceStatus,
+  ResourceHealth,
+} from "@/api/sdf/model/resource";
+import { RootStore } from "@/store";
+import Tooltip from "@/components/ui/Tooltip.vue";
+
+export default Vue.extend({
+  name: "SystemChart",
+  components: {
+    Tooltip,
+  },
+  props: {
+    system: {
+      type: Object as () => Entity,
+    },
+    width: {
+      type: Number,
+      default: 14,
+    },
+    height: {
+      type: Number,
+      default: 14,
+    },
+    rgbColor: {
+      type: String,
+      default: "0,0,255",
+    },
+  },
+  computed: {
+    entityStyle(): string {
+      return "fill:rgba(78,141,171,1)";
+    },
+  },
+});
+</script>
+

--- a/components/si-web-app/src/store/modules/editor.ts
+++ b/components/si-web-app/src/store/modules/editor.ts
@@ -54,6 +54,11 @@ export interface ActionChangeSetCreate {
   name: string;
 }
 
+export interface ActionEntityAction {
+  action: string;
+  nodeId?: string;
+}
+
 export interface ActionNodeCreate {
   kind: NodeKind;
   objectType: string;
@@ -390,13 +395,18 @@ export const editor: Module<EditorStore, RootStore> = {
         await dispatch("entityAction", payload);
       }
     },
-    async entityAction({ state, rootGetters }, payload: string) {
+    async entityAction({ state, rootGetters }, payload: ActionEntityAction) {
       let organization = rootGetters["organization/current"];
       let workspace = rootGetters["workspace/current"];
       let changeSet = state.changeSet;
       let editSession = state.editSession;
       let system = state.system;
-      let node = state.node;
+      let node: Node | undefined;
+      if (payload.nodeId) {
+        node = await Node.get({ id: payload.nodeId });
+      } else {
+        node = state.node;
+      }
       if (
         organization &&
         workspace &&
@@ -407,7 +417,7 @@ export const editor: Module<EditorStore, RootStore> = {
       ) {
         let op = {
           entityAction: {
-            action: payload,
+            action: payload.action,
             systemId: system.id,
           },
         };


### PR DESCRIPTION
This PR fixes [ch548], [ch545], and [ch546].

It adds a square for each service in the application, with that services
health and status (which will eventually be a roll-up of the
status/health of all objects underneath it). When you hover over them,
you get a helpful tooltip.

When you are in a changeSet, you can now hit the "deploy" button, and it
will automatically schedule a deploy of the entire application (which will recursively
call the services, etc) in the change set, and then execute it.

The results are a closed changeset and a deployed thingamajig.

We're into it.

![](https://media0.giphy.com/media/l0HlGmv4WqldO9c5y/200.gif?cid=5a38a5a2jc4la333387scw0nl37n1bc32a4nw842n5witwmn&rid=200.gif)

Love,
Adam and Fletcher