### PR TITLE
fix: re-implement node delete behavior

### DIFF
--- a/components/si-model/src/queries/entity_for_change_set.sql
+++ b/components/si-model/src/queries/entity_for_change_set.sql
@@ -1,6 +1,6 @@
 SELECT COALESCE(entities_change_set_projection.obj, entities_head.obj) AS object
 FROM entities
-LEFT JOIN entities_change_set_projection ON entities_change_set_projection.id = entities.id
-                                         AND entities_change_set_projection.change_set_id = si_id_to_primary_key_v1($2)
-LEFT JOIN entities_head ON entities_head.id = entities.id
+         LEFT JOIN entities_change_set_projection ON entities_change_set_projection.id = entities.id
+    AND entities_change_set_projection.change_set_id = si_id_to_primary_key_v1($2)
+         LEFT JOIN entities_head ON entities_head.id = entities.id
 WHERE entities.id = si_id_to_primary_key_v1($1);

--- a/components/si-model/src/queries/entity_for_edit_session.sql
+++ b/components/si-model/src/queries/entity_for_edit_session.sql
@@ -1,9 +1,9 @@
 SELECT COALESCE(entities_edit_session_projection.obj, entities_change_set_projection.obj, entities_head.obj) AS object
 FROM entities
-LEFT JOIN entities_edit_session_projection ON entities_edit_session_projection.id = entities.id
-                                            AND entities_edit_session_projection.change_set_id = si_id_to_primary_key_v1($2)
-                                            AND entities_edit_session_projection.edit_session_id = si_id_to_primary_key_v1($3)
-LEFT JOIN entities_change_set_projection ON entities_change_set_projection.id = entities.id
-                                         AND entities_change_set_projection.change_set_id = si_id_to_primary_key_v1($2)
-LEFT JOIN entities_head ON entities_head.id = entities.id
+         LEFT JOIN entities_edit_session_projection ON entities_edit_session_projection.id = entities.id
+    AND entities_edit_session_projection.change_set_id = si_id_to_primary_key_v1($2)
+    AND entities_edit_session_projection.edit_session_id = si_id_to_primary_key_v1($3)
+         LEFT JOIN entities_change_set_projection ON entities_change_set_projection.id = entities.id
+    AND entities_change_set_projection.change_set_id = si_id_to_primary_key_v1($2)
+         LEFT JOIN entities_head ON entities_head.id = entities.id
 WHERE entities.id = si_id_to_primary_key_v1($1);

--- a/components/si-model/src/queries/entity_for_head.sql
+++ b/components/si-model/src/queries/entity_for_head.sql
@@ -1,4 +1,4 @@
 SELECT entities_head.obj AS object
 FROM entities
-LEFT JOIN entities_head ON entities_head.id = entities.id
+         LEFT JOIN entities_head ON entities_head.id = entities.id
 WHERE entities.id = si_id_to_primary_key_v1($1);

--- a/components/si-sdf/src/handlers/schematic_dal.rs
+++ b/components/si-sdf/src/handlers/schematic_dal.rs
@@ -537,7 +537,7 @@ pub struct DeleteNodeRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteNodeReply {
-    pub schematic: Schematic,
+    pub deleted: bool,
 }
 pub async fn delete_node(
     pg: PgPool,
@@ -602,24 +602,10 @@ pub async fn delete_node(
         .await
         .map_err(HandlerError::from)?;
 
-    let schematic = Schematic::get(
-        &txn,
-        &request.application_id,
-        Some(request.change_set_id.clone()),
-        Some(request.edit_session_id),
-        vec![
-            EdgeKind::Configures,
-            EdgeKind::Deployment,
-            EdgeKind::Implementation,
-        ],
-    )
-    .await
-    .map_err(HandlerError::from)?;
-
     txn.commit().await.map_err(HandlerError::from)?;
     nats.commit().await.map_err(HandlerError::from)?;
 
-    let reply = DeleteNodeReply { schematic };
+    let reply = DeleteNodeReply { deleted: true };
 
     Ok(warp::reply::json(&reply))
 }

--- a/components/si-web-app/src/api/sdf/dal/schematicDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/schematicDal.ts
@@ -194,12 +194,12 @@ export interface INodeDeleteRequest {
 }
 
 export interface INodeDeleteReplySuccess {
-  schematic: Schematic;
+  deleted: boolean;
   error?: never;
 }
 
 export interface INodeDeleteReplyFailure {
-  schematic?: never;
+  deleted?: never;
   error: SDFError;
 }
 

--- a/components/si-web-app/src/observables.ts
+++ b/components/si-web-app/src/observables.ts
@@ -310,6 +310,8 @@ export const workflowRunSteps$: Subject<WorkflowRunStep> = new Subject();
 export const workflowRunStepEntities$: Subject<WorkflowRunStepEntity> = new Subject();
 
 // Schematic
+export const refreshSchematic$ = new BehaviorSubject<boolean>(true);
+
 export const deploymentSchematicSelectNode$ = new ReplaySubject<ISchematicNode | null>(
   1,
 );
@@ -343,6 +345,12 @@ export const nameAttributeChanged$ = new ReplaySubject<NameAttributeChanged | nu
   1,
 );
 nameAttributeChanged$.next(null);
