### PR TITLE
fix(si-web): Cannot interpolate colors for short paths

### DIFF
--- a/components/si-web-app/src/organisims/AttributeViewer.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer.vue
@@ -160,7 +160,13 @@ export default Vue.extend({
       }
     },
     backgroundColors(): number[][] {
-      let longestProp = 0;
+      let longestProp = 50;
+      // BUG: There is a bug here - this will increase
+      //      the longestProp number if there is a clearly nested, non-array
+      //      object depth greater than 50. But it won't deal with array's
+      //      at all. If we need to figure out how to deal with nested arrays
+      //      of objects that are more than 50 levels deep, this code will
+      //      need to be fixed.
       if (this.editFields) {
         for (const field of this.editFields) {
           if (field.path) {


### PR DESCRIPTION
We determine the color of a given header level by interpolating it as a
gradient between two color destinations. We attempt to dynamically do
this by determining the highest path length thats present in the schema,
where the baseline value is 0.

Two bad things happening here.

* The first is that we might have a deeply nested path in an array, or
  an array of arrays, and they won't count to the total of the longest
  path.
* The second is that we allow a longestPath of 1 - which means that
  there is no way to interpolate the gradient between the two colors,
  because there is no gradient. The result is a gradient of NaNs.

This PR fixes the issue by setting the mininmal depth to 50. If we have
an object that has a deeply nested array object with a depth greater
than 50, headers will fail to render again.