### PR TITLE
feat(web, sdf): resource sync and implementation

### DIFF
--- a/components/si-entity/src/index.ts
+++ b/components/si-entity/src/index.ts
@@ -9,4 +9,9 @@ export {
   EditField,
 } from "./siEntity";
 export { SiStorable } from "./siStorable";
-export { Resource, ResourceHealth, ResourceStatus } from "./resource";
+export {
+  Resource,
+  SubResource,
+  ResourceInternalHealth,
+  ResourceInternalStatus,
+} from "./resource";

--- a/components/si-entity/src/resource.ts
+++ b/components/si-entity/src/resource.ts
@@ -1,13 +1,13 @@
 import { SiStorable } from "./siStorable";
 
-export enum ResourceHealth {
+export enum ResourceInternalHealth {
   Ok = "ok",
   Warning = "warning",
   Error = "error",
   Unknown = "unknown",
 }
 
-export enum ResourceStatus {
+export enum ResourceInternalStatus {
   Pending = "pending",
   InProgress = "inProgress",
   Created = "created",
@@ -15,14 +15,29 @@ export enum ResourceStatus {
   Deleted = "deleted",
 }
 
+export interface SubResource {
+  unixTimestamp: number;
+  timestamp: string;
+  state: string;
+  health: string;
+  internalStatus: ResourceInternalStatus;
+  internalHealth: ResourceInternalHealth;
+  data: Record<string, unknown>;
+  error?: string;
+}
+
 export interface Resource {
   id: string;
   unixTimestamp: number;
   timestamp: string;
-  state: Record<string, unknown>;
-  status: ResourceStatus;
-  health: ResourceHealth;
+  state: string;
+  health: string;
+  internalStatus: ResourceInternalStatus;
+  internalHealth: ResourceInternalHealth;
+  data: Record<string, unknown>;
+  subResources: Record<string, SubResource>;
   systemId: string;
   entityId: string;
+  error?: string;
   siStorable: SiStorable;
 }

--- a/components/si-model/src/entity.rs
+++ b/components/si-model/src/entity.rs
@@ -15,6 +15,7 @@ const ENTITY_GET_HEAD_BY_NAME_AND_ENTITY_TYPE: &str =
 const ENTITY_FOR_EDIT_SESSION: &str = include_str!("./queries/entity_for_edit_session.sql");
 const ENTITY_FOR_CHANGE_SET: &str = include_str!("./queries/entity_for_change_set.sql");
 const ENTITY_FOR_HEAD: &str = include_str!("./queries/entity_for_head.sql");
+const ALL_HEAD_ENTITIES: &str = include_str!("./queries/all_head_entities.sql");
 
 #[derive(Error, Debug)]
 pub enum EntityError {
@@ -680,6 +681,17 @@ impl Entity {
                 &[&name, &entity_type, &workspace_id],
             )
             .await?;
+        for row in rows.into_iter() {
+            let entity_json: serde_json::Value = row.try_get("object")?;
+            let entity: Entity = serde_json::from_value(entity_json)?;
+            results.push(entity);
+        }
+        Ok(results)
+    }
+
+    pub async fn all_head(txn: &PgTxn<'_>) -> EntityResult<Vec<Entity>> {
+        let mut results = Vec::new();
+        let rows = txn.query(ALL_HEAD_ENTITIES, &[]).await?;
         for row in rows.into_iter() {
             let entity_json: serde_json::Value = row.try_get("object")?;
             let entity: Entity = serde_json::from_value(entity_json)?;

--- a/components/si-model/src/lib.rs
+++ b/components/si-model/src/lib.rs
@@ -76,7 +76,9 @@ pub use node_position::{NodePosition, NodePositionError};
 pub use organization::{Organization, OrganizationError};
 pub use output_line::{OutputLine, OutputLineStream};
 pub use qualification::{Qualification, QualificationError};
-pub use resource::{Resource, ResourceError, ResourceHealth, ResourceResult, ResourceStatus};
+pub use resource::{
+    Resource, ResourceError, ResourceInternalHealth, ResourceInternalStatus, ResourceResult,
+};
 pub use schematic::{Schematic, SchematicError, SchematicKind, SchematicNode, SchematicResult};
 pub use secret::{
     EncryptedSecret, Secret, SecretAlgorithm, SecretError, SecretKind, SecretObjectType,

--- a/components/si-model/src/migrations/U022__resources.sql
+++ b/components/si-model/src/migrations/U022__resources.sql
@@ -17,8 +17,8 @@ CREATE TABLE resources
 CREATE INDEX idx_resources_tenant_ids ON "resources" USING GIN ("tenant_ids");
 
 CREATE OR REPLACE FUNCTION resource_create_v1(this_state jsonb,
-                                              this_status text,
-                                              this_health text,
+                                              this_internal_status text,
+                                              this_internal_health text,
                                               this_timestamp text,
                                               this_unix_timestamp bigint,
                                               this_system_si_id text,
@@ -54,12 +54,16 @@ BEGIN
     SELECT jsonb_build_object(
                    'id', si_id,
                    'state', this_state,
-                   'status', this_status,
-                   'health', this_health,
+                   'internalStatus', this_internal_status,
+                   'internalHealth', this_internal_health,
+                   'state', 'unknown',
+                   'health', 'unknown',
                    'entityId', this_entity_si_id,
                    'systemId', this_system_si_id,
                    'unixTimestamp', this_unix_timestamp,
                    'timestamp', this_timestamp,
+                   'subResources', jsonb_build_object(),
+                   'data', jsonb_build_object(),
                    'siStorable', si_storable
                )
     INTO object;

--- a/components/si-model/src/queries/all_head_entities.sql
+++ b/components/si-model/src/queries/all_head_entities.sql
@@ -1,0 +1,1 @@
+SELECT obj AS object FROM entities_head;

--- a/components/si-model/src/support/veritech.rs
+++ b/components/si-model/src/support/veritech.rs
@@ -234,7 +234,7 @@ impl Veritech {
                     Ok(tungstenite::protocol::Message::Close(data)) => match data {
                         Some(frame) => match frame.code {
                             tungstenite::protocol::frame::coding::CloseCode::Normal => {
-                                dbg!("closed socket normally");
+                                //dbg!("closed socket normally");
                             }
                             err => {
                                 dbg!("request failed; err={:?}", err);

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -1,6 +1,13 @@
 import ValidatorJS from "validator";
 import { Optional } from "utility-types";
 
+export enum InternalHealth {
+  Ok = "ok",
+  Warning = "warning",
+  Error = "error",
+  Unknown = "unknown",
+}
+
 export enum SchematicKind {
   Deployment = "deployment",
   Component = "component",
@@ -257,4 +264,5 @@ export interface RegistryEntry {
   qualifications?: Qualification[];
   commands?: Command[];
   actions?: Action[];
+  healthStates?: Record<string, InternalHealth>;
 }

--- a/components/si-registry/src/schema/docker/dockerImage.ts
+++ b/components/si-registry/src/schema/docker/dockerImage.ts
@@ -51,12 +51,6 @@ const dockerImage: RegistryEntry = {
         "The docker image and tag specified must be accessible via a docker pull.",
       link: "https://docs.docker.com/engine/reference/commandline/pull/",
     },
-    {
-      name: "dockerImageIsTrue",
-      title: "Just here for a minute",
-      description:
-        "The docker image and tag specified must be accessible via a docker pull.",
-    },
   ],
   actions: [
     {

--- a/components/si-registry/src/schema/include/standardConceptInputs.ts
+++ b/components/si-registry/src/schema/include/standardConceptInputs.ts
@@ -16,10 +16,10 @@ export const standardConceptInputs: Input[] = [
     edgeKind: "configures",
     arity: Arity.Many,
   },
-  {
-    name: "dependencies",
-    types: "dependencies",
-    edgeKind: "configures",
-    arity: Arity.Many,
-  },
+  //{
+  //  name: "dependencies",
+  //  types: "dependencies",
+  //  edgeKind: "configures",
+  //  arity: Arity.Many,
+  //},
 ];

--- a/components/si-registry/src/schema/kubernetes/kubernetesService.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetesService.ts
@@ -39,7 +39,44 @@ const kubernetesService: RegistryEntry = {
       arity: Arity.Many,
     },
   ],
-  properties: [],
+  properties: [
+    {
+      type: "array",
+      name: "healthChecks",
+      itemProperty: {
+        type: "object",
+        properties: [
+          {
+            type: "string",
+            name: "protocol",
+            widget: {
+              name: "select",
+              options: {
+                items: [
+                  { label: "HTTP", value: "HTTP" },
+                  { label: "HTTPS", value: "HTTPS" },
+                  { label: "TCP", value: "TCP" },
+                  { label: "UDP", value: "UDP" },
+                ],
+              },
+            },
+          },
+          {
+            type: "string",
+            name: "host",
+          },
+          {
+            type: "string",
+            name: "port",
+          },
+          {
+            type: "string",
+            name: "path",
+          },
+        ],
+      },
+    },
+  ],
 };
 
 export default kubernetesService;

--- a/components/si-registry/src/schema/si/service.ts
+++ b/components/si-registry/src/schema/si/service.ts
@@ -24,6 +24,42 @@ const service: RegistryEntry = {
         inputName: "implementations",
       },
     },
+    {
+      type: "array",
+      name: "healthChecks",
+      itemProperty: {
+        type: "object",
+        properties: [
+          {
+            type: "string",
+            name: "protocol",
+            widget: {
+              name: "select",
+              options: {
+                items: [
+                  { label: "HTTP", value: "HTTP" },
+                  { label: "HTTPS", value: "HTTPS" },
+                  { label: "TCP", value: "TCP" },
+                  { label: "UDP", value: "UDP" },
+                ],
+              },
+            },
+          },
+          {
+            type: "string",
+            name: "host",
+          },
+          {
+            type: "string",
+            name: "port",
+          },
+          {
+            type: "string",
+            name: "path",
+          },
+        ],
+      },
+    },
   ],
   actions: [{ name: "deploy" }],
 };

--- a/components/si-sdf/src/bin/server.rs
+++ b/components/si-sdf/src/bin/server.rs
@@ -45,6 +45,13 @@ async fn main() -> anyhow::Result<()> {
     .await?;
     txn.commit().await?;
 
+    println!("*** Starting resource scheduler ***");
+    tokio::task::spawn(si_sdf::resource_scheduler::start(
+        pg.clone(),
+        nats.clone(),
+        veritech.clone(),
+    ));
+
     println!("*** Starting service ***");
     start(pg, nats, veritech, event_log_fs, settings).await;
 

--- a/components/si-sdf/src/lib.rs
+++ b/components/si-sdf/src/lib.rs
@@ -6,6 +6,7 @@ use warp::Filter;
 pub mod cli;
 pub mod filters;
 pub mod handlers;
+pub mod resource_scheduler;
 pub mod update;
 
 pub static mut PAGE_SECRET_KEY: Option<sodiumoxide::crypto::secretbox::Key> = None;

--- a/components/si-sdf/src/resource_scheduler.rs
+++ b/components/si-sdf/src/resource_scheduler.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use futures::{future::BoxFuture, Future, FutureExt};
+use thiserror::Error;
+use tokio::time;
+
+use si_data::{NatsConn, PgPool};
+use si_model::{Edge, EdgeError, EdgeKind, Entity, EntityError, Resource, ResourceError, Veritech};
+
+#[derive(Error, Debug)]
+pub enum ResourceSchedulerError {
+    #[error("deadpool error: {0}")]
+    Deadpool(#[from] deadpool_postgres::PoolError),
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+    #[error("entity error: {0}")]
+    Entity(#[from] EntityError),
+    #[error("edge error: {0}")]
+    Edge(#[from] EdgeError),
+    #[error("resource error: {0}")]
+    Resource(#[from] ResourceError),
+}
+
+pub type ResourceSchedulerResult<T> = Result<T, ResourceSchedulerError>;
+
+pub async fn start(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> ResourceSchedulerResult<()> {
+    let mut interval = time::interval(Duration::from_secs(30));
+    loop {
+        dbg!("waiting for a new resource sync run to be timed");
+        interval.tick().await;
+        dbg!("starting a new resource sync run");
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let all_entities = Entity::all_head(&txn)
+            .await?
+            .into_iter()
+            .filter(|e| e.entity_type != "system");
+        txn.commit().await?;
+        for entity in all_entities {
+            match sync_resource(&pg, &nats_conn, &veritech, &entity).await {
+                Ok(()) => {}
+                Err(e) => {
+                    dbg!("**** Scheduled resource run failed ***");
+                    dbg!(&e);
+                }
+            }
+            //tokio::spawn(sync_future);
+        }
+    }
+}
+
+pub fn sync_resource(
+    pg: &PgPool,
+    nats_conn: &NatsConn,
+    veritech: &Veritech,
+    entity: &Entity,
+) -> BoxFuture<'static, ResourceSchedulerResult<()>> {
+    let entity = entity.clone();
+    let pg = pg.clone();
+    let veritech = veritech.clone();
+    let nats_conn = nats_conn.clone();
+    let r = async move {
+        let mut conn = pg.pool.get().await?;
+        let txn = conn.transaction().await?;
+        let systems: Vec<Entity> = Entity::get_head_by_name_and_entity_type(
+            &txn,
+            "production",
+            "system",
+            &entity.si_storable.workspace_id,
+        )
+        .await?
+        .into_iter()
+        .filter(|s| s.si_storable.workspace_id == entity.si_storable.workspace_id)
+        .collect();
+        let system_id = systems.first().unwrap().id.clone();
+        let mut r = match Resource::get_by_entity_and_system(&txn, &entity.id, &system_id).await? {
+            Some(r) => r,
+            None => {
+                Resource::new(
+                    &pg,
+                    &nats_conn,
+                    serde_json::json!([]),
+                    &entity.id,
+                    &system_id,
+                    &entity.si_storable.workspace_id,
+                )
+                .await?
+            }
+        };
+        r.await_sync(pg.clone(), nats_conn.clone(), veritech.clone())
+            .await?;
+        txn.commit().await?;
+        Ok(())
+    };
+    r.boxed()
+}

--- a/components/si-veritech/src/controllers/syncResource.ts
+++ b/components/si-veritech/src/controllers/syncResource.ts
@@ -1,17 +1,28 @@
 import WebSocket from "ws";
 import Debug from "debug";
 
-import { SiEntity, Resource, ResourceStatus, ResourceHealth } from "si-entity";
+import {
+  SiEntity,
+  SubResource,
+  Resource,
+  ResourceInternalStatus,
+  ResourceInternalHealth,
+} from "si-entity";
+import { DecryptedSecret } from "../support";
+import intel from "../intel";
+import { SiCtx } from "../siCtx";
 
 const debug = Debug("veritech:controllers:syncResource");
 
 export interface SyncResourceRequest {
   entity: SiEntity;
   resource: Resource;
-  predecessors: {
+  system: SiEntity;
+  context: {
     entity: SiEntity;
-    resource?: Resource;
+    secret?: DecryptedSecret;
   }[];
+  resourceContext: Resource[];
 }
 
 export interface CommandProtocolStart {
@@ -20,28 +31,66 @@ export interface CommandProtocolStart {
 
 export interface CommandProtocolFinish {
   finish: {
-    state: Record<string, unknown>;
-    status: ResourceStatus;
-    health: ResourceHealth;
+    data: Record<string, unknown>;
+    state: string;
+    health: string;
+    internalStatus: ResourceInternalStatus;
+    internalHealth: ResourceInternalHealth;
+    subResources: Record<string, SubResource>;
     error?: string;
   };
 }
 
+export type SyncResourceCallback = (
+  ctx: typeof SiCtx,
+  request: SyncResourceRequest,
+  ws: WebSocket,
+) => Promise<CommandProtocolFinish["finish"]>;
+
 export type CommandProtocol = CommandProtocolStart | CommandProtocolFinish;
 
+// TODO: Plumb the callback through, and then implement the actual resource data
+// for given things.
 export async function syncResource(ws: WebSocket, req: string): Promise<void> {
   debug("/syncResource BEGIN");
   const request: SyncResourceRequest = JSON.parse(req);
+  request.entity = SiEntity.fromJson(request.entity);
+  request.system = SiEntity.fromJson(request.system);
+  for (const p of request.context) {
+    p.entity = SiEntity.fromJson(p.entity);
+  }
   debug("request %O", request);
 
   send(ws, { start: true });
-  send(ws, {
-    finish: {
-      state: request.resource.state,
-      status: ResourceStatus.Created,
-      health: ResourceHealth.Ok,
-    },
-  });
+  const entityType = request.entity.entityType;
+  const intelFuncs = intel[entityType];
+  if (intelFuncs && intelFuncs.syncResource) {
+    try {
+      const response = await intelFuncs.syncResource(SiCtx, request, ws);
+      send(ws, { finish: response });
+    } catch (e) {
+      const response = {
+        data: request.resource.data,
+        state: request.resource.state,
+        health: request.resource.health,
+        internalStatus: request.resource.internalStatus,
+        internalHealth: request.resource.internalHealth,
+        subResources: request.resource.subResources,
+        error: `sync failed: ${e}`,
+      };
+      send(ws, { finish: response });
+    }
+  } else {
+    const response = {
+      data: request.resource.data,
+      state: "created",
+      health: "ok",
+      internalStatus: ResourceInternalStatus.Created,
+      internalHealth: ResourceInternalHealth.Ok,
+      subResources: request.resource.subResources,
+    };
+    send(ws, { finish: response });
+  }
   close(ws);
   debug("finished");
 }

--- a/components/si-veritech/src/intel.ts
+++ b/components/si-veritech/src/intel.ts
@@ -7,16 +7,27 @@ import k8sService from "./intel/k8sService";
 import awsEksCluster from "./intel/awsEksCluster";
 import azureResourceGroup from "./intel/azureResourceGroup";
 import azureAksCluster from "./intel/azureAksCluster";
+import azureServicePrincipal from "./intel/azureServicePrincipal";
+import azure from "./intel/azure";
+import aws from "./intel/aws";
+import awsEks from "./intel/awsEks";
+import azureAks from "./intel/azureAks";
+import cloudProvider from "./intel/cloudProvider";
+import kubernetesCluster from "./intel/kubernetesCluster";
+import kubernetesService from "./intel/kubernetesService";
+import service from "./intel/service";
 import {
   InferPropertiesReply,
   InferPropertiesRequest,
 } from "./controllers/inferProperties";
 import { RunCommandCallbacks } from "./controllers/runCommand";
+import { SyncResourceCallback } from "./controllers/syncResource";
 
 export interface Intel {
   inferProperties?(request: InferPropertiesRequest): InferPropertiesReply;
   checkQualifications?: CheckQualificationCallbacks;
   runCommands?: RunCommandCallbacks;
+  syncResource?: SyncResourceCallback;
 }
 
 const intel: Record<string, Intel> = {
@@ -29,6 +40,15 @@ const intel: Record<string, Intel> = {
   awsEksCluster,
   azureResourceGroup,
   azureAksCluster,
+  azureServicePrincipal,
+  azure,
+  aws,
+  cloudProvider,
+  awsEks,
+  azureAks,
+  kubernetesCluster,
+  kubernetesService,
+  service,
 };
 
 export default intel;

--- a/components/si-veritech/src/intel/aws.ts
+++ b/components/si-veritech/src/intel/aws.ts
@@ -1,0 +1,52 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import { awsAccessKeysEnvironment } from "../support";
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  let awsEnv;
+  try {
+    awsEnv = awsAccessKeysEnvironment(req);
+  } catch (e) {
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    response.state = "error";
+    response.error = "Cannot find AWS access keys!";
+    return response;
+  }
+
+  const output = await ctx.exec("aws", ["iam", "list-access-keys"], {
+    env: awsEnv,
+    reject: false,
+  });
+  if (output.exitCode != 0) {
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    response.state = "error";
+    response.error = output.all;
+  }
+
+  response.health = "ok";
+  response.internalHealth = ResourceInternalHealth.Ok;
+  response.state = "ok";
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/awsEks.ts
+++ b/components/si-veritech/src/intel/awsEks.ts
@@ -1,0 +1,55 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+import { findEntityByType } from "../support";
+
+export async function syncResource(
+  _ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const cluster = findEntityByType(req, "awsEksCluster");
+
+  if (!cluster) {
+    response.error = "No cluster connected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const clusterResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == cluster.id,
+  );
+  if (clusterResource) {
+    response.data = clusterResource.data;
+    response.error = clusterResource.error;
+    response.state = clusterResource.state;
+    response.health = clusterResource.health;
+    response.internalHealth = clusterResource.internalHealth;
+    response.internalStatus = clusterResource.internalStatus;
+    response.subResources = clusterResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/awsEksCluster.ts
+++ b/components/si-veritech/src/intel/awsEksCluster.ts
@@ -1,9 +1,17 @@
+import { ResourceInternalHealth } from "si-entity";
 import { OpSource } from "si-entity/dist/siEntity";
 import { Qualification } from "si-registry";
 import {
   InferPropertiesReply,
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import { awsKubeConfigPath } from "../support";
+import WebSocket from "ws";
 //import Debug from "debug";
 //const _debug = Debug("veritech:controllers:intel:dockerImage");
 
@@ -22,4 +30,63 @@ function inferProperties(
   return { entity: request.entity };
 }
 
-export default { inferProperties };
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const system = req.system.id;
+  const defaultArgs = ["get", "--raw=/readyz?verbose"];
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+  const kubeConfigDir = await awsKubeConfigPath(
+    req,
+    req.entity.getProperty({ system, path: ["name"] }),
+  );
+  const result = await ctx.exec(
+    "kubectl",
+    [...defaultArgs, "--kubeconfig", `${kubeConfigDir.path}/config`],
+    { reject: false },
+  );
+  if (result.exitCode != 0) {
+    response.error = result.all;
+    response.state = "not ready";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+  } else {
+    response.data["readyz"] = result.all.split("\n");
+    response.state = "ready";
+    response.health = "ok";
+    response.internalHealth = ResourceInternalHealth.Ok;
+  }
+  const nodesResult = await ctx.exec(
+    "kubectl",
+    [
+      "get",
+      "nodes",
+      "-o",
+      "json",
+      "--kubeconfig",
+      `${kubeConfigDir.path}/config`,
+    ],
+    { reject: false },
+  );
+  if (nodesResult.exitCode != 0) {
+    response.error = nodesResult.all;
+    response.state = "nodes failing";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+  } else {
+    response.data["nodes"] = JSON.parse(nodesResult.stdout);
+  }
+
+  return response;
+}
+
+export default { inferProperties, syncResource };

--- a/components/si-veritech/src/intel/azure.ts
+++ b/components/si-veritech/src/intel/azure.ts
@@ -1,0 +1,38 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import { azureLogin } from "../support";
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+  try {
+    await azureLogin(req);
+  } catch (e) {
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    response.state = "error";
+    response.error = "Cannot authenticate with Azure";
+    return response;
+  }
+  response.health = "ok";
+  response.internalHealth = ResourceInternalHealth.Ok;
+  response.state = "ok";
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/azureAks.ts
+++ b/components/si-veritech/src/intel/azureAks.ts
@@ -1,0 +1,55 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+import { findEntityByType } from "../support";
+
+export async function syncResource(
+  _ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const cluster = findEntityByType(req, "azureAksCluster");
+
+  if (!cluster) {
+    response.error = "No cluster connected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const clusterResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == cluster.id,
+  );
+  if (clusterResource) {
+    response.data = clusterResource.data;
+    response.error = clusterResource.error;
+    response.state = clusterResource.state;
+    response.health = clusterResource.health;
+    response.internalHealth = clusterResource.internalHealth;
+    response.internalStatus = clusterResource.internalStatus;
+    response.subResources = clusterResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/azureAksCluster.ts
+++ b/components/si-veritech/src/intel/azureAksCluster.ts
@@ -1,8 +1,16 @@
 import { OpSource } from "si-entity/dist/siEntity";
+import { ResourceInternalHealth } from "si-entity";
 import {
   InferPropertiesReply,
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import { azureKubeConfigPath } from "../support";
+import WebSocket from "ws";
 
 function inferProperties(
   request: InferPropertiesRequest,
@@ -19,4 +27,63 @@ function inferProperties(
   return { entity: request.entity };
 }
 
-export default { inferProperties };
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const system = req.system.id;
+  const defaultArgs = ["get", "--raw=/readyz?verbose"];
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+  const kubeConfigDir = await azureKubeConfigPath(
+    req,
+    req.entity.getProperty({ system, path: ["name"] }),
+  );
+  const result = await ctx.exec(
+    "kubectl",
+    [...defaultArgs, "--kubeconfig", `${kubeConfigDir.path}/config`],
+    { reject: false },
+  );
+  if (result.exitCode != 0) {
+    response.error = result.all;
+    response.state = "not ready";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+  } else {
+    response.data["readyz"] = result.all.split("\n");
+    response.state = "ready";
+    response.health = "ok";
+    response.internalHealth = ResourceInternalHealth.Ok;
+  }
+  const nodesResult = await ctx.exec(
+    "kubectl",
+    [
+      "get",
+      "nodes",
+      "-o",
+      "json",
+      "--kubeconfig",
+      `${kubeConfigDir.path}/config`,
+    ],
+    { reject: false },
+  );
+  if (nodesResult.exitCode != 0) {
+    response.error = nodesResult.all;
+    response.state = "nodes failing";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+  } else {
+    response.data["nodes"] = JSON.parse(nodesResult.stdout);
+  }
+
+  return response;
+}
+
+export default { inferProperties, syncResource };

--- a/components/si-veritech/src/intel/azureResourceGroup.ts
+++ b/components/si-veritech/src/intel/azureResourceGroup.ts
@@ -4,6 +4,14 @@ import {
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
 import { setPropertyFromEntity } from "./inferShared";
+import { SiCtx } from "../siCtx";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { ResourceInternalHealth } from "si-entity";
+import { azureLogin } from "../support";
+import WebSocket from "ws";
 
 function inferProperties(
   request: InferPropertiesRequest,
@@ -29,4 +37,45 @@ function inferProperties(
   return { entity: request.entity };
 }
 
-export default { inferProperties };
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const system = req.system.id;
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+  await azureLogin(req);
+  const name: string | null = req.entity.getProperty({
+    system,
+    path: ["name"],
+  });
+  if (name) {
+    const result = await ctx.exec("az", [
+      "group",
+      "show",
+      "--resource-group",
+      name,
+    ]);
+    response.data = JSON.parse(result.stdout);
+    if (result.exitCode != 0) {
+      response.health = "error";
+      response.internalHealth = ResourceInternalHealth.Error;
+      response.state = "error";
+    } else {
+      response.health = "ok";
+      response.internalHealth = ResourceInternalHealth.Ok;
+      response.state = "ok";
+    }
+  }
+
+  return response;
+}
+
+export default { inferProperties, syncResource };

--- a/components/si-veritech/src/intel/azureServicePrincipal.ts
+++ b/components/si-veritech/src/intel/azureServicePrincipal.ts
@@ -1,0 +1,29 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+
+export async function syncResource(
+  _ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+  response.health = "ok";
+  response.internalHealth = ResourceInternalHealth.Ok;
+  response.state = "ok";
+
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/cloudProvider.ts
+++ b/components/si-veritech/src/intel/cloudProvider.ts
@@ -1,0 +1,57 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const system = req.system.id;
+  const implementation = req.entity.getProperty({
+    system,
+    path: ["implementation"],
+  });
+  if (!implementation) {
+    response.error = "No implementation selected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const implementationResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == implementation,
+  );
+  if (implementationResource) {
+    response.data = implementationResource.data;
+    response.error = implementationResource.error;
+    response.state = implementationResource.state;
+    response.health = implementationResource.health;
+    response.internalHealth = implementationResource.internalHealth;
+    response.internalStatus = implementationResource.internalStatus;
+    response.subResources = implementationResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/k8sDeployment.ts
+++ b/components/si-veritech/src/intel/k8sDeployment.ts
@@ -5,6 +5,8 @@ import {
   baseInferProperties,
   baseCheckQualifications,
   baseRunCommands,
+  baseSyncResource,
+  forEachCluster,
 } from "./k8sShared";
 import {
   InferPropertiesReply,
@@ -20,6 +22,15 @@ import {
   setPropertyFromProperty,
 } from "./inferShared";
 import _ from "lodash";
+import { RunCommandCallbacks } from "../controllers/runCommand";
+import { findEntityByType } from "../support";
+import {
+  CommandProtocolFinish,
+  SyncResourceRequest,
+} from "../controllers/syncResource";
+import WebSocket from "ws";
+import { ResourceInternalHealth } from "si-entity";
+import { SiCtx } from "../siCtx";
 
 export function inferProperties(
   request: InferPropertiesRequest,
@@ -113,8 +124,63 @@ export function inferProperties(
   return { entity };
 }
 
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response = await baseSyncResource(ctx, req, ws);
+  const nameSpace = findEntityByType(req, "k8sNamespace");
+  const system = req.system.id;
+  const defaultArgs = ["rollout", "status", "deployment", "-w", "--timeout=5s"];
+  if (nameSpace) {
+    defaultArgs.push("-n");
+    defaultArgs.push(
+      nameSpace.getProperty({ system, path: ["metadata", "name"] }),
+    );
+  }
+
+  await forEachCluster(
+    ctx,
+    req,
+    ws,
+    async (_kubeYaml, kubeConfigDir, kubeCluster) => {
+      const result = await ctx.exec(
+        "kubectl",
+        [
+          ...defaultArgs,
+          "--kubeconfig",
+          `${kubeConfigDir.path}/config`,
+          req.entity.getProperty({ system, path: ["metadata", "name"] }),
+        ],
+        { reject: false },
+      );
+      if (result.exitCode != 0) {
+        response.health = "error";
+        response.state = "error";
+        response.internalHealth = ResourceInternalHealth.Error;
+        response.error = result.all;
+        if (response.subResources[kubeCluster.id]) {
+          // @ts-ignore
+          response.subResources[kubeCluster.id].state = "error";
+          // @ts-ignore
+          response.subResources[kubeCluster.id].health = "error";
+          // @ts-ignore
+          response.subResources[kubeCluster.id].internalHealth =
+            ResourceInternalHealth.Error;
+          // @ts-ignore
+          response.subResources[kubeCluster.id].error = result.all;
+        }
+      }
+    },
+  );
+  response.data = response.subResources;
+  return response;
+}
+
 export default {
   inferProperties,
   checkQualifications: baseCheckQualifications,
   runCommands: baseRunCommands,
+  syncResource,
 };

--- a/components/si-veritech/src/intel/k8sNamespace.ts
+++ b/components/si-veritech/src/intel/k8sNamespace.ts
@@ -2,10 +2,12 @@ import {
   baseInferProperties,
   baseCheckQualifications,
   baseRunCommands,
+  baseSyncResource,
 } from "./k8sShared";
 
 export default {
   inferProperties: baseInferProperties,
   checkQualifications: baseCheckQualifications,
   runCommands: baseRunCommands,
+  syncResource: baseSyncResource,
 };

--- a/components/si-veritech/src/intel/k8sService.ts
+++ b/components/si-veritech/src/intel/k8sService.ts
@@ -5,6 +5,8 @@ import {
   baseInferProperties,
   baseCheckQualifications,
   baseRunCommands,
+  baseSyncResource,
+  forEachCluster,
 } from "./k8sShared";
 import {
   InferPropertiesReply,
@@ -20,6 +22,14 @@ import {
   setPropertyFromProperty,
 } from "./inferShared";
 import _ from "lodash";
+import { SiCtx } from "../siCtx";
+import {
+  CommandProtocolFinish,
+  SyncResourceRequest,
+} from "../controllers/syncResource";
+import { findEntityByType } from "../support";
+import WebSocket from "ws";
+import { ResourceInternalHealth } from "si-entity";
 
 export function inferProperties(
   request: InferPropertiesRequest,
@@ -95,8 +105,85 @@ export function inferProperties(
   return { entity };
 }
 
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response = await baseSyncResource(ctx, req, ws);
+  const system = req.system.id;
+
+  const serviceType = req.entity.getProperty({
+    system,
+    path: ["spec", "type"],
+  });
+  const ports = req.entity.getProperty({ system, path: ["spec", "ports"] });
+  if (serviceType == "LoadBalancer") {
+    if (ports) {
+      await forEachCluster(
+        ctx,
+        req,
+        ws,
+        async (_kubeYaml, _kubeConfigDir, kubeCluster) => {
+          if (
+            response.data[kubeCluster.id] &&
+            // @ts-ignore
+            response.data[kubeCluster.id]["data"] &&
+            // @ts-ignore
+            response.data[kubeCluster.id]["data"]["status"] &&
+            // @ts-ignore
+            response.data[kubeCluster.id]["data"]["status"]["loadBalancer"] &&
+            // @ts-ignore
+            response.data[kubeCluster.id]["data"]["status"]["loadBalancer"][
+              "ingress"
+            ]
+          ) {
+            // @ts-ignore
+            for (const ingress of response.data[kubeCluster.id]["data"][
+              "status"
+            ]["loadBalancer"]["ingress"]) {
+              // @ts-ignore
+              if (ingress["hostname"]) {
+                // @ts-ignore
+                for (const port of ports) {
+                  const result = await ctx.exec(
+                    "nc",
+                    ["-z", "-v", "-w5", ingress["hostname"], port["port"]],
+                    { reject: false },
+                  );
+                  if (result.exitCode != 0) {
+                    response.health = "error";
+                    response.state = "error";
+                    response.internalHealth = ResourceInternalHealth.Error;
+                    response.error = result.all;
+                    if (response.subResources[kubeCluster.id]) {
+                      response.subResources[kubeCluster.id].health = "error";
+                      response.subResources[kubeCluster.id].state = "error";
+                      response.subResources[kubeCluster.id].internalHealth =
+                        ResourceInternalHealth.Error;
+                      response.subResources[kubeCluster.id].error = result.all;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+      );
+      response.data = response.subResources;
+    } else {
+      response.state = "invalid";
+      response.health = "unknown";
+      response.internalHealth = ResourceInternalHealth.Unknown;
+      response.error = "no port entries in spec; service cannot function";
+    }
+  }
+  return response;
+}
+
 export default {
   inferProperties,
   checkQualifications: baseCheckQualifications,
   runCommands: baseRunCommands,
+  syncResource,
 };

--- a/components/si-veritech/src/intel/kubernetesCluster.ts
+++ b/components/si-veritech/src/intel/kubernetesCluster.ts
@@ -1,0 +1,57 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  _ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const system = req.system.id;
+  const implementation = req.entity.getProperty({
+    system,
+    path: ["implementation"],
+  });
+  if (!implementation) {
+    response.error = "No implementation selected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const implementationResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == implementation,
+  );
+  if (implementationResource) {
+    response.data = implementationResource.data;
+    response.error = implementationResource.error;
+    response.state = implementationResource.state;
+    response.health = implementationResource.health;
+    response.internalHealth = implementationResource.internalHealth;
+    response.internalStatus = implementationResource.internalStatus;
+    response.subResources = implementationResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/intel/kubernetesService.ts
+++ b/components/si-veritech/src/intel/kubernetesService.ts
@@ -1,0 +1,198 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+import { findEntityByType } from "../support";
+import {
+  InferPropertiesReply,
+  InferPropertiesRequest,
+} from "../controllers/inferProperties";
+import {
+  SetArrayEntryFromAllEntities,
+  setArrayEntryFromAllEntities,
+} from "./inferShared";
+import { forEachCluster } from "./k8sShared";
+
+export function inferProperties(
+  request: InferPropertiesRequest,
+): InferPropertiesReply {
+  const context = request.context;
+  const entity = request.entity;
+
+  setArrayEntryFromAllEntities({
+    entity,
+    context,
+    entityType: "k8sService",
+    toPath: ["healthChecks"],
+    valuesCallback(
+      fromEntity,
+    ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
+      const toSet: { path: string[]; value: any; system: string }[] = [];
+
+      const portsBySystem: Record<
+        string,
+        Record<string, any>[]
+      > = fromEntity.getPropertyForAllSystems({
+        path: ["spec", "ports"],
+      });
+      for (const system in portsBySystem) {
+        const ports = portsBySystem[system];
+        for (const port of ports) {
+          if (port["port"] == "80" || port["port"] == "8080") {
+            toSet.push({
+              path: ["protocol"],
+              value: "HTTP",
+              system,
+            });
+            toSet.push({
+              path: ["port"],
+              value: port["port"],
+              system,
+            });
+          }
+        }
+      }
+      return toSet;
+    },
+  });
+
+  return { entity };
+}
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const system = req.system.id;
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const service = findEntityByType(req, "k8sService");
+
+  if (!service) {
+    response.error = "No service connected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const clusterResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == service.id,
+  );
+  if (clusterResource) {
+    response.data = clusterResource.data;
+    response.error = clusterResource.error;
+    response.state = clusterResource.state;
+    response.health = clusterResource.health;
+    response.internalHealth = clusterResource.internalHealth;
+    response.internalStatus = clusterResource.internalStatus;
+    response.subResources = clusterResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+
+  const healthChecks = req.entity.getProperty({
+    system,
+    path: ["healthChecks"],
+  });
+  for (const healthCheck of healthChecks) {
+    if (healthCheck["protocol"] == "HTTP") {
+      const host = healthCheck["host"];
+      const port = healthCheck["port"];
+      const path = healthCheck["path"];
+      if (!host) {
+        for (const kubeClusterId of Object.keys(response.subResources)) {
+          if (
+            response.data[kubeClusterId] &&
+            // @ts-ignore
+            response.data[kubeClusterId]["data"] &&
+            // @ts-ignore
+            response.data[kubeClusterId]["data"]["status"] &&
+            // @ts-ignore
+            response.data[kubeClusterId]["data"]["status"]["loadBalancer"] &&
+            // @ts-ignore
+            response.data[kubeClusterId]["data"]["status"]["loadBalancer"][
+              "ingress"
+            ]
+          ) {
+            // @ts-ignore
+            for (const ingress of response.data[kubeClusterId]["data"][
+              "status"
+            ]["loadBalancer"]["ingress"]) {
+              let hostName;
+              // @ts-ignore
+              if (ingress["hostname"]) {
+                hostName = ingress["hostname"];
+              } else {
+                hostName = ingress["ip"];
+              }
+              if (hostName) {
+                let url = `http://${hostName}:${port}`;
+                if (path) {
+                  url += path;
+                }
+                response.subResources[kubeClusterId].data[
+                  "healthCheckUrl"
+                ] = url;
+                const result = await ctx.exec(
+                  "curl",
+                  ["-v", "-i", "-m", "10", url],
+                  {
+                    reject: false,
+                  },
+                );
+                if (result.exitCode != 0) {
+                  response.health = "error";
+                  response.state = "error";
+                  response.internalHealth = ResourceInternalHealth.Error;
+                  response.error = result.all;
+                  if (response.subResources[kubeClusterId]) {
+                    response.subResources[kubeClusterId].health = "error";
+                    response.subResources[kubeClusterId].state = "error";
+                    response.subResources[kubeClusterId].internalHealth =
+                      ResourceInternalHealth.Error;
+                    response.subResources[kubeClusterId].error = result.all;
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        let url = `http://${host}:${port}`;
+        if (path) {
+          url += path;
+        }
+        // @ts-ignore
+        response.subResources[kubeClusterId]["healthCheckUrl"] = url;
+        const result = await ctx.exec("curl", ["-v", "-i", "-m", "10", url], {
+          reject: false,
+        });
+        if (result.exitCode != 0) {
+          response.health = "error";
+          response.state = "error";
+          response.internalHealth = ResourceInternalHealth.Error;
+          response.error = result.all;
+        }
+      }
+    }
+  }
+  return response;
+}
+
+export default { inferProperties, syncResource };

--- a/components/si-veritech/src/intel/service.ts
+++ b/components/si-veritech/src/intel/service.ts
@@ -1,0 +1,95 @@
+import { ResourceInternalHealth } from "si-entity";
+import {
+  SyncResourceRequest,
+  CommandProtocolFinish,
+} from "../controllers/syncResource";
+import { SiCtx } from "../siCtx";
+import WebSocket from "ws";
+import _ from "lodash";
+import { findEntityByType } from "../support";
+
+export async function syncResource(
+  ctx: typeof SiCtx,
+  req: SyncResourceRequest,
+  ws: WebSocket,
+): Promise<CommandProtocolFinish["finish"]> {
+  const system = req.system.id;
+  const response: CommandProtocolFinish["finish"] = {
+    data: {},
+    state: req.resource.state,
+    health: req.resource.health,
+    internalStatus: req.resource.internalStatus,
+    internalHealth: req.resource.internalHealth,
+    subResources: req.resource.subResources,
+  };
+
+  const system = req.system.id;
+  const implementation = req.entity.getProperty({
+    system,
+    path: ["implementation"],
+  });
+  if (!implementation) {
+    response.error = "No implementation selected";
+    response.state = "error";
+    response.health = "error";
+    response.internalHealth = ResourceInternalHealth.Error;
+    return response;
+  }
+  const implementationResource = _.find(
+    req.resourceContext,
+    (r) => r.entityId == implementation,
+  );
+  if (implementationResource) {
+    response.data = implementationResource.data;
+    response.error = implementationResource.error;
+    response.state = implementationResource.state;
+    response.health = implementationResource.health;
+    response.internalHealth = implementationResource.internalHealth;
+    response.internalStatus = implementationResource.internalStatus;
+    response.subResources = implementationResource.subResources;
+  } else {
+    response.state = "unknown";
+    response.health = "unknown";
+    response.internalHealth = ResourceInternalHealth.Unknown;
+    return response;
+  }
+
+  const healthChecks: any = req.entity.getProperty({
+    system,
+    path: ["healthChecks"],
+  });
+  if (healthChecks) {
+    console.log("healthChecks");
+    for (const healthCheck of healthChecks) {
+      console.log("healthChecks", { healthCheck });
+      if (healthCheck["protocol"] == "HTTP") {
+        const host = healthCheck["host"];
+        const port = healthCheck["port"];
+        const path = healthCheck["path"];
+        if (host) {
+          let url = `http://${host}`;
+          if (port) {
+            url += `:${port}`;
+          }
+          if (path) {
+            url += path;
+          }
+          // @ts-ignore
+          response.data["healthCheckUrl"] = url;
+          const result = await ctx.exec("curl", ["-v", "-i", "-m", "10", url], {
+            reject: false,
+          });
+          if (result.exitCode != 0) {
+            response.health = "error";
+            response.state = "error";
+            response.internalHealth = ResourceInternalHealth.Error;
+            response.error = result.all;
+          }
+        }
+      }
+    }
+  }
+  return response;
+}
+
+export default { syncResource };

--- a/components/si-veritech/src/support.ts
+++ b/components/si-veritech/src/support.ts
@@ -142,10 +142,15 @@ export interface KubeConfigDir {
   directory: string;
 }
 
-export async function awsKubeConfigPath(context: Context): Promise<TempDir> {
+export async function awsKubeConfigPath(
+  context: Context,
+  clusterName?: string,
+): Promise<TempDir> {
   const awsEnv = awsAccessKeysEnvironment(context);
   const region = awsRegion(context);
-  const clusterName = awsEksClusterName(context);
+  if (!clusterName) {
+    clusterName = awsEksClusterName(context);
+  }
   const kubeTempDir = await tempDir({});
   const kubeconfigPath = path.join(kubeTempDir.path, "config");
   await SiCtx.exec(
@@ -167,8 +172,13 @@ export async function awsKubeConfigPath(context: Context): Promise<TempDir> {
   return kubeTempDir;
 }
 
-export async function azureLogin(context: Context): Promise<void> {
-  const secret = findSecret(context, SecretKind.AzureServicePrincipal);
+export async function azureLogin(
+  context: Context,
+  secret?: Record<string, any>,
+): Promise<void> {
+  if (!secret) {
+    secret = findSecret(context, SecretKind.AzureServicePrincipal);
+  }
   if (secret) {
     await SiCtx.exec("az", [
       "login",
@@ -207,10 +217,15 @@ export function azureAksClusterName(context: Context): string {
   }
 }
 
-export async function azureKubeConfigPath(context: Context): Promise<TempDir> {
+export async function azureKubeConfigPath(
+  context: Context,
+  clusterName?: string,
+): Promise<TempDir> {
   await azureLogin(context);
   const resourceGroup = azureResourceGroup(context);
-  const clusterName = azureAksClusterName(context);
+  if (!clusterName) {
+    clusterName = azureAksClusterName(context);
+  }
   const kubeTempDir = await tempDir({});
   const kubeconfigPath = path.join(kubeTempDir.path, "config");
   await SiCtx.exec("az", [

--- a/components/si-web-app/src/organisims/AttributePanel.vue
+++ b/components/si-web-app/src/organisims/AttributePanel.vue
@@ -473,8 +473,6 @@ export default Vue.extend({
             resource.entityId == entityId
           ) {
             this.resource = resource;
-          } else {
-            this.resource = null;
           }
         }),
       ),

--- a/components/si-web-app/src/organisims/ResourceViewer.vue
+++ b/components/si-web-app/src/organisims/ResourceViewer.vue
@@ -10,7 +10,6 @@
 
     <div
       class="relative flex flex-row items-center pt-2 pb-2 pl-6 pr-6 text-base text-white bg-black"
-      v-if="resource"
     >
       <div class="flex">
         <button
@@ -23,8 +22,8 @@
       </div>
     </div>
 
-    <div v-if="resource" class="flex w-full pt-2 overflow-auto">
-      <div class="flex flex-col w-full">
+    <div class="flex w-full pt-2 overflow-auto">
+      <div class="flex flex-col w-full" v-if="resource">
         <VueJsonPretty :data="resource" />
       </div>
     </div>


### PR DESCRIPTION
This PR implements resources for all of our entities, and periodic sync.
It fixes [ch1219].

The specific behavior for a given entity lives in the si-veritech intel
functions in a `syncResource` callback. It is responsible for both
populating runtime data about the resource and checking its health.

The scheduler is very simple - it tries to schedule all the resources as
closet to every 30 seconds as possible. It will run long, but it will
never be more often than 30 seconds.

Some resources also have sub-resources. If these are present, then the
key in the sub-resource hash is the entity id of a cluster they are
attached to.

This PR requires wiping your database, so be ready for that. :)

Best,
Adam