### PR TITLE
feat(cyclone): add optional watch endpoint to monitor server activeness

### DIFF
--- a/components/si-cyclone/src/bin/cyclone/args.rs
+++ b/components/si-cyclone/src/bin/cyclone/args.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, net::SocketAddr, path::PathBuf};
+use std::{convert::TryFrom, net::SocketAddr, path::PathBuf, time::Duration};
 
 use clap::{AppSettings, ArgSettings, Clap};
 use si_cyclone::server::{Config, ConfigError, IncomingStream};
@@ -32,6 +32,18 @@ pub(crate) struct Args {
     /// Binds service to a unix domain socket [example: /var/run/cyclone.sock]
     #[clap(long, group = "bind")]
     pub(crate) bind_uds: Option<PathBuf>,
+
+    /// Enables active/watch behavior.
+    #[clap(long, group = "watch")]
+    pub(crate) enable_watch: bool,
+
+    /// Disables active/watch behavior.
+    #[clap(long, group = "watch")]
+    pub(crate) disable_watch: bool,
+
+    /// Active/watch timeout in seconds.
+    #[clap(long, default_value = "10")]
+    pub(crate) watch_timeout: u64,
 
     /// Enables ping endpoint.
     #[clap(long, group = "ping")]
@@ -73,6 +85,12 @@ impl TryFrom<Args> for Config {
         }
         if let Some(pathbuf) = args.bind_uds {
             builder.incoming_stream(IncomingStream::UnixDomainSocket(pathbuf));
+        }
+
+        if args.enable_watch {
+            builder.watch(Some(Duration::from_secs(args.watch_timeout)));
+        } else if args.disable_watch {
+            builder.watch(None);
         }
 
         if args.enable_ping {

--- a/components/si-cyclone/src/server.rs
+++ b/components/si-cyclone/src/server.rs
@@ -13,3 +13,4 @@ mod server;
 pub mod telemetry;
 pub(crate) mod tower;
 mod uds;
+pub mod watch;

--- a/components/si-cyclone/src/server/config.rs
+++ b/components/si-cyclone/src/server/config.rs
@@ -1,6 +1,7 @@
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use derive_builder::Builder;
@@ -22,6 +23,9 @@ type Result<T> = std::result::Result<T, ConfigError>;
 
 #[derive(Debug, Builder)]
 pub struct Config {
+    #[builder(default)]
+    watch: Option<Duration>,
+
     #[builder(default = "false")]
     enable_ping: bool,
 
@@ -43,6 +47,11 @@ impl Config {
     #[must_use]
     pub fn builder() -> ConfigBuilder {
         ConfigBuilder::default()
+    }
+
+    /// Gets a reference to the config's watch.
+    pub fn watch(&self) -> Option<Duration> {
+        self.watch
     }
 
     /// Gets a reference to the config's enable ping.

--- a/components/si-cyclone/src/server/watch.rs
+++ b/components/si-cyclone/src/server/watch.rs
@@ -1,0 +1,79 @@
+use std::time::Duration;
+
+use axum::extract::ws::WebSocket;
+use thiserror::Error;
+use tokio::{sync::mpsc, time};
+use tracing::{info, trace, warn};
+
+use super::server::ShutdownSource;
+use crate::server::WebSocketMessage;
+
+pub fn run(keepalive_tx: mpsc::Sender<()>, timeout: Duration) -> WatchRun {
+    WatchRun {
+        keepalive_tx,
+        timeout,
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum WatchError {
+    #[error("failed to send server keepalive")]
+    Mpsc(#[from] mpsc::error::SendError<()>),
+    #[error("failed to send websocket message")]
+    WSSendIO(#[from] axum::Error),
+}
+
+type Result<T> = std::result::Result<T, WatchError>;
+
+#[derive(Debug)]
+pub struct WatchRun {
+    keepalive_tx: mpsc::Sender<()>,
+    timeout: Duration,
+}
+
+impl WatchRun {
+    pub async fn start(self, ws: &mut WebSocket) -> Result<()> {
+        let mut heartbeat_interval = time::interval(
+            self.timeout
+                .checked_div(3)
+                .expect("only fails when arg is 0"),
+        );
+        let msg = vec![];
+
+        loop {
+            let _instant = heartbeat_interval.tick().await;
+
+            trace!("sending server keepalive");
+            self.keepalive_tx.send(()).await?;
+            trace!("sending websocket ping");
+            ws.send(WebSocketMessage::Ping(msg.clone())).await?;
+        }
+    }
+}
+
+pub async fn watch_timeout_task(
+    watch_timeout: Duration,
+    shutdown_tx: mpsc::Sender<ShutdownSource>,
+    mut keepalive_rx: mpsc::Receiver<()>,
+) {
+    loop {
+        match time::timeout(watch_timeout, keepalive_rx.recv()).await {
+            Ok(Some(_)) => {
+                // Got a keepalive
+                trace!("watch_timeout_task got keepalive");
+            }
+            Ok(None) | Err(_) => {
+                // Timeout has elapsed
+                info!("watch_timeout_task timeout elapsed");
+                if shutdown_tx
+                    .send(ShutdownSource::WatchTimeout)
+                    .await
+                    .is_err()
+                {
+                    warn!("failed to send shutdown, receiver has already dropped");
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds an opt-in `/watch` WebSocket endpoint which actively
re-sets a shutdown timer. As long as a client has an active `/watch`
request open, the server will keep running. If a client is not connected
to `/watch` for a period longer than `--watch-timeout`, then the server
performs a graceful shutdown.

With this addition, veritech will be able to manage a fleet of cyclone
instances running with the following args:

```sh
cyclone \
    --oneshot --enable-watch --watch-timeout 12 --enable-resolver \
    --lang-server ...
```

which will run a cyclone instance until either 1 function resolver
execution is requested *or* a client has failed to check in with a
`/watch` session for longer than 12 seconds.

---

This behavior can be trialed by building `si-lang-js`, and in the
`components/si-cyclone` directory running:

```sh
env SI_LOG=info,si_cyclone=trace cargo run -- \
  --lang-server ../si-lang-js/target/si-lang-js \
  --limit-requests 3 --enable-watch --watch-timeout 5 \
  --enable-ping
```

then in another terminal, using the `websocat` CLI tool
(https://github.com/vi/websocat), run:

```sh
websocat -E -v ws://localhost:8080/watch
```

which will keep a watch session active. You can see cyclone emitting
trace logging with keepalive details. Then in a third terminal, run:

```sh
websocat -E ws://localhost:8080/execute/ping
```

to execute one request. You will see cyclone emitting trace logging with
the requests remaining details. Running this command 2 more times will
drain the remaining requests and gracefully terminate the cyclone
server. Finally, try running the cyclone server without starting a
client `/watch` session and watch cyclone timeout and gracefully
shut down.

Cool.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>