### PR TITLE
chore(sdf): add node_position model

### DIFF
--- a/components/si-sdf/src/data/migrations/U024__node_positions.sql
+++ b/components/si-sdf/src/data/migrations/U024__node_positions.sql
@@ -1,0 +1,97 @@
+CREATE TABLE node_positions
+(
+    id                 bigint PRIMARY KEY,
+    si_id              text UNIQUE,
+    node_id            bigint                   NOT NULL REFERENCES nodes (id),
+    context_id         text                     NOT NULL,
+    billing_account_id bigint                   NOT NULL REFERENCES billing_accounts (id),
+    organization_id    bigint                   NOT NULL REFERENCES organizations (id),
+    workspace_id       bigint                   NOT NULL REFERENCES workspaces (id),
+    epoch              bigint                   not null,
+    update_count       bigint                   not null,
+    tenant_ids         text[]                   NOT NULL,
+    obj                jsonb                    NOT NULL,
+    created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (node_id, context_id)
+);
+
+CREATE OR REPLACE FUNCTION node_position_create_v1(si_node_id text,
+                                                   context_id text,
+                                                   x text,
+                                                   y text,
+                                                   si_workspace_id text,
+                                                   this_epoch bigint,
+                                                   this_update_count bigint,
+                                                   OUT object jsonb) AS
+$$
+DECLARE
+    this_id                 bigint;
+    si_id                   text;
+    this_workspace_id       bigint;
+    this_organization_id    bigint;
+    this_billing_account_id bigint;
+    this_node_id            bigint;
+    tenant_ids              text[];
+    created_at              timestamp with time zone;
+    updated_at              timestamp with time zone;
+    si_storable             jsonb;
+BEGIN
+    SELECT next_si_id_v1() INTO this_id;
+    SELECT 'nodePosition:' || this_id INTO si_id;
+    SELECT NOW() INTO created_at;
+    SELECT NOW() INTO updated_at;
+
+    SELECT our_si_storable, our_organization_id, our_billing_account_id, our_workspace_id, our_tenant_ids
+    INTO si_storable, this_organization_id, this_billing_account_id, this_workspace_id, tenant_ids
+    FROM si_storable_create_v1(si_id, si_workspace_id, created_at, updated_at, this_epoch, this_update_count);
+
+    SELECT si_id_to_primary_key_v1(si_node_id) INTO this_node_id;
+
+    SELECT jsonb_build_object(
+                   'id', si_id,
+                   'nodeId', si_node_id,
+                   'contextId', context_id,
+                   'x', x,
+                   'y', y,
+                   'siStorable', si_storable
+               )
+    INTO object;
+
+    INSERT INTO node_positions(id, si_id, node_id, context_id, billing_account_id, organization_id, workspace_id, epoch,
+                               update_count, tenant_ids, obj, created_at, updated_at)
+    VALUES (this_id, si_id, this_node_id, context_id, this_billing_account_id, this_organization_id, this_workspace_id,
+            this_epoch, this_update_count, tenant_ids, object, created_at, updated_at);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION node_position_save_v1(input_node_position jsonb,
+                                        OUT object jsonb) AS
+$$
+DECLARE
+    this_current node_positions%rowtype;
+    this_id      bigint;
+BEGIN
+    /* extract the id */
+    SELECT si_id_to_primary_key_v1(input_node_position ->> 'id') INTO this_id;
+
+    SELECT * INTO this_current FROM node_positions WHERE id = this_id;
+    IF NOT FOUND THEN
+        RAISE WARNING 'node position id % not found', this_id;
+    END IF;
+
+    /* bail if it is a tenancy violation */
+    IF si_id_to_primary_key_v1(input_node_position -> 'siStorable' ->> 'billingAccountId') !=
+       this_current.billing_account_id THEN
+        RAISE WARNING 'mutated billing account id; not allowed!';
+    END IF;
+
+    UPDATE node_positions
+    SET epoch        = (input_node_position -> 'siStorable' -> 'updateClock' ->> 'epoch')::bigint,
+        update_count = (input_node_position -> 'siStorable' -> 'updateClock' ->> 'updateCount')::bigint,
+        obj          = input_node_position,
+        updated_at   = NOW()
+    WHERE id = this_id
+    RETURNING obj INTO object;
+END
+$$ LANGUAGE PLPGSQL;

--- a/components/si-sdf/src/data/queries/node_position_by_node_id.sql
+++ b/components/si-sdf/src/data/queries/node_position_by_node_id.sql
@@ -1,0 +1,3 @@
+SELECT obj AS object
+FROM node_positions
+WHERE node_id = si_id_to_primary_key_v1($1);

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -1,17 +1,16 @@
+use crate::{
+    data::{EventLogFS, NatsConn, PgPool},
+    handlers, models,
+    veritech::Veritech,
+};
 use sodiumoxide::crypto::secretbox;
 use warp::{filters::BoxedFilter, Filter};
