### PR TITLE
chore(rust): add `publish = false` to all private crates

### DIFF
--- a/cmd/cyclone/Cargo.toml
+++ b/cmd/cyclone/Cargo.toml
@@ -3,6 +3,7 @@ name = "cyclone-cli"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
+publish = false
 
 [[bin]]
 name = "cyclone"

--- a/cmd/veritech/Cargo.toml
+++ b/cmd/veritech/Cargo.toml
@@ -3,6 +3,7 @@ name = "veritech-cli"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
+publish = false
 
 [[bin]]
 name = "veritech"

--- a/components/si-data/Cargo.toml
+++ b/components/si-data/Cargo.toml
@@ -3,6 +3,7 @@ name = "si-data"
 version = "0.1.0"
 authors = ["Adam Jacob <adam@systeminit.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/si-model/Cargo.toml
+++ b/components/si-model/Cargo.toml
@@ -3,6 +3,7 @@ name = "si-model"
 version = "0.1.0"
 authors = ["Adam Jacob <adam@systeminit.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/si-sdf/Cargo.toml
+++ b/components/si-sdf/Cargo.toml
@@ -3,6 +3,7 @@ name = "si-sdf"
 version = "0.1.0"
 authors = ["Adam Jacob <adam@systeminit.com>"]
 edition = "2018"
+publish = false
 default-run = "si-sdf-server"
 
 [[bin]]

--- a/components/si-settings/Cargo.toml
+++ b/components/si-settings/Cargo.toml
@@ -3,6 +3,7 @@ name = "si-settings"
 version = "0.1.0"
 authors = ["Adam Jacob <adam@systeminit.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 config = { version = "0.11", features = ["toml"] }

--- a/pkg/cyclone/Cargo.toml
+++ b/pkg/cyclone/Cargo.toml
@@ -3,6 +3,7 @@ name = "cyclone"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
+publish = false
 
 [features]
 # By default, no features are enabled--consumers of this crate need to opt-in

--- a/pkg/deadpool-cyclone/Cargo.toml
+++ b/pkg/deadpool-cyclone/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-cyclone"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pkg/veritech/Cargo.toml
+++ b/pkg/veritech/Cargo.toml
@@ -3,6 +3,7 @@ name = "veritech"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
+publish = false
 
 [features]
 # By default, no features are enabled--consumers of this crate need to opt-in


### PR DESCRIPTION
This is a safety feature with disallows accidental publishing of System
Initiative-proprietary code to Crates.io.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>