### PR TITLE
feat: add kubernetes secret object

### DIFF
--- a/components/si-registry/src/components/si-kubernetes/secret.ts
+++ b/components/si-registry/src/components/si-kubernetes/secret.ts
@@ -1,0 +1,133 @@
+import {
+  PropObject,
+  PropText,
+  PropLink,
+  PropEnum,
+  PropCode,
+  PropAction,
+  PropMap,
+} from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "kubernetesSecret",
+  displayTypeName: "Kubernetes Secret Object",
+  siPathName: "si-kubernetes",
+  serviceName: "kubernetes",
+  options(c) {
+    c.entity.inputType("kubernetesCluster");
+    c.entity.inputType("kubernetesNamespace");
+
+    c.entity.associations.belongsTo({
+      fromFieldPath: ["siProperties", "billingAccountId"],
+      typeName: "billingAccount",
+    });
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+
+    // Constraints
+    c.constraints.addEnum({
+      name: "kubernetesVersion",
+      label: "Kubernetes Version",
+      options(p: PropEnum) {
+        p.variants = ["v1.12", "v1.13", "v1.14", "v1.15"];
+        p.baseDefaultValue = "v1.15";
+      },
+    });
+
+    // Properties
+    c.properties.addObject({
+      name: "kubernetesObject",
+      label: "Kubernetes Object",
+      options(p: PropObject) {
+        p.relationships.updates({
+          partner: {
+            typeName: "kubernetesNamespace",
+            names: ["properties", "kubernetesObjectYaml"],
+          },
+        });
+        p.relationships.either({
+          partner: {
+            typeName: "kubernetesNamespace",
+            names: ["properties", "kubernetesObjectYaml"],
+          },
+        });
+        p.properties.addText({
+          name: "apiVersion",
+          label: "API Version",
+          options(p: PropText) {
+            p.required = true;
+          },
+        });
+        p.properties.addText({
+          name: "kind",
+          label: "Kind",
+          options(p: PropText) {
+            p.required = true;
+            p.baseDefaultValue = "Secret";
+            p.baseValidation = p
+              .validation()
+              .min(3)
+              .max(10)
+              .required();
+          },
+        });
+        p.properties.addLink({
+          name: "metadata",
+          label: "Metadata",
+          options(p: PropLink) {
+            p.lookup = {
+              typeName: "kubernetesMetadata",
+            };
+          },
+        });
+        p.properties.addMap({
+          name: "data",
+          label: "Data",
+        });
+        p.properties.addMap({
+          name: "stringData",
+          label: "StringData",
+        });
+        p.properties.addBool({
+          name: "immutable",
+          label: "immutable",
+        });
+        p.properties.addText({
+          name: "type",
+          label: "type",
+        });
+      },
+    });
+    c.properties.addCode({
+      name: "kubernetesObjectYaml",
+      label: "Kubernetes Object YAML",
+      options(p: PropCode) {
+        p.relationships.updates({
+          partner: {
+            typeName: "kubernetesNamespace",
+            names: ["properties", "kubernetesObject"],
+          },
+        });
+        p.relationships.either({
+          partner: {
+            typeName: "kubernetesNamespace",
+            names: ["properties", "kubernetesObject"],
+          },
+        });
+        p.language = "yaml";
+      },
+    });
+
+    // Entity Actions
+    c.entity.methods.addAction({
+      name: "apply",
+      label: "Apply",
+      options(p: PropAction) {
+        p.mutation = true;
+      },
+    });
+  },
+});

--- a/components/si-registry/src/loader.ts
+++ b/components/si-registry/src/loader.ts
@@ -41,3 +41,4 @@ import "./components/si-kubernetes/namespace";
 import "./components/si-kubernetes/minikube";
 import "./components/si-kubernetes/deployment";
 import "./components/si-kubernetes/service";
+import "./components/si-kubernetes/secret";

