### PR TITLE
chore(sdf): add Vimspector debugging configuration

### DIFF
--- a/components/si-sdf/.vimspector.json
+++ b/components/si-sdf/.vimspector.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
+  "configurations": {
+    "Launch si-sdf-server": {
+      "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "launch",
+        "program": "${workspaceRoot}/../../target/debug/si-sdf-server",
+        "sourceLanguages": ["rust"]
+      }
+    },
+    "Attach to running si-sdf-server": {
+      "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "attach",
+        "program": "${workspaceRoot}/../../target/debug/si-sdf-server",
+        "sourceLanguages": ["rust"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
If you're a Vim/nvim user, in short you can add something like the
following to your `.vimrc`:

```vim
call plug#begin()
  " Use `vimspector` if Vim version supports and if it is compiled with Python 3
  if v:version >= 802 && has('python3')
    Plug 'puremourning/vimspector'
  endif
call plug#end()

let g:vimspector_enable_mappings='HUMAN'
```

Then, open a source file for sdf, hit `F9` to toggle a breakpoint, and
hit `F5` to start the debugger. Choose `Launch si-sdf-server` to have
the debugger spawn the server process (note, for the moment it must
already be compiled), or choose `Attach to running si-sdf-server` to
connect to an already running instance (note, the binary must have been
built in debug, that is, not release mode).

Note that to attach to a process the `CAP_SYS_PTRACE` privilege must not
be disabled. If on Arch Linux you can do the following to disable the
attach protection, which will last until your next reboot:

```sh
echo': sudo sh -c "echo 0 >/proc/sys/kernel/yama/ptrace_scope"
```

Reference: https://github.com/puremourning/vimspector

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>