### PR TITLE
build(deps): update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -1665,9 +1665,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -2401,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"
@@ -2511,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2566,18 +2566,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2621,9 +2621,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2834,7 +2834,8 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 [[package]]
 name = "tracing"
 version = "0.1.26"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
  "log",
@@ -2846,7 +2847,8 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.15"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2856,7 +2858,8 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.19"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -2874,7 +2877,8 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.1.2"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -2884,7 +2888,8 @@ dependencies = [
 [[package]]
 name = "tracing-opentelemetry"
 version = "0.15.0"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -2896,7 +2901,8 @@ dependencies = [
 [[package]]
 name = "tracing-serde"
 version = "0.1.2"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde 1.0.130",
  "tracing-core",
@@ -2905,7 +2911,8 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.2.20"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=326d74f280a4394b4696a8137eb08f53ad626c8e#326d74f280a4394b4696a8137eb08f53ad626c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2978,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "uname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,3 @@ members = [
   "components/si-model",
   "components/si-model-test",
 ]
-
-[patch.crates-io]
-# pending next release of `tracing-subscriber`, post-0.2.19
-# git rev is current commit in the `v0.1.x` branch
-tracing = { git = "https://github.com/tokio-rs/tracing.git", rev = "326d74f280a4394b4696a8137eb08f53ad626c8e" }
-tracing-opentelemetry = { git = "https://github.com/tokio-rs/tracing.git", rev = "326d74f280a4394b4696a8137eb08f53ad626c8e" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing.git", rev = "326d74f280a4394b4696a8137eb08f53ad626c8e" }


### PR DESCRIPTION
* clap remains un-upgraded pending some breaking change work
* tungstenite remains un-upgraded, pending a release of
  toktio-tungstenite

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>