### PR TITLE
fix(si-web-app): only show sync button if the resource exists

### DIFF
--- a/components/si-web-app/src/organisims/ResourceViewer.vue
+++ b/components/si-web-app/src/organisims/ResourceViewer.vue
@@ -11,7 +11,7 @@
         <button
           class="flex items-center focus:outline-none button"
           ref="sync"
-          v-if="!editMode"
+          v-if="!editMode && resource"
           @click="runSync()"
         >
           <RefreshCwIcon size="1x" class="text-sm" :class="healthColor" />


### PR DESCRIPTION
You can test this by creating a new node, have the resource panel open,
then save and apply into head and wait for the scheduled first resource
sync to come back and fail. Before that, no button, and after the first
resource update comes back, a button is ready to click.

References: only show the sync resource button if the [ch1387]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>