### PR TITLE
feat(model,registry,veritech): connect dockerHubCredential to k8sSecret

### DIFF
--- a/components/si-registry/src/schema/kubernetes/k8sSecret.ts
+++ b/components/si-registry/src/schema/kubernetes/k8sSecret.ts
@@ -36,6 +36,12 @@ const k8sSecret: RegistryEntry = {
       edgeKind: "configures",
       arity: Arity.One,
     },
+    {
+      name: "dockerHubCredential",
+      types: ["dockerHubCredential"],
+      edgeKind: "configures",
+      arity: Arity.One,
+    },
   ],
   properties: [
     apiVersion("v1"),

--- a/components/si-veritech/src/controllers/inferProperties.ts
+++ b/components/si-veritech/src/controllers/inferProperties.ts
@@ -4,15 +4,21 @@ import api from "@opentelemetry/api";
 import Debug from "debug";
 const debug = Debug("veritech:controllers:inferProperties");
 
-import { SiEntity as Entity, Resource, OpType, OpSource } from "si-entity";
-import { registry, RegistryEntry } from "si-registry";
+import { SiEntity as Entity } from "si-entity";
+import { registry } from "si-registry";
 
 import intel from "../intel";
+import { DecryptedSecret } from "../support";
+
+export interface InferPropertiesRequestContextEntry {
+  entity: Entity;
+  secret: Record<string, DecryptedSecret | null>;
+}
 
 export interface InferPropertiesRequest {
   entityType: string;
   entity: Entity;
-  context: Entity[];
+  context: InferPropertiesRequestContextEntry[];
 }
 
 export interface InferPropertiesReply {
@@ -46,7 +52,7 @@ export function inferProperties(ctx: Context): void {
   request.entity = Entity.fromJson(request.entity);
   request.entity.setDefaultProperties();
   for (let x = 0; x < request.context.length; x++) {
-    request.context[x] = Entity.fromJson(request.context[x]);
+    request.context[x].entity = Entity.fromJson(request.context[x].entity);
   }
 
   // Check if this object has the right intel functions

--- a/components/si-veritech/src/intel/k8sDeployment.ts
+++ b/components/si-veritech/src/intel/k8sDeployment.ts
@@ -79,11 +79,11 @@ export function inferProperties(
     entityType: "k8sSecret",
     toPath: ["spec", "template", "spec", "imagePullSecrets"],
     valuesCallback(
-      fromEntity,
+      fromEntry,
     ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
       const toSet: { path: string[]; value: any; system: string }[] = [];
 
-      const secretValues = fromEntity.getPropertyForAllSystems({
+      const secretValues = fromEntry.entity.getPropertyForAllSystems({
         path: ["metadata", "name"],
       });
       if (secretValues) {
@@ -108,11 +108,11 @@ export function inferProperties(
     entityType: "k8sConfigMap",
     toPath: ["spec", "template", "spec", "volumes"],
     valuesCallback(
-      fromEntity,
+      fromEntry,
     ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
       const toSet: { path: string[]; value: any; system: string }[] = [];
 
-      const configMapValues = fromEntity.getPropertyForAllSystems({
+      const configMapValues = fromEntry.entity.getPropertyForAllSystems({
         path: ["metadata", "name"],
       });
       if (configMapValues) {
@@ -145,15 +145,15 @@ export function inferProperties(
     entityType: "dockerImage",
     toPath: ["spec", "template", "spec", "containers"],
     valuesCallback(
-      fromEntity,
+      fromEntry,
     ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
       const toSet: { path: string[]; value: any; system: string }[] = [];
       toSet.push({
         path: ["name"],
-        value: fromEntity.name,
+        value: fromEntry.entity.name,
         system: "baseline",
       });
-      const imageValues = fromEntity.getPropertyForAllSystems({
+      const imageValues = fromEntry.entity.getPropertyForAllSystems({
         path: ["image"],
       });
       for (const system in imageValues) {
@@ -172,7 +172,7 @@ export function inferProperties(
           toSet.push({ path: ["imagePullPolicy"], value: "Always", system });
         }
       }
-      const exposedPortValues = fromEntity.getPropertyForAllSystems({
+      const exposedPortValues = fromEntry.entity.getPropertyForAllSystems({
         path: ["ExposedPorts"],
       });
       for (const system in exposedPortValues) {

--- a/components/si-veritech/src/intel/k8sService.ts
+++ b/components/si-veritech/src/intel/k8sService.ts
@@ -2,7 +2,6 @@ import { OpSource, SiEntity } from "si-entity/dist/siEntity";
 import Debug from "debug";
 const debug = Debug("veritech:controllers:intel:k8sService");
 import {
-  baseInferProperties,
   baseCheckQualifications,
   baseRunCommands,
   baseSyncResource,
@@ -13,21 +12,16 @@ import {
   InferPropertiesRequest,
 } from "../controllers/inferProperties";
 import {
-  allEntitiesByType,
-  findProperty,
   SetArrayEntriesFromAllEntities,
   setArrayEntriesFromAllEntites,
   setProperty,
   setPropertyFromEntity,
-  setPropertyFromProperty,
 } from "./inferShared";
-import _ from "lodash";
 import { SiCtx } from "../siCtx";
 import {
   CommandProtocolFinish,
   SyncResourceRequest,
 } from "../controllers/syncResource";
-import { findEntityByType } from "../support";
 import WebSocket from "ws";
 import { ResourceInternalHealth } from "si-entity";
 
@@ -58,13 +52,13 @@ export function inferProperties(
     entityType: "k8sDeployment",
     toPath: ["spec", "ports"],
     valuesCallback(
-      fromEntity,
+      fromEntry,
     ): ReturnType<SetArrayEntriesFromAllEntities["valuesCallback"]> {
       const toSet = [];
       const containersBySystem: Record<
         string,
         Record<string, any>[]
-      > = fromEntity.getPropertyForAllSystems({
+      > = fromEntry.entity.getPropertyForAllSystems({
         path: ["spec", "template", "spec", "containers"],
       });
       for (const system in containersBySystem) {

--- a/components/si-veritech/src/intel/kubernetesService.ts
+++ b/components/si-veritech/src/intel/kubernetesService.ts
@@ -39,14 +39,14 @@ export function inferProperties(
     entityType: "k8sService",
     toPath: ["healthChecks"],
     valuesCallback(
-      fromEntity,
+      fromEntry,
     ): ReturnType<SetArrayEntryFromAllEntities["valuesCallback"]> {
       const toSet: { path: string[]; value: any; system: string }[] = [];
 
       const portsBySystem: Record<
         string,
         Record<string, any>[]
-      > = fromEntity.getPropertyForAllSystems({
+      > = fromEntry.entity.getPropertyForAllSystems({
         path: ["spec", "ports"],
       });
       for (const system in portsBySystem) {


### PR DESCRIPTION
This change allows a single `dockerHubCredential` to infer the type and
data payload of a `k8sSecret`. Currently the protected SI secret is
decrypted and serialized into the `k8sSecret` body and is therefore no
longer protected, so take note of that, okay?

Prior to this change decrypted secrets were not being passed into
`inferProperties` calls (as they should not leak private credentials),
but for the moment this unlocks the functionality before we close this
loophole by other means. As a result, this is a churny change in
Veritech and SDF.

To support the intelligence functions a new helper
`setPropertyFromEntitySecret` is added which has a mandatory callback
called `transform` which yields the decrypted `message` payload as a JS
object and returns a return type of `string | number | boolean` so we
can set the result as a property value ultimately.

And finally, the existing `setPropertyFromEntity` helper gains an
optional `transform` callback, yielding the value plucked from the
context's entity and the expects a return type of `string | number |
boolean` for a final `OpSet`.

References: ability to connect a dockerHubCredential [ch1484]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>