### PR TITLE
feat(si-web): green field names for driven fields

### DIFF
--- a/components/si-entity/src/siEntity.ts
+++ b/components/si-entity/src/siEntity.ts
@@ -754,7 +754,6 @@ export class SiEntity implements ISiEntity {
       return false;
     }
   }
-
   valueOpForPath({
     path,
     system,
@@ -812,6 +811,26 @@ export class SiEntity implements ISiEntity {
         }
       }
       return finalOp;
+    } else {
+      return undefined;
+    }
+  }
+  valueFromOp({
+    path,
+    system,
+    source,
+  }: {
+    path: OpSet["path"];
+    system: OpSet["system"];
+    source: OpSet["source"];
+  }): OpSet | undefined {
+    const op = _.find(
+      this.ops,
+      (o) =>
+        o.source == source && _.isEqual(o.path, path) && o.system == system,
+    );
+    if (op) {
+      return op as OpSet;
     } else {
       return undefined;
     }

--- a/components/si-web-app/src/assets/main.css
+++ b/components/si-web-app/src/assets/main.css
@@ -17,6 +17,10 @@
   color: #ce7f3e;
 }
 
+.text-green {
+  color: #69e39b;
+}
+
 .input-bg-color-grey {
   background-color: #292c2d;
 }

--- a/components/si-web-app/src/atoms/Tooltip.vue
+++ b/components/si-web-app/src/atoms/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tooltip">
+  <div class="w-auto tooltip">
     <div @click="toggleVisibility()">
       <slot />
     </div>
@@ -82,7 +82,7 @@ export default Vue.extend({
 .tooltip .tooltip-text {
   visibility: hidden;
   position: absolute;
-  z-index: 100;
+  z-index: 999;
   border-color: #3a4145;
   background-color: #222629;
 }

--- a/components/si-web-app/src/organisims/AttributeViewer/ArrayField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/ArrayField.vue
@@ -4,12 +4,13 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
     v-on="$listeners"
   >
     <template slot="widget">
       <div class="flex flex-col flex-grow">
         <div
-          class="flex flex-row border-b-2 pb-2 border-gray-800"
+          class="flex flex-row pb-2 border-b-2 border-gray-800"
           v-for="(editFields, index) in items"
           :key="index"
         >
@@ -30,7 +31,7 @@
             @unset="unset(arrayEntryEditField(index))"
           />
         </div>
-        <div class="flex flex-row pl-2 pt-2">
+        <div class="flex flex-row pt-2 pl-2">
           <button>
             <PlusIcon @click="addItem" size="1x" />
           </button>

--- a/components/si-web-app/src/organisims/AttributeViewer/BaseField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/BaseField.vue
@@ -74,6 +74,27 @@ export default Vue.extend({
       }
       return false;
     },
+    fieldNameColor(): Record<string, boolean> {
+      const opSet = this.entity.valueOpForPath({
+        path: this.editField.path,
+        system: this.systemId,
+      });
+      if (opSet) {
+        if (opSet.source == OpSource.Inferred) {
+          return {
+            "text-green": true,
+          };
+        } else {
+          return {
+            "text-green": false,
+          };
+        }
+      } else {
+        return {
+          "text-green": false,
+        };
+      }
+    },
     borderColor(): Record<string, boolean> {
       let gold = hasDiff(
         this.diff,

--- a/components/si-web-app/src/organisims/AttributeViewer/CheckboxField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/CheckboxField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <div class="flex flex-grow">

--- a/components/si-web-app/src/organisims/AttributeViewer/Field.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/Field.vue
@@ -3,7 +3,8 @@
     <div class="flex flex-col w-full">
       <div class="flex flex-row items-center w-full">
         <div
-          class="w-1/4 break-all px-2 text-sm leading-tight text-right text-white flex-wrap"
+          class="w-1/4 break-all px-2 text-sm leading-tight text-right flex-wrap"
+          :class="nameClasses"
           v-if="name"
         >
           {{ name }}
@@ -59,6 +60,9 @@ export default Vue.extend({
     editMode: {
       type: Boolean,
       required: true,
+    },
+    nameClasses: {
+      type: Object as PropType<Record<string, boolean>>,
     },
   },
 });

--- a/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <div class="flex flex-row w-full pl-5">
@@ -98,7 +99,10 @@
           v-for="(value, key) in currentValue"
           :key="key"
         >
-          <div class="flex flex-row justify-end">{{ key }}:</div>
+          <div class="flex flex-row justify-end">
+            <span :class="fieldNameColorForKey(key)"> {{ key }}</span
+            >:
+          </div>
           <div class="flex flex-row">
             {{ value }}
           </div>
@@ -181,6 +185,27 @@ export default BaseField.extend({
     },
   },
   methods: {
+    fieldNameColorForKey(key: string): Record<string, boolean> {
+      const opSet = this.entity.valueOpForPath({
+        path: _.concat(this.editField.path, key),
+        system: this.systemId,
+      });
+      if (opSet) {
+        if (opSet.source == OpSource.Inferred) {
+          return {
+            "text-green": true,
+          };
+        } else {
+          return {
+            "text-green": false,
+          };
+        }
+      } else {
+        return {
+          "text-green": false,
+        };
+      }
+    },
     textColorForKey(key: string): Record<string, boolean> {
       let gold = hasDiff(
         this.diff,

--- a/components/si-web-app/src/organisims/AttributeViewer/NumberField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/NumberField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <input
@@ -57,7 +58,7 @@ interface Data {
 }
 
 export default BaseField.extend({
-  name: "CheckboxField",
+  name: "NumberField",
   mixins: [BaseField],
   components: {
     TombstoneEdit,

--- a/components/si-web-app/src/organisims/AttributeViewer/PasswordField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/PasswordField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <input

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <select

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromInputField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <select

--- a/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/SelectFromSecretField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <select

--- a/components/si-web-app/src/organisims/AttributeViewer/TextAreaField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/TextAreaField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <textarea

--- a/components/si-web-app/src/organisims/AttributeViewer/TextField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/TextField.vue
@@ -4,6 +4,7 @@
     :showField="showField"
     :errors="errors"
     :editMode="editMode"
+    :nameClasses="fieldNameColor"
   >
     <template slot="widget">
       <input

--- a/components/si-web-app/src/organisims/AttributeViewer/Tombstone.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/Tombstone.vue
@@ -184,7 +184,7 @@
                           <SquareApplicationIcon size="1x" />
                         </button>
                       </div>
-                      <div class="flex flex-grow ml-2">
+                      <div class="flex  flex-grow ml-2">
                         {{
                           valueFrom({
                             source: "inferred",


### PR DESCRIPTION
This PR partially solves [ch1186].

It turns (most) fields that are inferred green. It doesn't show you
where it comes from - but it does show that the value is inferred from
another source.

Currently if you are in a deeply nested array, things go off the rails,
for reasons I'm not enitrely sure of, but think has to do with how we
collapse the empty positions in existing arrays.