### PR TITLE
refactor(sdf): refactor Resource.sync to chunk it up

### DIFF
--- a/components/si-sdf/src/models/node.rs
+++ b/components/si-sdf/src/models/node.rs
@@ -355,7 +355,7 @@ impl Node {
                 .map_err(|e| ResourceError::Entity(e.to_string()))?
         };
         resource
-            .sync(pg.clone(), txn, nats_conn.clone(), veritech)
+            .sync(pg.clone(), txn, nats_conn.clone(), veritech.clone())
             .await?;
         Ok(())
     }


### PR DESCRIPTION
Namely, extracting the spawned task code to its own proper function
which surfaced several useless clones and variables that were intended
to be used, but weren't, etc.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>