--- a/components/si-registry/src/veritech/components/kubernetesSecret.ts
+++ b/components/si-registry/src/veritech/components/kubernetesSecret.ts
@@ -1,0 +1,58 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  SyncResourceRequest,
+  SyncResourceReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+} from "../../veritech/intelligence";
+import {
+  kubernetesNamespaceProperties,
+  kubernetesSync,
+  kubernetesApply,
+} from "./kubernetesShared";
+
+const kubernetesSecret = registry.get("kubernetesSecret") as EntityObject;
+const intelligence = kubernetesSecret.intelligence;
+
+intelligence.calculateProperties = function(
+  req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  console.log(`calulating properties for kubernetesSecret`, { req });
+  console.dir(req, { depth: Infinity });
+
+  let result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {
+        kubernetesObject: {
+          apiVersion: "v1",
+          kind: "Secret",
+          type: "Opaque",
+          metadata: {
+            name: `${req.entity.name}`,
+          },
+        },
+      },
+    },
+  };
+  for (const pred of req.predecessors) {
+    if (pred.entity.objectType == "kubernetesNamespace") {
+      result = kubernetesNamespaceProperties(result, pred.entity);
+    }
+  }
+  return result;
+};
+
+intelligence.syncResource = async function(
+  request: SyncResourceRequest,
+): Promise<SyncResourceReply> {
+  return await kubernetesSync(request);
+};
+
+intelligence.actions = {
+  async apply(request: ActionRequest): Promise<ActionReply> {
+    return await kubernetesApply(request);
+  },
+};

