### PR TITLE
fix(web): infinite counting of resources bug fixed

### DIFF
--- a/components/si-web-app/src/molecules/MenuSummary.vue
+++ b/components/si-web-app/src/molecules/MenuSummary.vue
@@ -221,48 +221,48 @@ export default Vue.extend({
       ),
       resources: resources$.pipe(
         tap(r => {
-          let isUpdated = false;
+          let isNew = true;
           if (r.entityType == "service") {
             //@ts-ignore
             for (let x = 0; x < this.servicesCache.length; x++) {
               // @ts-ignore
               if (r.id == this.servicesCache[x].id) {
-                isUpdated = true;
+                isNew = false;
                 //@ts-ignore
                 Vue.set(this.servicesCache, x, r);
               }
-              if (!isUpdated) {
-                //@ts-ignore
-                this.servicesCache.push(r);
-              }
+            }
+            if (isNew) {
+              //@ts-ignore
+              this.servicesCache.push(r);
             }
           } else if (r.entityType == "kubernetesCluster") {
             //@ts-ignore
             for (let x = 0; x < this.computingResourcesCache.length; x++) {
               // @ts-ignore
               if (r.id == this.computingResourcesCache[x].id) {
-                isUpdated = true;
+                isNew = false;
                 //@ts-ignore
                 Vue.set(this.computingResourcesCache, x, r);
               }
-              if (!isUpdated) {
-                //@ts-ignore
-                this.computingResourcesCache.push(r);
-              }
+            }
+            if (isNew) {
+              //@ts-ignore
+              this.computingResourcesCache.push(r);
             }
           } else if (r.entityType == "cloudProvider") {
             //@ts-ignore
             for (let x = 0; x < this.providersCache.length; x++) {
               // @ts-ignore
               if (r.id == this.providersCache[x].id) {
-                isUpdated = true;
+                isNew = false;
                 //@ts-ignore
                 Vue.set(this.providersCache, x, r);
               }
-              if (!isUpdated) {
-                //@ts-ignore
-                this.providersCache.push(r);
-              }
+            }
+            if (isNew) {
+              //@ts-ignore
+              this.providersCache.push(r);
             }
           }
         }),


### PR DESCRIPTION
This fixes a bug where we were not actually checking the whole loop to
update resource state in the menu summary, and instead were just
constantly adding values (as soon as there was more than one resource).
It was a really dumb bug.