### PR TITLE
feat: implement "Deploy" button services summary

### DIFF
--- a/components/si-model/src/workflow.rs
+++ b/components/si-model/src/workflow.rs
@@ -476,6 +476,7 @@ impl Workflow {
     ) -> &'static str {
         let action_name = action_name.as_ref();
         let s = match (&entity.entity_type[..], action_name) {
+            ("application", "deploy") => "application:deploy",
             ("service", "deploy") => "service:deploy",
             ("kubernetesCluster", "deploy") => "kubernetesCluster:deploy",
             ("kubernetesService", "deploy") => "kubernetesService:deploy",

--- a/components/si-registry/src/workflow.ts
+++ b/components/si-registry/src/workflow.ts
@@ -171,7 +171,7 @@ export interface Selector {
   types?: string[];
   fromProperty?: string[];
   depth?: "immediate" | "all";
-  edgeKind?: "configures" | "deployment";
+  edgeKind?: "configures" | "deployment" | "includes";
   direction?: "input" | "output";
 }
 
@@ -240,6 +240,27 @@ export const universalDeploy: Workflow = {
       },
       strategy: { kind: VariableKind.String, value: "linear" },
       failIfMissing: { kind: VariableKind.Bool, value: false },
+    },
+  ],
+};
+
+export const applicationDeploy: Workflow = {
+  name: "application:deploy",
+  kind: WorkflowKind.Action,
+  title: "Application Deployment",
+  description: "Deploy application",
+  steps: [
+    {
+      kind: StepKind.Action,
+      inputs: {
+        name: { kind: VariableKind.String, value: "deploy" },
+      },
+      selector: {
+        edgeKind: "includes",
+        depth: "immediate",
+        direction: "output",
+        types: ["service"],
+      },
     },
   ],
 };
@@ -385,6 +406,7 @@ export const kubernetesApply: Workflow = {
 
 export const workflows: Record<string, Workflow> = {
   serviceDeploy,
+  applicationDeploy,
   kubernetesServiceDeploy,
   kubernetesClusterDeploy,
   universalDeploy,

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -544,6 +544,11 @@ pub fn application_dal(
 ) -> BoxedFilter<(impl warp::Reply,)> {
     application_dal_create_application(pg.clone(), nats_conn.clone(), veritech.clone())
         .or(application_dal_list_applications(pg.clone()))
+        .or(application_dal_deploy_services(
+            pg.clone(),
+            nats_conn.clone(),
+            veritech.clone(),
+        ))
         .boxed()
 }
 
@@ -574,6 +579,24 @@ pub fn application_dal_create_application(
             handlers::application_dal::CreateApplicationRequest,
         >())
         .and_then(handlers::application_dal::create_application)
+        .boxed()
+}
+
+pub fn application_dal_deploy_services(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("applicationDal" / "deployServices")
+        .and(warp::post())
+        .and(with_pg(pg))
+        .and(with_nats_conn(nats_conn))
+        .and(with_veritech(veritech))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<
+            handlers::application_dal::DeployServicesRequest,
+        >())
+        .and_then(handlers::application_dal::deploy_services)
         .boxed()
 }
 

--- a/components/si-sdf/src/handlers/application_dal.rs
+++ b/components/si-sdf/src/handlers/application_dal.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use si_data::{NatsConn, PgPool};
-use si_model::{application, ApplicationListEntry, Veritech};
+use si_model::{
+    application, ApplicationListEntry, Entity, Veritech, Workflow, WorkflowContext, WorkflowRun,
+    Workspace,
+};
 
 use crate::handlers::{authenticate, authorize, validate_tenancy, HandlerError};
 
