### PR TITLE
bug: remove 401 error on node creation

### DIFF
--- a/components/si-sdf/src/handlers/nodes.rs
+++ b/components/si-sdf/src/handlers/nodes.rs
@@ -308,12 +308,13 @@ pub async fn get(
     let txn = conn.transaction().await.map_err(HandlerError::from)?;
 
     let claim = authenticate(&txn, &token).await?;
-    validate_tenancy(&txn, "nodes", &node_id, &claim.billing_account_id).await?;
     authorize(&txn, &claim.user_id, &"nodes", "get").await?;
 
     let object = Node::get(&txn, &node_id)
         .await
-        .map_err(HandlerError::from)?;
+        .map_err(|_| HandlerError::NotFound)?;
+
+    validate_tenancy(&txn, "nodes", &node_id, &claim.billing_account_id).await?;
 
     let item = serde_json::to_value(object).map_err(HandlerError::from)?;
 

--- a/components/si-web-app/src/api/sdf/model/node.ts
+++ b/components/si-web-app/src/api/sdf/model/node.ts
@@ -163,6 +163,17 @@ export class Node implements INode {
     return fetched;
   }
 
+  static async get_cache(
+    request: IGetRequest<INode["id"]>,
+  ): Promise<Node | undefined> {
+    const obj = await db.nodes.get(request.id);
+    if (obj) {
+      return new Node(obj);
+    } else {
+      return undefined;
+    }
+  }
+
   static async find(index: "id", value: string): Promise<Node[]> {
     let items = await db.nodes
       .where(index)

--- a/components/si-web-app/src/store/modules/application.ts
+++ b/components/si-web-app/src/store/modules/application.ts
@@ -179,9 +179,10 @@ export const application: Module<ApplicationStore, RootStore> = {
     },
     async fromResource({ state, commit }, payload: Resource) {
       let node;
-      try {
-        node = await Node.get({ id: payload.nodeId });
-      } catch (e) {
+      // We use get_cache here, because the resource gets committed
+      // before the node is created.
+      node = await Node.get_cache({ id: payload.nodeId });
+      if (!node) {
         return;
       }
       const predecessors = await node.predecessors();


### PR DESCRIPTION
We were seeing a 401 Unauthorized error on node creation. This was from
the associated Resource object being created (and pushed down the
websocket) before the Node itself was committed. That resulted in the
Update code dispatching the saved Resource to the application store,
which then tries to update the list of resources on the application
list. When it can't find the node, it caught the exception, but chrome
automatically logs the 401.

This commit refactors the node get handler to return a 404 if the
resource doesn't exist, moving the tenancy check to *after* the fetch.
This way we know we're getting the right error, at least.

It also updates the code in the application store to use a new
`get_cache` method. This doesn't do the fallback get, and instead only
returns if it has been cached. The side effects should be minimal, since
the next time we see the resource the node will have been cached. The
result is there is no more error in the console, and if there is, we
will get the right error code back regardless.

![](https://media2.giphy.com/media/kDBhX1Il2PZL66ljiL/giphy.gif?cid=5a38a5a26wtqdu1narp223rxf3rurcqtxp6nizirmopdc4r5&rid=giphy.gif)
