### PR TITLE
feat(si): trigger a node action from a new CLI, `si`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "cexpr",
  "cfg-if",
  "clang-sys",
- "clap",
+ "clap 2.33.3",
  "env_logger",
  "hashbrown 0.1.8",
  "lazy_static",
@@ -415,10 +415,42 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.12.1",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn",
 ]
 
 [[package]]
@@ -891,6 +923,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1394,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-util",
+ "hyper 0.13.8",
+ "log",
+ "rustls",
+ "tokio 0.2.22",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,19 +1420,6 @@ dependencies = [
  "hyper 0.12.35",
  "native-tls",
  "tokio-io",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
-dependencies = [
- "bytes 0.5.6",
- "hyper 0.13.8",
- "native-tls",
- "tokio 0.2.22",
- "tokio-tls",
 ]
 
 [[package]]
@@ -2034,6 +2079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "p256"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2214,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,7 +2297,7 @@ dependencies = [
  "idna 0.2.0",
  "lazy_static",
  "regex",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -2442,9 +2517,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2464,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -2492,7 +2567,7 @@ dependencies = [
  "futures 0.1.30",
  "http 0.1.21",
  "hyper 0.12.35",
- "hyper-tls 0.3.2",
+ "hyper-tls",
  "log",
  "mime",
  "mime_guess",
@@ -2525,25 +2600,26 @@ dependencies = [
  "http 0.2.1",
  "http-body 0.3.1",
  "hyper 0.13.8",
- "hyper-tls 0.4.3",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
+ "rustls",
  "serde 1.0.116",
  "serde_json",
  "serde_urlencoded 0.6.1",
  "tokio 0.2.22",
- "tokio-tls",
- "url 2.1.1",
+ "tokio-rustls",
+ "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.7.0",
 ]
 
@@ -2822,7 +2898,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde 1.0.116",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -2880,6 +2956,7 @@ dependencies = [
  "base64 0.12.3",
  "blake2",
  "chrono",
+ "clap 3.0.0-beta.2",
  "couchbase",
  "crossbeam",
  "futures 0.3.6",
@@ -2889,6 +2966,7 @@ dependencies = [
  "nats",
  "opentelemetry",
  "opentelemetry-jaeger",
+ "regex",
  "reqwest 0.10.8",
  "serde 1.0.116",
  "serde_json",
@@ -2905,6 +2983,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url 2.2.0",
  "uuid 0.8.1",
  "warp",
 ]
@@ -3037,6 +3116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3205,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -3335,6 +3429,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+dependencies = [
+ "futures-core",
+ "rustls",
+ "tokio 0.2.22",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-sync"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,16 +3502,6 @@ dependencies = [
  "futures 0.1.30",
  "slab",
  "tokio-executor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3613,7 +3709,7 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "sha-1 0.9.1",
- "url 2.1.1",
+ "url 2.2.0",
  "utf-8",
 ]
 
@@ -3702,10 +3798,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -3925,6 +4022,15 @@ checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/components/si-registry/src/components/si-kubernetes/deployment.ts
+++ b/components/si-registry/src/components/si-kubernetes/deployment.ts
@@ -16,6 +16,7 @@ registry.componentAndEntity({
   serviceName: "kubernetes",
   options(c) {
     c.entity.inputType("dockerImage");
+    c.entity.inputType("aws");
     c.entity.inputType("awsEks");
     c.entity.inputType("awsAccessKeyCredential");
     c.entity.inputType("kubernetesNamespace");

--- a/components/si-registry/src/components/si-kubernetes/namespace.ts
+++ b/components/si-registry/src/components/si-kubernetes/namespace.ts
@@ -15,6 +15,7 @@ registry.componentAndEntity({
   serviceName: "kubernetes",
   options(c) {
     c.entity.inputType("application");
+    c.entity.inputType("aws");
     c.entity.inputType("awsEks");
     c.entity.inputType("awsAccessKeyCredential");
     c.entity.inputType("service");

--- a/components/si-registry/src/components/si-kubernetes/service.ts
+++ b/components/si-registry/src/components/si-kubernetes/service.ts
@@ -17,6 +17,7 @@ registry.componentAndEntity({
   serviceName: "kubernetes",
   options(c) {
     c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("aws");
     c.entity.inputType("awsEks");
     c.entity.inputType("kubernetesDeployment");
     c.entity.inputType("kubernetesNamespace");

--- a/components/si-sdf/Cargo.toml
+++ b/components/si-sdf/Cargo.toml
@@ -31,7 +31,7 @@ nats = "0.8"
 #nats = { git = "https://github.com/systeminit/nats.rs", branch = "nkeys-upgrade" }
 opentelemetry = "0.8"
 opentelemetry-jaeger = "0.7"
-reqwest = { version = "0.10", features = ["default-tls", "json"] }
+reqwest = { version = "0.10", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 si-settings = { path = "../si-settings" }
@@ -49,6 +49,9 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = "0.2"
 tokio-tungstenite = "0.11"
 blake2 = "0.9"
+clap = "3.0.0-beta.2"
+url = "2.2.0"
+regex = "1.4.2"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/components/si-sdf/src/cli/bin/cli.rs
+++ b/components/si-sdf/src/cli/bin/cli.rs
@@ -1,0 +1,270 @@
+use clap::{AppSettings, ArgSettings, Clap};
+use lazy_static::lazy_static;
+use regex::Regex;
+use si_sdf::cli::server::command::change_run::NodeSetCommand;
+use std::{fmt, str::FromStr};
+use strum::VariantNames;
+use strum_macros::{Display, EnumString, EnumVariantNames};
+use thiserror::Error;
+use url::Url;
+
+const NAME: &str = env!("CARGO_BIN_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const AUTHOR: &str = "The System Initiative <info@systeminit.com>\n\n";
+
+pub(crate) fn parse() -> Args {
+    Args::parse()
+}
+
+/// The command line client for the System Initiative
+///
+/// https://www.systeminit.com/
+#[derive(Clap, Debug)]
+#[clap(
+    global_setting(AppSettings::ColoredHelp),
+    global_setting(AppSettings::UnifiedHelpMessage),
+    max_term_width = 79,
+    name = NAME,
+    author = AUTHOR,
+    version = VERSION
+)]
+pub(crate) struct Args {
+    #[clap(subcommand)]
+    pub(crate) subcmd: SubCmd,
+}
+
+#[derive(Clap, Debug)]
+pub(crate) struct GlobalArgs {
+    /// SI Client API host
+    #[clap(
+        short = 'H',
+        long,
+        default_value = "ws://localhost:5156",
+        env = "SI_HOST",
+        setting(ArgSettings::HideEnvValues)
+    )]
+    pub(crate) host: Url,
+
+    /// SI Client token
+    #[clap(
+        short = 'T',
+        long,
+        env = "SI_TOKEN",
+        setting(ArgSettings::HideEnvValues)
+    )]
+    pub(crate) token: String,
+}
+
+#[derive(Clap, Debug)]
+pub(crate) enum SubCmd {
+    Node(SubCmdNode),
+}
+
+/// Manage nodes
+#[derive(Clap, Debug)]
+pub(crate) enum SubCmdNode {
+    Run(ArgsNodeRun),
+}
+
+/// Runs an action on a node in a system
+///
+/// Optionally, a set of properties can be set on specific nodes which allows you to update
+/// versions, tags, etc. for a deployment for example.
+#[derive(Clap, Debug)]
+pub(crate) struct ArgsNodeRun {
+    #[clap(flatten)]
+    pub(crate) global: GlobalArgs,
+
+    /// Output formatter to use
+    #[clap(
+        short = 'F',
+        long,
+        possible_values = OutputFormatter::VARIANTS,
+        default_value = "simple",
+        env = "SI_OUTPUT_FORMATTER",
+        setting(ArgSettings::HideEnvValues)
+    )]
+    pub(crate) formatter: OutputFormatter,
+
+    /// Set a property on a node [ex: node:bd345f3ec2dd41d3867d02bd9d5e2d8d.image=nginx:1.19.5]
+    #[clap(short = 's', long)]
+    pub(crate) set: Vec<NodeSet>,
+
+    /// System id for the node
+    #[clap(rename_all = "screaming_snake_case")]
+    pub(crate) system_id: SystemId,
+
+    /// Target node id
+    #[clap(rename_all = "screaming_snake_case")]
+    pub(crate) node_id: NodeId,
+
+    /// Action to invoke [ex: deploy]
+    #[clap(rename_all = "screaming_snake_case")]
+    pub(crate) action: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SystemId(String);
+
+impl fmt::Display for SystemId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("could not parse a system id")]
+pub struct SystemIdParseError;
+
+impl FromStr for SystemId {
+    type Err = SystemIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new("^system:[a-f0-9]{32}$").unwrap();
+        }
+
+        if RE.is_match(s) {
+            Ok(Self(s.to_string()))
+        } else {
+            Err(SystemIdParseError)
+        }
+    }
+}
+
+impl From<SystemId> for String {
+    fn from(value: SystemId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct NodeId(String);
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("could not parse an entity id")]
+pub struct NodeIdParseError;
+
+impl FromStr for NodeId {
+    type Err = NodeIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new("^node:[a-f0-9]{32}$").unwrap();
+        }
+
+        if RE.is_match(s) {
+            Ok(Self(s.to_string()))
+        } else {
+            Err(NodeIdParseError)
+        }
+    }
+}
+
+impl From<NodeId> for String {
+    fn from(value: NodeId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct NodeSet(NodeSetCommand);
+
+#[derive(Debug, Error)]
+pub enum NodeSetParseError {
+    #[error("could not parse an node set command")]
+    Malformed,
+    #[error("could not parse node id in set command: {0}")]
+    NodeId(NodeIdParseError),
+}
+
+impl FromStr for NodeSet {
+    type Err = NodeSetParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut kv_parts = s.splitn(2, "=");
+        let (key, raw_value) = match (kv_parts.next(), kv_parts.next(), kv_parts.next()) {
+            (Some(key), Some(value), None) => (key, value),
+            (_, _, _) => return Err(NodeSetParseError::Malformed),
+        };
+        let mut key_parts = key.splitn(2, ".");
+        let (id, path_expr) = match (key_parts.next(), key_parts.next(), key_parts.next()) {
+            (Some(node_id), Some(path), None) => (node_id, path),
+            (_, _, _) => return Err(NodeSetParseError::Malformed),
+        };
+
+        let node_id = NodeId::from_str(id).map_err(NodeSetParseError::NodeId)?;
+        let path: Vec<_> = path_expr.split(".").map(|s| s.to_string()).collect();
+        let value = serde_json::json!(raw_value);
+
+        Ok(Self(NodeSetCommand::new(node_id, path, value)))
+    }
+}
+
+impl From<NodeSet> for NodeSetCommand {
+    fn from(value: NodeSet) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Display, EnumString, EnumVariantNames, Eq, PartialEq)]
+#[strum(serialize_all = "kebab_case")]
+pub(crate) enum OutputFormatter {
+    Debug,
+    Simple,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod system_id {
+        use super::*;
+        #[test]
+        fn from_str() {
+            let id = SystemId::from_str("system:123e4567e89b12d3a456426614174000")
+                .expect("should be valid");
+
+            assert_eq!(
+                SystemId("system:123e4567e89b12d3a456426614174000".to_string()),
+                id
+            )
+        }
+
+        #[test]
+        fn from_str_invalid() {
+            match SystemId::from_str("nope:123e4567e89b12d3a456426614174000") {
+                Err(SystemIdParseError) => assert!(true),
+                Ok(_) => panic!("should not succeed"),
+            }
+        }
+    }
+
+    mod node_id {
+        use super::*;
+        #[test]
+        fn from_str() {
+            let id =
+                NodeId::from_str("node:123e4567e89b12d3a456426614174000").expect("should be valid");
+
+            assert_eq!(
+                NodeId("node:123e4567e89b12d3a456426614174000".to_string()),
+                id
+            )
+        }
+
+        #[test]
+        fn from_str_invalid() {
+            match NodeId::from_str("nope:123e4567e89b12d3a456426614174000") {
+                Err(NodeIdParseError) => assert!(true),
+                Ok(_) => panic!("should not succeed"),
+            }
+        }
+    }
+}

--- a/components/si-sdf/src/cli/formatter.rs
+++ b/components/si-sdf/src/cli/formatter.rs
@@ -1,4 +1,5 @@
 use crate::cli::client::{CliMessage, ClientResult};
+use crate::models::OutputLineStream;
 
 pub trait Formatter {
     fn process_message(&mut self, message: CliMessage) -> ClientResult<()>;
@@ -16,6 +17,35 @@ impl DebugFormatter {
 impl Formatter for DebugFormatter {
     fn process_message(&mut self, message: CliMessage) -> ClientResult<()> {
         dbg!(message);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct SimpleFormatter;
+
+impl SimpleFormatter {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Formatter for SimpleFormatter {
+    fn process_message(&mut self, message: CliMessage) -> ClientResult<()> {
+        match message {
+            CliMessage::Event(event) => {
+                println!("--- {} ({})", event.message, event.start_timestamp);
+            }
+            CliMessage::EventLog(event_log) => {
+                println!("  - {}", event_log.message);
+            }
+            CliMessage::OutputLine(output_line) => match output_line.stream {
+                OutputLineStream::Stdout | OutputLineStream::All => {
+                    println!("        {}", output_line.line)
+                }
+                OutputLineStream::Stderr => eprintln!("!!!     {}", output_line.line),
+            },
+        };
         Ok(())
     }
 }

--- a/components/si-sdf/src/cli/server/command.rs
+++ b/components/si-sdf/src/cli/server/command.rs
@@ -1,3 +1,3 @@
 pub mod change_run;
 
-pub use crate::cli::server::command::change_run::ChangeRun;
+pub use crate::cli::server::command::change_run::NodeChangeRun;

--- a/components/si-sdf/src/models/api_client.rs
+++ b/components/si-sdf/src/models/api_client.rs
@@ -1,3 +1,9 @@
+use super::upsert_model;
+use crate::data::{Connection, Db};
+use crate::models::{
+    check_secondary_key, generate_id, get_model, insert_model, Group, GroupError, JwtKeyError,
+    JwtKeyPrivate, ModelError, SiStorableError, SimpleStorable,
+};
 use blake2::{Blake2b, Digest};
 use jwt_simple::algorithms::RSAKeyPairLike;
 use jwt_simple::claims::Claims;
@@ -5,16 +11,6 @@ use jwt_simple::coarsetime::Duration;
 use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::secretbox;
 use thiserror::Error;
-
-use std::collections::HashMap;
-
-use crate::data::{Connection, Db};
-use crate::models::{
-    check_secondary_key, generate_id, get_model, insert_model, Group, GroupError, JwtKeyError,
-    JwtKeyPrivate, ModelError, SiStorableError, SimpleStorable,
-};
-
-use super::upsert_model;
 
 #[derive(Error, Debug)]
 pub enum ApiClientError {
@@ -108,10 +104,8 @@ impl ApiClient {
         let jwt = signing_key
             .sign(claims)
             .map_err(|e| ApiClientError::SignError(e.to_string()))?;
-        let valid_token_hash = format!(
-            "{:x}",
-            blake2::Blake2b::digest(format!("Bearer {}", &jwt).as_ref())
-        );
+        let valid_token_hash =
+            format!("{:x}", Blake2b::digest(format!("Bearer {}", &jwt).as_ref()));
 
         let object = ApiClient {
             id: id.clone(),


### PR DESCRIPTION
This change adds a new CLI program `si` with a `node run` subcommand
which will trigger an action on a given Node in a System and optionally
set multiple properties on arbitrary Nodes. Our canonical example is to
trigger a `deploy` action on a service Node and set the `image` property
on a dockerImage. The Nodes are identified using their nodeId.

References: [ch973]

Building
--------

To compile a development build, you can run the following from the root
of the project or in the `components/si-sdf` subdirectory:

```console
$ cargo build --bin si
```

Likely the CI release build will be:

```console
$ cargo build --bin si --release --verbose
$ cp ./target/release/si /path/to/dst/
```

Example
-------

For example, assuming an `SI_TOKEN` environment variable is set with a suitable
client token,

```console
$ si node run \
  --set node:ff6031e63bdd48b88090de73276d0b83.image=nginx:latest \
  system:d872097c2ef54fa1ad102fd5b514329e \
  node:14a3861d171f4268ab8d6abc0040ba88 \
  deploy
```

Top level short help
--------------------

```console
$ si -h
si 0.1.0
The System Initiative <info@systeminit.com>

The command line client for the System Initiative

USAGE:
    si <SUBCOMMAND>

OPTIONS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    node    Manage nodes
```

Top level long help
-------------------

```console
$ si --help
si 0.1.0
The System Initiative <info@systeminit.com>

The command line client for the System Initiative

https://www.systeminit.com/

USAGE:
    si <SUBCOMMAND>

OPTIONS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information

SUBCOMMANDS:
    help
            Prints this message or the help of the given subcommand(s)

    node
            Manage nodes
```

Node run subcommand short help
------------------------------

```console
$ si node run -h
si-node-run
Runs an action on a node in a system

USAGE:
    si node run <SYSTEM_ID> <NODE_ID> <ACTION> --token <token>

ARGS:
    <SYSTEM_ID>    System id for the node
    <NODE_ID>      Target node id
    <ACTION>       Action to invoke [ex: deploy]

OPTIONS:
    -F, --formatter <formatter>
            Output formatter to use [env: SI_OUTPUT_FORMATTER] [default:
            simple] [possible values: debug, simple]

    -h, --help                     Prints help information
    -H, --host <host>
            SI Client API host [env: SI_HOST] [default: ws://localhost:5156]

    -s, --set <set>...
            Set a property on a node [ex:
            node:bd345f3ec2dd41d3867d02bd9d5e2d8d.image=nginx:1.19.5]

    -T, --token <token>            SI Client token [env: SI_TOKEN]
    -V, --version                  Prints version information
```

Node run subcommand short help
------------------------------

```console
$ si node run --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/si node run --help`
si-node-run
Runs an action on a node in a system

Optionally, a set of properties can be set on specific nodes which allows you
to update versions, tags, etc. for a deployment for example.

USAGE:
    si node run <SYSTEM_ID> <NODE_ID> <ACTION> --token <token>

ARGS:
    <SYSTEM_ID>
            System id for the node
    <NODE_ID>
            Target node id
    <ACTION>
            Action to invoke [ex: deploy]

OPTIONS:
    -F, --formatter <formatter>
            Output formatter to use [env: SI_OUTPUT_FORMATTER] [default:
            simple] [possible values: debug, simple]

    -h, --help
            Prints help information

    -H, --host <host>
            SI Client API host [env: SI_HOST] [default: ws://localhost:5156]

    -s, --set <set>...
            Set a property on a node [ex:
            node:bd345f3ec2dd41d3867d02bd9d5e2d8d.image=nginx:1.19.5]

    -T, --token <token>
            SI Client token [env: SI_TOKEN]

    -V, --version
            Prints version information
```

![tenor-164999314](https://user-images.githubusercontent.com/261548/100939593-c727d980-34b3-11eb-8eee-1846b02a71f8.gif)

 (this happy dancing person showed up when searching for `"cli"`--so, their name might be… Cli??)