### PR TITLE
chore: Schematic panel can create, select nodes, and list

### DIFF
--- a/components/si-sdf/src/handlers.rs
+++ b/components/si-sdf/src/handlers.rs
@@ -10,8 +10,8 @@ use crate::data::{NatsTxnError, PgTxn};
 use crate::models::{
     ApiClientError, BillingAccountError, ChangeSetError, EdgeError, EditSessionError, EntityError,
     EventError, EventLogError, JwtKeyError, KeyPairError, ModelError, NodeError, OpError,
-    OrganizationError, PageTokenError, QueryError, SecretError, SystemError, UserError,
-    WorkspaceError,
+    OrganizationError, PageTokenError, QueryError, SchematicError, SecretError, SystemError,
+    UserError, WorkspaceError,
 };
 
 const AUTHORIZE_USER: &str = include_str!("./data/queries/authorize_user.sql");
@@ -36,6 +36,8 @@ pub mod workspaces;
 
 pub mod application_context_dal;
 pub mod application_dal;
+pub mod editor_dal;
+pub mod schematic_dal;
 pub mod session_dal;
 pub mod signup_dal;
 
@@ -103,6 +105,8 @@ pub enum HandlerError {
     Workspace(#[from] WorkspaceError),
     #[error("system error: {0}")]
     System(#[from] SystemError),
+    #[error("schematic error: {0}")]
+    Schematic(#[from] SchematicError),
 }
 
 pub type HandlerResult<T> = Result<T, HandlerError>;

--- a/components/si-sdf/src/handlers/editor_dal.rs
+++ b/components/si-sdf/src/handlers/editor_dal.rs
@@ -1,0 +1,151 @@
+use crate::{
+    data::{NatsConn, PgPool},
+    handlers::{authenticate, authorize, validate_tenancy, HandlerError},
+    models::{Entity, Node, NodeKind, System},
+    veritech::Veritech,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeCreateForApplicationRequest {
+    pub name: Option<String>,
+    pub kind: NodeKind,
+    pub object_type: String,
+    pub workspace_id: String,
+    pub change_set_id: String,
+    pub edit_session_id: String,
+    pub system_id: String,
+    pub application_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeObject {
+    pub entity: Option<Entity>,
+    pub system: Option<System>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeCreateReply {
+    pub node: Node,
+    pub object: NodeObject,
+}
+
+pub async fn node_create_for_application(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+    token: String,
+    request: NodeCreateForApplicationRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let mut conn = pg.pool.get().await.map_err(HandlerError::from)?;
+    let txn = conn.transaction().await.map_err(HandlerError::from)?;
+    let nats = nats_conn.transaction();
+
+    let claim = authenticate(&txn, &token).await?;
+    authorize(&txn, &claim.user_id, "editorDal", "nodeCreate").await?;
+    validate_tenancy(
+        &txn,
+        "workspaces",
+        &request.workspace_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "change_sets",
+        &request.change_set_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "edit_sessions",
+        &request.edit_session_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "systems",
+        &request.system_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.application_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+
+    let (node, object) = if request.kind == NodeKind::Entity {
+        let node = Node::new(
+            &pg,
+            &txn,
+            &nats_conn,
+            &nats,
+            &veritech,
+            request.name,
+            request.kind,
+            request.object_type,
+            request.workspace_id,
+            request.change_set_id.clone(),
+            request.edit_session_id,
+            Some(vec![request.system_id.clone()]),
+        )
+        .await
+        .map_err(HandlerError::from)?;
+        let entity = node
+            .get_projection_object_entity(&txn, &request.change_set_id)
+            .await
+            .map_err(HandlerError::from)?;
+        let object = NodeObject {
+            entity: Some(entity),
+            system: None,
+        };
+        (node, object)
+    } else {
+        let node = Node::new(
+            &pg,
+            &txn,
+            &nats_conn,
+            &nats,
+            &veritech,
+            request.name,
+            request.kind,
+            request.object_type,
+            request.workspace_id,
+            request.change_set_id.clone(),
+            request.edit_session_id,
+            None,
+        )
+        .await
+        .map_err(HandlerError::from)?;
+        let system = node
+            .get_projection_object_system(&txn, &request.change_set_id)
+            .await
+            .map_err(HandlerError::from)?;
+        let object = NodeObject {
+            entity: None,
+            system: Some(system),
+        };
+        (node, object)
+    };
+
+    let application_entity = Entity::get_head(&txn, &request.application_id)
+        .await
+        .map_err(HandlerError::from)?;
+    node.configured_by(&txn, &nats, &application_entity.node_id)
+        .await
+        .map_err(HandlerError::from)?;
+
+    txn.commit().await.map_err(HandlerError::from)?;
+    nats.commit().await.map_err(HandlerError::from)?;
+
+    let reply = NodeCreateReply { node, object };
+    Ok(warp::reply::json(&reply))
+}

--- a/components/si-sdf/src/handlers/schematic_dal.rs
+++ b/components/si-sdf/src/handlers/schematic_dal.rs
@@ -1,0 +1,77 @@
+use crate::{
+    data::{NatsConn, PgPool},
+    handlers::{authenticate, authorize, validate_tenancy, HandlerError},
+    models::{EdgeKind, Schematic},
+    veritech::Veritech,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetApplicationSystemSchematicRequest {
+    pub workspace_id: String,
+    pub root_object_id: String,
+    pub change_set_id: Option<String>,
+    pub system_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetApplicationSystemSchematicReply {
+    schematic: Schematic,
+}
+
+pub async fn get_application_system_schematic(
+    pg: PgPool,
+    token: String,
+    request: GetApplicationSystemSchematicRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let mut conn = pg.pool.get().await.map_err(HandlerError::from)?;
+    let txn = conn.transaction().await.map_err(HandlerError::from)?;
+
+    let claim = authenticate(&txn, &token).await?;
+    authorize(
+        &txn,
+        &claim.user_id,
+        "schematicDal",
+        "getApplicationSystemSchematic",
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "workspaces",
+        &request.workspace_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "systems",
+        &request.system_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.root_object_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+
+    let schematic = Schematic::get(
+        &txn,
+        &request.root_object_id,
+        &request.workspace_id,
+        &request.system_id,
+        request.change_set_id,
+        vec![EdgeKind::Configures],
+    )
+    .await
+    .map_err(HandlerError::from)?;
+
+    txn.commit().await.map_err(HandlerError::from)?;
+
+    let reply = GetApplicationSystemSchematicReply { schematic };
+    Ok(warp::reply::json(&reply))
+}

--- a/components/si-sdf/src/models.rs
+++ b/components/si-sdf/src/models.rs
@@ -71,6 +71,8 @@ pub use ops::{
 };
 pub mod update;
 pub use update::{websocket_run, WebsocketToken};
+pub mod schematic;
+pub use schematic::{Schematic, SchematicError};
 
 use crate::data::pg::PgTxn;
 use crate::PAGE_SECRET_KEY;

--- a/components/si-sdf/src/models/edge.rs
+++ b/components/si-sdf/src/models/edge.rs
@@ -99,7 +99,7 @@ impl Vertex {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum EdgeKind {
     Configures,
@@ -116,7 +116,7 @@ impl std::fmt::Display for EdgeKind {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Edge {
     pub id: String,

--- a/components/si-sdf/src/models/entity.rs
+++ b/components/si-sdf/src/models/entity.rs
@@ -442,6 +442,33 @@ impl Entity {
         Ok(object)
     }
 
+    pub async fn get_relevant_projection_or_head(
+        txn: &PgTxn<'_>,
+        entity_id: impl AsRef<str>,
+        change_set_id: Option<String>,
+    ) -> EntityResult<Option<Entity>> {
+        let entity_check = if let Some(change_set_id) = change_set_id {
+            match Entity::get_projection_or_head(&txn, &entity_id, &change_set_id).await {
+                Ok(e) => Some(e),
+                Err(err) => {
+                    dbg!("projecton_or_head");
+                    dbg!(err);
+                    None
+                }
+            }
+        } else {
+            match Entity::get_head(&txn, &entity_id).await {
+                Ok(e) => Some(e),
+                Err(err) => {
+                    dbg!("get_head");
+                    dbg!(err);
+                    None
+                }
+            }
+        };
+        Ok(entity_check)
+    }
+
     pub async fn get_projection(
         txn: &PgTxn<'_>,
         id: impl AsRef<str>,

--- a/components/si-sdf/src/models/schematic.rs
+++ b/components/si-sdf/src/models/schematic.rs
@@ -1,0 +1,232 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use thiserror::Error;
+
+use crate::{
+    data::{DataError, PgTxn},
+    models::{Edge, EdgeError, EdgeKind, Entity, EntityError, ModelError, Node, NodeError},
+};
+
+#[derive(Error, Debug)]
+pub enum SchematicError {
+    #[error("error in core model functions: {0}")]
+    Model(#[from] ModelError),
+    #[error("data layer error: {0}")]
+    Data(#[from] DataError),
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+    #[error("serde error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("entity error: {0}")]
+    Entity(#[from] EntityError),
+    #[error("edge error: {0}")]
+    Edge(#[from] EdgeError),
+    #[error("node error: {0}")]
+    Node(#[from] NodeError),
+}
+
+pub type SchematicResult<T> = Result<T, SchematicError>;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+enum SchematicKind {
+    System,
+    Deployment,
+    Implementation,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConnectionEdge {
+    edge_id: String,
+    node_id: String,
+    socket_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Connections {
+    predecessors: HashMap<String, Vec<ConnectionEdge>>,
+    successors: HashMap<String, Vec<ConnectionEdge>>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+enum SocketKind {
+    Input,
+    Output,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+enum SocketType {
+    Object,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Socket {
+    id: String,
+    socket_kind: SocketKind,
+    socket_type: SocketType,
+    object_type: Option<String>,
+}
+
+// Translating from schematic node sockets from the typescript model
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SchematicNodeSockets {
+    inputs: Vec<Socket>,
+    outputs: Vec<Socket>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SchematicNode {
+    node: Node,
+    sockets: SchematicNodeSockets,
+    object: serde_json::Value,
+    connections: Connections,
+}
+
+impl SchematicNode {
+    fn new(node: Node, object: serde_json::Value) -> SchematicNode {
+        let sockets = SchematicNodeSockets {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        };
+        let connections = Connections {
+            predecessors: HashMap::new(),
+            successors: HashMap::new(),
+        };
+        SchematicNode {
+            node,
+            object,
+            sockets,
+            connections,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Schematic {
+    // nodeId -> schematicNode
+    nodes: HashMap<String, SchematicNode>,
+    // edgeKind -> Edges
+    edges: HashMap<String, Edge>,
+}
+
+impl Schematic {
+    pub async fn get(
+        txn: &PgTxn<'_>,
+        root_object_id: impl AsRef<str>,
+        workspace_id: impl AsRef<str>,
+        system_id: impl AsRef<str>,
+        change_set_id: Option<String>,
+        edge_kinds: Vec<EdgeKind>,
+    ) -> SchematicResult<Schematic> {
+        // Get the root object
+        // Get its descendent edges
+        // Populate the data
+        // Profit!
+        let root_object_id = root_object_id.as_ref();
+        let workspace_id = workspace_id.as_ref();
+        let root_entity = if let Some(change_set_id) = change_set_id.as_ref() {
+            Entity::get_projection_or_head(&txn, &root_object_id, change_set_id).await?
+        } else {
+            Entity::get_head(&txn, &root_object_id).await?
+        };
+        let root_node = Node::get(&txn, &root_entity.node_id).await?;
+
+        let mut edges: HashMap<String, Edge> = HashMap::new();
+        let mut nodes: HashMap<String, SchematicNode> = HashMap::new();
+
+        // An edge is included only if the object it points to has a head or a projection for this
+        // changeset - otherwise, it doesn't exist in the schematic!
+        for edge_kind in edge_kinds.iter() {
+            let successor_edges =
+                Edge::all_successor_edges_by_node_id(&txn, edge_kind, &root_node.id).await?;
+            for successor_edge in successor_edges.into_iter() {
+                if successor_edge.si_storable.workspace_id != workspace_id {
+                    continue;
+                }
+                let successor_entity_id = &successor_edge.head_vertex.object_id;
+                let relevant_successor_object = Entity::get_relevant_projection_or_head(
+                    &txn,
+                    successor_entity_id,
+                    change_set_id.clone(),
+                )
+                .await?;
+                if let Some(successor_entity) = relevant_successor_object {
+                    edges.insert(successor_edge.id.clone(), successor_edge.clone());
+                    let successor_node = Node::get(&txn, &successor_entity.node_id).await?;
+                    let schematic_node =
+                        if let Some(schematic_node) = nodes.get_mut(&successor_node.id) {
+                            schematic_node
+                        } else {
+                            let successor_node_id = successor_node.id.clone();
+                            let sn = SchematicNode::new(
+                                successor_node.clone(),
+                                serde_json::json![successor_entity],
+                            );
+                            nodes.insert(successor_node_id.clone(), sn);
+                            // You just inserted it.. so it's cool.
+                            nodes.get_mut(&successor_node_id).unwrap()
+                        };
+
+                    // Add a predecessors entry for the edge that we're on
+                    schematic_node
+                        .connections
+                        .predecessors
+                        .entry(successor_edge.kind.to_string())
+                        .and_modify(|p| {
+                            let connection_edge = ConnectionEdge {
+                                edge_id: successor_edge.id.clone(),
+                                node_id: successor_edge.tail_vertex.node_id.clone(),
+                                socket_id: successor_edge.tail_vertex.socket.clone(),
+                            };
+                            p.push(connection_edge);
+                        })
+                        .or_insert_with(|| {
+                            let connection_edge = ConnectionEdge {
+                                edge_id: successor_edge.id.clone(),
+                                node_id: successor_edge.tail_vertex.node_id.clone(),
+                                socket_id: successor_edge.tail_vertex.socket.clone(),
+                            };
+                            let p = vec![connection_edge];
+                            p
+                        });
+                    if successor_edge.head_vertex.node_id != successor_node.id {
+                        nodes
+                            .entry(successor_edge.head_vertex.node_id.clone())
+                            .and_modify(|ns| {
+                                ns.connections
+                                    .successors
+                                    .entry(successor_edge.kind.to_string())
+                                    .and_modify(|s| {
+                                        let connection_edge = ConnectionEdge {
+                                            edge_id: successor_edge.id.clone(),
+                                            node_id: successor_edge.head_vertex.node_id.clone(),
+                                            socket_id: successor_edge.head_vertex.socket.clone(),
+                                        };
+                                        s.push(connection_edge);
+                                    })
+                                    .or_insert_with(|| {
+                                        let connection_edge = ConnectionEdge {
+                                            edge_id: successor_edge.id.clone(),
+                                            node_id: successor_edge.head_vertex.node_id.clone(),
+                                            socket_id: successor_edge.head_vertex.socket.clone(),
+                                        };
+                                        let s = vec![connection_edge];
+                                        s
+                                    });
+                            });
+                    }
+                }
+            }
+        }
+        let schematic = Schematic { nodes, edges };
+        Ok(schematic)
+    }
+}

--- a/components/si-web-app/package-lock.json
+++ b/components/si-web-app/package-lock.json
@@ -34093,6 +34093,14 @@
       "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-3.5.0.tgz",
       "integrity": "sha512-yWNhG3B6g6lvYqNInP0WaDWNZG/SNb6XnltkjR0wYC5pmLm6jvdiotj8er7Mui8qkJGfLZe6ULjrZdHWjegAUg=="
     },
+    "vue-content-loader": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vue-content-loader/-/vue-content-loader-0.2.3.tgz",
+      "integrity": "sha512-gJlNEdXkuHGvgnyY0lBMsrSsOMk+TTog5uNAil5MSLv08f/mE7Apag0VavpxJ6ieb4P5J1iVKEIhHI41HQNq9Q==",
+      "requires": {
+        "babel-helper-vue-jsx-merge-props": "^2.0.3"
+      }
+    },
     "vue-eslint-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",

--- a/components/si-web-app/package.json
+++ b/components/si-web-app/package.json
@@ -40,6 +40,7 @@
     "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
     "vue": "^2.6.11",
     "vue-chartjs": "^3.5.0",
+    "vue-content-loader": "^0.2.3",
     "vue-feather-icons": "^5.0.0",
     "vue-gtag": "^1.1.1",
     "vue-js-modal": "^2.0.0-rc.3",

--- a/components/si-web-app/src/api/partyBus/NodeCreatedEvent.ts
+++ b/components/si-web-app/src/api/partyBus/NodeCreatedEvent.ts
@@ -1,0 +1,25 @@
+import { PartyBusEvent } from "@/api/partyBus/partyBusEvent";
+import { INodeObject } from "@/api/sdf/dal/editorDal";
+import { Node } from "@/api/sdf/model/node";
+
+const NAME = "NodeCreated";
+
+interface IConstructor {
+  node: Node;
+  object: INodeObject;
+}
+
+export class NodeCreatedEvent extends PartyBusEvent {
+  node: Node | null;
+  object: INodeObject | null;
+
+  constructor(payload: IConstructor) {
+    super(NAME);
+    this.node = payload.node;
+    this.object = payload.object;
+  }
+
+  static eventName(): string {
+    return NAME;
+  }
+}

--- a/components/si-web-app/src/api/partyBus/SchematicNodeSelectedEvent.ts
+++ b/components/si-web-app/src/api/partyBus/SchematicNodeSelectedEvent.ts
@@ -1,0 +1,21 @@
+import { PartyBusEvent } from "@/api/partyBus/partyBusEvent";
+import { ISchematicNode } from "@/api/sdf/model/schematic";
+
+const NAME = "SchematicNodeSelected";
+
+interface IConstructor {
+  schematicNode: ISchematicNode;
+}
+
+export class SchematicNodeSelectedEvent extends PartyBusEvent {
+  schematicNode: ISchematicNode;
+
+  constructor(payload: IConstructor) {
+    super(NAME);
+    this.schematicNode = payload.schematicNode;
+  }
+
+  static eventName(): string {
+    return NAME;
+  }
+}

--- a/components/si-web-app/src/api/partyBus/editSessionCurrentSetEvent.ts
+++ b/components/si-web-app/src/api/partyBus/editSessionCurrentSetEvent.ts
@@ -1,0 +1,17 @@
+import { PartyBusEvent } from "@/api/partyBus/partyBusEvent";
+import { EditSession } from "@/api/sdf/model/editSession";
+
+const NAME = "EditSessionCurrentSet";
+
+export class EditSessionCurrentSetEvent extends PartyBusEvent {
+  editSession: EditSession | null;
+
+  constructor(editSession: EditSession | null) {
+    super(NAME);
+    this.editSession = editSession;
+  }
+
+  static eventName(): string {
+    return NAME;
+  }
+}

--- a/components/si-web-app/src/api/sdf/dal/editorDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/editorDal.ts
@@ -1,0 +1,70 @@
+import { NodeKind, Node } from "@/api/sdf/model/node";
+import { Entity } from "@/api/sdf/model/entity";
+import { SDFError } from "@/api/sdf";
+import { System } from "@/api/sdf/model/system";
+import Bottle from "bottlejs";
+import { NodeCreatedEvent } from "@/api/partyBus/NodeCreatedEvent";
+
+export interface INodeCreateForApplicationRequest extends INodeCreateRequest {
+  applicationId: string;
+}
+
+export interface INodeCreateRequest {
+  name?: string;
+  kind: NodeKind;
+  objectType: string;
+  workspaceId: string;
+  changeSetId: string;
+  editSessionId: string;
+  systemId: string;
+}
+
+export interface INodeObjectEntity {
+  entity: Entity;
+  system?: never;
+}
+
+export interface INodeObjectSystem {
+  entity?: never;
+  system: System;
+}
+
+export type INodeObject = INodeObjectEntity | INodeObjectSystem;
+
+export interface INodeCreateReplySuccess {
+  node: Node;
+  object: INodeObject;
+  error?: never;
+}
+
+export interface INodeCreateReplyFailure {
+  node?: never;
+  object?: never;
+  error: SDFError;
+}
+
+export type INodeCreateReply =
+  | INodeCreateReplySuccess
+  | INodeCreateReplyFailure;
+
+async function nodeCreateForApplication(
+  request: INodeCreateForApplicationRequest,
+): Promise<INodeCreateReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: INodeCreateReply = await sdf.post(
+    "editorDal/nodeCreateForApplication",
+    request,
+  );
+
+  if (!reply.error) {
+    new NodeCreatedEvent(reply).publish();
+  }
+
+  return reply;
+}
+
+export const EditorDal = {
+  nodeCreateForApplication,
+};

--- a/components/si-web-app/src/api/sdf/dal/schematicDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/schematicDal.ts
@@ -1,0 +1,45 @@
+import { SDFError } from "@/api/sdf";
+import Bottle from "bottlejs";
+import { Schematic } from "@/api/sdf/model/schematic";
+
+export interface IGetSchematicRequest {
+  workspaceId: string;
+  rootObjectId: string;
+  changeSetId?: string;
+}
+
+export interface IGetSchematicReplySuccess {
+  schematic: Schematic;
+  error?: never;
+}
+
+export interface IGetSchematicReplyFailure {
+  schematic?: never;
+  error: SDFError;
+}
+
+export type IGetSchematicReply =
+  | IGetSchematicReplySuccess
+  | IGetSchematicReplyFailure;
+
+export interface IGetApplicationSystemSchematicRequest
+  extends IGetSchematicRequest {
+  systemId: string;
+}
+
+export async function getApplicationSystemSchematic(
+  request: IGetApplicationSystemSchematicRequest,
+): Promise<IGetSchematicReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IGetSchematicReply = await sdf.get(
+    "schematicDal/getApplicationSystemSchematic",
+    request,
+  );
+  return reply;
+}
+
+export const SchematicDal = {
+  getApplicationSystemSchematic,
+};

--- a/components/si-web-app/src/api/sdf/model/edge.ts
+++ b/components/si-web-app/src/api/sdf/model/edge.ts
@@ -1,0 +1,42 @@
+import _ from "lodash";
+
+import { ISiStorable } from "@/api/sdf/model/siStorable";
+
+export interface IVertex {
+  nodeId: string;
+  objectId: string;
+  socket: string;
+  typeName: string;
+}
+
+export enum EdgeKind {
+  Configures = "configures",
+  Includes = "includes",
+}
+
+export interface IEdge {
+  id: string;
+  tailVertex: IVertex;
+  headVertex: IVertex;
+  bidirectional: boolean;
+  kind: EdgeKind;
+  siStorable: ISiStorable;
+}
+
+export class Edge implements IEdge {
+  id: IEdge["id"];
+  tailVertex: IEdge["tailVertex"];
+  headVertex: IEdge["headVertex"];
+  bidirectional: IEdge["bidirectional"];
+  kind: IEdge["kind"];
+  siStorable: IEdge["siStorable"];
+
+  constructor(args: IEdge) {
+    this.id = args.id;
+    this.tailVertex = args.tailVertex;
+    this.headVertex = args.headVertex;
+    this.bidirectional = args.bidirectional;
+    this.kind = args.kind;
+    this.siStorable = args.siStorable;
+  }
+}

--- a/components/si-web-app/src/api/sdf/model/node.ts
+++ b/components/si-web-app/src/api/sdf/model/node.ts
@@ -1,0 +1,44 @@
+import { IEntity, Entity } from "@/api/sdf/model/entity";
+import { ISystem, System } from "@/api/sdf/model/system";
+import { ISiStorable } from "@/api/sdf/model/siStorable";
+
+import _ from "lodash";
+
+export type INodeObject = IEntity | ISystem;
+export type NodeObject = Entity | System;
+
+export enum NodeKind {
+  Entity = "entity",
+  System = "system",
+}
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface INode {
+  id: string;
+  positions: {
+    [key: string]: Position;
+  };
+  kind: NodeKind;
+  objectType: string;
+  siStorable: ISiStorable;
+}
+
+export class Node implements INode {
+  id: INode["id"];
+  positions: INode["positions"];
+  kind: INode["kind"];
+  objectType: INode["objectType"];
+  siStorable: INode["siStorable"];
+
+  constructor(args: INode) {
+    this.id = args.id;
+    this.positions = args.positions;
+    this.kind = args.kind;
+    this.objectType = args.objectType;
+    this.siStorable = args.siStorable;
+  }
+}

--- a/components/si-web-app/src/api/sdf/model/schematic.ts
+++ b/components/si-web-app/src/api/sdf/model/schematic.ts
@@ -1,0 +1,77 @@
+import { Node, INodeObject } from "@/api/sdf/model/node";
+import { Edge } from "@/api/sdf/model/edge";
+
+export enum SchematicKind {
+  System = "system",
+  Deployment = "deployment",
+  Implementation = "implementation",
+}
+
+export interface IConnectionEdge {
+  edgeId: string;
+  nodeId: string;
+  socketId: string;
+}
+
+export interface IConnections {
+  predeccessors: {
+    [edgeKind: string]: IConnectionEdge[];
+  };
+  successors: {
+    [edgeKind: string]: IConnectionEdge[];
+  };
+}
+
+export enum ISocketKind {
+  Input = "input",
+  Output = "output",
+}
+
+export enum ISocketTypes {
+  Object = "object",
+}
+
+export interface ISocketObject {
+  id: string;
+  kind: ISocketKind;
+  type: "object";
+  objectType: string;
+}
+
+export interface ISocketPrimitive {
+  id: string;
+  socketKind: ISocketKind;
+  socketType: string;
+  objectType?: never;
+}
+
+export type ISocket = ISocketObject | ISocketPrimitive;
+
+export interface ISchematicNode {
+  node: Node;
+  sockets: {
+    inputs: ISocket[];
+    outputs: ISocket[];
+  };
+  object: INodeObject;
+  connections: IConnections;
+}
+
+export interface ISchematic {
+  nodes: {
+    [nodeId: string]: ISchematicNode;
+  };
+  edges: {
+    [edgeId: string]: Edge;
+  };
+}
+
+export class Schematic implements ISchematic {
+  nodes: ISchematic["nodes"];
+  edges: ISchematic["edges"];
+
+  constructor(schematic: ISchematic) {
+    this.nodes = schematic.nodes;
+    this.edges = schematic.edges;
+  }
+}

--- a/components/si-web-app/src/molecules/NodeAddMenu.vue
+++ b/components/si-web-app/src/molecules/NodeAddMenu.vue
@@ -1,0 +1,250 @@
+<template>
+  <div class="relative w-auto z-100">
+    <button
+      @click="isOpen = !isOpen"
+      class="w-full focus:outline-none"
+      :disabled="disabled"
+      data-cy="editor-schematic-node-add-button"
+    >
+      <div
+        class="items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
+        :class="{
+          'text-gray-200': !isOpen,
+          'menu-selected': isOpen,
+          'text-gray-600': disabled,
+        }"
+      >
+        Add
+      </div>
+    </button>
+
+    <ul
+      v-show="isOpen"
+      class="absolute w-auto ml-2 text-gray-200 border shadow-md options"
+    >
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category"
+        v-for="item in menuList"
+        :data-cy="
+          'editor-schematic-node-add-menu-' +
+          item.id.replace(/\s/g, '-').replace(/:/g, '')
+        "
+        :key="item.id"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.id }}
+        </div>
+
+        <ul
+          v-if="item.childs"
+          class="relative w-auto border shadow-md category-items options"
+        >
+          <li
+            class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
+            v-for="child in item.childs"
+            :key="child.id"
+            :data-cy="
+              'editor-schematic-node-add-menu-' +
+              item.id.replace(/\s/g, '-').replace(/:/g, '') +
+              '-' +
+              child.id.replace(/\s/g, '-').replace(/:/g, '')
+            "
+            @click="onSelect(child)"
+          >
+            {{ child.id }}
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import _ from "lodash";
+
+import { registry } from "si-registry";
+import {
+  EntityObject,
+  UiMenuCategory,
+  UiMenuSubCategory,
+} from "si-registry/lib/systemComponent";
+import Bottle from "bottlejs";
+
+type MenuElement = MenuCategory | MenuItem | undefined;
+
+interface MenuCategory {
+  kind: "category";
+  id: string;
+  childs: MenuCategory[] | MenuItem[] | undefined;
+}
+
+interface MenuItem {
+  kind: "item";
+  id: string;
+  iEntity: EntityObject;
+  parent: MenuCategory | undefined;
+}
+
+interface Data {
+  entityTypeList: EntityObject[];
+  isOpen: boolean;
+  selected: MenuItem | undefined;
+  menuList: MenuElement[];
+}
+
+export default Vue.extend({
+  name: "NodeAddMenu",
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  components: {},
+  data(): Data {
+    let entityTypeList = _.sortBy(registry.listEntities(), ["typeName"]);
+    return {
+      entityTypeList,
+      isOpen: false,
+      selected: undefined,
+      menuList: [],
+    };
+  },
+  methods: {
+    onSelect(item: MenuItem): void {
+      this.$emit("selected", item.iEntity);
+      this.isOpen = false;
+    },
+    menuItemList(): MenuElement[] {
+      // Filter the entityTypeList for entities that are uiVisible
+      var filteredList = _.remove(
+        this.entityTypeList,
+        function (entity: EntityObject) {
+          if (entity.iEntity?.uiVisible) {
+            return entity;
+          }
+        },
+      );
+
+      // Sort the filtered list
+      let sortedList = _.sortBy(filteredList, ["iEntity.uiMenuDisplayName"]);
+
+      let menuList: MenuElement[] = [];
+
+      sortedList.forEach(function (entity: EntityObject) {
+        // Check if this entity has a uiMenuCategory
+        if (entity.iEntity?.uiMenuCategory) {
+          let menuElement: any;
+          // Find the menuElement tht represents the entity uiMenuCategory.
+          menuElement = _.find(menuList, function (e: MenuElement) {
+            return e?.id === entity.iEntity?.uiMenuCategory;
+          });
+
+          // Create a menuElement to represent the entity uiMenuCategory if it doesn't already exist
+          if (!menuElement) {
+            if (
+              entity.iEntity?.uiMenuCategory &&
+              menuElement?.kind !== "category"
+            ) {
+              let menuCategory: MenuCategory = {
+                kind: "category",
+                id: entity.iEntity.uiMenuCategory,
+                childs: [],
+              };
+              menuList.push(menuCategory);
+              menuList = _.sortBy(menuList, ["id"]);
+              menuElement = _.find(menuList, function (e: MenuElement) {
+                return e?.id === entity.iEntity?.uiMenuCategory;
+              });
+            }
+          }
+
+          // Add menuItem to MenuCategory
+          if (
+            menuElement?.kind === "category" &&
+            entity.iEntity.uiMenuDisplayName
+          ) {
+            let menuItemId: string;
+
+            if (entity.iEntity.uiMenuSubCategory) {
+              menuItemId =
+                entity.iEntity.uiMenuSubCategory +
+                " : " +
+                entity.iEntity.uiMenuDisplayName;
+            } else {
+              menuItemId = entity.iEntity.uiMenuDisplayName;
+            }
+
+            let menuItem: MenuItem = {
+              kind: "item",
+              id: menuItemId,
+              iEntity: entity,
+              parent: menuElement,
+            };
+            menuElement?.childs?.push(menuItem);
+          }
+        }
+      });
+      return menuList;
+    },
+    onMouseEnter(): void {
+      this.isOpen = true;
+    },
+  },
+  mounted() {
+    this.menuList = this.menuItemList();
+  },
+  created() {
+    const handleEscape = (e: any) => {
+      if (e.key === "Esc" || e.key === "Escape") {
+        if (this.isOpen) {
+          this.isOpen = false;
+        }
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    this.$once("hook:beforeDestroy", () => {
+      document.removeEventListener("keydown", handleEscape);
+    });
+  },
+});
+</script>
+
+<style>
+.menu {
+  background-color: #2d3748;
+  border-color: #485359;
+}
+
+.menu-selected {
+  background-color: #edf2f8;
+  color: #000000;
+}
+
+.menu-not-selected {
+  color: red;
+}
+
+.options {
+  background-color: #1f2631;
+  border-color: #485359;
+}
+.options:hover {
+  background-color: #3d4b62;
+  border-color: #454d3e;
+}
+
+.menu-category .category-items {
+  visibility: hidden;
+  position: absolute;
+  left: 100%;
+  top: auto;
+  margin-top: -1.305rem;
+  z-index: 1000;
+}
+
+.menu-category:hover .category-items {
+  visibility: visible;
+}
+</style>

--- a/components/si-web-app/src/molecules/Panel.vue
+++ b/components/si-web-app/src/molecules/Panel.vue
@@ -104,7 +104,7 @@ export default Vue.extend({
       return [
         { label: "", value: PanelType.Empty },
         {
-          label: "System Schematic",
+          label: "Schematic",
           value: PanelType.SystemSchematic,
         },
       ];

--- a/components/si-web-app/src/organisims/Editor.vue
+++ b/components/si-web-app/src/organisims/Editor.vue
@@ -5,13 +5,30 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
+import Vue, { PropType } from "vue";
 import PanelTree from "@/organisims/PanelTree.vue";
+import { IEditorContext, setupEditor } from "@/store/modules/editor";
 
 export default Vue.extend({
   name: "Editor",
+  props: {
+    context: {
+      type: Object as PropType<IEditorContext>,
+    },
+  },
   components: {
     PanelTree,
+  },
+  created() {
+    setupEditor();
+  },
+  async mounted() {
+    await this.$store.dispatch("editor/setContext", this.context);
+  },
+  watch: {
+    async context(newContext: IEditorContext) {
+      await this.$store.dispatch("editor/setContext", newContext);
+    },
   },
 });
 </script>

--- a/components/si-web-app/src/organisims/SystemSchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SystemSchematicPanel.vue
@@ -7,11 +7,45 @@
     :initialMaximizedFull="initialMaximizedFull"
     v-on="$listeners"
   >
+    <template v-slot:menuButtons>
+      <SiSelect
+        size="xs"
+        id="schematicSelect"
+        name="schematicSelect"
+        :options="schematicKinds"
+        v-model="schematicKind"
+        class="pl-1"
+      />
+      <NodeAddMenu
+        class="pl-1"
+        @selected="nodeCreate"
+        :disabled="!isEditable"
+      />
+    </template>
     <template v-slot:content>
-      <div class="relative w-full h-full">
-        <div class="z-20 flex flex-col absolute bg-transparent">
-          <div>Swoop</div>
-          <div>Monkey nuts</div>
+      <CodeLoader
+        v-if="isLoading"
+        viewBox="0 0 300 200"
+        primaryColor="#2d3748"
+        secondaryColor="#000000"
+      ></CodeLoader>
+      <div class="relative w-full h-full" v-else>
+        <div
+          class="z-20 flex flex-col absolute bg-transparent"
+          v-if="schematic"
+        >
+          <div
+            v-for="(schematicNode, key, index) in schematic.nodes"
+            :key="index"
+            class="p-2"
+          >
+            <button
+              @click="nodeSelect(schematicNode)"
+              class="bg-gray-600 rounded-sm p-1"
+            >
+              {{ schematicNode.object.name }} - {{ schematicNode.node.id }}
+            </button>
+          </div>
         </div>
         <SiGrid class="z-10 absolute" />
       </div>
@@ -24,6 +58,32 @@ import Vue from "vue";
 
 import Panel from "@/molecules/Panel.vue";
 import SiGrid from "@/atoms/SiGrid.vue";
+import NodeAddMenu from "@/molecules/NodeAddMenu.vue";
+import { EntityObject } from "si-registry/lib/systemComponent";
+import { PanelEventBus } from "@/atoms/PanelEventBus";
+import { INodeCreateReply } from "@/api/sdf/dal/editorDal";
+import {
+  ctxMapState,
+  InstanceStoreContext,
+  registerStore,
+  unregisterStore,
+} from "@/store";
+import { SchematicStore, schematicStore } from "@/store/modules/schematic";
+import { mapGetters, mapState } from "vuex";
+import { SessionStore } from "@/store/modules/session";
+import SiLoader from "@/atoms/SiLoader.vue";
+import { CodeLoader } from "vue-content-loader";
+import SiSelect, { SelectProps } from "@/atoms/SiSelect.vue";
+import { ISchematicNode, SchematicKind } from "@/api/sdf/model/schematic";
+import { IGetApplicationContextRequest } from "@/api/sdf/dal/applicationContextDal";
+import { IGetApplicationSystemSchematicRequest } from "@/api/sdf/dal/schematicDal";
+import { EditorStore } from "@/store/modules/editor";
+
+interface IData {
+  schematicStoreCtx: InstanceStoreContext<SchematicStore>;
+  isLoading: boolean;
+  schematicKind: SchematicKind;
+}
 
 export default Vue.extend({
   name: "SystemSchematicPanel",
@@ -36,6 +96,121 @@ export default Vue.extend({
   components: {
     Panel,
     SiGrid,
+    NodeAddMenu,
+    CodeLoader,
+    SiSelect,
+  },
+  data(): IData {
+    let schematicStoreCtx: InstanceStoreContext<SchematicStore> = new InstanceStoreContext(
+      {
+        storeName: "schematic",
+        componentId: "schematicPanel",
+        instanceId: "0",
+      },
+    );
+    return {
+      schematicStoreCtx,
+      isLoading: true,
+      schematicKind: SchematicKind.System,
+    };
+  },
+  computed: {
+    ...mapState({
+      currentWorkspace: (state: any): SessionStore["currentWorkspace"] =>
+        state.session.currentWorkspace,
+      sessionContext: (state: any): SessionStore["sessionContext"] =>
+        state.session.sessionContext,
+      currentChangeSet: (state: any): EditorStore["currentChangeSet"] =>
+        state.editor.currentChangeSet,
+      currentSystem: (state: any): SessionStore["currentSystem"] =>
+        state.session.currentSystem,
+    }),
+    ...mapGetters({
+      isEditable: "editor/inEditable",
+    }),
+    schematicKinds(): SelectProps["options"] {
+      return [
+        { label: "System", value: SchematicKind.System },
+        { label: "Deployment", value: SchematicKind.Deployment },
+        { label: "Implementation", value: SchematicKind.Implementation },
+      ];
+    },
+    rootObjectId(): SchematicStore["rootObjectId"] {
+      return this.schematicStoreCtx.state.rootObjectId;
+    },
+    schematic(): SchematicStore["schematic"] {
+      return this.schematicStoreCtx.state.schematic;
+    },
+  },
+  methods: {
+    async nodeSelect(schematicNode: ISchematicNode) {
+      console.log("selected", { schematicNode });
+    },
+    async nodeCreate(entityObject: EntityObject) {
+      let reply: INodeCreateReply = await this.$store.dispatch(
+        "editor/nodeCreate",
+        entityObject,
+      );
+      if (reply.error) {
+        PanelEventBus.$emit("editor-error-message", reply.error.message);
+      }
+    },
+    async loadSchematic() {
+      this.isLoading = true;
+      if (this.currentWorkspace && this.rootObjectId && this.currentSystem) {
+        if (this.schematicKind == SchematicKind.System) {
+          let request: Record<string, any> = {
+            workspaceId: this.currentWorkspace.id,
+            rootObjectId: this.rootObjectId,
+            systemId: this.currentSystem.id,
+          };
+          if (this.currentChangeSet) {
+            request["changeSetId"] = this.currentChangeSet.id;
+          }
+          let reply = await this.schematicStoreCtx.dispatch(
+            "loadApplicationSystemSchematic",
+            request,
+          );
+          if (reply.error) {
+            PanelEventBus.$emit("editor-error-message", reply.error.message);
+          }
+        }
+      }
+      this.isLoading = false;
+    },
+  },
+  async created() {
+    registerStore(this.schematicStoreCtx, schematicStore);
+  },
+  async mounted() {
+    if (this.sessionContext) {
+      this.isLoading = true;
+      await this.schematicStoreCtx.dispatch(
+        "setRootObjectId",
+        this.sessionContext.applicationId,
+      );
+      this.loadSchematic();
+    }
+  },
+  async beforeDestroy() {
+    unregisterStore(this.schematicStoreCtx);
+  },
+  watch: {
+    async sessionContext(sessionContext: SessionStore["sessionContext"]) {
+      let applicationId = this.sessionContext?.applicationId;
+      if (!applicationId) {
+        throw new Error(
+          "failed to extract a root object id from the session; you need to set the context",
+        );
+      }
+      this.isLoading = true;
+      await this.schematicStoreCtx.dispatch("setRootObjectId", applicationId);
+      await this.loadSchematic();
+    },
+    async currentChangeSet() {
+      this.isLoading = true;
+      await this.loadSchematic();
+    },
   },
 });
 </script>

--- a/components/si-web-app/src/store/modules/editor.ts
+++ b/components/si-web-app/src/store/modules/editor.ts
@@ -1,0 +1,114 @@
+import { Module } from "vuex";
+import { EntityObject } from "si-registry/lib/systemComponent";
+import { INodeCreateReply } from "@/api/sdf/dal/editorDal";
+import { SessionStore } from "@/store/modules/session";
+import { ChangeSet } from "@/api/sdf/model/changeSet";
+import { PartyBus } from "@/api/partyBus";
+import { EditSession } from "@/api/sdf/model/editSession";
+import Bottle from "bottlejs";
+import { CurrentChangeSetEvent } from "@/api/partyBus/currentChangeSetEvent";
+import { EditSessionCurrentSetEvent } from "@/api/partyBus/editSessionCurrentSetEvent";
+import { EditorDal } from "@/api/sdf/dal/editorDal";
+import { NodeKind } from "@/api/sdf/model/node";
+
+export type IEditorContext = IEditorContextApplication;
+
+export interface IEditorContextApplication {
+  applicationId: string;
+}
+
+export interface EditorStore {
+  version: number;
+  context: IEditorContext | null;
+  currentChangeSet: ChangeSet | null;
+  currentEditSession: EditSession | null;
+}
+
+export function setupEditor() {
+  const bottle = Bottle.pop("default");
+  const partyBus: PartyBus = bottle.container.PartyBus;
+  partyBus.subscribeToEvents("editor", undefined, [
+    CurrentChangeSetEvent,
+    EditSessionCurrentSetEvent,
+  ]);
+}
+
+export const editor: Module<EditorStore, any> = {
+  namespaced: true,
+  state: {
+    version: 1,
+    currentChangeSet: null,
+    currentEditSession: null,
+    context: null,
+  },
+  getters: {
+    inEditable(state): boolean {
+      if (state.currentChangeSet && state.currentEditSession && state.context) {
+        return true;
+      } else {
+        return false;
+      }
+    },
+  },
+  mutations: {
+    setCurrentChangeSet(state, payload: EditorStore["currentChangeSet"]) {
+      state.currentChangeSet = payload;
+    },
+    setCurrentEditSession(state, payload: EditorStore["currentEditSession"]) {
+      state.currentEditSession = payload;
+    },
+    setContext(state, payload: EditorStore["context"]) {
+      state.context = payload;
+    },
+  },
+  actions: {
+    async onCurrentChangeSet({ commit }, event: CurrentChangeSetEvent) {
+      commit("setCurrentChangeSet", event.changeSet);
+    },
+    async onEditSessionCurrentSet(
+      { commit },
+      event: EditSessionCurrentSetEvent,
+    ) {
+      commit("setCurrentEditSession", event.editSession);
+    },
+    async setContext({ commit }, context: EditorStore["context"]) {
+      commit("setContext", context);
+    },
+    async nodeCreate(
+      { state, rootState },
+      entityObject: EntityObject,
+    ): Promise<INodeCreateReply> {
+      let currentWorkspace: SessionStore["currentWorkspace"] =
+        rootState.session.currentWorkspace;
+      let currentSystem: SessionStore["currentSystem"] =
+        rootState.session.currentSystem;
+      if (
+        !currentWorkspace ||
+        !currentSystem ||
+        !state.currentEditSession ||
+        !state.currentChangeSet ||
+        !state.context
+      ) {
+        throw new Error(
+          "Cannot call nodeCreate without a workspace, system, changeSet and editSession or EditContext! bug!",
+        );
+      }
+      let reply;
+      if (state.context.applicationId) {
+        reply = EditorDal.nodeCreateForApplication({
+          kind: NodeKind.Entity,
+          objectType: entityObject.typeName,
+          workspaceId: currentWorkspace.id,
+          changeSetId: state.currentChangeSet.id,
+          editSessionId: state.currentEditSession.id,
+          systemId: currentSystem.id,
+          applicationId: state.context.applicationId,
+        });
+      } else {
+        throw new Error("cannot create without an editor context");
+      }
+
+      return reply;
+    },
+  },
+};

--- a/components/si-web-app/src/store/modules/schematic.ts
+++ b/components/si-web-app/src/store/modules/schematic.ts
@@ -1,0 +1,62 @@
+import { Module } from "vuex";
+
+import {
+  Schematic,
+  SchematicKind,
+  ISchematicNode,
+} from "@/api/sdf/model/schematic";
+import {
+  IGetApplicationSystemSchematicRequest,
+  IGetSchematicReply,
+  SchematicDal,
+} from "@/api/sdf/dal/schematicDal";
+import { SchematicNodeSelectedEvent } from "@/api/partyBus/SchematicNodeSelectedEvent";
+
+export interface SchematicStore {
+  kind: SchematicKind | null;
+  schematic: Schematic | null;
+  rootObjectId: string | null;
+  selectedNode: ISchematicNode | null;
+}
+
+export const schematicStore: Module<SchematicStore, any> = {
+  namespaced: true,
+  state(): SchematicStore {
+    return {
+      kind: null,
+      schematic: null,
+      rootObjectId: null,
+      selectedNode: null,
+    };
+  },
+  mutations: {
+    setRootObjectId(state, payload: SchematicStore["rootObjectId"]) {
+      state.rootObjectId = payload;
+    },
+    setSchematic(state, payload: SchematicStore["schematic"]) {
+      state.schematic = payload;
+    },
+    setSelectedNode(state, payload: SchematicStore["selectedNode"]) {
+      state.selectedNode = payload;
+    },
+  },
+  actions: {
+    setRootObjectId({ commit }, payload: SchematicStore["rootObjectId"]) {
+      commit("setRootObjectId", payload);
+    },
+    async loadApplicationSystemSchematic(
+      { commit },
+      request: IGetApplicationSystemSchematicRequest,
+    ): Promise<IGetSchematicReply> {
+      let reply = await SchematicDal.getApplicationSystemSchematic(request);
+      if (!reply.error) {
+        commit("setSchematic", reply.schematic);
+      }
+      return reply;
+    },
+    async nodeSelect({ commit }, schematicNode: ISchematicNode) {
+      commit("selectedNode", schematicNode);
+      new SchematicNodeSelectedEvent({ schematicNode: schematicNode });
+    },
+  },
+};

--- a/components/si-web-app/src/store/modules/session.ts
+++ b/components/si-web-app/src/store/modules/session.ts
@@ -16,12 +16,25 @@ import { SDFError } from "@/api/sdf";
 
 export type ISetDefaultsReply = IGetDefaultsReply;
 
+export enum ISessionContextKind {
+  ApplicationSystem = "applicationSystem",
+}
+
+export interface ISessionContextApplicationSystem {
+  kind: ISessionContextKind.ApplicationSystem;
+  applicationId: string;
+  systemId: string;
+}
+
+export type SessionContext = ISessionContextApplicationSystem;
+
 export interface SessionStore {
   user: null | User;
   billingAccount: null | BillingAccount;
   currentWorkspace: null | Workspace;
   currentOrganization: null | Organization;
   currentSystem: null | System;
+  sessionContext: null | SessionContext;
 }
 
 export const session: Module<SessionStore, any> = {
@@ -32,6 +45,7 @@ export const session: Module<SessionStore, any> = {
     currentWorkspace: null,
     currentOrganization: null,
     currentSystem: null,
+    sessionContext: null,
   },
   mutations: {
     setUser(state, payload: SessionStore["user"]) {
@@ -51,6 +65,9 @@ export const session: Module<SessionStore, any> = {
     },
     setCurrentSystem(state, payload: SessionStore["currentSystem"]) {
       state.currentSystem = payload;
+    },
+    setSessionContext(state, payload: SessionStore["sessionContext"]) {
+      state.sessionContext = payload;
     },
   },
   actions: {
@@ -104,8 +121,13 @@ export const session: Module<SessionStore, any> = {
         commit("setCurrentOrganization", reply.organization);
         commit("setCurrentWorkspace", reply.workspace);
         commit("setCurrentSystem", reply.system);
+      } else {
+        console.log("error in set defaults", { reply });
       }
       return reply;
+    },
+    setSessionContext({ commit }, sessionContext: SessionContext | null) {
+      commit("setSessionContext", sessionContext);
     },
   },
 };

--- a/components/si-web-app/tests/unit/organisims/ApplicationContext.spec.ts
+++ b/components/si-web-app/tests/unit/organisims/ApplicationContext.spec.ts
@@ -1,8 +1,11 @@
 import { render, fireEvent, waitFor } from "@testing-library/vue";
 import userEvent from "@testing-library/user-event";
 import { storeData, InstanceStoreContext } from "@/store";
-import { registerStatusBar } from "@/store/modules/statusBar";
-import { registerApplicationContext } from "@/store/modules/applicationContext";
+import { registerStatusBar, StatusBarStore } from "@/store/modules/statusBar";
+import {
+  registerApplicationContext,
+  ApplicationContextStore,
+} from "@/store/modules/applicationContext";
 import _ from "lodash";
 import routes from "@/router/routes";
 import { bottleSetup, bottleClear, bottleSetStore } from "@/di";
@@ -24,8 +27,8 @@ interface Setup {
   application: Entity;
   nba: INewBillingAccount;
   sessionDefaults: ISetDefaultsReply;
-  applicationContextCtx: InstanceStoreContext;
-  statusBarCtx: InstanceStoreContext;
+  applicationContextCtx: InstanceStoreContext<ApplicationContextStore>;
+  statusBarCtx: InstanceStoreContext<StatusBarStore>;
   initialChangeSet: ICreateChangeSetAndEditSessionReplySuccess;
 }
 
@@ -42,16 +45,20 @@ async function setup(): Promise<Setup> {
   // Get the default organization and workspace
   let sessionDefaults = await store.dispatch("session/setDefaults");
   let application = await createApplication();
-  let applicationContextCtx = new InstanceStoreContext({
-    storeName: "applicationContext",
-    componentId: "ApplicationDetails",
-    instanceId: "applicationDetails",
-  });
-  let statusBarCtx = new InstanceStoreContext({
-    storeName: "statusBar",
-    componentId: "ApplicationDetails",
-    instanceId: "applicationDetails",
-  });
+  let applicationContextCtx: InstanceStoreContext<ApplicationContextStore> = new InstanceStoreContext(
+    {
+      storeName: "applicationContext",
+      componentId: "ApplicationDetails",
+      instanceId: "applicationDetails",
+    },
+  );
+  let statusBarCtx: InstanceStoreContext<StatusBarStore> = new InstanceStoreContext(
+    {
+      storeName: "statusBar",
+      componentId: "ApplicationDetails",
+      instanceId: "applicationDetails",
+    },
+  );
   let reply = await createChangeSet();
   if (reply.error) {
     throw new Error(`cannot create new change set: ${reply.error.message}`);


### PR DESCRIPTION
The schematic panel can now create, select, and list nodes. A
"schematic" is now a model in the core domain, and the web UI accesses
it through the schematicDal.

When a node is selected in a schematic, that schematics store sends a
SchematicNodeSelectedEvent to the PartyBus.