### PR TITLE
chore(si-web-app): support source maps in web browser debugger

### DIFF
--- a/components/si-web-app/vue.config.js
+++ b/components/si-web-app/vue.config.js
@@ -10,6 +10,7 @@ module.exports = {
     resolve: {
       symlinks: false,
     },
+    devtool: "source-map",
   },
   pluginOptions: {
     apollo: {


### PR DESCRIPTION
This is a small bug glorious change to support debugging in the web
browser (tested in Firefox but should be equally good in Chrome) by
mapping the original Vue/TypeScript source back to the debugger.

The oddest thing was seeing other related files for a Vue component,
like `SquareChart.vue` and `SquareChart.vue?ff15` until I remembered
that our Vue components are multiple things including a JavaScript
template, a stylesheet, and JavaScript code. This explains why in say
`SquareChart.vue`, there are a ton of empty/blank lines at the start of
the file--that's the HTML template source!

Color me happy to have a debugger at my fingers going forward.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>