### PR TITLE
build: enable clean run of root `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 
 include ./components/build/deps.mk
 
-COMPONENTS = components/si-data components/si-entity components/si-model components/si-model-test components/si-veritech components/si-registry components/si-settings components/si-web-app components/si-sdf
+COMPONENTS = components/si-data components/si-entity components/si-model components/si-model-test components/si-veritech components/si-registry components/si-settings components/si-sdf components/si-web-app
 RELEASEABLE_COMPONENTS = components/si-veritech components/si-sdf components/si-web-app
 RUNNABLE_COMPONENTS = components/si-veritech components/si-sdf components/si-web-app
 BUILDABLE = $(patsubst %,build//%,$(COMPONENTS))

--- a/components/si-entity/Makefile
+++ b/components/si-entity/Makefile
@@ -2,6 +2,16 @@ include ../build/typescript.mk
 COMPONENT = si-entity
 .DEFAULT_GOAL := build
 
+registry:
+	@echo "--- [$(shell basename ${CURDIR})] $@"
+	$(MAKE) -C ../si-registry build
+.PHONY: registry
+
+build: registry
+	@echo "--- [$(shell basename ${CURDIR})] $@"
+	$(MAKE) node_modules
+	env NODE_ENV=production npm run build
+
 watch:
 	@echo "--- [$(shell basename ${CURDIR})] $@"
 	npm run watch

--- a/components/si-web-app/Makefile
+++ b/components/si-web-app/Makefile
@@ -5,7 +5,7 @@ CONTAINER = si-web-app
 
 registry:
 	@echo "--- [$(shell basename ${CURDIR})] $@"
-	$(MAKE) -C ../si-registry build_js build_types
+	$(MAKE) -C ../si-registry build
 .PHONY: registry
 
 build: registry


### PR DESCRIPTION
This change update some of the Make targets to allow a reasonably
successful run of `make build` from the root of the project. I say
reasonably today because we presently have several TypeScript production
compilation errors which prevent `si-web-app` from building to
completion. As a result of this, I pushed the building of the web app
until the end, after building SDF as our backend should likely *always*
be buildable.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>