### PR TITLE
bug(si-web): allow textareas in map values

### DIFF
--- a/components/si-registry/src/schema/kubernetes/k8sConfigMap.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sConfigMap.ts
@@ -39,6 +39,9 @@ const k8sConfigMap: RegistryEntry = {
       name: "data",
       valueProperty: {
         type: "string",
+        widget: {
+          name: "textArea",
+        },
       },
     },
   ],

--- a/components/si-registry/src/schema/kubernetes/k8sSecret.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sSecret.ts
@@ -80,6 +80,9 @@ const k8sSecret: RegistryEntry = {
       name: "data",
       valueProperty: {
         type: "string",
+        widget: {
+          name: "textArea",
+        },
       },
     },
   ],

--- a/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
+++ b/components/si-web-app/src/organisims/AttributeViewer/MapField.vue
@@ -28,12 +28,23 @@
             </div>
             <div class="flex ml-2">
               <input
+                v-if="valueWidget == 'text'"
                 type="text"
                 @focus="onFocus"
                 @blur="onBlurForKeyValue(mapValue.key)"
                 @keyup.enter="onEnterKey($event)"
                 v-model="currentValue[mapValue.key]"
                 class="w-full pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
+                :class="borderColorForKey(mapValue.key)"
+                placeholder="value"
+              />
+              <textarea
+                v-else
+                @focus="onFocus"
+                @blur="onBlurForKeyValue(mapValue.key)"
+                @keyup.enter="onEnterKey($event)"
+                v-model="currentValue[mapValue.key]"
+                class="w-full h-5 pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
                 :class="borderColorForKey(mapValue.key)"
                 placeholder="value"
               />
@@ -66,8 +77,15 @@
               <div class="flex mr-2">
                 <input
                   type="text"
+                  v-if="valueWidget == 'text'"
                   v-model="newValue"
                   class="w-full pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey input-border-grey si-property disabled:opacity-50"
+                  placeholder="value"
+                />
+                <textarea
+                  v-else
+                  v-model="newValue"
+                  class="w-full h-5 pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey input-border-grey si-property disabled:opacity-50"
                   placeholder="value"
                 />
               </div>
@@ -107,7 +125,17 @@
               <span :class="fieldNameColorForKey(key)"> {{ key }}</span
               >:
             </div>
-            <div class="ml-1 font-light text-left">
+            <div
+              class="ml-1 font-light text-left"
+              v-if="valueWidget == 'textArea'"
+            >
+              <pre>
+              <code class="whitespace-pre">
+{{ value }}
+              </code>
+              </pre>
+            </div>
+            <div class="ml-1 font-light text-left" v-else>
               {{ value }}
             </div>
           </div>
@@ -187,6 +215,14 @@ export default BaseField.extend({
         this.keyValue[index] = sorted[index].key;
       }
       return _.sortBy(data, ["key"]);
+    },
+    valueWidget(): "text" | "textArea" {
+      if (this.editField.schema.type == "map") {
+        if (this.editField.schema.valueProperty.widget?.name == "textArea") {
+          return "textArea";
+        }
+      }
+      return "text";
     },
   },
   methods: {


### PR DESCRIPTION
This allows you to set the widget for a valueProperty of a map in the
schema to be a 'textArea'. If you do, you will get a one line sized text
area, that acceps the raw input - suitable for pasting, writing YAML
directly, or whatever your heart desires.

It also displays the output correctly when viewing it not in edit mode.

This change updates the k8sConfigMap and k8sSecret to have their `data`
maps have their value set to textArea.

Caveats:

* I would not say this is a great user experience for editing big inline
  data like this - we probably should think about how using Monaco might
  work even better. Maybe a way to switch from a textArea to monaco?
  Could be neato.

![good](https://media2.giphy.com/media/J8FZIm9VoBU6Q/200.gif?cid=5a38a5a2fggp9w5i5v1ghui6yuledn2sjmxigjcz00dez5ga&rid=200.gif&ct=g)