### PR TITLE
chore(si-data,si-model,si-sdf): drop native libssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,21 +600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,19 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,24 +1214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nats"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,37 +1375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
-dependencies = [
- "autocfg 1.0.1",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2034,20 +1961,17 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2316,7 +2240,6 @@ dependencies = [
  "deadpool-postgres",
  "lazy_static",
  "refinery",
- "reqwest",
  "serde 1.0.126",
  "serde_json",
  "si-settings",
@@ -2731,16 +2654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,12 +3050,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/components/si-data/Cargo.toml
+++ b/components/si-data/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 
 [dependencies]
 async-nats = "0.9.4"
+bytes = "1.0.1"
 deadpool = "0.8.1"
 deadpool-postgres = "0.9.0"
 lazy_static = "1.4.0"
 refinery = { version = "0.6.0", features = ["tokio-postgres", "tokio"] }
-reqwest = "0.11.1"
 serde = "1.0.123"
 serde_json = "1.0.64"
 si-settings = { path = "../si-settings" }
@@ -21,5 +21,4 @@ strum_macros = "0.21.1"
 thiserror = "1.0.24"
 tokio = { version = "1.2.0", features = ["full"] }
 tokio-postgres = { version ="0.7.0", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
-bytes = "1.0.1"
 tracing = "0.1.26"

--- a/components/si-model/Cargo.toml
+++ b/components/si-model/Cargo.toml
@@ -15,7 +15,7 @@ jwt-simple = "0.10.1"
 names = "0.11.0"
 rand = "0.8.3"
 refinery = "0.6.0"
-reqwest = { version = "0.11.1", features = ["json"] }
+reqwest = { version = "0.11.1", default-features = false, features = ["json"] }
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 si-data = { path = "../si-data" }


### PR DESCRIPTION
It turns out we don't use SSL/TLS anywhere in our stack at the moment
client or server side in SDF. Despite this we've been building it into
`si-data` and into the `reqwest` HTTP client in `si-model`. This change
drops the extra compile time, the LibreSSL/OpenSSL dependencies, etc.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>