### PR TITLE
chore: remove compilation warnings

### DIFF
--- a/components/si-model/src/discovery.rs
+++ b/components/si-model/src/discovery.rs
@@ -672,7 +672,7 @@ pub async fn task_discover(
                                 )
                                 .await
                                 {
-                                    Ok(edge) => {}
+                                    Ok(_edge) => {}
                                     Err(EdgeError::EdgeExists) => {}
                                     Err(e) => return Err(DiscoveryError::from(e)),
                                 };
@@ -693,7 +693,7 @@ pub async fn task_discover(
                                     )
                                     .await
                                     {
-                                        Ok(edge) => {}
+                                        Ok(_edge) => {}
                                         Err(EdgeError::EdgeExists) => {}
                                         Err(e) => return Err(DiscoveryError::from(e)),
                                     };

--- a/components/si-model/src/workflow/selector.rs
+++ b/components/si-model/src/workflow/selector.rs
@@ -119,7 +119,7 @@ impl SelectionEntry {
             let concept_deployment_edge_entity =
                 match Entity::for_head(&txn, &concept_edge.tail_vertex.object_id).await {
                     Ok(p) => p,
-                    Err(e) => {
+                    Err(_e) => {
                         // This is not the correct way to handle this! we should check specifics.
                         continue;
                     }

--- a/components/si-sdf/src/handlers/attribute_dal.rs
+++ b/components/si-sdf/src/handlers/attribute_dal.rs
@@ -7,8 +7,7 @@ use si_model::{
     application, discovery,
     entity::diff::{diff_for_props, Diffs},
     ApplicationEntities, Connection, Connections, DiscoveryListEntry, Edge, EdgeKind, Entity,
-    LabelList, LabelListItem, NodePosition, Qualification, Schematic, SchematicKind, Veritech,
-    Vertex,
+    LabelList, LabelListItem, Qualification, Schematic, SchematicKind, Veritech,
 };
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/components/si-web-app/src/organisims/SchematicPanel.vue
+++ b/components/si-web-app/src/organisims/SchematicPanel.vue
@@ -563,7 +563,7 @@ export default Vue.extend({
 
           if (schematic) {
             for (const node of Object.values(schematic.nodes)) {
-              if (node.node.objectId == resource.entityId) {
+              if (node.object.id == resource.entityId) {
                 Vue.set(
                   schematic.nodes[node.node.id].resources,
                   resource.systemId,
@@ -581,7 +581,7 @@ export default Vue.extend({
 
           if (schematic) {
             for (let node of Object.values(schematic.nodes)) {
-              if (node.node.objectId == qualification.entityId) {
+              if (node.object.id == qualification.entityId) {
                 let updated = false;
                 for (let x = 0; x < node.qualifications.length; x++) {
                   let qcheck = node.qualifications[x];


### PR DESCRIPTION
This hits both TypeScript and Rust. In `si-web-app`, the warning
appeared to be legitimate this fix should be typewise, more accurate (in
fact this updates a bugfix which may not have been 100% even though it
seemed to work).

<3 Fletcher