### PR TITLE
feat(si-web): add menu is organized

### DIFF
--- a/components/si-registry/src/index.ts
+++ b/components/si-registry/src/index.ts
@@ -11,11 +11,10 @@ export {
   ValidatorKind,
   RegistryEntry,
   RegistryEntryUi,
-  MenuCategory,
   Qualification,
   NodeKind,
   CodeKind,
 } from "./registryEntry";
 export { workflows, Workflow, Step } from "./workflow";
-export { entityMenu, MenuCategoryItem } from "./menu";
+export { entityMenu, EntityMenuFilters, MenuItem, MenuList } from "./menu";
 export { registry, findProp } from "./registry";

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -6,26 +6,20 @@ export enum SchematicKind {
   Component = "component",
 }
 
-export enum MenuCategory {
-  Application = "application",
-  AWS = "AWS",
-  Service = "service",
-  Docker = "docker",
-  Kubernetes = "kubernetes",
-  Helm = "helm",
-}
-
-interface RegistryEntryUiHidden {
-  menuCategory?: never;
-  menuDisplayName?: never;
-  schematicKinds?: never;
+export interface RegistryEntryUiHidden {
+  menu?: never;
   hidden: true;
 }
 
-interface RegistryEntryUiPresent {
-  menuCategory: MenuCategory;
-  menuDisplayName: string;
-  schematicKinds: SchematicKind[];
+export interface RegistryEntryUiMenuItem {
+  name: string;
+  menuCategory: string[];
+  schematicKind: SchematicKind;
+  rootEntityTypes?: string[];
+}
+
+export interface RegistryEntryUiPresent {
+  menu: RegistryEntryUiMenuItem[];
   hidden?: never;
 }
 

--- a/components/si-registry/src/schema/aws/aws.ts
+++ b/components/si-registry/src/schema/aws/aws.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   SchematicKind,
   NodeKind,
   Arity,
@@ -10,9 +9,14 @@ const aws: RegistryEntry = {
   entityType: "aws",
   nodeKind: NodeKind.Implementation,
   ui: {
-    menuCategory: MenuCategory.AWS,
-    menuDisplayName: "AWS",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "aws",
+        menuCategory: ["implementation"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
   },
   implements: ["cloudProvider"],
   inputs: [

--- a/components/si-registry/src/schema/aws/awsAccessKey.ts
+++ b/components/si-registry/src/schema/aws/awsAccessKey.ts
@@ -1,7 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
-  ValidatorKind,
   SchematicKind,
   NodeKind,
   //Arity,
@@ -11,9 +9,14 @@ const awsAccessKey: RegistryEntry = {
   entityType: "awsAccessKey",
   nodeKind: NodeKind.Concrete,
   ui: {
-    menuCategory: MenuCategory.AWS,
-    menuDisplayName: "awsAccessKey",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "access key",
+        menuCategory: ["aws"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
   },
   inputs: [],
   properties: [

--- a/components/si-registry/src/schema/aws/awsEks.ts
+++ b/components/si-registry/src/schema/aws/awsEks.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   SchematicKind,
   NodeKind,
   Arity,
@@ -11,9 +10,14 @@ const awsEks: RegistryEntry = {
   entityType: "awsEks",
   nodeKind: NodeKind.Implementation,
   ui: {
-    menuCategory: MenuCategory.AWS,
-    menuDisplayName: "awsEks",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "eks",
+        menuCategory: ["implementation", "aws"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["kubernetesCluster"],
+      },
+    ],
   },
   implements: ["kubernetesCluster"],
   inputs: [

--- a/components/si-registry/src/schema/aws/awsEksCluster.ts
+++ b/components/si-registry/src/schema/aws/awsEksCluster.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   ValidatorKind,
   SchematicKind,
   NodeKind,
@@ -11,9 +10,14 @@ const awsEksCluster: RegistryEntry = {
   entityType: "awsEksCluster",
   nodeKind: NodeKind.Concrete,
   ui: {
-    menuCategory: MenuCategory.AWS,
-    menuDisplayName: "awsEksCluster",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "cluster",
+        menuCategory: ["aws", "eks"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["kubernetesCluster"],
+      },
+    ],
   },
   inputs: [],
   properties: [

--- a/components/si-registry/src/schema/aws/awsRegion.ts
+++ b/components/si-registry/src/schema/aws/awsRegion.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   ValidatorKind,
   SchematicKind,
   NodeKind,
@@ -216,9 +215,14 @@ const awsRegion: RegistryEntry = {
   entityType: "awsRegion",
   nodeKind: NodeKind.Concrete,
   ui: {
-    menuCategory: MenuCategory.AWS,
-    menuDisplayName: "awsRegion",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "region",
+        menuCategory: ["aws"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
   },
   inputs: [],
   properties: [

--- a/components/si-registry/src/schema/docker/dockerImage.ts
+++ b/components/si-registry/src/schema/docker/dockerImage.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   ValidatorKind,
   SchematicKind,
   NodeKind,
@@ -11,9 +10,14 @@ const dockerImage: RegistryEntry = {
   entityType: "dockerImage",
   nodeKind: NodeKind.Concrete,
   ui: {
-    menuCategory: MenuCategory.Docker,
-    menuDisplayName: "docker image",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "image",
+        menuCategory: ["container", "docker"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["service"],
+      },
+    ],
   },
   inputs: [],
   properties: [

--- a/components/si-registry/src/schema/kubernetes/k8sDeployment.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sDeployment.ts
@@ -1,4 +1,9 @@
-import { RegistryEntry, NodeKind, Arity } from "../../registryEntry";
+import {
+  RegistryEntry,
+  NodeKind,
+  Arity,
+  SchematicKind,
+} from "../../registryEntry";
 
 import { metadata } from "./shared/objectMeta";
 import {
@@ -7,7 +12,6 @@ import {
   qualifications,
   actions,
   commands,
-  ui,
   code,
 } from "./shared/standard";
 import { selector } from "./shared/labelSelector";
@@ -17,7 +21,16 @@ const k8sDeployment: RegistryEntry = {
   entityType: "k8sDeployment",
   nodeKind: NodeKind.Concrete,
   code: code(),
-  ui: ui("k8sDeployment"),
+  ui: {
+    menu: [
+      {
+        name: "deployment",
+        menuCategory: ["kubernetes"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["service"],
+      },
+    ],
+  },
   inputs: [
     {
       name: "dockerImage",

--- a/components/si-registry/src/schema/kubernetes/k8sNamespace.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sNamespace.ts
@@ -1,4 +1,4 @@
-import { RegistryEntry, NodeKind } from "../../registryEntry";
+import { RegistryEntry, NodeKind, SchematicKind } from "../../registryEntry";
 
 import { metadata } from "./shared/objectMeta";
 import {
@@ -7,7 +7,6 @@ import {
   qualifications,
   actions,
   commands,
-  ui,
   code,
 } from "./shared/standard";
 
@@ -15,7 +14,16 @@ const k8sNamespace: RegistryEntry = {
   entityType: "k8sNamespace",
   nodeKind: NodeKind.Concrete,
   code: code(),
-  ui: ui("k8sNamespace"),
+  ui: {
+    menu: [
+      {
+        name: "namespace",
+        menuCategory: ["kubernetes"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["service"],
+      },
+    ],
+  },
   inputs: [],
   properties: [apiVersion("v1"), kind("Namespace"), metadata],
   qualifications,

--- a/components/si-registry/src/schema/kubernetes/k8sService.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sService.ts
@@ -3,6 +3,7 @@ import {
   NodeKind,
   Arity,
   ValidatorKind,
+  SchematicKind,
 } from "../../registryEntry";
 
 import { metadata } from "./shared/objectMeta";
@@ -12,7 +13,6 @@ import {
   qualifications,
   actions,
   commands,
-  ui,
   code,
 } from "./shared/standard";
 
@@ -20,7 +20,16 @@ const k8sService: RegistryEntry = {
   entityType: "k8sService",
   nodeKind: NodeKind.Concrete,
   code: code(),
-  ui: ui("k8sService"),
+  ui: {
+    menu: [
+      {
+        name: "service",
+        menuCategory: ["kubernetes"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["service"],
+      },
+    ],
+  },
   inputs: [
     {
       name: "k8sNamespace",

--- a/components/si-registry/src/schema/kubernetes/kubernetes.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetes.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   SchematicKind,
   NodeKind,
   Arity,
@@ -11,9 +10,14 @@ const kubernetesCluster: RegistryEntry = {
   entityType: "kubernetesCluster",
   nodeKind: NodeKind.Concept,
   ui: {
-    menuCategory: MenuCategory.Application,
-    menuDisplayName: "kubernetes",
-    schematicKinds: [SchematicKind.Deployment],
+    menu: [
+      {
+        name: "kubernetes",
+        menuCategory: ["compute"],
+        schematicKind: SchematicKind.Deployment,
+        rootEntityTypes: ["application"],
+      },
+    ],
   },
   inputs: [
     ...standardConceptInputs,

--- a/components/si-registry/src/schema/kubernetes/kubernetesService.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetesService.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   SchematicKind,
   NodeKind,
   Arity,
@@ -10,9 +9,14 @@ const kubernetesService: RegistryEntry = {
   entityType: "kubernetesService",
   nodeKind: NodeKind.Implementation,
   ui: {
-    menuCategory: MenuCategory.Service,
-    menuDisplayName: "kubernetesService",
-    schematicKinds: [SchematicKind.Component],
+    menu: [
+      {
+        name: "kubernetes",
+        menuCategory: ["implementation"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["service"],
+      },
+    ],
   },
   implements: ["service"],
   inputs: [

--- a/components/si-registry/src/schema/kubernetes/shared/standard.ts
+++ b/components/si-registry/src/schema/kubernetes/shared/standard.ts
@@ -1,23 +1,13 @@
 import {
   CodeKind,
-  MenuCategory,
   PropString,
   RegistryEntry,
-  SchematicKind,
   ValidatorKind,
 } from "../../../registryEntry";
 import _ from "lodash";
 
 export function code(): RegistryEntry["code"] {
   return { kind: CodeKind.YAML };
-}
-
-export function ui(entityType: string): RegistryEntry["ui"] {
-  return {
-    menuCategory: MenuCategory.Kubernetes,
-    menuDisplayName: entityType,
-    schematicKinds: [SchematicKind.Component],
-  };
 }
 
 export function apiVersion(apiVersion: string): PropString {

--- a/components/si-registry/src/schema/si/cloudProvider.ts
+++ b/components/si-registry/src/schema/si/cloudProvider.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   SchematicKind,
   NodeKind,
   Arity,
@@ -11,9 +10,14 @@ const cloudProvider: RegistryEntry = {
   entityType: "cloudProvider",
   nodeKind: NodeKind.Concept,
   ui: {
-    menuCategory: MenuCategory.Application,
-    menuDisplayName: "cloudProvider",
-    schematicKinds: [SchematicKind.Deployment],
+    menu: [
+      {
+        name: "cloud",
+        menuCategory: ["provider"],
+        schematicKind: SchematicKind.Deployment,
+        rootEntityTypes: ["application"],
+      },
+    ],
   },
   inputs: [
     ...onlyImplementation,

--- a/components/si-registry/src/schema/si/service.ts
+++ b/components/si-registry/src/schema/si/service.ts
@@ -1,18 +1,18 @@
-import {
-  RegistryEntry,
-  MenuCategory,
-  SchematicKind,
-  NodeKind,
-} from "../../registryEntry";
+import { RegistryEntry, SchematicKind, NodeKind } from "../../registryEntry";
 import { standardConceptInputs } from "../include/standardConceptInputs";
 
 const service: RegistryEntry = {
   entityType: "service",
   nodeKind: NodeKind.Concept,
   ui: {
-    menuCategory: MenuCategory.Application,
-    menuDisplayName: "service",
-    schematicKinds: [SchematicKind.Deployment],
+    menu: [
+      {
+        name: "service",
+        menuCategory: ["application"],
+        schematicKind: SchematicKind.Deployment,
+        rootEntityTypes: ["application"],
+      },
+    ],
   },
   inputs: [...standardConceptInputs],
   properties: [

--- a/components/si-registry/src/schema/test/leftHandPath.ts
+++ b/components/si-registry/src/schema/test/leftHandPath.ts
@@ -1,8 +1,8 @@
 import {
   RegistryEntry,
-  MenuCategory,
   ValidatorKind,
   NodeKind,
+  SchematicKind,
 } from "../../registryEntry";
 import frobNob from "./frobNob";
 
@@ -10,9 +10,13 @@ const leftHandPath: RegistryEntry = {
   entityType: "leftHandPath",
   nodeKind: NodeKind.Concept,
   ui: {
-    menuCategory: MenuCategory.Kubernetes,
-    menuDisplayName: "leftHandPath",
-    schematicKinds: [],
+    menu: [
+      {
+        name: "left hand path",
+        menuCategory: ["testing"],
+        schematicKind: SchematicKind.Component,
+      },
+    ],
   },
   inputs: [],
   properties: [

--- a/components/si-registry/src/schema/test/torture.ts
+++ b/components/si-registry/src/schema/test/torture.ts
@@ -1,6 +1,5 @@
 import {
   RegistryEntry,
-  MenuCategory,
   ValidatorKind,
   SchematicKind,
   NodeKind,
@@ -13,9 +12,20 @@ const torture: RegistryEntry = {
   nodeKind: NodeKind.Concrete,
   code: { kind: CodeKind.YAML },
   ui: {
-    menuCategory: MenuCategory.Application,
-    menuDisplayName: "torture test",
-    schematicKinds: [SchematicKind.Component, SchematicKind.Deployment],
+    hidden: true,
+    //menu: [
+    //  {
+    //    name: "torture test",
+    //    menuCategory: ["testing"],
+    //    schematicKind: SchematicKind.Component,
+    //  },
+    //  {
+    //    name: "torture test",
+    //    menuCategory: ["testing", "torture"],
+    //    schematicKind: SchematicKind.Deployment,
+    //    rootEntityTypes: ["application"],
+    //  },
+    //],
   },
   inputs: [
     {

--- a/components/si-registry/tests/menu.spec.ts
+++ b/components/si-registry/tests/menu.spec.ts
@@ -1,26 +1,45 @@
 import { entityMenu } from "../src/menu";
+import { SchematicKind } from "../src/registryEntry";
 
 describe("menu", () => {
   describe("entityMenu", () => {
     test("returns the entity menu", () => {
-      const result = entityMenu();
+      const result = entityMenu({
+        schematicKind: SchematicKind.Deployment,
+        rootEntityType: "application",
+      });
       expect(result).toEqual(
         expect.objectContaining({
           list: expect.arrayContaining([
             expect.objectContaining({
               name: "application",
+              kind: "category",
               items: expect.arrayContaining([
                 expect.objectContaining({
                   entityType: "service",
-                  displayName: "service",
+                  name: "service",
                 }),
               ]),
             }),
             expect.objectContaining({
-              name: "helm",
+              name: "compute",
+              kind: "category",
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  entityType: "kubernetesCluster",
+                  name: "kubernetes",
+                }),
+              ]),
             }),
             expect.objectContaining({
-              name: "kubernetes",
+              name: "provider",
+              kind: "category",
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  entityType: "cloudProvider",
+                  name: "cloud",
+                }),
+              ]),
             }),
           ]),
         }),

--- a/components/si-web-app/src/atoms/DropdownMenu.vue
+++ b/components/si-web-app/src/atoms/DropdownMenu.vue
@@ -1,0 +1,569 @@
+<template>
+  <div class="bp-dropdown" :class="{ className, 'bp-dropdown--sub': role }">
+    <span
+      :class="{
+        [`bp-dropdown__${role ? 'sub' : 'btn'}`]: true,
+        [`bp-dropdown__${role ? 'sub' : 'btn'}--active`]: !isHidden,
+        [`${className}-bp__btn`]: className,
+        [`${className}-bp__btn--active`]: !isHidden,
+      }"
+      @click="_onToggle"
+      @mouseenter="_onBtnEnter"
+      @mouseleave="_onBtnLeave"
+    >
+      <slot name="btn"></slot>
+      <slot name="icon" v-if="isIcon">
+        <svg
+          v-if="isLoading"
+          class="bp-dropdown__icon bp-dropdown__icon--spin"
+          viewBox="0 0 512 512"
+        >
+          <path
+            fill="currentColor"
+            d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+          ></path>
+        </svg>
+        <svg
+          v-else
+          class="bp-dropdown__icon"
+          :class="{ [`bp-dropdown__icon--${align}`]: align }"
+          viewBox="0 0 256 512"
+        >
+          <path
+            fill="currentColor"
+            d="M119.5 326.9L3.5 209.1c-4.7-4.7-4.7-12.3 0-17l7.1-7.1c4.7-4.7 12.3-4.7 17 0L128 287.3l100.4-102.2c4.7-4.7 12.3-4.7 17 0l7.1 7.1c4.7 4.7 4.7 12.3 0 17L136.5 327c-4.7 4.6-12.3 4.6-17-.1z"
+          ></path>
+        </svg>
+      </slot>
+    </span>
+    <transition name="fade">
+      <div
+        v-if="!isHidden"
+        class="text-sm subpixel-antialiased font-light tracking-tight bp-dropdown__body"
+        :id="id"
+        :style="{ minWidth: `${width}px`, top: `${top}px`, left: `${left}px` }"
+        :class="{ [`${className}-bp__body`]: className }"
+        @click="_onBodyClick"
+        @mouseenter="_onBodyEnter"
+        @mouseleave="_onBodyLeave"
+      >
+        <slot name="body"></slot>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+// From https://github.com/borisbutenko/bp-vuejs-dropdown
+//
+// MIT License
+//
+// Copyright (c) 2017-present, Boris Butenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export default {
+  name: "bp-vuejs-dropdown",
+
+  props: {
+    role: {
+      type: String,
+      required: false,
+      default: "",
+    },
+
+    unscroll: {
+      type: [HTMLElement, String],
+      required: false,
+      default: null,
+    },
+
+    align: {
+      type: String,
+      required: false,
+      default: "auto",
+    },
+
+    alignOrder: {
+      type: Array,
+      required: false,
+      default: () => [
+        "right-bottom",
+        "right-top",
+        "left-bottom",
+        "left-top",
+        "bottom-left",
+        "bottom-right",
+        "top-left",
+        "top-right",
+      ],
+    },
+
+    x: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
+
+    y: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
+
+    beforeOpen: {
+      type: Function,
+      required: false,
+      default: resolve => resolve(),
+    },
+
+    trigger: {
+      type: String,
+      required: false,
+      default: "click",
+    },
+
+    closeOnClick: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    isIcon: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+
+    className: {
+      type: String,
+      required: false,
+      default: "",
+    },
+  },
+
+  data() {
+    return {
+      isHidden: true,
+      isLoading: false,
+
+      id: null,
+      timeout: null,
+
+      top: undefined,
+      right: undefined,
+      bottom: undefined,
+      left: undefined,
+      width: undefined,
+    };
+  },
+
+  watch: {
+    isHidden(isHidden) {
+      if (this.unscroll) {
+        const el =
+          this.unscroll instanceof HTMLElement
+            ? this.unscroll
+            : document.querySelector(this.unscroll);
+
+        if (el) {
+          el.style.overflow = !isHidden ? "hidden" : "";
+        }
+      }
+    },
+  },
+
+  created() {
+    const $root = this.$root;
+
+    // --- hide dropdown if other dropdowns show
+    // --- or document clicked
+    $root.$on("bp-dropdown:open", () => (this.isHidden = true));
+    $root.$on("bp-dropdown:hide", () => (this.isHidden = true));
+
+    // --- hide dropdown on document click event
+    if (this.trigger === "click" && !$root["is-bp-dropdown"]) {
+      Object.defineProperty($root, "is-bp-dropdown", {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+        value: true,
+      });
+
+      document.onmousedown = e => {
+        const target = e.target;
+        const dropdown =
+          target.closest(".bp-dropdown__btn") ||
+          target.closest(".bp-dropdown__body");
+
+        if (!dropdown) {
+          $root.$emit("bp-dropdown:hide");
+        }
+      };
+    }
+
+    this.id = "bp-dropdown-" + this.generateRandomId();
+  },
+
+  methods: {
+    // --- generate random id for query selector
+    generateRandomId() {
+      return Math.random()
+        .toString(36)
+        .substr(2, 10);
+    },
+
+    _onToggle(e) {
+      if (this.trigger !== "click") {
+        return;
+      }
+
+      this.checkCustomCallback(e);
+    },
+
+    _onBtnEnter(e) {
+      if (this.trigger !== "hover" || !this.isHidden) {
+        return;
+      }
+
+      this.checkCustomCallback(e);
+    },
+
+    _onBtnLeave(e) {
+      if (this.trigger !== "hover") {
+        return;
+      }
+
+      if (this.role) {
+        this.timeout = setTimeout(() => (this.isHidden = true), 100);
+      }
+
+      const to = e.toElement;
+      if (!to) {
+        return;
+      }
+
+      const isDropdown =
+        to.closest(".bp-dropdown__btn") || to.closest(".bp-dropdown__body");
+      if (isDropdown) {
+        return;
+      }
+
+      this.prepare();
+    },
+
+    _onBodyClick() {
+      if (this.closeOnClick) {
+        this.isHidden = true;
+      }
+    },
+
+    _onBodyEnter() {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+    },
+
+    _onBodyLeave(e) {
+      if (this.trigger !== "hover") {
+        return;
+      }
+
+      const to = e.toElement;
+      if (!to) {
+        return;
+      }
+
+      if (to.closest(".bp-dropdown__btn") || to.closest(".bp-dropdown__sub")) {
+        return;
+      }
+
+      this.prepare();
+    },
+
+    checkCustomCallback(e) {
+      if (!this.isHidden) {
+        this.prepare();
+        return;
+      }
+
+      // --- custom callback before open
+      const promise = new Promise(resolve => {
+        this.isLoading = true;
+        this.beforeOpen.call(this, resolve);
+      });
+
+      promise.then(() => {
+        this.isLoading = false;
+        if (!e.target.closest(".bp-dropdown__body")) {
+          // --- hide dropdown if other dropdowns show
+          this.$root.$emit("bp-dropdown:open");
+        }
+
+        setTimeout(this.prepare, 0);
+      });
+
+      promise.catch(() => {
+        throw Error("bp-dropdown promise error");
+      });
+    },
+
+    prepare() {
+      this.isHidden = !this.isHidden;
+      if (!this.isHidden) {
+        this.$nextTick(() => {
+          const button = this.$el.firstElementChild;
+          const container = document.getElementById(this.id);
+
+          this.setWidth(button.offsetWidth);
+          this.setPosition(button, container);
+        });
+      }
+    },
+
+    setWidth(width) {
+      this.width = width;
+    },
+
+    setPosition(btn, body) {
+      if (!btn || !body) {
+        return;
+      }
+
+      let rect;
+      if (this.align === "auto") {
+        // --- view port size
+        const vpWidth = document.documentElement.clientWidth;
+        const vpHeight = document.documentElement.clientHeight;
+
+        for (let i = 0; i <= this.alignOrder.length; i++) {
+          const align =
+            i === this.alignOrder.length
+              ? this.alignOrder[0]
+              : this.alignOrder[i];
+          rect = this.calcRectFromAlign(btn, body, align);
+
+          if (
+            rect.left >= pageXOffset &&
+            rect.top >= pageYOffset &&
+            rect.right <= pageXOffset + vpWidth &&
+            rect.bottom <= pageYOffset + vpHeight
+          ) {
+            break;
+          }
+        }
+      } else {
+        rect = this.calcRectFromAlign(btn, body, this.align);
+      }
+
+      this.top = rect.top;
+      this.left = rect.left;
+    },
+
+    calcRectFromAlign(btn, body, align) {
+      const coords = this.getCoords(btn);
+
+      // --- current position
+      const currentTop = coords.top;
+      const currentLeft = coords.left;
+
+      // --- btn size
+      const btnWidth = btn.offsetWidth;
+      const btnHeight = btn.offsetHeight;
+
+      // --- body size
+      const bodyWidth = body.offsetWidth;
+      const bodyHeight = body.offsetHeight;
+
+      let _top, _left;
+
+      switch (align) {
+        case "top":
+        case "top-right":
+          _top = currentTop + pageYOffset - bodyHeight;
+          _left = currentLeft + pageXOffset;
+          break;
+        case "top-left":
+          _top = currentTop + pageYOffset - bodyHeight;
+          _left = currentLeft + pageXOffset - bodyWidth + btnWidth;
+          break;
+        case "right":
+        case "right-bottom":
+          _top = currentTop + pageYOffset;
+          _left = currentLeft + pageXOffset + btnWidth;
+          break;
+        case "right-top":
+          _top = currentTop + pageYOffset - bodyHeight + btnHeight;
+          _left = currentLeft + pageXOffset + btnWidth;
+          break;
+        case "bottom-left":
+          _top = currentTop + pageYOffset + btnHeight;
+          _left = currentLeft + pageXOffset - bodyWidth + btnWidth;
+          break;
+        case "left":
+        case "left-bottom":
+          _top = currentTop + pageYOffset;
+          _left = currentLeft + pageXOffset - bodyWidth;
+          break;
+        case "left-top":
+          _top = currentTop + pageYOffset - bodyHeight + btnHeight;
+          _left = currentLeft + pageXOffset - bodyWidth;
+          break;
+        case "bottom":
+        case "bottom-right":
+        default:
+          _top = currentTop + pageYOffset + btnHeight;
+          _left = currentLeft + pageXOffset;
+          break;
+      }
+
+      _top += this.y;
+      _left += this.x;
+
+      return {
+        top: _top,
+        left: _left,
+        bottom: _top + bodyHeight,
+        right: _left + bodyWidth,
+      };
+    },
+
+    getCoords(el) {
+      el = el.getBoundingClientRect();
+      return {
+        top: el.top - pageYOffset,
+        left: el.left - pageXOffset,
+      };
+    },
+  },
+};
+</script>
+
+<style>
+.bp-dropdown--sub {
+  width: 100%;
+}
+
+.bp-dropdown--sub .bp-dropdown__btn,
+.bp-dropdown--sub .bp-dropdown__sub {
+  width: 100%;
+}
+
+.bp-dropdown--sub .bp-dropdown__icon {
+  margin-left: auto;
+}
+
+.bp-dropdown__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 5px;
+  /* border: 1px solid #efefef; */
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.bp-dropdown__sub {
+  display: inline-flex;
+  align-items: center;
+}
+
+.bp-dropdown__btn--active {
+  /* background-color: #eee; */
+}
+
+.bp-dropdown__icon {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  overflow: visible;
+  transition: transform 0.1s ease;
+}
+
+.bp-dropdown__icon--spin {
+  width: 12px;
+  height: 12px;
+  animation: spin 2s infinite linear;
+}
+
+.bp-dropdown__icon--top {
+  transform: rotate(-180deg);
+}
+
+.bp-dropdown__icon--right {
+  transform: rotate(-90deg);
+}
+
+.bp-dropdown__icon--bottom {
+  transform: rotate(0);
+}
+
+.bp-dropdown__icon--left {
+  transform: rotate(-270deg);
+}
+
+.bp-dropdown__btn--active .bp-dropdown__icon--top,
+.bp-dropdown__sub--active .bp-dropdown__icon--top {
+  transform: rotate(0);
+}
+
+.bp-dropdown__btn--active .bp-dropdown__icon--right,
+.bp-dropdown__sub--active .bp-dropdown__icon--right {
+  transform: rotate(-270deg);
+}
+
+.bp-dropdown__btn--active .bp-dropdown__icon--bottom,
+.bp-dropdown__sub--active .bp-dropdown__icon--bottom {
+  transform: rotate(-180deg);
+}
+
+.bp-dropdown__btn--active .bp-dropdown__icon--left,
+.bp-dropdown__sub--active .bp-dropdown__icon--left {
+  transform: rotate(-90deg);
+}
+
+.bp-dropdown__body {
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding: 6px 8px;
+  background-color: #1f2631;
+  border: 1px solid #485359;
+  box-shadow: 0 5px 15px -5px rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.1s;
+}
+
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/components/si-web-app/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
+++ b/components/si-web-app/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
@@ -1,0 +1,96 @@
+<template>
+  <ul :class="listClasses" v-show="isOpen">
+    <template v-for="item in menuItems">
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category whitespace-nowrap"
+        v-if="item.kind == 'category'"
+        @mouseenter="open(item.name)"
+        @mouseleave="close(item.name)"
+        :key="item.name"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.name }}
+        </div>
+        <NodeAddMenuCategory
+          :menuItems="item.items"
+          :isOpen="isCategoryOpen(item.name)"
+          @selected="selectedType"
+        />
+      </li>
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
+        v-if="item.kind == 'item'"
+        :key="item.name"
+        @click="selectedType(item.entityType, $event)"
+      >
+        <div class="whitespace-no-wrap">
+          {{ item.name }}
+        </div>
+      </li>
+    </template>
+  </ul>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import { MenuItem } from "si-registry";
+
+interface Data {
+  openCategories: {
+    [category: string]: boolean;
+  };
+}
+
+export default Vue.extend({
+  name: "NodeAddMenuCategory",
+  props: {
+    menuItems: {
+      type: Array as PropType<MenuItem[]>,
+    },
+    rootMenu: { type: Boolean, default: false },
+    isOpen: { type: Boolean },
+  },
+  data(): Data {
+    return {
+      openCategories: {},
+    };
+  },
+  computed: {
+    listClasses(): Record<string, boolean> {
+      if (this.rootMenu) {
+        return {
+          absolute: true,
+          "w-auto": true,
+          "text-gray-200": true,
+          border: true,
+          "shadow-md": true,
+          options: true,
+        };
+      } else {
+        return {
+          relative: true,
+          "w-auto": true,
+          border: true,
+          "shadow-md": true,
+          "category-items": true,
+          options: true,
+        };
+      }
+    },
+  },
+  methods: {
+    selectedType(entityType: string, event: MouseEvent) {
+      this.$emit("selected", entityType, event);
+    },
+    open(category: string): void {
+      Vue.set(this.openCategories, category, true);
+    },
+    close(category: string): void {
+      Vue.set(this.openCategories, category, false);
+    },
+    isCategoryOpen(category: string): boolean {
+      return this.openCategories[category];
+    },
+  },
+});
+</script>

--- a/components/si-web-app/src/organisims/SchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SchematicPanel.vue
@@ -108,6 +108,7 @@ import {
   INodeCreateForApplicationRequest,
 } from "@/api/sdf/dal/schematicDal";
 import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+import { EntityMenuFilters } from "si-registry";
 
 interface Data {
   schematicKind: SchematicKind;
@@ -128,9 +129,9 @@ export default Vue.extend({
   },
   components: {
     Panel,
-    NodeAddMenu,
     SiSelect,
     SchematicViewer,
+    NodeAddMenu,
   },
   data(): Data {
     return {
@@ -327,8 +328,29 @@ export default Vue.extend({
         return this.editMode;
       }
     },
-    addMenuFilters(): SchematicKind[] {
-      return [this.schematicKind];
+    addMenuFilters(this: any): EntityMenuFilters {
+      if (this.schematicKind == SchematicKind.Deployment) {
+        return {
+          rootEntityType: "application",
+          schematicKind: this.schematicKind,
+        };
+      } else {
+        if (
+          this.deploymentSchematicSelectNode &&
+          this.deploymentSchematicSelectNode != "noSelectedDeploymentNode"
+        ) {
+          return {
+            rootEntityType: this.deploymentSchematicSelectNode.object
+              .entityType,
+            schematicKind: this.schematicKind,
+          };
+        } else {
+          return {
+            rootEntityType: "never",
+            schematicKind: this.schematicKind,
+          };
+        }
+      }
     },
     schematicKinds(): ILabelList {
       let labels: ILabelList = [];


### PR DESCRIPTION
This PR fixes [ch1174]. It organizes the Node Add Menu according to an
arbitrarily nested category, and is filtered both by the kind of
schematic and the root object of that schematic.

New nodes fill in their menu entry in their schema, and can appear in
multiple schematics, in multiple places, with arbitrary names. Pretty
much we can classify anything we want into whatever menu we want.

It also improves the node add menu:

* It now has an artifically wide "target" for mouse over, making it
  easier to directly access the menu without it closing.
* There is a half-second delay between the mouse leaving the menu and
  the menu automatically closing.
* If the mouse re-enters the menu within that half second delay, the
  menu will not close.

May the new menus live long and prosper.