### PR TITLE
feat: Add Helm support

### DIFF
--- a/components/si-registry/package-lock.json
+++ b/components/si-registry/package-lock.json
@@ -11393,6 +11393,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "ts-essentials": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.1.tgz",
+      "integrity": "sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==",
+      "dev": true
+    },
     "ts-jest": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",

--- a/components/si-registry/package.json
+++ b/components/si-registry/package.json
@@ -41,6 +41,7 @@
     "nodemon": "^2.0.4",
     "nodemon-webpack-plugin": "^4.3.1",
     "prettier": "^1.18.2",
+    "ts-essentials": "^7.0.1",
     "ts-jest": "^24.3.0",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^3.6.4",

--- a/components/si-registry/src/components/si-core/helmRepoCredential.ts
+++ b/components/si-registry/src/components/si-core/helmRepoCredential.ts
@@ -1,0 +1,23 @@
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "helmRepoCredential",
+  displayTypeName: "Helm Repo Credential",
+  siPathName: "si-core",
+  serviceName: "core",
+  options(c) {
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+    c.entity.secretType("credential", "helmRepo");
+    c.properties.addText({
+      name: "username",
+      label: "Username",
+    });
+    c.properties.addText({
+      name: "password",
+      label: "Password",
+    });
+  },
+});

--- a/components/si-registry/src/components/si-kubernetes/helmChart.ts
+++ b/components/si-registry/src/components/si-kubernetes/helmChart.ts
@@ -1,0 +1,43 @@
+import { PropText, PropAction } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "helmChart",
+  displayTypeName: "Helm Chart",
+  siPathName: "si-kubernetes",
+  serviceName: "kubernetes",
+  options(c) {
+    c.entity.inputType("helmRepoCredential");
+    c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("aws");
+    c.entity.inputType("awsEks");
+    c.entity.inputType("helmRepo");
+
+    c.entity.associations.belongsTo({
+      fromFieldPath: ["siProperties", "billingAccountId"],
+      typeName: "billingAccount",
+    });
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+
+    c.properties.addText({
+      name: "name",
+      label: "Chart Name",
+      options(p: PropText) {
+        p.required = true;
+      },
+    });
+
+    c.properties.addText({
+      name: "version",
+      label: "Chart Version",
+    });
+
+    c.properties.addBool({
+      name: "insecureSkipTlsVerify",
+      label: "Insecure Skip TLS Verify",
+    });
+  },
+});

--- a/components/si-registry/src/components/si-kubernetes/helmRelease.ts
+++ b/components/si-registry/src/components/si-kubernetes/helmRelease.ts
@@ -1,0 +1,103 @@
+import { PropText, PropAction } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "helmRelease",
+  displayTypeName: "Helm Release",
+  siPathName: "si-kubernetes",
+  serviceName: "kubernetes",
+  options(c) {
+    c.entity.inputType("helmRepoCredential");
+    c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("aws");
+    c.entity.inputType("awsEks");
+    c.entity.inputType("helmRepo");
+    c.entity.inputType("helmChart");
+
+    c.entity.associations.belongsTo({
+      fromFieldPath: ["siProperties", "billingAccountId"],
+      typeName: "billingAccount",
+    });
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+
+    c.entity.methods.addAction({
+      name: "install",
+      label: "install",
+      options(p: PropAction) {
+        p.mutation = true;
+      },
+    });
+
+    c.entity.methods.addAction({
+      name: "upgrade",
+      label: "upgrade",
+      options(p: PropAction) {
+        p.mutation = true;
+      },
+    });
+
+    c.entity.methods.addAction({
+      name: "apply",
+      label: "apply",
+      options(p: PropAction) {
+        p.mutation = true;
+      },
+    });
+
+    c.properties.addText({
+      name: "name",
+      label: "Release Name",
+      options(p: PropText) {
+        p.required = true;
+      },
+    });
+
+    c.properties.addText({
+      name: "description",
+      label: "Release Description",
+    });
+
+    c.properties.addTextArea({
+      name: "valuesYaml",
+      label: "Values YAML",
+    });
+
+    c.properties.addBool({
+      name: "atomic",
+      label: "Atomic install",
+    });
+
+    c.properties.addBool({
+      name: "noHooks",
+      label: "Don't run hooks",
+    });
+
+    c.properties.addBool({
+      name: "renderSubchartNotes",
+      label: "Render subchart notes",
+    });
+
+    c.properties.addBool({
+      name: "skipCrds",
+      label: "Skip CRDs",
+    });
+
+    c.properties.addBool({
+      name: "wait",
+      label: "wait for all resources",
+    });
+
+    c.properties.addText({
+      name: "timeout",
+      label: "Timeout for each k8s operation",
+    });
+
+    c.properties.addBool({
+      name: "insecureSkipTlsVerify",
+      label: "Insecure Skip TLS Verify",
+    });
+  },
+});

