### PR TITLE
feat: input sockets and edge safety

### DIFF
--- a/components/si-registry/src/index.ts
+++ b/components/si-registry/src/index.ts
@@ -13,6 +13,7 @@ export {
   RegistryEntryUi,
   MenuCategory,
   Qualification,
+  NodeKind,
 } from "./registryEntry";
 export { workflows, Workflow, Step } from "./workflow";
 export { entityMenu, MenuCategoryItem } from "./menu";

--- a/components/si-registry/src/registry.ts
+++ b/components/si-registry/src/registry.ts
@@ -10,6 +10,9 @@ import system from "./schema/si/system";
 import service from "./schema/si/service";
 import application from "./schema/si/application";
 import dockerImage from "./schema/docker/dockerImage";
+import kubernetesService from "./schema/kubernetes/kubernetesService";
+import k8sDeployment from "./schema/kubernetes/k8sDeployment";
+import k8sNamespace from "./schema/kubernetes/k8sNamespace";
 
 export const registry: { [entityType: string]: RegistryEntry } = {
   leftHandPath,
@@ -19,6 +22,9 @@ export const registry: { [entityType: string]: RegistryEntry } = {
   application,
   torture,
   dockerImage,
+  kubernetesService,
+  k8sDeployment,
+  k8sNamespace,
 };
 
 export function findProp(path: string[]): Prop | undefined {

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -8,6 +8,7 @@ export enum SchematicKind {
 
 export enum MenuCategory {
   Application = "application",
+  Service = "service",
   Docker = "docker",
   Kubernetes = "kubernetes",
   Helm = "helm",
@@ -207,15 +208,23 @@ export enum Arity {
 
 export interface Input {
   name: string;
-  types: string[];
+  types: string[] | "implementations";
   edgeKind: "deployment" | "component" | "configures";
   arity: Arity;
   required?: boolean;
 }
 
+export enum NodeKind {
+  Concept = "concept",
+  Implementation = "implementation",
+  Concrete = "concrete",
+}
+
 export interface RegistryEntry {
   entityType: string;
+  nodeKind: NodeKind;
   ui?: RegistryEntryUi;
+  implements?: string[];
   inputs: Input[];
   properties: Prop[];
   qualifications?: Qualification[];

--- a/components/si-registry/src/schema/docker/dockerImage.ts
+++ b/components/si-registry/src/schema/docker/dockerImage.ts
@@ -3,24 +3,19 @@ import {
   MenuCategory,
   ValidatorKind,
   SchematicKind,
-  Arity,
+  NodeKind,
+  //Arity,
 } from "../../registryEntry";
 
 const dockerImage: RegistryEntry = {
   entityType: "dockerImage",
+  nodeKind: NodeKind.Concrete,
   ui: {
     menuCategory: MenuCategory.Docker,
     menuDisplayName: "docker image",
     schematicKinds: [SchematicKind.Component],
   },
-  inputs: [
-    {
-      name: "image",
-      types: ["service"],
-      edgeKind: "configures",
-      arity: Arity.One,
-    },
-  ],
+  inputs: [],
   properties: [
     {
       type: "string",

--- a/components/si-registry/src/schema/include/standardConceptInputs.ts
+++ b/components/si-registry/src/schema/include/standardConceptInputs.ts
@@ -7,4 +7,16 @@ export const standardConceptInputs: Input[] = [
     edgeKind: "component",
     arity: Arity.Many,
   },
+  {
+    name: "poop",
+    types: ["service"],
+    edgeKind: "deployment",
+    arity: Arity.Many,
+  },
+  {
+    name: "implementations",
+    types: "implementations",
+    edgeKind: "configures",
+    arity: Arity.Many,
+  },
 ];

--- a/components/si-registry/src/schema/kubernetes/k8sDeployment.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sDeployment.ts
@@ -1,0 +1,34 @@
+import {
+  RegistryEntry,
+  MenuCategory,
+  SchematicKind,
+  NodeKind,
+  Arity,
+} from "../../registryEntry";
+
+const k8sDeployment: RegistryEntry = {
+  entityType: "k8sDeployment",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menuCategory: MenuCategory.Kubernetes,
+    menuDisplayName: "k8sDeployment",
+    schematicKinds: [SchematicKind.Component],
+  },
+  inputs: [
+    {
+      name: "dockerImage",
+      types: ["dockerImage"],
+      edgeKind: "configures",
+      arity: Arity.Many,
+    },
+    {
+      name: "k8sNamespace",
+      types: ["k8sNamespace"],
+      edgeKind: "configures",
+      arity: Arity.One,
+    },
+  ],
+  properties: [],
+};
+
+export default k8sDeployment;

--- a/components/si-registry/src/schema/kubernetes/k8sNamespace.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sNamespace.ts
@@ -1,0 +1,20 @@
+import {
+  RegistryEntry,
+  MenuCategory,
+  SchematicKind,
+  NodeKind,
+} from "../../registryEntry";
+
+const k8sNamespace: RegistryEntry = {
+  entityType: "k8sNamespace",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menuCategory: MenuCategory.Kubernetes,
+    menuDisplayName: "k8sNamespace",
+    schematicKinds: [SchematicKind.Component],
+  },
+  inputs: [],
+  properties: [],
+};
+
+export default k8sNamespace;

--- a/components/si-registry/src/schema/kubernetes/kubernetesService.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetesService.ts
@@ -1,0 +1,41 @@
+import {
+  RegistryEntry,
+  MenuCategory,
+  SchematicKind,
+  NodeKind,
+  Arity,
+} from "../../registryEntry";
+
+const kubernetesService: RegistryEntry = {
+  entityType: "kubernetesService",
+  nodeKind: NodeKind.Implementation,
+  ui: {
+    menuCategory: MenuCategory.Service,
+    menuDisplayName: "kubernetesService",
+    schematicKinds: [SchematicKind.Component],
+  },
+  implements: ["service"],
+  inputs: [
+    {
+      name: "k8sDeployment",
+      types: ["k8sDeployment"],
+      edgeKind: "configures",
+      arity: Arity.Many,
+    },
+    {
+      name: "k8sService",
+      types: ["k8sService"],
+      edgeKind: "configures",
+      arity: Arity.Many,
+    },
+    {
+      name: "k8sPod",
+      types: ["k8sPod"],
+      edgeKind: "configures",
+      arity: Arity.Many,
+    },
+  ],
+  properties: [],
+};
+
+export default kubernetesService;

--- a/components/si-registry/src/schema/si/application.ts
+++ b/components/si-registry/src/schema/si/application.ts
@@ -1,10 +1,12 @@
-import { RegistryEntry } from "../../registryEntry";
+import { RegistryEntry, NodeKind } from "../../registryEntry";
 
 const application: RegistryEntry = {
   entityType: "application",
+  nodeKind: NodeKind.Concept,
   ui: {
     hidden: true,
   },
+  inputs: [],
   properties: [],
   actions: [
     {

--- a/components/si-registry/src/schema/si/service.ts
+++ b/components/si-registry/src/schema/si/service.ts
@@ -2,11 +2,13 @@ import {
   RegistryEntry,
   MenuCategory,
   SchematicKind,
+  NodeKind,
 } from "../../registryEntry";
 import { standardConceptInputs } from "../include/standardConceptInputs";
 
 const service: RegistryEntry = {
   entityType: "service",
+  nodeKind: NodeKind.Concept,
   ui: {
     menuCategory: MenuCategory.Application,
     menuDisplayName: "service",

--- a/components/si-registry/src/schema/si/system.ts
+++ b/components/si-registry/src/schema/si/system.ts
@@ -1,10 +1,12 @@
-import { RegistryEntry } from "../../registryEntry";
+import { RegistryEntry, NodeKind } from "../../registryEntry";
 
 const system: RegistryEntry = {
   entityType: "system",
+  nodeKind: NodeKind.Concept,
   ui: {
     hidden: true,
   },
+  inputs: [],
   properties: [],
 };
 

--- a/components/si-registry/src/schema/test/leftHandPath.ts
+++ b/components/si-registry/src/schema/test/leftHandPath.ts
@@ -2,16 +2,19 @@ import {
   RegistryEntry,
   MenuCategory,
   ValidatorKind,
+  NodeKind,
 } from "../../registryEntry";
 import frobNob from "./frobNob";
 
 const leftHandPath: RegistryEntry = {
   entityType: "leftHandPath",
+  nodeKind: NodeKind.Concept,
   ui: {
     menuCategory: MenuCategory.Kubernetes,
     menuDisplayName: "leftHandPath",
     schematicKinds: [],
   },
+  inputs: [],
   properties: [
     {
       type: "string",

--- a/components/si-registry/src/schema/test/noCallbacks.ts
+++ b/components/si-registry/src/schema/test/noCallbacks.ts
@@ -1,10 +1,12 @@
-import { RegistryEntry } from "../../registryEntry";
+import { RegistryEntry, NodeKind } from "../../registryEntry";
 
 const noCallbacks: RegistryEntry = {
   entityType: "noCallBacks",
+  nodeKind: NodeKind.Concept,
   ui: {
     hidden: true,
   },
+  inputs: [],
   properties: [
     {
       type: "string",

--- a/components/si-registry/src/schema/test/torture.ts
+++ b/components/si-registry/src/schema/test/torture.ts
@@ -3,10 +3,12 @@ import {
   MenuCategory,
   ValidatorKind,
   SchematicKind,
+  NodeKind,
 } from "../../registryEntry";
 
 const torture: RegistryEntry = {
   entityType: "torture",
+  nodeKind: NodeKind.Concrete,
   ui: {
     menuCategory: MenuCategory.Application,
     menuDisplayName: "torture test",

--- a/components/si-web-app/src/observables.ts
+++ b/components/si-web-app/src/observables.ts
@@ -232,3 +232,10 @@ export const nodePositionUpdated$ = new ReplaySubject<NodePositionUpdated | null
   1,
 );
 nodePositionUpdated$.next(null);
+
+export interface EdgeCreating {
+  entityType: string;
+  schematicKind: string;
+  entityId: string;
+}
+export const edgeCreating$ = new Subject<EdgeCreating | null>();

--- a/components/si-web-app/src/organisims/SchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SchematicPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <Panel
-    initialPanelType="diagram"
+    initialPanelType="schematic"
     :panelIndex="panelIndex"
     :panelRef="panelRef"
     :panelContainerRef="panelContainerRef"


### PR DESCRIPTION
This shows input sockets defined for a given schema on the Node, with
the connections arity displayed as a 1 or *. When an edge is drawn from
a node:

* all nodes that are not capable of accepting the edge turn transparent
* any node that you try and connect it to that doesnt accept the edge
  will reject the edge.

It implements both the specific array of types, and if the 'types' field
is set to 'implementations', it will then use the 'implements' field of
the source to determine if it is valid (letting the schema definition
for implementation nodes rest with the implementor, rather than a global
list on the implementation node.)

It also implements different colors based on wether a node is a 'concept' node,
an 'implementation' node, or a 'concrete' node. I expect that isn't actually the 
color scheme (and instead it's something else), but when you have a hammer..

It feels really cool.