### PR TITLE
feat: terminate services & delete Kubernetes objects

### DIFF
--- a/components/si-registry/src/schema/kubernetes/shared/standard.ts
+++ b/components/si-registry/src/schema/kubernetes/shared/standard.ts
@@ -49,6 +49,9 @@ export const qualifications = [
   },
 ];
 
-export const actions = [{ name: "apply" }];
+export const actions = [{ name: "apply" }, { name: "delete" }];
 
-export const commands = [{ name: "apply", description: "kubectl apply" }];
+export const commands = [
+  { name: "apply", description: "kubectl apply" },
+  { name: "delete", description: "kubectl delete" },
+];

--- a/components/si-registry/src/schema/si/service.ts
+++ b/components/si-registry/src/schema/si/service.ts
@@ -71,7 +71,7 @@ const service: RegistryEntry = {
       },
     },
   ],
-  actions: [{ name: "deploy" }],
+  actions: [{ name: "deploy" }, { name: "terminate" }],
 };
 
 export default service;

--- a/components/si-veritech/src/intel/k8sDeployment.ts
+++ b/components/si-veritech/src/intel/k8sDeployment.ts
@@ -1,8 +1,6 @@
-import { OpSource, SiEntity } from "si-entity/dist/siEntity";
 import Debug from "debug";
 const debug = Debug("veritech:controllers:intel:k8sDeployment");
 import {
-  baseInferProperties,
   baseCheckQualifications,
   baseRunCommands,
   baseSyncResource,
@@ -13,16 +11,12 @@ import {
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
 import {
-  allEntitiesByType,
-  findProperty,
   SetArrayEntryFromAllEntities,
   setArrayEntryFromAllEntities,
   setProperty,
   setPropertyFromEntity,
   setPropertyFromProperty,
 } from "./inferShared";
-import _ from "lodash";
-import { RunCommandCallbacks } from "../controllers/runCommand";
 import { findEntityByType } from "../support";
 import {
   CommandProtocolFinish,

--- a/components/si-veritech/src/intel/service.ts
+++ b/components/si-veritech/src/intel/service.ts
@@ -6,7 +6,6 @@ import {
 import { SiCtx } from "../siCtx";
 import WebSocket from "ws";
 import _ from "lodash";
-import { findEntityByType } from "../support";
 
 export async function syncResource(
   ctx: typeof SiCtx,


### PR DESCRIPTION
This change adds a `termintate` action and workflow on `service` nodes
that work through their implementation nodes for Kubernetes services. In
this case, the `delete` action is called on Kubernetes objects
(triggering a `kubectl delete` command to run) in a prescribed order
similar to that of Helm for uninstalling (similar to our "terminate").

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>