--- a/components/si-registry/src/veritech/components/kubernetesService.ts
+++ b/components/si-registry/src/veritech/components/kubernetesService.ts
@@ -23,7 +23,7 @@ intelligence.calculateProperties = function(
   console.log(`calulating properties for kubernetesService`, { req });
   console.dir(req, { depth: Infinity });
 
-  const result: CalculatePropertiesResult = {
+  let result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {
         kubernetesObject: {
@@ -106,7 +106,7 @@ intelligence.calculateProperties = function(
         }
       }
     } else if (pred.entity.objectType == "kubernetesNamespace") {
-      kubernetesNamespaceProperties(result, pred.entity);
+      result = kubernetesNamespaceProperties(result, pred.entity);
     }
   }
   return result;

--- a/components/si-registry/src/veritech/components/kubernetesShared.ts
+++ b/components/si-registry/src/veritech/components/kubernetesShared.ts
@@ -1,15 +1,175 @@
-import { Entity, CalculatePropertiesResult } from "../intelligence";
+import {
+  Entity,
+  CalculatePropertiesResult,
+  SyncResourceRequest,
+  SyncResourceReply,
+  ResourceHealth,
+  ResourceStatus,
+  ActionRequest,
+  ActionReply,
+} from "../intelligence";
 import _ from "lodash";
+import execa from "execa";
 
 export function kubernetesNamespaceProperties(
   result: CalculatePropertiesResult,
   namespace: Entity,
-): void {
+): CalculatePropertiesResult {
   if (namespace.properties.__baseline.kubernetesObject?.metadata?.name) {
     _.set(
       result.inferredProperties,
       ["__baseline", "kubernetesObject", "metadata", "namespace"],
       namespace.properties.__baseline.kubernetesObject.metadata.name,
     );
+  }
+  return result;
+}
+
+export async function kubernetesSync(
+  request: SyncResourceRequest,
+): Promise<SyncResourceReply> {
+  console.log(`syncing kubernetes`);
+  console.dir(request, { depth: Infinity });
+
+  const kubernetesCluster = _.find(request.predecessors, [
+    "entity.objectType",
+    "kubernetesCluster",
+  ]);
+  let currentContext = undefined;
+  if (kubernetesCluster?.resource.state.data) {
+    currentContext = kubernetesCluster.resource.state.data["current-context"];
+  }
+
+  if (kubernetesCluster && currentContext) {
+    const kubectlApply = await execa(
+      "kubectl",
+      [
+        "apply",
+        "-o",
+        "json",
+        "--context",
+        currentContext,
+        "--dry-run=server",
+        "-f",
+        "-",
+      ],
+      {
+        input: request.entity.properties.__baseline["kubernetesObjectYaml"],
+      },
+    );
+    if (kubectlApply.failed) {
+      const reply: SyncResourceReply = {
+        resource: {
+          state: {
+            data: request.resource.state?.data,
+            errorMsg: "kubectl apply failed",
+            errorOutput: kubectlApply.stderr,
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+      };
+      return reply;
+    } else {
+      const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
+      const reply: SyncResourceReply = {
+        resource: {
+          state: {
+            data: kubectlApplyJson,
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+      };
+      return reply;
+    }
+  } else {
+    const reply: SyncResourceReply = {
+      resource: {
+        state: {
+          data: request.resource.state?.data,
+          errorMsg: "No kubernetesCluster attached!",
+        },
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+    };
+    return reply;
+  }
+}
+
+export async function kubernetesApply(
+  request: ActionRequest,
+): Promise<ActionReply> {
+  const actions: ActionReply["actions"] = [];
+  console.log(`applying kubernetes`);
+  console.dir(request, { depth: Infinity });
+  const kubernetesCluster = _.find(request.predecessors, [
+    "entity.objectType",
+    "kubernetesCluster",
+  ]);
+  let currentContext = undefined;
+  if (kubernetesCluster?.resource.state.data) {
+    currentContext = kubernetesCluster.resource.state.data["current-context"];
+  }
+
+  if (kubernetesCluster && currentContext) {
+    const applyArgs = [
+      "apply",
+      "-o",
+      "json",
+      "--context",
+      currentContext,
+      "-f",
+      "-",
+    ];
+    if (request.hypothetical) {
+      applyArgs.push("--dry-run=server");
+    }
+
+    const kubectlApply = await execa("kubectl", applyArgs, {
+      input: request.entity.properties.__baseline["kubernetesObjectYaml"],
+    });
+    if (kubectlApply.failed) {
+      const reply: ActionReply = {
+        resource: {
+          state: {
+            data: request.resource.state?.data,
+            errorMsg: "kubectl apply failed",
+            errorOutput: kubectlApply.stderr,
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+        actions,
+      };
+      return reply;
+    } else {
+      const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
+      const reply: ActionReply = {
+        resource: {
+          state: {
+            data: kubectlApplyJson,
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+        actions,
+      };
+      return reply;
+    }
+  } else {
+    const reply: ActionReply = {
+      resource: {
+        state: {
+          data: request.resource.state?.data,
+          errorMsg: "No kubernetesCluster attached!",
+        },
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+      actions,
+    };
+    return reply;
   }
 }

--- a/components/si-registry/src/veritech/server.ts
+++ b/components/si-registry/src/veritech/server.ts
@@ -7,6 +7,8 @@ import "@/veritech/components/kubernetesDeployment";
 import "@/veritech/components/kubernetesCluster";
 import "@/veritech/components/kubernetesNamespace";
 import "@/veritech/components/kubernetesService";
+import "@/veritech/components/kubernetesSecret";
+
 import { registry } from "@/registry";
 
 import {


### PR DESCRIPTION
![](https://media1.giphy.com/media/l0MYsxZiDtc1wPHmU/200.gif?cid=5a38a5a2xqogolxnw6g4rrcyg8q1092lm212o6x8fmxbvj5a&rid=200.gif)

Closes [ch855].

This PR adds a kubernetes secret object. It defaults to the Opaque
secret type, and supports both stringData and the base64 required data
field.

It does not implement the docker hub secret integration, but that makes
sense (we aren't there yet).

It refactors the shared kubernetes code into a single kubernetesShared
library.