### PR TITLE
feat: deploy an application, cascading to services

### DIFF
--- a/components/si-registry/src/components/si-core/application.ts
+++ b/components/si-registry/src/components/si-core/application.ts
@@ -1,11 +1,5 @@
-import { PropBool, PropText, PropSelect } from "../../components/prelude";
+import { PropSelect } from "../../components/prelude";
 import { registry } from "../../registry";
-import {
-  ActionRequest,
-  ActionReply,
-  ResourceHealth,
-  ResourceStatus,
-} from "../../veritech/intelligence";
 
 registry.componentAndEntity({
   typeName: "application",
@@ -26,25 +20,5 @@ registry.componentAndEntity({
         p.repeated = true;
       },
     });
-
-    c.entity.intelligence.actions = {
-      async deploy(request: ActionRequest): Promise<ActionReply> {
-        const actions: ActionReply["actions"] = [];
-        for (const child of request.successors) {
-          if (child.entity.objectType == "service") {
-            actions.push({ action: "deploy", entityId: child.entity.id });
-          }
-        }
-        const reply: ActionReply = {
-          resource: {
-            state: { edward: "van halen" },
-            health: ResourceHealth.Ok,
-            status: ResourceStatus.Created,
-          },
-          actions,
-        };
-        return reply;
-      },
-    };
   },
 });