+
+export interface NodeDeleted {
+  nodeId: string;
+}
+export const nodeDeleted$ = new ReplaySubject<NodeDeleted | null>(1);
+nodeDeleted$.next(null);
 
 export interface EdgeCreating {
   entityType: string;

--- a/components/si-web-app/src/organisims/EditorMenuBar.vue
+++ b/components/si-web-app/src/organisims/EditorMenuBar.vue
@@ -198,6 +198,7 @@ import {
   revision$,
   refreshChangesSummary$,
   refreshActivitySummary$,
+  refreshSchematic$,
 } from "@/observables";
 import _ from "lodash";
 import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
@@ -505,6 +506,7 @@ export default Vue.extend({
           editSession$.next(null);
           editMode$.next(false);
           refreshChangesSummary$.next(true);
+          refreshSchematic$.next(true);
         }
       }
     },
@@ -537,6 +539,7 @@ export default Vue.extend({
       } else {
         editSession$.next(null);
         editMode$.next(false);
+        refreshSchematic$.next(true);
       }
     },
     async cancelChangeSetApply() {
@@ -563,6 +566,7 @@ export default Vue.extend({
           editSession$.next(null);
           editMode$.next(false);
           refreshActivitySummary$.next(true);
+          refreshSchematic$.next(true);
         }
       }
       this.clearChangeSetApplyForm();

--- a/components/si-web-app/src/organisims/SchematicViewer.vue
+++ b/components/si-web-app/src/organisims/SchematicViewer.vue
@@ -131,6 +131,7 @@ import {
   nodePositionUpdated$,
   edgeCreating$,
   refreshChangesSummary$,
+  nodeDeleted$,
 } from "@/observables";
 import { SiEntity } from "si-entity";
 import { Entity } from "@/api/sdf/model/entity";
@@ -705,24 +706,20 @@ export default Vue.extend({
         this.currentEditSession &&
         this.currentSystem
       ) {
-        const request: INodeDeleteRequest = {
-          nodeId: this.selectedNode.node.id,
+        const nodeId = this.selectedNode.node.id;
+        const reply = await SchematicDal.nodeDelete({
+          nodeId,
           applicationId: this.currentApplicationId,
           workspaceId: this.currentWorkspace.id,
           changeSetId: this.currentChangeSet.id,
           editSessionId: this.currentEditSession.id,
           systemId: this.currentSystem.id,
-        };
-        let reply: INodeDeleteReply = await SchematicDal.nodeDelete(request);
-        if (!reply.error) {
-          schematicUpdated$.next({
-            schematicKind: this.schematicKind,
-            schematic: reply.schematic,
-          });
-        } else {
+        });
+        if (reply.error) {
           emitEditorErrorMessage(reply.error.message);
+          return;
         }
-        return reply;
+        nodeDeleted$.next({ nodeId });
       }
     },
     spacebarEvent(event: ShortcutUpdateEvent) {

--- a/components/si-web-app/src/organisims/ShortcutsEventBroker.vue
+++ b/components/si-web-app/src/organisims/ShortcutsEventBroker.vue
@@ -70,7 +70,7 @@ interface IData {
 }
 
 export const SpaceBarEvents = new Subject();
-export const BackspaceEvents = new Subject();
+export const BackspaceEvents: Subject<ShortcutUpdateEvent> = new Subject();
 
 const MousecDown = fromEvent(document, "mousedown");
 const MousecUp = fromEvent(document, "mouseup");


### PR DESCRIPTION
This change fixes up what happens when nodes are deleted (using the
backspace key) in various contexts:

1. In edit session with brand new node: deleted node is still displayed
   with a red border in edit mode, and removed/disappears from
   schematic/view when edit session is saved
2. In edit session with node already in change set but not yet head:
   deleted node is still displayed with a red border in edit mode,
   remains in same state when edit session is saved, and
   removed/disappears from schematic/view when change set is applied to
   head
3. In edit session with node already in change set and in head: deleted
   node is still displayed with a red border in edit mode, remains in
   same state when edit session is saved, and removed/disappears from
   schematic/view when change set is applied to head
4. In edit session with node already in head but not in change set: same
   as number 3

Additionally, custom error types are added for Entity when calling
`for_edit_session`, `for_head_or_change_set`, `for_head`, and
`for_head_or_change_set_or_edit_session` when no Entity can be found.
Prior to this all we had was a generic PG error that had no insight into
a found/not found scenario.

References: Re-implement node delete behaviors [ch1197]

![tenor-4883692](https://user-images.githubusercontent.com/261548/120086121-a626f680-c09a-11eb-83cf-a0c397dd11dd.gif)
