### PR TITLE
chore: deploy initial semi-manual dev si instance

### DIFF
--- a/support/dev/.gitignore
+++ b/support/dev/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+terraform.tfstate*

--- a/support/dev/init.sh
+++ b/support/dev/init.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+main() {
+  set -eux
+
+  # Redirect output to log file and console
+  exec > >(
+    tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console
+  ) 2>&1
+
+  local user=si
+  local group="$user"
+  local hostname=si-dev
+  local gh_users=(fnichol adamhjk alex-init)
+
+  update_system
+  install_sudo
+  setup_user "$user" "$group"
+  setup_workstation "$user" "$hostname"
+  add_authorized_keys "$user" "${gh_users[@]}"
+  save_cookie
+  echo "--- All Done"
+}
+
+update_system() {
+  pacman -Syu --noconfirm
+}
+
+install_sudo() {
+  pacman -S --noconfirm bash bash-completion sudo
+  echo "%wheel ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/01_wheel
+}
+
+setup_user() {
+  local user="$1"
+  local group="$2"
+
+  groupadd --gid 1001 "$group"
+  useradd \
+    --create-home \
+    --shell /bin/bash \
+    --groups wheel \
+    --gid "$group" --uid 1001 "$user"
+
+}
+
+setup_workstation() {
+  local user="$1"
+  local hostname="$2"
+
+  pacman -S --noconfirm git
+
+  local user_home
+  user_home="$(getent passwd "$user" | cut -d: -f 6)"
+
+  sudo -u "$user" git clone \
+    https://github.com/fnichol/workstation.git \
+    "$user_home/workstation"
+
+  rm -f "$user_home/.bashrc"
+
+  cd "$user_home/workstation"
+  sudo -u "$user" ./bin/log ./bin/prep \
+    --profile=headless \
+    --skip=ruby,go \
+    "$hostname"
+}
+
+add_authorized_keys() {
+  local user="$1"
+  shift
+
+  sudo -u "$user" paru -S --noconfirm python-distro ssh-import-id
+
+  local gh_user
+  for gh_user in "$@"; do
+    sudo -u "$user" ssh-import-id "gh:$gh_user"
+  done
+}
+
+save_cookie() {
+  touch /.provision_complete
+}
+
+main "$@"

--- a/support/dev/main.tf
+++ b/support/dev/main.tf
@@ -1,0 +1,156 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.46"
+    }
+  }
+}
+
+variable "region" {
+  default = "us-east-2"
+}
+
+variable "ami" {
+  default = "ami-008ef391bf64d8b7f"
+}
+
+variable "instance_type" {
+  default = "t2.xlarge"
+}
+
+variable "key_name" {
+  default = "si@aws-2021-07-19T22:56:24Z"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource "aws_security_group" "remote_access" {
+  name        = "remote-access"
+  description = "Allow SSH and Mosh remote access traffic"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = "60000"
+    to_port     = "60010"
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "vpc_web" {
+  name        = "vpc-web"
+  description = "Allow web traffic from VPC"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.default.cidr_block]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "lb_web" {
+  name        = "lb-web"
+  description = "Allow web traffic to the load balancer"
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "si_dev" {
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  associate_public_ip_address = true
+  root_block_device {
+    volume_size = 40
+  }
+  key_name               = var.key_name
+  vpc_security_group_ids = [aws_security_group.remote_access.id, aws_security_group.vpc_web.id]
+  user_data              = file("init.sh")
+}
+
+resource "aws_lb_target_group" "si_dev" {
+  name     = "si-lb-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.aws_vpc.default.id
+}
+
+resource "aws_lb_target_group_attachment" "si_dev" {
+  target_group_arn = aws_lb_target_group.si_dev.arn
+  target_id        = aws_instance.si_dev.id
+  port             = 80
+}
+
+resource "aws_lb" "si_dev" {
+  name               = "si-dev-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb_web.id]
+  subnets            = data.aws_subnet_ids.default.ids
+}
+
+resource "aws_lb_listener" "si_dev" {
+  load_balancer_arn = aws_lb.si_dev.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.si_dev.arn
+  }
+}
+
+output "ssh_user" {
+  value = "si"
+}
+
+output "si_dev_public_dns" {
+  value = aws_instance.si_dev.public_dns
+}
+
+output "si_dev_public_ip" {
+  value = aws_instance.si_dev.public_ip
+}
+
+output "lb_dns_name" {
+  value = aws_lb.si_dev.dns_name
+}
+


### PR DESCRIPTION
This change adds a minimal Terraform setup for a single EC2 development
node fronted with an AWS/ALB load balancer.

* deployment details and credentials are in 1password
* nginx configuration is pretty much by hand on the host
* services are running in a tmux session
* deployed using primary branch Git checkout, built with `make build` in
  the project root
* SSH and Mosh connection is possible to host (user `si`) using a public
  key published to GitHub
* for the moment, primary front-end set download is protected with basic
  auth (credentials in 1password). API endpoints are not as JWT authn/z
  covers most endpoints and web client is not basic auth aware for
  backend calls and websocket connections
* currently no SSL or custom DNS, leaving it rather hard to find on the
  internet--not such a bad thing

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>