### PR TITLE
chore(si-sdf,si-veritech,si-web-app): add build image label metadata

### DIFF
--- a/components/si-sdf/bin/build-image.sh
+++ b/components/si-sdf/bin/build-image.sh
@@ -101,7 +101,7 @@ invoke_cli() {
   if [ -z "${CI:-}" ]; then
     setup_buildx
   fi
-  build "$img" "$push" "$ci_mode" "$@"
+  build "$img" "$push" "$ci_mode" "$author" "$@"
 }
 
 setup_buildx() {
@@ -119,19 +119,42 @@ build() {
   shift
   local ci_mode="$1"
   shift
+  local author="$1"
+  shift
 
   need_cmd date
   need_cmd docker
   need_cmd git
 
+  # Get a build time in UTC, allowing for override by SOURCE_DATE_EPOCH
+  # See: https://reproducible-builds.org/specs/source-date-epoch/
+  local build_time
+  build_time="${SOURCE_DATE_EPOCH:-$(date -u +%s)}"
+
+  local created
+  created="$(date -u -d "@$build_time" +%FT%TZ)"
+
+  local revision
+  revision="$(git show -s --format=%H)"
+
   local build_version
-  build_version="$(date -u +%Y%m%d.%H%M%S).0-sha.$(git show -s --format=%h)"
+  build_version="$(
+    date -u -d "@$build_time" +%Y%m%d.%H%M%S
+  ).0-sha.$(git show -s --format=%h)"
 
   cd "${0%/*}/.."
 
   local args
   args=(
     buildx build
+    --label "name=$img"
+    --label "maintainer=$author"
+    --label "org.opencontainers.image.version=$build_version"
+    --label "org.opencontainers.image.authors=$author"
+    --label "org.opencontainers.image.licenses=PROPRIETARY"
+    --label "org.opencontainers.image.source=http://github.com/systeminit/si.git"
+    --label "org.opencontainers.image.revision=$revision"
+    --label "org.opencontainers.image.created=$created"
     --tag "$img:$build_version"
     --tag "$img:latest"
   )

--- a/components/si-veritech/bin/build-image.sh
+++ b/components/si-veritech/bin/build-image.sh
@@ -101,7 +101,7 @@ invoke_cli() {
   if [ -z "${CI:-}" ]; then
     setup_buildx
   fi
-  build "$img" "$push" "$ci_mode" "$@"
+  build "$img" "$push" "$ci_mode" "$author" "$@"
 }
 
 setup_buildx() {
@@ -119,19 +119,42 @@ build() {
   shift
   local ci_mode="$1"
   shift
+  local author="$1"
+  shift
 
   need_cmd date
   need_cmd docker
   need_cmd git
 
+  # Get a build time in UTC, allowing for override by SOURCE_DATE_EPOCH
+  # See: https://reproducible-builds.org/specs/source-date-epoch/
+  local build_time
+  build_time="${SOURCE_DATE_EPOCH:-$(date -u +%s)}"
+
+  local created
+  created="$(date -u -d "@$build_time" +%FT%TZ)"
+
+  local revision
+  revision="$(git show -s --format=%H)"
+
   local build_version
-  build_version="$(date -u +%Y%m%d.%H%M%S).0-sha.$(git show -s --format=%h)"
+  build_version="$(
+    date -u -d "@$build_time" +%Y%m%d.%H%M%S
+  ).0-sha.$(git show -s --format=%h)"
 
   cd "${0%/*}/.."
 
   local args
   args=(
     buildx build
+    --label "name=$img"
+    --label "maintainer=$author"
+    --label "org.opencontainers.image.version=$build_version"
+    --label "org.opencontainers.image.authors=$author"
+    --label "org.opencontainers.image.licenses=PROPRIETARY"
+    --label "org.opencontainers.image.source=http://github.com/systeminit/si.git"
+    --label "org.opencontainers.image.revision=$revision"
+    --label "org.opencontainers.image.created=$created"
     --tag "$img:$build_version"
     --tag "$img:latest"
   )


### PR DESCRIPTION
This change adds several labels to the SI service images on build as a
means to track the artifact back to the when/how it was built.

Here's an example after building `si-sdf` (when using `docker image
inspect`):

```json
"Labels": {
    "maintainer": "The System Initiative <dev@systeminit.com>",
    "name": "systeminit/si-sdf",
    "org.opencontainers.image.authors": "The System Initiative <dev@systeminit.com>",
    "org.opencontainers.image.created": "2021-08-18T22:40:47Z",
    "org.opencontainers.image.licenses": "PROPRIETARY",
    "org.opencontainers.image.revision": "90e578fa9ab14b4f728cc1ce0c66447af4607994",
    "org.opencontainers.image.source": "http://github.com/systeminit/si.git",
    "org.opencontainers.image.version": "20210818.224047.0-sha.90e578fa"
}
```

As this impacts the image metadata, a new sha layer is produced now on
each build, however it only contains this metadata and is near
instantaneous. Thus, we can inspect label metadata with:

```sh
docker inspect systeminit/si-sdf:latest | jq .[0].Config.Labels
```

for local images, or for dynamic remote inspection with skopeo (killer):

```sh
skopeo inspect docker://docker.io/systeminit/si-sdf:stable | jq .Labels
```