### PR TITLE
feat: add array edit partial support for custom per-entry edit fields

### DIFF
--- a/components/si-entity/src/siEntity.ts
+++ b/components/si-entity/src/siEntity.ts
@@ -75,6 +75,7 @@ export interface OpSet extends OpBase {
   op: OpType.Set;
   path: string[];
   value: string | number | boolean | null;
+  editPartial?: string;
 }
 
 export interface OpUnset extends OpBase {

--- a/components/si-model/src/discovery.rs
+++ b/components/si-model/src/discovery.rs
@@ -616,6 +616,7 @@ pub async fn task_discover(
                                         path: vec!["implementation".to_string()],
                                         value: serde_json::json![entity.id],
                                         from: None,
+                                        edit_partial: None,
                                     });
                                     concept_entity
                                         .infer_properties_for_edit_session(

--- a/components/si-model/src/entity.rs
+++ b/components/si-model/src/entity.rs
@@ -163,6 +163,7 @@ pub struct Op {
     pub path: Vec<String>,
     pub value: serde_json::Value,
     pub from: Option<OpFrom>,
+    pub edit_partial: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]

--- a/components/si-registry/src/registryEntry.ts
+++ b/components/si-registry/src/registryEntry.ts
@@ -138,6 +138,20 @@ export type Widgets =
   | WidgetSelectFromSecret
   | WidgetUnknown;
 
+export interface EditPartialCategory {
+  kind: "category";
+  name: string;
+  items: EditPartialItem[];
+}
+
+export interface EditPartialItem {
+  kind: "item";
+  name: string;
+  propertyPaths: string[][];
+}
+
+export type EditPartial = EditPartialItem | EditPartialCategory;
+
 export interface PropBase {
   type: string;
   name: string;
@@ -166,6 +180,7 @@ export interface PropBool extends PropBase {
 export interface PropObject extends PropBase {
   type: "object";
   properties: Prop[];
+  editPartials?: EditPartial[];
 }
 
 export interface PropMap extends PropBase {

--- a/components/si-registry/src/schema/kubernetes/shared/podSpec.ts
+++ b/components/si-registry/src/schema/kubernetes/shared/podSpec.ts
@@ -105,6 +105,42 @@ export const podSpec: RegistryEntry["properties"] = [
                 ],
               },
             ],
+            editPartials: [
+              {
+                kind: "item",
+                name: "env.value",
+                propertyPaths: [["name"], ["value"]],
+              },
+              {
+                kind: "category",
+                name: "env.valueFrom",
+                items: [
+                  {
+                    kind: "item",
+                    name: "env.valueFrom.configMapRef",
+                    propertyPaths: [["name"], ["valueFrom", "configMapRef"]],
+                  },
+                  {
+                    kind: "item",
+                    name: "env.valueFrom.fieldRef",
+                    propertyPaths: [["name"], ["valueFrom", "fieldRef"]],
+                  },
+                  {
+                    kind: "item",
+                    name: "env.valueFrom.resourceFieldRef",
+                    propertyPaths: [
+                      ["name"],
+                      ["valueFrom", "resourceFieldRef"],
+                    ],
+                  },
+                  {
+                    kind: "item",
+                    name: "env.valueFrom.secretKeyRef",
+                    propertyPaths: [["name"], ["valueFrom", "secretKeyRef"]],
+                  },
+                ],
+              },
+            ],
           },
         },
         {

--- a/components/si-web-app/src/molecules/ArrayAddEntry.vue
+++ b/components/si-web-app/src/molecules/ArrayAddEntry.vue
@@ -1,0 +1,270 @@
+<template>
+  <div
+    class="relative w-auto menu-root"
+    @mouseleave="onMouseLeave"
+    @mouseenter="cancelClose"
+  >
+    <button @click="clickButton">
+      <PlusIcon size="1x" />
+    </button>
+
+    <ArrayAddEntryCategory
+      :isOpen="isOpen"
+      :menuItems="menuItems"
+      rootMenu
+      class="menu-root"
+      @selected="onSelect"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import _ from "lodash";
+import { PlusIcon } from "vue-feather-icons";
+import { EditField, OpSet, OpType, OpSource } from "si-entity/dist/siEntity";
+import { EditPartial } from "si-registry/dist/registryEntry";
+import { Entity } from "@/api/sdf/model/entity";
+import { emitEditorErrorMessage } from "@/atoms/PanelEventBus";
+import { updateEntity } from "@/observables";
+import ArrayAddEntryCategory from "./ArrayAddEntry/ArrayAddEntryCategory.vue";
+
+interface Data {
+  isOpen: boolean;
+}
+
+const debounceIsOpen = _.debounce((component: any, isOpen: boolean) => {
+  component.isOpen = isOpen;
+}, 500);
+
+export default Vue.extend({
+  name: "ArrayAddEntry",
+  components: {
+    ArrayAddEntryCategory,
+    PlusIcon,
+  },
+  props: {
+    entity: {
+      type: Object as PropType<Entity>,
+      required: true,
+    },
+    editField: {
+      type: Object as PropType<EditField>,
+      required: true,
+    },
+    systemId: {
+      type: String,
+    },
+    items: {
+      type: Array as PropType<EditField[][]>,
+      required: true,
+    },
+  },
+  data(): Data {
+    return {
+      isOpen: false,
+    };
+  },
+  computed: {
+    menuItems(): EditPartial[] | undefined {
+      if (
+        this.editField.schema.type == "array" &&
+        this.editField.schema.itemProperty.type == "object"
+      ) {
+        return this.editField.schema.itemProperty.editPartials;
+      } else {
+        return undefined;
+      }
+    },
+    hasEditPartials(): boolean {
+      if (this.menuItems) {
+        return true;
+      } else {
+        return false;
+      }
+    },
+  },
+  methods: {
+    clickButton(): void {
+      if (this.hasEditPartials) {
+        this.toggleOpen();
+      } else {
+        this.addItem();
+      }
+    },
+    toggleOpen(): void {
+      this.isOpen = !this.isOpen;
+    },
+    onSelect(name: string, event: MouseEvent): void {
+      event.preventDefault();
+      this.$emit("selected", name, event);
+      this.isOpen = false;
+      this.addItemEditPartial(name);
+    },
+    onMouseLeave(): void {
+      if (this.menuItems) {
+        debounceIsOpen(this, false);
+      }
+    },
+    cancelClose(): void {
+      if (this.menuItems) {
+        debounceIsOpen.cancel();
+      }
+    },
+    arrayEditFields(): EditField[] {
+      if (this.entity) {
+        let nextIndex = this.nextIndex();
+        return this.entity.arrayEditFields(this.editField, nextIndex);
+      } else {
+        return [];
+      }
+    },
+    nextIndex(): number {
+      let fullPath = [this.entity.entityType].concat(this.editField.path);
+      let arrayMetaKey = this.entity.pathToString(fullPath);
+      let arrayLength = this.entity.arrayMeta[arrayMetaKey]?.length;
+      if (!arrayLength) {
+        arrayLength = 0;
+      }
+      return arrayLength;
+    },
+    pathRoot(): string[] {
+      let path = _.cloneDeep(this.editField.path);
+      const nextIndex = this.nextIndex();
+      path.push(`${nextIndex}`);
+      return path;
+    },
+    propertyPathPrefixes(
+      name: string,
+      pathRoot: string[],
+      menuItems?: EditPartial[],
+    ): string[][] | null {
+      if (!menuItems) {
+        menuItems = this.menuItems;
+      }
+      if (!menuItems) {
+        return null;
+      }
+
+      for (const editPartial of menuItems) {
+        if (editPartial.kind == "item") {
+          if (editPartial.name == name) {
+            return editPartial.propertyPaths.map(e => pathRoot.concat(e));
+          }
+        } else {
+          const result = this.propertyPathPrefixes(
+            name,
+            pathRoot,
+            editPartial.items,
+          );
+          if (result) {
+            return result;
+          }
+        }
+      }
+      return null;
+    },
+    addItem() {
+      this.$emit("add-item-edit-fields", this.arrayEditFields());
+      this.setRootOp();
+    },
+    addItemEditPartial(name: string) {
+      const entity = this.entity;
+      const pathRoot = this.pathRoot();
+      const pathPrefixes = this.propertyPathPrefixes(name, pathRoot);
+      if (!pathPrefixes) {
+        // TODO(fnichol): handle!
+        throw new Error(
+          "there should be property path prefixes--you messed up",
+        );
+      }
+      const arrayEditFields = _.filter(this.arrayEditFields(), function(
+        editField,
+      ) {
+        return _.some(pathPrefixes, function(prefix) {
+          return entity.subPath(editField.path, prefix);
+        });
+      });
+      this.$emit("add-item-edit-fields", arrayEditFields);
+      this.setRootOp(name);
+    },
+    setRootOp(editPartial?: string) {
+      const path = this.pathRoot();
+      let value: unknown = "";
+      if (this.editField.schema.type == "array") {
+        if (this.editField.schema.itemProperty.type == "string") {
+          value = "";
+        } else if (this.editField.schema.itemProperty.type == "number") {
+          value = 0;
+        } else if (this.editField.schema.itemProperty.type == "boolean") {
+          value = false;
+        } else if (this.editField.schema.itemProperty.type == "object") {
+          value = {};
+        } else if (this.editField.schema.itemProperty.type == "array") {
+          value = [];
+        } else if (this.editField.schema.itemProperty.type == "map") {
+          value = {};
+        }
+      }
+      const opSet: OpSet = {
+        op: OpType.Set,
+        source: OpSource.Manual,
+        path,
+        // @ts-ignore
+        value: _.cloneDeep(value),
+        system: this.systemId,
+      };
+      if (editPartial) {
+        opSet.editPartial = editPartial;
+      }
+      const result = this.entity.addOpSet(opSet);
+      if (!result.success) {
+        emitEditorErrorMessage(result.errors.join("\n"));
+      }
+      this.entity.computeProperties();
+      updateEntity(this.entity).subscribe(reply => {
+        if (reply.error) {
+          emitEditorErrorMessage(reply.error.message);
+        }
+      });
+    },
+  },
+});
+</script>
+
+<style>
+.menu-root {
+  z-index: 999;
+}
+
+.menu {
+  background-color: #2d3748;
+  border-color: #485359;
+}
+
+.menu-selected {
+  background-color: #edf2f8;
+  color: #000000;
+}
+
+.menu-not-selected {
+  color: red;
+}
+
+.options {
+  background-color: #1f2631;
+  border-color: #485359;
+}
+.options:hover {
+  background-color: #3d4b62;
+  border-color: #454d3e;
+}
+
+.menu-category .category-items {
+  /*  visibility: hidden; */
+  position: absolute;
+  left: 100%;
+  top: auto;
+  margin-top: -1.305rem;
+}
+</style>

--- a/components/si-web-app/src/molecules/ArrayAddEntry/ArrayAddEntryCategory.vue
+++ b/components/si-web-app/src/molecules/ArrayAddEntry/ArrayAddEntryCategory.vue
@@ -1,0 +1,97 @@
+<template>
+  <ul :class="listClasses" v-show="isOpen && menuItems">
+    <template v-for="item in menuItems">
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category whitespace-nowrap"
+        v-if="item.kind == 'category'"
+        @mouseenter="open(item.name)"
+        @mouseleave="close(item.name)"
+        :key="item.name"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.name }}
+        </div>
+        <ArrayAddEntryCategory
+          :menuItems="item.items"
+          :isOpen="isCategoryOpen(item.name)"
+          @selected="selectedType"
+        />
+      </li>
+      <li
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
+        v-if="item.kind == 'item'"
+        :key="item.name"
+        @click="selectedType(item.name, $event)"
+      >
+        <div class="whitespace-no-wrap">
+          {{ item.name }}
+        </div>
+      </li>
+    </template>
+  </ul>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import { EditPartial } from "si-registry/dist/registryEntry";
+
+interface Data {
+  openCategories: {
+    [category: string]: boolean;
+  };
+}
+
+export default Vue.extend({
+  name: "ArrayAddEntryCategory",
+  props: {
+    menuItems: {
+      type: Array as PropType<EditPartial[]>,
+    },
+    rootMenu: { type: Boolean, default: false },
+    isOpen: { type: Boolean },
+  },
+  data(): Data {
+    return {
+      openCategories: {},
+    };
+  },
+  computed: {
+    listClasses(): Record<string, boolean> {
+      if (this.rootMenu) {
+        return {
+          absolute: true,
+          "w-auto": true,
+          "text-gray-200": true,
+          border: true,
+          "shadow-md": true,
+          options: true,
+          inline: true,
+        };
+      } else {
+        return {
+          relative: true,
+          "w-auto": true,
+          border: true,
+          "shadow-md": true,
+          "category-items": true,
+          options: true,
+        };
+      }
+    },
+  },
+  methods: {
+    selectedType(name: string, event: MouseEvent) {
+      this.$emit("selected", name, event);
+    },
+    open(category: string): void {
+      Vue.set(this.openCategories, category, true);
+    },
+    close(category: string): void {
+      Vue.set(this.openCategories, category, false);
+    },
+    isCategoryOpen(category: string): boolean {
+      return this.openCategories[category];
+    },
+  },
+});
+</script>


