### PR TITLE
fix(si-web-app): account for empty & / pathname in SDF client baseUrl

### DIFF
--- a/components/si-web-app/src/api/sdf.ts
+++ b/components/si-web-app/src/api/sdf.ts
@@ -85,7 +85,24 @@ export class SDF {
   }
 
   requestUrl(pathString: string): URL {
-    return new URL(`${this.baseUrl.pathname}/${pathString}`, this.baseUrl);
+    let basePath;
+    if (this.baseUrl.pathname.endsWith("/")) {
+      basePath = this.baseUrl.pathname.slice(
+        0,
+        this.baseUrl.pathname.length - 1,
+      );
+    } else {
+      basePath = this.baseUrl.pathname;
+    }
+    let requestPath;
+    if (pathString.startsWith("/")) {
+      requestPath = pathString.slice(1);
+    } else {
+      requestPath = pathString;
+    }
+    const url = new URL(`${basePath}/${requestPath}`, this.baseUrl);
+
+    return url;
   }
 
   async get<T>(


### PR DESCRIPTION
Oh yay, JavaScript's `URL` object is pure evil. You need to be insanely
careful not to end up with a pathname that has a double slash, otherwise
it replaces any domain AND port number in the base URL (the optional
second argument). So yeah, that's pretty un-awesome.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>