### PR TITLE
fix(si-model): make names be si-1234

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,7 @@ dependencies = [
  "jwt-simple",
  "lazy_static",
  "names",
+ "rand 0.8.3",
  "refinery",
  "reqwest",
  "serde 1.0.123",

--- a/components/si-model/Cargo.toml
+++ b/components/si-model/Cargo.toml
@@ -30,6 +30,7 @@ tungstenite = "0.13.0"
 reqwest = { version = "0.11.1", features = ["json"] }
 chrono = "0.4.19"
 deadpool-postgres = "0.7.0"
+rand = "0.8.3"
 
 [dev-dependencies]
 anyhow = "1.0.38"

--- a/components/si-model/src/lib.rs
+++ b/components/si-model/src/lib.rs
@@ -76,6 +76,7 @@ pub use node_position::{NodePosition, NodePositionError};
 pub use organization::{Organization, OrganizationError};
 pub use output_line::{OutputLine, OutputLineStream};
 pub use qualification::{Qualification, QualificationError};
+use rand::Rng;
 pub use resource::{
     Resource, ResourceError, ResourceInternalHealth, ResourceInternalStatus, ResourceResult,
 };
@@ -93,6 +94,8 @@ pub use user::{LoginReply, LoginRequest, SiClaims, User, UserError, UserResult};
 pub use workflow::{Workflow, WorkflowContext, WorkflowError, WorkflowRun};
 pub use workspace::{Workspace, WorkspaceError};
 
+const NAME_CHARSET: &[u8] = b"0123456789";
+
 #[derive(Error, Debug)]
 pub enum ModelError {
     #[error("migration error: {0}")]
@@ -109,7 +112,15 @@ pub fn generate_name(name: Option<String>) -> String {
     if name.is_some() {
         return name.unwrap();
     }
-    let mut name_generator = names::Generator::with_naming(names::Name::Numbered);
-    let name = name_generator.next().unwrap();
-    return name;
+    let mut rng = rand::thread_rng();
+    let unique_id: String = (0..4)
+        .map(|_| {
+            let idx = rng.gen_range(0..NAME_CHARSET.len());
+            NAME_CHARSET[idx] as char
+        })
+        .collect();
+    return format!("si-{}", unique_id);
+    //let mut name_generator = names::Generator::with_naming(names::Name::Numbered);
+    //let name = name_generator.next().unwrap();
+    //return name;
 }


### PR DESCRIPTION
This PR makes our auto-generated names become si-1234, where 1234 is a
random 4 digit number.

Pretty unlikely to collide, at least on the same type of entity.