--- a/components/si-registry/src/components/si-kubernetes/helmRepo.ts
+++ b/components/si-registry/src/components/si-kubernetes/helmRepo.ts
@@ -1,0 +1,45 @@
+import { PropText, PropAction } from "../../components/prelude";
+import { registry } from "../../registry";
+
+registry.componentAndEntity({
+  typeName: "helmRepo",
+  displayTypeName: "Helm Repo",
+  siPathName: "si-kubernetes",
+  serviceName: "kubernetes",
+  options(c) {
+    c.entity.inputType("helmRepoCredential");
+    c.entity.inputType("awsAccessKeyCredential");
+    c.entity.inputType("aws");
+    c.entity.inputType("awsEks");
+
+    c.entity.associations.belongsTo({
+      fromFieldPath: ["siProperties", "billingAccountId"],
+      typeName: "billingAccount",
+    });
+    c.entity.integrationServices.push({
+      integrationName: "aws",
+      integrationServiceName: "eks_kubernetes",
+    });
+
+    c.properties.addText({
+      name: "name",
+      label: "Repo Name",
+      options(p: PropText) {
+        p.required = true;
+      },
+    });
+
+    c.properties.addText({
+      name: "url",
+      label: "Repo Name",
+      options(p: PropText) {
+        p.required = true;
+      },
+    });
+
+    c.properties.addBool({
+      name: "insecureSkipTlsVerify",
+      label: "Insecure Skip TLS Verify",
+    });
+  },
+});

--- a/components/si-registry/src/loader.ts
+++ b/components/si-registry/src/loader.ts
@@ -47,3 +47,8 @@ import "./components/si-kubernetes/minikube";
 import "./components/si-kubernetes/secret";
 import "./components/si-kubernetes/deployment";
 import "./components/si-kubernetes/service";
+
+import "./components/si-core/helmRepoCredential";
+import "./components/si-kubernetes/helmRepo";
+import "./components/si-kubernetes/helmChart";
+import "./components/si-kubernetes/helmRelease";

--- a/components/si-registry/src/veritech/components/awsShared.ts
+++ b/components/si-registry/src/veritech/components/awsShared.ts
@@ -19,7 +19,7 @@ export interface AwsCliEnv {
   [key: string]: string;
 }
 
-interface AwsInputRequest {
+export interface AwsInputRequest {
   entity: Entity;
   predecessors: {
     entity: Entity;
@@ -154,6 +154,8 @@ export async function awsKubeConfig(
         status: ResourceStatus.Failed,
       }),
     };
+  } else {
+    await fs.chmod(kubeconfigPath, "0600");
   }
 
   return { kubeconfig: kubeconfigPath };

--- a/components/si-registry/src/veritech/components/helmChart.ts
+++ b/components/si-registry/src/veritech/components/helmChart.ts
@@ -1,0 +1,159 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  SyncResourceRequest,
+  SyncResourceReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+  findEntityByType,
+  ResourceHealth,
+  ResourceStatus,
+} from "../../veritech/intelligence";
+import { Event } from "../../veritech/eventLog";
+import {
+  kubernetesNamespaceProperties,
+  kubernetesSync,
+  kubernetesApply,
+} from "./kubernetesShared";
+import { awsCredential, awsKubeConfig, AwsCliEnv } from "./awsShared";
+import { siExec } from "../siExec";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import {
+  helmCommandPrepare,
+  helmKubeConfig,
+  helmCommandAuthPrepare,
+  helmRepoAdd,
+} from "./helmShared";
+import _ from "lodash";
+import yaml from "yaml";
+
+const intelligence = (registry.get("helmChart") as EntityObject).intelligence;
+
+intelligence.calculateProperties = function(
+  req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  const helmRepo = findEntityByType(req.predecessors, "helmRepo");
+  let name: string;
+  if (helmRepo) {
+    name = `${helmRepo.properties.__baseline.name}/${req.entity.name}`;
+  } else {
+    name = req.entity.name;
+  }
+  const result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {
+        name,
+      },
+    },
+  };
+  return result;
+};
+
+intelligence.syncResource = async function(
+  request: SyncResourceRequest,
+  event: Event,
+): Promise<SyncResourceReply> {
+  const helmKubeConfigResult = await helmKubeConfig(request, event);
+  if (helmKubeConfigResult.failure) {
+    return helmKubeConfigResult.failure;
+  }
+  const awsEnv = helmKubeConfigResult.awsEnv;
+  const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+
+  const repo = findEntityByType(request.predecessors, "helmRepo");
+
+  let helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+
+  const helmRepoAddResult = await helmRepoAdd(
+    request,
+    event,
+    kubeconfigPath,
+    awsEnv,
+    repo?.properties.__baseline.name,
+    repo?.properties.__baseline.url,
+    _.clone(helmArgs),
+  );
+  if (helmRepoAddResult.failure) {
+    return helmRepoAddResult.failure;
+  }
+
+  const chartName: string = request.entity.properties.__baseline.name;
+  helmArgs.push("pull");
+  helmArgs.push(chartName);
+
+  const helmAuthArgs = helmCommandAuthPrepare(request);
+  helmArgs = helmArgs.concat(helmAuthArgs);
+
+  const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "helmpull-"));
+  helmArgs.push("--destination");
+  helmArgs.push(tempdir);
+  helmArgs.push("--untar");
+
+  if (request.entity.properties.__baseline.version) {
+    helmArgs.push("--version", request.entity.properties.__baseline.version);
+  }
+
+  const helmRepoPull = await siExec(event, "helm", helmArgs, {
+    env: awsEnv,
+    reject: false,
+  });
+
+  if (helmRepoPull.failed) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "helm repo pull failed",
+      errorOutput: helmRepoPull.stderr,
+    };
+
+    return {
+      resource: {
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+    };
+  } else {
+    const chartFullName: string = request.entity.properties.__baseline.name;
+    const chartParts = chartFullName.split("/");
+    const chartName = chartParts[1];
+
+    const chartYamlRaw = await fs.readFile(
+      path.join(tempdir, chartName, "Chart.yaml"),
+    );
+    const chartYaml = yaml.parse(chartYamlRaw.toString());
+
+    let valuesYaml = {};
+    try {
+      const valuesYamlRaw = await fs.readFile(
+        path.join(tempdir, chartName, "values.yaml"),
+      );
+      valuesYaml = yaml.parse(valuesYamlRaw.toString());
+    } catch {}
+
+    let valuesSchemaJson = {};
+    try {
+      const valuesSchemaJsonRaw = await fs.readFile(
+        path.join(tempdir, chartName, "values.schema.json"),
+      );
+      valuesSchemaJson = JSON.parse(valuesSchemaJsonRaw.toString());
+    } catch (_e) {}
+
+    return {
+      resource: {
+        state: {
+          data: {
+            chartYaml,
+            valuesYaml,
+            valuesSchemaJson,
+          },
+        },
+        health: ResourceHealth.Ok,
+        status: ResourceStatus.Created,
+      },
+    };
+  }
+};

