### PR TITLE
fix(si-veritech): map all k8sDeployment ports into k8sService

### DIFF
--- a/components/si-veritech/src/intel/k8sService.ts
+++ b/components/si-veritech/src/intel/k8sService.ts
@@ -15,8 +15,8 @@ import {
 import {
   allEntitiesByType,
   findProperty,
-  SetArrayEntryFromAllEntities,
-  setArrayEntryFromAllEntities,
+  SetArrayEntriesFromAllEntities,
+  setArrayEntriesFromAllEntites,
   setProperty,
   setPropertyFromEntity,
   setPropertyFromProperty,
@@ -52,15 +52,15 @@ export function inferProperties(
     toPath: ["metadata", "namespace"],
   });
 
-  setArrayEntryFromAllEntities({
+  setArrayEntriesFromAllEntites({
     entity,
     context,
     entityType: "k8sDeployment",
     toPath: ["spec", "ports"],
     valuesCallback(
       fromEntity,
-    ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
-      const toSet: { path: string[]; value: any; system: string }[] = [];
+    ): ReturnType<SetArrayEntriesFromAllEntities["valuesCallback"]> {
+      const toSet = [];
       const containersBySystem: Record<
         string,
         Record<string, any>[]
@@ -72,24 +72,29 @@ export function inferProperties(
         for (const container of containers) {
           if (container["ports"]) {
             for (const portDef of container["ports"]) {
+              const entry = [];
               if (portDef["containerPort"]) {
-                toSet.push({
+                entry.push({
                   path: ["port"],
                   value: portDef["containerPort"],
                   system,
                 });
               }
               if (portDef["protocol"]) {
-                toSet.push({
+                entry.push({
                   path: ["protocol"],
                   value: portDef["protocol"],
                   system,
                 });
               }
+              if (entry.length > 0) {
+                toSet.push(entry);
+              }
             }
           }
         }
       }
+      debug("ready toSet", { toSet: JSON.stringify(toSet) });
       return toSet;
     },
   });


### PR DESCRIPTION
This change fixes an issue in the `k8sService`'s infer properties
intelligence. Rather than build and appending a object of port entries,
the code was pushing single objects of with only a `port` or `protocol`
(but not both, together). In short, this author has no idea how we were
getting anything of value to be derived. Likely "bad data" was thrown
out at a certain stage and the last bit of remaining "good data" was the
last entry with a `port` key in it. But now it's all here, cool!

Note that likely replaying this intelligence could lead to duplicate
entries or a different order. There may be more work to do here, but
it's also working within the strengths and limitations of where this
code is at. A little "Demoer Beware" should go far.

![tenor-244387640](https://user-images.githubusercontent.com/261548/130276882-3f1f5257-7e2a-4cb2-81a6-18b5c7fadcbf.gif)

References: Create a port entry for each exposed port [ch1475]