### PR TITLE
fix(si-sdf): update node name when name attribute changed

### DIFF
--- a/components/si-web-app/src/observables.ts
+++ b/components/si-web-app/src/observables.ts
@@ -330,6 +330,18 @@ export const nodePositionUpdated$ = new ReplaySubject<NodePositionUpdated | null
 );
 nodePositionUpdated$.next(null);
 
+export interface NameAttributeChanged {
+  nodeId: string;
+  entityId: string;
+  entityType: string;
+  oldValue: string;
+  newValue: string;
+}
+export const nameAttributeChanged$ = new ReplaySubject<NameAttributeChanged | null>(
+  1,
+);
+nameAttributeChanged$.next(null);
+
 export interface EdgeCreating {
   entityType: string;
   schematicKind: string;


### PR DESCRIPTION
This ended up being a *much* more subtle issue than I initially thought,
despite the solution being rather small and the elusive bit for me was
missing that an rxjs Observable is *not* awaited by its nature--however
it can be converted to a Promise which can then be awaited.

The solution flow works like this:

1. In `NameField`, when the `onBlur` event is fired, assuming the value
   has changed, we fire the `updateEntity` observable. With this change,
   we convert the single yielded value (`updateEntity` has a `take(1)`
   at the end of the chain and thus returns 1 value before completing)
   into a `Promise` so that we can await its value (the reply type of an
   update Entity Dal call).
2. If the update Entity API reply contains an error, emit an error
   message and early return.
3. Otherwise we push a `NameAttributeChange` message on the
   `nameAttributeChanged$` observable with the node ID, old value, new
   value, etc.
4. Meanwhile in `SchematicPanel.vue`...we subscribe to the
   `nameAttributeChanged$` observable and check each new change event.
   If a name change is on a node that is in our `Schematic`, then update
   the name property on that Node's object in the schematic, causing a
   preemptive/optimistic update of the node name for any sub-component
   which is passed this schematic as a prop. Finally, we push a value on
   the `refreshSchematic$` observable, which is local to
   `SchematicPanel`.
5. In `SchematicPanel.vue`'s `loadSchematic$` observable, we augment the
   `combineLatest` composition to also use the new `refreshSchematic$`
   observable. When step 4 above pushes a new value on
   `refreshSchematic$`, it is reacted to here, causing a reloading of
   the current `Schematic` from the API. As the name attribute has
   already been committed in API back in step 1, the new name flows back
   in the Schematic reply. In almost all circumstances the "patched"
   name change in step 4 should exactly match the current name from the
   API so no change should be observed by a user. However, we should be
   guaranteed that the state of the client matches the state of the
   backend and all is good.

The subtle bug in `Namefield#onBlur` was that the observable was
scheduled and run off asynchronously, but *not* awaited within `onBlur`
meaning that any steps after that, or any reactive triggers after that
might not necessarily have an up-to-date picture of the data at a point
in time after the name was updated in the API.

The sequencing of updates and subsequent reactivitiy may need to be
carefully thought out in some parts of our system, less it start acting
strange, marching to its own drum.

![tenor-180440561](https://user-images.githubusercontent.com/261548/119206091-6d15d300-ba57-11eb-9fd7-88b6bb33cd14.gif)


Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>