### PR TITLE
chore(sdf): prepare new crates for server updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,8 +25,9 @@ A-cyclone:
   - Cargo.lock
   - rust-toolchain
   - rustfmt.toml
-A-si-sdf:
-  - components/si-sdf/**/*
+A-sdf:
+  - cmd/sdf/**/*
+  - pkg/sdf/**/*
   - .cargo/**/*
   - Cargo.lock
   - rust-toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdf"
+version = "0.1.0"
+
+[[package]]
+name = "sdf-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "sdf",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,19 @@ debug = true
 [workspace]
 members = [
   "cmd/cyclone",
+  "cmd/sdf",
   "cmd/veritech",
   "components/si-data",
   "components/si-model",
-  "components/si-sdf",
   "components/si-settings",
   "pkg/bytes-lines-codec",
   "pkg/cyclone",
   "pkg/deadpool-cyclone",
+  "pkg/sdf",
   "pkg/veritech",
+
+  # TODO(fnichol): remove when fully deprecated
+  "components/si-sdf",
 ]
 
 [patch.crates-io]

--- a/cmd/sdf/Cargo.toml
+++ b/cmd/sdf/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sdf-cli"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.56"
+publish = false
+
+[[bin]]
+name = "sdf"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "3.0.0-beta.4" }
+color-eyre = { version = "0.5.11" }
+sdf = { path = "../../pkg/sdf" }
+tokio = { version = "1.12.0", features = ["full"] }
+
+# TODO(fnichol): extract into `pkg/telemetry`
+opentelemetry = { version = "0.16.0", features = ["rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.9.0" }
+opentelemetry-semantic-conventions = { version = "0.8.0" }
+thiserror = { version = "1.0" }
+tracing = { version = "0.1" }
+tracing-opentelemetry = { version = "0.15.0" }
+tracing-subscriber = { version = "0.2.19" }

--- a/cmd/sdf/src/args.rs
+++ b/cmd/sdf/src/args.rs
@@ -1,0 +1,25 @@
+use clap::{AppSettings, Clap};
+
+/// Parse, validate, and return the CLI arguments as a typed struct.
+pub(crate) fn parse() -> Args {
+    Args::parse()
+}
+
+/// The System Initiative API service.
+///
+/// Super Dimension Fortress (SDF) is the central and primary API surface which handles front end
+/// calls and dispatches function executions, among other great things.
+#[derive(Clap, Debug)]
+#[clap(
+    name = "sdf",
+    global_setting = AppSettings::ColoredHelp,
+    global_setting = AppSettings::UnifiedHelpMessage,
+    max_term_width = 100,
+)]
+pub(crate) struct Args {
+    /// Sets the verbosity mode.
+    ///
+    /// Multiple -v options increase verbosity. The maximum is 4.
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
+    pub(crate) verbose: usize,
+}

--- a/cmd/sdf/src/main.rs
+++ b/cmd/sdf/src/main.rs
@@ -1,0 +1,17 @@
+use color_eyre::Result;
+use tracing::debug;
+
+mod args;
+mod telemetry;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    telemetry::init()?;
+    let args = args::parse();
+    debug!(arguments = ?args);
+
+    println!("Hello, world!");
+
+    Ok(())
+}

--- a/cmd/sdf/src/telemetry.rs
+++ b/cmd/sdf/src/telemetry.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use opentelemetry::{
+    global,
+    sdk::{
+        propagation::TraceContextPropagator,
+        resource::{EnvResourceDetector, OsResourceDetector, ProcessResourceDetector},
+        trace::{self, Tracer},
+        Resource,
+    },
+    trace::TraceError,
+};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_semantic_conventions::resource;
+use thiserror::Error;
+use tracing_subscriber::{prelude::*, util::TryInitError, Registry};
+
+#[derive(Debug, Error)]
+pub enum InitError {
+    #[error("{0}")]
+    Trace(#[from] TraceError),
+    #[error("{0}")]
+    TryInit(#[from] TryInitError),
+}
+
+type Result<T> = std::result::Result<T, InitError>;
+
+pub fn init() -> Result<()> {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    tracing_subscriber()?.try_init()?;
+    Ok(())
+}
+
+pub fn tracing_subscriber() -> Result<impl tracing::Subscriber + Send + Sync> {
+    Ok(Registry::default()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_env("SI_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true),
+        )
+        .with(tracing_opentelemetry::layer().with_tracer(try_tracer()?)))
+}
+
+fn try_tracer() -> std::result::Result<Tracer, TraceError> {
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_env())
+        .with_trace_config(trace::config().with_resource(telemetry_resource()))
+        .install_batch(opentelemetry::runtime::Tokio)
+}
+
+fn telemetry_resource() -> Resource {
+    // TODO(fnichol): create opentelemetry-resource-detector-aws for ec2 & eks detection
+    Resource::from_detectors(
+        Duration::from_secs(3),
+        vec![
+            Box::new(EnvResourceDetector::new()),
+            Box::new(OsResourceDetector),
+            Box::new(ProcessResourceDetector),
+        ],
+    )
+    .merge(&Resource::new(vec![
+        resource::SERVICE_NAME.string(env!("CARGO_PKG_NAME")),
+        resource::SERVICE_VERSION.string(env!("CARGO_PKG_VERSION")),
+        resource::SERVICE_NAMESPACE.string("si"),
+    ]))
+}

--- a/pkg/sdf/Cargo.toml
+++ b/pkg/sdf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sdf"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.56"
+publish = false
+
+[dependencies]

--- a/pkg/sdf/src/lib.rs
+++ b/pkg/sdf/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
SDF breaks down into 2 primary crates:

- `pkg/sdf`: currently only the server implementation, as a library
- `cmd/sdf`: the program/CLI implementation of SDF

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>