--- a/components/si-registry/src/veritech/components/helmRelease.ts
+++ b/components/si-registry/src/veritech/components/helmRelease.ts
@@ -1,0 +1,486 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  SyncResourceRequest,
+  SyncResourceReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+  findEntityByType,
+  ResourceHealth,
+  ResourceStatus,
+} from "../../veritech/intelligence";
+import { Event } from "../../veritech/eventLog";
+import {
+  kubernetesNamespaceProperties,
+  kubernetesSync,
+  kubernetesApply,
+} from "./kubernetesShared";
+import { awsCredential, awsKubeConfig, AwsCliEnv } from "./awsShared";
+import { siExec } from "../siExec";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import {
+  helmCommandPrepare,
+  helmKubeConfig,
+  helmCommandAuthPrepare,
+  helmRepoAdd,
+} from "./helmShared";
+import _ from "lodash";
+import yaml from "yaml";
+
+const intelligence = (registry.get("helmRelease") as EntityObject).intelligence;
+
+intelligence.calculateProperties = function(
+  req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  const name: string = req.entity.name;
+  const result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {
+        name,
+      },
+    },
+  };
+  return result;
+};
+
+intelligence.syncResource = async function(
+  request: SyncResourceRequest,
+  event: Event,
+): Promise<SyncResourceReply> {
+  const helmKubeConfigResult = await helmKubeConfig(request, event);
+  if (helmKubeConfigResult.failure) {
+    return helmKubeConfigResult.failure;
+  }
+  const awsEnv = helmKubeConfigResult.awsEnv;
+  const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+
+  const repo = findEntityByType(request.predecessors, "helmRepo");
+
+  let helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+
+  const helmRepoAddResult = await helmRepoAdd(
+    request,
+    event,
+    kubeconfigPath,
+    awsEnv,
+    repo?.properties.__baseline.name,
+    repo?.properties.__baseline.url,
+    _.clone(helmArgs),
+  );
+  if (helmRepoAddResult.failure) {
+    return helmRepoAddResult.failure;
+  }
+
+  const chart = findEntityByType(request.predecessors, "helmChart");
+  helmArgs.push(
+    "install",
+    request.entity.properties.__baseline.name,
+    chart?.properties.__baseline.name,
+  );
+
+  const helmAuthArgs = helmCommandAuthPrepare(request);
+  helmArgs = helmArgs.concat(helmAuthArgs);
+
+  helmArgs.push("--dry-run");
+
+  if (chart?.properties.__baseline.version) {
+    helmArgs.push("--version", chart.properties.__baseline.version);
+  }
+
+  const options: { flag: string; if: boolean; value?: string }[] = [
+    {
+      flag: "--description",
+      if: !!request.entity.properties.__baseline.description,
+      value: request.entity.properties.__baseline.description,
+    },
+    {
+      flag: "--atomic",
+      if: !!request.entity.properties.__baseline.atomic,
+    },
+    {
+      flag: "--no-hooks",
+      if: !!request.entity.properties.__baseline.noHooks,
+    },
+    {
+      flag: "--render-subchart-notes",
+      if: !!request.entity.properties.__baseline.renderSubchartNotes,
+    },
+    {
+      flag: "--skip-crds",
+      if: !!request.entity.properties.__baseline.skipCrds,
+    },
+    {
+      flag: "--timeout",
+      if: !!request.entity.properties.__baseline.timeout,
+      value: request.entity.properties.__baseline.timeout,
+    },
+  ];
+  for (const option of options) {
+    if (option.if) {
+      helmArgs.push(option.flag);
+      if (option.hasOwnProperty("value")) {
+        helmArgs.push(`${option.value}`);
+      }
+    }
+  }
+
+  const helmRepoInstall = await siExec(event, "helm", helmArgs, {
+    env: awsEnv,
+    reject: false,
+  });
+
+  if (helmRepoInstall.failed) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "helm repo install failed",
+      errorOutput: helmRepoInstall.stderr,
+    };
+
+    return {
+      resource: {
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+    };
+  } else {
+    return {
+      resource: {
+        state: {
+          data: {
+            output: `${helmRepoInstall.all}`,
+          },
+        },
+        health: ResourceHealth.Ok,
+        status: ResourceStatus.Created,
+      },
+    };
+  }
+};
+
+intelligence.actions = {
+  async apply(request: ActionRequest, event: Event): Promise<ActionReply> {
+    const reply = { actions: [] };
+    const helmKubeConfigResult = await helmKubeConfig(request, event);
+    if (helmKubeConfigResult.failure) {
+      return { ...reply, ...helmKubeConfigResult.failure };
+    }
+    const awsEnv = helmKubeConfigResult.awsEnv;
+    const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+
+    const repo = findEntityByType(request.predecessors, "helmRepo");
+
+    const helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+
+    const helmRepoAddResult = await helmRepoAdd(
+      request,
+      event,
+      kubeconfigPath,
+      awsEnv,
+      repo?.properties.__baseline.name,
+      repo?.properties.__baseline.url,
+      _.clone(helmArgs),
+    );
+    if (helmRepoAddResult.failure) {
+      return { ...reply, ...helmRepoAddResult.failure };
+    }
+
+    helmArgs.push(
+      "list",
+      "-f",
+      `^${request.entity.properties.__baseline.name}$`,
+      "-q",
+    );
+
+    const helmList = await siExec(event, "helm", helmArgs, {
+      env: awsEnv,
+      reject: false,
+    });
+
+    if (helmList.failed) {
+      const state = {
+        data: request.resource.state?.data,
+        errorMsg: "helm list failed",
+        errorOutput: helmList.stderr,
+      };
+
+      return {
+        ...reply,
+        resource: {
+          state,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
+        },
+      };
+    }
+    if (helmList.all == request.entity.properties.__baseline.name) {
+      if (intelligence.actions?.upgrade) {
+        return await intelligence.actions.upgrade(request, event);
+      }
+    } else {
+      if (intelligence.actions?.install) {
+        return await intelligence.actions.install(request, event);
+      }
+    }
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "cannot decide what to do with helm!! bug",
+      errorOutput: helmList.stderr,
+    };
+
+    return {
+      ...reply,
+      resource: {
+        state,
+        health: ResourceHealth.Error,
+        status: ResourceStatus.Failed,
+      },
+    };
+  },
+
+  async upgrade(request: ActionRequest, event: Event): Promise<ActionReply> {
+    const reply = { actions: [] };
+    const helmKubeConfigResult = await helmKubeConfig(request, event);
+    if (helmKubeConfigResult.failure) {
+      return { ...reply, ...helmKubeConfigResult.failure };
+    }
+    const awsEnv = helmKubeConfigResult.awsEnv;
+    const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+
+    const repo = findEntityByType(request.predecessors, "helmRepo");
+
+    let helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+
+    const helmRepoAddResult = await helmRepoAdd(
+      request,
+      event,
+      kubeconfigPath,
+      awsEnv,
+      repo?.properties.__baseline.name,
+      repo?.properties.__baseline.url,
+      _.clone(helmArgs),
+    );
+    if (helmRepoAddResult.failure) {
+      return { ...reply, ...helmRepoAddResult.failure };
+    }
+
+    const chart = findEntityByType(request.predecessors, "helmChart");
+    helmArgs.push(
+      "upgrade",
+      request.entity.properties.__baseline.name,
+      chart?.properties.__baseline.name,
+    );
+
+    const helmAuthArgs = helmCommandAuthPrepare(request);
+    helmArgs = helmArgs.concat(helmAuthArgs);
+
+    if (chart?.properties.__baseline.version) {
+      helmArgs.push("--version", chart.properties.__baseline.version);
+    }
+
+    const options: { flag: string; if: boolean; value?: string }[] = [
+      {
+        flag: "--dry-run",
+        if: request.hypothetical,
+      },
+      {
+        flag: "--description",
+        if: !!request.entity.properties.__baseline.description,
+        value: request.entity.properties.__baseline.description,
+      },
+      {
+        flag: "--atomic",
+        if: !!request.entity.properties.__baseline.atomic,
+      },
+      {
+        flag: "--no-hooks",
+        if: !!request.entity.properties.__baseline.noHooks,
+      },
+      {
+        flag: "--render-subchart-notes",
+        if: !!request.entity.properties.__baseline.renderSubchartNotes,
+      },
+      {
+        flag: "--skip-crds",
+        if: !!request.entity.properties.__baseline.skipCrds,
+      },
+      {
+        flag: "--wait",
+        if: !!request.entity.properties.__baseline.wait,
+      },
+      {
+        flag: "--timeout",
+        if: !!request.entity.properties.__baseline.timeout,
+        value: request.entity.properties.__baseline.timeout,
+      },
+    ];
+    for (const option of options) {
+      if (option.if) {
+        helmArgs.push(option.flag);
+        if (option.hasOwnProperty("value")) {
+          helmArgs.push(`${option.value}`);
+        }
+      }
+    }
+
+    const helmRepoInstall = await siExec(event, "helm", helmArgs, {
+      env: awsEnv,
+      reject: false,
+    });
+
+    if (helmRepoInstall.failed) {
+      const state = {
+        data: request.resource.state?.data,
+        errorMsg: "helm repo install failed",
+        errorOutput: helmRepoInstall.stderr,
+      };
+
+      return {
+        ...reply,
+        resource: {
+          state,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
+        },
+      };
+    } else {
+      return {
+        ...reply,
+        resource: {
+          state: {
+            data: {
+              output: `${helmRepoInstall.all}`,
+            },
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+      };
+    }
+  },
+
+  async install(request: ActionRequest, event: Event): Promise<ActionReply> {
+    const reply = { actions: [] };
+    const helmKubeConfigResult = await helmKubeConfig(request, event);
+    if (helmKubeConfigResult.failure) {
+      return { ...reply, ...helmKubeConfigResult.failure };
+    }
+    const awsEnv = helmKubeConfigResult.awsEnv;
+    const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+
+    const repo = findEntityByType(request.predecessors, "helmRepo");
+
+    let helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+
+    const helmRepoAddResult = await helmRepoAdd(
+      request,
+      event,
+      kubeconfigPath,
+      awsEnv,
+      repo?.properties.__baseline.name,
+      repo?.properties.__baseline.url,
+      _.clone(helmArgs),
+    );
+    if (helmRepoAddResult.failure) {
+      return { ...reply, ...helmRepoAddResult.failure };
+    }
+
+    const chart = findEntityByType(request.predecessors, "helmChart");
+    helmArgs.push(
+      "install",
+      request.entity.properties.__baseline.name,
+      chart?.properties.__baseline.name,
+    );
+
+    const helmAuthArgs = helmCommandAuthPrepare(request);
+    helmArgs = helmArgs.concat(helmAuthArgs);
+
+    if (chart?.properties.__baseline.version) {
+      helmArgs.push("--version", chart.properties.__baseline.version);
+    }
+
+    const options: { flag: string; if: boolean; value?: string }[] = [
+      {
+        flag: "--dry-run",
+        if: request.hypothetical,
+      },
+      {
+        flag: "--description",
+        if: !!request.entity.properties.__baseline.description,
+        value: request.entity.properties.__baseline.description,
+      },
+      {
+        flag: "--atomic",
+        if: !!request.entity.properties.__baseline.atomic,
+      },
+      {
+        flag: "--no-hooks",
+        if: !!request.entity.properties.__baseline.noHooks,
+      },
+      {
+        flag: "--render-subchart-notes",
+        if: !!request.entity.properties.__baseline.renderSubchartNotes,
+      },
+      {
+        flag: "--skip-crds",
+        if: !!request.entity.properties.__baseline.skipCrds,
+      },
+      {
+        flag: "--wait",
+        if: !!request.entity.properties.__baseline.wait,
+      },
+      {
+        flag: "--timeout",
+        if: !!request.entity.properties.__baseline.timeout,
+        value: request.entity.properties.__baseline.timeout,
+      },
+    ];
+    for (const option of options) {
+      if (option.if) {
+        helmArgs.push(option.flag);
+        if (option.hasOwnProperty("value")) {
+          helmArgs.push(`${option.value}`);
+        }
+      }
+    }
+
+    const helmRepoInstall = await siExec(event, "helm", helmArgs, {
+      env: awsEnv,
+      reject: false,
+    });
+
+    if (helmRepoInstall.failed) {
+      const state = {
+        data: request.resource.state?.data,
+        errorMsg: "helm repo install failed",
+        errorOutput: helmRepoInstall.stderr,
+      };
+
+      return {
+        ...reply,
+        resource: {
+          state,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
+        },
+      };
+    } else {
+      return {
+        ...reply,
+        resource: {
+          state: {
+            data: {
+              output: `${helmRepoInstall.all}`,
+            },
+          },
+          health: ResourceHealth.Ok,
+          status: ResourceStatus.Created,
+        },
+      };
+    }
+  },
+};

--- a/components/si-registry/src/veritech/components/helmRepo.ts
+++ b/components/si-registry/src/veritech/components/helmRepo.ts
@@ -1,0 +1,75 @@
+import { registry } from "@/registry";
+import { EntityObject } from "@/systemComponent";
+import {
+  ActionRequest,
+  ActionReply,
+  SyncResourceRequest,
+  SyncResourceReply,
+  CalculatePropertiesRequest,
+  CalculatePropertiesResult,
+  findEntityByType,
+  ResourceHealth,
+  ResourceStatus,
+} from "../../veritech/intelligence";
+import { Event } from "../../veritech/eventLog";
+import {
+  kubernetesNamespaceProperties,
+  kubernetesSync,
+  kubernetesApply,
+} from "./kubernetesShared";
+import { awsCredential, awsKubeConfig, AwsCliEnv } from "./awsShared";
+import { siExec } from "../siExec";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { helmKubeConfig, helmRepoAdd } from "./helmShared";
+
+const intelligence = (registry.get("helmRepo") as EntityObject).intelligence;
+
+intelligence.calculateProperties = function(
+  req: CalculatePropertiesRequest,
+): CalculatePropertiesResult {
+  const result: CalculatePropertiesResult = {
+    inferredProperties: {
+      __baseline: {
+        name: `${req.entity.name}`,
+      },
+    },
+  };
+  return result;
+};
+
+intelligence.syncResource = async function(
+  request: SyncResourceRequest,
+  event: Event,
+): Promise<SyncResourceReply> {
+  const helmKubeConfigResult = await helmKubeConfig(request, event);
+  if (helmKubeConfigResult.failure) {
+    return helmKubeConfigResult.failure;
+  }
+  const awsEnv = helmKubeConfigResult.awsEnv;
+  const kubeconfigPath = helmKubeConfigResult.kubeconfigPath;
+  const helmRepoAddResult = await helmRepoAdd(
+    request,
+    event,
+    kubeconfigPath,
+    awsEnv,
+    request.entity.properties.__baseline.name,
+    request.entity.properties.__baseline.url,
+  );
+
+  if (helmRepoAddResult.failure) {
+    return helmRepoAddResult.failure;
+  }
+  return {
+    resource: {
+      state: {
+        data: {
+          added: true,
+        },
+      },
+      health: ResourceHealth.Ok,
+      status: ResourceStatus.Created,
+    },
+  };
+};

--- a/components/si-registry/src/veritech/components/helmShared.ts
+++ b/components/si-registry/src/veritech/components/helmShared.ts
@@ -1,0 +1,159 @@
+import {
+  awsCredential,
+  awsKubeConfig,
+  AwsCliEnv,
+  AwsInputRequest,
+} from "./awsShared";
+import { Event } from "../../veritech/eventLog";
+import {
+  SyncResourceReply,
+  ResourceHealth,
+  ResourceStatus,
+  findEntityByType,
+} from "../intelligence";
+import { siExec, SiExecResult } from "../siExec";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { XOR } from "ts-essentials";
+
+interface HelmFailureResult {
+  failure: SyncResourceReply;
+}
+
+interface HelmKubeConfigResponse {
+  kubeconfigPath: string;
+  awsEnv: AwsCliEnv;
+}
+type HelmKubeConfigResult = XOR<HelmFailureResult, HelmKubeConfigResponse>;
+
+export async function helmKubeConfig(
+  request: AwsInputRequest,
+  event: Event,
+): Promise<HelmKubeConfigResult> {
+  const awsCredResult = awsCredential(request);
+  if (awsCredResult.syncResourceReply) {
+    return { failure: awsCredResult.syncResourceReply };
+  } else if (!awsCredResult.awsCliEnv) {
+    throw new Error("aws cli function didn't return an environment");
+  }
+  const awsEnv: AwsCliEnv = awsCredResult.awsCliEnv;
+  const awsKubeConfigResult = await awsKubeConfig(request, event, awsEnv);
+  if (awsKubeConfigResult.syncResourceReply) {
+    return { failure: awsKubeConfigResult.syncResourceReply };
+  } else if (!awsKubeConfigResult.kubeconfig) {
+    throw new Error("no reply or resource for aws kube config");
+  }
+  const kubeconfigPath = awsKubeConfigResult.kubeconfig;
+  if (!kubeconfigPath) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "No kubernetesCluster attached!",
+    };
+
+    return {
+      failure: {
+        resource: {
+          state,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
+        },
+      },
+    };
+  }
+
+  return { kubeconfigPath, awsEnv };
+}
+
+export async function helmCommandPrepare(
+  request: AwsInputRequest,
+  kubeconfigPath: string,
+): Promise<string[]> {
+  const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "helmconfig-"));
+  const helmConfigPath = path.join(tempdir, "config");
+  const helmCachePath = path.join(tempdir, "cache");
+  const helmRegistryConfigPath = path.join(helmConfigPath, "registry.json");
+  const helmRepositoryCachePath = path.join(helmCachePath, "repository");
+  const helmRepositoryConfigPath = path.join(
+    helmConfigPath,
+    "repositories.yaml",
+  );
+
+  const helmArgs = [
+    "--kubeconfig",
+    kubeconfigPath,
+    "--registry-config",
+    helmRegistryConfigPath,
+    "--repository-config",
+    helmRepositoryConfigPath,
+    "--repository-cache",
+    helmRepositoryCachePath,
+  ];
+
+  return helmArgs;
+}
+
+export function helmCommandAuthPrepare(request: AwsInputRequest): string[] {
+  const helmArgs = [];
+  const helmRepoCredential = findEntityByType(
+    request.predecessors,
+    "helmRepoCredential",
+  );
+  if (helmRepoCredential) {
+    helmArgs.push("--username");
+    helmArgs.push(helmRepoCredential.properties.__baseline.decrypted.username);
+    helmArgs.push("--password");
+    helmArgs.push(helmRepoCredential.properties.__baseline.decrypted.password);
+  }
+
+  if (request.entity.properties.__baseline.insecureSkipTlsVerify) {
+    helmArgs.push("--insecure-skip-tls-verify");
+  }
+  return helmArgs;
+}
+
+interface HelmRepoAddResponse {
+  helmRepoAdd: SiExecResult;
+}
+
+type HelmRepoAddResult = XOR<HelmFailureResult, HelmRepoAddResponse>;
+
+export async function helmRepoAdd(
+  request: AwsInputRequest,
+  event: Event,
+  kubeconfigPath: string,
+  awsEnv: AwsCliEnv,
+  name: string,
+  url: string,
+  helmArgs?: string[],
+): Promise<HelmRepoAddResult> {
+  if (!helmArgs) {
+    helmArgs = await helmCommandPrepare(request, kubeconfigPath);
+  }
+
+  helmArgs.push("repo", "add", name, url);
+
+  const helmRepoAdd = await siExec(event, "helm", helmArgs, {
+    env: awsEnv,
+    reject: false,
+  });
+
+  if (helmRepoAdd.failed) {
+    const state = {
+      data: request.resource.state?.data,
+      errorMsg: "helm repo add failed",
+      errorOutput: helmRepoAdd.stderr,
+    };
+
+    return {
+      failure: {
+        resource: {
+          state,
+          health: ResourceHealth.Error,
+          status: ResourceStatus.Failed,
+        },
+      },
+    };
+  }
+  return { helmRepoAdd };
+}

