### PR TITLE
chore: Schematic responds to node create events

### DIFF
--- a/components/si-web-app/src/api/sdf/dal/editorDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/editorDal.ts
@@ -3,7 +3,6 @@ import { Entity } from "@/api/sdf/model/entity";
 import { SDFError } from "@/api/sdf";
 import { System } from "@/api/sdf/model/system";
 import Bottle from "bottlejs";
-import { NodeCreatedEvent } from "@/api/partyBus/NodeCreatedEvent";
 
 export interface INodeCreateForApplicationRequest extends INodeCreateRequest {
   applicationId: string;
@@ -57,11 +56,6 @@ async function nodeCreateForApplication(
     "editorDal/nodeCreateForApplication",
     request,
   );
-
-  if (!reply.error) {
-    new NodeCreatedEvent(reply).publish();
-  }
-
   return reply;
 }
 

--- a/components/si-web-app/src/organisims/SystemSchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SystemSchematicPanel.vue
@@ -68,7 +68,11 @@ import {
   registerStore,
   unregisterStore,
 } from "@/store";
-import { SchematicStore, schematicStore } from "@/store/modules/schematic";
+import {
+  SchematicStore,
+  schematicStore,
+  schematicStoreSubscribeEvents,
+} from "@/store/modules/schematic";
 import { mapGetters, mapState } from "vuex";
 import { SessionStore } from "@/store/modules/session";
 import SiLoader from "@/atoms/SiLoader.vue";
@@ -180,7 +184,11 @@ export default Vue.extend({
     },
   },
   async created() {
-    registerStore(this.schematicStoreCtx, schematicStore);
+    registerStore(
+      this.schematicStoreCtx,
+      schematicStore,
+      schematicStoreSubscribeEvents,
+    );
   },
   async mounted() {
     if (this.sessionContext) {

--- a/components/si-web-app/src/store.ts
+++ b/components/si-web-app/src/store.ts
@@ -6,6 +6,7 @@ import { session } from "@/store/modules/session";
 import { editor } from "@/store/modules/editor";
 import Bottle from "bottlejs";
 import _ from "lodash";
+import { PartyBus } from "./api/partyBus";
 
 export type SiVuexStore = Store<RootStore>;
 
@@ -96,6 +97,7 @@ export class InstanceStoreContext<State> {
 export async function registerStore(
   ctx: InstanceStoreContext<any>,
   moduleData: Module<any, any>,
+  events?: { eventName: () => string }[],
 ) {
   const bottle = Bottle.pop("default");
   const store: SiVuexStore = bottle.container.Store;
@@ -104,6 +106,10 @@ export async function registerStore(
     !store.hasModule([ctx.storeName, ctx.instanceId])
   ) {
     store.registerModule([ctx.storeName, ctx.instanceId], moduleData);
+  }
+  if (events && events.length) {
+    let partyBus: PartyBus = bottle.container.PartyBus;
+    partyBus.subscribeToEvents(ctx.storeName, ctx.instanceId, events);
   }
 }
 

--- a/components/si-web-app/src/store/modules/editor.ts
+++ b/components/si-web-app/src/store/modules/editor.ts
@@ -10,6 +10,7 @@ import { CurrentChangeSetEvent } from "@/api/partyBus/currentChangeSetEvent";
 import { EditSessionCurrentSetEvent } from "@/api/partyBus/editSessionCurrentSetEvent";
 import { EditorDal } from "@/api/sdf/dal/editorDal";
 import { NodeKind } from "@/api/sdf/model/node";
+import { NodeCreatedEvent } from "@/api/partyBus/NodeCreatedEvent";
 
 export type IEditorContext = IEditorContextApplication;
 
@@ -93,9 +94,9 @@ export const editor: Module<EditorStore, any> = {
           "Cannot call nodeCreate without a workspace, system, changeSet and editSession or EditContext! bug!",
         );
       }
-      let reply;
+      let reply: INodeCreateReply;
       if (state.context.applicationId) {
-        reply = EditorDal.nodeCreateForApplication({
+        reply = await EditorDal.nodeCreateForApplication({
           kind: NodeKind.Entity,
           objectType: entityObject.typeName,
           workspaceId: currentWorkspace.id,
@@ -106,6 +107,9 @@ export const editor: Module<EditorStore, any> = {
         });
       } else {
         throw new Error("cannot create without an editor context");
+      }
+      if (!reply.error) {
+        new NodeCreatedEvent(reply).publish();
       }
 
       return reply;

--- a/components/si-web-app/src/templates/vue-content-loader.d.ts
+++ b/components/si-web-app/src/templates/vue-content-loader.d.ts
@@ -1,0 +1,1 @@
+declare module "vue-content-loader";


### PR DESCRIPTION
This PR makes the schematic reload when a NodeCreatedEvent is
dispatched, according to whatever the last requested schematic was. It
also adds blank typings for the loading image.