### PR TITLE
feat(*): add v1 of discovery

### DIFF
--- a/components/si-entity/src/siEntity.ts
+++ b/components/si-entity/src/siEntity.ts
@@ -631,6 +631,29 @@ export class SiEntity implements ISiEntity {
     return registry[this.entityType];
   }
 
+  discoverable(): RegistryEntry[] {
+    const discoverable: RegistryEntry[] = [];
+    for (const entry of Object.values(registry)) {
+      if (entry.discoverableFrom) {
+        const match = _.find(
+          entry.discoverableFrom,
+          (e) => e == this.entityType,
+        );
+        if (match) {
+          if (entry) {
+            discoverable.push(entry);
+          } else {
+            console.log(
+              "A discoverable entity was found, but it was not in the registry! bug!",
+              { match, entity: this },
+            );
+          }
+        }
+      }
+    }
+    return discoverable;
+  }
+
   toEditField(
     editFields: EditField[],
     checkProp: {

--- a/components/si-model/src/discovery.rs
+++ b/components/si-model/src/discovery.rs
@@ -1,0 +1,346 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use si_data::{NatsConn, PgPool, PgTxn};
+
+use crate::{
+    entity::Op,
+    resource,
+    workflow::selector::{SelectionEntry, SelectionEntryPredecessor},
+    ChangeSet, ChangeSetError, Edge, EdgeError, EdgeKind, EditSession, EditSessionError, Entity,
+    EntityError, Node, NodeError, Resource, ResourceError, Veritech, VeritechError, Vertex,
+    WorkflowError,
+};
+
+pub const DISCOVERY_LIST: &str = include_str!("./queries/discovery_list.sql");
+
+#[derive(Error, Debug)]
+pub enum DiscoveryError {
+    #[error("pg error: {0}")]
+    TokioPg(#[from] tokio_postgres::Error),
+    #[error("serde error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Deadpool(#[from] deadpool_postgres::PoolError),
+    #[error("entity error: {0}")]
+    Entity(#[from] EntityError),
+    #[error("discovery request entity is not in a system, invalid request")]
+    NoSystem,
+    #[error("workflow error: {0}")]
+    Workflow(#[from] WorkflowError),
+    #[error("veritech error: {0}")]
+    Veritech(#[from] VeritechError),
+    #[error("changeSet error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
+    #[error("editSession error: {0}")]
+    EditSession(#[from] EditSessionError),
+    #[error("node error: {0}")]
+    Node(#[from] NodeError),
+    #[error("edge error: {0}")]
+    Edge(#[from] EdgeError),
+    #[error("resource error: {0}")]
+    Resource(#[from] ResourceError),
+}
+
+pub type DiscoveryResult<T> = Result<T, DiscoveryError>;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryListEntry {
+    entity: Entity,
+    resource: Resource,
+}
+
+pub async fn list(
+    txn: &PgTxn<'_>,
+    workspace_id: impl AsRef<str>,
+    entity_type: impl AsRef<str>,
+) -> DiscoveryResult<Vec<DiscoveryListEntry>> {
+    let workspace_id = workspace_id.as_ref();
+    let entity_type = entity_type.as_ref();
+    let rows = txn
+        .query(DISCOVERY_LIST, &[&workspace_id, &entity_type])
+        .await?;
+
+    let mut list = Vec::new();
+    for row in rows.into_iter() {
+        let entity_json: serde_json::Value = row.try_get("entity")?;
+        let entity: Entity = serde_json::from_value(entity_json)?;
+        let resource_json: serde_json::Value = row.try_get("resource")?;
+        let resource: Resource = serde_json::from_value(resource_json)?;
+
+        list.push(DiscoveryListEntry { entity, resource });
+    }
+    Ok(list)
+}
+
+pub async fn implementations_list(
+    txn: &PgTxn<'_>,
+    workspace_id: impl AsRef<str>,
+    application_id: impl AsRef<str>,
+    implementation_entity_types: Vec<String>,
+) -> DiscoveryResult<HashMap<String, Vec<DiscoveryListEntry>>> {
+    let mut reply = HashMap::new();
+    let application_id = application_id.as_ref();
+    let workspace_id = workspace_id.as_ref();
+    let application_edges =
+        Edge::direct_successor_edges_by_object_id(&txn, &EdgeKind::Includes, &application_id)
+            .await?;
+    for implementation_entity_type in implementation_entity_types.into_iter() {
+        let impls = list(&txn, &workspace_id, &implementation_entity_type).await?;
+        let filter_impls: Vec<DiscoveryListEntry> = impls
+            .into_iter()
+            .filter(|i| {
+                application_edges
+                    .iter()
+                    .any(|ae| ae.head_vertex.object_id == i.entity.id)
+                    != true
+            })
+            .collect();
+        reply.insert(implementation_entity_type, filter_impls);
+    }
+    Ok(reply)
+}
+
+pub async fn discover(
+    pg: &PgPool,
+    nats_conn: &NatsConn,
+    veritech: &Veritech,
+    workspace_id: impl Into<String>,
+    entity_id: impl Into<String>,
+    entity_type: impl Into<String>,
+) -> DiscoveryResult<()> {
+    let workspace_id = workspace_id.into();
+    let entity_id = entity_id.into();
+    let entity_type = entity_type.into();
+    let pg = pg.clone();
+    let nats_conn = nats_conn.clone();
+    let veritech = veritech.clone();
+    tokio::spawn(async move {
+        match task_discover(
+            pg,
+            nats_conn,
+            veritech,
+            workspace_id,
+            entity_id,
+            entity_type,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(e) => {
+                dbg!("who knows what happened doing discovery: {:?}", &e);
+            }
+        };
+    });
+    Ok(())
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryRequest<'a> {
+    entity: &'a Entity,
+    system: &'a Entity,
+    entity_type: &'a str,
+    context: Vec<SelectionEntryPredecessor>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PartialEntity {
+    name: String,
+    ops: Vec<Op>,
+    entity_type: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverEntity {
+    entity: PartialEntity,
+    configures: Vec<DiscoverEntity>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryFinish {
+    pub discovered: Vec<DiscoverEntity>,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum DiscoveryProtocol {
+    Start(bool),
+    Finish(DiscoveryFinish),
+}
+
+pub async fn task_discover(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+    workspace_id: String,
+    entity_id: String,
+    entity_type: String,
+) -> DiscoveryResult<()> {
+    let mut conn = pg.pool.get().await?;
+    let txn = conn.transaction().await?;
+
+    // The root entity that will be doing discovery
+    let entity = Entity::for_head(&txn, &entity_id).await?;
+
+    let system =
+        Entity::get_head_by_name_and_entity_type(&txn, "production", "system", &workspace_id)
+            .await?
+            .into_iter()
+            .nth(0)
+            .ok_or(DiscoveryError::NoSystem)?;
+
+    let context = SelectionEntry::new(&txn, &entity.id, &system).await?;
+
+    txn.commit().await?;
+
+    let request = DiscoveryRequest {
+        entity: &entity,
+        system: &system,
+        entity_type: &entity_type,
+        context: context.context,
+    };
+
+    let (progress_tx, mut progress_rx) =
+        tokio::sync::mpsc::unbounded_channel::<DiscoveryProtocol>();
+
+    veritech
+        .send_async("discover", request, progress_tx)
+        .await?;
+    while let Some(message) = progress_rx.recv().await {
+        match message {
+            DiscoveryProtocol::Start(_) => {}
+            DiscoveryProtocol::Finish(finish) => {
+                for discovered in finish.discovered.into_iter() {
+                    let mut to_discover: Vec<(Option<Entity>, DiscoverEntity)> =
+                        vec![(None, discovered)];
+                    let mut index = 0;
+                    while index < to_discover.len() {
+                        let txn = conn.transaction().await?;
+                        let nats = nats_conn.transaction();
+                        let (parent, discover) = to_discover[index].clone();
+                        index = index + 1;
+                        let has_entity = Entity::get_head_by_name_and_entity_type(
+                            &txn,
+                            &discover.entity.name,
+                            &discover.entity.entity_type,
+                            &workspace_id,
+                        )
+                        .await?
+                        .len()
+                            > 0;
+                        if !has_entity {
+                            let mut change_set = ChangeSet::new(
+                                &txn,
+                                &nats,
+                                Some(format!(
+                                    "d({} {})",
+                                    &discover.entity.entity_type, &discover.entity.name
+                                )),
+                                workspace_id.clone(),
+                            )
+                            .await?;
+                            let mut edit_session = EditSession::new(
+                                &txn,
+                                &nats,
+                                None,
+                                change_set.id.clone(),
+                                workspace_id.clone(),
+                            )
+                            .await?;
+
+                            let node = Node::new(
+                                &pg,
+                                &txn,
+                                &nats_conn,
+                                &nats,
+                                &veritech,
+                                Some(discover.entity.name.clone()),
+                                &discover.entity.entity_type,
+                                workspace_id.clone(),
+                                change_set.id.clone(),
+                                edit_session.id.clone(),
+                            )
+                            .await?;
+
+                            let mut entity = Entity::for_edit_session(
+                                &txn,
+                                &node.object_id,
+                                &change_set.id,
+                                &edit_session.id,
+                            )
+                            .await?;
+                            entity.ops = discover.entity.ops.clone();
+                            entity
+                                .infer_properties_for_edit_session(
+                                    &txn,
+                                    &veritech,
+                                    &change_set.id,
+                                    &edit_session.id,
+                                )
+                                .await?;
+                            entity
+                                .save_for_edit_session(&txn, &change_set.id, &edit_session.id)
+                                .await?;
+
+                            if let Some(parent_entity) = parent {
+                                let tail_vertex = Vertex::new(
+                                    &entity.node_id,
+                                    &entity.id,
+                                    "output",
+                                    &entity.entity_type,
+                                );
+                                let head_vertex = Vertex::new(
+                                    &parent_entity.node_id,
+                                    &parent_entity.id,
+                                    &entity.entity_type,
+                                    &parent_entity.entity_type,
+                                );
+                                Edge::new(
+                                    &txn,
+                                    &nats,
+                                    tail_vertex,
+                                    head_vertex,
+                                    false,
+                                    EdgeKind::Configures,
+                                    &workspace_id,
+                                )
+                                .await?;
+                            }
+
+                            edit_session.save_session(&txn).await?;
+                            change_set.apply(&txn).await?;
+                            txn.commit().await?;
+
+                            entity
+                                .check_qualifications_for_edit_session(
+                                    &pg,
+                                    &nats_conn,
+                                    &veritech,
+                                    Some(system.id.clone()),
+                                    &change_set.id,
+                                    &edit_session.id,
+                                )
+                                .await?;
+
+                            resource::sync_resource(&pg, &nats_conn, &veritech, &entity).await?;
+
+                            for child in discover.configures.iter() {
+                                to_discover.push((Some(entity.clone()), child.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/components/si-model/src/lib.rs
+++ b/components/si-model/src/lib.rs
@@ -24,6 +24,7 @@ pub mod application;
 pub mod billing_account;
 pub mod change_set;
 pub mod connection;
+pub mod discovery;
 pub mod edge;
 pub mod edit_session;
 pub mod entity;
@@ -59,6 +60,7 @@ pub use application::{
 pub use billing_account::{BillingAccount, BillingAccountError, BillingAccountResult};
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetResult, ChangeSetStatus, SiChangeSet};
 pub use connection::{Connection, ConnectionError, ConnectionPoint, Connections};
+pub use discovery::{DiscoveryError, DiscoveryListEntry};
 pub use edge::{Edge, EdgeError, EdgeKind, EdgeResult, Edges, Vertex};
 pub use edit_session::{EditSession, EditSessionError, EditSessionResult};
 pub use entity::diff::{diff_for_props, DiffError};

--- a/components/si-model/src/queries/discovery_list.sql
+++ b/components/si-model/src/queries/discovery_list.sql
@@ -1,0 +1,6 @@
+SELECT entities_head.obj AS entity, resources.obj AS resource
+FROM entities
+         INNER JOIN entities_head ON entities.id = entities_head.id
+         INNER JOIN resources ON entities.id = resources.entity_id
+WHERE entities.entity_type = $2
+  AND entities.workspace_id = si_id_to_primary_key_v1($1)

--- a/components/si-model/src/schematic.rs
+++ b/components/si-model/src/schematic.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use crate::{
-    workflow::{step::WorkflowRunStep, WorkflowRunListItem},
-    Edge, EdgeError, EdgeKind, Entity, EntityError, ModelError, Node, NodeError, NodePosition,
-    NodePositionError, Qualification, QualificationError, Resource, ResourceError, SiStorable,
-    WorkflowError, WorkflowRun,
+    workflow::WorkflowRunListItem, Edge, EdgeError, EdgeKind, Entity, EntityError, ModelError,
+    Node, NodeError, NodePosition, NodePositionError, Qualification, QualificationError, Resource,
+    ResourceError, SiStorable, WorkflowError, WorkflowRun,
 };
 use si_data::PgTxn;
 

--- a/components/si-model/src/workflow.rs
+++ b/components/si-model/src/workflow.rs
@@ -378,8 +378,6 @@ impl WorkflowRun {
     }
 
     pub async fn refresh(&mut self, txn: &PgTxn<'_>) -> WorkflowResult<()> {
-        let json = serde_json::to_value(&self)?;
-
         let row = txn
             .query_one(
                 "SELECT obj AS object FROM workflow_runs WHERE si_id = $1",

--- a/components/si-model/src/workflow/step.rs
+++ b/components/si-model/src/workflow/step.rs
@@ -8,13 +8,10 @@ use crate::{
     Resource,
 };
 use crate::{
-    workflow::{
-        SelectionEntry, WorkflowContext, WorkflowError, WorkflowResult, WorkflowRun,
-        WorkflowRunState,
-    },
+    workflow::{WorkflowContext, WorkflowError, WorkflowResult, WorkflowRun, WorkflowRunState},
     EdgeKind,
 };
-use crate::{Entity, SiStorable, Veritech, Workspace};
+use crate::{Entity, SiStorable, Veritech};
 use chrono::Utc;
 
 use super::selector::{SelectionEntryPredecessor, SelectorDepth, SelectorDirection};

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -272,6 +272,7 @@ export interface RegistryEntry {
   nodeKind: NodeKind;
   ui?: RegistryEntryUi;
   implements?: string[];
+  discoverableFrom?: string[];
   inputs: Input[];
   omitOutputsInSchematic?: SchematicKind[];
   properties: Prop[];

--- a/components/si-registry/src/schema/aws/awsEks.ts
+++ b/components/si-registry/src/schema/aws/awsEks.ts
@@ -20,6 +20,7 @@ const awsEks: RegistryEntry = {
     ],
   },
   implements: ["kubernetesCluster"],
+  discoverableFrom: ["aws"],
   inputs: [
     {
       name: "awsEksCluster",

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -180,6 +180,18 @@ pub fn attribute_dal(
     veritech: &Veritech,
 ) -> BoxedFilter<(impl warp::Reply,)> {
     attribute_dal_get_entity(pg.clone())
+        .or(attribute_dal_discover(
+            pg.clone(),
+            nats_conn.clone(),
+            veritech.clone(),
+        ))
+        .or(attribute_dal_import_implementation(
+            pg.clone(),
+            nats_conn.clone(),
+            veritech.clone(),
+        ))
+        .or(attribute_dal_get_discovery_list(pg.clone()))
+        .or(attribute_dal_get_implementations_list(pg.clone()))
         .or(attribute_dal_get_entity_list(pg.clone()))
         .or(attribute_dal_get_connections(pg.clone()))
         .or(attribute_dal_delete_connection(
@@ -207,6 +219,64 @@ pub fn attribute_dal_get_entity(pg: PgPool) -> BoxedFilter<(impl warp::Reply,)> 
         .and(warp::header::<String>("authorization"))
         .and(warp::query::<handlers::attribute_dal::GetEntityRequest>())
         .and_then(handlers::attribute_dal::get_entity)
+        .boxed()
+}
+
+pub fn attribute_dal_discover(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("attributeDal" / "discover")
+        .and(warp::post())
+        .and(with_pg(pg))
+        .and(with_nats_conn(nats_conn))
+        .and(with_veritech(veritech))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<handlers::attribute_dal::DiscoverRequest>())
+        .and_then(handlers::attribute_dal::discover)
+        .boxed()
+}
+
+pub fn attribute_dal_import_implementation(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("attributeDal" / "importImplementation")
+        .and(warp::post())
+        .and(with_pg(pg))
+        .and(with_nats_conn(nats_conn))
+        .and(with_veritech(veritech))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<
+            handlers::attribute_dal::ImportImplementationRequest,
+        >())
+        .and_then(handlers::attribute_dal::import_implementation)
+        .boxed()
+}
+
+pub fn attribute_dal_get_discovery_list(pg: PgPool) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("attributeDal" / "getDiscoveryList")
+        .and(warp::get())
+        .and(with_pg(pg))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::query::<
+            handlers::attribute_dal::GetDiscoveryListRequest,
+        >())
+        .and_then(handlers::attribute_dal::get_discovery_list)
+        .boxed()
+}
+
+pub fn attribute_dal_get_implementations_list(pg: PgPool) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("attributeDal" / "getImplementationsList")
+        .and(warp::post())
+        .and(with_pg(pg))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<
+            handlers::attribute_dal::GetImplementationsListRequest,
+        >())
+        .and_then(handlers::attribute_dal::get_implementations_list)
         .boxed()
 }
 

--- a/components/si-sdf/src/handlers.rs
+++ b/components/si-sdf/src/handlers.rs
@@ -7,11 +7,11 @@ use std::convert::Infallible;
 
 use si_data::{NatsTxnError, PgTxn};
 use si_model::{
-    ApiClientError, ApplicationError, BillingAccountError, ChangeSetError, DiffError, EdgeError,
-    EditSessionError, EntityError, EventError, EventLogError, JwtKeyError, KeyPairError,
-    ModelError, NodeError, NodePositionError, OrganizationError, QualificationError, ResourceError,
-    SchematicError, SecretError, SessionError, UserError, VisualizationError, WorkflowError,
-    WorkspaceError,
+    ApiClientError, ApplicationError, BillingAccountError, ChangeSetError, DiffError,
+    DiscoveryError, EdgeError, EditSessionError, EntityError, EventError, EventLogError,
+    JwtKeyError, KeyPairError, ModelError, NodeError, NodePositionError, OrganizationError,
+    QualificationError, ResourceError, SchematicError, SecretError, SessionError, UserError,
+    VisualizationError, WorkflowError, WorkspaceError,
 };
 
 pub mod application_context_dal;
@@ -104,6 +104,8 @@ pub enum HandlerError {
     Resource(#[from] ResourceError),
     #[error("visualization error: {0}")]
     Visualization(#[from] VisualizationError),
+    #[error("discovery error: {0}")]
+    Discovery(#[from] DiscoveryError),
 }
 
 pub type HandlerResult<T> = Result<T, HandlerError>;

--- a/components/si-sdf/src/handlers/workflow_dal.rs
+++ b/components/si-sdf/src/handlers/workflow_dal.rs
@@ -1,7 +1,7 @@
 use crate::handlers::{authenticate, authorize, validate_tenancy, HandlerError};
 use serde::{Deserialize, Serialize};
 use si_data::{NatsConn, PgPool};
-use si_model::{workflow::WorkflowRunListItem, Resource};
+use si_model::workflow::WorkflowRunListItem;
 use si_model::{Entity, Veritech, Workflow, WorkflowContext, WorkflowRun, Workspace};
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/components/si-sdf/src/resource_scheduler.rs
+++ b/components/si-sdf/src/resource_scheduler.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
-use futures::{future::BoxFuture, Future, FutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use thiserror::Error;
 use tokio::time;
 
 use si_data::{NatsConn, PgPool};
-use si_model::{Edge, EdgeError, EdgeKind, Entity, EntityError, Resource, ResourceError, Veritech};
+use si_model::{EdgeError, Entity, EntityError, Resource, ResourceError, Veritech};
 
 #[derive(Error, Debug)]
 pub enum ResourceSchedulerError {

--- a/components/si-veritech/src/app.ts
+++ b/components/si-veritech/src/app.ts
@@ -55,3 +55,15 @@ router.get("/syncResource", async (ctx: Context) => {
     });
   }
 });
+router.get("/discover", async (ctx: Context) => {
+  if (ctx.ws) {
+    const ws = await ctx.ws();
+
+    ws.on("message", function (msg: string) {
+      controller.discover(ws, msg);
+    });
+    ws.on("close", (code: number, reason: string) => {
+      debug("socket closed", { code, reason });
+    });
+  }
+});

--- a/components/si-veritech/src/controllers.ts
+++ b/components/si-veritech/src/controllers.ts
@@ -3,6 +3,7 @@ import { checkQualifications } from "./controllers/checkQualifications";
 import { loadWorkflows } from "./controllers/loadWorkflows";
 import { runCommand } from "./controllers/runCommand";
 import { syncResource } from "./controllers/syncResource";
+import { discover } from "./controllers/discover";
 
 const controller = {
   inferProperties,
@@ -10,6 +11,7 @@ const controller = {
   loadWorkflows,
   runCommand,
   syncResource,
+  discover,
 };
 
 export default controller;

--- a/components/si-veritech/src/controllers/discover.ts
+++ b/components/si-veritech/src/controllers/discover.ts
@@ -1,0 +1,89 @@
+import WebSocket from "ws";
+import Debug from "debug";
+
+import {
+  SiEntity,
+  SubResource,
+  Resource,
+  ResourceInternalStatus,
+  ResourceInternalHealth,
+} from "si-entity";
+import { DecryptedSecret } from "../support";
+import intel from "../intel";
+import { SiCtx } from "../siCtx";
+
+const debug = Debug("veritech:controllers:discover");
+
+export interface DiscoveryRequest {
+  entity: SiEntity;
+  system: SiEntity;
+  entityType: string;
+  context: {
+    entity: SiEntity;
+    secret?: DecryptedSecret;
+  }[];
+}
+
+export interface DiscoveryProtocolStart {
+  start: boolean;
+}
+
+export interface DiscoverEntity {
+  entity: SiEntity;
+  configures: DiscoverEntity[];
+}
+
+export interface DiscoveryProtocolFinish {
+  finish: {
+    discovered: DiscoverEntity[];
+    error?: string;
+  };
+}
+
+export type DiscoveryCallback = (
+  ctx: typeof SiCtx,
+  request: DiscoveryRequest,
+  ws: WebSocket,
+) => Promise<DiscoveryProtocolFinish["finish"]>;
+
+export type DiscoveryProtocol =
+  | DiscoveryProtocolStart
+  | DiscoveryProtocolFinish;
+
+export async function discover(ws: WebSocket, req: string): Promise<void> {
+  debug("/discover BEGIN");
+  const request: DiscoveryRequest = JSON.parse(req);
+  request.entity = SiEntity.fromJson(request.entity);
+  request.system = SiEntity.fromJson(request.system);
+  for (const p of request.context) {
+    p.entity = SiEntity.fromJson(p.entity);
+  }
+  debug("request %O", request.entity.name);
+
+  send(ws, { start: true });
+  const intelFuncs = intel[request.entityType];
+  if (intelFuncs && intelFuncs.discover) {
+    try {
+      const response = await intelFuncs.discover(SiCtx, request, ws);
+      send(ws, { finish: response });
+    } catch (e) {
+      const response: DiscoveryProtocolFinish["finish"] = {
+        error: `sync failed: ${e}`,
+        discovered: [],
+      };
+      send(ws, { finish: response });
+    }
+  } else {
+    send(ws, { finish: { discovered: [] } });
+  }
+  close(ws);
+  debug("finished");
+}
+
+function send(ws: WebSocket, message: DiscoveryProtocol) {
+  ws.send(JSON.stringify({ protocol: message }));
+}
+
+function close(ws: WebSocket) {
+  ws.close(1000, "finished");
+}

--- a/components/si-veritech/src/intel.ts
+++ b/components/si-veritech/src/intel.ts
@@ -22,12 +22,14 @@ import {
 } from "./controllers/inferProperties";
 import { RunCommandCallbacks } from "./controllers/runCommand";
 import { SyncResourceCallback } from "./controllers/syncResource";
+import { DiscoveryCallback } from "./controllers/discover";
 
 export interface Intel {
   inferProperties?(request: InferPropertiesRequest): InferPropertiesReply;
   checkQualifications?: CheckQualificationCallbacks;
   runCommands?: RunCommandCallbacks;
   syncResource?: SyncResourceCallback;
+  discover?: DiscoveryCallback;
 }
 
 const intel: Record<string, Intel> = {

--- a/components/si-veritech/src/intel/awsEks.ts
+++ b/components/si-veritech/src/intel/awsEks.ts
@@ -1,4 +1,4 @@
-import { ResourceInternalHealth } from "si-entity";
+import { OpSource, OpType, ResourceInternalHealth, SiEntity } from "si-entity";
 import {
   SyncResourceRequest,
   CommandProtocolFinish,
@@ -6,7 +6,11 @@ import {
 import { SiCtx } from "../siCtx";
 import WebSocket from "ws";
 import _ from "lodash";
-import { findEntityByType } from "../support";
+import { awsAccessKeysEnvironment, findEntityByType } from "../support";
+import {
+  DiscoveryProtocolFinish,
+  DiscoveryRequest,
+} from "../controllers/discover";
 
 export async function syncResource(
   _ctx: typeof SiCtx,
@@ -52,4 +56,56 @@ export async function syncResource(
   return response;
 }
 
-export default { syncResource };
+export async function discover(
+  ctx: typeof SiCtx,
+  req: DiscoveryRequest,
+  _ws: WebSocket,
+): Promise<DiscoveryProtocolFinish["finish"]> {
+  const response: DiscoveryProtocolFinish["finish"] = {
+    discovered: [],
+  };
+  const awsEnv = awsAccessKeysEnvironment(req);
+  const output = await ctx.exec("aws", ["eks", "list-clusters"], {
+    env: awsEnv,
+  });
+  const listClusters: Record<string, string[]> = JSON.parse(output.stdout);
+  if (listClusters["clusters"]) {
+    for (const cluster of listClusters["clusters"]) {
+      const clusterOutput = await ctx.exec(
+        "aws",
+        ["eks", "describe-cluster", "--name", cluster],
+        { env: awsEnv },
+      );
+      const clusterData: Record<string, any> = JSON.parse(clusterOutput.stdout);
+      if (clusterData["cluster"]) {
+        const awsEksCluster = new SiEntity({ entityType: "awsEksCluster" });
+        awsEksCluster.name = clusterData["cluster"]["name"];
+        awsEksCluster.addOpSet({
+          op: OpType.Set,
+          source: OpSource.Inferred,
+          path: ["name"],
+          value: awsEksCluster.name,
+          system: "baseline",
+        });
+        awsEksCluster.addOpSet({
+          op: OpType.Set,
+          source: OpSource.Inferred,
+          path: ["kubernetesVersion"],
+          value: clusterData["cluster"]["version"],
+          system: "baseline",
+        });
+
+        const awsEks = new SiEntity({ entityType: "awsEks" });
+        awsEks.name = clusterData["cluster"]["name"];
+
+        response.discovered.push({
+          entity: awsEks,
+          configures: [{ entity: awsEksCluster, configures: [] }],
+        });
+      }
+    }
+  }
+  return response;
+}
+
+export default { syncResource, discover };

--- a/components/si-web-app/src/api/sdf/dal/attributeDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/attributeDal.ts
@@ -7,6 +7,7 @@ import { Qualification } from "@/api/sdf/model/qualification";
 import { ILabelList } from "../dal";
 import { SchematicKind } from "../model/schematic";
 import { Connection } from "../model/connection";
+import { Resource } from "si-entity";
 
 export interface IGetEntityListRequest {
   workspaceId: string;
@@ -37,6 +38,138 @@ export async function getEntityList(
 
   const reply: IGetEntityListReply = await sdf.get(
     "attributeDal/getEntityList",
+    request,
+  );
+  return reply;
+}
+
+export interface IGetDiscoveryListRequest {
+  workspaceId: string;
+  entityType: string;
+}
+
+export interface IGetDiscoveryListReplySuccess {
+  list: { entity: Entity; resource: Resource }[];
+  error?: never;
+}
+
+export interface IGetDiscoveryListReplyFailure {
+  objectList?: never;
+  error: SDFError;
+}
+
+export type IGetDiscoveryListReply =
+  | IGetDiscoveryListReplySuccess
+  | IGetDiscoveryListReplyFailure;
+
+export async function getDiscoveryList(
+  request: IGetDiscoveryListRequest,
+): Promise<IGetDiscoveryListReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IGetDiscoveryListReply = await sdf.get(
+    "attributeDal/getDiscoveryList",
+    request,
+  );
+  return reply;
+}
+
+export interface IGetImplementationsListRequest {
+  workspaceId: string;
+  applicationId: string;
+  implementationEntityTypes: string[];
+}
+
+export interface IGetImplementationsListReplySuccess {
+  list: {
+    [entityType: string]: { entity: Entity; resource: Resource }[];
+  };
+  error?: never;
+}
+
+export interface IGetImplementationsListReplyFailure {
+  objectList?: never;
+  error: SDFError;
+}
+
+export type IGetImplementationsListReply =
+  | IGetImplementationsListReplySuccess
+  | IGetImplementationsListReplyFailure;
+
+export async function getImplementationsList(
+  request: IGetImplementationsListRequest,
+): Promise<IGetImplementationsListReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IGetImplementationsListReply = await sdf.post(
+    "attributeDal/getImplementationsList",
+    request,
+  );
+  return reply;
+}
+
+export interface IDiscoverRequest {
+  workspaceId: string;
+  entityId: string;
+  entityType: string;
+}
+
+export interface IDiscoverReplySuccess {
+  success: boolean;
+  error?: never;
+}
+
+export interface IDiscoverReplyFailure {
+  success?: never;
+  error: SDFError;
+}
+
+export type IDiscoverReply = IDiscoverReplySuccess | IDiscoverReplyFailure;
+
+export async function discover(
+  request: IDiscoverRequest,
+): Promise<IDiscoverReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IDiscoverReply = await sdf.post(
+    "attributeDal/discover",
+    request,
+  );
+  return reply;
+}
+
+export interface IImportImplementationRequest {
+  workspaceId: string;
+  implementationEntityId: string;
+  entityId: string;
+  applicationId: string;
+}
+
+export interface IImportImplementationReplySuccess {
+  success: boolean;
+  error?: never;
+}
+
+export interface IImportImplementationReplyFailure {
+  success?: never;
+  error: SDFError;
+}
+
+export type IImportImplementationReply =
+  | IImportImplementationReplySuccess
+  | IImportImplementationReplyFailure;
+
+export async function importImplementation(
+  request: IImportImplementationRequest,
+): Promise<IImportImplementationReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IImportImplementationReply = await sdf.post(
+    "attributeDal/importImplementation",
     request,
   );
   return reply;
@@ -271,4 +404,8 @@ export const AttributeDal = {
   updateEntity,
   getInputLabels,
   checkQualifications,
+  getDiscoveryList,
+  discover,
+  getImplementationsList,
+  importImplementation,
 };

--- a/components/si-web-app/src/observables.ts
+++ b/components/si-web-app/src/observables.ts
@@ -409,3 +409,4 @@ export const refreshSecretList$ = new BehaviorSubject<true>(true);
 export const refreshChangesSummary$ = new BehaviorSubject<true>(true);
 export const refreshActivitySummary$ = new BehaviorSubject<true>(true);
 export const refreshResourceSummary$ = new BehaviorSubject<true>(true);
+export const refreshImplementations$ = new BehaviorSubject<true>(true);

--- a/components/si-web-app/src/organisims/AttributePanel.vue
+++ b/components/si-web-app/src/organisims/AttributePanel.vue
@@ -75,6 +75,13 @@
           >
             <Link2Icon size="1.1x" />
           </button>
+          <button
+            class="pl-1 text-white focus:outline-none"
+            :class="discoveryViewClasses()"
+            @click="switchToDiscoveryView()"
+          >
+            <AtSignIcon size="1.1x" />
+          </button>
         </div>
 
         <div class="flex items-center">
@@ -143,6 +150,10 @@
           :entity="entity"
           :connections="connections"
         />
+        <DiscoveryViewer
+          v-else-if="activeView == 'discovery'"
+          :entity="entity"
+        />
 
         <div v-else class="text-xs">
           Not implemented
@@ -187,6 +198,7 @@ import {
   CheckSquareIcon,
   PlayIcon,
   Link2Icon,
+  AtSignIcon,
   BoxIcon,
 } from "vue-feather-icons";
 import "vue-json-pretty/lib/styles.css";
@@ -198,6 +210,7 @@ import ActionViewer from "@/organisims/ActionViewer.vue";
 import CodeViewer from "@/organisims/CodeViewer.vue";
 import ConnectionViewer from "@/organisims/ConnectionViewer.vue";
 import ResourceViewer from "@/organisims/ResourceViewer.vue";
+import DiscoveryViewer from "@/organisims/DiscoveryViewer.vue";
 import {
   loadEntityForEdit,
   loadConnections,
@@ -241,6 +254,7 @@ interface IData {
     | "connection"
     | "event"
     | "qualification"
+    | "discovery"
     | "resource";
   entity: Entity | null;
   connections: Connections;
@@ -277,7 +291,9 @@ export default Vue.extend({
     PlayIcon,
     ActionViewer,
     ConnectionViewer,
+    DiscoveryViewer,
     Link2Icon,
+    AtSignIcon,
     VueJsonPretty,
     ResourceViewer,
   },
@@ -570,6 +586,9 @@ export default Vue.extend({
     connectionViewClasses(): Record<string, any> {
       return this.viewClasses("connection");
     },
+    discoveryViewClasses(): Record<string, any> {
+      return this.viewClasses("discovery");
+    },
     resourceViewClasses(): Record<string, any> {
       return this.viewClasses("resource");
     },
@@ -596,6 +615,9 @@ export default Vue.extend({
     },
     switchToResourceView() {
       this.activeView = "resource";
+    },
+    switchToDiscoveryView() {
+      this.activeView = "discovery";
     },
     async toggleSelectionLock() {
       if (this.selectionIsLocked) {

--- a/components/si-web-app/src/organisims/DiscoveryViewer.vue
+++ b/components/si-web-app/src/organisims/DiscoveryViewer.vue
@@ -1,0 +1,448 @@
+<template>
+  <div class="flex flex-col w-full" v-if="entity">
+    <div
+      class="flex flex-row items-center justify-between h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
+    >
+      <div class="text-lg">
+        {{ entity.entityType }} {{ entity.name }} discovery
+      </div>
+    </div>
+
+    <div
+      class="flex flex-row items-center justify-between h-10 px-8 py-2 mt-2 text-base text-white align-middle property-section-bg-color"
+      v-if="implementable && hasImplItems"
+    >
+      <div class="text-base">
+        Importable Implementations
+      </div>
+    </div>
+
+    <div
+      class="flex flex-row"
+      v-if="
+        implementable && hasImplItems && Object.keys(implementations).length > 0
+      "
+    >
+      <div class="w-full h-full pb-2">
+        <div class="flex flex-col w-full pl-4 pr-4">
+          <div
+            class="flex flex-col w-full py-2"
+            v-for="entityType in implementationOrder"
+            :key="entityType"
+          >
+            <div
+              class="flex flex-row items-center h-8 pl-2 text-base header-background header-title"
+            >
+              <div>
+                {{ entityType }}
+              </div>
+            </div>
+            <div class="flex flex-col text-xs header-background">
+              <div
+                class="flex flex-row pl-8 mb-2"
+                v-for="impl in implementations[entityType]"
+                :key="impl.entity.id"
+              >
+                <div class="flex">
+                  {{ impl.entity.name }}
+                </div>
+                <div class="flex pl-2">
+                  <BoxIcon
+                    size="1x"
+                    :class="resourceStatusClass(impl.resource)"
+                  />
+                </div>
+                <div class="flex pl-2">
+                  <button
+                    class="flex items-center focus:outline-none button"
+                    v-if="!editMode && !changeSet"
+                    @click="importImplementation(impl.entity.id)"
+                  >
+                    <PlusCircleIcon size="1x" class="text-sm" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="flex flex-row items-center justify-between h-10 px-8 py-2 mt-2 text-base text-white align-middle property-section-bg-color"
+      v-if="discoverable.length > 0"
+    >
+      <div class="text-base">
+        Discoverable
+      </div>
+    </div>
+
+    <div class="flex flex-row">
+      <div class="w-full h-full pb-2">
+        <div
+          class="flex flex-col w-full pl-4 pr-4"
+          v-if="discoverable.length > 0"
+        >
+          <div
+            class="flex flex-col w-full py-2"
+            v-for="schema in discoverable"
+            :key="schema.entityType"
+          >
+            <div
+              class="flex flex-row items-center h-8 pl-2 text-base header-background header-title"
+            >
+              <div>
+                {{ schema.entityType }}
+              </div>
+              <div class="flex justify-end flex-grow pr-2">
+                <div class="flex pl-1">
+                  <button
+                    class="flex items-center focus:outline-none button"
+                    v-if="!editMode"
+                    @click="runSync($event, schema.entityType)"
+                  >
+                    <RefreshCwIcon size="1x" class="text-sm" />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="flex flex-col text-xs header-background">
+              <div
+                class="flex flex-row items-center pl-8 mb-2"
+                v-for="discovered in discoveredFor(schema.entityType)"
+                :key="discovered.entity.id"
+              >
+                <div class="flex">
+                  {{ discovered.entity.entityType }}
+                  {{ discovered.entity.name }}
+                </div>
+                <div class="flex pl-2">
+                  <BoxIcon
+                    size="1x"
+                    :class="resourceStatusClass(discovered.resource)"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col items-center w-full h-full pl-2" v-else>
+          <img
+            v-if="!implementable"
+            width="300px"
+            :src="require('@/assets/images/cheech-and-chong.svg')"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import { Entity } from "@/api/sdf/model/entity";
+import { RegistryEntry, NodeKind, registry } from "si-registry";
+import { RefreshCwIcon, PlusCircleIcon, BoxIcon } from "vue-feather-icons";
+import { pluck, tap } from "rxjs/operators";
+import { combineLatest } from "rxjs";
+import {
+  AttributeDal,
+  IGetDiscoveryListReplySuccess,
+} from "@/api/sdf/dal/attributeDal";
+import {
+  workspace$,
+  resources$,
+  applicationId$,
+  refreshSchematic$,
+  refreshEntityLabelList$,
+  editMode$,
+  changeSet$,
+  refreshImplementations$,
+} from "@/observables";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+import { Resource, ResourceInternalHealth } from "si-entity";
+
+interface Data {
+  implementations: {
+    [entityType: string]: {
+      entity: Entity;
+      resource: Resource;
+    }[];
+  };
+  discovered: {
+    [entityType: string]: {
+      entity: Entity;
+      resource: Resource;
+    }[];
+  };
+}
+
+export default Vue.extend({
+  name: "DiscoveryViewer",
+  props: {
+    entity: {
+      type: Object as PropType<Entity>,
+      required: true,
+    },
+  },
+  data(): Data {
+    return {
+      discovered: {},
+      implementations: {},
+    };
+  },
+  components: {
+    RefreshCwIcon,
+    PlusCircleIcon,
+    BoxIcon,
+  },
+  subscriptions(): Record<string, any> {
+    let entity$ = this.$watchAsObservable("entity", { immediate: true }).pipe(
+      pluck("newValue"),
+    );
+    let discoverable$ = this.$watchAsObservable("discoverable", {
+      immediate: true,
+    }).pipe(pluck("newValue"));
+    let fetchDiscovered$ = combineLatest(discoverable$, workspace$).pipe(
+      tap(async ([discoverable, workspace]) => {
+        let result: Record<string, IGetDiscoveryListReplySuccess["list"]> = {};
+        if (discoverable && workspace) {
+          for (const schema of discoverable) {
+            let reply = await AttributeDal.getDiscoveryList({
+              entityType: schema.entityType,
+              workspaceId: workspace.id,
+            });
+            if (reply.error) {
+              emitEditorErrorMessage(reply.error.message);
+            } else {
+              result[schema.entityType] = reply.list;
+            }
+          }
+          // @ts-ignore
+          this.discovered = result;
+        } else {
+          // @ts-ignore
+          this.discovered = {};
+        }
+      }),
+    );
+    let fetchDiscoveredRefresh$ = combineLatest(
+      discoverable$,
+      workspace$,
+      resources$,
+    ).pipe(
+      tap(async ([discoverable, workspace, resource]) => {
+        if (discoverable && workspace) {
+          for (const schema of discoverable) {
+            if (schema.entityType == resource.entityType) {
+              let reply = await AttributeDal.getDiscoveryList({
+                entityType: schema.entityType,
+                workspaceId: workspace.id,
+              });
+              if (reply.error) {
+                emitEditorErrorMessage(reply.error.message);
+              } else {
+                // @ts-ignore
+                Vue.set(this.discovered, schema.entityType, reply.list);
+              }
+            }
+          }
+        }
+      }),
+    );
+
+    let implementable$ = this.$watchAsObservable("implementable", {
+      immediate: true,
+    }).pipe(pluck("newValue"));
+
+    let fetchImplementations$ = combineLatest(
+      applicationId$,
+      implementable$,
+      workspace$,
+      entity$,
+      refreshImplementations$,
+    ).pipe(
+      tap(async ([applicationId, implementable, workspace, entity]) => {
+        if (applicationId && implementable && workspace && entity) {
+          let implementationEntityTypes: string[] = [];
+          for (const schema of Object.values(registry)) {
+            if (schema.implements) {
+              for (const implement of schema.implements) {
+                if (implement == entity.entityType) {
+                  implementationEntityTypes.push(schema.entityType);
+                }
+              }
+            }
+          }
+          if (implementationEntityTypes.length > 0) {
+            let reply = await AttributeDal.getImplementationsList({
+              workspaceId: workspace.id,
+              applicationId,
+              implementationEntityTypes,
+            });
+            if (reply.error) {
+              emitEditorErrorMessage(reply.error.message);
+            } else {
+              // @ts-ignore
+              this.implementations = reply.list;
+            }
+          }
+        }
+      }),
+    );
+
+    return {
+      fetchDiscovered: fetchDiscovered$,
+      fetchDiscoveredRefresh: fetchDiscoveredRefresh$,
+      fetchImplementations: fetchImplementations$,
+      workspace: workspace$,
+      applicationId: applicationId$,
+      refreshImplementations$: refreshImplementations$,
+      editMode: editMode$,
+      changeSet: changeSet$,
+    };
+  },
+  computed: {
+    implementable(): boolean {
+      let schema = this.entity.schema();
+      let is_concept = schema.nodeKind == NodeKind.Concept;
+      return is_concept;
+    },
+    hasImplItems(): boolean {
+      let has_impl_types = this.implementationOrder.length > 0;
+      let has_impl_items = false;
+      for (const impl of this.implementationOrder) {
+        if (this.implementations[impl].length > 0) {
+          has_impl_items = true;
+        }
+      }
+      return has_impl_types && has_impl_items;
+    },
+    implementationOrder(): string[] {
+      return Object.keys(this.implementations).sort();
+    },
+    discoverable(): RegistryEntry[] {
+      let discoverable: RegistryEntry[] = [];
+      if (this.entity) {
+        discoverable = this.entity.discoverable();
+      }
+      return discoverable;
+    },
+  },
+  methods: {
+    discoveredFor(entityType: string): IGetDiscoveryListReplySuccess["list"] {
+      if (this.discovered && this.discovered[entityType]) {
+        return this.discovered[entityType];
+      } else {
+        return [];
+      }
+    },
+    async importImplementation(implementationEntityId: string) {
+      // @ts-ignore
+      if (this.applicationId && this.entity && this.workspace) {
+        let reply = await AttributeDal.importImplementation({
+          // @ts-ignore
+          workspaceId: this.workspace.id,
+          implementationEntityId,
+          entityId: this.entity.id,
+          // @ts-ignore
+          applicationId: this.applicationId,
+        });
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        }
+        refreshSchematic$.next(true);
+        refreshEntityLabelList$.next(true);
+        refreshImplementations$.next(true);
+      }
+    },
+    async runSync(event: MouseEvent, entityType: string) {
+      if (event.target) {
+        this.animateSyncButton(event.target);
+      }
+      // @ts-ignore
+      if (this.workspace && this.entity) {
+        let reply = await AttributeDal.discover({
+          // @ts-ignore
+          workspaceId: this.workspace.id,
+          entityId: this.entity.id,
+          entityType,
+        });
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        }
+      }
+    },
+    animateSyncButton(target: EventTarget) {
+      const button = target as HTMLElement;
+      if (button) {
+        button.animate(
+          [{ transform: "rotate(0deg)" }, { transform: "rotate(720deg)" }],
+          {
+            duration: 2500,
+            easing: "linear",
+          },
+        );
+      }
+    },
+    resourceStatusClass(r: Resource): Record<string, any> {
+      let style: Record<string, any> = {};
+      if (r.internalHealth == ResourceInternalHealth.Error) {
+        style["error"] = true;
+        return style;
+      } else if (r.internalHealth == ResourceInternalHealth.Warning) {
+        style["warning"] = true;
+        return style;
+      } else if (r.internalHealth == ResourceInternalHealth.Ok) {
+        style["ok"] = true;
+      } else {
+        style["unknown"] = true;
+      }
+      return style;
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.1;
+
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+.header-background {
+  background-color: #1f2122;
+}
+.header-title {
+  color: #cccdb1;
+}
+
+.button:hover {
+  filter: brightness($button-brightness);
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+
+.ok {
+  color: #86f0ad;
+}
+
+.warning {
+  color: #f0d286;
+}
+
+.error {
+  color: #f08686;
+}
+
+.unknown {
+  color: #bbbbbb;
+}
+</style>


### PR DESCRIPTION
This PR adds discovery to SI. It allows you to specify that a given
implementation is `discoverableFrom` another. For example, an 'awsEks'
implementation is discoverableFrom `aws`.

When you view the new discovery sub-panel on `aws`, you will see a list
of entity types that are discoverable. Hit the refresh button, and we
will discover all the existing implementations of that kind within your
account. This must be done *outside of a change set or edit session*.

You can then go to, say, a `kubernetesCluster` node that has importable
implementations. While still outside of a change set or edit session,
you can import the implementation into your current schematic. This
happens outside of a change set because, unfortunately, there is no
other way to make sure the relevant objects all exist in head (which is
a requirement for making the whole thing work).

The implementation and its nodes will appear on the graph already
connected, but there will be no connection between the implementation
and the concept. You do that yourself in a new edit session.