### PR TITLE
feat(*): Add discovery of k8s objects

### DIFF
--- a/components/si-model/src/discovery.rs
+++ b/components/si-model/src/discovery.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use si_data::{NatsConn, PgPool, PgTxn};
+use si_data::{NatsConn, NatsTxnError, PgPool, PgTxn};
 
 use crate::{
     entity::Op,
     resource,
     workflow::selector::{SelectionEntry, SelectionEntryPredecessor},
     ChangeSet, ChangeSetError, Edge, EdgeError, EdgeKind, EditSession, EditSessionError, Entity,
-    EntityError, Node, NodeError, Resource, ResourceError, Veritech, VeritechError, Vertex,
-    WorkflowError,
+    EntityError, Node, NodeError, NodePosition, NodePositionError, Resource, ResourceError,
+    Veritech, VeritechError, Vertex, WorkflowError,
 };
 
 pub const DISCOVERY_LIST: &str = include_str!("./queries/discovery_list.sql");
@@ -42,6 +42,12 @@ pub enum DiscoveryError {
     Edge(#[from] EdgeError),
     #[error("resource error: {0}")]
     Resource(#[from] ResourceError),
+    #[error("node position error: {0}")]
+    NodePosition(#[from] NodePositionError),
+    #[error("no conceptual node could be found")]
+    NoConcept,
+    #[error("nats txn error: {0}")]
+    NatsTxn(#[from] NatsTxnError),
 }
 
 pub type DiscoveryResult<T> = Result<T, DiscoveryError>;
@@ -104,6 +110,287 @@ pub async fn implementations_list(
     Ok(reply)
 }
 
+pub async fn import_concept(
+    pg: &PgPool,
+    nats_conn: &NatsConn,
+    _veritech: &Veritech,
+    workspace_id: impl AsRef<str>,
+    application_id: impl AsRef<str>,
+    implementation_entity_id: impl AsRef<str>,
+) -> DiscoveryResult<()> {
+    let workspace_id = workspace_id.as_ref();
+    let application_id = application_id.as_ref();
+    let implementation_entity_id = implementation_entity_id.as_ref();
+
+    let mut conn = pg.pool.get().await?;
+    let txn = conn.transaction().await?;
+    let nats = nats_conn.transaction();
+
+    let application_entity = Entity::for_head(&txn, &application_id).await?;
+
+    let mut concept_edges =
+        Edge::by_kind_and_head_object_id(&txn, &EdgeKind::Component, &implementation_entity_id)
+            .await?;
+    let concept_edge = concept_edges.pop().ok_or(DiscoveryError::NoConcept)?;
+    let concept_entity = Entity::for_head(&txn, &concept_edge.tail_vertex.object_id).await?;
+
+    // Add an edge for the concept to the application
+    let _edge = Edge::new(
+        &txn,
+        &nats,
+        Vertex::from_entity(&application_entity, "output"),
+        Vertex::from_entity(&concept_entity, "application"),
+        false,
+        EdgeKind::Component,
+        workspace_id.clone(),
+    )
+    .await?;
+
+    match Edge::new(
+        &txn,
+        &nats,
+        Vertex::from_entity(&application_entity, "output"),
+        Vertex::from_entity(&concept_entity, "includes"),
+        false,
+        EdgeKind::Includes,
+        workspace_id.clone(),
+    )
+    .await
+    {
+        Ok(_edge) => {}
+        Err(EdgeError::EdgeExists) => {}
+        Err(e) => return Err(DiscoveryError::from(e)),
+    };
+
+    // Set position on the deployment diagram
+    let pos_deployment_context_id = format!("{}.deployment", application_entity.id);
+    let pos_context_id = format!("{}.component", concept_entity.id);
+    let concept_deployment_x: f64 = 3893.0;
+    let mut concept_deployment_y: f64 = 4131.0;
+    if concept_entity.entity_type == "service" {
+        concept_deployment_y = concept_deployment_y - 125 as f64;
+    }
+    let concept_component_x: f64 = 3893.0;
+    let concept_component_y: f64 = 4131.0;
+
+    let _concept_deployment_node_positions = NodePosition::create_or_update(
+        &txn,
+        &nats,
+        &concept_entity.node_id,
+        &pos_deployment_context_id,
+        format!("{:.0}", concept_deployment_x),
+        format!("{:.0}", concept_deployment_y),
+        &workspace_id,
+    )
+    .await?;
+    let _concept_component_node_positions = NodePosition::create_or_update(
+        &txn,
+        &nats,
+        &concept_entity.node_id,
+        &pos_context_id,
+        format!("{:.0}", concept_component_x),
+        format!("{:.0}", concept_component_y),
+        &workspace_id,
+    )
+    .await?;
+
+    let impl_entity = Entity::for_head(&txn, &implementation_entity_id).await?;
+    let impl_entity_predecessor_edges =
+        Edge::all_predecessor_edges_by_object_id(&txn, &EdgeKind::Configures, &impl_entity.id)
+            .await?;
+    let mut impls_to_import = vec![impl_entity];
+    for edge in impl_entity_predecessor_edges.into_iter() {
+        let sentity = Entity::for_head(&txn, &edge.tail_vertex.object_id).await?;
+        impls_to_import.push(sentity);
+    }
+
+    let mut impl_pos_x: f64 = concept_component_x.clone();
+    let impl_pos_y: f64 = concept_component_y.clone();
+
+    let mut seen_ids: Vec<String> = vec![];
+    for i_entity in impls_to_import.iter() {
+        let has_id = seen_ids
+            .iter()
+            .find(|id| &i_entity.id[..] == &id[..])
+            .is_some();
+        if has_id {
+            continue;
+        } else {
+            seen_ids.push(i_entity.id.clone());
+        }
+
+        impl_pos_x = impl_pos_x - 200 as f64;
+        NodePosition::create_or_update(
+            &txn,
+            &nats,
+            &i_entity.node_id,
+            &pos_context_id,
+            format!("{:.0}", impl_pos_x),
+            format!("{:.0}", impl_pos_y),
+            &workspace_id,
+        )
+        .await?;
+
+        match Edge::new(
+            &txn,
+            &nats,
+            Vertex::from_entity(&application_entity, "output"),
+            Vertex::from_entity(&i_entity, "includes"),
+            false,
+            EdgeKind::Includes,
+            workspace_id.clone(),
+        )
+        .await
+        {
+            Ok(_edge) => {}
+            Err(EdgeError::EdgeExists) => {}
+            Err(e) => return Err(DiscoveryError::from(e)),
+        };
+    }
+
+    match concept_entity.entity_type.as_ref() {
+        "service" => {
+            let all_entities_for_app = Edge::direct_successor_edges_by_object_id(
+                &txn,
+                &EdgeKind::Component,
+                &application_entity.id,
+            )
+            .await?;
+            let kubernetes_cluster_edge = all_entities_for_app
+                .into_iter()
+                .find(|e| e.head_vertex.object_type == "kubernetesCluster");
+            if let Some(kubernetes_cluster_edge) = kubernetes_cluster_edge {
+                let kubernetes_cluster_entity =
+                    Entity::for_head(&txn, kubernetes_cluster_edge.head_vertex.object_id).await?;
+                let _edge = Edge::new(
+                    &txn,
+                    &nats,
+                    Vertex::from_entity(&concept_entity, "output"),
+                    Vertex::from_entity(&kubernetes_cluster_entity, &concept_entity.entity_type),
+                    false,
+                    EdgeKind::Deployment,
+                    workspace_id.clone(),
+                )
+                .await?;
+            }
+        }
+        "kubernetesCluster" => {
+            let all_entities_for_app = Edge::direct_successor_edges_by_object_id(
+                &txn,
+                &EdgeKind::Component,
+                &application_entity.id,
+            )
+            .await?;
+            let cloud_edge = all_entities_for_app
+                .into_iter()
+                .find(|e| e.head_vertex.object_type == "cloudProvider");
+            if let Some(cloud_edge) = cloud_edge {
+                let cloud_entity = Entity::for_head(&txn, cloud_edge.head_vertex.object_id).await?;
+                let _edge = Edge::new(
+                    &txn,
+                    &nats,
+                    Vertex::from_entity(&concept_entity, "output"),
+                    Vertex::from_entity(&cloud_entity, &concept_entity.entity_type),
+                    false,
+                    EdgeKind::Deployment,
+                    workspace_id.clone(),
+                )
+                .await?;
+            }
+        }
+        _ => {}
+    }
+
+    txn.commit().await?;
+
+    Ok(())
+}
+
+pub async fn import_implementation(
+    pg: &PgPool,
+    nats_conn: &NatsConn,
+    _veritech: &Veritech,
+    workspace_id: impl AsRef<str>,
+    application_id: impl AsRef<str>,
+    importing_entity_id: impl AsRef<str>,
+    implementation_entity_id: impl AsRef<str>,
+) -> DiscoveryResult<()> {
+    let workspace_id = workspace_id.as_ref();
+    let application_id = application_id.as_ref();
+    let importing_entity_id = importing_entity_id.as_ref();
+    let implementation_entity_id = implementation_entity_id.as_ref();
+
+    let mut conn = pg.pool.get().await?;
+    let txn = conn.transaction().await?;
+    let nats = nats_conn.transaction();
+
+    let application_entity = Entity::for_head(&txn, &application_id).await?;
+    let importing_concept_entity = Entity::for_head(&txn, &importing_entity_id).await?;
+    let importing_concept_node_positions =
+        NodePosition::get_by_node_id(&txn, &importing_concept_entity.node_id).await?;
+    let impl_entity = Entity::for_head(&txn, &implementation_entity_id).await?;
+    let impl_entity_predecessor_edges =
+        Edge::all_predecessor_edges_by_object_id(&txn, &EdgeKind::Configures, &impl_entity.id)
+            .await?;
+    let mut impls_to_import = vec![impl_entity];
+    for edge in impl_entity_predecessor_edges.into_iter() {
+        let sentity = Entity::for_head(&txn, &edge.tail_vertex.object_id).await?;
+        impls_to_import.push(sentity);
+    }
+
+    let pos_context_id = format!("{}.component", importing_concept_entity.id);
+    let mut impl_pos_x: f64 = 0 as f64;
+    let mut impl_pos_y: f64 = 0 as f64;
+
+    if let Some(concept_pos) = importing_concept_node_positions
+        .iter()
+        .find(|cnp| cnp.context_id == pos_context_id)
+    {
+        let concept_pos_x: f64 = concept_pos.x.parse().expect("should be a number");
+        let concept_pos_y: f64 = concept_pos.x.parse().expect("should be a number");
+        impl_pos_x = concept_pos_x;
+        impl_pos_y = concept_pos_y;
+    }
+    for i_entity in impls_to_import.iter() {
+        impl_pos_x = impl_pos_x - 200 as f64;
+        NodePosition::create_or_update(
+            &txn,
+            &nats,
+            &i_entity.node_id,
+            &pos_context_id,
+            format!("{:.0}", impl_pos_x),
+            format!("{:.0}", impl_pos_y),
+            &workspace_id,
+        )
+        .await?;
+
+        let _edge = Edge::new(
+            &txn,
+            &nats,
+            Vertex::from_entity(&application_entity, "output"),
+            Vertex::from_entity(&i_entity, "includes"),
+            false,
+            EdgeKind::Includes,
+            workspace_id.clone(),
+        )
+        .await?;
+
+        let _edge = Edge::new(
+            &txn,
+            &nats,
+            Vertex::from_entity(&importing_concept_entity, "output"),
+            Vertex::from_entity(&i_entity, "deployment"),
+            false,
+            EdgeKind::Component,
+            workspace_id.clone(),
+        )
+        .await?;
+    }
+    txn.commit().await?;
+
+    Ok(())
+}
+
 pub async fn discover(
     pg: &PgPool,
     nats_conn: &NatsConn,
@@ -152,6 +439,9 @@ pub struct DiscoveryRequest<'a> {
 pub struct PartialEntity {
     name: String,
     ops: Vec<Op>,
+    array_meta: serde_json::Value,
+    properties: serde_json::Value,
+    code: serde_json::Value,
     entity_type: String,
 }
 
@@ -211,6 +501,7 @@ pub async fn task_discover(
     let (progress_tx, mut progress_rx) =
         tokio::sync::mpsc::unbounded_channel::<DiscoveryProtocol>();
 
+    let mut seen_entities: Vec<Entity> = vec![];
     veritech
         .send_async("discover", request, progress_tx)
         .await?;
@@ -219,6 +510,9 @@ pub async fn task_discover(
             DiscoveryProtocol::Start(_) => {}
             DiscoveryProtocol::Finish(finish) => {
                 for discovered in finish.discovered.into_iter() {
+                    let mut concept_entity: Option<Entity> = None;
+                    let mut namespace_entity: Option<Entity> = None;
+                    let concept = discovered.clone();
                     let mut to_discover: Vec<(Option<Entity>, DiscoverEntity)> =
                         vec![(None, discovered)];
                     let mut index = 0;
@@ -226,7 +520,6 @@ pub async fn task_discover(
                         let txn = conn.transaction().await?;
                         let nats = nats_conn.transaction();
                         let (parent, discover) = to_discover[index].clone();
-                        index = index + 1;
                         let has_entity = Entity::get_head_by_name_and_entity_type(
                             &txn,
                             &discover.entity.name,
@@ -278,6 +571,9 @@ pub async fn task_discover(
                             )
                             .await?;
                             entity.ops = discover.entity.ops.clone();
+                            entity.properties = discover.entity.properties.clone();
+                            entity.code = discover.entity.code.clone();
+                            entity.array_meta = discover.entity.array_meta.clone();
                             entity
                                 .infer_properties_for_edit_session(
                                     &txn,
@@ -290,6 +586,57 @@ pub async fn task_discover(
                                 .save_for_edit_session(&txn, &change_set.id, &edit_session.id)
                                 .await?;
 
+                            if entity.entity_type == "k8sNamespace" {
+                                namespace_entity = Some(entity.clone());
+                            }
+
+                            // If this is the conceptual entity itself, replace the stub version
+                            // with the fully realized one.
+                            if concept.entity.entity_type == entity.entity_type {
+                                concept_entity = Some(entity.clone());
+                            }
+
+                            if let Some(concept_entity) = concept_entity.as_mut() {
+                                if concept_entity.id != entity.id {
+                                    let _edge = Edge::new(
+                                        &txn,
+                                        &nats,
+                                        Vertex::from_entity(&concept_entity, "output"),
+                                        Vertex::from_node(&node, "deployment"),
+                                        false,
+                                        EdgeKind::Component,
+                                        workspace_id.clone(),
+                                    )
+                                    .await?;
+                                }
+                                if index == 1 {
+                                    concept_entity.ops.push(Op {
+                                        op: crate::entity::OpType::Set,
+                                        source: crate::entity::OpSource::Manual,
+                                        system: system.id.clone(),
+                                        path: vec!["implementation".to_string()],
+                                        value: serde_json::json![entity.id],
+                                        from: None,
+                                    });
+                                    concept_entity
+                                        .infer_properties_for_edit_session(
+                                            &txn,
+                                            &veritech,
+                                            &change_set.id,
+                                            &edit_session.id,
+                                        )
+                                        .await?;
+                                    concept_entity
+                                        .save_for_edit_session(
+                                            &txn,
+                                            &change_set.id,
+                                            &edit_session.id,
+                                        )
+                                        .await?;
+                                    seen_entities.push(concept_entity.clone());
+                                }
+                            }
+
                             if let Some(parent_entity) = parent {
                                 let tail_vertex = Vertex::new(
                                     &entity.node_id,
@@ -297,13 +644,24 @@ pub async fn task_discover(
                                     "output",
                                     &entity.entity_type,
                                 );
-                                let head_vertex = Vertex::new(
-                                    &parent_entity.node_id,
-                                    &parent_entity.id,
-                                    &entity.entity_type,
-                                    &parent_entity.entity_type,
-                                );
-                                Edge::new(
+                                let head_vertex = match parent_entity.entity_type.as_ref() {
+                                    // TODO: This is a big hack! We need to detect if we're a
+                                    // conceptual entity or not from the schema, and make the right
+                                    // decision.
+                                    "kubernetesCluster" | "service" => Vertex::new(
+                                        &parent_entity.node_id,
+                                        &parent_entity.id,
+                                        "implementations",
+                                        &entity.entity_type,
+                                    ),
+                                    _ => Vertex::new(
+                                        &parent_entity.node_id,
+                                        &parent_entity.id,
+                                        &entity.entity_type,
+                                        &parent_entity.entity_type,
+                                    ),
+                                };
+                                match Edge::new(
                                     &txn,
                                     &nats,
                                     tail_vertex,
@@ -312,12 +670,38 @@ pub async fn task_discover(
                                     EdgeKind::Configures,
                                     &workspace_id,
                                 )
-                                .await?;
+                                .await
+                                {
+                                    Ok(edge) => {}
+                                    Err(EdgeError::EdgeExists) => {}
+                                    Err(e) => return Err(DiscoveryError::from(e)),
+                                };
                             }
 
                             edit_session.save_session(&txn).await?;
                             change_set.apply(&txn).await?;
+                            if let Some(namespace_entity) = namespace_entity.as_ref() {
+                                if entity.entity_type == "k8sDeployment" {
+                                    match Edge::new(
+                                        &txn,
+                                        &nats,
+                                        Vertex::from_entity(&namespace_entity, "output"),
+                                        Vertex::from_entity(&entity, &namespace_entity.entity_type),
+                                        false,
+                                        EdgeKind::Configures,
+                                        workspace_id.clone(),
+                                    )
+                                    .await
+                                    {
+                                        Ok(edge) => {}
+                                        Err(EdgeError::EdgeExists) => {}
+                                        Err(e) => return Err(DiscoveryError::from(e)),
+                                    };
+                                }
+                            }
+
                             txn.commit().await?;
+                            nats.commit().await?;
 
                             entity
                                 .check_qualifications_for_edit_session(
@@ -335,12 +719,57 @@ pub async fn task_discover(
                             for child in discover.configures.iter() {
                                 to_discover.push((Some(entity.clone()), child.clone()));
                             }
+                            index = index + 1;
+
+                            if let Some(concept_entity) = concept_entity.as_ref() {
+                                if concept_entity.id != entity.id {
+                                    seen_entities.push(entity.clone());
+                                }
+                            } else {
+                                seen_entities.push(entity.clone());
+                            }
                         }
                     }
                 }
             }
         }
     }
+
+    let txn = conn.transaction().await?;
+    let nats = nats_conn.transaction();
+    let mut change_set =
+        ChangeSet::new(&txn, &nats, Some(format!("d prop",)), workspace_id.clone()).await?;
+    let mut edit_session = EditSession::new(
+        &txn,
+        &nats,
+        None,
+        change_set.id.clone(),
+        workspace_id.clone(),
+    )
+    .await?;
+
+    for entity in seen_entities.iter_mut().rev() {
+        entity
+            .infer_properties_for_edit_session(&txn, &veritech, &change_set.id, &edit_session.id)
+            .await?;
+        entity
+            .check_qualifications_for_edit_session(
+                &pg,
+                &nats_conn,
+                &veritech,
+                Some(system.id.clone()),
+                &change_set.id,
+                &edit_session.id,
+            )
+            .await?;
+        entity
+            .save_for_edit_session(&txn, &change_set.id, &edit_session.id)
+            .await?;
+    }
+    edit_session.save_session(&txn).await?;
+    change_set.apply(&txn).await?;
+    txn.commit().await?;
+    nats.commit().await?;
 
     Ok(())
 }

--- a/components/si-model/src/entity.rs
+++ b/components/si-model/src/entity.rs
@@ -147,12 +147,12 @@ pub struct OpFrom {
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Op {
-    op: OpType,
-    source: OpSource,
-    system: String,
-    path: Vec<String>,
-    value: serde_json::Value,
-    from: Option<OpFrom>,
+    pub op: OpType,
+    pub source: OpSource,
+    pub system: String,
+    pub path: Vec<String>,
+    pub value: serde_json::Value,
+    pub from: Option<OpFrom>,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]

--- a/components/si-model/src/workflow/selector.rs
+++ b/components/si-model/src/workflow/selector.rs
@@ -115,10 +115,11 @@ impl SelectionEntry {
             Edge::direct_predecessor_edges_by_object_id(&txn, &EdgeKind::Component, &entity.id)
                 .await?;
         for concept_edge in concept_edges {
+            dbg!(&concept_edge);
             let concept_deployment_edge_entity =
                 match Entity::for_head(&txn, &concept_edge.tail_vertex.object_id).await {
                     Ok(p) => p,
-                    Err(_e) => {
+                    Err(e) => {
                         // This is not the correct way to handle this! we should check specifics.
                         continue;
                     }
@@ -138,6 +139,7 @@ impl SelectionEntry {
                 &concept_deployment_edge_entity.id,
             )
             .await?;
+
             let concept_entity_context = SelectionEntryPredecessor::new_from_entity(
                 &txn,
                 concept_deployment_edge_entity,

--- a/components/si-registry/src/schema/kubernetes/kubernetesService.ts
+++ b/components/si-registry/src/schema/kubernetes/kubernetesService.ts
@@ -19,6 +19,7 @@ const kubernetesService: RegistryEntry = {
     ],
   },
   implements: ["service"],
+  discoverableFrom: ["awsEks"],
   inputs: [
     {
       name: "k8sDeployment",

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -190,6 +190,11 @@ pub fn attribute_dal(
             nats_conn.clone(),
             veritech.clone(),
         ))
+        .or(attribute_dal_import_concept(
+            pg.clone(),
+            nats_conn.clone(),
+            veritech.clone(),
+        ))
         .or(attribute_dal_get_discovery_list(pg.clone()))
         .or(attribute_dal_get_implementations_list(pg.clone()))
         .or(attribute_dal_get_entity_list(pg.clone()))
@@ -253,6 +258,24 @@ pub fn attribute_dal_import_implementation(
             handlers::attribute_dal::ImportImplementationRequest,
         >())
         .and_then(handlers::attribute_dal::import_implementation)
+        .boxed()
+}
+
+pub fn attribute_dal_import_concept(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("attributeDal" / "importConcept")
+        .and(warp::post())
+        .and(with_pg(pg))
+        .and(with_nats_conn(nats_conn))
+        .and(with_veritech(veritech))
+        .and(warp::header::<String>("authorization"))
+        .and(warp::body::json::<
+            handlers::attribute_dal::ImportConceptRequest,
+        >())
+        .and_then(handlers::attribute_dal::import_concept)
         .boxed()
 }
 

--- a/components/si-veritech/src/controllers/discover.ts
+++ b/components/si-veritech/src/controllers/discover.ts
@@ -67,13 +67,15 @@ export async function discover(ws: WebSocket, req: string): Promise<void> {
       const response = await intelFuncs.discover(SiCtx, request, ws);
       send(ws, { finish: response });
     } catch (e) {
+      console.log("got here", e);
       const response: DiscoveryProtocolFinish["finish"] = {
-        error: `sync failed: ${e}`,
+        error: `discovery failed: ${e}`,
         discovered: [],
       };
       send(ws, { finish: response });
     }
   } else {
+    console.log("nothing to see here");
     send(ws, { finish: { discovered: [] } });
   }
   close(ws);

--- a/components/si-veritech/src/intel/awsEks.ts
+++ b/components/si-veritech/src/intel/awsEks.ts
@@ -98,9 +98,19 @@ export async function discover(
         const awsEks = new SiEntity({ entityType: "awsEks" });
         awsEks.name = clusterData["cluster"]["name"];
 
+        const kubernetesCluster = new SiEntity({
+          entityType: "kubernetesCluster",
+        });
+        kubernetesCluster.name = clusterData["cluster"]["name"];
+
         response.discovered.push({
-          entity: awsEks,
-          configures: [{ entity: awsEksCluster, configures: [] }],
+          entity: kubernetesCluster,
+          configures: [
+            {
+              entity: awsEks,
+              configures: [{ entity: awsEksCluster, configures: [] }],
+            },
+          ],
         });
       }
     }

--- a/components/si-veritech/src/intel/kubernetesService.ts
+++ b/components/si-veritech/src/intel/kubernetesService.ts
@@ -1,4 +1,5 @@
-import { ResourceInternalHealth } from "si-entity";
+import Debug from "debug";
+import { OpSource, OpType, ResourceInternalHealth, SiEntity } from "si-entity";
 import {
   SyncResourceRequest,
   CommandProtocolFinish,
@@ -6,7 +7,11 @@ import {
 import { SiCtx } from "../siCtx";
 import WebSocket from "ws";
 import _ from "lodash";
-import { findEntityByType } from "../support";
+import {
+  awsKubeConfigPath,
+  findEntityByType,
+  k8sDiscoverEntity,
+} from "../support";
 import {
   InferPropertiesReply,
   InferPropertiesRequest,
@@ -15,6 +20,11 @@ import {
   SetArrayEntryFromAllEntities,
   setArrayEntryFromAllEntities,
 } from "./inferShared";
+import {
+  DiscoveryProtocolFinish,
+  DiscoveryRequest,
+} from "../controllers/discover";
+const debug = Debug("veritech:controllers:discover:kubernetesService");
 
 export function inferProperties(
   request: InferPropertiesRequest,
@@ -200,4 +210,301 @@ export async function syncResource(
   return response;
 }
 
-export default { inferProperties, syncResource };
+export async function discover(
+  ctx: typeof SiCtx,
+  req: DiscoveryRequest,
+  _ws: WebSocket,
+): Promise<DiscoveryProtocolFinish["finish"]> {
+  debug("discovery starting");
+  const system = req.system.id;
+  const response: DiscoveryProtocolFinish["finish"] = {
+    discovered: [],
+  };
+  const cluster = findEntityByType(req, "awsEksCluster");
+  debug({ cluster, req });
+  const kubeConfigDir = await awsKubeConfigPath(
+    req,
+    cluster.getProperty({ system, path: ["name"] }),
+  );
+
+  const servicesResult = await ctx.exec("kubectl", [
+    "get",
+    "services",
+    "-A",
+    "-o",
+    "json",
+    "--kubeconfig",
+    `${kubeConfigDir.path}/config`,
+  ]);
+  const listServices: Record<string, any> = JSON.parse(servicesResult.stdout);
+  if (listServices["items"]) {
+    for (const serviceDataFull of listServices["items"]) {
+      const k8sServiceConfigures: any = [];
+
+      if (
+        !serviceDataFull["metadata"] ||
+        !serviceDataFull["metadata"]["annotations"] ||
+        !serviceDataFull["metadata"]["annotations"][
+          "kubectl.kubernetes.io/last-applied-configuration"
+        ]
+      ) {
+        debug(serviceDataFull);
+        continue;
+      }
+
+      const serviceData = JSON.parse(
+        serviceDataFull["metadata"]["annotations"][
+          "kubectl.kubernetes.io/last-applied-configuration"
+        ],
+      );
+      const k8sService = new SiEntity({ entityType: "k8sService" });
+      k8sService.addOpSet({
+        op: OpType.Set,
+        source: OpSource.Manual,
+        path: ["spec", "type"],
+        value: "LoadBalancer",
+        system: "baseline",
+      });
+
+      //k8sService.name = serviceData["metadata"]["name"].replace("-service", "");
+      k8sDiscoverEntity(k8sService, serviceData);
+      //k8sService.computeProperties();
+      //k8sService.computeCode();
+      const serviceNamespace = _.get(serviceData, ["metadata", "namespace"]);
+      if (serviceNamespace) {
+        const namespaceResult = await ctx.exec("kubectl", [
+          "get",
+          "namespace",
+          "-o",
+          "json",
+          "--kubeconfig",
+          `${kubeConfigDir.path}/config`,
+          serviceNamespace,
+        ]);
+        const namespaceDataFull: Record<string, any> = JSON.parse(
+          namespaceResult.stdout,
+        );
+        if (
+          namespaceDataFull["metadata"] &&
+          namespaceDataFull["metadata"]["name"] != "default"
+        ) {
+          const namespaceData = JSON.parse(
+            namespaceDataFull["metadata"]["annotations"][
+              "kubectl.kubernetes.io/last-applied-configuration"
+            ],
+          );
+
+          const k8sNamespace = new SiEntity({
+            entityType: "k8sNamespace",
+          });
+          k8sDiscoverEntity(k8sNamespace, namespaceData);
+          k8sNamespace.computeProperties();
+          k8sNamespace.computeCode();
+
+          k8sServiceConfigures.push({
+            entity: k8sNamespace,
+            configures: [],
+          });
+        }
+      }
+
+      const kubernetesService = new SiEntity({
+        entityType: "kubernetesService",
+      });
+      kubernetesService.name = k8sService.name;
+
+      const deploymentSelectorKey = [];
+      if (serviceData["spec"]["selector"]) {
+        for (const key of Object.keys(serviceData["spec"]["selector"])) {
+          deploymentSelectorKey.push(
+            `${key}=${serviceData["spec"]["selector"][key]}`,
+          );
+        }
+      }
+      //if (serviceData["spec"]["ports"]) {
+      //  for (let x = 0; x < serviceData["spec"]["ports"]; x++) {
+      //    const portData = serviceData["spec"]["ports"][x];
+      //    kubernetesService.addOpSet({
+      //      op: OpType.Set,
+      //      source: OpSource.Inferred,
+      //      path: ["healthChecks", `${x}`],
+      //      // @ts-ignore
+      //      value: {},
+      //      system: "baseline",
+      //    });
+      //    kubernetesService.addOpSet({
+      //      op: OpType.Set,
+      //      source: OpSource.Inferred,
+      //      path: ["healthChecks", `${x}`, "port"],
+      //      value: portData["port"],
+      //      system: "baseline",
+      //    });
+      //    if (portData["port"] == 80) {
+      //      kubernetesService.addOpSet({
+      //        op: OpType.Set,
+      //        source: OpSource.Inferred,
+      //        path: ["healthChecks", `${x}`, "protocol"],
+      //        value: "HTTP",
+      //        system: "baseline",
+      //      });
+      //    } else if (portData["port"] == 443) {
+      //      kubernetesService.addOpSet({
+      //        op: OpType.Set,
+      //        source: OpSource.Inferred,
+      //        path: ["healthChecks", `${x}`, "protocol"],
+      //        value: "HTTPS",
+      //        system: "baseline",
+      //      });
+      //    } else {
+      //      kubernetesService.addOpSet({
+      //        op: OpType.Set,
+      //        source: OpSource.Inferred,
+      //        path: ["healthChecks", `${x}`, "protocol"],
+      //        value: "TCP",
+      //        system: "baseline",
+      //      });
+      //    }
+      //  }
+      //}
+
+      // Now, discover the kubernetes deployment via the selector
+      const deploymentResult = await ctx.exec("kubectl", [
+        "get",
+        "deployments",
+        "-A",
+        "-o",
+        "json",
+        "--kubeconfig",
+        `${kubeConfigDir.path}/config`,
+        "-l",
+        deploymentSelectorKey.join(","),
+      ]);
+      const deploymentsList: Record<string, any> = JSON.parse(
+        deploymentResult.stdout,
+      );
+      if (deploymentsList["items"]) {
+        for (const deploymentDataFull of deploymentsList["items"]) {
+          const deploymentData = JSON.parse(
+            deploymentDataFull["metadata"]["annotations"][
+              "kubectl.kubernetes.io/last-applied-configuration"
+            ],
+          );
+          const k8sDeployment = new SiEntity({
+            entityType: "k8sDeployment",
+          });
+          k8sDiscoverEntity(k8sDeployment, deploymentData);
+          const k8sDeploymentConfigures: any[] = [];
+
+          const containerList = _.get(deploymentData, [
+            "spec",
+            "template",
+            "spec",
+            "containers",
+          ]);
+          if (containerList && containerList.length > 0) {
+            for (const containerData of containerList) {
+              const dockerImage = new SiEntity({
+                entityType: "dockerImage",
+              });
+              dockerImage.name = containerData["name"];
+              dockerImage.addOpSet({
+                op: OpType.Set,
+                source: OpSource.Manual,
+                path: ["image"],
+                value: containerData["image"],
+                system: "baseline",
+              });
+              if (containerData["ports"]) {
+                for (let x = 0; x < containerData["ports"].length; x++) {
+                  const portData = containerData["ports"][x];
+                  dockerImage.addOpSet({
+                    op: OpType.Set,
+                    source: OpSource.Manual,
+                    path: ["ExposedPorts", `${x}`],
+                    value: `${portData["containerPort"]}/${_.toLower(
+                      portData["protocol"],
+                    )}`,
+                    system: "baseline",
+                  });
+                }
+              }
+              //dockerImage.computeProperties();
+              //dockerImage.computeCode();
+
+              k8sDeploymentConfigures.push({
+                entity: dockerImage,
+                configures: [],
+              });
+            }
+          }
+
+          //const deploymentNamespace = _.get(deploymentData, [
+          //  "metadata",
+          //  "namespace",
+          //]);
+          //if (deploymentNamespace) {
+          //  const namespaceResult = await ctx.exec("kubectl", [
+          //    "get",
+          //    "namespace",
+          //    "-o",
+          //    "json",
+          //    "--kubeconfig",
+          //    `${kubeConfigDir.path}/config`,
+          //    deploymentNamespace,
+          //  ]);
+          //  const namespaceDataFull: Record<string, any> = JSON.parse(
+          //    namespaceResult.stdout,
+          //  );
+          //  const namespaceData = JSON.parse(
+          //    namespaceDataFull["metadata"]["annotations"][
+          //      "kubectl.kubernetes.io/last-applied-configuration"
+          //    ],
+          //  );
+
+          //  const k8sNamespace = new SiEntity({
+          //    entityType: "k8sNamespace",
+          //  });
+          //  k8sDiscoverEntity(k8sNamespace, namespaceData);
+          //  k8sNamespace.computeProperties();
+          //  k8sNamespace.computeCode();
+
+          //  k8sDeploymentConfigures.push({
+          //    entity: k8sNamespace,
+          //    configures: [],
+          //  });
+          //}
+          //k8sDeployment.computeProperties();
+          //k8sDeployment.computeCode();
+
+          k8sServiceConfigures.push({
+            entity: k8sDeployment,
+            configures: k8sDeploymentConfigures,
+          });
+        }
+      }
+
+      const service = new SiEntity({ entityType: "service" });
+      service.name = k8sService.name;
+      //service.computeCode();
+      //service.computeProperties();
+
+      response.discovered.push({
+        entity: service,
+        configures: [
+          {
+            entity: kubernetesService,
+            configures: [
+              { entity: k8sService, configures: k8sServiceConfigures },
+            ],
+          },
+        ],
+      });
+    }
+  }
+
+  debug("***** maybe tomorrow *****");
+  debug(response);
+  return response;
+}
+
+export default { inferProperties, syncResource, discover };

--- a/components/si-web-app/src/api/sdf/dal/attributeDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/attributeDal.ts
@@ -146,6 +146,7 @@ export interface IImportImplementationRequest {
   implementationEntityId: string;
   entityId: string;
   applicationId: string;
+  withConcept?: true;
 }
 
 export interface IImportImplementationReplySuccess {
@@ -170,6 +171,39 @@ export async function importImplementation(
 
   const reply: IImportImplementationReply = await sdf.post(
     "attributeDal/importImplementation",
+    request,
+  );
+  return reply;
+}
+
+export interface IImportConceptRequest {
+  workspaceId: string;
+  implementationEntityId: string;
+  applicationId: string;
+}
+
+export interface IImportConceptReplySuccess {
+  success: boolean;
+  error?: never;
+}
+
+export interface IImportConceptReplyFailure {
+  success?: never;
+  error: SDFError;
+}
+
+export type IImportConceptReply =
+  | IImportConceptReplySuccess
+  | IImportConceptReplyFailure;
+
+export async function importConcept(
+  request: IImportConceptRequest,
+): Promise<IImportConceptReply> {
+  let bottle = Bottle.pop("default");
+  let sdf = bottle.container.SDF;
+
+  const reply: IImportConceptReply = await sdf.post(
+    "attributeDal/importConcept",
     request,
   );
   return reply;
@@ -408,4 +442,5 @@ export const AttributeDal = {
   discover,
   getImplementationsList,
   importImplementation,
+  importConcept,
 };

--- a/components/si-web-app/src/organisims/DiscoveryViewer.vue
+++ b/components/si-web-app/src/organisims/DiscoveryViewer.vue
@@ -122,6 +122,15 @@
                     :class="resourceStatusClass(discovered.resource)"
                   />
                 </div>
+                <div class="flex pl-2">
+                  <button
+                    class="flex items-center focus:outline-none button"
+                    v-if="!editMode && !changeSet"
+                    @click="importConcept(discovered.entity.id)"
+                  >
+                    <PlusCircleIcon size="1x" class="text-sm" />
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -356,6 +365,25 @@ export default Vue.extend({
         refreshImplementations$.next(true);
       }
     },
+    async importConcept(implementationEntityId: string) {
+      // @ts-ignore
+      if (this.applicationId && this.entity && this.workspace) {
+        let reply = await AttributeDal.importConcept({
+          // @ts-ignore
+          workspaceId: this.workspace.id,
+          implementationEntityId,
+          // @ts-ignore
+          applicationId: this.applicationId,
+        });
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        }
+        refreshSchematic$.next(true);
+        refreshEntityLabelList$.next(true);
+        refreshImplementations$.next(true);
+      }
+    },
+
     async runSync(event: MouseEvent, entityType: string) {
       if (event.target) {
         this.animateSyncButton(event.target);


### PR DESCRIPTION
This adds a v1 of k8s objects. It causes some errors in the dashboards,
because we were being pretty silly about how we decide what counts as an
update. You can always hard refresh to make it better.

Otherwise, it does successfully discover the 'play-2048' service from
the cluster. Don't try anything else, as I make no guarantees. :)

You should be able to deploy the service as well.