### PR TITLE
feat(*): allow linking to existing nodes

### DIFF
--- a/components/si-model/src/queries/edge_exists.sql
+++ b/components/si-model/src/queries/edge_exists.sql
@@ -1,0 +1,8 @@
+SELECT obj AS object FROM edges WHERE
+    edges.tail_vertex_node_si_id = $1
+     AND edges.tail_vertex_object_type = $2
+     AND edges.tail_vertex_socket = $3
+     AND edges.head_vertex_node_si_id = $4
+     AND edges.head_vertex_object_type = $5
+     AND edges.head_vertex_socket = $6;
+

--- a/components/si-model/src/queries/entity_for_link_menu.sql
+++ b/components/si-model/src/queries/entity_for_link_menu.sql
@@ -1,0 +1,15 @@
+SELECT COALESCE(entities_edit_session_projection.obj, entities_change_set_projection.obj,
+                         entities_head.obj) AS object
+FROM entities
+         LEFT JOIN entities_edit_session_projection ON entities_edit_session_projection.id = entities.id
+    AND entities_edit_session_projection.change_set_id = si_id_to_primary_key_v1($3)
+    AND entities_edit_session_projection.edit_session_id = si_id_to_primary_key_v1($4)
+         LEFT JOIN entities_change_set_projection ON entities_change_set_projection.id = entities.id
+    AND entities_change_set_projection.change_set_id = si_id_to_primary_key_v1($3)
+         LEFT JOIN entities_head ON entities_head.id = entities.id
+WHERE entities.entity_type = ANY ($1)
+  AND entities.workspace_id = si_id_to_primary_key_v1($5)
+  AND entities.si_id NOT IN (SELECT edges.head_vertex_object_si_id
+                             FROM edges
+                             WHERE edges.tail_vertex_object_si_id = $2
+                               AND edges.kind = 'component')

--- a/components/si-registry/package-lock.json
+++ b/components/si-registry/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "si-registry",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {

--- a/components/si-registry/src/index.ts
+++ b/components/si-registry/src/index.ts
@@ -17,5 +17,12 @@ export {
   allFieldsValidQualification,
 } from "./registryEntry";
 export { workflows, Workflow, Step } from "./workflow";
-export { entityMenu, EntityMenuFilters, MenuItem, MenuList } from "./menu";
+export {
+  entityMenu,
+  entityTypesForMenu,
+  EntityMenuFilters,
+  MenuItem,
+  MenuList,
+  LinkNodeItem,
+} from "./menu";
 export { registry, findProp } from "./registry";

--- a/components/si-sdf/src/filters.rs
+++ b/components/si-sdf/src/filters.rs
@@ -405,6 +405,12 @@ pub fn schematic_dal(
             nats_conn.clone(),
         ))
         .or(schematic_dal_delete_node(pg.clone(), nats_conn.clone()))
+        .or(schematic_dal_node_link_for_application(
+            pg.clone(),
+            nats_conn.clone(),
+            veritech.clone(),
+        ))
+        .or(schematic_dal_get_node_link_menu(pg.clone()))
         .boxed()
 }
 
@@ -485,6 +491,36 @@ pub fn schematic_dal_delete_node(
         .and(with_pg(pg))
         .and(with_nats_conn(nats_conn))
         .and_then(handlers::schematic_dal::delete_node)
+        .boxed()
+}
+
+pub fn schematic_dal_node_link_for_application(
+    pg: PgPool,
+    nats_conn: NatsConn,
+    veritech: Veritech,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("schematicDal" / "nodeLinkForApplication")
+        .and(warp::post())
+        .and(authenticated(pg.clone()))
+        .and(warp::body::json::<
+            handlers::schematic_dal::NodeLinkForApplicationRequest,
+        >())
+        .and(with_pg(pg))
+        .and(with_nats_conn(nats_conn))
+        .and(with_veritech(veritech))
+        .and_then(handlers::schematic_dal::node_link_for_application)
+        .boxed()
+}
+
+pub fn schematic_dal_get_node_link_menu(pg: PgPool) -> BoxedFilter<(impl warp::Reply,)> {
+    warp::path!("schematicDal" / "getNodeLinkMenu")
+        .and(warp::post())
+        .and(authenticated(pg.clone()))
+        .and(warp::body::json::<
+            handlers::schematic_dal::GetNodeLinkMenuRequest,
+        >())
+        .and(with_pg(pg))
+        .and_then(handlers::schematic_dal::get_node_link_menu)
         .boxed()
 }
 

