### PR TITLE
fix(si-sdf): when calculating successor props, fall back to head

### DIFF
--- a/components/si-sdf/src/models/change_set.rs
+++ b/components/si-sdf/src/models/change_set.rs
@@ -296,9 +296,12 @@ impl ChangeSet {
                         processed_list.push(edge.head_vertex.object_id.clone());
                         calculate_properties(db, &mut entity_json, Some(&mc)).await?;
                     } else {
-                        let entity =
-                            Entity::get_projection(&db, &edge.head_vertex.object_id, &self.id)
-                                .await?;
+                        let entity = Entity::get_projection_or_head(
+                            &db,
+                            &edge.head_vertex.object_id,
+                            &self.id,
+                        )
+                        .await?;
                         let entity_id = entity.id.clone();
                         let mut entity_json = serde_json::to_value(entity)?;
                         processed_list.push(edge.head_vertex.object_id.clone());

--- a/components/si-sdf/src/models/entity.rs
+++ b/components/si-sdf/src/models/entity.rs
@@ -414,6 +414,18 @@ impl Entity {
         }
     }
 
+    pub async fn get_projection_or_head(
+        db: &Db,
+        entity_id: impl AsRef<str>,
+        change_set_id: impl AsRef<str>,
+    ) -> EntityResult<Entity> {
+        match Self::get_projection(db, &entity_id, change_set_id).await {
+            Ok(entity) => Ok(entity),
+            Err(EntityError::NoHead) => Self::get_head(db, entity_id).await,
+            Err(e) => Err(e),
+        }
+    }
+
     pub async fn get_all(db: &Db, entity_id: impl AsRef<str>) -> EntityResult<Vec<Entity>> {
         let entity_id = entity_id.as_ref();
         let query = format!(


### PR DESCRIPTION
This fixes an issue when executing a changeset (real or hypothetical)
where a successor is *not* a participant in the changeset. Prior to this
change, the code to calculate the properties of successors called
`Entity::get_projection` which would fail with a `NoHead` error and thus
causing the execution to abort. This change recognizes that a successor
might not be found in the change set, and if that is the case, it uses
the `head` version of Entity.

References: [ch975]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>