### PR TITLE
bug(si-entity): yaml number replacement improvements

### DIFF
--- a/components/si-entity/tests/yamlCode.spec.ts
+++ b/components/si-entity/tests/yamlCode.spec.ts
@@ -6,6 +6,7 @@ import {
   OpTombstone,
   OpUnset,
 } from "../src/siEntity";
+import _ from "lodash";
 
 interface TestData {
   entity: SiEntity;
@@ -26,10 +27,255 @@ function setupTest(): TestData {
   return { entity };
 }
 
-describe("_YAMLDocToPaths", () => {
-  test("returns YamlDocPaths", () => {
+describe("getCodeDecorations", () => {
+  test("returns code decorations for yaml", () => {
     const { entity } = setupTest();
     const stuff = entity.getCodeDecorations("baseline", []);
     expect(stuff.length).toBe(3);
+  });
+});
+
+function setupNumberTest(): TestData {
+  const entity = new SiEntity({ entityType: "yamlNumbers" });
+  entity.name = "aerosmith";
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["stringType"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["numberType"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["stringMap", "stringKey"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["numberMap", "numberKey"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["stringArray", "0"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["stringArray", "1"],
+    value: "1984",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["numberArray", "0"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["numberArray", "1"],
+    value: "1984",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectString"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectNumber"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectStringMap", "eddie"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectNumberMap", "alex"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectStringArray", "0"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectNumberArray", "0"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectArrayArray", "0", "0", "deeplyNestedString"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: ["nestedObject", "objectArrayArray", "0", "0", "deeplyNestedNumber"],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.addOpSet({
+    op: OpType.Set,
+    path: [
+      "nestedObject",
+      "objectArrayArray",
+      "0",
+      "0",
+      "deeplyNestedArrayNumber",
+      "0",
+    ],
+    value: "5150",
+    source: OpSource.Inferred,
+    system: "baseline",
+  });
+
+  entity.setDefaultProperties();
+  entity.computeProperties();
+  return { entity };
+}
+
+describe("yamlNumberReplacer", () => {
+  test("stringType", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const stringType = _.get(numberifiedProperties, ["baseline", "stringType"]);
+    expect(stringType).toBe("5150");
+  });
+
+  test("numberType", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const numberType = _.get(numberifiedProperties, ["baseline", "numberType"]);
+    expect(numberType).toBe(5150);
+  });
+
+  test("stringMap", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const stringMapValue = _.get(numberifiedProperties, [
+      "baseline",
+      "stringMap",
+    ]);
+    expect(stringMapValue).toStrictEqual({ stringKey: "5150" });
+  });
+
+  test("numberMap", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const numberMapValue = _.get(numberifiedProperties, [
+      "baseline",
+      "numberMap",
+    ]);
+    expect(numberMapValue).toStrictEqual({ numberKey: 5150 });
+  });
+
+  test("stringArray", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const stringArray = _.get(numberifiedProperties, [
+      "baseline",
+      "stringArray",
+    ]);
+    expect(stringArray).toStrictEqual(["5150", "1984"]);
+  });
+
+  test("numberArray", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const numberArray = _.get(numberifiedProperties, [
+      "baseline",
+      "numberArray",
+    ]);
+    expect(numberArray).toStrictEqual([5150, 1984]);
+  });
+
+  test("nestedObject", () => {
+    const { entity } = setupNumberTest();
+    const numberifiedProperties = entity.yamlNumberReplacer();
+
+    const nestedObject = _.get(numberifiedProperties, [
+      "baseline",
+      "nestedObject",
+    ]);
+    expect(nestedObject).toStrictEqual({
+      objectString: "5150",
+      objectNumber: 5150,
+      objectStringMap: {
+        eddie: "5150",
+      },
+      objectNumberMap: {
+        alex: 5150,
+      },
+      objectStringArray: ["5150"],
+      objectNumberArray: [5150],
+      objectArrayArray: [
+        [
+          {
+            deeplyNestedString: "5150",
+            deeplyNestedNumber: 5150,
+            deeplyNestedArrayNumber: [5150],
+          },
+        ],
+      ],
+    });
   });
 });

--- a/components/si-registry/src/schema/test/yamlNumbers.ts
+++ b/components/si-registry/src/schema/test/yamlNumbers.ts
@@ -1,0 +1,132 @@
+import {
+  RegistryEntry,
+  ValidatorKind,
+  SchematicKind,
+  NodeKind,
+  CodeKind,
+  Arity,
+} from "../../registryEntry";
+
+const yamlNumbers: RegistryEntry = {
+  entityType: "yamlNumbers",
+  nodeKind: NodeKind.Concrete,
+  code: { kind: CodeKind.YAML },
+  ui: {
+    hidden: true,
+  },
+  inputs: [],
+  commands: [],
+  actions: [],
+  properties: [
+    {
+      type: "string",
+      name: "stringType",
+    },
+    {
+      type: "number",
+      name: "numberType",
+    },
+    {
+      type: "map",
+      name: "stringMap",
+      valueProperty: {
+        type: "string",
+      },
+    },
+    {
+      type: "map",
+      name: "numberMap",
+      valueProperty: {
+        type: "number",
+      },
+    },
+    {
+      type: "array",
+      name: "stringArray",
+      itemProperty: {
+        type: "string",
+      },
+    },
+    {
+      type: "array",
+      name: "numberArray",
+      itemProperty: {
+        type: "number",
+      },
+    },
+    {
+      type: "object",
+      name: "nestedObject",
+      properties: [
+        {
+          type: "string",
+          name: "objectString",
+        },
+        {
+          type: "number",
+          name: "objectNumber",
+        },
+        {
+          type: "map",
+          name: "objectStringMap",
+          valueProperty: {
+            type: "string",
+          },
+        },
+        {
+          type: "map",
+          name: "objectNumberMap",
+          valueProperty: {
+            type: "number",
+          },
+        },
+        {
+          type: "array",
+          name: "objectStringArray",
+          itemProperty: {
+            type: "string",
+          },
+        },
+        {
+          type: "array",
+          name: "objectNumberArray",
+          itemProperty: {
+            type: "number",
+          },
+        },
+        {
+          type: "array",
+          name: "objectArrayArray",
+          itemProperty: {
+            type: "array",
+            itemProperty: {
+              type: "array",
+              itemProperty: {
+                type: "object",
+                properties: [
+                  {
+                    type: "string",
+                    name: "deeplyNestedString",
+                  },
+                  {
+                    type: "number",
+                    name: "deeplyNestedNumber",
+                  },
+                  {
+                    type: "array",
+                    name: "deeplyNestedArrayNumber",
+                    itemProperty: {
+                      type: "number",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export default yamlNumbers;

--- a/components/si-registry/tests/registry.spec.ts
+++ b/components/si-registry/tests/registry.spec.ts
@@ -1,7 +1,7 @@
 import { findProp } from "../src/registry";
 
 describe("registry", () => {
-  describe("findProperty", () => {
+  describe("findProp", () => {
     test("simple property", () => {
       const simpleString = findProp(["leftHandPath", "simpleString"]);
       expect(simpleString).not.toBeUndefined();
@@ -38,6 +38,22 @@ describe("registry", () => {
         expect.objectContaining({
           name: "abnormal",
           type: "array",
+        }),
+      );
+    });
+    test("deeply nested array of arrays with an object", () => {
+      const prop = findProp([
+        "yamlNumbers",
+        "nestedObject",
+        "objectArrayArray",
+        "0",
+        "0",
+        "deeplyNestedString",
+      ]);
+      expect(prop).toEqual(
+        expect.objectContaining({
+          name: "deeplyNestedString",
+          type: "string",
         }),
       );
     });


### PR DESCRIPTION

This should resolve the bug where we do not correctly translate between
numbers in the schema and numbers in YAML. It uses a hybrid approach,
where the property object itself is walked, and each path we encounter
becomes a fake op, which we use to look up the correct prop from the
schema. If that prop declares it should be a number, then we swap the
value to a number.

This PR also adds more test coverage for both finding properties (which
needed to be re-written for this to work) and the eventual results of
YAML numbers.

![numbers](https://media4.giphy.com/media/hvLwZ5wmarjnNKEJqq/200w.gif?cid=5a38a5a2qs3fczmf2b4fqb90o5ib46whbe67htb067qdv3n4&rid=200w.gif&ct=g)