--- a/components/si-veritech/package-lock.json
+++ b/components/si-veritech/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "si-veritech",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {

--- a/components/si-web-app/src/api/sdf/dal/schematicDal.ts
+++ b/components/si-web-app/src/api/sdf/dal/schematicDal.ts
@@ -120,6 +120,13 @@ export interface INodeCreateForApplicationRequest extends INodeCreateRequest {
   deploymentSelectedEntityId?: string;
 }
 
+export interface INodeLinkForApplicationRequest extends INodeCreateRequest {
+  applicationId: string;
+  deploymentSelectedEntityId?: string;
+  nodeId: string;
+  entityId: string;
+}
+
 export interface INodeCreateRequest {
   name?: string;
   entityType: string;
@@ -151,6 +158,8 @@ export type INodeCreateReply =
   | INodeCreateReplySuccess
   | INodeCreateReplySuccessWithSchematic
   | INodeCreateReplyFailure;
+
+export type INodeLinkReply = INodeCreateReply;
 
 export interface INodeObjectEntity {
   entity: Entity;
@@ -246,10 +255,76 @@ async function nodeDelete(
   return reply;
 }
 
+async function nodeLinkForApplication(
+  request: INodeLinkForApplicationRequest,
+): Promise<INodeLinkReply> {
+  const bottle = Bottle.pop("default");
+  const sdf = bottle.container.SDF;
+
+  const reply: INodeLinkReply = await sdf.post(
+    "schematicDal/nodeLinkForApplication",
+    request,
+  );
+  return reply;
+}
+
+export interface LinkNodeItem {
+  kind: "link";
+  entityType: string;
+  nodeId: string;
+  entityId: string;
+  name: string;
+}
+
+export interface IGetNodeLinkMenuRequest {
+  entityTypes: string[];
+  workspaceId: string;
+  changeSetId: string;
+  editSessionId: string;
+  positionCtx: string;
+}
+
+export interface IGetNodeLinkMenuReplySuccess {
+  link: LinkNodeItem[];
+  error?: never;
+}
+
+export interface IGetNodeLinkMenuReplyFailure {
+  link?: never;
+  error: SDFError;
+}
+
+export type IGetNodeLinkMenuReply =
+  | IGetNodeLinkMenuReplySuccess
+  | IGetNodeLinkMenuReplyFailure;
+
+async function getNodeLinkMenu(
+  request: IGetNodeLinkMenuRequest,
+): Promise<IGetNodeLinkMenuReply> {
+  const bottle = Bottle.pop("default");
+  const sdf = bottle.container.SDF;
+  const componentEntityId = request.positionCtx.split(".")[0];
+  const data = {
+    workspaceId: request.workspaceId,
+    changeSetId: request.changeSetId,
+    editSessionId: request.editSessionId,
+    entityTypes: request.entityTypes,
+    componentEntityId,
+  };
+
+  const reply: IGetNodeLinkMenuReply = await sdf.post(
+    "schematicDal/getNodeLinkMenu",
+    data,
+  );
+  return reply;
+}
+
 export const SchematicDal = {
   getApplicationSystemSchematic,
   connectionCreate,
   nodeCreateForApplication,
+  nodeLinkForApplication,
   nodeUpdatePosition,
   nodeDelete,
+  getNodeLinkMenu,
 };

--- a/components/si-web-app/src/molecules/NodeLinkMenu.vue
+++ b/components/si-web-app/src/molecules/NodeLinkMenu.vue
@@ -1,0 +1,241 @@
+<template>
+  <div
+    class="relative w-auto menu-root"
+    @mouseleave="onMouseLeave"
+    @mouseenter="cancelClose"
+  >
+    <button
+      @click="isOpen = !isOpen"
+      class="w-full focus:outline-none"
+      :disabled="isDisabled"
+      data-cy="editor-schematic-node-add-button"
+    >
+      <div
+        class="items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
+        :class="{
+          'text-gray-200': !isOpen,
+          'menu-selected': isOpen,
+          'text-gray-600': isDisabled,
+        }"
+      >
+        Link
+      </div>
+    </button>
+
+    <NodeLinkMenuCategory
+      :isOpen="isOpen"
+      :menuItems="menuItems"
+      rootMenu
+      class="menu-root"
+      @selected="onSelect"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import _ from "lodash";
+
+import {
+  entityMenu,
+  entityTypesForMenu,
+  MenuItem,
+  LinkNodeItem,
+} from "si-registry";
+import NodeLinkMenuCategory from "./NodeLinkMenu/NodeLinkMenuCategory.vue";
+import { Workspace } from "@/api/sdf/model/workspace";
+import { ChangeSet } from "@/api/sdf/model/changeSet";
+import { EditSession } from "@/api/sdf/model/editSession";
+import { pluck, switchMap, tap } from "rxjs/operators";
+import { Observable, combineLatest, of, from } from "rxjs";
+import { workspace$, changeSet$, editSession$ } from "@/observables";
+import {
+  IGetNodeLinkMenuRequest,
+  SchematicDal,
+  IGetNodeLinkMenuReplySuccess,
+} from "@/api/sdf/dal/schematicDal";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+
+interface Data {
+  isOpen: boolean;
+}
+
+export interface AddMenuSelectedPayload {
+  entityType: string;
+  event: MouseEvent;
+}
+
+const debounceIsOpen = _.debounce((component: any, isOpen: boolean) => {
+  component.isOpen = isOpen;
+}, 500);
+
+export default Vue.extend({
+  name: "NodeLinkMenu",
+  props: {
+    positionCtx: {
+      type: String,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    filter: {
+      type: Object as PropType<Parameters<typeof entityMenu>[0]>,
+    },
+  },
+  components: {
+    NodeLinkMenuCategory,
+  },
+  data(): Data {
+    return {
+      isOpen: false,
+    };
+  },
+  computed: {
+    isDisabled(): boolean {
+      if (this.disabled) {
+        return true;
+      } else {
+        // @ts-ignore
+        if (this.menuItems && this.menuItems.length) {
+          return false;
+        } else {
+          return true;
+        }
+      }
+    },
+  },
+  subscriptions(): Record<string, any> {
+    const positionCtx$: Observable<string> = this.$watchAsObservable<string>(
+      () =>
+        // @ts-ignore
+        this.positionCtx,
+      {
+        immediate: true,
+      },
+    ).pipe(pluck("newValue"));
+    const filter$: Observable<Parameters<
+      typeof entityMenu
+    >[0]> = this.$watchAsObservable<Parameters<typeof entityMenu>[0]>(
+      () =>
+        // @ts-ignore
+        this.filter,
+      {
+        immediate: true,
+      },
+    ).pipe(pluck("newValue"));
+
+    const menuItems$: Observable<MenuItem[]> = combineLatest(
+      filter$,
+      positionCtx$,
+      workspace$,
+      changeSet$,
+      editSession$,
+    ).pipe(
+      switchMap(([filter, positionCtx, workspace, changeSet, editSession]) => {
+        if (filter && positionCtx && workspace && changeSet && editSession) {
+          const entityTypes = entityTypesForMenu(filter);
+          const request: IGetNodeLinkMenuRequest = {
+            entityTypes,
+            workspaceId: workspace.id,
+            changeSetId: changeSet.id,
+            editSessionId: editSession.id,
+            positionCtx,
+          };
+          return from(SchematicDal.getNodeLinkMenu(request));
+        } else {
+          let defaultData: IGetNodeLinkMenuReplySuccess = {
+            link: [],
+          };
+          return from([defaultData]);
+        }
+      }),
+      tap(result => {
+        if (result.error) {
+          emitEditorErrorMessage(result.error.message);
+        }
+      }),
+      switchMap(reply => {
+        if (reply.link) {
+          // @ts-ignore
+          const menu = entityMenu(this.filter, reply.link).list;
+          return of(menu);
+        } else {
+          return of([]);
+        }
+      }),
+    );
+
+    return {
+      menuItems: menuItems$,
+    };
+  },
+  methods: {
+    onSelect(toLink: LinkNodeItem, event: MouseEvent): void {
+      event.preventDefault();
+      this.$emit("selected", toLink, event);
+      this.isOpen = false;
+    },
+    onMouseLeave(): void {
+      debounceIsOpen(this, false);
+    },
+    cancelClose(): void {
+      debounceIsOpen.cancel();
+    },
+  },
+  created() {
+    const handleEscape = (e: any) => {
+      if (e.key === "Esc" || e.key === "Escape") {
+        if (this.isOpen) {
+          this.isOpen = false;
+        }
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    this.$once("hook:beforeDestroy", () => {
+      document.removeEventListener("keydown", handleEscape);
+    });
+  },
+});
+</script>
+
+<style>
+.menu-root {
+  z-index: 999;
+}
+
+.menu {
+  background-color: #2d3748;
+  border-color: #485359;
+}
+
+.menu-selected {
+  background-color: #edf2f8;
+  color: #000000;
+}
+
+.menu-not-selected {
+  color: red;
+}
+
+.options {
+  background-color: #1f2631;
+  border-color: #485359;
+}
+.options:hover {
+  background-color: #3d4b62;
+  border-color: #454d3e;
+}
+
+.menu-category .category-items {
+  /*  visibility: hidden; */
+  position: absolute;
+  left: 100%;
+  top: auto;
+  margin-top: -1.305rem;
+}
+
+.menu-category:hover .category-items {
+  /* visibility: visible; */
+}
+</style>

--- a/components/si-web-app/src/molecules/NodeLinkMenu/NodeLinkMenuCategory.vue
+++ b/components/si-web-app/src/molecules/NodeLinkMenu/NodeLinkMenuCategory.vue
@@ -1,0 +1,112 @@
+<template>
+  <ul :class="listClasses" v-show="isOpen" v-on="$listeners">
+    <template v-for="item in menuItems">
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category whitespace-nowrap"
+        v-if="item.kind == 'category'"
+        @mouseenter="open(item.name)"
+        @mouseleave="close(item.name)"
+        :key="item.name"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.name }}
+        </div>
+        <NodeLinkMenuCategory
+          :menuItems="item.items"
+          :isOpen="isCategoryOpen(item.name)"
+          v-on="$listeners"
+        />
+      </li>
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category whitespace-nowrap"
+        v-if="item.kind == 'item'"
+        @mouseenter="open(item.name)"
+        @mouseleave="close(item.name)"
+        :key="item.name"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.name }}
+        </div>
+        <NodeLinkMenuCategory
+          :menuItems="item.links"
+          :isOpen="isCategoryOpen(item.name)"
+          v-on="$listeners"
+        />
+      </li>
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
+        v-if="item.kind == 'link'"
+        :key="item.name"
+        @click="selectedLink(item, $event)"
+      >
+        <div class="whitespace-no-wrap">
+          {{ item.name }}
+        </div>
+      </li>
+    </template>
+  </ul>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import { MenuItem, LinkNodeItem } from "si-registry";
+
+interface Data {
+  openCategories: {
+    [category: string]: boolean;
+  };
+}
+
+export default Vue.extend({
+  name: "NodeLinkMenuCategory",
+  props: {
+    menuItems: {
+      type: Array as PropType<MenuItem[]>,
+    },
+    rootMenu: { type: Boolean, default: false },
+    isOpen: { type: Boolean },
+  },
+  data(): Data {
+    return {
+      openCategories: {},
+    };
+  },
+  computed: {
+    listClasses(): Record<string, boolean> {
+      if (this.rootMenu) {
+        return {
+          absolute: true,
+          "w-auto": true,
+          "text-gray-200": true,
+          border: true,
+          "shadow-md": true,
+          options: true,
+        };
+      } else {
+        return {
+          relative: true,
+          "w-auto": true,
+          border: true,
+          "shadow-md": true,
+          "category-items": true,
+          options: true,
+        };
+      }
+    },
+  },
+  methods: {
+    selectedLink(link: LinkNodeItem, event: MouseEvent): void {
+      this.$emit("selected", link, event);
+    },
+    open(category: string): void {
+      Vue.set(this.openCategories, category, true);
+    },
+    close(category: string): void {
+      Vue.set(this.openCategories, category, false);
+    },
+    isCategoryOpen(category: string): boolean {
+      return this.openCategories[category];
+    },
+  },
+});
+</script>


### PR DESCRIPTION
Enable linking existing nodes into the current context. You can link to
an existing node via the Link menu. If the menu is enabled, it will
follow the same path as the add menu, but the individual nodes of that
type in the workspace (that are not in the current view) will be
present. You can then add them to the current schematic.

If the node you are linking to has incoming edges, we are *not*
currently pulling those nodes in along for the ride. So if you want to
see all of the configuration, you need to add all those nodes as well
via the link menu. We expect that another PR will flesh out that side of
the work - essentially make it so that when an edge is created for a
given entity, we ensure the inbound entities are also in the same
contexts. But tomorrows problem. :)

![link](https://media4.giphy.com/media/PjIKNsWUOhwL6/giphy.gif?cid=5a38a5a2aq0l8rg9tmbx0phxm5tnljqb159rwh45wxvq9glk&rid=giphy.gif&ct=g)