### PR TITLE
feat(si-web): implement save on enter

### DIFF
--- a/components/si-web-app/src/organisims/AttributeViewer/BaseField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/BaseField.vue
@@ -12,9 +12,6 @@ import {
   OpTombstone,
 } from "si-entity/dist/siEntity";
 
-import TombstoneEdit from "@/organisims/AttributeViewer/Tombstone.vue";
-import Unset from "@/organisims/AttributeViewer/Unset.vue";
-import Field from "@/organisims/AttributeViewer/Field.vue";
 import { updateEntity } from "@/observables";
 import { Entity } from "@/api/sdf/model/entity";
 import { ValidateFailure } from "si-entity/dist/validation";
@@ -189,12 +186,20 @@ export default Vue.extend({
       }
       return true;
     },
+    onInputSelect(): void {
+      this.onInput();
+      this.onBlur();
+    },
     onInput() {
       this.validate();
     },
     onFocus() {
       this.setStartValueToCurrentValue();
       this.updating = true;
+    },
+    onEnterKey(event: KeyboardEvent) {
+      // @ts-ignore
+      event.target.blur();
     },
     async onBlur(editField?: EditField, value?: unknown) {
       if (!editField || editField.type == "blur") {

--- a/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
@@ -18,6 +18,7 @@
                 type="text"
                 @focus="onFocus"
                 @blur="onBlurForKey(mapValue.key, index)"
+                @keyup.enter="onEnterKey($event)"
                 v-model="keyValue[index]"
                 class="w-full pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey input-border-grey si-property disabled:opacity-50"
                 placeholder="key"
@@ -28,6 +29,7 @@
                 type="text"
                 @focus="onFocus"
                 @blur="onBlurForKeyValue(mapValue.key)"
+                @keyup.enter="onEnterKey($event)"
                 v-model="currentValue[mapValue.key]"
                 class="w-full pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey input-border-grey si-property disabled:opacity-50"
                 placeholder="value"
@@ -110,7 +112,6 @@ import {
   OpSet,
   OpType,
   OpSource,
-  OpUnset,
   OpTombstone,
 } from "si-entity/dist/siEntity";
 
@@ -192,7 +193,7 @@ export default BaseField.extend({
       let editField = this.editFieldForKey(key);
       this.unset(editField);
     },
-    onBlurForKey(oldKey: string, index: string): void {
+    onBlurForKey(oldKey: string, index: number): void {
       this.updating = false;
       if (_.isEqual(oldKey, this.keyValue[index])) {
         return;

--- a/components/si-web-app/src/organisims/AttributeViewer/NameField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/NameField.vue
@@ -15,6 +15,7 @@
         aria-label="name"
         placeholder="text"
         v-model="currentValue"
+        @keyup.enter="onEnterKey($event)"
         @focus="onFocus"
         @blur="onBlur"
       />
@@ -74,6 +75,12 @@ export default Vue.extend({
     };
   },
   methods: {
+    onEnterKey(event: KeyboardEvent) {
+      if (event.target) {
+        // @ts-ignore
+        event.target.blur();
+      }
+    },
     onFocus() {
       this.setStartValueToCurrentValue();
       this.updating = true;

--- a/components/si-web-app/src/organisims/AttributeViewer/NumberField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/NumberField.vue
@@ -14,6 +14,7 @@
         v-model="currentValue"
         :disabled="isDisabled"
         @input="onInput"
+        @keyup.enter="onEnterKey($event)"
         @focus="onFocus"
         @blur="onBlur"
       />

--- a/components/si-web-app/src/organisims/AttributeViewer/PasswordField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/PasswordField.vue
@@ -13,6 +13,7 @@
         placeholder="secret text"
         v-model="currentValue"
         :disabled="isDisabled"
+        @keyup.enter="onEnterKey($event)"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @change="onInput"
+        @change="onInputSelect"
         @focus="onFocus"
         @blur="onBlur"
       >

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @change="onInput"
+        @change="onInputSelect"
         @focus="onFocus"
         @blur="onBlur"
       >

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
@@ -11,7 +11,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
-        @change="onInput"
+        @change="onInputSelect"
         @focus="onFocus"
         @blur="onBlur"
       >

--- a/components/si-web-app/src/organisims/AttributeViewer/TextAreaField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/TextAreaField.vue
@@ -11,6 +11,8 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
+        @keyup.enter.shift="onEnterKey($event)"
+        @keyup.enter.alt="onEnterKey($event)"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"

--- a/components/si-web-app/src/organisims/AttributeViewer/TextField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/TextField.vue
@@ -13,6 +13,7 @@
         placeholder="text"
         v-model="currentValue"
         :disabled="isDisabled"
+        @keyup.enter="onEnterKey($event)"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"


### PR DESCRIPTION
This PR fixes [ch1173].

When in the attribute editor, all the "text" fields (text, numbers,
etc.) will now unfocus and save when you hit 'enter'.

When you are in a select box, we now automatically save the field when
you make a selection. We do not unfocus the select box, though.

When you are in a text area (currently only accessible via the torture
test node) you can save and unfocus the current field with either
"shift+enter" or "alt+enter".