### PR TITLE
chore(cyclone,veritech): enable no features by default

### DIFF
--- a/cmd/cyclone/Cargo.toml
+++ b/cmd/cyclone/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "3.0.0-beta.4" }
 color-eyre = { version = "0.5.11" }
-cyclone = { path = "../../pkg/cyclone", default-features = false, features = ["server"] }
+cyclone = { path = "../../pkg/cyclone", features = ["server"] }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }
 

--- a/cmd/veritech/Cargo.toml
+++ b/cmd/veritech/Cargo.toml
@@ -14,7 +14,7 @@ color-eyre = { version = "0.5.11" }
 # TODO(fnichol): I *think* we can boil this off?
 si-settings = { path = "../../components/si-settings" }
 tokio = { version = "1.12.0", features = ["full"] }
-veritech = { path = "../../pkg/veritech", default-features = false, features = ["server"] }
+veritech = { path = "../../pkg/veritech", features = ["server"] }
 
 # TODO(fnichol): extract into `pkg/telemetry`
 opentelemetry = { version = "0.16.0", features = ["rt-tokio", "trace"] }

--- a/components/deadpool-cyclone/Cargo.toml
+++ b/components/deadpool-cyclone/Cargo.toml
@@ -12,7 +12,7 @@ deadpool = { version = "0.9.0", features = ["rt_tokio_1"] }
 derive_builder = { version = "0.10.2" }
 futures = { version = "0.3.17" }
 nix = { version = "0.23.0" }
-cyclone = { path = "../../pkg/cyclone", default-features = false, features = ["client"] }
+cyclone = { path = "../../pkg/cyclone", features = ["client"] }
 tempfile = { version = "3.2.0" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/pkg/cyclone/Cargo.toml
+++ b/pkg/cyclone/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
-# TODO(fnichol): remove "client" feature from default
-default = ["client", "server"]
+# By default, no features are enabled--consumers of this crate need to opt-in
+# to the features they desire.
+default = []
 
+# The client implementation for a cyclone server.
 client = [
   "async-trait",
   "futures-lite",
@@ -18,6 +18,7 @@ client = [
   "tokio-tungstenite",
 ]
 
+# The server side implementation of cyclone, as a library.
 server = [
   "axum",
   "bytes-lines-codec",

--- a/pkg/veritech/Cargo.toml
+++ b/pkg/veritech/Cargo.toml
@@ -5,18 +5,21 @@ edition = "2021"
 rust-version = "1.56"
 
 [features]
-# TODO(fnichol): remove "client" feature from default
-default = ["client", "server"]
+# By default, no features are enabled--consumers of this crate need to opt-in
+# to the features they desire.
+default = []
 
+# The client implementation for a veritech service.
 client = []
 
+# The server side implementation of veritech, as a library.
 server = [
   "derive_builder",
   "futures-lite",
 ]
 
 [dependencies]
-# server and client
+# server and client dependencies
 futures = { version = "0.3.17"}
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
@@ -29,8 +32,6 @@ tokio = { version = "1.2.0", features = ["full"] }
 toml = "0.5"
 tracing = { version = "0.1" }
 
-# client only
-
-# server only
+# server only dependencies
 derive_builder = { version = "0.10.2", optional = true }
 futures-lite = { version = "1.12.0", optional = true }


### PR DESCRIPTION
This change ensures that consumers of both the cyclone and veritech
crates have to explicitly opt-in to either the `client` or `server`
features (or both).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>