### PR DESCRIPTION
This feature is to support the ability for a user to select a custom
"view" or subset of an object when adding Kubernetes environment entries
in a Deployment/StatefulSet/DaemonSet. The Kubernetes specification for
these environment variable entries to be one of 5 possible kinds (where
each kind refers to the source of the value):

* manually setting the `value` field with a value
* pulling the value from a deployed `ConfigMap`, at a specific key
* pulling the value from a field of the pod spec itself, for example
  from the `metadata.name`, `metadata.annotations[KEY]`, etc (see the
  spec for more details)
* pulling the value from the resources of the container, such as
  `limits.cpu`, `requests.memory`, etc.
* pulling the value a deployed `SecretKey`, at a specific key

As each of these value sources are mutually exclusive--that is, it is
semantically invalid to populate both the `value` field and the
`valuFrom.configMapRef` object for example--it would be beneficial to
only display one of these potential "views" at each array entry. That is
what this change allows for.

The registry schema has been extended in a limited way, by adding an
optional `editPartials` entry on `PropObject`s (and by extention
`PropObjectItem`s), which allow a schema author to describe zero or more
edit partials which have a name and a set of property paths that are
paths relative to the targeted object. These edit partials can be
grouped under zero or more categories which allow for tree-like
organization, similar to the add menu categories. Currently, edit
partials are only used in edit mode in the attribute viewer and *not* in
read-only mode. If the type of partial currently being used wants to be
changed by an end user, they will have to delete the old entry and add a
new entry with the different partial type. This shouldn't be a problem
in practice as the Kubernetes spec describes environment variables as an
array of entries (as opposed to a map/hash/directory), so presumably the
last entry "wins" over old ones, even if there are 2 or more entries
corresponding to the same name.

References: improve the ux of adding container environment [ch1495]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>