### PR TITLE
feat: add aws Entity to model AWS connectivity to regions

### DIFF
--- a/components/si-registry/src/components/si-core/aws.ts
+++ b/components/si-registry/src/components/si-core/aws.ts
@@ -1,0 +1,29 @@
+import { PropSelect } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "aws",
+  displayTypeName: "AWS",
+  siPathName: "si-core",
+  serviceName: "core",
+  options(c) {
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+
+    c.entity.properties.addSelect({
+      name: "region",
+      label: "region",
+      options(p: PropSelect) {
+        p.required = true;
+        p.options = [
+          { key: "US East (N. Virginia) us-east-1", value: "us-east-1" },
+          { key: "US East (Ohio) us-east-2", value: "us-east-2" },
+          { key: "US West (N. California) us-west-1", value: "us-west-1" },
+          { key: "US West (Oregon) us-west-2", value: "us-west-2" },
+        ];
+      },
+    });
+  },
+});

--- a/components/si-registry/src/components/si-core/awsEks.ts
+++ b/components/si-registry/src/components/si-core/awsEks.ts
@@ -8,24 +8,12 @@ registry.componentAndEntity({
   serviceName: "core",
   options(c) {
     c.entity.inputType("kubernetesCluster");
+    c.entity.inputType("aws");
     c.entity.inputType("awsAccessKeyCredential");
 
     c.entity.integrationServices.push({
       integrationName: "aws",
       integrationServiceName: "eks_kubernetes",
-    });
-    c.entity.properties.addSelect({
-      name: "region",
-      label: "region",
-      options(p: PropSelect) {
-        p.required = true;
-        p.options = [
-          { key: "US East (N. Virginia) us-east-1", value: "us-east-1" },
-          { key: "US East (Ohio) us-east-2", value: "us-east-2" },
-          { key: "US West (N. California) us-west-1", value: "us-west-1" },
-          { key: "US West (Oregon) us-west-2", value: "us-west-2" },
-        ];
-      },
     });
     c.entity.properties.addText({
       name: "clusterName",

--- a/components/si-registry/src/veritech/syncResource.ts
+++ b/components/si-registry/src/veritech/syncResource.ts
@@ -1,0 +1,71 @@
+import {
+  ActionReply,
+  ResourceHealth,
+  ResourceStatus,
+  SyncResourceReply,
+} from "./intelligence";
+
+interface FailSyncResourceReplyRequest {
+  resource: {
+    state?: any;
+    health: ResourceHealth;
+    status: ResourceStatus;
+  };
+}
+
+export function failSyncResourceReply(
+  request: FailSyncResourceReplyRequest,
+  opts?: {
+    infoMsg?: string;
+    errorMsg?: string;
+    errorOutput?: string;
+    status?: ResourceStatus;
+    health?: ResourceHealth;
+  },
+): SyncResourceReply {
+  const data = request.resource.state?.data ? request.resource.state.data : {};
+  const state = { data };
+  if (opts?.infoMsg) {
+    state.data.infoMsg = opts.infoMsg;
+  }
+  if (opts?.errorMsg) {
+    state.data.infoMsg = opts.errorMsg;
+  }
+  if (opts?.errorOutput) {
+    state.data.errorOutput = opts.errorOutput;
+  }
+  const health: ResourceHealth = opts?.health
+    ? opts.health
+    : request.resource.health;
+  const status: ResourceStatus = opts?.status
+    ? opts.status
+    : request.resource.status;
+
+  const reply = {
+    resource: {
+      state,
+      health,
+      status,
+    },
+  };
+  return reply;
+}
+
+export function failActionReply(
+  request: FailSyncResourceReplyRequest,
+  opts?: {
+    infoMsg?: string;
+    errorMsg?: string;
+    errorOutput?: string;
+    status?: ResourceStatus;
+    health?: ResourceHealth;
+  },
+): ActionReply {
+  const resource = failSyncResourceReply(request, opts).resource;
+
+  const reply = {
+    resource,
+    actions: [],
+  };
+  return reply;
+}


### PR DESCRIPTION
This change adds a new `aws` Entity which can be used to configure other
AWS objects in a more consistent way. There are few AWS objects which
are region agnostic (for example, IAM objects), however the vast
majority are region-specific.

Additionally, some refactoring is included to make future work in
veritech intelligence functions a little easier/faster, namely early
returning error responses.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>