### PR TITLE
chore: use a `dockerHubCredential` in a `dockerImage`

### DIFF
--- a/components/si-registry/src/components/si-core/dockerImage.ts
+++ b/components/si-registry/src/components/si-core/dockerImage.ts
@@ -8,6 +8,7 @@ registry.componentAndEntity({
   serviceName: "core",
   options(c) {
     c.entity.inputType("service");
+    c.entity.inputType("dockerHubCredential");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/loader.ts
+++ b/components/si-registry/src/loader.ts
@@ -33,8 +33,8 @@ import "./components/si-core/server";
 import "./components/si-core/ubuntu";
 import "./components/si-core/ami";
 import "./components/si-core/ec2instance";
-import "./components/si-core/dockerImage";
 import "./components/si-core/dockerHubCredential";
+import "./components/si-core/dockerImage";
 
 import "./components/si-kubernetes/kubernetes";
 import "./components/si-kubernetes/cluster";

--- a/components/si-sdf/src/models/node.rs
+++ b/components/si-sdf/src/models/node.rs
@@ -373,7 +373,7 @@ impl Node {
                 &self.si_storable.billing_account_id,
             )
             .await?;
-            let edge_entity: Entity = if let Some(ref change_set_id) = change_set_id {
+            let mut edge_entity: Entity = if let Some(ref change_set_id) = change_set_id {
                 match edge_node.get_object_projection(&db, change_set_id).await {
                     Ok(edge_entity) => edge_entity,
                     Err(_) => edge_node.get_head_object(db).await?,
@@ -383,6 +383,7 @@ impl Node {
             } else {
                 return Err(NodeError::NoHead);
             };
+            edge_entity.update_properties_if_secret(db).await?;
             let edge_resource = Resource::get(&db, &edge_entity.id, &system_id).await?;
             let predecessor = VeritechSyncPredecessor {
                 entity: edge_entity,

--- a/components/si-sdf/src/models/ops.rs
+++ b/components/si-sdf/src/models/ops.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 
 use crate::data::{Connection, Db, REQWEST};
 use crate::models::{
-    insert_model, EdgeError, ModelError, NodeError, ResourceError, SiChangeSet, SiChangeSetError,
-    SiChangeSetEvent, SiStorable, SiStorableError,
+    insert_model, EdgeError, EntityError, ModelError, NodeError, ResourceError, SiChangeSet,
+    SiChangeSetError, SiChangeSetEvent, SiStorable, SiStorableError,
 };
 
 pub mod entity_delete;
@@ -20,6 +20,8 @@ pub enum OpError {
     SiChangeSet(#[from] SiChangeSetError),
     #[error("error in core model functions: {0}")]
     Model(#[from] ModelError),
+    #[error("entity error: {0}")]
+    Entity(#[from] EntityError),
     #[error("cannot set value: path({0}) value({1})")]
     Failed(String, serde_json::Value),
     #[error("malformed target")]

--- a/components/si-sdf/src/models/ops/entity_action.rs
+++ b/components/si-sdf/src/models/ops/entity_action.rs
@@ -170,13 +170,14 @@ impl OpEntityAction {
                     &entity.si_storable.billing_account_id,
                 )
                 .await?;
-                let edge_entity: Entity = match edge_node
+                let mut edge_entity: Entity = match edge_node
                     .get_object_projection(&db, &this_action.si_change_set.change_set_id)
                     .await
                 {
                     Ok(edge_entity) => edge_entity,
                     Err(_) => edge_node.get_head_object(&db).await?,
                 };
+                edge_entity.update_properties_if_secret(&db).await?;
 
                 let edge_resource =
                     Resource::get(&db, &edge_entity.id, &this_action.system_id).await?;
@@ -198,13 +199,14 @@ impl OpEntityAction {
                     &entity.si_storable.billing_account_id,
                 )
                 .await?;
-                let edge_entity: Entity = match edge_node
+                let mut edge_entity: Entity = match edge_node
                     .get_object_projection(&db, &this_action.si_change_set.change_set_id)
                     .await
                 {
                     Ok(edge_entity) => edge_entity,
                     Err(_) => edge_node.get_head_object(&db).await?,
                 };
+                edge_entity.update_properties_if_secret(&db).await?;
                 let edge_resource =
                     Resource::get(&db, &edge_entity.id, &this_action.system_id).await?;
                 predecessors.push(ActionRequestThunk {

--- a/components/si-sdf/src/models/secret.rs
+++ b/components/si-sdf/src/models/secret.rs
@@ -2,7 +2,7 @@ use crate::{
     data::{Connection, Db},
     models::{
         key_pair::KeyPair,
-        {insert_model, KeyPairError, ModelError, SiStorable, SiStorableError},
+        {get_model, insert_model, KeyPairError, ModelError, SiStorable, SiStorableError},
     },
 };
 use serde::{Deserialize, Serialize};
@@ -241,9 +241,16 @@ impl EncryptedSecret {
         Ok(model)
     }
 
-    // TODO(fnichol): this function is not yet used, so has `dead_code` allowed for the moment.
-    // Once the `veritech` prep code needs this, drop the lint.
-    #[allow(dead_code)]
+    pub(crate) async fn get(
+        db: &Db,
+        id: impl AsRef<str> + std::fmt::Debug,
+        billing_account_id: impl AsRef<str> + std::fmt::Debug,
+    ) -> SecretResult<Self> {
+        get_model(db, id, billing_account_id)
+            .await
+            .map_err(SecretError::from)
+    }
+
     pub(crate) async fn decrypt(self, db: &Db) -> SecretResult<DecryptedSecret> {
         let key_pair =
             KeyPair::get(db, &self.key_pair_id, &self.si_storable.billing_account_id).await?;
@@ -293,7 +300,7 @@ pub(crate) struct DecryptedSecret {
     pub name: String,
     pub object_type: SecretObjectType,
     pub kind: SecretKind,
-    message: Value,
+    pub message: Value,
 }
 
 #[cfg(test)]

--- a/components/si-web-app/src/store/modules/secret.ts
+++ b/components/si-web-app/src/store/modules/secret.ts
@@ -49,7 +49,7 @@ export const secret: Module<SecretStore, RootStore> = {
 
       const json = JSON.stringify(
         {
-          usename: payload.dockerHubUsername,
+          username: payload.dockerHubUsername,
           password: payload.dockerHubPassword,
         },
         null,


### PR DESCRIPTION
This change allows us to consume a `dockerHubCredential` in a
`dockerImage` in situations where the image needs authentication.

Closes: [ch896]

Co-authored-by: Fletcher Nichol <fletcher@systeminit.com>
Co-authored-by: Adam Jacob <adam@systeminit.com>
Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>