### PR TITLE
feat: workflows and resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tags
 .DS_Store
 node_modules
 .vagrant
+.idea
 target
 kubeconfig.yml
 components/si-pedant/cypress.env.json

--- a/components/si-entity/src/index.ts
+++ b/components/si-entity/src/index.ts
@@ -9,4 +9,4 @@ export {
   EditField,
 } from "./siEntity";
 export { SiStorable } from "./siStorable";
-export { Resource } from "./resource";
+export { Resource, ResourceHealth, ResourceStatus } from "./resource";

--- a/components/si-model/Makefile
+++ b/components/si-model/Makefile
@@ -1,4 +1,4 @@
 include ../build/rust.mk
 COMPONENT = si-model
 .DEFAULT_GOAL := build
-
+WATCH_TASK = build

--- a/components/si-model/src/action.rs
+++ b/components/si-model/src/action.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+use thiserror::Error;
+
+use si_data::{NatsConn, NatsTxn, NatsTxnError, PgPool, PgTxn};
+
+use crate::{entity::diff::Diffs, Resource, SiStorable};
+
+#[derive(Error, Debug)]
+pub enum ActionError {
+    #[error("json serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("nats txn error: {0}")]
+    NatsTxn(#[from] NatsTxnError),
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+}
+
+pub type ActionResult<T> = Result<T, ActionError>;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Display, Clone)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum ActionState {
+    Running,
+    Success,
+    Failure,
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Action {
+    pub id: String,
+    pub name: String,
+    pub dry_run: bool,
+    pub state: ActionState,
+    pub resource: Option<Resource>,
+    pub resource_diff: Option<Diffs>,
+    pub start_unix_timestamp: i64,
+    pub start_timestamp: String,
+    pub end_unix_timestamp: Option<i64>,
+    pub end_timestamp: Option<String>,
+    pub output: Option<String>,
+    pub error: Option<String>,
+    pub entity_id: String,
+    pub system_id: String,
+    pub workflow_run_id: String,
+    pub si_storable: SiStorable,
+}

--- a/components/si-model/src/entity/diff.rs
+++ b/components/si-model/src/entity/diff.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use super::Entity;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum DiffEntry {
     Edit(Edit),
@@ -12,7 +12,7 @@ pub enum DiffEntry {
     RepeatedSize(RepeatedSize),
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Edit {
     pub path: Vec<String>,
@@ -20,21 +20,21 @@ pub struct Edit {
     pub after: serde_json::Value,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Add {
     pub path: Vec<String>,
     pub after: serde_json::Value,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Remove {
     pub path: Vec<String>,
     pub before: serde_json::Value,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RepeatedSize {
     pub path: Vec<String>,

--- a/components/si-model/src/lib.rs
+++ b/components/si-model/src/lib.rs
@@ -18,6 +18,7 @@ mod embedded {
     embed_migrations!("./src/migrations");
 }
 
+pub mod action;
 pub mod api_client;
 pub mod application;
 pub mod billing_account;
@@ -44,8 +45,10 @@ pub mod si_storable;
 pub mod support;
 pub mod system;
 pub mod user;
+pub mod workflow;
 pub mod workspace;
 
+pub use action::{Action, ActionError, ActionResult};
 pub use api_client::{ApiClaim, ApiClient, ApiClientError, ApiClientKind, ApiClientResult};
 pub use application::{
     ApplicationContext, ApplicationEntities, ApplicationError, ApplicationListEntry,
@@ -79,9 +82,11 @@ pub use secret::{
 };
 pub use session::{SessionError, SessionResult};
 pub use si_storable::{MinimalStorable, SiStorable, SimpleStorable};
+pub use support::lodash::{self, LodashError};
 pub use support::veritech::{Veritech, VeritechError};
 pub use system::{SystemError, SystemResult};
 pub use user::{LoginReply, LoginRequest, SiClaims, User, UserError, UserResult};
+pub use workflow::{Workflow, WorkflowContext, WorkflowError, WorkflowRun};
 pub use workspace::{Workspace, WorkspaceError};
 
 #[derive(Error, Debug)]

--- a/components/si-model/src/migrations/U013__events.sql
+++ b/components/si-model/src/migrations/U013__events.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION event_create_v1(this_message text,
                                            OUT object jsonb) AS
 $$
 DECLARE
-    this_id                      bigint;
+    this_id                 bigint;
     si_id                   text;
     this_workspace_id       bigint;
     this_organization_id    bigint;
@@ -84,7 +84,7 @@ CREATE OR REPLACE FUNCTION event_save_v1(input_event jsonb,
 $$
 DECLARE
     this_current events%rowtype;
-    this_id            bigint;
+    this_id      bigint;
 BEGIN
     /* extract the id */
     SELECT si_id_to_primary_key_v1(input_event ->> 'id') INTO this_id;

--- a/components/si-model/src/migrations/U019__nodes.sql
+++ b/components/si-model/src/migrations/U019__nodes.sql
@@ -10,7 +10,8 @@ CREATE TABLE nodes
     tenant_ids         text[]                   NOT NULL,
     obj                jsonb                    NOT NULL,
     created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (object_type, object_si_id)
 );
 
 CREATE OR REPLACE FUNCTION node_create_v1(this_object_type text,

--- a/components/si-model/src/migrations/U022__resources.sql
+++ b/components/si-model/src/migrations/U022__resources.sql
@@ -5,51 +5,16 @@ CREATE TABLE resources
     billing_account_id bigint                   NOT NULL REFERENCES billing_accounts (id),
     organization_id    bigint                   NOT NULL REFERENCES organizations (id),
     workspace_id       bigint                   NOT NULL REFERENCES workspaces (id),
-    node_id            bigint                   UNIQUE NOT NULL,
     entity_id          bigint                   NOT NULL REFERENCES entities (id),
     system_id          bigint                   NOT NULL REFERENCES entities (id),
     tenant_ids         text[]                   NOT NULL,
+    obj                jsonb                    NOT NULL,
     created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (entity_id, system_id)
 );
 
 CREATE INDEX idx_resources_tenant_ids ON "resources" USING GIN ("tenant_ids");
-
-CREATE TABLE resources_head
-(
-    id           bigint PRIMARY KEY REFERENCES resources (id),
-    obj          jsonb                    NOT NULL,
-    system_id          bigint                   NOT NULL REFERENCES entities (id),
-    tenant_ids   text[]                   NOT NULL,
-    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE resources_change_set_projection
-(
-    id            bigint REFERENCES resources (id),
-    obj           jsonb                    NOT NULL,
-    change_set_id bigint                   NOT NULL REFERENCES change_sets (id),
-    system_id          bigint                   NOT NULL REFERENCES entities(id),
-    tenant_ids    text[]                   NOT NULL,
-    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    UNIQUE (id, change_set_id, system_id)
-);
-
-CREATE TABLE resources_edit_session_projection
-(
-    id            bigint REFERENCES resources (id),
-    obj           jsonb                    NOT NULL,
-    change_set_id bigint                   NOT NULL REFERENCES change_sets (id),
-    edit_session_id bigint                   NOT NULL REFERENCES edit_sessions (id),
-    system_id          bigint                   NOT NULL,
-    tenant_ids    text[]                   NOT NULL,
-    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-
-    updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    UNIQUE (id, change_set_id, edit_session_id, system_id)
-);
 
 CREATE OR REPLACE FUNCTION resource_create_v1(this_state jsonb,
                                               this_status text,
@@ -57,10 +22,7 @@ CREATE OR REPLACE FUNCTION resource_create_v1(this_state jsonb,
                                               this_timestamp text,
                                               this_unix_timestamp bigint,
                                               this_system_si_id text,
-                                              this_node_si_id text,
                                               this_entity_si_id text,
-                                              this_change_set_si_id text,
-                                              this_edit_session_si_id text,
                                               si_workspace_id text,
                                               OUT object jsonb) AS
 $$
@@ -70,16 +32,12 @@ DECLARE
     this_workspace_id       bigint;
     this_organization_id    bigint;
     this_billing_account_id bigint;
-    this_change_set_id      bigint;
-    this_edit_session_id    bigint;
-    this_node_id            bigint;
     this_system_id          bigint;
     this_entity_id          bigint;
     tenant_ids              text[];
     created_at              timestamp with time zone;
     updated_at              timestamp with time zone;
     si_storable             jsonb;
-    si_change_set           jsonb;
 BEGIN
     SELECT next_si_id_v1() INTO this_id;
     SELECT 'resource:' || this_id INTO si_id;
@@ -90,103 +48,54 @@ BEGIN
     INTO si_storable, this_organization_id, this_billing_account_id, this_workspace_id, tenant_ids
     FROM si_storable_create_v1(si_id, si_workspace_id, created_at, updated_at);
 
-    SELECT si_id_to_primary_key_v1(this_change_set_si_id) INTO this_change_set_id;
-    SELECT si_id_to_primary_key_v1(this_node_si_id) INTO this_node_id;
     SELECT si_id_to_primary_key_v1(this_system_si_id) INTO this_system_id;
     SELECT si_id_to_primary_key_v1(this_entity_si_id) INTO this_entity_id;
-    SELECT si_id_to_primary_key_v1(this_edit_session_si_id) INTO this_edit_session_id;
-
-    SELECT jsonb_build_object('changeSetId', this_change_set_si_id,
-                              'editSessionId', this_edit_session_si_id)
-    INTO si_change_set;
 
     SELECT jsonb_build_object(
                    'id', si_id,
                    'state', this_state,
                    'status', this_status,
                    'health', this_health,
-                   'nodeId', this_node_si_id,
                    'entityId', this_entity_si_id,
                    'systemId', this_system_si_id,
                    'unixTimestamp', this_unix_timestamp,
                    'timestamp', this_timestamp,
-                   'siChangeSet', si_change_set,
                    'siStorable', si_storable
                )
     INTO object;
 
-    INSERT INTO resources (id, si_id, billing_account_id, organization_id, workspace_id, node_id, entity_id, system_id,
-                           tenant_ids, created_at, updated_at)
+    INSERT INTO resources (id, si_id, billing_account_id, organization_id, workspace_id, entity_id, system_id,
+                           tenant_ids, obj, created_at, updated_at)
     VALUES (this_id, si_id, this_billing_account_id, this_organization_id, this_workspace_id,
-            this_node_id, this_entity_id, this_system_id, tenant_ids, created_at, updated_at);
-
-    INSERT INTO resources_edit_session_projection (id, obj, change_set_id, edit_session_id, system_id, tenant_ids, created_at, updated_at)
-    VALUES (this_id, object, this_change_set_id, this_edit_session_id, this_system_id, tenant_ids, created_at, updated_at);
-END;
+            this_entity_id, this_system_id, tenant_ids, object, created_at, updated_at);
+END ;
 $$ LANGUAGE PLPGSQL VOLATILE;
 
-CREATE OR REPLACE FUNCTION resource_save_head_v1(input_resource jsonb,
-                                                 OUT object jsonb) AS
+CREATE OR REPLACE FUNCTION resource_save_v1(input_resource jsonb,
+                                            OUT object jsonb) AS
 $$
 DECLARE
-    this_id                      bigint;
-    this_change_set_si_id        text;
-    this_tenant_ids              text[];
-    input_resource_no_change_set jsonb;
+    this_current resources%rowtype;
+    this_id      bigint;
 BEGIN
     /* extract the id */
     SELECT si_id_to_primary_key_v1(input_resource ->> 'id') INTO this_id;
 
-    SELECT tenant_ids FROM resources WHERE id = this_id INTO this_tenant_ids;
-    SELECT input_resource ->> 'changeSetId' INTO this_change_set_si_id;
+    SELECT * INTO this_current FROM resources WHERE id = this_id;
+    IF NOT FOUND THEN
+        RAISE WARNING 'resource id % not found', this_id;
+    END IF;
 
-    SELECT input_resource - 'changeSetId' INTO input_resource_no_change_set;
+    /* bail if it is a tenancy violation */
+    IF si_id_to_primary_key_v1(input_resource -> 'siStorable' ->> 'billingAccountId') !=
+       this_current.billing_account_id THEN
+        RAISE WARNING 'mutated billing account id; not allowed!';
+    END IF;
 
-    INSERT INTO resources_head (id, obj, tenant_ids, epoch, update_count, created_at, updated_at)
-    VALUES (this_id, input_resource_no_change_set, this_tenant_ids,
-            (input_resource_no_change_set -> 'siStorable' -> 'updateClock' ->> 'epoch')::bigint,
-            (input_resource_no_change_set -> 'siStorable' -> 'updateClock' ->> 'updateCount')::bigint,
-            DEFAULT,
-            DEFAULT)
-    ON CONFLICT (id) DO UPDATE SET obj          = input_resource_no_change_set,
-                                   epoch        = (input_resource_no_change_set -> 'siStorable' -> 'updateClock' ->> 'epoch')::bigint,
-                                   update_count = (input_resource_no_change_set -> 'siStorable' -> 'updateClock' ->>
-                                                   'updateCount')::bigint,
-                                   updated_at   = now()
-    RETURNING obj INTO object;
-
-    --- Hey, it's us again--you might want this back one day
-    --- IF this_change_set_si_id IS NOT NULL THEN
-    ---     DELETE
-    ---     FROM resources_projection
-    ---     WHERE id = this_id
-    ---       AND change_set_id = si_id_to_primary_key_v1(this_change_set_si_id);
-    --- END IF;
-END
-$$ LANGUAGE PLPGSQL;
-
-CREATE OR REPLACE FUNCTION resource_save_projection_v1(input_resource jsonb,
-                                                       OUT object jsonb) AS
-$$
-DECLARE
-    this_id         bigint;
-    this_tenant_ids text[];
-BEGIN
-    /* extract the id */
-    SELECT si_id_to_primary_key_v1(input_resource ->> 'id') INTO this_id;
-
-    SELECT tenant_ids FROM resources WHERE id = this_id INTO this_tenant_ids;
-
-    INSERT INTO resources_projection (id, obj, change_set_id, tenant_ids, epoch, update_count, created_at, updated_at)
-    VALUES (this_id, input_resource, si_id_to_primary_key_v1(input_resource ->> 'changeSetId'), this_tenant_ids,
-            (input_resource -> 'siStorable' -> 'updateClock' ->> 'epoch')::bigint,
-            (input_resource -> 'siStorable' -> 'updateClock' ->> 'updateCount')::bigint,
-            DEFAULT,
-            DEFAULT)
-    ON CONFLICT (id, change_set_id) DO UPDATE SET obj          = input_resource,
-                                                               epoch        = (input_resource -> 'siStorable' -> 'updateClock' ->> 'epoch')::bigint,
-                                                               update_count = (input_resource -> 'siStorable' -> 'updateClock' ->> 'updateCount')::bigint,
-                                                               updated_at   = now()
+    UPDATE resources
+    SET obj        = input_resource,
+        updated_at = NOW()
+    WHERE id = this_id
     RETURNING obj INTO object;
 END
 $$ LANGUAGE PLPGSQL;

--- a/components/si-model/src/migrations/U026__workflows.sql
+++ b/components/si-model/src/migrations/U026__workflows.sql
@@ -1,0 +1,353 @@
+CREATE TABLE workflows
+(
+    id         bigint PRIMARY KEY,
+    si_id      text UNIQUE,
+    name       text UNIQUE              NOT NULL,
+    obj        jsonb                    NOT NULL,
+    tenant_ids text[]                   NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (name)
+);
+
+CREATE OR REPLACE FUNCTION workflow_create_or_update_v1(data jsonb,
+                                                        OUT object jsonb) AS
+$$
+DECLARE
+    this_name      text;
+    this_id        bigint;
+    si_id          text;
+    our_tenant_ids text[];
+    created_at     timestamp with time zone;
+    updated_at     timestamp with time zone;
+    si_storable    jsonb;
+BEGIN
+    SELECT data ->> 'name' INTO this_name;
+    SELECT id INTO this_id FROM workflows WHERE name = this_name;
+    IF NOT FOUND THEN
+        SELECT next_si_id_v1() INTO this_id;
+    END IF;
+
+    SELECT 'workflow:' || this_id INTO si_id;
+    SELECT NOW() INTO created_at;
+    SELECT NOW() INTO updated_at;
+
+    SELECT jsonb_build_object(
+                   'typeName', 'workflow',
+                   'objectId', si_id,
+                   'deleted', false,
+                   'createdAt', created_at,
+                   'updatedAt', updated_at
+               )
+    INTO si_storable;
+
+
+    SELECT ARRAY [si_id]
+    INTO our_tenant_ids;
+
+    SELECT jsonb_build_object(
+                   'id', si_id,
+                   'name', this_name,
+                   'data', data,
+                   'siStorable', si_storable
+               )
+    INTO object;
+
+    -- We don't care if a workflow already exists! --
+    INSERT INTO workflows (id, si_id, name, obj, tenant_ids, created_at, updated_at)
+    VALUES (this_id, si_id, this_name, object, our_tenant_ids, created_at, updated_at)
+    ON CONFLICT (id) DO UPDATE SET obj = object, updated_at = NOW();
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE TABLE workflow_runs
+(
+    id                 bigint PRIMARY KEY,
+    si_id              text UNIQUE,
+    workflow_id        bigint                   NOT NULL REFERENCES workflows (id),
+    dry_run            bool                     NOT NULL DEFAULT false,
+    billing_account_id bigint                   NOT NULL REFERENCES billing_accounts (id),
+    organization_id    bigint                   NOT NULL REFERENCES organizations (id),
+    workspace_id       bigint                   NOT NULL REFERENCES workspaces (id),
+    tenant_ids         text[]                   NOT NULL,
+    obj                jsonb                    NOT NULL,
+    created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION workflow_run_create_v1(this_workflow_si_id text,
+                                                  workflow_name text,
+                                                  data jsonb,
+                                                  ctx jsonb,
+                                                  state text,
+                                                  start_timestamp text,
+                                                  start_unix_timestamp bigint,
+                                                  OUT object jsonb) AS
+$$
+DECLARE
+    this_id                 bigint;
+    si_id                   text;
+    this_workflow_id        bigint;
+    this_workspace_id       bigint;
+    this_organization_id    bigint;
+    this_billing_account_id bigint;
+    tenant_ids              text[];
+    created_at              timestamp with time zone;
+    updated_at              timestamp with time zone;
+    si_storable             jsonb;
+    si_workspace_id         text;
+    this_dry_run            bool;
+BEGIN
+    SELECT next_si_id_v1() INTO this_id;
+    SELECT 'workflowRun:' || this_id INTO si_id;
+    SELECT NOW() INTO created_at;
+    SELECT NOW() INTO updated_at;
+
+    SELECT si_id_to_primary_key_v1(this_workflow_si_id) INTO this_workflow_id;
+
+    SELECT ctx -> 'workspace' ->> 'id' INTO si_workspace_id;
+    SELECT our_si_storable, our_organization_id, our_billing_account_id, our_workspace_id, our_tenant_ids
+    INTO si_storable, this_organization_id, this_billing_account_id, this_workspace_id, tenant_ids
+    FROM si_storable_create_v1(si_id, si_workspace_id, created_at, updated_at);
+
+    SELECT (ctx ->> 'dryRun')::bool INTO this_dry_run;
+    SELECT jsonb_build_object(
+                   'id', si_id,
+                   'startTimestamp', start_timestamp,
+                   'startUnixTimestamp', start_unix_timestamp,
+                   'state', state,
+                   'workflowId', this_workflow_si_id,
+                   'workflowName', workflow_name,
+                   'data', data,
+                   'ctx', ctx,
+                   'siStorable', si_storable
+               )
+    INTO object;
+
+    INSERT INTO workflow_runs (id, si_id, workflow_id, dry_run, billing_account_id, organization_id, workspace_id,
+                               tenant_ids, obj,
+                               created_at, updated_at)
+    VALUES (this_id, si_id, this_workflow_id, this_dry_run, this_billing_account_id, this_organization_id,
+            this_workspace_id, tenant_ids,
+            object, created_at, updated_at);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION workflow_run_save_v1(input jsonb,
+                                                     OUT object jsonb) AS
+$$
+DECLARE
+    this_current workflow_runs%rowtype;
+    this_id      bigint;
+BEGIN
+    /* extract the id */
+    SELECT si_id_to_primary_key_v1(input ->> 'id') INTO this_id;
+
+    SELECT * INTO this_current FROM workflow_runs WHERE id = this_id;
+    IF NOT FOUND THEN
+        RAISE WARNING 'workflow run id % not found', this_id;
+    END IF;
+
+    /* bail if it is a tenancy violation */
+    IF si_id_to_primary_key_v1(input -> 'siStorable' ->> 'billingAccountId') !=
+       this_current.billing_account_id THEN
+        RAISE WARNING 'mutated billing account id; not allowed!';
+    END IF;
+
+    UPDATE workflow_runs
+    SET obj        = input,
+        updated_at = NOW()
+    WHERE id = this_id
+    RETURNING obj INTO object;
+END
+$$ LANGUAGE PLPGSQL;
+
+
+CREATE TABLE workflow_run_steps
+(
+    id                 bigint PRIMARY KEY,
+    si_id              text UNIQUE,
+    workflow_run_id    bigint                   NOT NULL REFERENCES workflow_runs (id),
+    billing_account_id bigint                   NOT NULL REFERENCES billing_accounts (id),
+    organization_id    bigint                   NOT NULL REFERENCES organizations (id),
+    workspace_id       bigint                   NOT NULL REFERENCES workspaces (id),
+    tenant_ids         text[]                   NOT NULL,
+    obj                jsonb                    NOT NULL,
+    created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION workflow_run_step_create_v1(this_workflow_run_si_id text,
+                                                       this_step jsonb,
+                                                       this_state text,
+                                                       start_timestamp text,
+                                                       start_unix_timestamp bigint,
+                                                       this_workspace_si_id text,
+                                                       OUT object jsonb) AS
+$$
+DECLARE
+    this_id                 bigint;
+    si_id                   text;
+    this_workflow_run_id    bigint;
+    this_workspace_id       bigint;
+    this_organization_id    bigint;
+    this_billing_account_id bigint;
+    tenant_ids              text[];
+    created_at              timestamp with time zone;
+    updated_at              timestamp with time zone;
+    si_storable             jsonb;
+BEGIN
+    SELECT next_si_id_v1() INTO this_id;
+    SELECT 'workflowRunStep:' || this_id INTO si_id;
+    SELECT NOW() INTO created_at;
+    SELECT NOW() INTO updated_at;
+
+    SELECT our_si_storable, our_organization_id, our_billing_account_id, our_workspace_id, our_tenant_ids
+    INTO si_storable, this_organization_id, this_billing_account_id, this_workspace_id, tenant_ids
+    FROM si_storable_create_v1(si_id, this_workspace_si_id, created_at, updated_at);
+
+    SELECT si_id_to_primary_key_v1(this_workflow_run_si_id) INTO this_workflow_run_id;
+
+    SELECT jsonb_build_object(
+                   'id', si_id,
+                   'workflowRunId', this_workflow_run_si_id,
+                   'startTimestamp', start_timestamp,
+                   'startUnixTimestamp', start_unix_timestamp,
+                   'state', this_state,
+                   'step', this_step,
+                   'siStorable', si_storable
+               )
+    INTO object;
+
+    INSERT INTO workflow_run_steps (id, si_id, workflow_run_id, billing_account_id, organization_id, workspace_id,
+                                    tenant_ids, obj, created_at, updated_at)
+    VALUES (this_id, si_id, this_workflow_run_id, this_billing_account_id, this_organization_id, this_workspace_id,
+            tenant_ids, object, created_at, updated_at);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION workflow_run_step_save_v1(input jsonb,
+                                                     OUT object jsonb) AS
+$$
+DECLARE
+    this_current workflow_run_steps%rowtype;
+    this_id      bigint;
+BEGIN
+    /* extract the id */
+    SELECT si_id_to_primary_key_v1(input ->> 'id') INTO this_id;
+
+    SELECT * INTO this_current FROM workflow_run_steps WHERE id = this_id;
+    IF NOT FOUND THEN
+        RAISE WARNING 'workflow run step id % not found', this_id;
+    END IF;
+
+    /* bail if it is a tenancy violation */
+    IF si_id_to_primary_key_v1(input -> 'siStorable' ->> 'billingAccountId') !=
+       this_current.billing_account_id THEN
+        RAISE WARNING 'mutated billing account id; not allowed!';
+    END IF;
+
+    UPDATE workflow_run_steps
+    SET obj        = input,
+        updated_at = NOW()
+    WHERE id = this_id
+    RETURNING obj INTO object;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE TABLE workflow_run_step_entities
+(
+    id                   bigint PRIMARY KEY,
+    si_id                text UNIQUE,
+    workflow_run_step_id bigint                   NOT NULL REFERENCES workflow_run_steps (id),
+    entity_id            bigint                   NOT NULL REFERENCES entities (id),
+    billing_account_id   bigint                   NOT NULL REFERENCES billing_accounts (id),
+    organization_id      bigint                   NOT NULL REFERENCES organizations (id),
+    workspace_id         bigint                   NOT NULL REFERENCES workspaces (id),
+    tenant_ids           text[]                   NOT NULL,
+    obj                  jsonb                    NOT NULL,
+    created_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION workflow_run_step_entity_create_v1(this_workflow_run_si_id text,
+                                                              this_workflow_run_step_si_id text,
+                                                              this_entity_si_id text,
+                                                              this_state text,
+                                                              start_timestamp text,
+                                                              start_unix_timestamp bigint,
+                                                              this_workspace_si_id text,
+                                                              OUT object jsonb) AS
+$$
+DECLARE
+    this_id                   bigint;
+    si_id                     text;
+    this_entity_id            bigint;
+    this_workflow_run_step_id bigint;
+    this_workspace_id         bigint;
+    this_organization_id      bigint;
+    this_billing_account_id   bigint;
+    tenant_ids                text[];
+    created_at                timestamp with time zone;
+    updated_at                timestamp with time zone;
+    si_storable               jsonb;
+BEGIN
+    SELECT next_si_id_v1() INTO this_id;
+    SELECT 'workflowRunStepEntity:' || this_id INTO si_id;
+    SELECT NOW() INTO created_at;
+    SELECT NOW() INTO updated_at;
+
+    SELECT our_si_storable, our_organization_id, our_billing_account_id, our_workspace_id, our_tenant_ids
+    INTO si_storable, this_organization_id, this_billing_account_id, this_workspace_id, tenant_ids
+    FROM si_storable_create_v1(si_id, this_workspace_si_id, created_at, updated_at);
+
+    SELECT si_id_to_primary_key_v1(this_workflow_run_step_si_id) INTO this_workflow_run_step_id;
+    SELECT si_id_to_primary_key_v1(this_entity_si_id) INTO this_entity_id;
+
+    SELECT jsonb_build_object(
+                   'id', si_id,
+                   'entityId', this_entity_si_id,
+                   'workflowRunId', this_workflow_run_si_id,
+                   'workflowRunStepId', this_workflow_run_step_si_id,
+                   'startTimestamp', start_timestamp,
+                   'startUnixTimestamp', start_unix_timestamp,
+                   'state', this_state,
+                   'siStorable', si_storable
+               )
+    INTO object;
+
+    INSERT INTO workflow_run_step_entities (id, si_id, workflow_run_step_id, entity_id, billing_account_id,
+                                            organization_id, workspace_id, tenant_ids, obj, created_at, updated_at)
+    VALUES (this_id, si_id, this_workflow_run_step_id, this_entity_id, this_billing_account_id, this_organization_id,
+            this_workspace_id, tenant_ids, object, created_at, updated_at);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION workflow_run_step_entity_save_v1(input jsonb,
+                                                     OUT object jsonb) AS
+$$
+DECLARE
+    this_current workflow_run_step_entities%rowtype;
+    this_id      bigint;
+BEGIN
+    /* extract the id */
+    SELECT si_id_to_primary_key_v1(input ->> 'id') INTO this_id;
+
+    SELECT * INTO this_current FROM workflow_run_step_entities WHERE id = this_id;
+    IF NOT FOUND THEN
+        RAISE WARNING 'workflow run step id % not found', this_id;
+    END IF;
+
+    /* bail if it is a tenancy violation */
+    IF si_id_to_primary_key_v1(input -> 'siStorable' ->> 'billingAccountId') !=
+       this_current.billing_account_id THEN
+        RAISE WARNING 'mutated billing account id; not allowed!';
+    END IF;
+
+    UPDATE workflow_run_step_entities
+    SET obj        = input,
+        updated_at = NOW()
+    WHERE id = this_id
+    RETURNING obj INTO object;
+END
+$$ LANGUAGE PLPGSQL;

--- a/components/si-model/src/qualification.rs
+++ b/components/si-model/src/qualification.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{ModelError, SiChangeSet, SiStorable};
-use si_data::{NatsConn, NatsTxn, NatsTxnError, PgPool, PgTxn};
+use crate::{SiChangeSet, SiStorable};
+use si_data::{NatsTxn, NatsTxnError, PgTxn};
 
 const QUALIFICATION_FOR_EDIT_SESSION: &str =
     include_str!("./queries/qualification_for_edit_session.sql");
@@ -23,9 +23,6 @@ pub enum QualificationError {
 }
 
 pub type QualificationResult<T> = Result<T, QualificationError>;
-
-// TODO: Implement the edit session and change set apply saves for the
-// qualifications
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/components/si-model/src/queries/resource_get_by_entity_and_system.sql
+++ b/components/si-model/src/queries/resource_get_by_entity_and_system.sql
@@ -1,0 +1,4 @@
+SELECT obj AS object
+FROM resources
+WHERE entity_id = si_id_to_primary_key_v1($1)
+  AND system_id = si_id_to_primary_key_v1($2);

--- a/components/si-model/src/queries/resources_for_edit_session.sql
+++ b/components/si-model/src/queries/resources_for_edit_session.sql
@@ -1,9 +1,0 @@
-SELECT COALESCE(resources_edit_session_projection.obj, resources_change_set_projection.obj, resources_head.obj) AS object
-FROM resources
-LEFT JOIN resources_edit_session_projection ON resources_edit_session_projection.id = resources.id
-                                            AND resources_edit_session_projection.change_set_id = si_id_to_primary_key_v1($2)
-                                            AND resources_edit_session_projection.edit_session_id = si_id_to_primary_key_v1($3)
-LEFT JOIN resources_change_set_projection ON resources_change_set_projection.id = resources.id
-                                         AND resources_change_set_projection.change_set_id = si_id_to_primary_key_v1($2)
-LEFT JOIN resources_head ON resources_head.id = resources.id
-WHERE resources.entity_id = si_id_to_primary_key_v1($1);

--- a/components/si-model/src/queries/workflow_action_list_all.sql
+++ b/components/si-model/src/queries/workflow_action_list_all.sql
@@ -1,0 +1,6 @@
+SELECT obj as object
+FROM workflow_runs
+WHERE obj -> 'ctx' -> 'entity' ->> 'id' = $1
+AND obj -> 'ctx' -> 'system' ->> 'id' = $2
+AND obj -> 'ctx' -> 'workspace' ->> 'id' = $3
+ORDER BY created_at DESC;

--- a/components/si-model/src/queries/workflow_get_by_name.sql
+++ b/components/si-model/src/queries/workflow_get_by_name.sql
@@ -1,0 +1,3 @@
+SELECT obj AS object
+FROM workflows
+WHERE name = $1;

--- a/components/si-model/src/queries/workflow_run_step_entities_all.sql
+++ b/components/si-model/src/queries/workflow_run_step_entities_all.sql
@@ -1,0 +1,3 @@
+SELECT obj AS object
+FROM workflow_run_step_entities
+WHERE workflow_run_step_id = si_id_to_primary_key_v1($1);

--- a/components/si-model/src/queries/workflow_run_steps_all.sql
+++ b/components/si-model/src/queries/workflow_run_steps_all.sql
@@ -1,0 +1,3 @@
+SELECT obj AS object
+FROM workflow_run_steps
+WHERE workflow_run_id = si_id_to_primary_key_v1($1);

--- a/components/si-model/src/resource.rs
+++ b/components/si-model/src/resource.rs
@@ -1,13 +1,15 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use si_data::{NatsTxn, NatsTxnError, PgTxn};
+use si_data::{NatsConn, NatsTxn, NatsTxnError, PgPool, PgTxn};
 use strum_macros::Display;
 use thiserror::Error;
+use tokio::sync::oneshot;
 
-use crate::{EdgeError, Entity, Node, SiChangeSet, SiStorable};
+use crate::{Edge, EdgeError, EdgeKind, Entity, Node, SiStorable, Veritech, VeritechError};
 
-const RESOURCES_FOR_EDIT_SESSION: &str = include_str!("./queries/resources_for_edit_session.sql");
+const RESOURCE_GET_BY_ENTITY_AND_SYSTEM: &str =
+    include_str!("./queries/resource_get_by_entity_and_system.sql");
 
 #[derive(Error, Debug)]
 pub enum ResourceError {
@@ -19,6 +21,8 @@ pub enum ResourceError {
     TokioPg(#[from] tokio_postgres::Error),
     #[error("nats txn error: {0}")]
     NatsTxn(#[from] NatsTxnError),
+    #[error("pg error: {0}")]
+    Deadpool(#[from] deadpool_postgres::PoolError),
     #[error("serde error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("entity error: {0}")]
@@ -27,6 +31,10 @@ pub enum ResourceError {
     Node(String),
     #[error("edge error: {0}")]
     Edge(#[from] EdgeError),
+    #[error("veritech error: {0}")]
+    Veritech(#[from] VeritechError),
+    #[error("oneshot recv error: {0}")]
+    Recv(#[from] oneshot::error::RecvError),
 }
 
 #[derive(Serialize, Debug)]
@@ -85,6 +93,38 @@ pub enum ResourceHealth {
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct Predecessor {
+    entity: Entity,
+    resource: Resource,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncRequest<'a> {
+    entity: &'a Entity,
+    resource: &'a Resource,
+    system: &'a Entity,
+    predecessors: Vec<Predecessor>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncFinish {
+    pub state: serde_json::Value,
+    pub status: ResourceStatus,
+    pub health: ResourceHealth,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncProtocol {
+    Start(bool),
+    Finish(SyncFinish),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Resource {
     pub id: String,
     pub unix_timestamp: i64,
@@ -93,9 +133,7 @@ pub struct Resource {
     pub status: ResourceStatus,
     pub health: ResourceHealth,
     pub system_id: String,
-    pub node_id: String,
     pub entity_id: String,
-    pub si_change_set: Option<SiChangeSet>,
     pub si_storable: SiStorable,
 }
 
@@ -104,26 +142,20 @@ impl Resource {
         txn: &PgTxn<'_>,
         nats: &NatsTxn,
         state: serde_json::Value,
-        system_id: impl AsRef<str>,
-        node_id: impl AsRef<str>,
         entity_id: impl AsRef<str>,
+        system_id: impl AsRef<str>,
         workspace_id: impl AsRef<str>,
-        change_set_id: impl AsRef<str>,
-        edit_session_id: impl AsRef<str>,
     ) -> ResourceResult<Resource> {
         let system_id = system_id.as_ref();
-        let node_id = node_id.as_ref();
         let entity_id = entity_id.as_ref();
         let workspace_id = workspace_id.as_ref();
-        let change_set_id = change_set_id.as_ref();
-        let edit_session_id = edit_session_id.as_ref();
         let current_time = Utc::now();
         let unix_timestamp = current_time.timestamp_millis();
         let timestamp = format!("{}", current_time);
 
         let row = txn
             .query_one(
-                "SELECT object FROM resource_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+                "SELECT object FROM resource_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
                 &[
                     &state,
                     &ResourceStatus::Pending.to_string(),
@@ -131,10 +163,7 @@ impl Resource {
                     &timestamp,
                     &unix_timestamp,
                     &system_id,
-                    &node_id,
                     &entity_id,
-                    &change_set_id,
-                    &edit_session_id,
                     &workspace_id,
                 ],
             )
@@ -146,29 +175,197 @@ impl Resource {
         Ok(object)
     }
 
-    pub async fn for_edit_session_by_entity_id(
+    pub async fn get_by_entity_and_system(
         txn: &PgTxn<'_>,
         entity_id: impl AsRef<str>,
-        change_set_id: impl AsRef<str>,
-        edit_session_id: impl AsRef<str>,
-    ) -> ResourceResult<Vec<Resource>> {
+        system_id: impl AsRef<str>,
+    ) -> ResourceResult<Option<Self>> {
         let entity_id = entity_id.as_ref();
-        let change_set_id = change_set_id.as_ref();
-        let edit_session_id = edit_session_id.as_ref();
-        let rows = txn
-            .query(
-                RESOURCES_FOR_EDIT_SESSION,
-                &[&entity_id, &change_set_id, &edit_session_id],
+        let system_id = system_id.as_ref();
+        let row = match txn
+            .query_opt(RESOURCE_GET_BY_ENTITY_AND_SYSTEM, &[&entity_id, &system_id])
+            .await?
+        {
+            Some(row) => row,
+            None => return Ok(None),
+        };
+        let object: serde_json::Value = row.try_get("object")?;
+        let object: Self = serde_json::from_value(object)?;
+
+        Ok(Some(object))
+    }
+
+    pub async fn for_system(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        entity_id: impl AsRef<str>,
+        system_id: impl AsRef<str>,
+        workspace_id: impl AsRef<str>,
+    ) -> ResourceResult<Self> {
+        let entity_id = entity_id.as_ref();
+        let system_id = system_id.as_ref();
+
+        let object = match Self::get_by_entity_and_system(txn, entity_id, system_id).await? {
+            Some(object) => object,
+            None => {
+                Self::new(
+                    txn,
+                    nats,
+                    // TODO: likely better defaults here--but does this come from the registry??
+                    serde_json::json!([]),
+                    entity_id,
+                    system_id,
+                    workspace_id,
+                )
+                .await?
+            }
+        };
+
+        Ok(object)
+    }
+
+    pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> ResourceResult<()> {
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+        self.timestamp = timestamp;
+        self.unix_timestamp = unix_timestamp;
+
+        let json = serde_json::to_value(&self)?;
+
+        let row = txn
+            .query_one("SELECT object FROM resource_save_v1($1)", &[&json])
+            .await?;
+        let updated_result: serde_json::Value = row.try_get("object")?;
+        nats.publish(&updated_result).await?;
+
+        let mut updated: Self = serde_json::from_value(updated_result)?;
+        std::mem::swap(self, &mut updated);
+        Ok(())
+    }
+
+    pub async fn sync(
+        self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+    ) -> ResourceResult<()> {
+        self.sync_inner(pg, nats_conn, veritech, None).await
+    }
+
+    pub async fn await_sync(
+        &mut self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+    ) -> ResourceResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sync_inner(pg, nats_conn, veritech, Some(tx)).await?;
+
+        let mut updated = rx.await??;
+        std::mem::swap(self, &mut updated);
+
+        Ok(())
+    }
+
+    async fn sync_inner(
+        &self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+        wait_channel: Option<oneshot::Sender<ResourceResult<Self>>>,
+    ) -> ResourceResult<()> {
+        let resource = self.clone();
+        let resource_id = self.id.clone();
+
+        tokio::spawn(async move {
+            let result = resource.sync_task(pg, nats_conn, veritech).await;
+
+            if let Err(ref err) = result {
+                dbg!("syncing resource {} failed {:?}", resource_id, err);
+            }
+            if let Some(wait_channel) = wait_channel {
+                let _ = wait_channel.send(result);
+            }
+        });
+        Ok(())
+    }
+
+    pub async fn sync_task(
+        mut self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+    ) -> ResourceResult<Self> {
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let nats = nats_conn.transaction();
+
+        let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<SyncProtocol>();
+
+        let entity = Entity::for_head(&txn, &self.entity_id)
+            .await
+            .map_err(|err| ResourceError::Entity(err.to_string()))?;
+        let system = Entity::for_head(&txn, &self.system_id)
+            .await
+            .map_err(|err| ResourceError::Entity(err.to_string()))?;
+
+        let predecessor_edges =
+            Edge::direct_predecessor_edges_by_object_id(&txn, &EdgeKind::Configures, &entity.id)
+                .await?;
+        let mut predecessors: Vec<Predecessor> = Vec::new();
+        for edge in predecessor_edges {
+            let edge_entity = Entity::for_head(&txn, &edge.tail_vertex.object_id)
+                .await
+                .map_err(|e| ResourceError::Entity(e.to_string()))?;
+            let predecessor_resource = Self::for_system(
+                &txn,
+                &nats,
+                &edge_entity.id,
+                &system.id,
+                &self.si_storable.workspace_id,
             )
             .await?;
-
-        let mut results: Vec<Resource> = Vec::new();
-        for row in rows.into_iter() {
-            let json: serde_json::Value = row.try_get("object")?;
-            let resource: Resource = serde_json::from_value(json)?;
-            results.push(resource);
+            let predecessor = Predecessor {
+                entity: edge_entity,
+                resource: predecessor_resource,
+            };
+            predecessors.push(predecessor);
         }
 
-        Ok(results)
+        let request = SyncRequest {
+            entity: &entity,
+            resource: &self,
+            system: &system,
+            predecessors,
+        };
+
+        veritech
+            .send_async("syncResource", request, progress_tx)
+            .await?;
+
+        while let Some(message) = progress_rx.recv().await {
+            match message {
+                SyncProtocol::Start(_) => {
+                    dbg!("started!");
+                }
+                SyncProtocol::Finish(finish) => {
+                    dbg!("command finished!: {:?}", &finish);
+                    self.state = finish.state;
+                    self.status = finish.status;
+                    self.health = finish.health;
+                    if let Some(err_msg) = finish.error {
+                        dbg!("uh oh, error when syncing resource: {}", err_msg);
+                    }
+                }
+            }
+        }
+
+        self.save(&txn, &nats).await?;
+
+        txn.commit().await?;
+        nats.commit().await?;
+
+        Ok(self)
     }
 }

--- a/components/si-model/src/si_storable.rs
+++ b/components/si-model/src/si_storable.rs
@@ -22,7 +22,7 @@ pub struct SimpleStorable {
     pub deleted: bool,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MinimalStorable {
     pub type_name: String,

--- a/components/si-model/src/support.rs
+++ b/components/si-model/src/support.rs
@@ -1,1 +1,2 @@
+pub mod lodash;
 pub mod veritech;

--- a/components/si-model/src/support/lodash.rs
+++ b/components/si-model/src/support/lodash.rs
@@ -1,0 +1,127 @@
+// This is an implementation of the logic from lodash's 'get' method.
+//
+// It allows a path separated list of items to retrieve from a serde_json::Value.
+//
+// It does not support defaults - yet!
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LodashError {
+    #[error("initial get must be on a serde_json::Value::Object")]
+    InvalidFirstObject,
+    #[error("array value requires numeric index")]
+    NumericIndex(#[from] std::num::ParseIntError),
+}
+
+pub type LodashResult<T> = Result<T, LodashError>;
+
+pub fn get(
+    json: &serde_json::Value,
+    path: &Vec<impl AsRef<str>>,
+) -> LodashResult<Option<serde_json::Value>> {
+    if !json.is_object() {
+        return Err(LodashError::InvalidFirstObject);
+    }
+    if path.is_empty() {
+        return Ok(Some(json.clone()));
+    }
+    let mut current_value = json;
+    let list_entry_index = path.len() - 1;
+    for (i, entry) in path.into_iter().enumerate() {
+        let entry = entry.as_ref();
+        let is_last_entry = i == list_entry_index;
+        if current_value.is_array() {
+            let index: usize = entry.parse::<usize>()?;
+            let value = current_value.as_array().unwrap().get(index);
+            if is_last_entry {
+                return Ok(value.map(|v| v.clone()));
+            } else {
+                match value {
+                    Some(v) => current_value = v,
+                    None => return Ok(None),
+                }
+            }
+        } else if current_value.is_object() {
+            let object = current_value.as_object().unwrap();
+            let value = object.get(entry);
+            if is_last_entry {
+                return Ok(value.map(|v| v.clone()));
+            } else {
+                match value {
+                    Some(v) => current_value = v,
+                    None => return Ok(None),
+                }
+            }
+        } else {
+            // If it isn't an array or an object - then what was asked for
+            // does not exist.
+            return Ok(None);
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn no_object_errors() {
+        let json = serde_json::json!["pinky"];
+        let result = get(&json, &vec!["making us", "hostile"]);
+        assert_eq!(result.is_err(), true, "should error");
+    }
+
+    #[test]
+    fn top_level_value() {
+        let json = serde_json::json![{"pinky":"the brain" }];
+        let result = get(&json, &vec!["pinky"])
+            .expect("lookup should succeed")
+            .expect("lookup should have a value");
+        assert_eq!(result, serde_json::json!["the brain"]);
+    }
+
+    #[test]
+    fn nested_value() {
+        let json = serde_json::json![{"pinky":{"what will we do tonight": "same thing we do every night" }}];
+        let result = get(&json, &vec!["pinky", "what will we do tonight"])
+            .expect("lookup should succeed")
+            .expect("lookup should have a value");
+        assert_eq!(result, serde_json::json!["same thing we do every night"]);
+    }
+
+    #[test]
+    fn nested_value_array() {
+        let json = serde_json::json![{"pinky":{"what will we do tonight": ["nothing", "same thing we do every night"] }}];
+        let result = get(&json, &vec!["pinky", "what will we do tonight", "1"])
+            .expect("lookup should succeed")
+            .expect("lookup should have a value");
+        assert_eq!(result, serde_json::json!["same thing we do every night"]);
+    }
+
+    #[test]
+    fn nested_value_array_bad_index() {
+        let json = serde_json::json![{"pinky":{"what will we do tonight": ["nothing", "same thing we do every night"] }}];
+        let result = get(&json, &vec!["pinky", "what will we do tonight", "55"])
+            .expect("lookup should succeed");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn nested_value_array_bad_index_not_a_number() {
+        let json = serde_json::json![{"pinky":{"what will we do tonight": ["nothing", "same thing we do every night"] }}];
+        let result = get(
+            &json,
+            &vec!["pinky", "what will we do tonight", "fiftyfive"],
+        );
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn path_does_not_exist() {
+        let json = serde_json::json![{"pinky":{"what will we do tonight": ["nothing", "same thing we do every night"] }}];
+        let result = get(&json, &vec!["what", "is", "my", "pinky"]).expect("lookup should succeed");
+        assert_eq!(result, None);
+    }
+}

--- a/components/si-model/src/support/veritech.rs
+++ b/components/si-model/src/support/veritech.rs
@@ -4,10 +4,7 @@ use thiserror::Error;
 
 use si_data::{EventLogFS, EventLogFSError};
 
-use crate::{
-    entity::{InferPropertiesRequest, InferPropertiesResponse},
-    Entity,
-};
+use crate::entity::{InferPropertiesRequest, InferPropertiesResponse};
 
 #[derive(Error, Debug)]
 pub enum VeritechError {

--- a/components/si-model/src/workflow.rs
+++ b/components/si-model/src/workflow.rs
@@ -1,0 +1,573 @@
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+use thiserror::Error;
+use tokio::sync::oneshot;
+
+use si_data::{NatsConn, NatsTxn, NatsTxnError, PgPool, PgTxn};
+
+use crate::{
+    Edge, EdgeError, EdgeKind, Entity, LodashError, MinimalStorable, Resource, ResourceError,
+    SiStorable, Veritech, VeritechError, Workspace,
+};
+
+const WORKFLOW_GET_BY_NAME: &str = include_str!("./queries/workflow_get_by_name.sql");
+const WORKFLOW_ACTION_LIST_ALL: &str = include_str!("./queries/workflow_action_list_all.sql");
+const WORKFLOW_RUN_STEPS_ALL: &str = include_str!("./queries/workflow_run_steps_all.sql");
+const WORKFLOW_RUN_STEP_ENTITIES_ALL: &str =
+    include_str!("./queries/workflow_run_step_entities_all.sql");
+
+pub mod step;
+pub mod variable;
+
+use crate::workflow::step::Step;
+
+use self::step::{WorkflowRunStep, WorkflowRunStepEntity};
+
+#[derive(Error, Debug)]
+pub enum WorkflowError {
+    #[error("json serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("nats txn error: {0}")]
+    NatsTxn(#[from] NatsTxnError),
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+    #[error("pg error: {0}")]
+    Deadpool(#[from] deadpool_postgres::PoolError),
+    #[error("veritech error: {0}")]
+    Veritech(#[from] VeritechError),
+    #[error("lodash error: {0}")]
+    Lodash(#[from] LodashError),
+    #[error("no selector or implicit entity provided; invalid step!")]
+    NoSelectorOrEntity,
+    #[error("no {0} value found in {1} for path {2}")]
+    NoValue(String, String, String),
+    #[error("expected {0} recevied {:?}")]
+    WrongType(String, serde_json::Value),
+    #[error("invalid strategy: {0}")]
+    InvalidStrategy(String),
+    #[error("no inputs when they were required")]
+    NoInputs,
+    #[error("no system is provided, but is required!")]
+    SystemRequired,
+    #[error("edge error: {0}")]
+    Edge(#[from] EdgeError),
+    #[error("entity error: {0}")]
+    Entity(String),
+    #[error("resource error: {0}")]
+    Resource(#[from] ResourceError),
+}
+
+pub type WorkflowResult<T> = Result<T, WorkflowError>;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Display, Clone)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum WorkflowRunState {
+    Invoked,
+    Running,
+    Success,
+    Failure,
+    Unknown,
+}
+
+impl Default for WorkflowRunState {
+    fn default() -> Self {
+        Self::Invoked
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunListItem {
+    workflow_run: WorkflowRun,
+    steps: Vec<WorkflowRunListStepsItem>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunListStepsItem {
+    step: WorkflowRunStep,
+    step_entities: Vec<WorkflowRunStepEntity>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRun {
+    pub id: String,
+    pub start_unix_timestamp: i64,
+    pub start_timestamp: String,
+    pub end_unix_timestamp: Option<i64>,
+    pub end_timestamp: Option<String>,
+    pub state: WorkflowRunState,
+    pub workflow_id: String,
+    pub workflow_name: String,
+    pub data: WorkflowData,
+    pub ctx: WorkflowContext,
+    pub si_storable: SiStorable,
+}
+
+impl WorkflowRun {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        workflow: &Workflow,
+        ctx: WorkflowContext,
+    ) -> WorkflowResult<Self> {
+        let workflow_data = serde_json::to_value(workflow.data.clone())?;
+        let ctx = serde_json::to_value(ctx)?;
+        let state = WorkflowRunState::default();
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM workflow_run_create_v1($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &workflow.id,
+                    &workflow.name,
+                    &workflow_data,
+                    &ctx,
+                    &state.to_string(),
+                    &timestamp,
+                    &unix_timestamp,
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish(&json).await?;
+        let object: Self = serde_json::from_value(json)?;
+
+        Ok(object)
+    }
+
+    pub async fn list_actions(
+        txn: &PgTxn<'_>,
+        entity_id: impl AsRef<str>,
+        system_id: impl AsRef<str>,
+        workspace_id: impl AsRef<str>,
+        action_name: Option<impl AsRef<str>>,
+    ) -> WorkflowResult<Vec<WorkflowRunListItem>> {
+        let entity_id = entity_id.as_ref();
+        let system_id = system_id.as_ref();
+        let workspace_id = workspace_id.as_ref();
+        let rows = if let Some(action_name) = action_name {
+            let action_name = action_name.as_ref();
+            // TODO: Don't leave this like that ;)
+            let rows = txn
+                .query(
+                    WORKFLOW_ACTION_LIST_ALL,
+                    &[&entity_id, &system_id, &workspace_id],
+                )
+                .await?;
+            rows
+        } else {
+            let rows = txn
+                .query(
+                    WORKFLOW_ACTION_LIST_ALL,
+                    &[&entity_id, &system_id, &workspace_id],
+                )
+                .await?;
+            rows
+        };
+        let mut results: Vec<WorkflowRunListItem> = vec![];
+
+        for row in rows.into_iter() {
+            let workflow_run_json: serde_json::Value = row.try_get("object")?;
+            let workflow_run: WorkflowRun = serde_json::from_value(workflow_run_json)?;
+            let workflow_run_steps_rows = txn
+                .query(WORKFLOW_RUN_STEPS_ALL, &[&workflow_run.id])
+                .await?;
+            let mut wrs_results: Vec<WorkflowRunListStepsItem> = vec![];
+            for wrs_row in workflow_run_steps_rows.into_iter() {
+                let workflow_run_step_json: serde_json::Value = wrs_row.try_get("object")?;
+                let workflow_run_step: WorkflowRunStep =
+                    serde_json::from_value(workflow_run_step_json)?;
+                let workflow_run_step_entity_rows = txn
+                    .query(WORKFLOW_RUN_STEP_ENTITIES_ALL, &[&workflow_run_step.id])
+                    .await?;
+                let mut wrse_results: Vec<WorkflowRunStepEntity> = vec![];
+                for wrse_row in workflow_run_step_entity_rows.into_iter() {
+                    let workflow_run_step_entity_json: serde_json::Value =
+                        wrse_row.try_get("object")?;
+                    let workflow_run_step_entity: WorkflowRunStepEntity =
+                        serde_json::from_value(workflow_run_step_entity_json)?;
+                    wrse_results.push(workflow_run_step_entity);
+                }
+                wrs_results.push(WorkflowRunListStepsItem {
+                    step: workflow_run_step,
+                    step_entities: wrse_results,
+                });
+            }
+            results.push(WorkflowRunListItem {
+                workflow_run,
+                steps: wrs_results,
+            });
+        }
+        Ok(results)
+    }
+
+    pub async fn invoke(
+        &self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+        wait_channel: Option<oneshot::Sender<WorkflowResult<()>>>,
+    ) -> WorkflowResult<()> {
+        let workflow_name = self.workflow_name.clone();
+        let workflow_run = self.clone();
+        tokio::spawn(async move {
+            let result = workflow_run.invoke_task(pg, nats_conn, veritech).await;
+
+            if let Err(ref err) = result {
+                dbg!("invoking workflow {} failed: {:?}", workflow_name, err);
+            }
+            if let Some(wait_channel) = wait_channel {
+                let _ = wait_channel.send(result);
+            }
+        });
+        Ok(())
+    }
+
+    async fn invoke_task(
+        mut self,
+        pg: PgPool,
+        nats_conn: NatsConn,
+        veritech: Veritech,
+    ) -> WorkflowResult<()> {
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let nats = nats_conn.transaction();
+
+        self.state = WorkflowRunState::Running;
+        self.save(&txn, &nats).await?;
+        txn.commit().await?;
+
+        let mut final_state = WorkflowRunState::Success;
+        let mut final_error: Option<WorkflowError> = None;
+        for step in self.data.steps() {
+            match step.run(&pg, &nats_conn, &veritech, &mut self).await {
+                Ok(_) => {}
+                Err(e) => {
+                    final_error = Some(e);
+                    final_state = WorkflowRunState::Failure;
+                    break;
+                }
+            }
+        }
+
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+        self.end_timestamp = Some(timestamp);
+        self.end_unix_timestamp = Some(unix_timestamp);
+        self.state = final_state;
+        let txn = conn.transaction().await?;
+        self.save(&txn, &nats).await?;
+        nats.commit().await?;
+        txn.commit().await?;
+        if let Some(error) = final_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> WorkflowResult<()> {
+        let json = serde_json::to_value(&self)?;
+
+        let row = txn
+            .query_one("SELECT object FROM workflow_run_save_v1($1)", &[&json])
+            .await?;
+        let updated_result: serde_json::Value = row.try_get("object")?;
+        nats.publish(&updated_result).await?;
+
+        let mut updated: Self = serde_json::from_value(updated_result)?;
+        std::mem::swap(self, &mut updated);
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowForAction {
+    name: String,
+    title: String,
+    description: String,
+    steps: Vec<Step>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowTop {
+    name: String,
+    title: String,
+    description: String,
+    steps: Vec<Step>,
+    args: serde_json::Value,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum WorkflowData {
+    Action(WorkflowForAction),
+    //Top(WorkflowTop),
+}
+
+impl WorkflowData {
+    // TODO: This is so unneccsary, but going to work fine.
+    pub fn steps(&self) -> Vec<Step> {
+        match self {
+            WorkflowData::Action(w) => w.steps.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Workflow {
+    id: String,
+    name: String,
+    data: WorkflowData,
+    si_storable: MinimalStorable,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadWorkflowRequest {
+    doit: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadWorkflowReply {
+    workflows: Vec<WorkflowData>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionEntryPredecessor {
+    entity: Entity,
+    resource: Resource,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionEntry {
+    entity: Entity,
+    resource: Resource,
+    predecessors: Vec<SelectionEntryPredecessor>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowContext {
+    pub dry_run: bool,
+    pub entity: Option<Entity>,
+    pub system: Option<Entity>,
+    pub selection: Vec<SelectionEntry>,
+    pub strategy: Option<String>,
+    pub fail_if_missing: Option<bool>,
+    pub inputs: Option<serde_json::Value>,
+    pub args: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub store: Option<serde_json::Value>,
+    pub workspace: Workspace,
+}
+
+impl WorkflowContext {
+    pub async fn for_step(
+        &mut self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        step: &Step,
+    ) -> WorkflowResult<()> {
+        // First, evaluate any selector. If no selector, use the entity from
+        // the workflow run context. If there isn't one, fail with a message
+        // requiring a selector.
+        let selector_entities = match step.selector() {
+            Some(_selector) => {
+                todo!("implement selector resolution");
+            }
+            None => match &self.entity {
+                Some(entity) => {
+                    let mut conn = pg.pool.get().await?;
+                    let txn = conn.transaction().await?;
+                    let nats = nats_conn.transaction();
+                    let system_id = self
+                        .system
+                        .as_ref()
+                        .ok_or(WorkflowError::SystemRequired)?
+                        .id
+                        .clone();
+                    let predecessor_edges = Edge::direct_predecessor_edges_by_object_id(
+                        &txn,
+                        &EdgeKind::Configures,
+                        &entity.id,
+                    )
+                    .await?;
+                    let mut predecessors: Vec<SelectionEntryPredecessor> = Vec::new();
+                    for edge in predecessor_edges {
+                        let edge_entity = Entity::for_head(&txn, &edge.tail_vertex.object_id)
+                            .await
+                            .map_err(|e| WorkflowError::Entity(e.to_string()))?;
+                        let predecessor_resource = Resource::for_system(
+                            &txn,
+                            &nats,
+                            &edge_entity.id,
+                            &system_id,
+                            &self.workspace.id,
+                        )
+                        .await?;
+                        let predecessor = SelectionEntryPredecessor {
+                            entity: edge_entity,
+                            resource: predecessor_resource,
+                        };
+                        predecessors.push(predecessor);
+                    }
+                    let resource = Resource::for_system(
+                        &txn,
+                        &nats,
+                        &entity.id,
+                        &system_id,
+                        &self.workspace.id,
+                    )
+                    .await?;
+                    vec![SelectionEntry {
+                        entity: entity.clone(),
+                        resource,
+                        predecessors,
+                    }]
+                }
+                None => return Err(WorkflowError::NoSelectorOrEntity),
+            },
+        };
+        self.selection = selector_entities;
+
+        // Then, evaluate the strategy for the step. If it isn't one of the
+        // valid values after computing, fail.
+        let strategy = step.strategy(&self)?;
+        match strategy.as_ref() {
+            "linear" => {}
+            _ => return Err(WorkflowError::InvalidStrategy(strategy)),
+        }
+        self.strategy = Some(strategy);
+
+        // Evaluate wether we should fail if the step is missing on the
+        // entities matched by the selector
+        let fail_if_missing = step.fail_if_missing(&self)?;
+        self.fail_if_missing = Some(fail_if_missing);
+
+        // Then, evaluate all the inputs and resolve them. Their values should
+        // be added to the context as 'inputs'.
+        let inputs = step.inputs(&self)?;
+        self.inputs = Some(inputs);
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum InvokeWorkflowProtocol {
+    Start(String),
+    Finished,
+}
+
+impl Workflow {
+    pub async fn load_builtins(pg: &PgPool, veritech: &Veritech) -> WorkflowResult<()> {
+        let reply: LoadWorkflowReply = veritech
+            .send_sync("loadWorkflows", LoadWorkflowRequest { doit: true })
+            .await?;
+
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        for workflow_data in reply.workflows {
+            Self::upsert_from(&txn, &workflow_data).await?;
+        }
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    pub async fn upsert_from(
+        txn: &PgTxn<'_>,
+        workflow_data: &WorkflowData,
+    ) -> WorkflowResult<Self> {
+        let json = serde_json::to_value(workflow_data)?;
+        let row = txn
+            .query_one(
+                "SELECT object from workflow_create_or_update_v1($1)",
+                &[&json],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        let object: Self = serde_json::from_value(json)?;
+
+        Ok(object)
+    }
+
+    pub async fn get_by_name(txn: &PgTxn<'_>, name: impl AsRef<str>) -> WorkflowResult<Self> {
+        let name = name.as_ref();
+
+        let row = txn.query_one(WORKFLOW_GET_BY_NAME, &[&name]).await?;
+        let object: serde_json::Value = row.try_get("object")?;
+        let workflow: Self = serde_json::from_value(object)?;
+
+        Ok(workflow)
+    }
+
+    pub async fn invoke(
+        &self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        veritech: &Veritech,
+        ctx: WorkflowContext,
+    ) -> WorkflowResult<WorkflowRun> {
+        self.inner_invoke(pg, nats_conn, veritech, ctx, None).await
+    }
+
+    pub async fn invoke_and_wait(
+        &self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        veritech: &Veritech,
+        ctx: WorkflowContext,
+    ) -> WorkflowResult<(WorkflowRun, oneshot::Receiver<WorkflowResult<()>>)> {
+        let (tx, rx) = oneshot::channel();
+        let result = self
+            .inner_invoke(pg, nats_conn, veritech, ctx, Some(tx))
+            .await?;
+        Ok((result, rx))
+    }
+
+    async fn inner_invoke(
+        &self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        veritech: &Veritech,
+        ctx: WorkflowContext,
+        wait_channel: Option<oneshot::Sender<WorkflowResult<()>>>,
+    ) -> WorkflowResult<WorkflowRun> {
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let nats = nats_conn.transaction();
+
+        let workflow_run = WorkflowRun::new(&txn, &nats, &self, ctx).await?;
+
+        txn.commit().await?;
+        nats.commit().await?;
+
+        workflow_run
+            .invoke(
+                pg.clone(),
+                nats_conn.clone(),
+                veritech.clone(),
+                wait_channel,
+            )
+            .await?;
+
+        Ok(workflow_run)
+    }
+}

--- a/components/si-model/src/workflow/step.rs
+++ b/components/si-model/src/workflow/step.rs
@@ -1,0 +1,475 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsConn, NatsTxn, PgPool, PgTxn};
+use strum_macros::Display;
+
+use crate::workflow::variable::{VariableArray, VariableBool, VariableScalar};
+use crate::workflow::{
+    SelectionEntry, WorkflowContext, WorkflowError, WorkflowResult, WorkflowRun,
+};
+use crate::{Entity, SiStorable, Veritech, Workspace};
+use chrono::Utc;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Display, Clone)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum WorkflowRunStepState {
+    Running,
+    Success,
+    Failure,
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunStep {
+    pub id: String,
+    pub workflow_run_id: String,
+    pub start_unix_timestamp: i64,
+    pub start_timestamp: String,
+    pub end_unix_timestamp: Option<i64>,
+    pub end_timestamp: Option<String>,
+    pub state: WorkflowRunStepState,
+    pub step: Step,
+    pub si_storable: SiStorable,
+}
+
+impl WorkflowRunStep {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        workflow_run: &WorkflowRun,
+        step: &Step,
+    ) -> WorkflowResult<Self> {
+        let workflow_run_id = &workflow_run.id[..];
+        let workspace_id = &workflow_run.si_storable.workspace_id[..];
+        let step = serde_json::to_value(step)?;
+        let state = WorkflowRunStepState::Running;
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM workflow_run_step_create_v1($1, $2, $3, $4, $5, $6)",
+                &[
+                    &workflow_run_id,
+                    &step,
+                    &state.to_string(),
+                    &timestamp,
+                    &unix_timestamp,
+                    &workspace_id,
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish(&json).await?;
+        let object: Self = serde_json::from_value(json)?;
+
+        Ok(object)
+    }
+
+    pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> WorkflowResult<()> {
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+        let json = serde_json::to_value(&self)?;
+
+        self.end_timestamp = Some(timestamp);
+        self.end_unix_timestamp = Some(unix_timestamp);
+
+        let row = txn
+            .query_one("SELECT object FROM workflow_run_step_save_v1($1)", &[&json])
+            .await?;
+        let updated_result: serde_json::Value = row.try_get("object")?;
+        nats.publish(&updated_result).await?;
+
+        let mut updated: Self = serde_json::from_value(updated_result)?;
+        std::mem::swap(self, &mut updated);
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Display, Clone)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum WorkflowRunStepEntityState {
+    Starting,
+    Running,
+    Success,
+    Failure,
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub struct WorkflowRunStepEntity {
+    pub id: String,
+    pub workflow_run_id: String,
+    pub workflow_run_step_id: String,
+    pub entity_id: String,
+    pub start_unix_timestamp: i64,
+    pub start_timestamp: String,
+    pub end_unix_timestamp: Option<i64>,
+    pub end_timestamp: Option<String>,
+    pub state: WorkflowRunStepEntityState,
+    pub output: Option<String>,
+    pub error: Option<String>,
+    pub si_storable: SiStorable,
+}
+
+impl WorkflowRunStepEntity {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        entity_id: impl AsRef<str>,
+        workflow_run_step: &WorkflowRunStep,
+    ) -> WorkflowResult<Self> {
+        let workflow_run_id = &workflow_run_step.workflow_run_id[..];
+        let workflow_run_step_id = &workflow_run_step.id[..];
+        let entity_id = entity_id.as_ref();
+        let workspace_id = &workflow_run_step.si_storable.workspace_id[..];
+        let state = WorkflowRunStepEntityState::Starting;
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM workflow_run_step_entity_create_v1($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &workflow_run_id,
+                    &workflow_run_step_id,
+                    &entity_id,
+                    &state.to_string(),
+                    &timestamp,
+                    &unix_timestamp,
+                    &workspace_id,
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish(&json).await?;
+        let object: Self = serde_json::from_value(json)?;
+
+        Ok(object)
+    }
+
+    pub async fn save(&mut self, txn: &PgTxn<'_>, nats: &NatsTxn) -> WorkflowResult<()> {
+        let json = serde_json::to_value(&self)?;
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM workflow_run_step_entity_save_v1($1)",
+                &[&json],
+            )
+            .await?;
+        let updated_result: serde_json::Value = row.try_get("object")?;
+        nats.publish(&updated_result).await?;
+
+        let mut updated: Self = serde_json::from_value(updated_result)?;
+        std::mem::swap(self, &mut updated);
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Selector {
+    by_id: VariableScalar,
+    depth: String,
+    edge_kind: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum Step {
+    Command(StepCommand),
+    Action(StepAction),
+    //Workflow(StepWorkflow),
+}
+
+impl Step {
+    pub async fn run(
+        &self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        veritech: &Veritech,
+        workflow_run: &mut WorkflowRun,
+    ) -> WorkflowResult<()> {
+        workflow_run.ctx.for_step(&pg, &nats_conn, self).await?;
+        match self {
+            Step::Command(s) => s.run(pg, nats_conn, veritech, workflow_run).await,
+            Step::Action(s) => s.run(pg, nats_conn, veritech, workflow_run).await,
+        }
+    }
+
+    pub fn selector(&self) -> Option<&Selector> {
+        let result = match self {
+            Step::Command(s) => s.selector.as_ref(),
+            Step::Action(s) => s.selector.as_ref(),
+        };
+        result
+    }
+
+    pub fn strategy(&self, ctx: &WorkflowContext) -> WorkflowResult<String> {
+        let result = match self {
+            Step::Command(s) => s.strategy.evaluate_as_string(ctx)?,
+            Step::Action(s) => s.strategy.evaluate_as_string(ctx)?,
+        };
+        Ok(result)
+    }
+
+    pub fn inputs(&self, ctx: &WorkflowContext) -> WorkflowResult<serde_json::Value> {
+        let result = match self {
+            Step::Command(s) => {
+                serde_json::json![{ "name": s.inputs.name.evaluate_as_string(ctx)? }]
+            }
+            Step::Action(s) => {
+                serde_json::json![{ "name": s.inputs.name.evaluate_as_string(ctx)? }]
+            }
+        };
+        Ok(result)
+    }
+
+    pub fn fail_if_missing(&self, ctx: &WorkflowContext) -> WorkflowResult<bool> {
+        let result = match self {
+            Step::Command(s) => s.fail_if_missing.evaluate_as_bool(ctx)?,
+            Step::Action(s) => s.fail_if_missing.evaluate_as_bool(ctx)?,
+        };
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepCommandInputs {
+    pub name: VariableScalar,
+    pub args: Option<VariableArray>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandRequest<'a> {
+    inputs: &'a serde_json::Value,
+    selection: &'a SelectionEntry,
+    system: Option<&'a Entity>,
+    workspace: &'a Workspace,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum CommandProtocol {
+    Start(bool),
+    Output(CommandOutput),
+    Finish(CommandFinish),
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum CommandOutput {
+    OutputLine(String),
+    ErrorLine(String),
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum CommandFinish {
+    Success(bool),
+    Error(String),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepCommand {
+    pub inputs: StepCommandInputs,
+    pub fail_if_missing: VariableScalar,
+    pub selector: Option<Selector>,
+    pub strategy: VariableScalar,
+}
+
+impl StepCommand {
+    pub async fn run(
+        &self,
+        pg: &PgPool,
+        nats_conn: &NatsConn,
+        veritech: &Veritech,
+        workflow_run: &WorkflowRun,
+    ) -> WorkflowResult<()> {
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let nats = nats_conn.transaction();
+
+        let mut workflow_run_step =
+            WorkflowRunStep::new(&txn, &nats, &workflow_run, &Step::Command(self.clone())).await?;
+
+        // TODO: Only the linear strategy is implemented! eventually, this should
+        // be some kind of wrapper around potential dispatch of this whole section.
+        //
+        // For now, it can just be a long ass adam special.
+        for selection in workflow_run.ctx.selection.iter() {
+            if workflow_run.ctx.inputs.is_none() {
+                return Err(WorkflowError::NoInputs);
+            }
+
+            let inputs = workflow_run.ctx.inputs.as_ref().unwrap(); // Safe, we just checked it.
+
+            let mut workflow_run_step_entity =
+                WorkflowRunStepEntity::new(&txn, &nats, &selection.entity.id, &workflow_run_step)
+                    .await?;
+
+            // Command reqeust!!
+            let request = CommandRequest {
+                inputs,
+                selection,
+                system: workflow_run.ctx.system.as_ref(),
+                workspace: &workflow_run.ctx.workspace,
+            };
+            dbg!("----- context! ----");
+            dbg!(&request);
+            dbg!(&workflow_run.ctx);
+
+            let (progress_tx, mut progress_rx) =
+                tokio::sync::mpsc::unbounded_channel::<CommandProtocol>();
+
+            veritech
+                .send_async("runCommand", request.clone(), progress_tx)
+                .await?;
+
+            while let Some(message) = progress_rx.recv().await {
+                match message {
+                    CommandProtocol::Start(_) => {
+                        dbg!("started!");
+                        workflow_run_step_entity.state = WorkflowRunStepEntityState::Running;
+                        workflow_run_step_entity.save(&txn, &nats).await?;
+                    }
+                    CommandProtocol::Finish(finish) => {
+                        match finish {
+                            CommandFinish::Success(_) => {
+                                workflow_run_step_entity.state =
+                                    WorkflowRunStepEntityState::Success;
+                                let current_time = Utc::now();
+                                let unix_timestamp = current_time.timestamp_millis();
+                                let timestamp = format!("{}", current_time);
+                                workflow_run_step_entity.end_timestamp = Some(timestamp);
+                                workflow_run_step_entity.end_unix_timestamp = Some(unix_timestamp);
+                                workflow_run_step_entity.save(&txn, &nats).await?;
+                                dbg!("command finished with success!");
+                            }
+                            CommandFinish::Error(error) => {
+                                workflow_run_step.state = WorkflowRunStepState::Failure;
+                                workflow_run_step_entity.state =
+                                    WorkflowRunStepEntityState::Failure;
+                                workflow_run_step_entity.error =
+                                    Some(workflow_run_step_entity.error.as_mut().map_or_else(
+                                        || error.clone(),
+                                        |o| {
+                                            o.push_str(&error);
+                                            o.to_string()
+                                        },
+                                    ));
+                                let current_time = Utc::now();
+                                let unix_timestamp = current_time.timestamp_millis();
+                                let timestamp = format!("{}", current_time);
+                                workflow_run_step_entity.end_timestamp = Some(timestamp);
+                                workflow_run_step_entity.end_unix_timestamp = Some(unix_timestamp);
+                                workflow_run_step_entity.save(&txn, &nats).await?;
+                                dbg!("command finished with error! {}", error);
+                            }
+                        }
+                        request
+                            .selection
+                            .resource
+                            .clone()
+                            .sync(pg.clone(), nats_conn.clone(), veritech.clone())
+                            .await?;
+                    }
+                    CommandProtocol::Output(output) => match output {
+                        CommandOutput::OutputLine(output) => {
+                            workflow_run_step_entity.output =
+                                Some(workflow_run_step_entity.output.as_mut().map_or_else(
+                                    || output.clone(),
+                                    |o| {
+                                        o.push_str(&output);
+                                        o.to_string()
+                                    },
+                                ));
+                            workflow_run_step_entity.save(&txn, &nats).await?;
+                            dbg!("stdout: {}", output);
+                        }
+                        CommandOutput::ErrorLine(error) => {
+                            workflow_run_step_entity.error =
+                                Some(workflow_run_step_entity.error.as_mut().map_or_else(
+                                    || error.clone(),
+                                    |o| {
+                                        o.push_str(&error);
+                                        o.to_string()
+                                    },
+                                ));
+                            workflow_run_step_entity.save(&txn, &nats).await?;
+
+                            dbg!("stderr: {}", error);
+                        }
+                    },
+                }
+            }
+        }
+
+        if workflow_run_step.state != WorkflowRunStepState::Failure {
+            workflow_run_step.state = WorkflowRunStepState::Success;
+        }
+        let current_time = Utc::now();
+        let unix_timestamp = current_time.timestamp_millis();
+        let timestamp = format!("{}", current_time);
+        workflow_run_step.end_timestamp = Some(timestamp);
+        workflow_run_step.end_unix_timestamp = Some(unix_timestamp);
+
+        workflow_run_step.save(&txn, &nats).await?;
+        txn.commit().await?;
+        nats.commit().await?;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepActionInputs {
+    name: VariableScalar,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepAction {
+    pub inputs: StepActionInputs,
+    pub fail_if_missing: VariableScalar,
+    pub selector: Option<Selector>,
+    pub strategy: VariableScalar,
+}
+
+impl StepAction {
+    pub async fn run(
+        &self,
+        _pg: &PgPool,
+        _nats_conn: &NatsConn,
+        _veritech: &Veritech,
+        _workflow_run: &WorkflowRun,
+    ) -> WorkflowResult<()> {
+        eprintln!("get ready for a surprise!");
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepWorkflowInputs {
+    name: VariableScalar,
+    args: Option<VariableArray>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StepWorkflow {
+    pub inputs: StepWorkflowInputs,
+    pub fail_if_missing: VariableBool,
+    pub selector: Option<Selector>,
+    pub strategy: VariableScalar,
+}

--- a/components/si-model/src/workflow/variable.rs
+++ b/components/si-model/src/workflow/variable.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::lodash;
+use crate::workflow::{WorkflowContext, WorkflowError, WorkflowResult};
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum Variable {
+    String(VariableString),
+    Number(VariableNumber),
+    Bool(VariableBool),
+    Array(VariableArray),
+    Object(VariableObject),
+    Args(VariableArgs),
+    Context(VariableContext),
+    Output(VariableOutput),
+    Store(VariableStore),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum VariableScalar {
+    Number(VariableNumber),
+    Bool(VariableBool),
+    String(VariableString),
+    Args(VariableArgs),
+    Context(VariableContext),
+    Output(VariableOutput),
+    Store(VariableStore),
+}
+
+impl VariableScalar {
+    pub fn evaluate_as_string(&self, ctx: &WorkflowContext) -> WorkflowResult<String> {
+        match self {
+            VariableScalar::String(var) => Ok(var.value.clone()),
+            VariableScalar::Args(var) => var.evaluate_as_string(&ctx),
+            _ => todo!("fill in the remaining string evaluations!"),
+        }
+    }
+
+    pub fn evaluate_as_bool(&self, ctx: &WorkflowContext) -> WorkflowResult<bool> {
+        match self {
+            VariableScalar::Bool(var) => Ok(var.value.clone()),
+            VariableScalar::Args(var) => var.evaluate_as_bool(&ctx),
+            _ => todo!("fill in the remaining string evaluations!"),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum VariableRef {
+    Args(VariableArgs),
+    Context(VariableContext),
+    Output(VariableOutput),
+    Store(VariableStore),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableBool {
+    pub value: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableString {
+    pub value: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableNumber {
+    pub value: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableArgs {
+    pub path: Vec<String>,
+}
+
+impl VariableArgs {
+    pub fn evaluate_as_bool(&self, ctx: &WorkflowContext) -> WorkflowResult<bool> {
+        match &ctx.args {
+            Some(json) => {
+                let result = lodash::get(&json, &self.path)?;
+                match result {
+                    Some(v) => {
+                        if v.is_boolean() {
+                            return Ok(v.as_bool().unwrap());
+                        } else {
+                            return Err(WorkflowError::WrongType("bool".to_string(), v.clone()));
+                        }
+                    }
+                    None => {
+                        return Err(WorkflowError::NoValue(
+                            "bool".to_string(),
+                            "args".to_string(),
+                            self.path.join(", "),
+                        ));
+                    }
+                }
+            }
+            None => {
+                return Err(WorkflowError::NoValue(
+                    "bool".to_string(),
+                    "args".to_string(),
+                    self.path.join(", "),
+                ))
+            }
+        }
+    }
+
+    pub fn evaluate_as_string(&self, ctx: &WorkflowContext) -> WorkflowResult<String> {
+        match &ctx.args {
+            Some(json) => {
+                let result = lodash::get(&json, &self.path)?;
+                match result {
+                    Some(v) => {
+                        if v.is_string() {
+                            return Ok(v.as_str().unwrap().to_string());
+                        } else {
+                            return Err(WorkflowError::WrongType("string".to_string(), v.clone()));
+                        }
+                    }
+                    None => {
+                        return Err(WorkflowError::NoValue(
+                            "string".to_string(),
+                            "args".to_string(),
+                            self.path.join(", "),
+                        ));
+                    }
+                }
+            }
+            None => {
+                return Err(WorkflowError::NoValue(
+                    "string".to_string(),
+                    "args".to_string(),
+                    self.path.join(", "),
+                ))
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableOutput {
+    pub path: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableStore {
+    pub path: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableContext {
+    pub path: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum VariableObjectValue {
+    Ref(VariableRef),
+    Map(HashMap<String, Variable>),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableObject {
+    pub value: VariableObjectValue,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum VariableArrayValue {
+    Ref(VariableRef),
+    List(Vec<Variable>),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableArray {
+    pub value: VariableArrayValue,
+}

--- a/components/si-model/src/workspace.rs
+++ b/components/si-model/src/workspace.rs
@@ -16,7 +16,7 @@ pub enum WorkspaceError {
 
 pub type WorkspaceResult<T> = Result<T, WorkspaceError>;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Workspace {
     pub id: String,

--- a/components/si-model/tests/model/mod.rs
+++ b/components/si-model/tests/model/mod.rs
@@ -16,4 +16,5 @@ mod qualification;
 mod resource;
 mod secret;
 mod user;
+mod workflow;
 mod workspace;

--- a/components/si-model/tests/model/resource.rs
+++ b/components/si-model/tests/model/resource.rs
@@ -48,22 +48,19 @@ async fn new() {
         &txn,
         &nats,
         serde_json::json!({ "foo": "bar" }),
-        &system_node.object_id,
-        &service_node.id,
         &service_node.object_id,
+        &system_node.object_id,
         &nba.workspace.id,
-        &change_set.id,
-        &edit_session.id,
     )
     .await
     .expect("resource is created");
 
-    assert_eq!(&resource.node_id, &service_node.id);
+    assert_eq!(&resource.system_id, &system_node.object_id);
     assert_eq!(&resource.entity_id, &service_node.object_id);
 }
 
 #[tokio::test]
-async fn for_edit_session_by_entity_id() {
+async fn get_by_entity_and_system() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
     let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
@@ -101,29 +98,263 @@ async fn for_edit_session_by_entity_id() {
     )
     .await;
 
-    let resource = Resource::new(
+    let created = Resource::new(
         &txn,
         &nats,
         serde_json::json!({ "foo": "bar" }),
-        &system_node.object_id,
-        &service_node.id,
         &service_node.object_id,
+        &system_node.object_id,
         &nba.workspace.id,
-        &change_set.id,
-        &edit_session.id,
     )
     .await
     .expect("resource is created");
 
-    let resources = Resource::for_edit_session_by_entity_id(
+    let resource =
+        Resource::get_by_entity_and_system(&txn, &service_node.object_id, &system_node.object_id)
+            .await
+            .expect("failed to query for the resource for system")
+            .expect("could not find resource for system");
+
+    assert_eq!(created, resource);
+}
+
+#[tokio::test]
+async fn get_by_entity_and_system_nonexistant() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+
+    let system_node = create_custom_node(
+        &pg,
         &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "system",
+    )
+    .await;
+    let service_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "service",
+    )
+    .await;
+
+    let resource =
+        Resource::get_by_entity_and_system(&txn, &service_node.object_id, &system_node.object_id)
+            .await
+            .expect("failed to query for the resource for system");
+
+    assert_eq!(None, resource);
+}
+
+#[tokio::test]
+async fn for_system_exists() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+
+    let system_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "system",
+    )
+    .await;
+    let service_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "service",
+    )
+    .await;
+
+    let created = Resource::new(
+        &txn,
+        &nats,
+        serde_json::json!({ "foo": "bar" }),
         &service_node.object_id,
-        &change_set.id,
-        &edit_session.id,
+        &system_node.object_id,
+        &nba.workspace.id,
     )
     .await
-    .expect("cannot get list of resources for edit session");
+    .expect("resource is created");
 
-    assert_eq!(resources.len(), 1);
-    assert_eq!(resources[0], resource);
+    let resource = Resource::for_system(
+        &txn,
+        &nats,
+        &service_node.object_id,
+        &system_node.object_id,
+        &nba.workspace.id,
+    )
+    .await
+    .expect("failed to query for the resource for system");
+
+    assert_eq!(created, resource);
+}
+
+#[tokio::test]
+async fn for_system_nonexistant() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+
+    let system_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "system",
+    )
+    .await;
+    let service_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "service",
+    )
+    .await;
+
+    let resource = Resource::for_system(
+        &txn,
+        &nats,
+        &service_node.object_id,
+        &system_node.object_id,
+        &nba.workspace.id,
+    )
+    .await
+    .expect("failed to query for the resource for system");
+
+    assert_eq!(&resource.system_id, &system_node.object_id);
+    assert_eq!(&resource.entity_id, &service_node.object_id);
+}
+
+#[tokio::test]
+async fn await_sync() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+
+    let mut change_set = create_change_set(&txn, &nats, &nba).await;
+    let mut edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+
+    let system_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "system",
+    )
+    .await;
+    let service_node = create_custom_node(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "service",
+    )
+    .await;
+
+    edit_session
+        .save_session(&txn)
+        .await
+        .expect("failed to save edit session");
+    change_set
+        .apply(&txn)
+        .await
+        .expect("failed to apply change set");
+
+    txn.commit().await.expect("cannot commit txn");
+    nats.commit().await.expect("cannot commit nats txn");
+
+    let txn = conn.transaction().await.expect("cannot get transaction");
+    let nats = nats_conn.transaction();
+
+    let mut resource = Resource::new(
+        &txn,
+        &nats,
+        serde_json::json!({ "foo": "bar" }),
+        &service_node.object_id,
+        &system_node.object_id,
+        &nba.workspace.id,
+    )
+    .await
+    .expect("resource is created");
+
+    let updated_at_created = resource.timestamp.clone();
+
+    txn.commit().await.expect("cannot commit txn");
+    nats.commit().await.expect("cannot commit nats txn");
+
+    resource
+        .await_sync(pg.clone(), nats_conn.clone(), veritech.clone())
+        .await
+        .expect("failed to sync resource");
+
+    assert_ne!(updated_at_created, resource.timestamp);
 }

--- a/components/si-model/tests/model/workflow.rs
+++ b/components/si-model/tests/model/workflow.rs
@@ -1,0 +1,75 @@
+use si_data::{NatsConn, NatsTxn, PgPool, PgTxn};
+use si_model::{
+    system::assign_entity_to_system_by_name, Entity, Veritech, Workflow, WorkflowContext,
+};
+use si_model_test::{
+    create_change_set, create_custom_entity, create_edit_session, one_time_setup,
+    signup_new_billing_account, NewBillingAccount, TestContext,
+};
+use std::time::Duration;
+
+#[tokio::test]
+async fn new() {
+    one_time_setup().await.expect("one time setup failed");
+    let ctx = TestContext::init().await;
+    let (pg, nats_conn, veritech, _event_log_fs, _secret_key) = ctx.entries();
+    let nats = nats_conn.transaction();
+    let mut conn = pg.pool.get().await.expect("cannot connect to pg");
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let nba = signup_new_billing_account(&pg, &txn, &nats, &nats_conn, &veritech).await;
+
+    let system =
+        Entity::get_head_by_name_and_entity_type(&txn, "production", "system", &nba.workspace.id)
+            .await
+            .expect("failed to fetch production system")
+            .pop();
+    let change_set = create_change_set(&txn, &nats, &nba).await;
+    let edit_session = create_edit_session(&txn, &nats, &nba, &change_set).await;
+    let entity = create_custom_entity(
+        &pg,
+        &txn,
+        &nats_conn,
+        &nats,
+        &veritech,
+        &nba,
+        &change_set,
+        &edit_session,
+        "dockerImage",
+    )
+    .await;
+    assign_entity_to_system_by_name(&txn, &nats, "production", &entity)
+        .await
+        .expect("failed to assign entity to system");
+
+    txn.commit().await.expect("failed to commit transaction");
+    nats.commit().await.expect("failed to commit nats");
+
+    let txn = conn.transaction().await.expect("cannot create txn");
+
+    let ctx = WorkflowContext {
+        dry_run: true,
+        entity: Some(entity),
+        system,
+        selection: vec![],
+        strategy: None,
+        fail_if_missing: None,
+        inputs: None,
+        args: None,
+        output: None,
+        store: None,
+        workspace: nba.workspace.clone(),
+    };
+
+    let (_run, rx) = Workflow::get_by_name(&txn, "universal:deploy")
+        .await
+        .expect("failed to get workflow")
+        .invoke_and_wait(&pg, &nats_conn, &veritech, ctx)
+        .await
+        .expect("failed to invoke workflow");
+    rx.await
+        .expect("failed to wait")
+        .expect("failed during workflow run");
+
+    assert!(false);
+}

--- a/components/si-registry/src/index.ts
+++ b/components/si-registry/src/index.ts
@@ -14,5 +14,6 @@ export {
   MenuCategory,
   Qualification,
 } from "./registryEntry";
+export { workflows, Workflow, Step } from "./workflow";
 export { entityMenu } from "./menu";
 export { registry, findProp } from "./registry";

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -111,9 +111,35 @@ export interface Qualification {
   link?: string;
 }
 
+export interface CommandBase {
+  name: string;
+  description: string;
+}
+
+export interface CommandAlias extends CommandBase {
+  name: string;
+  description: string;
+  aliasTo: string;
+  args?: never;
+}
+
+export interface CommandDirect extends CommandBase {
+  aliastTo?: never;
+  args?: Prop[];
+}
+
+export type Command = CommandDirect | CommandAlias;
+
+export interface Action {
+  name: string;
+  args?: Prop[];
+}
+
 export interface RegistryEntry {
   entityType: string;
   ui?: RegistryEntryUi;
   properties: Prop[];
   qualifications?: Qualification[];
+  commands?: Command[];
+  actions?: Action[];
 }

--- a/components/si-registry/src/schema/docker/dockerImage.ts
+++ b/components/si-registry/src/schema/docker/dockerImage.ts
@@ -41,6 +41,20 @@ const dockerImage: RegistryEntry = {
         "The docker image and tag specified must be accessible via a docker pull.",
     },
   ],
+  actions: [
+    {
+      name: "deploy",
+    },
+    {
+      name: "pull",
+    },
+  ],
+  commands: [
+    {
+      name: "universal:deploy",
+      description: "Deploy",
+    },
+  ],
 };
 
 export default dockerImage;

--- a/components/si-registry/src/schema/si/application.ts
+++ b/components/si-registry/src/schema/si/application.ts
@@ -6,6 +6,11 @@ const application: RegistryEntry = {
     hidden: true,
   },
   properties: [],
+  actions: [
+    {
+      name: "deploy",
+    },
+  ],
 };
 
 export default application;

--- a/components/si-registry/src/schema/test/torture.ts
+++ b/components/si-registry/src/schema/test/torture.ts
@@ -4,7 +4,7 @@ import {
   ValidatorKind,
 } from "../../registryEntry";
 
-const service: RegistryEntry = {
+const torture: RegistryEntry = {
   entityType: "torture",
   ui: {
     menuCategory: MenuCategory.Application,
@@ -64,6 +64,45 @@ const service: RegistryEntry = {
       ],
     },
   ],
+  commands: [
+    {
+      name: "doit5.pl",
+      description: "do what I want",
+      args: [
+        {
+          type: "string",
+          name: "echo",
+        },
+      ],
+    },
+    {
+      name: "universal:deploy",
+      description: "deploy this entity",
+      aliasTo: "doit5.pl",
+    },
+  ],
+  // RulesetGroup --> Set of (action, ruleset) (select between them)
+  // RulesetGroup is tied to entity type
+  // you can set a default ruleset group for the entity type
+  // you can set a default ruleset group for the entity type and system
+  // you can set a specific ruleset gfroup for a given entity instance
+  // you can set a specific ruleset group for a given entity instance and system
+  //
+  // Each ruleset group contains
+  //   Action: Ruleset [
+  //     boolean expression -> workflow <-- rules!
+  //     boolean expression -> workflow
+  //   ]
+  //
+  // Rulesets can be set to a value for the rulesetgroup
+  // Rulesets can be set to a value for the rulesetgroup and entity instance
+  // Rulesets can be set to a value for the rulesetgroup and entity instance system
+  //
+  actions: [
+    {
+      name: "universal:deploy",
+    },
+  ],
 };
 
-export default service;
+export default torture;

--- a/components/si-registry/src/workflow.ts
+++ b/components/si-registry/src/workflow.ts
@@ -1,0 +1,277 @@
+import { Prop } from "./registryEntry";
+
+export enum WorkflowKind {
+  Action = "action",
+  Top = "top",
+}
+
+export interface WorkflowBase {
+  name: string;
+  kind: WorkflowKind;
+  title: string;
+  description: string;
+  steps: Step[];
+}
+
+export interface WorkflowForAction extends WorkflowBase {
+  args?: never;
+}
+
+export interface WorkflowTop extends WorkflowBase {
+  args: Prop[];
+}
+
+export type Workflow = WorkflowTop | WorkflowForAction;
+
+export enum VariableKind {
+  String = "string",
+  Number = "number",
+  Bool = "bool",
+  Array = "array",
+  Object = "object",
+  Args = "args",
+  Context = "context",
+  Output = "output",
+  Store = "store",
+}
+
+export interface VariableBase {
+  kind: VariableKind;
+  value: unknown;
+}
+
+export interface VariableBool extends VariableBase {
+  kind: VariableKind.Bool;
+  value: boolean;
+}
+
+export interface VariableString extends VariableBase {
+  kind: VariableKind.String;
+  value: string;
+}
+
+export interface VariableNumber extends VariableBase {
+  kind: VariableKind.Number;
+  value: number;
+}
+
+export interface VariableArgs {
+  kind: VariableKind.Args;
+  path: string[];
+}
+
+export interface VariableContext {
+  kind: VariableKind.Context;
+  path: string[];
+}
+
+export interface VariableOutput {
+  kind: VariableKind.Output;
+  path: string[];
+}
+
+export interface VariableStore {
+  kind: VariableKind.Store;
+  path: string[];
+}
+
+export interface VariableArray {
+  kind: VariableKind.Array;
+  value: Variable[] | VariableRef;
+}
+
+export interface VariableObject {
+  kind: VariableKind.Object;
+  value: { [key: string]: Variable } | VariableRef;
+}
+
+export type Variable =
+  | VariableString
+  | VariableNumber
+  | VariableArgs
+  | VariableContext
+  | VariableOutput
+  | VariableStore;
+
+export type VariableRef =
+  | VariableArgs
+  | VariableOutput
+  | VariableStore
+  | VariableContext;
+
+export type VariableScalar =
+  | VariableString
+  | VariableNumber
+  | VariableBool
+  | VariableRef;
+
+export enum OrderByDirection {
+  ASC = "asc",
+  DESC = "desc",
+}
+
+export enum BooleanTerm {
+  And = "and",
+  Or = "or",
+}
+
+export enum Comparison {
+  Equals = "equals",
+  NotEquals = "notEquals",
+  Contains = "contains",
+  Like = "like",
+  NotLike = "notLike",
+}
+
+export enum FieldType {
+  String = "string",
+  Int = "int",
+  Boolean = "boolean",
+}
+
+export interface Expression {
+  field: string;
+  value: VariableScalar;
+  comparison: Comparison;
+  fieldType: FieldType;
+}
+
+export interface Item {
+  query?: Query;
+  expression?: Expression;
+}
+
+export interface Query {
+  booleanTerm?: BooleanTerm;
+  isNot?: boolean;
+  items: Item[];
+}
+
+export interface FilterItem {
+  filter?: Filter;
+  expression?: Expression;
+}
+
+export interface Filter {
+  booleanTerm?: BooleanTerm;
+  isNot?: boolean;
+  filters: FilterItem[];
+}
+
+export enum StepKind {
+  Command = "command",
+  Action = "action",
+  Workflow = "workflow",
+}
+
+export interface Selector {
+  query?: Query;
+  byId?: VariableScalar;
+  filter?: Filter;
+  depth?: "immediate" | "all" | "none";
+  edgeKind?: "configures" | "deployment" | string;
+}
+
+export interface StepBase {
+  kind: StepKind;
+  inputs?: unknown;
+  outputs?: unknown;
+  storeOutput?: string[];
+}
+
+export interface StepCommand extends StepBase {
+  kind: StepKind.Command;
+  inputs: {
+    name: VariableScalar;
+    args?: VariableArray;
+  };
+  failIfMissing?: VariableBool;
+  selector?: Selector;
+  strategy?: VariableScalar;
+}
+
+export interface StepAction extends StepBase {
+  kind: StepKind.Action;
+  inputs: {
+    name: VariableScalar;
+  };
+  failIfMissing?: VariableBool;
+  selector?: Selector;
+  strategy?: VariableScalar;
+}
+
+export interface StepWorkflow extends StepBase {
+  kind: StepKind.Workflow;
+  inputs: {
+    name: VariableScalar;
+    args: VariableObject;
+  };
+  failIfMissing?: VariableBool;
+  selector?: Selector;
+  strategy?: VariableScalar;
+}
+
+export type Step = StepCommand | StepAction | StepWorkflow;
+
+// * Workflows can target global state
+// * Workflows can be built for a specific slot, which means they don't take arguments (they inherit the slot)
+// * Workflows that aren't a specific slot can take arguments, and they might user provided
+// * Workflows can call actions, actions only take arguments that are specific to the intent - (shutdown -h/-r)
+// * Workflows are assigned to slots on entities by class, or by specific entity
+// * Actions update resource state
+// * Reactions can watch resource state and trigger workflows (either on a slot or global if the global workflow doesn't require user input)
+// * Workflows can be executed by the user either directly for a global workflow or you entity slot directly or by a reaction
+// * Entities have default implementations of their workflow slots, so you don't specify it all
+// * Context to the workflow is always the real context of where it was triggered
+
+export const universalDeploy: Workflow = {
+  name: "universal:deploy",
+  kind: WorkflowKind.Action,
+  title: "Universal Deploy",
+  description: "Deploy Things!! so fun!",
+  steps: [
+    {
+      kind: StepKind.Command,
+      inputs: {
+        name: { kind: VariableKind.String, value: "universal:deploy" },
+      },
+      strategy: { kind: VariableKind.String, value: "linear" },
+      failIfMissing: { kind: VariableKind.Bool, value: false },
+    },
+    //{
+    //  kind: StepKind.Action,
+    //  inputs: {
+    //    name: { kind: VariableKind.String, value: "universal:deploy" },
+    //  },
+    //  selector: {
+    //    byId: {
+    //      kind: VariableKind.Context,
+    //      path: ["entity", "id"],
+    //    },
+    //    //query: {
+    //    //  items: [
+    //    //    {
+    //    //      expression: {
+    //    //        field: "id",
+    //    //        value: {
+    //    //          kind: VariableKind.Context,
+    //    //          path: ["entity", "id"],
+    //    //        },
+    //    //        comparison: Comparison.Equals,
+    //    //        fieldType: FieldType.String,
+    //    //      },
+    //    //    },
+    //    //  ],
+    //    //},
+    //    depth: "immediate",
+    //    edgeKind: "configures",
+    //  },
+    //  strategy: { kind: VariableKind.String, value: "linear" },
+    //  failIfMissing: { kind: VariableKind.Bool, value: false },
+    //},
+  ],
+};
+
+export const workflows: Record<string, Workflow> = {
+  universalDeploy,
+};

--- a/components/si-sdf/src/bin/server.rs
+++ b/components/si-sdf/src/bin/server.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use si_data::{EventLogFS, NatsConn, PgPool};
-use si_model::{jwt_key, migrate, Veritech};
+use si_model::{jwt_key, migrate, Veritech, Workflow};
 use si_sdf::start;
 
 #[tokio::main]
@@ -29,6 +29,9 @@ async fn main() -> anyhow::Result<()> {
 
     println!("*** Initializing Veritech ***");
     let veritech = Veritech::new(&settings.veritech, event_log_fs.clone());
+
+    println!("*** Loading workflow builtins ***");
+    Workflow::load_builtins(&pg, &veritech).await?;
 
     println!("*** Checking for JWT keys ***");
     let mut conn = pg.pool.get().await?;

--- a/components/si-sdf/src/handlers.rs
+++ b/components/si-sdf/src/handlers.rs
@@ -10,7 +10,7 @@ use si_model::{
     ApiClientError, ApplicationError, BillingAccountError, ChangeSetError, DiffError, EdgeError,
     EditSessionError, EntityError, EventError, EventLogError, JwtKeyError, KeyPairError,
     ModelError, NodeError, NodePositionError, OrganizationError, QualificationError,
-    SchematicError, SecretError, SessionError, UserError, WorkspaceError,
+    SchematicError, SecretError, SessionError, UserError, WorkflowError, WorkspaceError,
 };
 
 pub mod application_context_dal;
@@ -22,6 +22,7 @@ pub mod secret_dal;
 pub mod session_dal;
 pub mod signup_dal;
 pub mod updates;
+pub mod workflow_dal;
 
 #[derive(Error, Debug)]
 pub enum HandlerError {
@@ -91,6 +92,8 @@ pub enum HandlerError {
     Diff(#[from] DiffError),
     #[error("qualification error: {0}")]
     Qualification(#[from] QualificationError),
+    #[error("workflow error: {0}")]
+    Workflow(#[from] WorkflowError),
 }
 
 pub type HandlerResult<T> = Result<T, HandlerError>;

--- a/components/si-sdf/src/handlers/workflow_dal.rs
+++ b/components/si-sdf/src/handlers/workflow_dal.rs
@@ -1,0 +1,156 @@
+use crate::handlers::{authenticate, authorize, validate_tenancy, HandlerError};
+use serde::{Deserialize, Serialize};
+use si_data::{NatsConn, PgPool};
+use si_model::workflow::WorkflowRunListItem;
+use si_model::{
+    Action, ActionError, Entity, Veritech, Workflow, WorkflowContext, WorkflowError, WorkflowRun,
+    Workspace,
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RunActionRequest {
+    pub workspace_id: String,
+    pub entity_id: String,
+    pub action_name: String,
+    pub system_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RunActionReply {
+    pub workflow_run: WorkflowRun,
+}
+
+pub async fn run_action(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+    token: String,
+    request: RunActionRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let mut conn = pg.pool.get().await.map_err(HandlerError::from)?;
+    let txn = conn.transaction().await.map_err(HandlerError::from)?;
+    let nats = nats_conn.transaction();
+
+    let claim = authenticate(&txn, &token).await?;
+    authorize(&txn, &claim.user_id, "workflowDal", "runAction").await?;
+    validate_tenancy(
+        &txn,
+        "workspaces",
+        &request.workspace_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.entity_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.system_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+
+    let entity = Entity::for_head(&txn, &request.entity_id)
+        .await
+        .map_err(HandlerError::from)?;
+    let system = Entity::for_head(&txn, &request.system_id)
+        .await
+        .map_err(HandlerError::from)?;
+    let workspace = Workspace::get(&txn, &request.workspace_id)
+        .await
+        .map_err(HandlerError::from)?;
+
+    let ctx = WorkflowContext {
+        dry_run: true,
+        entity: Some(entity),
+        system: Some(system),
+        selection: vec![],
+        strategy: None,
+        fail_if_missing: None,
+        inputs: None,
+        args: None,
+        output: None,
+        store: None,
+        workspace,
+    };
+
+    let workflow_run = Workflow::get_by_name(&txn, "universal:deploy")
+        .await
+        .map_err(HandlerError::from)?
+        .invoke(&pg, &nats_conn, &veritech, ctx)
+        .await
+        .map_err(HandlerError::from)?;
+
+    let reply = RunActionReply { workflow_run };
+
+    Ok(warp::reply::json(&reply))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListActionRequest {
+    pub workspace_id: String,
+    pub entity_id: String,
+    pub system_id: String,
+    pub action_name: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListActionReply {
+    pub workflow_runs: Vec<WorkflowRunListItem>,
+}
+
+pub async fn list_action(
+    pg: PgPool,
+    token: String,
+    request: ListActionRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let mut conn = pg.pool.get().await.map_err(HandlerError::from)?;
+    let txn = conn.transaction().await.map_err(HandlerError::from)?;
+
+    let claim = authenticate(&txn, &token).await?;
+    authorize(&txn, &claim.user_id, "workflowDal", "listAction").await?;
+    validate_tenancy(
+        &txn,
+        "workspaces",
+        &request.workspace_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.entity_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.system_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+
+    let workflow_runs = WorkflowRun::list_actions(
+        &txn,
+        &request.entity_id,
+        &request.system_id,
+        &request.workspace_id,
+        request.action_name.as_ref(),
+    )
+    .await
+    .map_err(HandlerError::from)?;
+
+    let reply = ListActionReply { workflow_runs };
+
+    Ok(warp::reply::json(&reply))
+}

--- a/components/si-veritech/src/app.ts
+++ b/components/si-veritech/src/app.ts
@@ -5,7 +5,6 @@ import logger from "koa-logger";
 import json from "koa-json";
 import koaBody from "koa-body";
 import controller from "./controllers";
-import { BehaviorSubject } from "rxjs";
 import Debug from "debug";
 const debug = Debug("veritech");
 
@@ -19,12 +18,37 @@ app.use(router.routes());
 app.use(router.allowedMethods());
 
 router.post("/inferProperties", controller.inferProperties);
+router.post("/loadWorkflows", controller.loadWorkflows);
 router.get("/checkQualifications", async (ctx: Context) => {
   if (ctx.ws) {
     const ws = await ctx.ws();
 
     ws.on("message", function (msg: string) {
       controller.checkQualifications(ws, msg);
+    });
+    ws.on("close", (code: number, reason: string) => {
+      debug("socket closed", { code, reason });
+    });
+  }
+});
+router.get("/runCommand", async (ctx: Context) => {
+  if (ctx.ws) {
+    const ws = await ctx.ws();
+
+    ws.on("message", function (msg: string) {
+      controller.runCommand(ws, msg);
+    });
+    ws.on("close", (code: number, reason: string) => {
+      debug("socket closed", { code, reason });
+    });
+  }
+});
+router.get("/syncResource", async (ctx: Context) => {
+  if (ctx.ws) {
+    const ws = await ctx.ws();
+
+    ws.on("message", function (msg: string) {
+      controller.syncResource(ws, msg);
     });
     ws.on("close", (code: number, reason: string) => {
       debug("socket closed", { code, reason });

--- a/components/si-veritech/src/controllers.ts
+++ b/components/si-veritech/src/controllers.ts
@@ -1,9 +1,15 @@
 import { inferProperties } from "./controllers/inferProperties";
 import { checkQualifications } from "./controllers/checkQualifications";
+import { loadWorkflows } from "./controllers/loadWorkflows";
+import { runCommand } from "./controllers/runCommand";
+import { syncResource } from "./controllers/syncResource";
 
 const controller = {
   inferProperties,
   checkQualifications,
+  loadWorkflows,
+  runCommand,
+  syncResource,
 };
 
 export default controller;

--- a/components/si-veritech/src/controllers/loadWorkflows.ts
+++ b/components/si-veritech/src/controllers/loadWorkflows.ts
@@ -1,0 +1,22 @@
+import { Context } from "koa";
+
+import Debug from "debug";
+const debug = Debug("veritech:controllers:loadWorkflows");
+
+import { workflows } from "si-registry";
+
+export function loadWorkflows(ctx: Context): void {
+  debug("/loadWorkflows BEGIN");
+  debug("request body: %O", ctx.request.body);
+  ctx.response.status = 200;
+  const response = { workflows: Object.values(workflows) };
+  //const response = { workflows: [] };
+
+  // output json on the console with line numbers, because....debugging
+  const str = JSON.stringify(response, null, 2);
+  str.split("\n").forEach((line, index) => {
+    debug("body(%s)%s", (index + 1).toString().padStart(3, "0"), line);
+  });
+
+  ctx.response.body = str;
+}

--- a/components/si-veritech/src/controllers/runCommand.ts
+++ b/components/si-veritech/src/controllers/runCommand.ts
@@ -1,0 +1,107 @@
+import WebSocket from "ws";
+import Debug from "debug";
+
+import { Resource, SiEntity } from "si-entity";
+
+import { SiCtx } from "../siCtx";
+import intel from "../intel";
+const debug = Debug("veritech:controllers:runCommand");
+
+export interface RunCommandRequest {
+  commandName: string;
+  inputs: {
+    name: string;
+    args: Record<string, unknown>;
+  };
+  selection: {
+    entity: SiEntity;
+    resource: Resource;
+    predecessors: {
+      entity: SiEntity;
+      resource: Resource;
+    }[];
+  };
+  system: SiEntity;
+}
+
+export interface CommandProtocolStart {
+  start: boolean;
+}
+
+export interface CommandProtocolOutputOutputLine {
+  outputLine: string;
+  errorLine?: never;
+}
+
+export interface CommandProtocolOutputErrorLine {
+  outputLine?: never;
+  errorLine: string;
+}
+
+export interface CommandProtocolOutput {
+  output: CommandProtocolOutputOutputLine | CommandProtocolOutputErrorLine;
+}
+
+export interface CommandProtocolFinishSuccess {
+  success: boolean;
+  error?: never;
+}
+
+export interface CommandProtocolFinishError {
+  success?: never;
+  error: string;
+}
+
+export interface CommandProtocolFinish {
+  finish: CommandProtocolFinishSuccess | CommandProtocolFinishError;
+}
+
+export type CommandProtocol =
+  | CommandProtocolStart
+  | CommandProtocolOutput
+  | CommandProtocolFinish;
+
+export type RunCommandCallback = (
+  ctx: typeof SiCtx,
+  request: RunCommandRequest,
+  ws: WebSocket,
+) => Promise<void>;
+
+export interface RunCommandCallbacks {
+  [commandName: string]: RunCommandCallback;
+}
+
+export async function runCommand(ws: WebSocket, req: string): Promise<void> {
+  debug("/runCommand BEGIN");
+  const request: RunCommandRequest = JSON.parse(req);
+  request.selection.entity = SiEntity.fromJson(request.selection.entity);
+  request.system = SiEntity.fromJson(request.system);
+  for (const p of request.selection.predecessors) {
+    p.entity = SiEntity.fromJson(p.entity);
+  }
+  debug("request %O", request);
+
+  const entityType = request.selection.entity.entityType;
+  const intelFuncs = intel[entityType];
+  if (intelFuncs.runCommands && intelFuncs.runCommands[request.inputs.name]) {
+    send(ws, { start: true });
+    try {
+      await intelFuncs.runCommands[request.inputs.name](SiCtx, request, ws);
+    } catch (e) {
+      send(ws, { finish: { error: `command failed: ${e}` } });
+    }
+    send(ws, { finish: { success: true } });
+  } else {
+    send(ws, { finish: { error: "no command found" } });
+  }
+  close(ws);
+  debug("finished");
+}
+
+function send(ws: WebSocket, message: CommandProtocol) {
+  ws.send(JSON.stringify({ protocol: message }));
+}
+
+function close(ws: WebSocket) {
+  ws.close(1000, "finished");
+}

--- a/components/si-veritech/src/controllers/syncResource.ts
+++ b/components/si-veritech/src/controllers/syncResource.ts
@@ -1,0 +1,56 @@
+import WebSocket from "ws";
+import Debug from "debug";
+
+import { SiEntity, Resource, ResourceStatus, ResourceHealth } from "si-entity";
+
+const debug = Debug("veritech:controllers:syncResource");
+
+export interface SyncResourceRequest {
+  entity: SiEntity;
+  resource: Resource;
+  predecessors: {
+    entity: SiEntity;
+    resource: Resource;
+  }[];
+}
+
+export interface CommandProtocolStart {
+  start: boolean;
+}
+
+export interface CommandProtocolFinish {
+  finish: {
+    state: Record<string, unknown>;
+    status: ResourceStatus;
+    health: ResourceHealth;
+    error?: string;
+  };
+}
+
+export type CommandProtocol = CommandProtocolStart | CommandProtocolFinish;
+
+export async function syncResource(ws: WebSocket, req: string): Promise<void> {
+  debug("/syncResource BEGIN");
+  const request: SyncResourceRequest = JSON.parse(req);
+  debug("request %O", request);
+
+  send(ws, { start: true });
+  send(ws, {
+    finish: {
+      state: request.resource.state,
+      status: request.resource.status,
+      health: request.resource.health,
+      error: "uh no, doing nothing",
+    },
+  });
+  close(ws);
+  debug("finished");
+}
+
+function send(ws: WebSocket, message: CommandProtocol) {
+  ws.send(JSON.stringify({ protocol: message }));
+}
+
+function close(ws: WebSocket) {
+  ws.close(1000, "finished");
+}

--- a/components/si-veritech/src/intel.ts
+++ b/components/si-veritech/src/intel.ts
@@ -5,10 +5,12 @@ import {
   InferPropertiesReply,
   InferPropertiesRequest,
 } from "./controllers/inferProperties";
+import { RunCommandCallbacks } from "./controllers/runCommand";
 
 export interface Intel {
   inferProperties?(request: InferPropertiesRequest): InferPropertiesReply;
   checkQualifications?: CheckQualificationCallbacks;
+  runCommands?: RunCommandCallbacks;
 }
 
 const intel: Record<string, Intel> = {

--- a/components/si-veritech/src/intel/dockerImage.ts
+++ b/components/si-veritech/src/intel/dockerImage.ts
@@ -5,7 +5,7 @@ import {
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
 import Debug from "debug";
-const debug = Debug("veritech:controllers:inferProperties:dockerImage");
+const debug = Debug("veritech:controllers:intel:dockerImage");
 import {
   CheckQualificationsItem,
   CheckQualificationsRequest,
@@ -13,6 +13,7 @@ import {
 import { SiCtx } from "../siCtx";
 
 import _ from "lodash";
+import { RunCommandCallbacks } from "../controllers/runCommand";
 
 function inferProperties(
   request: InferPropertiesRequest,
@@ -67,4 +68,17 @@ export const checkQualifications: CheckQualificationCallbacks = {
   },
 };
 
-export default { inferProperties, checkQualifications };
+export const runCommands: RunCommandCallbacks = {
+  "universal:deploy": async function (ctx, req, ws) {
+    debug("hello from inside");
+    await ctx.execStream(ws, "docker", [
+      "pull",
+      req.selection.entity.getProperty({
+        system: req.system.id,
+        path: ["image"],
+      }),
+    ]);
+  },
+};
+
+export default { inferProperties, checkQualifications, runCommands };

--- a/components/si-veritech/src/siCtx.ts
+++ b/components/si-veritech/src/siCtx.ts
@@ -1,5 +1,6 @@
-import { siExec } from "./siExec";
+import { siExec, siExecStream } from "./siExec";
 
 export const SiCtx = {
   exec: siExec,
+  execStream: siExecStream,
 };

--- a/components/si-veritech/src/siExec.ts
+++ b/components/si-veritech/src/siExec.ts
@@ -1,6 +1,7 @@
 import execa from "execa";
 import readline from "readline";
 import Debug from "debug";
+import WebSocket from "ws";
 const debug = Debug("veritech:siExec");
 
 export type SiExecResult = execa.ExecaReturnValue<string>;
@@ -19,4 +20,87 @@ export async function siExec(
     ...execaOptions,
   });
   return child;
+}
+
+export async function siExecStream(
+  ws: WebSocket,
+  execaFile: string,
+  execaArgs?: readonly string[],
+  execaOptions?: execa.Options<string>,
+): Promise<SiExecResult> {
+  console.log(`running command; cmd="${execaFile} ${execaArgs?.join(" ")}"`);
+  ws.send(
+    JSON.stringify({
+      protocol: {
+        output: {
+          outputLine: `running command; cmd="${execaFile} ${execaArgs?.join(
+            " ",
+          )}"`,
+        },
+      },
+    }),
+  );
+
+  let stdout = "";
+  let stderr = "";
+  let all = "";
+
+  const child = execa(execaFile, execaArgs, {
+    stdout: "pipe",
+    stderr: "pipe",
+    all: true,
+    buffer: false,
+    ...execaOptions,
+  });
+
+  if (child.stdout) {
+    const stdoutRl = readline.createInterface({
+      input: child.stdout,
+      crlfDelay: Infinity,
+    });
+    stdoutRl.on("line", (data) => {
+      ws.send(
+        JSON.stringify({
+          protocol: {
+            output: {
+              outputLine: `${data}\n`,
+            },
+          },
+        }),
+      );
+      stdout = stdout + data;
+    });
+  }
+  if (child.stderr) {
+    const stderrRl = readline.createInterface({
+      input: child.stderr,
+      crlfDelay: Infinity,
+    });
+    stderrRl.on("line", (data) => {
+      ws.send(
+        JSON.stringify({
+          protocol: {
+            output: {
+              errorLine: `${data}\n`,
+            },
+          },
+        }),
+      );
+      stderr = stderr + data;
+    });
+  }
+  if (child.all) {
+    const allRl = readline.createInterface({
+      input: child.all,
+      crlfDelay: Infinity,
+    });
+    allRl.on("line", (data) => {
+      all = all + data;
+    });
+  }
+  const r = await child;
+  r.stdout = stdout;
+  r.stderr = stderr;
+  r.all = all;
+  return r;
 }

--- a/components/si-web-app/src/api/sdf/dal/workflowDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/workflowDal.ts
@@ -1,0 +1,84 @@
+import { SDFError } from "@/api/sdf";
+import Bottle from "bottlejs";
+import {
+  WorkflowRun,
+  WorkflowRunStep,
+  WorkflowRunStepEntity,
+} from "../model/workflow";
+
+export interface IRunActionRequest {
+  workspaceId: string;
+  entityId: string;
+  systemId: string;
+  actionName: string;
+}
+
+export interface IRunActionReplySuccess {
+  workflowRun: WorkflowRun;
+  error?: never;
+}
+
+export interface IRunActionReplyFailure {
+  workflowRun?: never;
+  error: SDFError;
+}
+
+export type IRunActionReply = IRunActionReplySuccess | IRunActionReplyFailure;
+
+export async function runAction(
+  request: IRunActionRequest,
+): Promise<IRunActionReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IRunActionReply = await sdf.post(
+    "workflowDal/runAction",
+    request,
+  );
+  return reply;
+}
+
+export interface IListActionRequest {
+  workspaceId: string;
+  entityId: string;
+  systemId: string;
+  actionName?: string;
+}
+
+export interface IListActionReplySuccess {
+  workflowRuns: {
+    workflowRun: WorkflowRun;
+    steps: {
+      step: WorkflowRunStep;
+      stepEntities: WorkflowRunStepEntity[];
+    }[];
+  }[];
+  error?: never;
+}
+
+export interface IListActionReplyFailure {
+  workflowRuns?: never;
+  error: SDFError;
+}
+
+export type IActionListReply =
+  | IListActionReplySuccess
+  | IListActionReplyFailure;
+
+export async function listAction(
+  request: IListActionRequest,
+): Promise<IActionListReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IActionListReply = await sdf.get(
+    "workflowDal/listAction",
+    request,
+  );
+  return reply;
+}
+
+export const WorkflowDal = {
+  runAction,
+  listAction,
+};

--- a/components/si-web-app/src/api/sdf/model/action.ts
+++ b/components/si-web-app/src/api/sdf/model/action.ts
@@ -1,0 +1,29 @@
+import { Diff } from "./diff";
+import { Resource } from "./resource";
+import { ISiStorable } from "./siStorable";
+
+export enum ActionState {
+  Running = "running",
+  Success = "success",
+  Failure = "failure",
+  Unknown = "unknown",
+}
+
+export interface Action {
+  id: string;
+  name: string;
+  dryRun: boolean;
+  state: ActionState;
+  resource?: Resource;
+  resourceDiff?: Diff;
+  startUnixTimestamp: number;
+  startTimestamp: string;
+  endUnixTimestamp?: number;
+  endTimestamp?: string;
+  output?: string;
+  error?: string;
+  entityId: string;
+  systemId: string;
+  workflowRunId: string;
+  siStorable: ISiStorable;
+}

--- a/components/si-web-app/src/api/sdf/model/siStorable.ts
+++ b/components/si-web-app/src/api/sdf/model/siStorable.ts
@@ -1,4 +1,4 @@
-import { IUpdateClock } from "./updateClock";
+//import { IUpdateClock } from "./updateClock";
 
 export interface ISiStorable {
   typeName: string;
@@ -8,7 +8,6 @@ export interface ISiStorable {
   workspaceId: string;
   tenantIds: string[];
   createdByUserId?: string;
-  updateClock: IUpdateClock;
   deleted: boolean;
 }
 

--- a/components/si-web-app/src/api/sdf/model/update.ts
+++ b/components/si-web-app/src/api/sdf/model/update.ts
@@ -26,6 +26,9 @@ import { UpdateTracker } from "@/api/updateTracker";
 import {
   entityQualifications$,
   entityQualificationStart$,
+  workflowRuns$,
+  workflowRunSteps$,
+  workflowRunStepEntities$,
 } from "@/observables";
 
 export interface IUpdateClockGlobal extends IUpdateClock {
@@ -97,6 +100,12 @@ function onMessage(ev: MessageEvent) {
     entityQualifications$.next(modelData.model);
   } else if (modelData.model?.siStorable?.typeName == "qualificationStart") {
     entityQualificationStart$.next(modelData.model);
+  } else if (modelData.model?.siStorable?.typeName == "workflowRun") {
+    workflowRuns$.next(modelData.model);
+  } else if (modelData.model?.siStorable?.typeName == "workflowRunStep") {
+    workflowRunSteps$.next(modelData.model);
+  } else if (modelData.model?.siStorable?.typeName == "workflowRunStepEntity") {
+    workflowRunStepEntities$.next(modelData.model);
   } else {
     //console.log("websocket on message", { ev, model_data: modelData });
   }

--- a/components/si-web-app/src/api/sdf/model/workflow.ts
+++ b/components/si-web-app/src/api/sdf/model/workflow.ts
@@ -1,0 +1,90 @@
+import { Action } from "./action";
+import { ISiStorable } from "./siStorable";
+import { Workflow, Step } from "si-registry";
+import { Entity } from "./entity";
+import { Resource } from "si-entity";
+import { Workspace } from "./workspace";
+
+export interface WorkflowContext {
+  dryRun: boolean;
+  entity?: Entity;
+  system?: Entity;
+  selection: {
+    entity: Entity;
+    resource: Resource;
+    predecessors: {
+      entity: Entity;
+      resource: Resource;
+    }[];
+  };
+  strategy?: string;
+  failIfMissing?: boolean;
+  inputs?: Record<string, any>;
+  args?: Record<string, any>;
+  output?: Record<string, any>;
+  store?: Record<string, any>;
+  workspace: Workspace;
+}
+
+export enum WorkflowRunState {
+  Running = "running",
+  Success = "success",
+  Failure = "failure",
+  Unknown = "unknown",
+}
+
+export interface WorkflowRun {
+  id: string;
+  startUnixTimestamp: number;
+  startTimestamp: string;
+  endUnixTimestamp?: number;
+  endTimestamp?: string;
+  state: WorkflowRunState;
+  workflowId: string;
+  workflowName: string;
+  data: Workflow;
+  ctx: WorkflowContext;
+  siStorable: ISiStorable;
+}
+
+export enum WorkflowRunStepState {
+  Running = "running",
+  Success = "success",
+  Failure = "failure",
+  Unknown = "unknown",
+}
+
+export interface WorkflowRunStep {
+  id: string;
+  workflowRunId: string;
+  startUnixTimestamp: number;
+  startTimestamp: string;
+  endUnixTimestamp?: number;
+  endTimestamp?: string;
+  state: WorkflowRunStepState;
+  step: Step;
+  siStorable: ISiStorable;
+}
+
+export enum WorkflowRunStepEntityState {
+  Starting = "starting",
+  Running = "running",
+  Success = "success",
+  Failure = "failure",
+  Unknown = "unknown",
+}
+
+export interface WorkflowRunStepEntity {
+  id: string;
+  workflowRunId: string;
+  workflowRunStepId: string;
+  entityId: string;
+  startUnixTimestamp: number;
+  startTimestamp: string;
+  endUnixTimestamp?: number;
+  endTimestamp?: string;
+  state: WorkflowRunStepEntityState;
+  output?: string;
+  error?: string;
+  siStorable: ISiStorable;
+}

--- a/components/si-web-app/src/atoms/PanelHeader.vue
+++ b/components/si-web-app/src/atoms/PanelHeader.vue
@@ -1,0 +1,9 @@
+<template>
+  <div
+    class="relative flex flex-row items-center h-10 pt-2 pb-2 pl-6 pr-6 text-base text-white align-middle property-section-bg-color"
+  >
+    <div class="text-lg">
+      <slot name="header" />
+    </div>
+  </div>
+</template>

--- a/components/si-web-app/src/molecules/Panel.vue
+++ b/components/si-web-app/src/molecules/Panel.vue
@@ -150,6 +150,14 @@ export default Vue.extend({
           label: "Secret",
           value: PanelType.Secret,
         },
+        {
+          label: "Workflow",
+          value: PanelType.Workflow,
+        },
+        {
+          label: "Action",
+          value: PanelType.Action,
+        },
       ];
     },
   },

--- a/components/si-web-app/src/molecules/PanelSelector.vue
+++ b/components/si-web-app/src/molecules/PanelSelector.vue
@@ -49,6 +49,36 @@
       :isMaximizedContainerEnabled="isMaximizedContainerEnabled"
       v-else-if="panelType == 'schematic'"
     />
+    <WorkflowPanel
+      :isVisible="isVisible"
+      :panelIndex="panelIndex"
+      :panelRef="panelRef"
+      :panelContainerRef="panelContainerRef"
+      @change-panel="changePanelType"
+      @panel-maximized-full="setMaximizedFull($event)"
+      @panel-maximized-container="setMaximizedContainer($event)"
+      @panel-minimized-full="setMaximizedFull($event)"
+      @panel-minimized-container="setMaximizedContainer($event)"
+      :initialMaximizedFull="maximizedFull"
+      :initialMaximizedContainer="maximizedContainer"
+      :isMaximizedContainerEnabled="isMaximizedContainerEnabled"
+      v-else-if="panelType == 'workflow'"
+    />
+    <ActionPanel
+      :isVisible="isVisible"
+      :panelIndex="panelIndex"
+      :panelRef="panelRef"
+      :panelContainerRef="panelContainerRef"
+      @change-panel="changePanelType"
+      @panel-maximized-full="setMaximizedFull($event)"
+      @panel-maximized-container="setMaximizedContainer($event)"
+      @panel-minimized-full="setMaximizedFull($event)"
+      @panel-minimized-container="setMaximizedContainer($event)"
+      :initialMaximizedFull="maximizedFull"
+      :initialMaximizedContainer="maximizedContainer"
+      :isMaximizedContainerEnabled="isMaximizedContainerEnabled"
+      v-else-if="panelType == 'action'"
+    />
   </div>
 </template>
 
@@ -58,14 +88,18 @@ import EmptyPanel from "@/organisims/EmptyPanel.vue";
 import SecretPanel from "@/organisims/SecretPanel.vue";
 import AttributePanel from "@/organisims/AttributePanel.vue";
 import SchematicPanel from "@/organisims/SchematicPanel.vue";
+import WorkflowPanel from "@/organisims/WorkflowPanel.vue";
+import ActionPanel from "@/organisims/ActionPanel.vue";
 import { PanelEventBus } from "@/atoms/PanelEventBus";
 import Bottle from "bottlejs";
 import { Persister } from "@/api/persister";
 
 export enum PanelType {
+  Action = "action",
   Attribute = "attribute",
   Secret = "secret",
   Schematic = "schematic",
+  Workflow = "workflow",
 }
 
 export interface IData {
@@ -92,6 +126,8 @@ export default Vue.extend({
     SecretPanel,
     AttributePanel,
     SchematicPanel,
+    WorkflowPanel,
+    ActionPanel,
   },
   data(): IData {
     let bottle = Bottle.pop("default");

--- a/components/si-web-app/src/observables.ts
+++ b/components/si-web-app/src/observables.ts
@@ -26,6 +26,16 @@ import {
   Qualification,
   QualificationStart,
 } from "@/api/sdf/model/qualification";
+import {
+  IRunActionReply,
+  IRunActionRequest,
+  WorkflowDal,
+} from "./api/sdf/dal/workflowDal";
+import {
+  WorkflowRun,
+  WorkflowRunStep,
+  WorkflowRunStepEntity,
+} from "./api/sdf/model/workflow";
 
 export const workspace$ = new ReplaySubject<IWorkspace | null>(1);
 workspace$.next(null);
@@ -207,3 +217,7 @@ export const schematicSelectedEntityId$: BehaviorSubject<string> = new BehaviorS
 
 export const entityQualifications$: Subject<Qualification> = new Subject();
 export const entityQualificationStart$: Subject<QualificationStart> = new Subject();
+
+export const workflowRuns$: Subject<WorkflowRun> = new Subject();
+export const workflowRunSteps$: Subject<WorkflowRunStep> = new Subject();
+export const workflowRunStepEntities$: Subject<WorkflowRunStepEntity> = new Subject();

--- a/components/si-web-app/src/organisims/ActionPanel.vue
+++ b/components/si-web-app/src/organisims/ActionPanel.vue
@@ -1,0 +1,69 @@
+<template>
+  <Panel
+    initialPanelType="workflow"
+    :panelIndex="panelIndex"
+    :panelRef="panelRef"
+    :panelContainerRef="panelContainerRef"
+    :initialMaximizedContainer="initialMaximizedContainer"
+    :initialMaximizedFull="initialMaximizedFull"
+    :isVisible="isVisible"
+    :isMaximizedContainerEnabled="isMaximizedContainerEnabled"
+    v-on="$listeners"
+  >
+    <template v-slot:menuButtons>
+      <div class="flex">
+        <SiSelect
+          size="xs"
+          id="workflowPanelSelect"
+          name="workflowPanelSelect"
+          :options="workflowList"
+          v-model="selectedWorkflow"
+          class="pl-1"
+        />
+      </div>
+      <button
+        class="pl-1 focus:outline-none disabled:opacity-30"
+        :disabled="!selectedWorkflow"
+        @click="runThisWorkflow()"
+      >
+        <PlayCircleIcon size="1.1x" />
+      </button>
+      <div class="flex flex-row items-center pl-1">
+        <div class="flex">
+          <input type="checkbox" name="dryRun" v-model="dryRun" />
+        </div>
+        <div class="flex pl-1 text-xs">
+          Dry
+        </div>
+      </div>
+    </template>
+    <template v-slot:content>
+      Poop!
+    </template>
+  </Panel>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Panel from "@/molecules/Panel.vue";
+
+interface Data {
+  actionList: {};
+}
+
+export default Vue.extend({
+  name: "AttributePanel",
+  components: {
+    Panel,
+  },
+  props: {
+    panelIndex: Number,
+    panelRef: String,
+    panelContainerRef: String,
+    initialMaximizedFull: Boolean,
+    initialMaximizedContainer: Boolean,
+    isVisible: Boolean,
+    isMaximizedContainerEnabled: Boolean,
+  },
+});
+</script>

--- a/components/si-web-app/src/organisims/ActionViewer.vue
+++ b/components/si-web-app/src/organisims/ActionViewer.vue
@@ -1,0 +1,252 @@
+<template>
+  <div class="flex flex-col w-full overflow-hidden" v-if="entity">
+    <div
+      class="relative flex flex-row items-center pt-2 pb-2 pl-6 pr-6 text-base text-white property-section-bg-color"
+    >
+      <div class="text-lg">
+        {{ entity.entityType }} {{ entity.name }} actions
+      </div>
+    </div>
+    <div
+      class="relative flex flex-row items-center pt-2 pb-2 pl-6 pr-6 text-base text-white bg-black"
+    >
+      <div class="flex">
+        <SiSelect
+          size="xs"
+          id="actionPanelSelect"
+          name="actionPanelSelect"
+          :options="actionList"
+          v-model="selectedAction"
+          class="pl-1"
+        />
+      </div>
+      <button
+        class="pl-1 focus:outline-none disabled:opacity-30"
+        :disabled="!selectedAction || editMode"
+        @click="runThisAction()"
+      >
+        <PlayCircleIcon size="1.1x" />
+      </button>
+      <div class="flex flex-row items-center pl-1">
+        <div class="flex">
+          <input type="checkbox" name="dryRun" v-model="dryRun" />
+        </div>
+        <div class="flex pl-1 text-xs">
+          Dry
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="schema && schema.qualifications"
+      class="flex w-full pt-2 overflow-auto"
+    >
+      <div class="flex flex-col w-full">
+        <VueJsonPretty :data="workflowRuns" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+</style>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import _ from "lodash";
+
+import { Entity } from "@/api/sdf/model/entity";
+import { RegistryEntry, registry } from "si-registry";
+import {
+  WorkflowDal,
+  IListActionReplySuccess,
+  IListActionRequest,
+} from "@/api/sdf/dal/workflowDal";
+
+// TODO: Get the list of workflows run for this entity; if they select one, filter. If they hit play, run.
+import SiSelect from "@/atoms/SiSelect.vue";
+import { PlayCircleIcon } from "vue-feather-icons";
+import VueJsonPretty from "vue-json-pretty";
+import { ILabelListItem } from "@/api/sdf/dal";
+import {
+  system$,
+  workspace$,
+  editMode$,
+  workflowRuns$,
+  workflowRunSteps$,
+  workflowRunStepEntities$,
+} from "@/observables";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+import { combineLatest } from "rxjs";
+import { tap, pluck, map } from "rxjs/operators";
+import _ from "lodash";
+
+interface Data {
+  dryRun: boolean;
+  selectedAction: string;
+  workflowRuns: IListActionReplySuccess["workflowRuns"];
+}
+
+// The critical data are the 'worfklowRun', 'workflowRunStep', and 'workflowRunStepEntity'.
+
+export default Vue.extend({
+  name: "ActionViewer",
+  props: {
+    entity: {
+      type: Object as PropType<Entity>,
+      required: true,
+    },
+  },
+  components: {
+    PlayCircleIcon,
+    SiSelect,
+    VueJsonPretty,
+  },
+  data(): Data {
+    return {
+      dryRun: false,
+      selectedAction: "",
+      workflowRuns: [],
+    };
+  },
+  computed: {
+    schema(): RegistryEntry | null {
+      if (registry[this.entity.entityType]) {
+        return registry[this.entity.entityType];
+      } else {
+        return null;
+      }
+    },
+    actionList(): ILabelListItem[] {
+      let response = [{ label: "", value: "" }];
+      if (this.schema?.actions) {
+        for (const action of this.schema.actions) {
+          response.push({ label: action.name, value: action.name });
+        }
+      }
+      return response;
+    },
+  },
+  subscriptions(): Record<string, any> {
+    return {
+      editMode: editMode$,
+      system: system$,
+      workspace: workspace$,
+      workflowRunsUpdate: workflowRuns$.pipe(
+        tap(workflowRun => {
+          if (workflowRun.ctx.entity?.id == this.entity.id) {
+            console.log("have a new workflowRun", { workflowRun });
+            for (let x = 0; x < this.workflowRuns.length; x++) {
+              if (this.workflowRuns[x].workflowRun.id == workflowRun.id) {
+                let wfr = { workflowRun, steps: this.workflowRuns[x].steps };
+                Vue.set(this.workflowRuns, x, wfr);
+                return;
+              }
+            }
+            this.workflowRuns.unshift({ workflowRun, steps: [] });
+          }
+        }),
+      ),
+      workflowRunStepsUpdate: workflowRunSteps$.pipe(
+        tap(workflowRunStep => {
+          for (const run of this
+            .workflowRuns as IListActionReplySuccess["workflowRuns"]) {
+            if (run.workflowRun.id == workflowRunStep.workflowRunId) {
+              for (const step of run.steps) {
+                if (step.step.id == workflowRunStep.id) {
+                  step.step = workflowRunStep;
+                  return;
+                }
+              }
+              run.steps.push({ step: workflowRunStep, stepEntities: [] });
+              return;
+            }
+          }
+        }),
+      ),
+      workflowRunStepEntitiesUpdate: workflowRunStepEntities$.pipe(
+        tap(workflowRunStepEntity => {
+          for (const run of this
+            .workflowRuns as IListActionReplySuccess["workflowRuns"]) {
+            if (run.workflowRun.id == workflowRunStepEntity.workflowRunId) {
+              for (const step of run.steps) {
+                if (step.step.id == workflowRunStepEntity.workflowRunStepId) {
+                  for (let x = 0; x < step.stepEntities.length; x++) {
+                    if (step.stepEntities[x].id == workflowRunStepEntity.id) {
+                      Vue.set(step.stepEntities, x, workflowRunStepEntity);
+                      return;
+                    }
+                  }
+                  step.stepEntities.push(workflowRunStepEntity);
+                  return;
+                }
+              }
+            }
+          }
+        }),
+      ),
+      actionWorkflows: combineLatest(
+        system$,
+        workspace$,
+        this.$watchAsObservable("entity", { immediate: true }).pipe(
+          pluck("newValue"),
+          tap(entity => {
+            this.workflowRuns = []; // This might want to set a loading indicator!
+          }),
+          map(entity => entity.id),
+        ),
+        this.$watchAsObservable("selectedAction", { immediate: true }).pipe(
+          pluck("newValue"),
+        ),
+      ).pipe(
+        tap(async ([system, workspace, selectedAction]) => {
+          // Or maybe this might? Hard to say.
+          if (system && workspace) {
+            let request: IListActionRequest = {
+              workspaceId: workspace.id,
+              systemId: system.id,
+              // @ts-ignore
+              entityId: this.entity.id,
+            };
+            if (selectedAction) {
+              request.actionName = selectedAction;
+            }
+            let reply = await WorkflowDal.listAction(request);
+            if (reply.error) {
+              emitEditorErrorMessage(reply.error.message);
+            } else {
+              this.workflowRuns = reply.workflowRuns;
+            }
+          }
+        }),
+      ),
+    };
+  },
+  methods: {
+    async runThisAction(): Promise<void> {
+      // @ts-ignore
+      if (this.system && this.workspace) {
+        let reply = await WorkflowDal.runAction({
+          // @ts-ignore
+          systemId: this.system.id,
+          // @ts-ignore
+          workspaceId: this.workspace.id,
+          entityId: this.entity.id,
+          actionName: this.selectedAction,
+        });
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        } else {
+          //this.workflowRuns.unshift({
+          //  workflowRun: reply.workflowRun,
+          //  steps: [],
+          //});
+        }
+      }
+    },
+  },
+});
+</script>

--- a/components/si-web-app/src/organisims/AttributePanel.vue
+++ b/components/si-web-app/src/organisims/AttributePanel.vue
@@ -48,6 +48,13 @@
       >
         <CheckSquareIcon size="1.1x" />
       </button>
+      <button
+        class="pl-1 text-white focus:outline-none"
+        :class="actionViewClasses()"
+        @click="switchToActionView()"
+      >
+        <PlayIcon size="1.1x" />
+      </button>
 
       <button
         class="pl-1 text-white focus:outline-none"
@@ -56,6 +63,7 @@
       >
         <RadioIcon size="1.1x" />
       </button>
+
       <!--
       <button
         class="pl-1 text-white focus:outline-none"
@@ -80,17 +88,19 @@
           :qualifications="qualifications"
           :starting="qualificationStart"
         />
-        <!--
-        <CodeViewer
-          v-else-if="activeView == 'code'"
-          :attributePanelStoreCtx="attributePanelStoreCtx"
-        />
+        <ActionViewer v-else-if="activeView == 'action'" :entity="entity" />
+
         <div v-else>
           Not implemented
           <div>
             <VueJsonPretty :data="entity" />
           </div>
         </div>
+        <!--
+        <CodeViewer
+          v-else-if="activeView == 'code'"
+          :attributePanelStoreCtx="attributePanelStoreCtx"
+        />
         -->
       </div>
       <div class="flex w-full" v-else>
@@ -113,6 +123,7 @@ import {
   RadioIcon,
   DiscIcon,
   CheckSquareIcon,
+  PlayIcon,
 } from "vue-feather-icons";
 import "vue-json-pretty/lib/styles.css";
 import { Entity } from "@/api/sdf/model/entity";
@@ -120,6 +131,7 @@ import Bottle from "bottlejs";
 import { Persister } from "@/api/persister";
 import AttributeViewer from "@/organisims/AttributeViewer.vue";
 import QualificationViewer from "@/organisims/QualificationViewer.vue";
+import ActionViewer from "@/organisims/ActionViewer.vue";
 //import CodeViewer from "@/organisims/CodeViewer.vue";
 import {
   loadEntityForEdit,
@@ -145,7 +157,7 @@ interface IData {
   isLoading: boolean;
   selectedEntityId: string;
   selectionIsLocked: boolean;
-  activeView: "attribute" | "code" | "event" | "qualification";
+  activeView: "attribute" | "code" | "event" | "qualification" | "action";
   entity: Entity | null;
   diff: Diff;
   qualifications: Qualification[];
@@ -174,6 +186,8 @@ export default Vue.extend({
     CheckSquareIcon,
     AttributeViewer,
     QualificationViewer,
+    PlayIcon,
+    ActionViewer,
   },
   data(): IData {
     let bottle = Bottle.pop("default");
@@ -197,7 +211,7 @@ export default Vue.extend({
       };
     }
   },
-  subscriptions() {
+  subscriptions(): any {
     return {
       entityQualificationStart: combineLatest(
         entityQualificationStart$,
@@ -324,6 +338,9 @@ export default Vue.extend({
     codeViewClasses(): Record<string, any> {
       return this.viewClasses("code");
     },
+    actionViewClasses(): Record<string, any> {
+      return this.viewClasses("action");
+    },
     eventViewClasses(): Record<string, any> {
       return this.viewClasses("event");
     },
@@ -341,6 +358,9 @@ export default Vue.extend({
     },
     switchToQualificationView() {
       this.activeView = "qualification";
+    },
+    switchToActionView() {
+      this.activeView = "action";
     },
     async toggleSelectionLock() {
       if (this.selectionIsLocked) {

--- a/components/si-web-app/src/organisims/WorkflowPanel.vue
+++ b/components/si-web-app/src/organisims/WorkflowPanel.vue
@@ -1,0 +1,548 @@
+<template>
+  <Panel
+    initialPanelType="workflow"
+    :panelIndex="panelIndex"
+    :panelRef="panelRef"
+    :panelContainerRef="panelContainerRef"
+    :initialMaximizedContainer="initialMaximizedContainer"
+    :initialMaximizedFull="initialMaximizedFull"
+    :isVisible="isVisible"
+    :isMaximizedContainerEnabled="isMaximizedContainerEnabled"
+    v-on="$listeners"
+  >
+    <template v-slot:menuButtons>
+      <div class="flex">
+        <SiSelect
+          size="xs"
+          id="workflowPanelSelect"
+          name="workflowPanelSelect"
+          :options="workflowList"
+          v-model="selectedWorkflow"
+          class="pl-1"
+        />
+      </div>
+      <button
+        class="pl-1 focus:outline-none disabled:opacity-30"
+        :disabled="!selectedWorkflow"
+        @click="runThisWorkflow()"
+      >
+        <PlayCircleIcon size="1.1x" />
+      </button>
+      <div class="flex flex-row items-center pl-1">
+        <div class="flex">
+          <input type="checkbox" name="dryRun" v-model="dryRun" />
+        </div>
+        <div class="flex pl-1 text-xs">
+          Dry
+        </div>
+      </div>
+    </template>
+    <template v-slot:content>
+      <div class="flex flex-col w-full overflow-hidden">
+        <div
+          class="relative flex flex-row items-center w-full h-10 pt-2 pb-2 pl-6 pr-6 text-base text-white align-middle property-section-bg-color"
+        >
+          <div class="flex text-lg">
+            {{ workflowLabel }}
+          </div>
+          <div class="flex justify-end flex-grow text-xs text-gray-500">
+            <template v-if="dryRun">
+              Dry Run
+            </template>
+          </div>
+        </div>
+        <div class="flex flex-col mt-2 overflow-auto">
+          <div
+            class="flex flex-col w-full mb-2"
+            v-for="run in workflowRuns"
+            :key="run.id"
+          >
+            <div
+              class="flex flex-row w-full"
+              :class="workflowRunTitleClasses(run)"
+            >
+              <div class="flex">{{ run.startTime }} {{ run.state }}</div>
+              <div class="flex justify-end pl-1 text-xs" v-if="run.dryRun">
+                (dry run)
+              </div>
+              <div class="flex justify-end flex-grow pr-4">
+                <button @click.prevent="toggleActions(run.id)">
+                  <MoreHorizontalIcon />
+                </button>
+              </div>
+            </div>
+            <div
+              class="flex flex-col w-full pl-4 pr-4"
+              v-if="visibleActions[run.id]"
+            >
+              <div
+                class="flex flex-col pt-2"
+                v-for="action in run.actions"
+                :key="action.id"
+              >
+                <div
+                  class="flex flex-row w-full"
+                  :class="actionTitleClasses(action)"
+                >
+                  <div class="flex flex-row">
+                    {{ action.entityName }} {{ action.name }} {{ action.state }}
+                  </div>
+                  <div class="flex justify-end flex-grow pr-4">
+                    <button
+                      @click.prevent="toggleSpecificActions(run.id, action.id)"
+                    >
+                      <MoreHorizontalIcon />
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="flex flex-col w-full pl-4"
+                  v-if="visibleSpecificAction(run.id, action.id)"
+                >
+                  <div class="flex flex-row mt-2">
+                    <div class="flex justify-end w-20">
+                      startTime:
+                    </div>
+                    <div class="flex flex-grow pl-2">
+                      {{ action.startTime }}
+                    </div>
+                  </div>
+                  <div class="flex flex-row mt-2">
+                    <div class="flex justify-end w-20">
+                      endTime:
+                    </div>
+                    <div class="flex flex-grow pl-2">
+                      {{ action.endTime }}
+                    </div>
+                  </div>
+                  <div class="flex flex-row mt-2" v-if="action.output">
+                    <div class="flex justify-end w-20">
+                      output:
+                    </div>
+                    <div class="flex flex-grow pl-2">
+                      <CodeMirror
+                        :value="action.output"
+                        readOnly
+                        lineWrapping
+                        noHighlight
+                      />
+                    </div>
+                  </div>
+                  <div class="flex flex-row mt-2" v-if="action.error">
+                    <div class="flex justify-end w-20">
+                      error:
+                    </div>
+                    <div class="flex flex-grow pl-2">
+                      <CodeMirror
+                        :value="action.error"
+                        readOnly
+                        lineWrapping
+                        noHighlight
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="flex flex-row mt-2"
+                    v-if="action.resourceDiff.length"
+                  >
+                    <div class="flex justify-end w-20">
+                      diff:
+                    </div>
+                    <div class="flex flex-col flex-grow pl-2">
+                      <div
+                        class="flex flex-row"
+                        v-for="(diff, index) in action.resourceDiff"
+                        :key="index"
+                      >
+                        <div
+                          v-if="diff.edit"
+                          class="flex flex-col w-full border-b-2"
+                        >
+                          <div class="flex flex-row w-20">
+                            Edit: {{ diff.edit.path.join("/") }}
+                          </div>
+                          <div class="flex flex-row flex-grow">
+                            <div class="flex flex-col p-1">
+                              <div class="flex bg-gray-800">
+                                Before
+                              </div>
+                              <div class="flex">
+                                {{ diff.edit.before }}
+                              </div>
+                            </div>
+                            <div class="flex flex-col p-1">
+                              <div class="flex bg-gray-800">
+                                After
+                              </div>
+                              <div class="flex">
+                                {{ diff.edit.after }}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          v-else-if="diff.add"
+                          class="flex flex-col w-full border-b-2"
+                        >
+                          <div class="flex flex-row w-20">
+                            Add: {{ diff.add.path.join("/") }}
+                          </div>
+                          <div class="flex flex-col flex-grow">
+                            <div class="flex flex-col p-1">
+                              <div class="flex bg-gray-800">
+                                After:
+                              </div>
+                              <div class="flex">
+                                {{ diff.add.after }}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          v-else-if="diff.remove"
+                          class="flex flex-col w-full border-b-2"
+                        >
+                          <div class="flex flex-row w-20">
+                            Remove: {{ diff.remove.path.join("/") }}
+                          </div>
+                          <div class="flex flex-col flex-grow">
+                            <div class="flex flex-col p-1">
+                              <div class="flex bg-gray-800">
+                                Before:
+                              </div>
+                              <div class="flex">
+                                {{ diff.remove.before }}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </Panel>
+</template>
+
+<style scoped>
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+</style>
+
+<script lang="ts">
+import Vue from "vue";
+import _ from "lodash";
+
+import { workflows } from "si-registry";
+import {
+  Resource,
+  ResourceHealth,
+  ResourceStatus,
+} from "@/api/sdf/model/resource";
+
+import Panel from "@/molecules/Panel.vue";
+import SiSelect from "@/atoms/SiSelect.vue";
+import CodeMirror from "@/molecules/CodeMirror.vue";
+import { PlayCircleIcon, MoreHorizontalIcon } from "vue-feather-icons";
+
+import { WorkflowRunState, WorkflowRun } from "@/api/sdf/model/workflow";
+import { ActionState, Action } from "@/api/sdf/model/action";
+import { runWorkflow, system$, applicationId$ } from "@/observables";
+import { switchMap } from "rxjs/operators";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+
+interface WorkflowRunWithActions extends WorkflowRun {
+  actions: Actions[];
+}
+
+interface Data {
+  workflowList: {
+    label: string;
+    value: string;
+  }[];
+  selectedWorkflow: string;
+  dryRun: boolean;
+  workflowRuns: WorkflowRunWithActions[];
+  visibleActions: {
+    [runId: string]: boolean;
+  };
+  visibleSpecificActions: {
+    [key: string]: boolean;
+  };
+}
+
+export default Vue.extend({
+  name: "WorkflowPanel",
+  components: {
+    Panel,
+    SiSelect,
+    PlayCircleIcon,
+    MoreHorizontalIcon,
+    CodeMirror,
+  },
+  props: {
+    panelIndex: Number,
+    panelRef: String,
+    panelContainerRef: String,
+    initialMaximizedFull: Boolean,
+    initialMaximizedContainer: Boolean,
+    isVisible: Boolean,
+    isMaximizedContainerEnabled: Boolean,
+  },
+  data(): Data {
+    const workflowList: Data["workflowList"] = _.flatMap(workflows, w => {
+      return { label: w.title, value: w.name };
+    });
+    workflowList.unshift({ label: "", value: "" });
+
+    const workflowRuns: Data["workflowRuns"] = [
+      {
+        id: "1",
+        startTime: Date.now().toString(),
+        endTime: Date.now().toString(),
+        state: WorkflowRunState.Success,
+        dryRun: false,
+        actions: [
+          {
+            id: "1",
+            workflowRunId: "1",
+            dryRun: false,
+            name: "deploy",
+            startTime: Date.now().toString(),
+            endTime: Date.now().toString(),
+            entityId: "xx",
+            entityName: "poop",
+            state: ActionState.Success,
+            output: "there is no doubt you're in my heart now",
+            resourceDiff: [
+              {
+                edit: {
+                  path: ["health"],
+                  before: ResourceHealth.Error,
+                  after: ResourceHealth.Ok,
+                },
+              },
+              {
+                add: {
+                  path: ["health"],
+                  after: ResourceHealth.Ok,
+                },
+              },
+              {
+                remove: {
+                  path: ["health"],
+                  before: ResourceHealth.Ok,
+                },
+              },
+            ],
+            resource: {
+              id: "w",
+              unixTimestamp: Date.now().toString(),
+              timestamp: Date.now().toString(),
+              state: { wagon: "wheel" },
+              status: ResourceStatus.Created,
+              health: ResourceHealth.Ok,
+              systemId: "p",
+              nodeId: "n",
+              entityId: "e",
+              siStorable: {
+                typeName: "resource",
+                objectId: "r",
+                billingAccountId: "b",
+                organizationId: "o",
+                workspaceId: "w",
+                tenantIds: ["b", "o", "w"],
+                deleted: false,
+              },
+            },
+          },
+        ],
+      },
+      {
+        id: "2",
+        startTime: (Date.now() - 10).toString(),
+        endTime: (Date.now() + 10).toString(),
+        state: WorkflowRunState.Failure,
+        dryRun: false,
+        actions: [
+          {
+            id: "1",
+            workflowRunId: "2",
+            startTime: Date.now().toString(),
+            endTime: Date.now().toString(),
+            dryRun: false,
+            name: "deploy",
+            entityId: "xx",
+            entityName: "poop",
+            state: ActionState.Failure,
+            error: "just a little patience",
+            resourceDiff: [],
+            resource: {
+              id: "w",
+              unixTimestamp: Date.now().toString(),
+              timestamp: Date.now().toString(),
+              state: { wagon: "wheel" },
+              status: ResourceStatus.Created,
+              health: ResourceHealth.Ok,
+              systemId: "p",
+              nodeId: "n",
+              entityId: "e",
+              siStorable: {
+                typeName: "resource",
+                objectId: "r",
+                billingAccountId: "b",
+                organizationId: "o",
+                workspaceId: "w",
+                tenantIds: ["b", "o", "w"],
+                deleted: false,
+              },
+            },
+          },
+        ],
+      },
+      {
+        id: "3",
+        startTime: (Date.now() - 10).toString(),
+        endTime: (Date.now() + 10).toString(),
+        state: WorkflowRunState.Running,
+        dryRun: true,
+        actions: [
+          {
+            id: "1",
+            workflowRunId: "3",
+            startTime: Date.now().toString(),
+            endTime: Date.now().toString(),
+            dryRun: true,
+            name: "deploy",
+            entityId: "xx",
+            entityName: "poop",
+            state: ActionState.Failure,
+            error: "just a little patience",
+            resourceDiff: [],
+            resource: {
+              id: "w",
+              unixTimestamp: Date.now().toString(),
+              timestamp: Date.now().toString(),
+              state: { wagon: "wheel" },
+              status: ResourceStatus.Created,
+              health: ResourceHealth.Ok,
+              systemId: "p",
+              nodeId: "n",
+              entityId: "e",
+              siStorable: {
+                typeName: "resource",
+                objectId: "r",
+                billingAccountId: "b",
+                organizationId: "o",
+                workspaceId: "w",
+                tenantIds: ["b", "o", "w"],
+                deleted: false,
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    return {
+      workflowList,
+      selectedWorkflow: "",
+      workflowRuns,
+      dryRun: false,
+      visibleActions: {},
+      visibleSpecificActions: {},
+    };
+  },
+  computed: {
+    workflowLabel(): string {
+      if (workflows[this.selectedWorkflow]) {
+        return workflows[this.selectedWorkflow].title;
+      } else {
+        return "No Workflow Selected!";
+      }
+    },
+  },
+  subscriptions() {
+    return {
+      system: system$,
+      applicationId: applicationId$,
+    };
+  },
+  methods: {
+    runThisWorkflow(): void {
+      // @ts-ignore
+      if (this.selectedWorkflow && this.system && this.applicationId) {
+        runWorkflow({
+          workflowName: this.selectedWorkflow,
+          args: {
+            // @ts-ignore
+            system: this.system.id,
+            // @ts-ignore
+            application: this.applicationId,
+          },
+        }).subscribe(reply => {
+          // going to have to combine them!
+          if (reply.error && reply.error.code != 42) {
+            emitEditorErrorMessage(reply.error.message);
+          }
+        });
+      }
+    },
+    toggleSpecificActions(runId: string, actionId: string): void {
+      const newKey = `${runId}-${actionId}`;
+      if (this.visibleSpecificActions[newKey]) {
+        Vue.set(this.visibleSpecificActions, newKey, false);
+      } else {
+        Vue.set(this.visibleSpecificActions, newKey, true);
+      }
+    },
+    visibleSpecificAction(runId: string, actionId: string): boolean {
+      const newKey = `${runId}-${actionId}`;
+      if (this.visibleSpecificActions[newKey]) {
+        return this.visibleSpecificActions[newKey];
+      } else {
+        return false;
+      }
+    },
+    toggleActions(runId: string): void {
+      if (this.visibleActions[runId]) {
+        Vue.set(this.visibleActions, runId, false);
+      } else {
+        Vue.set(this.visibleActions, runId, true);
+      }
+    },
+    workflowRunTitleClasses(run: WorkflowRun): Record<string, any> {
+      const classes: Record<string, any> = {};
+      if (run.state == WorkflowRunState.Running) {
+        classes["bg-indigo-700"] = true;
+      } else if (run.state == WorkflowRunState.Success) {
+        classes["bg-green-700"] = true;
+      } else if (run.state == WorkflowRunState.Failure) {
+        classes["bg-red-700"] = true;
+      } else {
+        classes["bg-gray-700"] = true;
+      }
+      return classes;
+    },
+    actionTitleClasses(action: Action): Record<string, any> {
+      const classes: Record<string, any> = {};
+      if (action.state == ActionState.Running) {
+        classes["bg-indigo-700"] = true;
+      } else if (action.state == ActionState.Success) {
+        classes["bg-green-700"] = true;
+      } else if (action.state == ActionState.Failure) {
+        classes["bg-red-700"] = true;
+      } else {
+        classes["bg-gray-700"] = true;
+      }
+      return classes;
+    },
+  },
+});
+</script>


### PR DESCRIPTION
This commit adds in the concept of 'workflows', and specifically wires
together the 'actions' an entity can be asked to perform (which map to
workflows). Additionally, it brings 'resources' back in to the model,
but this time as strictly a run-time concern (you no longer have a
resource that gets updated in an edit session).

The workflow code itself is a little dense, but has some nice patterns.
In particular the 'invoke' tasks being able to be either stand-alone
async tasks or awaited via a one-shot channel is pretty great.

Workflows themselves are expressed as pure data in the registry,
alongside the schema for entities.

https://media4.giphy.com/media/PFXmxJoyTNfDG/200.gif?cid=5a38a5a2kodem9zym2qkmc0a4o6o3xgolirewaoz3qd2wpzy&rid=200.gif&ct=g