### PR TITLE
fix(si-web-app): remove "organizations/fromDb" dispatch

### DIFF
--- a/components/si-web-app/src/api/sdf/model/organization.ts
+++ b/components/si-web-app/src/api/sdf/model/organization.ts
@@ -110,7 +110,7 @@ export class Organization implements IOrganization {
   }
 
   async dispatch(): Promise<void> {
-    await store.dispatch("organizations/fromDb", this);
+    // await store.dispatch("organizations/fromDb", this);
   }
 
   static async restore(): Promise<void> {


### PR DESCRIPTION
This change removes a dispatch to "organizations/fromDb" in
`Organization.dispatch()`. I'm not 100% sure if `fromDb` used to exist
or should exist, but it really doesn't right now and causes more
frontend erroring in the console. And it no longer errors ;)

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>