### PR TITLE
feat(sdf): add encrypted secrets to API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2897,8 @@ dependencies = [
  "serde_json",
  "si-settings",
  "sodiumoxide",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio 0.2.22",
  "tokio-test",
@@ -3046,6 +3057,24 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strum"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
+
+[[package]]
+name = "strum_macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3651,6 +3680,12 @@ checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"

--- a/components/si-sdf/Cargo.toml
+++ b/components/si-sdf/Cargo.toml
@@ -15,31 +15,33 @@ path = "src/bin/keygen.rs"
 
 [dependencies]
 anyhow = "1.0"
+base64 = "0.12"
+chrono = "0.4"
 couchbase = { path = "../../vendor/couchbase-rs/couchbase" }
-tokio = { version = "0.2", features = ["full"] }
-warp = "0.2"
-tracing = "0.1"
-tracing-futures = { version = "0.2", features = ["tokio", "std-future"]}
-tracing-subscriber = "0.2.11"
-tracing-opentelemetry = "0.7"
+crossbeam = "0.7.3"
+futures = { version = "0.3", features = ["alloc"] }
+jwt-simple = "0.1"
+lazy_static = "1.4"
+names = "0.11"
+nats = { git = "https://github.com/systeminit/nats.rs", branch = "nkeys-upgrade" }
 opentelemetry = "0.8"
 opentelemetry-jaeger = "0.7"
-si-settings = { path = "../si-settings" }
+reqwest = { version = "0.10", features = ["default-tls", "json"] }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-thiserror = "1.0"
-names = "0.11"
-uuid = { version = "0.8", features = ["serde", "v4"] }
-reqwest = { version = "0.10", features = ["default-tls", "json"] }
+si-settings = { path = "../si-settings" }
 sodiumoxide = "0.2"
-jwt-simple = "0.1"
-base64 = "0.12"
-nats = { git = "https://github.com/systeminit/nats.rs", branch = "nkeys-upgrade" }
-futures = { version = "0.3", features = ["alloc"] }
-lazy_static = "1.4"
-crossbeam = "0.7.3"
-chrono = "0.4"
+strum = "0.19.5"
+strum_macros = "0.19.4"
+thiserror = "1.0"
+tokio = { version = "0.2", features = ["full"] }
 toml = "0.5"
+tracing = "0.1"
+tracing-futures = { version = "0.2", features = ["tokio", "std-future"]}
+tracing-opentelemetry = "0.7"
+tracing-subscriber = "0.2.11"
+uuid = { version = "0.8", features = ["serde", "v4"] }
+warp = "0.2"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/components/si-sdf/src/handlers/secrets.rs
+++ b/components/si-sdf/src/handlers/secrets.rs
@@ -1,0 +1,45 @@
+use crate::{
+    data::{Connection, Db},
+    handlers::{authenticate, authorize, HandlerError},
+    models::secret::{CreateReply, CreateRequest, Secret},
+};
+
+#[tracing::instrument(level = "trace", target = "secrets::create")]
+pub async fn create(
+    db: Db,
+    nats: Connection,
+    token: String,
+    request: CreateRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let claim = authenticate(&db, token).await?;
+    authorize(
+        &db,
+        &claim.user_id,
+        &claim.billing_account_id,
+        "secret",
+        "create",
+    )
+    .await?;
+
+    let secret = Secret::new(
+        &db,
+        &nats,
+        request.name,
+        request.object_type,
+        request.kind,
+        request.crypted,
+        request.key_pair_id,
+        request.version,
+        request.algorithm,
+        claim.billing_account_id,
+        request.organization_id,
+        request.workspace_id,
+        claim.user_id,
+    )
+    .await
+    .map_err(HandlerError::from)?;
+
+    let reply = CreateReply { item: secret };
+
+    Ok(warp::reply::json(&reply))
+}

--- a/components/si-sdf/src/handlers/users.rs
+++ b/components/si-sdf/src/handlers/users.rs
@@ -1,8 +1,8 @@
+use crate::data::Db;
 use jwt_simple::algorithms::RSAKeyPairLike;
 use jwt_simple::claims::Claims;
 use jwt_simple::coarsetime::Duration;
 use serde::{Deserialize, Serialize};
-use crate::data::Db;
 use sodiumoxide::crypto::secretbox;
 
 use crate::handlers::HandlerError;

--- a/components/si-sdf/src/models.rs
+++ b/components/si-sdf/src/models.rs
@@ -59,6 +59,12 @@ pub mod event_log;
 pub use event_log::{EventLog, EventLogError, EventLogLevel, EventLogResult};
 pub mod resource;
 pub use resource::{Resource, ResourceError, ResourceHealth, ResourceResult, ResourceStatus};
+pub mod key_pair;
+pub use key_pair::{KeyPairError, PublicKey};
+pub mod secret;
+pub use secret::{
+    Secret, SecretAlgorithm, SecretError, SecretKind, SecretObjectType, SecretVersion,
+};
 
 #[derive(Error, Debug)]
 pub enum ModelError {
@@ -316,6 +322,7 @@ pub async fn load_billing_account_model(
                 AND (a.siStorable.typeName = \"billingAccount\" 
                       OR a.siStorable.typeName = \"changeSetParticipant\" 
                       OR a.siStorable.typeName = \"eventLog\"
+                      OR a.siStorable.typeName = \"keyPair\"
                       OR a.siStorable.typeName = \"resource\")
         ",
         bucket = db.bucket_name,
@@ -509,11 +516,12 @@ pub async fn get_model_change_set(
     db: &Db,
     id: impl Into<String> + std::fmt::Debug,
     type_name: impl Into<String> + std::fmt::Debug,
-    billing_account_id: String,
+    billing_account_id: impl Into<String> + std::fmt::Debug,
     change_set_id: Option<String>,
 ) -> ModelResult<serde_json::Value> {
     let id = id.into();
     let type_name = type_name.into();
+    let billing_account_id = billing_account_id.into();
     if change_set_id.is_none() {
         let collection = db.bucket.default_collection();
         let response = collection.get(&id, None).await?;

--- a/components/si-sdf/src/models/key_pair.rs
+++ b/components/si-sdf/src/models/key_pair.rs
@@ -1,0 +1,92 @@
+use crate::{
+    data::{Connection, Db},
+    models::{generate_id, get_model, insert_model, BillingAccount, ModelError, SimpleStorable},
+};
+use serde::{Deserialize, Serialize};
+use sodiumoxide::crypto::box_::{self, PublicKey as BoxPublicKey, SecretKey as BoxSecretKey};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KeyPairError {
+    // Not using `BillingAccountError` as this leads us to a circular dependency of errors
+    #[error("error in billing account: {0}")]
+    BillingAccount(Box<dyn std::error::Error + Sync + Send + 'static>),
+    #[error("error in core model functions: {0}")]
+    Model(#[from] ModelError),
+}
+
+pub type KeyPairResult<T> = Result<T, KeyPairError>;
+
+/// A database-persisted libsodium box key pair.
+///
+/// Both the public key and secret key are accessible and therefore this type should *only* be used
+/// internally when decrypting secrets for use by `veritech`.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct KeyPair {
+    pub id: String,
+    pub name: String,
+    pub public_key: BoxPublicKey,
+    pub secret_key: BoxSecretKey,
+    pub si_storable: SimpleStorable,
+}
+
+impl KeyPair {
+    pub async fn new(
+        db: &Db,
+        nats: &Connection,
+        name: impl Into<String>,
+        billing_account_id: impl AsRef<str>,
+    ) -> KeyPairResult<Self> {
+        let name = name.into();
+        let (public_key, secret_key) = box_::gen_keypair();
+
+        let id = generate_id("keyPair");
+        let si_storable = SimpleStorable::new(&id, "keyPair", billing_account_id.as_ref());
+        let model = Self {
+            id,
+            name,
+            public_key,
+            secret_key,
+            si_storable,
+        };
+        insert_model(db, nats, &model.id, &model).await?;
+
+        Ok(model)
+    }
+
+    pub(crate) async fn get(
+        db: &Db,
+        id: impl AsRef<str> + std::fmt::Debug,
+        billing_account_id: impl AsRef<str> + std::fmt::Debug,
+    ) -> KeyPairResult<Self> {
+        get_model(db, id, billing_account_id)
+            .await
+            .map_err(KeyPairError::from)
+    }
+}
+
+/// A database-persisted libsodium box public key.
+///
+/// This type only contains the public half of the underlying key pair and is therefore safe to
+/// expose via external API.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublicKey {
+    pub id: String,
+    pub name: String,
+    pub public_key: BoxPublicKey,
+    pub si_storable: SimpleStorable,
+}
+
+impl PublicKey {
+    pub async fn get_current(db: &Db, billing_account_id: impl AsRef<str>) -> KeyPairResult<Self> {
+        let billing_account = BillingAccount::get(db, billing_account_id)
+            .await
+            .map_err(|err| KeyPairError::BillingAccount(Box::new(err)))?;
+        let object: Self =
+            get_model(db, billing_account.current_key_pair_id, billing_account.id).await?;
+
+        Ok(object)
+    }
+}

--- a/components/si-sdf/src/models/secret.rs
+++ b/components/si-sdf/src/models/secret.rs
@@ -1,0 +1,590 @@
+use crate::{
+    data::{Connection, Db},
+    models::{
+        key_pair::KeyPair,
+        {insert_model, KeyPairError, ModelError, SiStorable, SiStorableError},
+    },
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sodiumoxide::crypto::{
+    box_::{PublicKey, SecretKey},
+    sealedbox,
+};
+use strum_macros::{Display, EnumString};
+use thiserror::Error;
+use tracing::error;
+
+macro_rules! enum_impls {
+    ($ty:ty) => {
+        impl From<$ty> for String {
+            fn from(value: $ty) -> Self {
+                value.to_string()
+            }
+        }
+
+        impl std::convert::TryFrom<&str> for $ty {
+            type Error = strum::ParseError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                <Self as std::str::FromStr>::from_str(value)
+            }
+        }
+
+        impl std::convert::TryFrom<String> for $ty {
+            type Error = strum::ParseError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                <Self as std::str::FromStr>::from_str(value.as_str())
+            }
+        }
+    };
+}
+
+#[derive(Error, Debug)]
+pub enum SecretError {
+    #[error("error when decrypting crypted secret")]
+    DecryptionFailed,
+    #[error("failed to deserialize decrypted message as json: {0}")]
+    Deserialize(#[from] serde_json::Error),
+    #[error("error in key pair: {0}")]
+    KeyPair(#[from] KeyPairError),
+    #[error("error in core model functions: {0}")]
+    Model(#[from] ModelError),
+    #[error("secret is not found")]
+    NotFound,
+    #[error("si_storable error: {0}")]
+    SiStorable(#[from] SiStorableError),
+}
+
+pub type SecretResult<T> = Result<T, SecretError>;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRequest {
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+    pub crypted: Vec<u8>,
+    pub key_pair_id: String,
+    pub version: SecretVersion,
+    pub algorithm: SecretAlgorithm,
+    pub organization_id: String,
+    pub workspace_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateReply {
+    pub item: Secret,
+}
+
+#[derive(Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", try_from = "String", into = "String")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretObjectType {
+    Credential,
+}
+
+enum_impls!(SecretObjectType);
+
+#[derive(Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", try_from = "String", into = "String")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretKind {
+    DockerHub,
+}
+
+enum_impls!(SecretKind);
+
+#[derive(Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", try_from = "String", into = "String")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretVersion {
+    V1,
+}
+
+enum_impls!(SecretVersion);
+
+impl Default for SecretVersion {
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", try_from = "String", into = "String")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretAlgorithm {
+    Sealedbox,
+}
+
+enum_impls!(SecretAlgorithm);
+
+impl Default for SecretAlgorithm {
+    fn default() -> Self {
+        Self::Sealedbox
+    }
+}
+
+/// A reference to a database-persisted encrypted secret.
+///
+/// This type does not contain any encypted information nor any encryption metadata and is
+/// therefore safe to expose via external API.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Secret {
+    pub id: String,
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+    pub si_storable: SiStorable,
+}
+
+impl Secret {
+    pub async fn new(
+        db: &Db,
+        nats: &Connection,
+        name: impl Into<String>,
+        object_type: SecretObjectType,
+        kind: SecretKind,
+        crypted: impl Into<Vec<u8>>,
+        key_pair_id: impl Into<String>,
+        version: SecretVersion,
+        algorithm: SecretAlgorithm,
+        billing_account_id: String,
+        organization_id: String,
+        workspace_id: String,
+        created_by_user_id: String,
+    ) -> SecretResult<Self> {
+        Ok(EncryptedSecret::new(
+            db,
+            nats,
+            name,
+            object_type,
+            kind,
+            crypted,
+            key_pair_id,
+            version,
+            algorithm,
+            billing_account_id,
+            organization_id,
+            workspace_id,
+            created_by_user_id,
+        )
+        .await?
+        .into())
+    }
+}
+
+/// A database-persisted encrypted secret.
+///
+/// This type contains the raw encrypted payload as well as the necessary encryption metadata and
+/// therefore should *only* be used internally when decrypting secrets for use by `veritech`.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EncryptedSecret {
+    pub id: String,
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+    crypted: Vec<u8>,
+    key_pair_id: String,
+    version: SecretVersion,
+    algorithm: SecretAlgorithm,
+    pub si_storable: SiStorable,
+}
+
+impl EncryptedSecret {
+    pub async fn new(
+        db: &Db,
+        nats: &Connection,
+        name: impl Into<String>,
+        object_type: SecretObjectType,
+        kind: SecretKind,
+        crypted: impl Into<Vec<u8>>,
+        key_pair_id: impl Into<String>,
+        version: SecretVersion,
+        algorithm: SecretAlgorithm,
+        billing_account_id: String,
+        organization_id: String,
+        workspace_id: String,
+        created_by_user_id: String,
+    ) -> SecretResult<Self> {
+        let name = name.into();
+        let crypted = crypted.into();
+        let key_pair_id = key_pair_id.into();
+
+        let si_storable = SiStorable::new(
+            db,
+            "secret",
+            billing_account_id,
+            organization_id,
+            workspace_id,
+            Some(created_by_user_id),
+        )
+        .await?;
+        let id = si_storable.object_id.clone();
+        let model = Self {
+            id,
+            name,
+            object_type,
+            kind,
+            crypted,
+            key_pair_id,
+            version,
+            algorithm,
+            si_storable,
+        };
+        insert_model(db, nats, &model.id, &model).await?;
+
+        Ok(model)
+    }
+
+    // TODO(fnichol): this function is not yet used, so has `dead_code` allowed for the moment.
+    // Once the `veritech` prep code needs this, drop the lint.
+    #[allow(dead_code)]
+    pub(crate) async fn decrypt(self, db: &Db) -> SecretResult<DecryptedSecret> {
+        let key_pair =
+            KeyPair::get(db, &self.key_pair_id, &self.si_storable.billing_account_id).await?;
+
+        self.into_decrypted(&key_pair.public_key, &key_pair.secret_key)
+    }
+
+    fn into_decrypted(self, pk: &PublicKey, sk: &SecretKey) -> SecretResult<DecryptedSecret> {
+        // Explicitly match on (version, algorithm) tuple to ensure that any new
+        // versions/algorithms will trigger a compilation failure
+        match (self.version, self.algorithm) {
+            (SecretVersion::V1, SecretAlgorithm::Sealedbox) => Ok(DecryptedSecret {
+                id: self.id,
+                name: self.name,
+                object_type: self.object_type,
+                kind: self.kind,
+                message: serde_json::from_slice(
+                    &sealedbox::open(&self.crypted, pk, sk)
+                        .map_err(|_| SecretError::DecryptionFailed)?,
+                )?,
+            }),
+        }
+    }
+}
+
+impl From<EncryptedSecret> for Secret {
+    fn from(value: EncryptedSecret) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            object_type: value.object_type,
+            kind: value.kind,
+            si_storable: value.si_storable,
+        }
+    }
+}
+
+/// A secret that has been decrypted.
+///
+/// This type is returned by calling `EncyptedSecret.decrypt(&db).await?` which contains the raw
+/// decrypted message, and without the encrypted payload and other encyption metadata. It is not
+/// persistable and is only intended to be used internally when passing secrets into `veritech`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DecryptedSecret {
+    pub id: String,
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+    message: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::UpdateClock;
+    use sodiumoxide::crypto::{box_, sealedbox};
+
+    mod encrypted_secret {
+        use super::*;
+
+        fn encrypted_secret(
+            name: impl Into<String>,
+            object_type: SecretObjectType,
+            kind: SecretKind,
+            crypted: impl Into<Vec<u8>>,
+        ) -> EncryptedSecret {
+            let name = name.into();
+            let crypted = crypted.into();
+            let id = "secret:abc123".to_string();
+            let billing_account_id = "billingAccount:789".to_string();
+            let organization_id = "organization:0123".to_string();
+            let workspace_id = "workspace:456".to_string();
+            let tenant_ids = vec![
+                billing_account_id.clone(),
+                organization_id.clone(),
+                workspace_id.clone(),
+            ];
+
+            EncryptedSecret {
+                id: id.clone(),
+                name,
+                object_type,
+                kind,
+                crypted,
+                key_pair_id: "keyPair:def456".to_string(),
+                version: Default::default(),
+                algorithm: Default::default(),
+                si_storable: SiStorable {
+                    type_name: "secret".to_string(),
+                    object_id: id,
+                    billing_account_id,
+                    organization_id,
+                    workspace_id,
+                    tenant_ids,
+                    created_by_user_id: None,
+                    update_clock: UpdateClock {
+                        epoch: 1,
+                        update_count: 0,
+                    },
+                    deleted: false,
+                },
+            }
+        }
+
+        fn crypt<T>(value: &T, pk: &PublicKey) -> Vec<u8>
+        where
+            T: ?Sized + Serialize,
+        {
+            sealedbox::seal(&serde_json::to_vec(value).expect("failed to serialize"), pk)
+        }
+
+        #[test]
+        fn into_decrypted() {
+            sodiumoxide::init().expect("crypto failed to init");
+            let (pk, sk) = box_::gen_keypair();
+
+            let message = serde_json::json!({"username": "Kings's X", "password": "Black Flag"});
+            let crypted = crypt(&message, &pk);
+
+            let encrypted = encrypted_secret(
+                "kings-x",
+                SecretObjectType::Credential,
+                SecretKind::DockerHub,
+                crypted,
+            );
+            let decrypted = encrypted
+                .into_decrypted(&pk, &sk)
+                .expect("could not decrypt secret");
+
+            assert_eq!("secret:abc123", decrypted.id);
+            assert_eq!("kings-x", decrypted.name);
+            assert_eq!(SecretObjectType::Credential, decrypted.object_type);
+            assert_eq!(SecretKind::DockerHub, decrypted.kind);
+            assert_eq!(message, decrypted.message);
+        }
+    }
+
+    mod secret_object_type {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            object_type: SecretObjectType,
+        }
+
+        fn str() -> &'static str {
+            r#"{"objectType":"credential"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"objectType":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                object_type: SecretObjectType::Credential,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            match serde_json::from_str::<Object>(invalid()) {
+                Err(_) => assert!(true),
+                Ok(_) => panic!("deserialize should not succeed"),
+            }
+        }
+    }
+
+    mod secret_kind {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            kind: SecretKind,
+        }
+
+        fn str() -> &'static str {
+            r#"{"kind":"dockerHub"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"kind":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                kind: SecretKind::DockerHub,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            match serde_json::from_str::<Object>(invalid()) {
+                Err(_) => assert!(true),
+                Ok(_) => panic!("deserialize should not succeed"),
+            }
+        }
+    }
+
+    mod secret_version {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            version: SecretVersion,
+        }
+
+        fn str() -> &'static str {
+            r#"{"version":"v1"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"version":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                version: SecretVersion::V1,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            match serde_json::from_str::<Object>(invalid()) {
+                Err(_) => assert!(true),
+                Ok(_) => panic!("deserialize should not succeed"),
+            }
+        }
+
+        #[test]
+        fn default() {
+            // This test is intended to catch if and when we update the default variant for this
+            // type
+            assert_eq!(SecretVersion::V1, SecretVersion::default())
+        }
+    }
+
+    mod secret_algorithm {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            algorithm: SecretAlgorithm,
+        }
+
+        fn str() -> &'static str {
+            r#"{"algorithm":"sealedbox"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"algorithm":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                algorithm: SecretAlgorithm::Sealedbox,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            match serde_json::from_str::<Object>(invalid()) {
+                Err(_) => assert!(true),
+                Ok(_) => panic!("deserialize should not succeed"),
+            }
+        }
+
+        #[test]
+        fn default() {
+            // This test is intended to catch if and when we update the default variant for this
+            // type
+            assert_eq!(SecretAlgorithm::Sealedbox, SecretAlgorithm::default())
+        }
+    }
+}

