### PR TITLE
build(image): prefer `gdate` when computing build time & version info

### DIFF
--- a/components/si-sdf/bin/build-image.sh
+++ b/components/si-sdf/bin/build-image.sh
@@ -122,24 +122,33 @@ build() {
   local author="$1"
   shift
 
-  need_cmd date
   need_cmd docker
   need_cmd git
+
+  # Prefer `gdate` if available if we are running on macOS to try and favor the
+  # GNU version of date over the BSD version for epoch timestamp parsing.
+  local date_cmd
+  if command -v gdate >/dev/null 2>&1; then
+    date_cmd="gdate"
+  else
+    need_cmd date
+    date_cmd="date"
+  fi
 
   # Get a build time in UTC, allowing for override by SOURCE_DATE_EPOCH
   # See: https://reproducible-builds.org/specs/source-date-epoch/
   local build_time
-  build_time="${SOURCE_DATE_EPOCH:-$(date -u +%s)}"
+  build_time="${SOURCE_DATE_EPOCH:-$("$date_cmd" -u +%s)}"
 
   local created
-  created="$(date -u -d "@$build_time" +%FT%TZ)"
+  created="$("$date_cmd" -u -d "@$build_time" +%FT%TZ)"
 
   local revision
   revision="$(git show -s --format=%H)"
 
   local build_version
   build_version="$(
-    date -u -d "@$build_time" +%Y%m%d.%H%M%S
+    "$date_cmd" -u -d "@$build_time" +%Y%m%d.%H%M%S
   ).0-sha.$(git show -s --format=%h)"
 
   cd "${0%/*}/.."

--- a/components/si-veritech/bin/build-image.sh
+++ b/components/si-veritech/bin/build-image.sh
@@ -122,24 +122,33 @@ build() {
   local author="$1"
   shift
 
-  need_cmd date
   need_cmd docker
   need_cmd git
+
+  # Prefer `gdate` if available if we are running on macOS to try and favor the
+  # GNU version of date over the BSD version for epoch timestamp parsing.
+  local date_cmd
+  if command -v gdate >/dev/null 2>&1; then
+    date_cmd="gdate"
+  else
+    need_cmd date
+    date_cmd="date"
+  fi
 
   # Get a build time in UTC, allowing for override by SOURCE_DATE_EPOCH
   # See: https://reproducible-builds.org/specs/source-date-epoch/
   local build_time
-  build_time="${SOURCE_DATE_EPOCH:-$(date -u +%s)}"
+  build_time="${SOURCE_DATE_EPOCH:-$("$date_cmd" -u +%s)}"
 
   local created
-  created="$(date -u -d "@$build_time" +%FT%TZ)"
+  created="$("$date_cmd" -u -d "@$build_time" +%FT%TZ)"
 
   local revision
   revision="$(git show -s --format=%H)"
 
   local build_version
   build_version="$(
-    date -u -d "@$build_time" +%Y%m%d.%H%M%S
+    "$date_cmd" -u -d "@$build_time" +%Y%m%d.%H%M%S
   ).0-sha.$(git show -s --format=%h)"
 
   cd "${0%/*}/.."


### PR DESCRIPTION
We're preferring, or rather first checking for a `gdate` binary on
`$PATH` so that the release process can be run on macOS as well as
Linux systems, which is the current supported default.

On macOS, when using Homebrew a developer can install the `coreutils`
package which will install GNU versions of coreutils programs on
`$PATH`, with all programs prefixed with a `g`. In this way, our release
process should flow just as naturally on macOS as on Linux.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>