--- a/components/si-registry/src/components/si-core/dockerImage.ts
+++ b/components/si-registry/src/components/si-core/dockerImage.ts
@@ -7,8 +7,8 @@ registry.componentAndEntity({
   siPathName: "si-core",
   serviceName: "core",
   options(c) {
-    c.entity.inputType("service");
     c.entity.inputType("dockerHubCredential");
+    c.entity.inputType("service");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/components/si-kubernetes/deployment.ts
+++ b/components/si-registry/src/components/si-kubernetes/deployment.ts
@@ -20,6 +20,7 @@ registry.componentAndEntity({
     c.entity.inputType("awsAccessKeyCredential");
     c.entity.inputType("kubernetesNamespace");
     c.entity.inputType("kubernetesSecret");
+    c.entity.inputType("service");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/components/si-kubernetes/namespace.ts
+++ b/components/si-registry/src/components/si-kubernetes/namespace.ts
@@ -2,7 +2,6 @@ import {
   PropObject,
   PropText,
   PropLink,
-  PropNumber,
   PropEnum,
   PropCode,
   PropAction,
@@ -18,6 +17,7 @@ registry.componentAndEntity({
     c.entity.inputType("application");
     c.entity.inputType("awsEks");
     c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("service");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/components/si-kubernetes/secret.ts
+++ b/components/si-registry/src/components/si-kubernetes/secret.ts
@@ -14,10 +14,11 @@ registry.componentAndEntity({
   siPathName: "si-kubernetes",
   serviceName: "kubernetes",
   options(c) {
-    c.entity.inputType("kubernetesNamespace");
-    c.entity.inputType("dockerHubCredential");
-    c.entity.inputType("awsEks");
     c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("awsEks");
+    c.entity.inputType("dockerHubCredential");
+    c.entity.inputType("kubernetesNamespace");
+    c.entity.inputType("service");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/components/si-kubernetes/service.ts
+++ b/components/si-registry/src/components/si-kubernetes/service.ts
@@ -16,10 +16,11 @@ registry.componentAndEntity({
   siPathName: "si-kubernetes",
   serviceName: "kubernetes",
   options(c) {
-    c.entity.inputType("awsEks");
     c.entity.inputType("awsAccessKeyCredential");
-    c.entity.inputType("kubernetesNamespace");
+    c.entity.inputType("awsEks");
     c.entity.inputType("kubernetesDeployment");
+    c.entity.inputType("kubernetesNamespace");
+    c.entity.inputType("service");
 
     c.entity.associations.belongsTo({
       fromFieldPath: ["siProperties", "billingAccountId"],

--- a/components/si-registry/src/veritech/components/application.ts
+++ b/components/si-registry/src/veritech/components/application.ts
@@ -1,0 +1,64 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+  ResourceHealth,
+  ResourceStatus,
+  SyncResourceRequest,
+  SyncResourceReply,
+} from "../../veritech/intelligence";
+import _ from "lodash";
+
+const intelligence = (registry.get("application") as EntityObject).intelligence;
+
+intelligence.calculateProperties = function(
+  _req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  const result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {},
+    },
+  };
+
+  return result;
+};
+
+intelligence.syncResource = async function(
+  _request: SyncResourceRequest,
+): Promise<SyncResourceReply> {
+  const state = {};
+
+  return {
+    resource: {
+      state,
+      health: ResourceHealth.Ok,
+      status: ResourceStatus.Created,
+    },
+  };
+};
+
+intelligence.actions = {
+  async deploy(request: ActionRequest): Promise<ActionReply> {
+    const actions: ActionReply["actions"] = _.chain(request.successors)
+      .filter(["entity.objectType", "service"])
+      .map(s => ({ action: "deploy", entityId: s.entity.id }))
+      .value();
+
+    const state = {
+      deployedTs: Math.floor(+new Date() / 1000),
+    };
+
+    const reply = {
+      resource: {
+        state,
+        health: ResourceHealth.Ok,
+        status: ResourceStatus.Created,
+      },
+      actions,
+    };
+    return reply;
+  },
+};

--- a/components/si-registry/src/veritech/components/awsEks.ts
+++ b/components/si-registry/src/veritech/components/awsEks.ts
@@ -1,8 +1,6 @@
 import { registry } from "@/registry";
 import { EntityObject } from "@/systemComponent";
 import {
-  ActionRequest,
-  ActionReply,
   ResourceHealth,
   ResourceStatus,
   SyncResourceRequest,
@@ -12,21 +10,13 @@ import {
 } from "../../veritech/intelligence";
 import _ from "lodash";
 import execa from "execa";
-import { promises as fs } from "fs";
-import os from "os";
-import path from "path";
-
 import { awsCredential, AwsCliEnv, awsKubeConfig } from "./awsShared";
 
-const awsEks = registry.get("awsEks") as EntityObject;
-const intelligence = awsEks.intelligence;
+const intelligence = (registry.get("awsEks") as EntityObject).intelligence;
 
 intelligence.calculateProperties = function(
   req: CalculatePropertiesRequest,
 ): CalculatePropertiesResult {
-  console.log(`calulating properties for awsEks`, { req });
-  console.dir(req, { depth: Infinity });
-
   const result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {},
@@ -47,9 +37,6 @@ intelligence.calculateProperties = function(
 intelligence.syncResource = async function(
   request: SyncResourceRequest,
 ): Promise<SyncResourceReply> {
-  console.log(`syncing awsEks`);
-  console.dir(request, { depth: Infinity });
-
   const awsCredResult = awsCredential(request);
   if (awsCredResult.syncResourceReply) {
     return awsCredResult.syncResourceReply;
@@ -62,33 +49,32 @@ intelligence.syncResource = async function(
     throw new Error("aws cli function didn't return an environment");
   }
 
-  const awsCmd = await execa(
-    "aws",
-    [
-      "eks",
-      "describe-cluster",
-      "--region",
-      request.entity.properties.__baseline.region,
-      "--name",
-      request.entity.properties.__baseline.clusterName,
-    ],
-    {
-      env: awsEnv,
-    },
-  );
+  const awsArgs = [
+    "eks",
+    "describe-cluster",
+    "--region",
+    request.entity.properties.__baseline.region,
+    "--name",
+    request.entity.properties.__baseline.clusterName,
+  ];
+  console.log(`running command; cmd="aws ${awsArgs.join(" ")}"`);
+  const awsCmd = await execa("aws", awsArgs, { reject: false, env: awsEnv });
+
+  // If the describe-cluster failed, early return
   if (awsCmd.failed) {
-    const reply: SyncResourceReply = {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "aws eks describe-cluster failed",
+      errorOutput: awsCmd.stderr,
+    };
+
+    return {
       resource: {
-        state: {
-          data: request.resource.state?.data,
-          errorMsg: "aws eks describe-cluster failed",
-          errorOutput: awsCmd.stderr,
-        },
-        health: ResourceHealth.Ok,
-        status: ResourceStatus.Created,
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
       },
     };
-    return reply;
   }
 
   const awsKubeConfigResult = await awsKubeConfig(request, awsEnv);
@@ -100,26 +86,34 @@ intelligence.syncResource = async function(
   }
   const kubeconfigPath = awsKubeConfigResult.kubeconfig;
 
-  const kubectlVersionCmd = await execa(
-    "kubectl",
-    ["version", "--kubeconfig", kubeconfigPath, "--output", "json"],
-    {
-      env: awsEnv,
-    },
-  );
+  const kubectlVersionArgs = [
+    "version",
+    "--kubeconfig",
+    kubeconfigPath,
+    "--output",
+    "json",
+  ];
+  console.log(`running command; cmd="kubectl ${kubectlVersionArgs.join(" ")}"`);
+  const kubectlVersionCmd = await execa("kubectl", kubectlVersionArgs, {
+    reject: false,
+    env: awsEnv,
+  });
+
+  // If kubectl version failed, early return
   if (kubectlVersionCmd.failed) {
-    const reply: SyncResourceReply = {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "kubectl version command failed",
+      errorOutput: kubectlVersionCmd.stderr,
+    };
+
+    return {
       resource: {
-        state: {
-          data: request.resource.state?.data,
-          errorMsg: "kubectl version command failed",
-          errorOutput: kubectlVersionCmd.stderr,
-        },
-        health: ResourceHealth.Ok,
-        status: ResourceStatus.Created,
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
       },
     };
-    return reply;
   }
 
   const awsJson = JSON.parse(awsCmd.stdout);

--- a/components/si-registry/src/veritech/components/awsShared.ts
+++ b/components/si-registry/src/veritech/components/awsShared.ts
@@ -96,30 +96,30 @@ export async function awsKubeConfig(
             errorMsg: "aws eks update-kubeconfig failed",
             errorOutput: "no awsEks entity attached!",
           },
-          health: ResourceHealth.Ok,
-          status: ResourceStatus.Created,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
         },
       };
       return { syncResourceReply: reply };
     }
   }
 
-  const awsKubeConfigCmd = await execa(
-    "aws",
-    [
-      "eks",
-      "--region",
-      region,
-      "update-kubeconfig",
-      "--name",
-      clusterName,
-      "--kubeconfig",
-      kubeconfigPath,
-    ],
-    {
-      env: awsEnv,
-    },
-  );
+  const awsArgs = [
+    "eks",
+    "--region",
+    region,
+    "update-kubeconfig",
+    "--name",
+    clusterName,
+    "--kubeconfig",
+    kubeconfigPath,
+  ];
+  console.log(`running command; cmd="aws ${awsArgs.join(" ")}"`);
+  const awsKubeConfigCmd = await execa("aws", awsArgs, {
+    reject: false,
+    env: awsEnv,
+  });
+
   if (awsKubeConfigCmd.failed) {
     const reply: SyncResourceReply = {
       resource: {
@@ -128,8 +128,8 @@ export async function awsKubeConfig(
           errorMsg: "aws eks update-kubeconfig failed",
           errorOutput: awsKubeConfigCmd.stderr,
         },
-        health: ResourceHealth.Ok,
-        status: ResourceStatus.Created,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
       },
     };
     return { syncResourceReply: reply };

--- a/components/si-registry/src/veritech/components/kubernetesDeployment.ts
+++ b/components/si-registry/src/veritech/components/kubernetesDeployment.ts
@@ -3,28 +3,20 @@ import { EntityObject } from "@/systemComponent";
 import {
   ActionRequest,
   ActionReply,
-  ResourceHealth,
-  ResourceStatus,
   SyncResourceRequest,
   SyncResourceReply,
   CalculatePropertiesRequest,
   CalculatePropertiesResult,
 } from "../../veritech/intelligence";
 import _ from "lodash";
-import execa from "execa";
 import { kubernetesSync, kubernetesApply } from "./kubernetesShared";
 
-const kubernetesDeployment = registry.get(
-  "kubernetesDeployment",
-) as EntityObject;
-const intelligence = kubernetesDeployment.intelligence;
+const intelligence = (registry.get("kubernetesDeployment") as EntityObject)
+  .intelligence;
 
 intelligence.calculateProperties = function(
   req: CalculatePropertiesRequest,
 ): CalculatePropertiesResult {
-  console.log(`calulating properties for kubernetesDeployment`, { req });
-  console.dir(req, { depth: Infinity });
-
   const result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {
@@ -118,9 +110,7 @@ intelligence.calculateProperties = function(
       // add the image pull secret
     }
     if (pred.entity.objectType == "kubernetesNamespace") {
-      console.log("you're a namesacpe");
       if (pred.entity.properties.__baseline.kubernetesObject?.metadata?.name) {
-        console.log("setting namespace");
         _.set(
           result.inferredProperties,
           ["__baseline", "kubernetesObject", "metadata", "namespace"],

--- a/components/si-registry/src/veritech/components/kubernetesNamespace.ts
+++ b/components/si-registry/src/veritech/components/kubernetesNamespace.ts
@@ -3,26 +3,20 @@ import { EntityObject } from "@/systemComponent";
 import {
   ActionRequest,
   ActionReply,
-  ResourceHealth,
-  ResourceStatus,
   SyncResourceRequest,
   SyncResourceReply,
   CalculatePropertiesRequest,
   CalculatePropertiesResult,
 } from "../../veritech/intelligence";
 import _ from "lodash";
-import execa from "execa";
 import { kubernetesApply, kubernetesSync } from "./kubernetesShared";
 
-const kubernetesNamespace = registry.get("kubernetesNamespace") as EntityObject;
-const intelligence = kubernetesNamespace.intelligence;
+const intelligence = (registry.get("kubernetesNamespace") as EntityObject)
+  .intelligence;
 
 intelligence.calculateProperties = function(
   req: CalculatePropertiesRequest,
 ): CalculatePropertiesResult {
-  console.log(`calulating properties for kubernetesNamespace`, { req });
-  console.dir(req, { depth: Infinity });
-
   const result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {

--- a/components/si-registry/src/veritech/components/kubernetesSecret.ts
+++ b/components/si-registry/src/veritech/components/kubernetesSecret.ts
@@ -15,15 +15,12 @@ import {
 } from "./kubernetesShared";
 import yaml from "yaml";
 
-const kubernetesSecret = registry.get("kubernetesSecret") as EntityObject;
-const intelligence = kubernetesSecret.intelligence;
+const intelligence = (registry.get("kubernetesSecret") as EntityObject)
+  .intelligence;
 
 intelligence.calculateProperties = function(
   req: CalculatePropertiesRequest,
 ): CalculatePropertiesResult {
-  console.log(`calulating properties for kubernetesSecret`, { req });
-  console.dir(req, { depth: Infinity });
-
   let result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {

--- a/components/si-registry/src/veritech/components/kubernetesService.ts
+++ b/components/si-registry/src/veritech/components/kubernetesService.ts
@@ -3,8 +3,6 @@ import { EntityObject } from "@/systemComponent";
 import {
   ActionRequest,
   ActionReply,
-  ResourceHealth,
-  ResourceStatus,
   SyncResourceRequest,
   SyncResourceReply,
   CalculatePropertiesRequest,
@@ -12,18 +10,14 @@ import {
 } from "../../veritech/intelligence";
 import { kubernetesNamespaceProperties } from "./kubernetesShared";
 import _ from "lodash";
-import execa from "execa";
 import { kubernetesSync, kubernetesApply } from "./kubernetesShared";
 
-const kubernetesService = registry.get("kubernetesService") as EntityObject;
-const intelligence = kubernetesService.intelligence;
+const intelligence = (registry.get("kubernetesService") as EntityObject)
+  .intelligence;
 
 intelligence.calculateProperties = function(
   req: CalculatePropertiesRequest,
 ): CalculatePropertiesResult {
-  console.log(`calulating properties for kubernetesService`, { req });
-  console.dir(req, { depth: Infinity });
-
   let result: CalculatePropertiesResult = {
     inferredProperties: {
       __baseline: {
@@ -72,8 +66,6 @@ intelligence.calculateProperties = function(
       if (containers) {
         const ports = [];
         for (const container of containers) {
-          console.log("I am containing the shit out of you");
-          console.dir(container);
           if (container.ports) {
             for (const port of container.ports) {
               if (port.containerPort) {

--- a/components/si-registry/src/veritech/components/kubernetesShared.ts
+++ b/components/si-registry/src/veritech/components/kubernetesShared.ts
@@ -12,6 +12,47 @@ import _ from "lodash";
 import execa from "execa";
 import { awsCredential, awsKubeConfig, AwsCliEnv } from "./awsShared";
 
+// A canonical apply/install order, thanks to the Helm project. This is the
+// order of applying Kubernetes object when running a `helm install` command.
+//
+// Helm source reference: https://git.io/Jk0Y5
+export const kubernetesApplyOrder = [
+  "kubernetesNamespace",
+  "kubernetesNetworkPolicy",
+  "kubernetesResourceQuota",
+  "kubernetesLimitRange",
+  "kubernetesPodSecurityPolicy",
+  "kubernetesPodDisruptionBudget",
+  "kubernetesServiceAccount",
+  "kubernetesSecret",
+  "kubernetesSecretList",
+  "kubernetesConfigMap",
+  "kubernetesStorageClass",
+  "kubernetesPersistentVolume",
+  "kubernetesPersistentVolumeClaim",
+  "kubernetesCustomResourceDefinition",
+  "kubernetesClusterRole",
+  "kubernetesClusterRoleList",
+  "kubernetesClusterRoleBinding",
+  "kubernetesClusterRoleBindingList",
+  "kubernetesRole",
+  "kubernetesRoleList",
+  "kubernetesRoleBinding",
+  "kubernetesRoleBindingList",
+  "kubernetesService",
+  "kubernetesDaemonSet",
+  "kubernetesPod",
+  "kubernetesReplicationController",
+  "kubernetesReplicaSet",
+  "kubernetesDeployment",
+  "kubernetesHorizontalPodAutoscaler",
+  "kubernetesStatefulSet",
+  "kubernetesJob",
+  "kubernetesCronJob",
+  "kubernetesIngress",
+  "kubernetesAPIService",
+];
+
 export function kubernetesNamespaceProperties(
   result: CalculatePropertiesResult,
   namespace: Entity,
@@ -29,9 +70,6 @@ export function kubernetesNamespaceProperties(
 export async function kubernetesSync(
   request: SyncResourceRequest,
 ): Promise<SyncResourceReply> {
-  console.log(`syncing kubernetes`);
-  console.dir(request, { depth: Infinity });
-
   const awsCredResult = awsCredential(request);
   if (awsCredResult.syncResourceReply) {
     return awsCredResult.syncResourceReply;
@@ -47,76 +85,77 @@ export async function kubernetesSync(
   }
   const kubeconfigPath = awsKubeConfigResult.kubeconfig;
 
-  if (kubeconfigPath) {
-    console.log(request.entity.properties.__baseline["kubernetesObjectYaml"]);
-    const kubectlApply = await execa(
-      "kubectl",
-      [
-        "apply",
-        "-o",
-        "json",
-        "--kubeconfig",
-        kubeconfigPath,
-        "--dry-run=server",
-        "-f",
-        "-",
-      ],
-      {
-        input: request.entity.properties.__baseline["kubernetesObjectYaml"],
-        env: awsEnv,
-      },
-    );
-    if (kubectlApply.failed) {
-      const reply: SyncResourceReply = {
-        resource: {
-          state: {
-            data: request.resource.state?.data,
-            errorMsg: "kubectl apply failed",
-            errorOutput: kubectlApply.stderr,
-          },
-          health: ResourceHealth.Ok,
-          status: ResourceStatus.Created,
-        },
-      };
-      return reply;
-    } else {
-      const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
-      if (request.entity.objectType == "kubernetesSecret") {
-        _.set(kubectlApplyJson, ["data"], "redacted");
-        _.set(kubectlApplyJson, ["metadata", "annotations"], "redacted");
-      }
-      const reply: SyncResourceReply = {
-        resource: {
-          state: {
-            data: kubectlApplyJson,
-          },
-          health: ResourceHealth.Ok,
-          status: ResourceStatus.Created,
-        },
-      };
-      return reply;
-    }
-  } else {
-    const reply: SyncResourceReply = {
+  // If no valid kubeconfig, early return
+  if (!kubeconfigPath) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "No kubernetesCluster attached!",
+    };
+
+    return {
       resource: {
-        state: {
-          data: request.resource.state?.data,
-          errorMsg: "No kubernetesCluster attached!",
-        },
+        state,
         health: ResourceHealth.Error,
         status: ResourceStatus.Failed,
       },
     };
-    return reply;
   }
+
+  const kubectlArgs = [
+    "apply",
+    "-o",
+    "json",
+    "--kubeconfig",
+    kubeconfigPath,
+    "--dry-run=server",
+    "-f",
+    "-",
+  ];
+  console.log(`running command; cmd="kubectl ${kubectlArgs.join(" ")}"`);
+  const kubectlApply = await execa("kubectl", kubectlArgs, {
+    reject: false,
+    input: request.entity.properties.__baseline["kubernetesObjectYaml"],
+    env: awsEnv,
+  });
+
+  // If kubectl apply failed, early return
+  if (kubectlApply.failed) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "kubectl apply command failed",
+      errorOutput: kubectlApply.stderr,
+    };
+
+    return {
+      resource: {
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+    };
+  }
+
+  const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
+  if (request.entity.objectType == "kubernetesSecret") {
+    _.set(kubectlApplyJson, ["data"], "redacted");
+    _.set(kubectlApplyJson, ["metadata", "annotations"], "redacted");
+  }
+
+  return {
+    resource: {
+      state: {
+        data: kubectlApplyJson,
+      },
+      health: ResourceHealth.Ok,
+      status: ResourceStatus.Created,
+    },
+  };
 }
 
 export async function kubernetesApply(
   request: ActionRequest,
 ): Promise<ActionReply> {
   const actions: ActionReply["actions"] = [];
-  console.log(`applying kubernetes`);
-  console.dir(request, { depth: Infinity });
   const awsCredResult = awsCredential(request);
   if (awsCredResult.syncResourceReply) {
     return { resource: awsCredResult.syncResourceReply.resource, actions };
@@ -135,68 +174,74 @@ export async function kubernetesApply(
   }
   const kubeconfigPath = awsKubeConfigResult.kubeconfig;
 
-  if (kubeconfigPath) {
-    const applyArgs = [
-      "apply",
-      "-o",
-      "json",
-      "--kubeconfig",
-      kubeconfigPath,
-      "-f",
-      "-",
-    ];
-    if (request.hypothetical) {
-      applyArgs.push("--dry-run=server");
-    }
+  // If no valid kubeconfig, early return
+  if (!kubeconfigPath) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "No awsEks node attached!",
+    };
 
-    const kubectlApply = await execa("kubectl", applyArgs, {
-      input: request.entity.properties.__baseline["kubernetesObjectYaml"],
-      env: awsEnv,
-    });
-    if (kubectlApply.failed) {
-      const reply: ActionReply = {
-        resource: {
-          state: {
-            data: request.resource.state?.data,
-            errorMsg: "kubectl apply failed",
-            errorOutput: kubectlApply.stderr,
-          },
-          health: ResourceHealth.Ok,
-          status: ResourceStatus.Created,
-        },
-        actions,
-      };
-      return reply;
-    } else {
-      const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
-      if (request.entity.objectType == "kubernetesSecret") {
-        _.set(kubectlApplyJson, ["data"], "redacted");
-        _.set(kubectlApplyJson, ["metadata", "annotations"], "redacted");
-      }
-      const reply: ActionReply = {
-        resource: {
-          state: {
-            data: kubectlApplyJson,
-          },
-          health: ResourceHealth.Ok,
-          status: ResourceStatus.Created,
-        },
-        actions,
-      };
-      return reply;
-    }
-  } else {
-    const reply: ActionReply = {
+    return {
       resource: {
-        state: {
-          data: request.resource.state?.data,
-          errorMsg: "No awsEks node attached!",
-        },
+        state,
         health: ResourceHealth.Error,
         status: ResourceStatus.Failed,
       },
       actions,
     };
-    return reply;
   }
+
+  const kubectlArgs = [
+    "apply",
+    "-o",
+    "json",
+    "--kubeconfig",
+    kubeconfigPath,
+    "-f",
+    "-",
+  ];
+  if (request.hypothetical) {
+    kubectlArgs.push("--dry-run=server");
+  }
+  console.log(`running command; cmd="kubectl ${kubectlArgs.join(" ")}"`);
+  const kubectlApply = await execa("kubectl", kubectlArgs, {
+    reject: false,
+    input: request.entity.properties.__baseline["kubernetesObjectYaml"],
+    env: awsEnv,
+  });
+
+  // If kubectl apply failed, early return
+  if (kubectlApply.failed) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "kubectl apply command failed",
+      errorOutput: kubectlApply.stderr,
+    };
+
+    return {
+      resource: {
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+      actions,
+    };
+  }
+
+  const kubectlApplyJson = JSON.parse(kubectlApply.stdout);
+  if (request.entity.objectType == "kubernetesSecret") {
+    _.set(kubectlApplyJson, ["data"], "redacted");
+    _.set(kubectlApplyJson, ["metadata", "annotations"], "redacted");
+  }
+
+  return {
+    resource: {
+      state: {
+        data: kubectlApplyJson,
+      },
+      health: ResourceHealth.Ok,
+      status: ResourceStatus.Created,
+    },
+    actions,
+  };
 }

--- a/components/si-registry/src/veritech/components/service.ts
+++ b/components/si-registry/src/veritech/components/service.ts
@@ -1,0 +1,70 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+  ResourceHealth,
+  ResourceStatus,
+  SyncResourceRequest,
+  SyncResourceReply,
+} from "../../veritech/intelligence";
+import { kubernetesApplyOrder } from "./kubernetesShared";
+import _ from "lodash";
+
+const intelligence = (registry.get("service") as EntityObject).intelligence;
+
+intelligence.calculateProperties = function(
+  _req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  const result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {},
+    },
+  };
+
+  return result;
+};
+
+intelligence.syncResource = async function(
+  _request: SyncResourceRequest,
+): Promise<SyncResourceReply> {
+  const state = {};
+
+  return {
+    resource: {
+      state,
+      health: ResourceHealth.Ok,
+      status: ResourceStatus.Created,
+    },
+  };
+};
+
+intelligence.actions = {
+  async deploy(request: ActionRequest): Promise<ActionReply> {
+    const actions = _.filter(request.successors, s =>
+      kubernetesApplyOrder.includes(s.entity.objectType),
+    );
+    // Sort the actions in the order of a safe apply order.
+    // Thanks to Stack Overflow, hope I've passed the audition!
+    // See: https://stackoverflow.com/a/44063445
+    actions.sort(
+      (a, b) =>
+        kubernetesApplyOrder.indexOf(a.entity.objectType) -
+        kubernetesApplyOrder.indexOf(b.entity.objectType),
+    );
+
+    const reply: ActionReply = {
+      resource: {
+        state: {
+          deployedTs: Math.floor(+new Date() / 1000),
+        },
+        health: ResourceHealth.Ok,
+        status: ResourceStatus.Created,
+      },
+      actions: actions.map(s => ({ entityId: s.entity.id, action: "apply" })),
+    };
+    return reply;
+  },
+};

--- a/components/si-registry/src/veritech/intelligence.ts
+++ b/components/si-registry/src/veritech/intelligence.ts
@@ -126,7 +126,7 @@ export function calculateProperties(
   req: express.Request,
   res: express.Response,
 ): void {
-  console.log("POST /calculateProperties resolver begins");
+  console.log("POST /calculateProperties BEGIN");
   const intelReq: CalculatePropertiesRequest = req.body;
   const entity = intelReq.entity;
   let registryObj;
@@ -145,8 +145,6 @@ export function calculateProperties(
   );
   entity.properties = result.properties;
   entity.inferredProperties = result.inferredProperties;
-  console.dir(entity, { depth: Infinity });
-  //console.log("sending back the entity", { entity });
   const intelRes: CalculatePropertiesReply = {
     entity,
   };
@@ -172,9 +170,8 @@ interface ApplyOpReply {
 }
 
 export function applyOp(req: express.Request, res: express.Response): void {
-  console.log("POST /applyOp resolver begins");
+  console.log("POST /applyOp BEGIN");
   const opRequest: ApplyOpRequest = req.body;
-  console.dir(opRequest, { depth: Infinity });
   const object = opRequest.object;
   if (opRequest.operation == Operation.Set) {
     if (opRequest.value) {
@@ -200,8 +197,6 @@ export function applyOp(req: express.Request, res: express.Response): void {
   const opReply: ApplyOpReply = {
     object,
   };
-  console.log("sending applyOp reply");
-  console.dir(opReply, { depth: Infinity });
   res.send(opReply);
 }
 
@@ -227,7 +222,7 @@ export function calculateConfigures(
   req: express.Request,
   res: express.Response,
 ): void {
-  console.log("POST /calculateConfigures resolver begins");
+  console.log("POST /calculateConfigures BEGIN");
   const intelReq: CalculateConfiguresRequest = req.body;
   const entity = intelReq.entity;
   const configures = intelReq.configures;
@@ -249,8 +244,6 @@ export function calculateConfigures(
     configures,
     systems,
   );
-  console.dir(response, { depth: Infinity });
-  console.log("sending response", { response });
   res.send(response);
 }
 
@@ -280,9 +273,8 @@ export interface ActionReply {
 }
 
 export function action(req: express.Request, res: express.Response): void {
-  console.log("POST /action resolver begins");
+  console.log("POST /action BEGIN");
   const request: ActionRequest = req.body;
-  console.dir(request, { depth: Infinity });
   let registryObj;
   try {
     registryObj = registry.get(request.entity.objectType) as EntityObject;
@@ -298,8 +290,6 @@ export function action(req: express.Request, res: express.Response): void {
   registryObj
     .action(request)
     .then(reply => {
-      console.log("action reply");
-      console.dir(reply, { depth: Infinity });
       res.send(reply);
     })
     .catch(err => {
@@ -330,9 +320,8 @@ export function syncResource(
   req: express.Request,
   res: express.Response,
 ): void {
-  console.log("POST /syncResource resolver begins");
+  console.log("POST /syncResource BEGIN");
   const request: SyncResourceRequest = req.body;
-  console.dir(request, { depth: Infinity });
   let registryObj;
   try {
     registryObj = registry.get(request.entity.objectType) as EntityObject;
@@ -348,8 +337,6 @@ export function syncResource(
   registryObj
     .syncResource(request)
     .then(reply => {
-      console.log("sync reply");
-      console.dir(reply, { depth: Infinity });
       res.send(reply);
     })
     .catch(err => {

--- a/components/si-registry/src/veritech/server.ts
+++ b/components/si-registry/src/veritech/server.ts
@@ -2,13 +2,15 @@ import express from "express";
 import morgan from "morgan";
 import chalk from "chalk";
 import "@/loader";
-import "@/veritech/components/dockerImage";
-import "@/veritech/components/kubernetesDeployment";
-import "@/veritech/components/kubernetesCluster";
-import "@/veritech/components/kubernetesNamespace";
-import "@/veritech/components/kubernetesService";
-import "@/veritech/components/kubernetesSecret";
+import "@/veritech/components/application";
 import "@/veritech/components/awsEks.ts";
+import "@/veritech/components/dockerImage";
+import "@/veritech/components/kubernetesCluster";
+import "@/veritech/components/kubernetesDeployment";
+import "@/veritech/components/kubernetesNamespace";
+import "@/veritech/components/kubernetesSecret";
+import "@/veritech/components/kubernetesService";
+import "@/veritech/components/service";
 
 import { registry } from "@/registry";
 


### PR DESCRIPTION
This feature implements the logic for the big 'ol `deploy` button in the
Services pane. In particular:

* A `deploy` action is dispatched for the current Application
* The Application's `deploy` intelligence selects all successors that
  are Services
* For each successor Service, a `deploy` action is dispatched
* The Service's `deploy` intelligence selects all Kubernetes type
  successors, sorts them according to the same3 install/apply ordering
  as used by the Helm project, and for each Kubernetes object an `apply`
  action is dispatched
* The ChageSet execution logic handles the particulars of the invoking
  the actions and driving the entire works to completion

Note that this also implies that invoking `deploy` on a Service also
works for all relevant successor objects, and so-on.

References: [ch870]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>