--- a/components/si-sdf/src/models/si_storable.rs
+++ b/components/si-sdf/src/models/si_storable.rs
@@ -62,7 +62,7 @@ impl SiStorable {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SimpleStorable {
     pub type_name: String,

--- a/components/si-sdf/tests/filters/billing_accounts.rs
+++ b/components/si-sdf/tests/filters/billing_accounts.rs
@@ -1,10 +1,11 @@
-use serde_json;
-
-use crate::{billing_account_cleanup, one_time_setup, test_cleanup, TestAccount};
-use crate::{DB, NATS, SETTINGS};
-
-use si_sdf::filters::api;
-use si_sdf::models::billing_account;
+use crate::{
+    billing_account_cleanup, one_time_setup, test_cleanup, test_setup, TestAccount, DB, NATS,
+    SETTINGS,
+};
+use si_sdf::{
+    filters::api,
+    models::{billing_account, BillingAccount, GetReply, PublicKey},
+};
 
 pub async fn signup() -> billing_account::CreateReply {
     let fake_name = si_sdf::models::generate_id("clown");
@@ -23,7 +24,6 @@ pub async fn signup() -> billing_account::CreateReply {
         .json(&request)
         .reply(&filter)
         .await;
-    println!("{:?}", res);
     assert_eq!(res.status(), 200, "billing account is created");
     let reply: billing_account::CreateReply =
         serde_json::from_slice(res.body()).expect("could not deserialize response");
@@ -51,7 +51,6 @@ async fn create() {
         .json(&request)
         .reply(&filter)
         .await;
-    println!("{:?}", res);
     assert_eq!(res.status(), 200, "billing account is created");
     let reply: billing_account::CreateReply =
         serde_json::from_slice(res.body()).expect("could not deserialize response");
@@ -66,6 +65,79 @@ async fn create() {
         authorization: String::from("poop"),
         system_ids: None,
     };
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn get_public_key() {
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("GET")
+        .header("authorization", &test_account.authorization)
+        .path(
+            format!(
+                "/billingAccounts/{}/publicKey",
+                &test_account.billing_account_id
+            )
+            .as_ref(),
+        )
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model should be found");
+    let reply: GetReply =
+        serde_json::from_slice(res.body()).expect("cannot deserialize get model reply");
+    let item: PublicKey =
+        serde_json::from_value(reply.item).expect("cannot deserialize mode from get model reply");
+
+    assert_eq!(test_account.billing_account.current_key_pair_id, item.id);
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn rotate_public_key() {
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    async fn get_public_key(test_account: &TestAccount) -> PublicKey {
+        let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+        let res = warp::test::request()
+            .method("GET")
+            .header("authorization", &test_account.authorization)
+            .path(
+                format!(
+                    "/billingAccounts/{}/publicKey",
+                    &test_account.billing_account_id
+                )
+                .as_ref(),
+            )
+            .reply(&filter)
+            .await;
+        assert_eq!(res.status(), 200, "model should be found");
+        let reply: GetReply =
+            serde_json::from_slice(res.body()).expect("cannot deserialize get model reply");
+
+        serde_json::from_value(reply.item).expect("cannot deserialize mode from get model reply")
+    }
+
+    let current = get_public_key(&test_account).await;
+    assert_eq!(test_account.billing_account.current_key_pair_id, current.id);
+
+    BillingAccount::rotate_key_pair(&DB, &NATS, &test_account.billing_account_id)
+        .await
+        .expect("failed to rotate key pair");
+
+    let new = get_public_key(&test_account).await;
+    assert_ne!(new, current);
+    assert_ne!(test_account.billing_account.current_key_pair_id, new.id);
 
     test_cleanup(test_account)
         .await

--- a/components/si-sdf/tests/filters/mod.rs
+++ b/components/si-sdf/tests/filters/mod.rs
@@ -3,5 +3,6 @@ pub mod change_sets;
 pub mod edit_sessions;
 pub mod nodes;
 pub mod organizations;
+pub mod secrets;
 pub mod users;
 pub mod workspaces;

--- a/components/si-sdf/tests/filters/secrets.rs
+++ b/components/si-sdf/tests/filters/secrets.rs
@@ -1,0 +1,226 @@
+use crate::{test_cleanup, test_setup, TestAccount, DB, NATS, SETTINGS};
+use si_sdf::{
+    filters::api,
+    models::{
+        secret, GetReply, ListReply, Secret, SecretAlgorithm, SecretKind, SecretObjectType,
+        SecretVersion,
+    },
+};
+
+pub async fn create_secret(
+    test_account: &TestAccount,
+    name: impl Into<String>,
+    object_type: SecretObjectType,
+    kind: SecretKind,
+    crypted: impl Into<Vec<u8>>,
+    key_pair_id: impl Into<String>,
+) -> secret::CreateReply {
+    let name = name.into();
+    let crypted = crypted.into();
+    let key_pair_id = key_pair_id.into();
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+    let res = warp::test::request()
+        .method("POST")
+        .header("authorization", &test_account.authorization)
+        .json(&secret::CreateRequest {
+            name,
+            object_type,
+            kind,
+            crypted,
+            key_pair_id,
+            version: Default::default(),
+            algorithm: Default::default(),
+            organization_id: test_account.organization_id.clone(),
+            workspace_id: test_account.workspace_id.clone(),
+        })
+        .path("/secrets")
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model should be created");
+
+    serde_json::from_slice(res.body()).expect("cannot deserialize node reply")
+}
+
+#[tokio::test]
+async fn create() {
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("POST")
+        .header("authorization", &test_account.authorization)
+        .json(&secret::CreateRequest {
+            name: "my-fear".to_string(),
+            object_type: SecretObjectType::Credential,
+            kind: SecretKind::DockerHub,
+            crypted: "clown orgs".as_bytes().to_owned(),
+            key_pair_id: "keyPair:huh...".to_string(),
+            version: SecretVersion::V1,
+            algorithm: SecretAlgorithm::Sealedbox,
+            organization_id: test_account.organization_id.clone(),
+            workspace_id: test_account.workspace_id.clone(),
+        })
+        .path("/secrets")
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model should be created");
+    let reply: secret::CreateReply =
+        serde_json::from_slice(res.body()).expect("cannot deserialize create secret reply");
+
+    assert!(reply.item.id.starts_with("secret:"));
+    assert_eq!("my-fear", reply.item.name);
+    assert_eq!("secret", reply.item.si_storable.type_name);
+    assert_eq!(
+        test_account.billing_account_id,
+        reply.item.si_storable.billing_account_id
+    );
+    assert_eq!(
+        test_account.organization_id,
+        reply.item.si_storable.organization_id
+    );
+    assert_eq!(
+        test_account.workspace_id,
+        reply.item.si_storable.workspace_id
+    );
+    assert_eq!(
+        Some(&test_account.user_id),
+        reply.item.si_storable.created_by_user_id.as_ref()
+    );
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn get() {
+    let test_account = test_setup().await.expect("failed to setup test");
+    let created = create_secret(
+        &test_account,
+        "tom-petty",
+        SecretObjectType::Credential,
+        SecretKind::DockerHub,
+        "big-weekend",
+        "keyPair:huh...",
+    )
+    .await;
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("GET")
+        .header("authorization", &test_account.authorization)
+        .path(format!("/secrets/{}", &created.item.id).as_ref())
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model should be found");
+    let reply: GetReply =
+        serde_json::from_slice(res.body()).expect("cannot deserialize get model reply");
+    let fetched: Secret =
+        serde_json::from_value(reply.item).expect("cannot deserialize model from get model reply");
+
+    assert_eq!(created.item, fetched);
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn get_missing() {
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("GET")
+        .header("authorization", &test_account.authorization)
+        .path("/secrets/secret:this-surely-wont-be-an-id")
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 404, "model should not be found");
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn list() {
+    async fn secret(test_account: &TestAccount, name: &str, crypted: &str) -> secret::CreateReply {
+        create_secret(
+            test_account,
+            name,
+            SecretObjectType::Credential,
+            SecretKind::DockerHub,
+            crypted,
+            "keyPair:huh...",
+        )
+        .await
+    }
+
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    let alpha = secret(&test_account, "alpha", "bleep").await;
+    let charlie = secret(&test_account, "charlie", "blorp").await;
+    let bravo = secret(&test_account, "bravo", "blurp").await;
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("GET")
+        .header("authorization", &test_account.authorization)
+        .path("/secrets?pageSize=1000")
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model list should be found");
+    let reply: ListReply =
+        serde_json::from_slice(res.body()).expect("cannot deserialize get model reply");
+    let mut items: Vec<secret::Secret> = Vec::new();
+    for item in reply.items.into_iter() {
+        items.push(
+            serde_json::from_value(item)
+                .expect("cannot deserialze model from get list model reply"),
+        );
+    }
+
+    assert_eq!(3, reply.total_count);
+    assert!(reply.page_token.is_none());
+
+    let items_alpha = items.iter().find(|m| m.name == "alpha");
+    assert_eq!(Some(&alpha.item), items_alpha);
+    let items_bravo = items.iter().find(|m| m.name == "bravo");
+    assert_eq!(Some(&bravo.item), items_bravo);
+    let items_charlie = items.iter().find(|m| m.name == "charlie");
+    assert_eq!(Some(&charlie.item), items_charlie);
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}
+
+#[tokio::test]
+async fn list_none() {
+    let test_account = test_setup().await.expect("failed to setup test");
+
+    let filter = api(&DB, &NATS, &SETTINGS.jwt_encrypt.key);
+
+    let res = warp::test::request()
+        .method("GET")
+        .header("authorization", &test_account.authorization)
+        .path("/secrets?pageSize=1000")
+        .reply(&filter)
+        .await;
+    assert_eq!(res.status(), 200, "model list should be found");
+    let reply: ListReply =
+        serde_json::from_slice(res.body()).expect("cannot deserialize get model reply");
+
+    assert_eq!(0, reply.total_count);
+    assert!(reply.items.is_empty());
+    assert!(reply.page_token.is_none());
+
+    test_cleanup(test_account)
+        .await
+        .expect("failed to finish test");
+}


### PR DESCRIPTION
This change introduces the concept of secrets to the system. Currently,
secrets are not too dissimilar from Entities in that a `Secret` has an
object type and kind which are opaque to the backend. That is, the
message component of the secret is arbitrary data which the front end
will interpret and use as structured data.

![tenor-204539876](https://user-images.githubusercontent.com/261548/97929893-73e13080-1d27-11eb-846c-a9e2c943e2d3.gif)

A `Secret` currently has one object type of `Credential` with room to
create other types in the future (perhaps single value secret strings,
for example). Additionally, a `Secret` has a kind which helps the API
consumer to understand the message format. Currently there is one kind
which is `DockerHub`, likely consisting of a `username` and `password`
hash.

![tenor-238444573](https://user-images.githubusercontent.com/261548/97929914-80658900-1d27-11eb-9378-43568c59121a.gif)

Secrets are encrypted client side (in our case, the front end in the
browser) and send to the API on creation using the active billing
account's current public key (which is also new to the system). The API
only ever exposes a `Secret` type which boils down to its name and basic
type metadata, such as `object_type` and `kind`. Notably, neither the
encypted payload nor the unencrypted message will be exposed by the API,
but rather used internally when preparing to invoke JavaScript functions
in `veritech`. For this, an `EncryptedSecret` can be fetched from the
database and then decrypted via a fallible type conversion in Rust into
a `DecryptedSecret`.

![tenor-240030223](https://user-images.githubusercontent.com/261548/97929923-88252d80-1d27-11eb-94d7-9367d11b087a.gif)

The secrets API allows a secret to be created, fetched individually, and
as a list. Notably, the API currently does not support deleting a
`Secret` nor updating one and are therefore assumed to be immutable
(until we decide otherwise).

![tenor-77165021](https://user-images.githubusercontent.com/261548/97929937-94a98600-1d27-11eb-8a65-991d30ab4317.gif)

The public key API is a child under the billing accounts path, i.e.
`billingAccounts/{id}/publicKey`. This call fetches the single current
public key that should be used to encrypt any secrets. A simple
`rotate_public_key` method exists on `BillingAccount` to support future
key rotation so our front end code should be ready to use a new key
whenever encrypting a new secret.