### PR TITLE
chore(si-veritech): remove `-vol`/`-service` from inferProperties

### DIFF
--- a/components/si-veritech/src/intel/k8sDeployment.ts
+++ b/components/si-veritech/src/intel/k8sDeployment.ts
@@ -120,7 +120,7 @@ export function inferProperties(
           if (configMapValues[system]) {
             toSet.push({
               path: ["name"],
-              value: String(configMapValues[system]).concat("-vol"),
+              value: configMapValues[system],
               system,
             });
             toSet.push({
@@ -200,7 +200,7 @@ export function inferProperties(
           if (volumeMountsValues[system]) {
             toSet.push({
               path: ["volumeMounts", "name"],
-              value: String(volumeMountsValues[system]).concat("-vol"),
+              value: volumeMountsValues[system],
               system,
             });
           }

--- a/components/si-veritech/src/intel/k8sService.ts
+++ b/components/si-veritech/src/intel/k8sService.ts
@@ -40,7 +40,7 @@ export function inferProperties(
   setProperty({
     entity,
     toPath: ["metadata", "name"],
-    value: `${entity.name}-service`,
+    value: entity.name,
   });
 
   // Do you have a k8s namespace? If so, set the namespace.

--- a/components/si-veritech/src/intel/kubernetesService.ts
+++ b/components/si-veritech/src/intel/kubernetesService.ts
@@ -272,7 +272,6 @@ export async function discover(
         system: "baseline",
       });
 
-      //k8sService.name = serviceData["metadata"]["name"].replace("-service", "");
       k8sDiscoverEntity(k8sService, serviceData);
       //k8sService.computeProperties();
       //k8sService.computeCode();

--- a/components/si-veritech/src/support.ts
+++ b/components/si-veritech/src/support.ts
@@ -247,7 +247,6 @@ export function k8sDiscoverEntity(
 ): void {
   const path: string[] = [];
   const entityName = _.get(data, ["metadata", "name"]);
-  entity.name = entityName.replace("-service", "");
   //_k8sDiscoverEntityObject(entity, data, path);
 }
 


### PR DESCRIPTION
This applies to:

- removing `-serivce` on `k8sService` entites
- removing `-vol` on `k8sDeployment` entites

This also removes some discovery-related replacements that no longer
apply when trying to discover services.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>