### PR TITLE
chore(si-sdf): de-noise output & harden ws stream consuming

### DIFF
--- a/components/si-sdf/src/handlers/change_sets.rs
+++ b/components/si-sdf/src/handlers/change_sets.rs
@@ -1,4 +1,5 @@
 use crate::data::{Connection, Db};
+use tracing::trace;
 
 use crate::handlers::{authenticate, authorize, HandlerError};
 use crate::models::change_set::{
@@ -57,7 +58,7 @@ pub async fn patch(
 
     let reply = match request.op {
         PatchOps::Execute(execute_request) => {
-            tracing::error!("executing changeset");
+            trace!("executing changeset");
             let mut change_set: ChangeSet =
                 ChangeSet::get(&db, &change_set_id, &claim.billing_account_id)
                     .await

--- a/components/si-sdf/src/handlers/edges.rs
+++ b/components/si-sdf/src/handlers/edges.rs
@@ -71,7 +71,6 @@ pub async fn all_successors(
     token: String,
     request: edge::AllSuccessorsRequest,
 ) -> Result<impl warp::Reply, warp::reject::Rejection> {
-    tracing::error!("time for successors");
     let claim = authenticate(&db, &token).await?;
     authorize(
         &db,
@@ -81,23 +80,18 @@ pub async fn all_successors(
         "allSuccessors",
     )
     .await?;
-    tracing::error!("time for edges");
 
     let edges = if let Some(object_id) = request.object_id {
-        tracing::error!("time for object id");
         Edge::all_successor_edges_by_object_id(&db, request.edge_kind, &object_id)
             .await
             .map_err(HandlerError::from)?
     } else if let Some(node_id) = request.node_id {
-        tracing::error!("time for node id");
         Edge::all_successor_edges_by_node_id(&db, request.edge_kind, &node_id)
             .await
             .map_err(HandlerError::from)?
     } else {
         return Err(warp::reject::custom(HandlerError::InvalidRequest));
     };
-
-    tracing::error!("time for reply");
 
     let reply = edge::AllSuccessorsReply { edges };
 

--- a/components/si-sdf/src/handlers/edit_sessions.rs
+++ b/components/si-sdf/src/handlers/edit_sessions.rs
@@ -41,7 +41,7 @@ pub async fn create(
 }
 
 pub async fn patch(
-    change_set_id: String,
+    _change_set_id: String,
     edit_session_id: String,
     db: Db,
     nats: Connection,

--- a/components/si-sdf/src/models/edge.rs
+++ b/components/si-sdf/src/models/edge.rs
@@ -1,6 +1,7 @@
 use crossbeam::queue::SegQueue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::trace;
 
 use crate::data::{Connection, Db};
 use crate::models::{delete_model, insert_model, ModelError, SiStorable, SiStorableError};
@@ -433,7 +434,7 @@ impl Edge {
             object_id = head_object_id,
             type_name = tail_type_name,
         );
-        tracing::error!(?query, "edge query");
+        trace!(?query, "edge query");
         let query_results: Vec<Edge> = db.query_consistent(query, None).await?;
         Ok(query_results)
     }

--- a/components/si-sdf/src/models/resource.rs
+++ b/components/si-sdf/src/models/resource.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use thiserror::Error;
+use tracing::trace;
 
 use std::collections::HashMap;
 
@@ -187,7 +188,7 @@ impl Resource {
         self.unix_timestamp = unix_timestamp;
         self.timestamp = timestamp;
 
-        tracing::warn!(?self, "whats your deal");
+        trace!(?self, "whats your deal");
         upsert_model(db, nats, &self.id, &self).await?;
         Ok(())
     }

--- a/components/si-sdf/tests/filters/billing_accounts.rs
+++ b/components/si-sdf/tests/filters/billing_accounts.rs
@@ -1,6 +1,6 @@
 use serde_json;
 
-use crate::{one_time_setup, test_cleanup, TestAccount};
+use crate::{billing_account_cleanup, one_time_setup, test_cleanup, TestAccount};
 use crate::{DB, NATS, SETTINGS};
 
 use si_sdf::filters::api;
@@ -32,7 +32,10 @@ pub async fn signup() -> billing_account::CreateReply {
 
 #[tokio::test]
 async fn create() {
-    one_time_setup().await.expect("failed one time setup");
+    one_time_setup().await.expect("failed setup");
+    billing_account_cleanup()
+        .await
+        .expect("failed to delete billing account");
     let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
     let request = billing_account::CreateRequest {
         billing_account_name: "alice".into(),

--- a/components/si-sdf/tests/filters/nodes.rs
+++ b/components/si-sdf/tests/filters/nodes.rs
@@ -187,8 +187,6 @@ async fn patch_object() {
         .path(format!("/nodes/{}/object", &node.id).as_ref())
         .reply(&filter)
         .await;
-    let wtf = String::from_utf8(res.body().to_vec()).expect("cannot amke string fromb ody");
-    tracing::error!(?wtf, "wtf");
     let reply: node::ObjectPatchReply =
         serde_json::from_slice(res.body()).expect("cannot deserialize reply");
 

--- a/components/si-sdf/tests/integration.rs
+++ b/components/si-sdf/tests/integration.rs
@@ -126,3 +126,24 @@ pub async fn test_cleanup(test_account: TestAccount) -> Result<()> {
 
     Ok(())
 }
+
+pub async fn billing_account_cleanup() -> Result<()> {
+    let query = "DELETE FROM si_integration AS s
+        WHERE s.siStorable.typeName  = \"billingAccount\"
+          AND s.name = \"alice\"
+        RETURNING s";
+    let mut result = DB
+        .cluster
+        .query(query, None)
+        .await
+        .expect("could not delete the data for this billing account");
+    let mut result_stream = result.rows_as::<serde_json::Value>()?;
+    while let Some(r) = result_stream.next().await {
+        match r {
+            Ok(_) => (),
+            Err(e) => return Err(anyhow::Error::from(e)),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This change is mostly about de-noising the logging output of `si-sdf`,
namely demoting a lot of tracing info to....`trace` levels :)

![tenor-20388807](https://user-images.githubusercontent.com/261548/97061604-a71c0680-1554-11eb-8b08-e3f310d92d9d.gif)

However, a second part of this change is updating the web socket
streaming logic to handle all inner variants of a `warp::ws::Message`.
While running the system, I found that there were more messages being
consumed than the `Message::text` types of messages that we are
expecting. In my case, typically extra `Message::close` messages. This
lead me to read the warp and tungstenite code a bit and refactor the
consuming code to handle all possible message types.

![tenor-78877658](https://user-images.githubusercontent.com/261548/97061634-bd29c700-1554-11eb-94ad-2c91897ee133.gif)

Finally, the precondition state of testing a billing account signup is
fixed, allowing a developer to run the
`filters::billing_accounts::create` test more than once in a row.

![tenor-209764582](https://user-images.githubusercontent.com/261548/97061662-d0d52d80-1554-11eb-9c81-c30d37eb8d05.gif)
