### PR TITLE
fix(si-web-app): catch invalid schematic refresh on page leave

### DIFF
--- a/components/si-web-app/src/organisims/SchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SchematicPanel.vue
@@ -221,7 +221,10 @@ export default Vue.extend({
           _nodePositionUpdated,
           _edgeDeleted,
         ]) => {
-          if (rootObjectId == "noSelectedDeploymentNode") {
+          if (
+            rootObjectId == "noSelectedDeploymentNode" ||
+            rootObjectId == "noSelectedApplicationNode"
+          ) {
             this.schematic = null;
             return of({
               error: { message: "no selected deployment node", code: 42 },


### PR DESCRIPTION
This change fixes a bug where the user in on an application system
schematic page/view and then hits the application list navigation link.
Before this change, then unloading of the SchematicPanel would often
catch a change in the `rootObjectId$` observable which would trigger a
re-fetching of a schematic. As we're unloading state, this is not only
wasteful, but invalid. All that was missing was another check of
`rootObjectId` being equal to `"noSelectedApplicationNode"` which is set
elsewhere. Nice!

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>