### PR TITLE
fix(si-sdf): fix failing test due to `Resource::new` update

### DIFF
--- a/components/si-sdf/tests/filters/resource_dal.rs
+++ b/components/si-sdf/tests/filters/resource_dal.rs
@@ -74,12 +74,9 @@ async fn get_resource() {
     txn.commit().await.expect("cannot commit txn");
     nats.commit().await.expect("cannot commit nats txn");
 
-    let txn = conn.transaction().await.expect("cannot get transaction");
-    let nats = nats_conn.transaction();
-
     let resource = Resource::new(
-        &txn,
-        &nats,
+        &pg,
+        &nats_conn,
         serde_json::json!({ "cool": "beans" }),
         &entity.id,
         &system.id,
@@ -87,9 +84,6 @@ async fn get_resource() {
     )
     .await
     .expect("failed to create resource");
-
-    txn.commit().await.expect("cannot commit txn");
-    nats.commit().await.expect("cannot commit nats txn");
 
     let token = login_user(&ctx, &nba).await;
     let filter = api(pg, nats_conn, veritech, event_log_fs, secret_key);


### PR DESCRIPTION
![tenor-211117411](https://user-images.githubusercontent.com/261548/118734198-1c09a300-b7fb-11eb-8817-00c39b321a28.gif)

(resources? resources? get it?


hm, maybe a little thin here...)