### PR TITLE
fix(si-registry): remove `k8sPod` input from kubernetesService

### DIFF
--- a/components/si-registry/src/schema/kubernetes/kubernetesService.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetesService.ts
@@ -32,12 +32,6 @@ const kubernetesService: RegistryEntry = {
       edgeKind: "configures",
       arity: Arity.Many,
     },
-    {
-      name: "k8sPod",
-      types: ["k8sPod"],
-      edgeKind: "configures",
-      arity: Arity.Many,
-    },
   ],
   properties: [
     {


### PR DESCRIPTION
References: remove k8s pod input on k8s service [ch1369]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>