### PR TITLE
bug(si-entity): add compiler options for YAML next

### DIFF
--- a/components/si-entity/package.json
+++ b/components/si-entity/package.json
@@ -6,9 +6,9 @@
   "main": "dist/index.js",
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "tsc",
+    "build": "tsc --downlevelIteration",
     "build:clean": "npm run clean && npm run build",
-    "build:watch": "npm run clean && tsc --watch",
+    "build:watch": "npm run clean && tsc --downlevelIteration --watch",
     "watch": "npm run build:watch",
     "test": "jest",
     "test:watch": "jest --watch --forceExit",


### PR DESCRIPTION
This adds the --downlevelIteration flag for the compiler, which allows
it to use a more nuanced check for the existence of iterators on symbols
at compile time, rather than attempting to fully downlevel them into raw
for loops.