### PR TITLE
fix(ci): remove GH actions varible in `paths` entries

### DIFF
--- a/.github/workflows/release-si-sdf.yml
+++ b/.github/workflows/release-si-sdf.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - .github/workflows/${{ github.workflow }}.yml
+      - .github/workflows/release-si-sdf.yml
       - .Cargo.*
       - .cargo/**
       - components/si-data/**

--- a/.github/workflows/release-si-veritech.yml
+++ b/.github/workflows/release-si-veritech.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - .github/workflows/${{ github.workflow }}.yml
+      - .github/workflows/release-si-veritech.yml
       - .prettierrc.js
       - Makefile
       - babel.config.js

--- a/.github/workflows/release-si-web.yml
+++ b/.github/workflows/release-si-web.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - .github/workflows/${{ github.workflow }}.yml
+      - .github/workflows/release-si-web.yml
       - .prettierrc.js
       - babel.config.js
       - components/si-entity/**


### PR DESCRIPTION
It appears as though the `${{ github.workflow }}` expression is not
allowed in the `on.push.paths` array entries, despite the act tooling
being cool with it.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>