### PR TITLE
feat(entity,web): add decorators for derived fields

### DIFF
--- a/components/si-entity/package-lock.json
+++ b/components/si-entity/package-lock.json
@@ -8,14 +8,13 @@
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {
-        "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
         "si-registry": "../si-registry",
-        "validator": "^13.5.2"
+        "validator": "^13.5.2",
+        "yaml": "2.0.0-7"
       },
       "devDependencies": {
         "@types/jest": "^26.0.20",
-        "@types/js-yaml": "^4.0.1",
         "@types/json-schema": "^7.0.7",
         "@types/lodash": "^4.14.168",
         "@types/validator": "^13.1.3",
@@ -1040,12 +1039,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.1.tgz",
-      "integrity": "sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -1399,6 +1392,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -2585,6 +2579,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4362,6 +4357,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -6420,7 +6416,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
@@ -7314,6 +7311,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-7",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-7.tgz",
+      "integrity": "sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",
@@ -8215,12 +8220,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "@types/js-yaml": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.1.tgz",
-      "integrity": "sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -8460,6 +8459,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -9381,7 +9381,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -10770,6 +10771,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -12382,7 +12384,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -13079,6 +13082,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.0.0-7",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-7.tgz",
+      "integrity": "sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/components/si-entity/package.json
+++ b/components/si-entity/package.json
@@ -20,7 +20,6 @@
   "license": "Proprietary",
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/js-yaml": "^4.0.1",
     "@types/json-schema": "^7.0.7",
     "@types/lodash": "^4.14.168",
     "@types/validator": "^13.1.3",
@@ -36,10 +35,10 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "js-yaml": "^3.14.1",
     "lodash": "^4.17.21",
     "si-registry": "../si-registry",
-    "validator": "^13.5.2"
+    "validator": "^13.5.2",
+    "yaml": "2.0.0-7"
   },
   "volta": {
     "node": "16.5.0",

--- a/components/si-entity/src/index.ts
+++ b/components/si-entity/src/index.ts
@@ -7,6 +7,7 @@ export {
   OpType,
   OpSource,
   EditField,
+  CodeDecorationItem,
 } from "./siEntity";
 export { SiStorable } from "./siStorable";
 export {

--- a/components/si-entity/tests/siEntity.spec.ts
+++ b/components/si-entity/tests/siEntity.spec.ts
@@ -6,7 +6,6 @@ import {
   OpTombstone,
   OpUnset,
 } from "../src/siEntity";
-import yaml from "js-yaml";
 
 interface TestData {
   siAttr: SiEntity;

--- a/components/si-entity/tests/yamlCode.spec.ts
+++ b/components/si-entity/tests/yamlCode.spec.ts
@@ -1,0 +1,49 @@
+import {
+  SiEntity,
+  OpType,
+  OpSource,
+  OpSet,
+  OpTombstone,
+  OpUnset,
+} from "../src/siEntity";
+
+interface TestData {
+  entity: SiEntity;
+}
+
+function setupTest(): TestData {
+  const entity = new SiEntity({ entityType: "k8sDeployment" });
+  entity.name = "slayer";
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["spec", "replicas"],
+    value: 15,
+    source: OpSource.Manual,
+    system: "baseline",
+  });
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["metadata", "0", "again"],
+    value: "riding",
+    source: OpSource.Manual,
+    system: "baseline",
+  });
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["metadata", "0", "me"],
+    value: "15",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+  entity.setDefaultProperties();
+  entity.computeProperties();
+  return { entity };
+}
+
+describe("_YAMLDocToPaths", () => {
+  test("returns YamlDocPaths", () => {
+    const { entity } = setupTest();
+    const stuff = entity.getCodeDecorations("baseline");
+    expect(stuff.length).toBe(3); // The two default values, plus [metadata, 0, me] - everything that's inferred
+  });
+});

--- a/components/si-web-app/src/organisims/CodeViewer.vue
+++ b/components/si-web-app/src/organisims/CodeViewer.vue
@@ -11,6 +11,7 @@
         class="w-full h-full"
         :readOnly="!editMode"
         :value="codeValue"
+        :codeDecorations="codeDecorations"
         @input="setNewCodeValue"
         @blur="updateEntityFromCode"
       />
@@ -34,7 +35,7 @@ import { system$, updateEntity, editMode$ } from "@/observables";
 import { pluck, switchMap, tap } from "rxjs/operators";
 import { combineLatest, Observable, of } from "rxjs";
 import { Diff } from "@/api/sdf/model/diff";
-import { SiEntity, OpSource } from "si-entity";
+import { SiEntity, OpSource, CodeDecorationItem } from "si-entity";
 import { Qualification } from "@/api/sdf/model/qualification";
 import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
 import _ from "lodash";
@@ -68,6 +69,17 @@ export default Vue.extend({
       newCodeValue: "No code is the best code!",
     };
   },
+  computed: {
+    codeDecorations(): CodeDecorationItem[] {
+      // @ts-ignore
+      if (this.system && this.system.id) {
+        // @ts-ignore
+        return this.entity.getCodeDecorations(this.system.id);
+      } else {
+        return this.entity.getCodeDecorations("baseline");
+      }
+    },
+  },
   methods: {
     setNewCodeValue(value: string, _event: any) {
       this.newCodeValue = value;
@@ -80,10 +92,6 @@ export default Vue.extend({
       ) {
         return;
       }
-      console.log("hrm", {
-        codeValue: this.codeValue,
-        newCodeValue: this.newCodeValue,
-      });
 
       // @ts-ignore
       if (this.system) {


### PR DESCRIPTION
This PR adds decorators for derived fields. If the field is inferred, it
will have a blue line next to it. If it is manual, it will have a grey
line next to it.

It also sets the stage for future decorators, which will come in
subsequent PRs.