@@ -87,5 +90,95 @@ pub async fn list_applications(
         .map_err(HandlerError::from)?;
 
     let reply = ListApplicationsReply { list };
+    Ok(warp::reply::json(&reply))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployServicesRequest {
+    pub workspace_id: String,
+    pub system_id: String,
+    pub application_id: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployServicesReply {
+    pub workflow_run: WorkflowRun,
+}
+
+pub async fn deploy_services(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+    token: String,
+    request: DeployServicesRequest,
+) -> Result<impl warp::Reply, warp::reject::Rejection> {
+    let mut conn = pg.pool.get().await.map_err(HandlerError::from)?;
+    let txn = conn.transaction().await.map_err(HandlerError::from)?;
+    let nats = nats_conn.transaction();
+
+    let claim = authenticate(&txn, &token).await?;
+    authorize(&txn, &claim.user_id, "applicationDal", "deployServices").await?;
+    validate_tenancy(
+        &txn,
+        "workspaces",
+        &request.workspace_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.application_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+    validate_tenancy(
+        &txn,
+        "entities",
+        &request.system_id,
+        &claim.billing_account_id,
+    )
+    .await?;
+
+    let entity = Entity::for_head(&txn, &request.application_id)
+        .await
+        .map_err(HandlerError::from)?;
+    let system = Entity::for_head(&txn, &request.system_id)
+        .await
+        .map_err(HandlerError::from)?;
+    let workspace = Workspace::get(&txn, &request.workspace_id)
+        .await
+        .map_err(HandlerError::from)?;
+
+    let workflow_name = Workflow::entity_and_action_name_to_workflow_name(&entity, "deploy");
+
+    let ctx = WorkflowContext {
+        dry_run: false,
+        entity: Some(entity),
+        system: Some(system),
+        selection: vec![],
+        strategy: None,
+        fail_if_missing: None,
+        inputs: None,
+        args: None,
+        output: None,
+        store: None,
+        workspace,
+    };
+
+    let workflow_run = Workflow::get_by_name(&txn, workflow_name)
+        .await
+        .map_err(HandlerError::from)?
+        .invoke(&pg, &nats_conn, &veritech, ctx)
+        .await
+        .map_err(HandlerError::from)?;
+
+    txn.commit().await.map_err(HandlerError::from)?;
+    nats.commit().await.map_err(HandlerError::from)?;
+
+    let reply = DeployServicesReply { workflow_run };
+
     Ok(warp::reply::json(&reply))
 }

--- a/components/si-web-app/src/api/sdf/dal/applicationDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/applicationDal.ts
@@ -4,20 +4,11 @@ import { System } from "@/api/sdf/model/system";
 import { SDFError } from "@/api/sdf";
 import Bottle from "bottlejs";
 import _ from "lodash";
+import { WorkflowRun } from "../model/workflow";
 
 export interface IApplicationCreateRequest {
   applicationName: string;
   workspaceId: string;
-}
-
-export interface IServiceWithResources {
-  service: Entity;
-  resources: Resource[];
-}
-
-export interface IChangeSetCounts {
-  open: number;
-  closed: number;
 }
 
 export interface IApplicationCreateReplySuccess {
@@ -40,6 +31,44 @@ export type IApplicationCreateReply =
   | IApplicationCreateReplySuccess
   | IApplicationCreateReplyFailure;
 
+export interface IServiceWithResources {
+  service: Entity;
+  resources: Resource[];
+}
+
+export interface IChangeSetCounts {
+  open: number;
+  closed: number;
+}
+
+export async function createApplication(
+  request: IApplicationCreateRequest,
+): Promise<IApplicationCreateReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IApplicationCreateReply = await sdf.post(
+    "applicationDal/createApplication",
+    request,
+  );
+
+  if (!reply.error) {
+    reply.application = Entity.fromJson(reply.application);
+    reply.systems = _.map(reply.systems, isystem => {
+      return System.upgrade(isystem);
+    });
+    reply.servicesWithResources = _.map(reply.servicesWithResources, iswr => {
+      return {
+        service: Entity.fromJson(iswr.service),
+        resources: _.map(iswr.resources, r => {
+          return Resource.upgrade(r);
+        }),
+      };
+    });
+  }
+  return reply;
+}
+
 export interface IApplicationListRequest {
   workspaceId: string;
 }
@@ -58,19 +87,19 @@ export type IApplicationListReply =
   | IApplicationListReplySuccess
   | IApplicationListReplyFailure;
 
-export class ApplicationDal {
-  static async createApplication(
-    request: IApplicationCreateRequest,
-  ): Promise<IApplicationCreateReply> {
-    let bottle = Bottle.pop("default");
-    let sdf = bottle.container.SDF;
+export async function listApplications(
+  request: IApplicationListRequest,
+): Promise<IApplicationListReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
 
-    const reply: IApplicationCreateReply = await sdf.post(
-      "applicationDal/createApplication",
-      request,
-    );
+  const listReply: IApplicationListReply = await sdf.get(
+    "applicationDal/listApplications",
+    request,
+  );
 
-    if (!reply.error) {
+  if (!listReply.error) {
+    for (const reply of listReply.list) {
       reply.application = Entity.fromJson(reply.application);
       reply.systems = _.map(reply.systems, isystem => {
         return System.upgrade(isystem);
@@ -84,39 +113,45 @@ export class ApplicationDal {
         };
       });
     }
-    return reply;
   }
-
-  static async listApplications(
-    request: IApplicationListRequest,
-  ): Promise<IApplicationListReply> {
-    let bottle = Bottle.pop("default");
-    let sdf = bottle.container.SDF;
-
-    const listReply: IApplicationListReply = await sdf.get(
-      "applicationDal/listApplications",
-      request,
-    );
-
-    if (!listReply.error) {
-      for (const reply of listReply.list) {
-        reply.application = Entity.fromJson(reply.application);
-        reply.systems = _.map(reply.systems, isystem => {
-          return System.upgrade(isystem);
-        });
-        reply.servicesWithResources = _.map(
-          reply.servicesWithResources,
-          iswr => {
-            return {
-              service: Entity.fromJson(iswr.service),
-              resources: _.map(iswr.resources, r => {
-                return Resource.upgrade(r);
-              }),
-            };
-          },
-        );
-      }
-    }
-    return listReply;
-  }
+  return listReply;
 }
+
+export interface IDeployServicesRequest {
+  workspaceId: string;
+  systemId: string;
+  applicationId: string;
+}
+
+export interface IDeployServicesReplySuccess {
+  workflowRun: WorkflowRun;
+  error?: never;
+}
+
+export interface IDeployServicesReplyFailure {
+  workflowRun?: never;
+  error: SDFError;
+}
+
+export type IDeployServicesReply =
+  | IDeployServicesReplySuccess
+  | IDeployServicesReplyFailure;
+
+export async function deployServices(
+  request: IDeployServicesRequest,
+): Promise<IDeployServicesReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IDeployServicesReply = await sdf.post(
+    "applicationDal/deployServices",
+    request,
+  );
+  return reply;
+}
+
+export const ApplicationDal = {
+  createApplication,
+  listApplications,
+  deployServices,
+};

--- a/components/si-web-app/src/molecules/ServicesSummary.vue
+++ b/components/si-web-app/src/molecules/ServicesSummary.vue
@@ -18,7 +18,13 @@
           <div class="flex justify-end mt-2" v-show="showButton">
             <div class="flex items-center justify-center button">
               <!-- <upload-icon size="0.75x" class="mx-1 my-1 align-middle" /> -->
-              <div class="mx-1 align-middle button-text">Deploy</div>
+              <button
+                class="mx-1 align-middle button-text disabled:opacity-30"
+                :disabled="editMode"
+                @click="deploy()"
+              >
+                Deploy
+              </button>
             </div>
           </div>
         </div>
@@ -33,6 +39,9 @@ import Vue from "vue";
 import { servicesData, Service } from "@/api/visualization/servicesData";
 import ServiceVisualization from "@/molecules/ServicesSummary/ServiceVisualization.vue";
 import SummaryCard from "@/atoms/SummaryCard.vue";
+import { editMode$, system$, workspace$, applicationId$ } from "@/observables";
+import { ApplicationDal } from "@/api/sdf/dal/applicationDal";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
 
 interface IData {
   servicesData: Service[];
@@ -54,6 +63,32 @@ export default Vue.extend({
     return {
       servicesData: servicesData,
     };
+  },
+  subscriptions: function(this: any): Record<string, any> {
+    return {
+      editMode: editMode$,
+      system: system$,
+      workspace: workspace$,
+      applicationId: applicationId$,
+    };
+  },
+  methods: {
+    async deploy(): Promise<void> {
+      // @ts-ignore
+      if (this.applicationId && this.system && this.workspace) {
+        const reply = await ApplicationDal.deployServices({
+          // @ts-ignore
+          workspaceId: this.workspace.id,
+          // @ts-ignore
+          systemId: this.system.id,
+          // @ts-ignore
+          applicationId: this.applicationId,
+        });
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        }
+      }
+    },
   },
 });
 </script>


### PR DESCRIPTION
This change adds behavior to the "Deploy" button in the services summary
section in the application context. It's job it to run the "deploy"
action on the current application. The "application:deploy" workflow
finds all directly included "service" entities and calls their
"service:deploy" action.

Currently our selector strategies are rather limited--that is all
selected nodes are run in serial--but once we have parallel/concurrent
execution...woah!

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>