### PR TITLE
feat(si-web): deploy to azure

### DIFF
--- a/components/si-model/src/secret.rs
+++ b/components/si-model/src/secret.rs
@@ -94,6 +94,7 @@ pub enum SecretKind {
     DockerHub,
     AwsAccessKey,
     HelmRepo,
+    AzureServicePrincipal,
 }
 
 enum_impls!(SecretKind);

--- a/components/si-model/src/workflow/step.rs
+++ b/components/si-model/src/workflow/step.rs
@@ -2,18 +2,19 @@ use serde::{Deserialize, Serialize};
 use si_data::{NatsConn, NatsTxn, PgPool, PgTxn};
 use strum_macros::Display;
 
-use crate::workflow::{
-    SelectionEntry, WorkflowContext, WorkflowError, WorkflowResult, WorkflowRun,
-};
 use crate::{workflow::selector::Selector, Workflow};
 use crate::{
     workflow::variable::{VariableArray, VariableBool, VariableScalar},
     Resource,
 };
+use crate::{
+    workflow::{SelectionEntry, WorkflowContext, WorkflowError, WorkflowResult, WorkflowRun},
+    EdgeKind,
+};
 use crate::{Entity, SiStorable, Veritech, Workspace};
 use chrono::Utc;
 
-use super::selector::SelectionEntryPredecessor;
+use super::selector::{SelectionEntryPredecessor, SelectorDepth, SelectorDirection};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Display, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -291,11 +292,22 @@ pub enum CommandFinish {
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct ForEach {
+    types: Option<Vec<String>>,
+    from_property: Option<Vec<String>>,
+    depth: Option<SelectorDepth>,
+    edge_kind: Option<EdgeKind>,
+    direction: Option<SelectorDirection>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct StepCommand {
     pub inputs: StepCommandInputs,
     pub fail_if_missing: Option<VariableScalar>,
     pub selector: Option<Selector>,
     pub strategy: Option<VariableScalar>,
+    pub for_each: Option<ForEach>,
 }
 
 impl StepCommand {
@@ -520,6 +532,7 @@ pub struct StepAction {
     pub fail_if_missing: Option<VariableScalar>,
     pub selector: Option<Selector>,
     pub strategy: Option<VariableScalar>,
+    pub for_each: Option<ForEach>,
 }
 
 impl StepAction {

--- a/components/si-registry/src/registry.ts
+++ b/components/si-registry/src/registry.ts
@@ -21,6 +21,12 @@ import aws from "./schema/aws/aws";
 import awsRegion from "./schema/aws/awsRegion";
 import awsAccessKey from "./schema/aws/awsAccessKey";
 import awsEksCluster from "./schema/aws/awsEksCluster";
+import azure from "./schema/azure/azure";
+import azureAks from "./schema/azure/azureAks";
+import azureLocation from "./schema/azure/azureLocation";
+import azureAksCluster from "./schema/azure/azureAksCluster";
+import azureServicePrincipal from "./schema/azure/azureServicePrincipal";
+import azureResourceGroup from "./schema/azure/azureResourceGroup";
 
 export const registry: { [entityType: string]: RegistryEntry } = {
   leftHandPath,
@@ -41,6 +47,12 @@ export const registry: { [entityType: string]: RegistryEntry } = {
   awsRegion,
   awsAccessKey,
   awsEksCluster,
+  azure,
+  azureAks,
+  azureAksCluster,
+  azureLocation,
+  azureServicePrincipal,
+  azureResourceGroup,
 };
 
 export function findProp(path: string[]): Prop | undefined {

--- a/components/si-registry/src/schema/azure/azure.ts
+++ b/components/si-registry/src/schema/azure/azure.ts
@@ -1,0 +1,39 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  Arity,
+} from "../../registryEntry";
+
+const azure: RegistryEntry = {
+  entityType: "azure",
+  nodeKind: NodeKind.Implementation,
+  ui: {
+    menu: [
+      {
+        name: "azure",
+        menuCategory: ["implementation"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
+  },
+  implements: ["cloudProvider"],
+  inputs: [
+    {
+      name: "azureServicePrincipal",
+      types: ["azureServicePrincipal"],
+      edgeKind: "configures",
+      arity: Arity.One,
+    },
+    {
+      name: "azureLocation",
+      types: ["azureLocation"],
+      edgeKind: "configures",
+      arity: Arity.One,
+    },
+  ],
+  properties: [],
+};
+
+export default azure;

--- a/components/si-registry/src/schema/azure/azureAks.ts
+++ b/components/si-registry/src/schema/azure/azureAks.ts
@@ -1,0 +1,34 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  Arity,
+  //Arity,
+} from "../../registryEntry";
+
+const azureAks: RegistryEntry = {
+  entityType: "azureAks",
+  nodeKind: NodeKind.Implementation,
+  ui: {
+    menu: [
+      {
+        name: "aks",
+        menuCategory: ["implementation", "azure"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["kubernetesCluster"],
+      },
+    ],
+  },
+  implements: ["kubernetesCluster"],
+  inputs: [
+    {
+      name: "azureAksCluster",
+      edgeKind: "configures",
+      arity: Arity.One,
+      types: ["azureAksCluster"],
+    },
+  ],
+  properties: [],
+};
+
+export default azureAks;

--- a/components/si-registry/src/schema/azure/azureAksCluster.ts
+++ b/components/si-registry/src/schema/azure/azureAksCluster.ts
@@ -1,0 +1,168 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  Arity,
+  WidgetSelectOptionsItems,
+} from "../../registryEntry";
+
+import _ from "lodash";
+
+// taken from az aks get-versions -l centralus
+const kubernetesVersions = {
+  id:
+    "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/providers/Microsoft.ContainerService/locations/centralus/orchestrators",
+  name: "default",
+  orchestrators: [
+    {
+      default: null,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.18.14",
+      upgrades: [
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.18.17",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.19.7",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.19.9",
+        },
+      ],
+    },
+    {
+      default: null,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.18.17",
+      upgrades: [
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.19.7",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.19.9",
+        },
+      ],
+    },
+    {
+      default: null,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.19.7",
+      upgrades: [
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.19.9",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.20.2",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.20.5",
+        },
+      ],
+    },
+    {
+      default: true,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.19.9",
+      upgrades: [
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.20.2",
+        },
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.20.5",
+        },
+      ],
+    },
+    {
+      default: null,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.20.2",
+      upgrades: [
+        {
+          isPreview: null,
+          orchestratorType: "Kubernetes",
+          orchestratorVersion: "1.20.5",
+        },
+      ],
+    },
+    {
+      default: null,
+      isPreview: null,
+      orchestratorType: "Kubernetes",
+      orchestratorVersion: "1.20.5",
+      upgrades: null,
+    },
+  ],
+  type: "Microsoft.ContainerService/locations/orchestrators",
+};
+
+export function generateLabels(): WidgetSelectOptionsItems {
+  const items = _.map(kubernetesVersions.orchestrators, (v) => {
+    return { label: `${v.orchestratorVersion}`, value: v.orchestratorVersion };
+  });
+  return { items };
+}
+
+const azureAksCluster: RegistryEntry = {
+  entityType: "azureAksCluster",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menu: [
+      {
+        name: "cluster",
+        menuCategory: ["azure", "aks"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["kubernetesCluster"],
+      },
+    ],
+  },
+  inputs: [
+    {
+      name: "azureResourceGroup",
+      edgeKind: "configures",
+      arity: Arity.One,
+      types: ["azureResourceGroup"],
+    },
+  ],
+  properties: [
+    {
+      type: "string",
+      name: "name",
+    },
+    {
+      type: "string",
+      name: "kubernetesVersion",
+      defaultValue: "1.19.9",
+      widget: {
+        name: "select",
+        options: generateLabels(),
+      },
+    },
+  ],
+};
+
+export default azureAksCluster;

--- a/components/si-registry/src/schema/azure/azureLocation.ts
+++ b/components/si-registry/src/schema/azure/azureLocation.ts
@@ -1,0 +1,1453 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  WidgetSelectOptionsItems,
+  //Arity,
+} from "../../registryEntry";
+
+import _ from "lodash";
+
+// Taken from the output of az account list-locations on 2021-05-23
+export const azureLocations = [
+  {
+    displayName: "East US",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "37.3719",
+      longitude: "-79.8164",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus",
+          name: "westus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Virginia",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "eastus",
+    regionalDisplayName: "(US) East US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East US 2",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus2",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "36.6681",
+      longitude: "-78.3889",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centralus",
+          name: "centralus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Virginia",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "eastus2",
+    regionalDisplayName: "(US) East US 2",
+    subscriptionId: null,
+  },
+  {
+    displayName: "South Central US",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southcentralus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "29.4167",
+      longitude: "-98.5",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/northcentralus",
+          name: "northcentralus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Texas",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "southcentralus",
+    regionalDisplayName: "(US) South Central US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West US 2",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus2",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "47.233",
+      longitude: "-119.852",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westcentralus",
+          name: "westcentralus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Washington",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "westus2",
+    regionalDisplayName: "(US) West US 2",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West US 3",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus3",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "33.448376",
+      longitude: "-112.074036",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus",
+          name: "eastus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Phoenix",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "westus3",
+    regionalDisplayName: "(US) West US 3",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Australia East",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiaeast",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "-33.86",
+      longitude: "151.2094",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiasoutheast",
+          name: "australiasoutheast",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "New South Wales",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "australiaeast",
+    regionalDisplayName: "(Asia Pacific) Australia East",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Southeast Asia",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southeastasia",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "1.283",
+      longitude: "103.833",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastasia",
+          name: "eastasia",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Singapore",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "southeastasia",
+    regionalDisplayName: "(Asia Pacific) Southeast Asia",
+    subscriptionId: null,
+  },
+  {
+    displayName: "North Europe",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/northeurope",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "53.3478",
+      longitude: "-6.2597",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westeurope",
+          name: "westeurope",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Ireland",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "northeurope",
+    regionalDisplayName: "(Europe) North Europe",
+    subscriptionId: null,
+  },
+  {
+    displayName: "UK South",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uksouth",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "50.941",
+      longitude: "-0.799",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/ukwest",
+          name: "ukwest",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "London",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "uksouth",
+    regionalDisplayName: "(Europe) UK South",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West Europe",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westeurope",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "52.3667",
+      longitude: "4.9",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/northeurope",
+          name: "northeurope",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Netherlands",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "westeurope",
+    regionalDisplayName: "(Europe) West Europe",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Central US",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centralus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "41.5908",
+      longitude: "-93.6208",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus2",
+          name: "eastus2",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Iowa",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "centralus",
+    regionalDisplayName: "(US) Central US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "North Central US",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/northcentralus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "41.8819",
+      longitude: "-87.6278",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southcentralus",
+          name: "southcentralus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Illinois",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "northcentralus",
+    regionalDisplayName: "(US) North Central US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West US",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "37.783",
+      longitude: "-122.417",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus",
+          name: "eastus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "California",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "westus",
+    regionalDisplayName: "(US) West US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "South Africa North",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southafricanorth",
+    metadata: {
+      geographyGroup: "Africa",
+      latitude: "-25.731340",
+      longitude: "28.218370",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southafricawest",
+          name: "southafricawest",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Johannesburg",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "southafricanorth",
+    regionalDisplayName: "(Africa) South Africa North",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Central India",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centralindia",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "18.5822",
+      longitude: "73.9197",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southindia",
+          name: "southindia",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Pune",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "centralindia",
+    regionalDisplayName: "(Asia Pacific) Central India",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East Asia",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastasia",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "22.267",
+      longitude: "114.188",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southeastasia",
+          name: "southeastasia",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Hong Kong",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "eastasia",
+    regionalDisplayName: "(Asia Pacific) East Asia",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Japan East",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/japaneast",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "35.68",
+      longitude: "139.77",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/japanwest",
+          name: "japanwest",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Tokyo, Saitama",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "japaneast",
+    regionalDisplayName: "(Asia Pacific) Japan East",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Jio India West",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/jioindiawest",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "22.470701",
+      longitude: "70.05773",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/jioindiacentral",
+          name: "jioindiacentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Jamnagar",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "jioindiawest",
+    regionalDisplayName: "(Asia Pacific) Jio India West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Korea Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/koreacentral",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "37.5665",
+      longitude: "126.9780",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/koreasouth",
+          name: "koreasouth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Seoul",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "koreacentral",
+    regionalDisplayName: "(Asia Pacific) Korea Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Canada Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/canadacentral",
+    metadata: {
+      geographyGroup: "Canada",
+      latitude: "43.653",
+      longitude: "-79.383",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/canadaeast",
+          name: "canadaeast",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Toronto",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "canadacentral",
+    regionalDisplayName: "(Canada) Canada Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "France Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/francecentral",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "46.3772",
+      longitude: "2.3730",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/francesouth",
+          name: "francesouth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Paris",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "francecentral",
+    regionalDisplayName: "(Europe) France Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Germany West Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/germanywestcentral",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "50.110924",
+      longitude: "8.682127",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/germanynorth",
+          name: "germanynorth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Frankfurt",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "germanywestcentral",
+    regionalDisplayName: "(Europe) Germany West Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Norway East",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/norwayeast",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "59.913868",
+      longitude: "10.752245",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/norwaywest",
+          name: "norwaywest",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Norway",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "norwayeast",
+    regionalDisplayName: "(Europe) Norway East",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Switzerland North",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/switzerlandnorth",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "47.451542",
+      longitude: "8.564572",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/switzerlandwest",
+          name: "switzerlandwest",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Zurich",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "switzerlandnorth",
+    regionalDisplayName: "(Europe) Switzerland North",
+    subscriptionId: null,
+  },
+  {
+    displayName: "UAE North",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uaenorth",
+    metadata: {
+      geographyGroup: "Middle East",
+      latitude: "25.266666",
+      longitude: "55.316666",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uaecentral",
+          name: "uaecentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Dubai",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "uaenorth",
+    regionalDisplayName: "(Middle East) UAE North",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Brazil South",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/brazilsouth",
+    metadata: {
+      geographyGroup: "South America",
+      latitude: "-23.55",
+      longitude: "-46.633",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southcentralus",
+          name: "southcentralus",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Sao Paulo State",
+      regionCategory: "Recommended",
+      regionType: "Physical",
+    },
+    name: "brazilsouth",
+    regionalDisplayName: "(South America) Brazil South",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Central US (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centralusstage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "centralusstage",
+    regionalDisplayName: "(US) Central US (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East US (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastusstage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "eastusstage",
+    regionalDisplayName: "(US) East US (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East US 2 (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus2stage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "eastus2stage",
+    regionalDisplayName: "(US) East US 2 (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "North Central US (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/northcentralusstage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "northcentralusstage",
+    regionalDisplayName: "(US) North Central US (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "South Central US (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southcentralusstage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "southcentralusstage",
+    regionalDisplayName: "(US) South Central US (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West US (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westusstage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "westusstage",
+    regionalDisplayName: "(US) West US (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West US 2 (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus2stage",
+    metadata: {
+      geographyGroup: "US",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "westus2stage",
+    regionalDisplayName: "(US) West US 2 (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Asia",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/asia",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "asia",
+    regionalDisplayName: "Asia",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Asia Pacific",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/asiapacific",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "asiapacific",
+    regionalDisplayName: "Asia Pacific",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Australia",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australia",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "australia",
+    regionalDisplayName: "Australia",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Brazil",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/brazil",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "brazil",
+    regionalDisplayName: "Brazil",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Canada",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/canada",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "canada",
+    regionalDisplayName: "Canada",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Europe",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/europe",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "europe",
+    regionalDisplayName: "Europe",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Global",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/global",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "global",
+    regionalDisplayName: "Global",
+    subscriptionId: null,
+  },
+  {
+    displayName: "India",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/india",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "india",
+    regionalDisplayName: "India",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Japan",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/japan",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "japan",
+    regionalDisplayName: "Japan",
+    subscriptionId: null,
+  },
+  {
+    displayName: "United Kingdom",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uk",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "uk",
+    regionalDisplayName: "United Kingdom",
+    subscriptionId: null,
+  },
+  {
+    displayName: "United States",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/unitedstates",
+    metadata: {
+      geographyGroup: null,
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "unitedstates",
+    regionalDisplayName: "United States",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East Asia (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastasiastage",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "eastasiastage",
+    regionalDisplayName: "(Asia Pacific) East Asia (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Southeast Asia (Stage)",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southeastasiastage",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: null,
+      longitude: null,
+      pairedRegion: null,
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Logical",
+    },
+    name: "southeastasiastage",
+    regionalDisplayName: "(Asia Pacific) Southeast Asia (Stage)",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Central US EUAP",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centraluseuap",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "41.5908",
+      longitude: "-93.6208",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus2euap",
+          name: "eastus2euap",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "centraluseuap",
+    regionalDisplayName: "(US) Central US EUAP",
+    subscriptionId: null,
+  },
+  {
+    displayName: "East US 2 EUAP",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/eastus2euap",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "36.6681",
+      longitude: "-78.3889",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centraluseuap",
+          name: "centraluseuap",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: null,
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "eastus2euap",
+    regionalDisplayName: "(US) East US 2 EUAP",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West Central US",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westcentralus",
+    metadata: {
+      geographyGroup: "US",
+      latitude: "40.890",
+      longitude: "-110.234",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westus2",
+          name: "westus2",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Wyoming",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "westcentralus",
+    regionalDisplayName: "(US) West Central US",
+    subscriptionId: null,
+  },
+  {
+    displayName: "South Africa West",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southafricawest",
+    metadata: {
+      geographyGroup: "Africa",
+      latitude: "-34.075691",
+      longitude: "18.843266",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southafricanorth",
+          name: "southafricanorth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Cape Town",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "southafricawest",
+    regionalDisplayName: "(Africa) South Africa West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Australia Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiacentral",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "-35.3075",
+      longitude: "149.1244",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiacentral",
+          name: "australiacentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Canberra",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "australiacentral",
+    regionalDisplayName: "(Asia Pacific) Australia Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Australia Central 2",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiacentral2",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "-35.3075",
+      longitude: "149.1244",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiacentral2",
+          name: "australiacentral2",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Canberra",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "australiacentral2",
+    regionalDisplayName: "(Asia Pacific) Australia Central 2",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Australia Southeast",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiasoutheast",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "-37.8136",
+      longitude: "144.9631",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/australiaeast",
+          name: "australiaeast",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Victoria",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "australiasoutheast",
+    regionalDisplayName: "(Asia Pacific) Australia Southeast",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Japan West",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/japanwest",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "34.6939",
+      longitude: "135.5022",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/japaneast",
+          name: "japaneast",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Osaka",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "japanwest",
+    regionalDisplayName: "(Asia Pacific) Japan West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Korea South",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/koreasouth",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "35.1796",
+      longitude: "129.0756",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/koreacentral",
+          name: "koreacentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Busan",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "koreasouth",
+    regionalDisplayName: "(Asia Pacific) Korea South",
+    subscriptionId: null,
+  },
+  {
+    displayName: "South India",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southindia",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "12.9822",
+      longitude: "80.1636",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/centralindia",
+          name: "centralindia",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Chennai",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "southindia",
+    regionalDisplayName: "(Asia Pacific) South India",
+    subscriptionId: null,
+  },
+  {
+    displayName: "West India",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/westindia",
+    metadata: {
+      geographyGroup: "Asia Pacific",
+      latitude: "19.088",
+      longitude: "72.868",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/southindia",
+          name: "southindia",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Mumbai",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "westindia",
+    regionalDisplayName: "(Asia Pacific) West India",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Canada East",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/canadaeast",
+    metadata: {
+      geographyGroup: "Canada",
+      latitude: "46.817",
+      longitude: "-71.217",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/canadacentral",
+          name: "canadacentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Quebec",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "canadaeast",
+    regionalDisplayName: "(Canada) Canada East",
+    subscriptionId: null,
+  },
+  {
+    displayName: "France South",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/francesouth",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "43.8345",
+      longitude: "2.1972",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/francecentral",
+          name: "francecentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Marseille",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "francesouth",
+    regionalDisplayName: "(Europe) France South",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Germany North",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/germanynorth",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "53.073635",
+      longitude: "8.806422",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/germanywestcentral",
+          name: "germanywestcentral",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Berlin",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "germanynorth",
+    regionalDisplayName: "(Europe) Germany North",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Norway West",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/norwaywest",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "58.969975",
+      longitude: "5.733107",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/norwayeast",
+          name: "norwayeast",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Norway",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "norwaywest",
+    regionalDisplayName: "(Europe) Norway West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Switzerland West",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/switzerlandwest",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "46.204391",
+      longitude: "6.143158",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/switzerlandnorth",
+          name: "switzerlandnorth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Geneva",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "switzerlandwest",
+    regionalDisplayName: "(Europe) Switzerland West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "UK West",
+    id: "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/ukwest",
+    metadata: {
+      geographyGroup: "Europe",
+      latitude: "53.427",
+      longitude: "-3.084",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uksouth",
+          name: "uksouth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Cardiff",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "ukwest",
+    regionalDisplayName: "(Europe) UK West",
+    subscriptionId: null,
+  },
+  {
+    displayName: "UAE Central",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uaecentral",
+    metadata: {
+      geographyGroup: "Middle East",
+      latitude: "24.466667",
+      longitude: "54.366669",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/uaenorth",
+          name: "uaenorth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Abu Dhabi",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "uaecentral",
+    regionalDisplayName: "(Middle East) UAE Central",
+    subscriptionId: null,
+  },
+  {
+    displayName: "Brazil Southeast",
+    id:
+      "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/brazilsoutheast",
+    metadata: {
+      geographyGroup: "South America",
+      latitude: "-22.90278",
+      longitude: "-43.2075",
+      pairedRegion: [
+        {
+          id:
+            "/subscriptions/6602cdaf-54a1-43f3-afc6-d3efbf993c1c/locations/brazilsouth",
+          name: "brazilsouth",
+          subscriptionId: null,
+        },
+      ],
+      physicalLocation: "Rio",
+      regionCategory: "Other",
+      regionType: "Physical",
+    },
+    name: "brazilsoutheast",
+    regionalDisplayName: "(South America) Brazil Southeast",
+    subscriptionId: null,
+  },
+];
+
+export function generateLabels(): WidgetSelectOptionsItems {
+  const items = _.map(azureLocations, (l) => {
+    return { label: `${l.displayName} (${l.name})`, value: l.name };
+  });
+  return { items };
+}
+
+const azureLocation: RegistryEntry = {
+  entityType: "azureLocation",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menu: [
+      {
+        name: "location",
+        menuCategory: ["azure"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
+  },
+  inputs: [],
+  properties: [
+    {
+      type: "string",
+      name: "location",
+      widget: {
+        name: "select",
+        options: generateLabels(),
+      },
+    },
+  ],
+};
+
+export default azureLocation;

--- a/components/si-registry/src/schema/azure/azureResourceGroup.ts
+++ b/components/si-registry/src/schema/azure/azureResourceGroup.ts
@@ -1,0 +1,46 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  //Arity,
+} from "../../registryEntry";
+import { generateLabels } from "./azureLocation";
+
+const azureResourceGroup: RegistryEntry = {
+  entityType: "azureResourceGroup",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menu: [
+      {
+        name: "resource group",
+        menuCategory: ["azure"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["kubernetesCluster", "azure"],
+      },
+    ],
+  },
+  inputs: [],
+  properties: [
+    {
+      type: "string",
+      name: "name",
+    },
+    {
+      type: "string",
+      name: "location",
+      widget: {
+        name: "select",
+        options: generateLabels(),
+      },
+    },
+    {
+      type: "map",
+      name: "tags",
+      valueProperty: {
+        type: "string",
+      },
+    },
+  ],
+};
+
+export default azureResourceGroup;

--- a/components/si-registry/src/schema/azure/azureServicePrincipal.ts
+++ b/components/si-registry/src/schema/azure/azureServicePrincipal.ts
@@ -1,0 +1,34 @@
+import {
+  RegistryEntry,
+  SchematicKind,
+  NodeKind,
+  //Arity,
+} from "../../registryEntry";
+
+const azureServicePrincipal: RegistryEntry = {
+  entityType: "azureServicePrincipal",
+  nodeKind: NodeKind.Concrete,
+  ui: {
+    menu: [
+      {
+        name: "service principal",
+        menuCategory: ["azure"],
+        schematicKind: SchematicKind.Component,
+        rootEntityTypes: ["cloudProvider"],
+      },
+    ],
+  },
+  inputs: [],
+  properties: [
+    {
+      type: "string",
+      name: "secret",
+      widget: {
+        name: "selectFromSecret",
+        secretKind: "azureServicePrincipal",
+      },
+    },
+  ],
+};
+
+export default azureServicePrincipal;

--- a/components/si-registry/src/workflow.ts
+++ b/components/si-registry/src/workflow.ts
@@ -175,6 +175,12 @@ export interface Selector {
   direction?: "input" | "output";
 }
 
+export interface ForEach {
+  edgeKind?: "configures" | "deployment" | "includes";
+  direction?: "input" | "output";
+  depth?: "immediate" | "all";
+}
+
 export interface StepBase {
   kind: StepKind;
   inputs?: unknown;
@@ -191,6 +197,7 @@ export interface StepCommand extends StepBase {
   failIfMissing?: VariableBool;
   selector?: Selector;
   strategy?: VariableScalar;
+  forEach?: ForEach;
 }
 
 export interface StepAction extends StepBase {
@@ -201,6 +208,7 @@ export interface StepAction extends StepBase {
   failIfMissing?: VariableBool;
   selector?: Selector;
   strategy?: VariableScalar;
+  forEach?: ForEach;
 }
 
 export interface StepWorkflow extends StepBase {
@@ -289,6 +297,11 @@ export const serviceDeploy: Workflow = {
       },
       selector: {
         fromProperty: ["implementation"],
+      },
+      forEach: {
+        edgeKind: "deployment",
+        depth: "immediate",
+        direction: "output",
       },
     },
   ],

--- a/components/si-web-app/src/api/sdf/model/secret.ts
+++ b/components/si-web-app/src/api/sdf/model/secret.ts
@@ -19,6 +19,7 @@ export enum SecretKind {
   DockerHub = "dockerHub",
   AwsAccessKey = "awsAccessKey",
   HelmRepo = "helmRepo",
+  AzureServicePrincipal = "azureServicePrincipal",
 }
 
 export namespace SecretKind {
@@ -30,6 +31,8 @@ export namespace SecretKind {
         return "Docker Hub";
       case SecretKind.HelmRepo:
         return "Helm Repository";
+      case SecretKind.AzureServicePrincipal:
+        return "Azure Service Principal";
       default:
         throw Error(`Unknown SecretKind variant: ${secretKind}`);
     }
@@ -40,6 +43,7 @@ export namespace SecretKind {
       case SecretKind.AwsAccessKey:
       case SecretKind.DockerHub:
       case SecretKind.HelmRepo:
+      case SecretKind.AzureServicePrincipal:
         return SecretObjectType.Credential;
       default:
         throw Error(`Unknown SecretKind variant: ${secretKind}`);
@@ -64,6 +68,7 @@ export namespace SecretKind {
       selectPropOptionFor(SecretKind.AwsAccessKey),
       selectPropOptionFor(SecretKind.DockerHub),
       selectPropOptionFor(SecretKind.HelmRepo),
+      selectPropOptionFor(SecretKind.AzureServicePrincipal),
     ];
   }
 }

--- a/components/si-web-app/src/organisims/SecretCreate.vue
+++ b/components/si-web-app/src/organisims/SecretCreate.vue
@@ -38,6 +38,10 @@
     <AwsAccessKeyCredential @input="updateMessage" v-if="kindIsAwsAccesKey" />
     <DockerHubCredential @input="updateMessage" v-else-if="kindIsDockerHub" />
     <HelmRepoCredential @input="updateMessage" v-else-if="kindIsHelmRepo" />
+    <AzureServicePrincipal
+      @input="updateMessage"
+      v-else-if="kindIsAzureServicePrincipal"
+    />
 
     <div class="flex justify-end w-full">
       <div class="pr-2">
@@ -74,6 +78,7 @@ import {
 import AwsAccessKeyCredential from "@/organisims/SecretCreate/AwsAccessKeyCredential.vue";
 import DockerHubCredential from "@/organisims/SecretCreate/DockerHubCredential.vue";
 import HelmRepoCredential from "@/organisims/SecretCreate/HelmRepoCredential.vue";
+import AzureServicePrincipal from "@/organisims/SecretCreate/AzureServicePrincipal.vue";
 import { workspace$, refreshSecretList$ } from "@/observables";
 import { SecretDal, ICreateSecretRequest } from "@/api/sdf/dal/secretDal";
 import sealedBox from "tweetnacl-sealedbox-js";
@@ -112,6 +117,7 @@ export default Vue.extend({
     AwsAccessKeyCredential,
     DockerHubCredential,
     HelmRepoCredential,
+    AzureServicePrincipal,
     SiButton,
     SiError,
     SiSelect,
@@ -138,6 +144,9 @@ export default Vue.extend({
       let secretKinds = SecretKind.selectPropOptions();
       secretKinds.unshift({ label: "", value: "" });
       return secretKinds;
+    },
+    kindIsAzureServicePrincipal(): boolean {
+      return this.form.secretKind == SecretKind.AzureServicePrincipal;
     },
     kindIsAwsAccesKey(): boolean {
       return this.form.secretKind == SecretKind.AwsAccessKey;

--- a/components/si-web-app/src/organisims/SecretCreate/AzureServicePrincipal.vue
+++ b/components/si-web-app/src/organisims/SecretCreate/AzureServicePrincipal.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-right text-gray-400 align-middle">
+        <label for="tenant">Azure Tenant ID:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          name="tenantId"
+          placeholder=""
+          id="tenantId"
+          required
+          v-model="tenant"
+          @input="updateInput"
+        />
+      </div>
+    </div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-right text-gray-400 align-middle">
+        <label for="servicePrincipalUri">Service Principal URI:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          name="servicePrincipalUri"
+          placeholder=""
+          id="servicePrincipalUri"
+          required
+          v-model="servicePrincipalUri"
+          @input="updateInput"
+        />
+      </div>
+    </div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-right text-gray-400 align-middle">
+        <label for="password">Password:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          name="password"
+          placeholder=""
+          id="password"
+          required
+          v-model="password"
+          type="password"
+          @input="updateInput"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import SiTextBox from "@/atoms/SiTextBox.vue";
+
+interface IData {
+  servicePrincipalUri: string;
+  password: string;
+  tenant: string;
+}
+
+export default Vue.extend({
+  name: "AzureServicePrincipal",
+  components: {
+    SiTextBox,
+  },
+  data(): IData {
+    return {
+      servicePrincipalUri: "",
+      password: "",
+      tenant: "",
+    };
+  },
+  methods: {
+    updateInput() {
+      this.$emit("input", {
+        servicePrincipalUri: this.servicePrincipalUri,
+        password: this.password,
+        tenant: this.tenant,
+      } as IData);
+    },
+  },
+});
+</script>


### PR DESCRIPTION
This PR kicks the extra point of being able to deploy to either AWS or
Azure. There is no intelligence what-so-ever in the Azure resources yet,
but if you set it all up correctly, you can deploy to AKS.

Additionally, it very much hacks support for deploying to multiple
clusters at once. Right now, it does that by just looking to see if
there are multiple clusters present in the context for the command on
Veritech, and if there are, running the command multiple times. This
might even be the right approach, depending on what we think we should
do with resources. (Are they always 1:1?)

But it works!