--- a/components/si-registry/src/veritech/intelligence.ts
+++ b/components/si-registry/src/veritech/intelligence.ts
@@ -360,3 +360,15 @@ export function syncResource(ws: WebSocket, req: string): void {
       ws.close(1000, "finished");
     });
 }
+
+export function findEntityByType(
+  graph: { entity: Entity }[],
+  objectType: string,
+): Entity | undefined {
+  const result = _.find(graph, ["entity.objectType", objectType]);
+  if (result) {
+    return result.entity;
+  } else {
+    return undefined;
+  }
+}

--- a/components/si-registry/src/veritech/server.ts
+++ b/components/si-registry/src/veritech/server.ts
@@ -13,6 +13,9 @@ import "@/veritech/components/kubernetesNamespace";
 import "@/veritech/components/kubernetesSecret";
 import "@/veritech/components/kubernetesService";
 import "@/veritech/components/service";
+import "@/veritech/components/helmRepo";
+import "@/veritech/components/helmChart";
+import "@/veritech/components/helmRelease";
 
 import { registry } from "@/registry";
 

--- a/components/si-registry/src/veritech/siExec.ts
+++ b/components/si-registry/src/veritech/siExec.ts
@@ -2,12 +2,14 @@ import execa from "execa";
 import readline from "readline";
 import { Event, EventLogLevel } from "./eventLog";
 
