### PR TITLE
fix(aws): fix bad resource health

### DIFF
--- a/components/si-veritech/src/intel/aws.ts
+++ b/components/si-veritech/src/intel/aws.ts
@@ -36,16 +36,17 @@ export async function syncResource(
     env: awsEnv,
     reject: false,
   });
+
   if (output.exitCode != 0) {
     response.health = "error";
     response.internalHealth = ResourceInternalHealth.Error;
     response.state = "error";
     response.error = output.all;
+  } else {
+    response.health = "ok";
+    response.internalHealth = ResourceInternalHealth.Ok;
+    response.state = "ok";
   }
-
-  response.health = "ok";
-  response.internalHealth = ResourceInternalHealth.Ok;
-  response.state = "ok";
   return response;
 }
 


### PR DESCRIPTION
Fixes [ch1384]

We missed an `else` statement, and it meant that the AWS (and by
extension, the cloudProvider resource) could fail but mark themsleves as
healthy. They can't do that anymore.