-
-use crate::data::{EventLogFS, NatsConn, PgPool};
-use crate::veritech::Veritech;
-
-use crate::handlers;
-use crate::models::{self, OutputLineStream};
 
 pub fn api(
     pg: &PgPool,
     nats_conn: &NatsConn,
     veritech: &Veritech,
-    event_log_fs: &EventLogFS,
+    _event_log_fs: &EventLogFS,
     secret_key: &secretbox::Key,
 ) -> BoxedFilter<(impl warp::Reply,)> {
     //billing_accounts(pg, nats_conn, veritech)
@@ -936,11 +935,11 @@ fn with_nats_conn(
     warp::any().map(move || nats_conn.clone())
 }
 
-fn with_event_log_fs(
-    event_log_fs: EventLogFS,
-) -> impl Filter<Extract = (EventLogFS,), Error = std::convert::Infallible> + Clone {
-    warp::any().map(move || event_log_fs.clone())
-}
+// fn with_event_log_fs(
+//     event_log_fs: EventLogFS,
+// ) -> impl Filter<Extract = (EventLogFS,), Error = std::convert::Infallible> + Clone {
+//     warp::any().map(move || event_log_fs.clone())
+// }
 
 fn with_veritech(
     veritech: Veritech,
@@ -954,8 +953,8 @@ fn with_secret_key(
     warp::any().map(move || secret_key.clone())
 }
 
-fn with_string(
-    thingy: String,
-) -> impl Filter<Extract = (String,), Error = std::convert::Infallible> + Clone {
-    warp::any().map(move || thingy.clone())
-}
+// fn with_string(
+//     thingy: String,
+// ) -> impl Filter<Extract = (String,), Error = std::convert::Infallible> + Clone {
+//     warp::any().map(move || thingy.clone())
+// }

--- a/components/si-sdf/src/handlers/attribute_dal.rs
+++ b/components/si-sdf/src/handlers/attribute_dal.rs
@@ -1,8 +1,7 @@
 use crate::{
-    data::{NatsConn, PgPool},
+    data::PgPool,
     handlers::{authenticate, authorize, validate_tenancy, HandlerError, LabelListItem},
-    models::{Edge, EdgeKind, Entity, Node, Schematic},
-    veritech::Veritech,
+    models::{Edge, EdgeKind, Entity},
 };
 use serde::{Deserialize, Serialize};
 

--- a/components/si-sdf/src/handlers/schematic_dal.rs
+++ b/components/si-sdf/src/handlers/schematic_dal.rs
@@ -1,8 +1,7 @@
 use crate::{
-    data::{NatsConn, PgPool},
+    data::PgPool,
     handlers::{authenticate, authorize, validate_tenancy, HandlerError},
     models::{EdgeKind, Schematic},
-    veritech::Veritech,
 };
 use serde::{Deserialize, Serialize};
 

--- a/components/si-sdf/src/models.rs
+++ b/components/si-sdf/src/models.rs
@@ -63,7 +63,9 @@ pub use entity::{calculate_properties, Entity, EntityError, EntityResult};
 pub mod resource;
 pub use resource::{Resource, ResourceError, ResourceHealth, ResourceResult, ResourceStatus};
 pub mod node;
-pub use node::{Node, NodeError, NodeKind, NodeResult, Position};
+pub use node::{Node, NodeError, NodeKind, NodeResult};
+pub mod node_position;
+pub use node_position::{NodePosition, NodePositionError};
 pub mod ops;
 pub use ops::{
     OpEntityAction, OpEntityDelete, OpEntitySet, OpError, OpReply, OpRequest, OpResult, OpSetName,

--- a/components/si-sdf/src/models/node.rs
+++ b/components/si-sdf/src/models/node.rs
@@ -13,8 +13,6 @@ use crate::models::{
 
 use crate::models::{OpReply, OpRequest};
 
-use std::collections::HashMap;
-
 #[derive(Error, Debug)]
 pub enum NodeError {
     #[error("error with linked entity: {0}")]
@@ -100,14 +98,14 @@ pub struct PatchConfiguredByReply {
 #[serde(rename_all = "camelCase")]
 pub struct PatchSetPositionRequest {
     pub context: String,
-    pub position: Position,
+    // pub position: Position,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchSetPositionReply {
     pub context: String,
-    pub position: Position,
+    // pub position: Position,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -128,7 +126,6 @@ pub struct SyncResourceReply {
 pub enum PatchOp {
     IncludeSystem(PatchIncludeSystemRequest),
     ConfiguredBy(PatchConfiguredByRequest),
-    SetPosition(PatchSetPositionRequest),
     SyncResource(SyncResourceRequest),
 }
 
@@ -166,18 +163,6 @@ pub enum ObjectPatchReply {
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
-pub struct Position {
-    x: u64,
-    y: u64,
-}
-
-impl Position {
-    pub fn new(x: u64, y: u64) -> Self {
-        Self { x, y }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum NodeKind {
     Entity,
@@ -198,7 +183,6 @@ impl std::fmt::Display for NodeKind {
 #[serde(rename_all = "camelCase")]
 pub struct Node {
     pub id: String,
-    pub positions: HashMap<String, Position>,
     pub kind: NodeKind,
     pub object_type: String,
     pub object_id: String,
@@ -313,11 +297,6 @@ impl Node {
         let node: Node = serde_json::from_value(json)?;
         *self = node;
         Ok(())
-    }
-
-    pub fn set_position(&mut self, context: impl Into<String>, position: Position) {
-        let context = context.into();
-        self.positions.insert(context, position);
     }
 
     pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> NodeResult<()> {

--- a/components/si-sdf/src/models/node_position.rs
+++ b/components/si-sdf/src/models/node_position.rs
@@ -1,0 +1,108 @@
+use crate::{
+    data::{NatsTxn, NatsTxnError, PgTxn},
+    models::{next_update_clock, ModelError, SiStorable, UpdateClockError},
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const NODE_POSITION_BY_NODE_ID: &str = include_str!("../data/queries/node_position_by_node_id.sql");
+
+#[derive(Error, Debug)]
+pub enum NodePositionError {
+    #[error("error in core model functions: {0}")]
+    Model(#[from] ModelError),
+    #[error("nats txn error: {0}")]
+    NatsTxn(#[from] NatsTxnError),
+    #[error("json serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+    #[error("update clock: {0}")]
+    UpdateClock(#[from] UpdateClockError),
+}
+
+pub type NodePositionResult<T> = Result<T, NodePositionError>;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct NodePosition {
+    pub id: String,
+    pub node_id: String,
+    pub context_id: String,
+    pub x: String,
+    pub y: String,
+    pub si_storable: SiStorable,
+}
+
+impl NodePosition {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        node_id: impl AsRef<str>,
+        context_id: impl AsRef<str>,
+        x: impl AsRef<str>,
+        y: impl AsRef<str>,
+        workspace_id: impl AsRef<str>,
+    ) -> NodePositionResult<Self> {
+        let node_id = node_id.as_ref();
+        let context_id = context_id.as_ref();
+        let x = x.as_ref();
+        let y = y.as_ref();
+        let workspace_id = workspace_id.as_ref();
+
+        let workspace_update_clock = next_update_clock(workspace_id).await?;
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM node_position_create_v1($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &node_id,
+                    &context_id,
+                    &x,
+                    &y,
+                    &workspace_id,
+                    &workspace_update_clock.epoch,
+                    &workspace_update_clock.update_count,
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish(&json).await?;
+        let object: NodePosition = serde_json::from_value(json)?;
+
+        Ok(object)
+    }
+
+    pub async fn get_by_node_id(
+        txn: &PgTxn<'_>,
+        node_id: impl AsRef<str>,
+    ) -> NodePositionResult<Vec<NodePosition>> {
+        let node_id = node_id.as_ref();
+
+        let rows = txn.query(NODE_POSITION_BY_NODE_ID, &[&node_id]).await?;
+
+        let mut results: Vec<Self> = Vec::new();
+        for row in rows.into_iter() {
+            let json: serde_json::Value = row.try_get("object")?;
+            let object: Self = serde_json::from_value(json)?;
+            results.push(object);
+        }
+
+        Ok(results)
+    }
+
+    pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> NodePositionResult<()> {
+        let workspace_update_clock = next_update_clock(&self.si_storable.workspace_id).await?;
+        self.si_storable.update_clock = workspace_update_clock;
+
+        let json = serde_json::to_value(&self)?;
+        let row = txn
+            .query_one("SELECT object FROM node_position_save_v1($1)", &[&json])
+            .await?;
+        let updated_result: serde_json::Value = row.try_get("object")?;
+        nats.publish(&updated_result).await?;
+        let mut updated: Self = serde_json::from_value(updated_result)?;
+        std::mem::swap(self, &mut updated);
+        Ok(())
+    }
+}

--- a/components/si-sdf/src/models/schematic.rs
+++ b/components/si-sdf/src/models/schematic.rs
@@ -122,7 +122,7 @@ impl Schematic {
         txn: &PgTxn<'_>,
         root_object_id: impl AsRef<str>,
         workspace_id: impl AsRef<str>,
-        system_id: impl AsRef<str>,
+        _system_id: impl AsRef<str>,
         change_set_id: Option<String>,
         edge_kinds: Vec<EdgeKind>,
     ) -> SchematicResult<Schematic> {

--- a/components/si-sdf/tests/models/mod.rs
+++ b/components/si-sdf/tests/models/mod.rs
@@ -10,6 +10,7 @@ pub mod group;
 pub mod jwt_key;
 pub mod key_pair;
 pub mod node;
+pub mod node_position;
 pub mod ops;
 pub mod organization;
 pub mod resource;

--- a/components/si-sdf/tests/models/node_position.rs
+++ b/components/si-sdf/tests/models/node_position.rs
@@ -1,0 +1,201 @@
+use crate::{
+    models::{
+        billing_account::{signup_new_billing_account, NewBillingAccount},
+        change_set::create_change_set,
+        edit_session::create_edit_session,
+        node::create_entity_node,
+    },
+    one_time_setup, TestContext,
+};
+use si_sdf::{
+    data::{NatsTxn, PgTxn},
+    models::NodePosition,
+};
+
+async fn create_node_position(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    node_id: impl AsRef<str>,
+    context_id: impl AsRef<str>,
+    nba: &NewBillingAccount,
+) -> NodePosition {
+    let node_position = NodePosition::new(
+        &txn,
+        &nats,
+        node_id.as_ref(),
+        context_id.as_ref(),
+        "0",
+        "0",
+        &nba.workspace.id,
+    )
+    .await
+    .expect("cannot create new node position");
+
+    node_position
+}
+
+#[tokio::test]
+async fn new() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new billing account");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new change set");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let node = create_entity_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &nba.system,
+        &change_set,
+        &edit_session,
+    )
+    .await;
+
+    let context_id = "my-context";
+    let x = "1.21";
+    let y = "42001";
+
+    let node_position =
+        NodePosition::new(&txn, &nats, &node.id, context_id, x, y, &nba.workspace.id)
+            .await
+            .expect("cannot create new node position");
+
+    assert!(node_position.id.starts_with("nodePosition:"));
+    assert_eq!(node_position.node_id, node.id);
+    assert_eq!(node_position.context_id, context_id);
+    assert_eq!(node_position.x, x);
+    assert_eq!(node_position.y, y);
+}
+
+#[tokio::test]
+async fn by_node_id() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new billing account");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new change set");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let node_1 = create_entity_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &nba.system,
+        &change_set,
+        &edit_session,
+    )
+    .await;
+
+    let node_2 = create_entity_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &nba.system,
+        &change_set,
+        &edit_session,
+    )
+    .await;
+
+    let pos_1 = create_node_position(&txn, &nats, &node_1.id, "context-1", &nba).await;
+    let pos_2 = create_node_position(&txn, &nats, &node_1.id, "context-2", &nba).await;
+    let pos_3 = create_node_position(&txn, &nats, &node_1.id, "context-3", &nba).await;
+
+    let pos_4 = create_node_position(&txn, &nats, &node_2.id, "context-4", &nba).await;
+
+    let node_positions = NodePosition::get_by_node_id(&txn, &node_1.id)
+        .await
+        .expect("cannot get node positions");
+
+    assert_eq!(node_positions.len(), 3);
+    assert_eq!(true, node_positions.iter().any(|pos| pos == &pos_1));
+    assert_eq!(true, node_positions.iter().any(|pos| pos == &pos_2));
+    assert_eq!(true, node_positions.iter().any(|pos| pos == &pos_3));
+    assert_eq!(false, node_positions.iter().any(|pos| pos == &pos_4));
+}
+
+#[tokio::test]
+async fn save() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new billing account");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+    txn.commit()
+        .await
+        .expect("failed to commit the new change set");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let node = create_entity_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &nba.system,
+        &change_set,
+        &edit_session,
+    )
+    .await;
+
+    let mut pos = create_node_position(&txn, &nats, &node.id, "context-1", &nba).await;
+
+    pos.x = "123".to_string();
+    pos.y = "99.7".to_string();
+    pos.save(&txn, &nats)
+        .await
+        .expect("cannot save node position");
+
+    assert_eq!(pos.x, "123");
+    assert_eq!(pos.y, "99.7");
+}


### PR DESCRIPTION
This is a first step addition of a NodePosition model to track the x/y
positions of Nodes within a "contex"--that is, a uniquely named
identifier that allows one Node to have multiple positions in different
contexts.

Currently, the `positions` field on `Node` is removed, which breaks the
current contract with the front end, but that will be addressed in
future work.

Additionally, several unused warnings were cleaned up.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>