+export type SiExecResult = execa.ExecaReturnValue<string>;
+
 export async function siExec(
   event: Event,
   execaFile: string,
   execaArgs?: readonly string[],
   execaOptions?: execa.Options<string>,
-): Promise<execa.ExecaReturnValue<string>> {
+): Promise<SiExecResult> {
   console.log(`running command; cmd="${execaFile} ${execaArgs?.join(" ")}"`);
   const eventLog = event.log(
     EventLogLevel.Info,

--- a/components/si-sdf/src/models/secret.rs
+++ b/components/si-sdf/src/models/secret.rs
@@ -94,6 +94,7 @@ enum_impls!(SecretObjectType);
 pub enum SecretKind {
     DockerHub,
     AwsAccessKey,
+    HelmRepo,
 }
 
 enum_impls!(SecretKind);

--- a/components/si-web-app/src/api/sdf/model/secret.ts
+++ b/components/si-web-app/src/api/sdf/model/secret.ts
@@ -14,6 +14,7 @@ export enum SecretObjectType {
 export enum SecretKind {
   DockerHub = "dockerHub",
   AwsAccessKey = "awsAccessKey",
+  HelmRepo = "helmRepo",
 }
 
 export enum SecretVersion {

--- a/components/si-web-app/src/components/views/secret/HelmRepoCredential.vue
+++ b/components/si-web-app/src/components/views/secret/HelmRepoCredential.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <div class="flex flex-row mx-2 my-2">
+      <div class="text-white">helmRepo username:</div>
+
+      <input
+        data-cy="new-secret-form-secret-name"
+        class="ml-4 leading-tight text-gray-400 bg-transparent border-none appearance-none focus:outline-none input-bg-color"
+        type="text"
+        placeholder="helm repo username"
+        v-model="username"
+        @input="updateInput"
+      />
+    </div>
+    <div class="flex flex-row mx-2 my-2">
+      <div class="text-white">helmRepo password:</div>
+
+      <input
+        data-cy="new-secret-form-secret-name"
+        class="ml-4 leading-tight text-gray-400 bg-transparent border-none appearance-none focus:outline-none input-bg-color"
+        type="password"
+        placeholder="helm repo password"
+        v-model="password"
+        @input="updateInput"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+interface Data {
+  username: string;
+  password: string;
+}
+
+export default Vue.extend({
+  name: "HelmRepoCredential",
+  data(): Data {
+    return {
+      username: "",
+      password: "",
+    };
+  },
+  methods: {
+    updateInput() {
+      this.$emit("input", {
+        username: this.username,
+        password: this.password,
+      });
+    },
+  },
+});
+</script>
+
+<style scoped>
+.input-bg-color {
+  background-color: #25788a;
+}
+</style>
+

--- a/components/si-web-app/src/components/views/secret/SecretNew.vue
+++ b/components/si-web-app/src/components/views/secret/SecretNew.vue
@@ -3,9 +3,7 @@
     <div
       class="flex items-center justify-between pl-1 text-sm text-white bg-black"
     >
-      <div>
-        Create new secret
-      </div>
+      <div>Create new secret</div>
       <div>
         <button @click="hideModal" class="flex">
           <XIcon @click="hideModal"></XIcon>
@@ -15,9 +13,7 @@
 
     <div class="p-4">
       <div class="flex flex-row mx-2 my-2">
-        <div class="text-white">
-          name:
-        </div>
+        <div class="text-white">name:</div>
 
         <input
           data-cy="new-secret-form-secret-name"
@@ -28,9 +24,7 @@
         />
       </div>
       <div class="flex flex-row mx-2 my-2">
-        <div class="text-white">
-          kind:
-        </div>
+        <div class="text-white">kind:</div>
 
         <SiSelect
           size="xs"
@@ -45,6 +39,10 @@
       <AwsAccessKeyCredential
         v-model="message"
         v-else-if="secretKind == 'awsAccessKey'"
+      />
+      <HelmRepoCredential
+        v-model="message"
+        v-else-if="secretKind == 'helmRepo'"
       />
 
       <div class="flex flex-row" v-if="secretKind">
@@ -67,6 +65,7 @@ import { XIcon } from "vue-feather-icons";
 import SiSelect, { SelectProps } from "@/components/ui/SiSelect.vue";
 import DockerHubCredential from "@/components/views/secret/DockerHubCredential.vue";
 import AwsAccessKeyCredential from "@/components/views/secret/AwsAccessKeyCredential.vue";
+import HelmRepoCredential from "@/components/views/secret/HelmRepoCredential.vue";
 import { SecretKind } from "@/api/sdf/model/secret";
 
 interface Data {
@@ -83,6 +82,7 @@ export default Vue.extend({
     XIcon,
     DockerHubCredential,
     AwsAccessKeyCredential,
+    HelmRepoCredential,
   },
   data(): Data {
     let secretKindList = [{ value: "", label: "none" }];


### PR DESCRIPTION
This adds helm support. It allows the creation of a Helm Repo, which can
take an optional Helm Credential. This can then be used to configure a
Helm Chart, which can configure multiple Helm Releases with different
configurations.

This resolves [ch1035], [ch963], [ch938]. Happy helming!

![](https://media2.giphy.com/media/RfMzXQLEZLsRogX1Zb/200w.gif?cid=5a38a5a2gre2gbf61exmqfdfiljl9bqqbxzrfx8kgn6u54qi&rid=200w.gif)
