### PR TITLE
bug(si-web): mac native select controls fix

### DIFF
--- a/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @input="onInput"
+        @change="onInput"
         @focus="onFocus"
         @blur="onBlur"
       >

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @input="onInput"
+        @change="onInput"
         @focus="onFocus"
         @blur="onBlur"
       >

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @input="onInput"
+        @change="onInput"
         @focus="onFocus"
         @blur="onBlur"
       >


### PR DESCRIPTION
The mac native select controls do not appreciate having an 'input'
handler. It blocks the entire behavior, unlike on Linux or Windows. This
moves the `input` behavior of our select boxes in the attribute panel to
use `change` instead, which works correctly across different operating
systems.