### PR TITLE
bug(si-entity): YAML numbers now schema driven

### DIFF
--- a/components/si-entity/src/siEntity.ts
+++ b/components/si-entity/src/siEntity.ts
@@ -682,42 +682,25 @@ export class SiEntity implements ISiEntity {
 
   yamlNumberReplacer(): Record<string, any> {
     const numberified = _.cloneDeep(this.properties);
-    for (const key of Object.keys(numberified)) {
-      numberified[key] = this._replaceYamlNumberObject(numberified[key]);
+    for (const op of this.ops) {
+      if (op.op == OpType.Set) {
+        const prop = this.findProp(op);
+        if (prop) {
+          if (prop.type == "number") {
+            for (const system of Object.keys(numberified)) {
+              const value = _.get(numberified, [system, ...op.path]);
+              if (value) {
+                const number = _.toNumber(op.value);
+                if (!_.isNaN(number)) {
+                  _.set(numberified, [system, ...op.path], number);
+                }
+              }
+            }
+          }
+        }
+      }
     }
     return numberified;
-  }
-
-  _replaceYamlNumberObject(obj: Record<string, any>): Record<string, any> {
-    for (const key of Object.keys(obj)) {
-      if (_.isObjectLike(obj[key])) {
-        obj[key] = this._replaceYamlNumberObject(obj[key]);
-      } else if (_.isArray(obj[key])) {
-        obj[key] = this._replaceYamlNumberArray(obj[key]);
-      } else {
-        const maybeNumber = _.toNumber(obj[key]);
-        if (!_.isNaN(maybeNumber)) {
-          obj[key] = maybeNumber;
-        }
-      }
-    }
-    return obj;
-  }
-
-  _replaceYamlNumberArray(arr: any[]): any[] {
-    for (let x = 0; x < arr.length; x++) {
-      if (_.isObjectLike(arr[x])) {
-        arr[x] = this._replaceYamlNumberObject(arr[x]);
-      } else if (_.isArray(arr[x])) {
-        arr[x] = this._replaceYamlNumberArray(arr[x]);
-      } else {
-        const maybeNumber = _.toNumber(arr[x]);
-        if (!_.isNaN(maybeNumber)) {
-          arr[x] = maybeNumber;
-        }
-      }
-    }
-    return arr;
   }
 
   computeCode(): void {

--- a/components/si-entity/tests/yamlCode.spec.ts
+++ b/components/si-entity/tests/yamlCode.spec.ts
@@ -21,20 +21,6 @@ function setupTest(): TestData {
     source: OpSource.Manual,
     system: "baseline",
   });
-  entity.addOpSet({
-    op: OpType.Set,
-    path: ["metadata", "0", "again"],
-    value: "riding",
-    source: OpSource.Manual,
-    system: "baseline",
-  });
-  entity.addOpSet({
-    op: OpType.Set,
-    path: ["metadata", "0", "me"],
-    value: "15",
-    source: OpSource.Inferred,
-    system: "baseline",
-  });
   entity.setDefaultProperties();
   entity.computeProperties();
   return { entity };
@@ -43,7 +29,7 @@ function setupTest(): TestData {
 describe("_YAMLDocToPaths", () => {
   test("returns YamlDocPaths", () => {
     const { entity } = setupTest();
-    const stuff = entity.getCodeDecorations("baseline");
-    expect(stuff.length).toBe(3); // The two default values, plus [metadata, 0, me] - everything that's inferred
+    const stuff = entity.getCodeDecorations("baseline", []);
+    expect(stuff.length).toBe(3);
   });
 });


### PR DESCRIPTION
Previously, we scanned the entire property tree for anything that looked
like a number - and if it did, we turned it into a number when we
serialized. This broke the contract with k8s, because sometimes it
requires that everything be a string (for example, in an annotation).

This replaces that brute-force method with one that uses the ops on the
entity to determine if they are a number according to the schema, and if
they are, *then* replace them with the numeric representation rather
than a string. Otherwise they remain a string.

It also cleans up failing test from previously.