### PR TITLE
feat(web): Kubernetes image pull policy

### DIFF
--- a/components/si-registry/src/schema/kubernetes/shared/podSpec.ts
+++ b/components/si-registry/src/schema/kubernetes/shared/podSpec.ts
@@ -46,6 +46,11 @@ export const podSpec: RegistryEntry["properties"] = [
               ],
             },
           },
+          validation: [
+            {
+              kind: ValidatorKind.Required,
+            },
+          ],
         },
         {
           type: "array",

--- a/components/si-veritech/src/intel/k8sDeployment.ts
+++ b/components/si-veritech/src/intel/k8sDeployment.ts
@@ -92,6 +92,19 @@ export function inferProperties(
       });
       for (const system in imageValues) {
         toSet.push({ path: ["image"], value: imageValues[system], system });
+        const checkForTag = new RegExp("^.+(:.+)$");
+        const checkResult = checkForTag.exec(imageValues[system] as string);
+        if (checkResult && checkResult[1] == ":latest") {
+          toSet.push({ path: ["imagePullPolicy"], value: "Always", system });
+        } else if (checkResult) {
+          toSet.push({
+            path: ["imagePullPolicy"],
+            value: "IfNotPresent",
+            system,
+          });
+        } else {
+          toSet.push({ path: ["imagePullPolicy"], value: "Always", system });
+        }
       }
       const exposedPortValues = fromEntity.getPropertyForAllSystems({
         path: ["ExposedPorts"],


### PR DESCRIPTION
This PR makes the imagePullPolicy for a k8sDeployment be inferred from
the shape of the docker image string. If it does not have a tag, or the tag is
'latest', then the imagePullPolicy is set to 'Always'. If there is a tag
set to anything else, it is set to 'IfNotPresent'.

It is also now a required field.