### PR TITLE
chore(otelcol): use probabilistic sampling

### DIFF
--- a/components/otelcol/Dockerfile
+++ b/components/otelcol/Dockerfile
@@ -1,3 +1,3 @@
 ARG VERSION
-FROM otel/opentelemetry-collector:$VERSION
+FROM otel/opentelemetry-collector-contrib:$VERSION
 COPY config.yaml /etc/otel/config.yaml

--- a/components/otelcol/config.yaml
+++ b/components/otelcol/config.yaml
@@ -6,6 +6,9 @@ receivers:
 
 processors:
   batch:
+  probabilistic_sampler:
+    sampling_percentage: 10
+    hash_seed: 42
 
 exporters:
   logging:
@@ -25,7 +28,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [probabilistic_sampler, batch]
       exporters: [logging, otlp]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
This PR switches us from the build of otelcol that doesn't have any of
the contributed extensions to the one that has all of them. It also
enables a 10% sample rate, with a seed of 42.

Because its good to find enlightenment where you can, yes?