### PR TITLE
chore(db): add `relaunch.sh` for couchbase

### DIFF
--- a/components/couchbase/build.sh
+++ b/components/couchbase/build.sh
@@ -1,15 +1,36 @@
-#!/bin/sh -ex
+#!/usr/bin/env sh
+# shellcheck shell=sh disable=SC2039
 
-REPO="systeminit"
-TAG="latest"
-IMAGE="couchbase"
-DOCKER_CONTAINER_NAME="db"
+main() {
+  set -eu
+  if [ -n "${DEBUG:-}" ]; then set -v; fi
+  if [ -n "${TRACE:-}" ]; then set -xv; fi
 
-echo "# Couchbase Memory Configuration" > ./.env
-echo "export DATA_RAM_QUOTA=${DATA_RAM_QUOTA:-2048}" >> ./.env
-echo "export INDEX_RAM_QUOTA=${INDEX_RAM_QUOTA:-512}" >> ./.env
-echo "export FULL_TEXT_RAM_QUOTA=${FULL_TEXT_RAM_QUOTA:-512}" >> ./.env
-echo "export BUCKET_SI_RAM_QUOTA=${BUCKET_SI_RAM_QUOTA:-512}" >> ./.env
-echo "export BUCKET_SI_INTEGRATION_RAM_QUOTA=${BUCKET_SI_INTEGRATION_RAM_QUOTA:-512}" >> ./.env
+  local image="systeminit/couchbase:latest"
 
-docker rmi ${REPO}/${IMAGE}:${TAG} && docker build -t ${REPO}/${IMAGE}:${TAG} . || docker build -t ${REPO}/${IMAGE}:${TAG} .
+  if image_built "$image"; then
+    echo "--- Removing preexisting image '$image'"
+    docker image rm "$image"
+  fi
+
+  # Change to directory containing Dockerfile context
+  cd "${0%/*}"
+
+  echo "--- Building image '$image'"
+  cat <<-EOF >.env
+	# Couchbase Memory Configuration
+	export DATA_RAM_QUOTA=${DATA_RAM_QUOTA:-2048}
+	export INDEX_RAM_QUOTA=${INDEX_RAM_QUOTA:-512}
+	export FULL_TEXT_RAM_QUOTA=${FULL_TEXT_RAM_QUOTA:-512}
+	export BUCKET_SI_RAM_QUOTA=${BUCKET_SI_RAM_QUOTA:-512}
+	export BUCKET_SI_INTEGRATION_RAM_QUOTA=${BUCKET_SI_INTEGRATION_RAM_QUOTA:-512}
+	EOF
+  cat .env
+  docker image build --tag "$image" .
+}
+
+image_built() {
+  [ -n "$(docker image ls --quiet "$1")" ]
+}
+
+main "$@" || exit 1

--- a/components/couchbase/relaunch.sh
+++ b/components/couchbase/relaunch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+# shellcheck shell=sh disable=SC2039
+
+print_usage() {
+  local program="$1"
+
+  echo "$program
+
+    Re-launches a couchbase database container
+
+    This program effectively launches a new, empty database instance which can
+    be convenient when developing new features that affect the data model.
+
+    USAGE:
+        $program [FLAGS] [--]
+
+    FLAGS:
+        -h, --help      Prints help information
+    " | sed 's/^ \{1,4\}//g'
+}
+
+main() {
+  set -eu
+  if [ -n "${DEBUG:-}" ]; then set -v; fi
+  if [ -n "${TRACE:-}" ]; then set -xv; fi
+
+  local program
+  program="$(basename "$0")"
+
+  OPTIND=1
+  while getopts "h-:" arg; do
+    case "$arg" in
+      h)
+        print_usage "$program"
+        return 0
+        ;;
+      -)
+        case "$OPTARG" in
+          help)
+            print_usage "$program"
+            return 0
+            ;;
+          '')
+            # "--" terminates argument processing
+            break
+            ;;
+          *)
+            print_usage "$program" >&2
+            die "invalid argument --$OPTARG"
+            ;;
+        esac
+        ;;
+      \?)
+        print_usage "$program" >&2
+        die "invalid argument; arg=-$OPTARG"
+        ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
+
+  local name="db"
+
+  if is_running "$name"; then
+    echo "--- Stopping running container '$name'"
+    docker container stop "$name"
+    docker container wait "$name"
+  fi
+
+  if created "$name"; then
+    echo "--- Removing container '$name'"
+    docker container rm "$name"
+  fi
+
+  exec "${0%/*}/run.sh"
+}
+
+created() {
+  [ -n "$(docker container ls --filter "name=$1" --all --quiet)" ]
+}
+
+is_running() {
+  [ -n "$(
+    docker container ls --filter "name=$1" --filter "status=running" --quiet
+  )" ]
+}
+
+main "$@" || exit 1

--- a/components/couchbase/run.sh
+++ b/components/couchbase/run.sh
@@ -1,5 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env sh
+# shellcheck shell=sh disable=SC2039
 
-CONTAINER_NAME="db"
+main() {
+  set -eu
+  if [ -n "${DEBUG:-}" ]; then set -v; fi
+  if [ -n "${TRACE:-}" ]; then set -xv; fi
 
-docker start ${CONTAINER_NAME} || docker run -d --name ${CONTAINER_NAME} -p 8091-8096:8091-8096 -p 11210-11211:11210-11211 systeminit/couchbase:latest 
+  local name="db"
+  local image="systeminit/couchbase:latest"
+
+  if is_running "$name"; then
+    echo "--- Container '$name' is running, you're welcome"
+    return
+  fi
+
+  if created "$name"; then
+    echo "--- Starting stopped container '$name'"
+    docker container start "$name"
+  else
+    if ! image_built "$image"; then
+      "${0%/*}/build.sh"
+    fi
+
+    echo "--- Creating and running container '$name'"
+    docker container run \
+      --name "$name" \
+      --detach \
+      --publish 8091-8096:8091-8096 \
+      --publish 11210-11211:11210-11211 \
+      "$image"
+  fi
+}
+
+created() {
+  [ -n "$(docker container ls --filter "name=$1" --all --quiet)" ]
+}
+
+image_built() {
+  [ -n "$(docker image ls --quiet "$1")" ]
+}
+
+is_running() {
+  [ -n "$(
+    docker container ls --filter "name=$1" --filter "status=running" --quiet
+  )" ]
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
This change adds a `components/couchbase/relaunch.sh` script which will
destroy any currently running `db` container instance and re-launch a
fresh/new copy. This is useful when debugging or developing new features
that dramatically affect the data model. The `build.sh` and `run.sh`
scripts got a refresh so they could be more easily reused and called
from `launch.sh`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>