### PR TITLE
chore: update tunable/config'able nats pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,16 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dae854440faecce70f0664f41f09a588de1e7a4366931ec3962ded3d8f903c5"
-dependencies = [
- "blocking",
- "nats",
-]
-
-[[package]]
 name = "async-recursion"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,12 +1707,14 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.10.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cfa3903c3e613edddaa4a2f86b2053a1d6fbcf315a3ff352c25ba9f0a8585"
+checksum = "2a3097b182107db2cf690280d61f23f17ee31d49f3994ad152ee6a10261f77c3"
 dependencies = [
  "base64",
  "base64-url",
+ "blocking",
+ "chrono",
  "crossbeam-channel",
  "fastrand",
  "itoa",
@@ -1737,6 +1729,8 @@ dependencies = [
  "regex",
  "rustls",
  "rustls-native-certs",
+ "serde",
+ "serde_json",
  "webpki",
  "winapi",
 ]
@@ -2837,12 +2831,16 @@ dependencies = [
 name = "si-data"
 version = "0.1.0"
 dependencies = [
- "async-nats",
  "bytes",
+ "crossbeam-channel",
  "deadpool 0.8.2",
  "deadpool-postgres",
+ "futures",
  "lazy_static",
+ "nats",
+ "nkeys",
  "num_cpus",
+ "opentelemetry",
  "refinery",
  "serde",
  "serde_json",
@@ -2851,7 +2849,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tokio-test",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3619,6 +3619,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "futures-lite",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "si-data",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -20,7 +20,7 @@ refinery = "0.6.0"
 reqwest = { version = "0.11.1", default-features = false, features = ["json"] }
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
-si-data = { path = "../../lib/si-data" }
+si-data = { path = "../../lib/si-data", features = ["nats", "pg"] }
 veritech = { path = "../../lib/veritech", features = ["client"] }
 sodiumoxide = "0.2.6"
 strum = "0.21.0"

--- a/lib/dal/src/billing_account.rs
+++ b/lib/dal/src/billing_account.rs
@@ -6,7 +6,7 @@ use crate::{
     Timestamp, User, UserError, Visibility, Workspace, WorkspaceError,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use thiserror::Error;
 
 const BILLING_ACCOUNT_GET_BY_NAME: &str = include_str!("./queries/billing_account_get_by_name.sql");
@@ -18,7 +18,7 @@ pub enum BillingAccountError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/capability.rs
+++ b/lib/dal/src/capability.rs
@@ -4,7 +4,7 @@ use crate::{
     Timestamp, Visibility,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -14,7 +14,7 @@ pub enum CapabilityError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/group.rs
+++ b/lib/dal/src/group.rs
@@ -5,7 +5,7 @@ use crate::{
     Timestamp, User, UserId, Visibility,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -15,7 +15,7 @@ pub enum GroupError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -7,7 +7,7 @@ use crate::{
     HistoryEventError, StandardModel, StandardModelError, Tenancy, Timestamp, Visibility,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use sodiumoxide::crypto::box_::{self, PublicKey as BoxPublicKey, SecretKey as BoxSecretKey};
 use thiserror::Error;
 
@@ -20,7 +20,7 @@ pub enum KeyPairError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -43,7 +43,7 @@ pub use user::{User, UserClaim, UserError, UserId, UserResult};
 pub use visibility::{Visibility, VisibilityError};
 pub use workspace::{Workspace, WorkspaceError, WorkspaceId, WorkspacePk, WorkspaceResult};
 
-use si_data::{NatsConn, NatsTxnError, PgError, PgPool, PgPoolError};
+use si_data::{NatsClient, NatsError, PgError, PgPool, PgPoolError};
 
 mod embedded {
     use refinery::embed_migrations;
@@ -58,7 +58,7 @@ pub enum ModelError {
     #[error(transparent)]
     Migration(#[from] PgPoolError),
     #[error(transparent)]
-    NatsTxnError(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("database error")]
     PgError(#[from] PgError),
 }
@@ -72,7 +72,7 @@ pub async fn migrate(pg: &PgPool) -> ModelResult<()> {
 }
 
 #[instrument(skip(pg, nats))]
-pub async fn migrate_builtin_schemas(pg: &PgPool, nats: &NatsConn) -> ModelResult<()> {
+pub async fn migrate_builtin_schemas(pg: &PgPool, nats: &NatsClient) -> ModelResult<()> {
     let mut conn = pg.get().await?;
     let txn = conn.transaction().await?;
     let nats = nats.transaction();

--- a/lib/dal/src/organization.rs
+++ b/lib/dal/src/organization.rs
@@ -4,7 +4,7 @@ use crate::{
     StandardModelError, Tenancy, Timestamp, Visibility,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -14,7 +14,7 @@ pub enum OrganizationError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -9,7 +9,7 @@ use jwt_simple::algorithms::RSAKeyPairLike;
 use jwt_simple::claims::Claims;
 use jwt_simple::reexports::coarsetime::Duration;
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use sodiumoxide::crypto::pwhash::argon2id13;
 use sodiumoxide::crypto::secretbox;
 use thiserror::Error;
@@ -25,7 +25,7 @@ pub enum UserError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -4,7 +4,7 @@ use crate::{
     StandardModelError, Tenancy, Timestamp, Visibility,
 };
 use serde::{Deserialize, Serialize};
-use si_data::{NatsTxn, NatsTxnError, PgError, PgTxn};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -14,7 +14,7 @@ pub enum WorkspaceError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("nats txn error: {0}")]
-    NatsTxn(#[from] NatsTxnError),
+    Nats(#[from] NatsError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -34,7 +34,7 @@ impl State {
 #[must_use]
 pub fn routes(
     pg_pool: pg::PgPool,
-    nats: nats::NatsConn,
+    nats: nats::Client,
     jwt_signing_key: JwtSigningKey,
     shutdown_tx: mpsc::Sender<ShutdownSource>,
 ) -> Router {
@@ -68,9 +68,9 @@ pub fn test_routes(mut router: Router) -> Router {
 #[derive(Debug, Error)]
 pub enum AppError {
     #[error(transparent)]
-    Nats(#[from] si_data::NatsTxnError),
+    Nats(#[from] nats::Error),
     #[error(transparent)]
-    Pg(#[from] si_data::PgError),
+    Pg(#[from] pg::Error),
     #[error(transparent)]
     Server(#[from] ServerError),
 }

--- a/lib/sdf/src/server/service/session.rs
+++ b/lib/sdf/src/server/service/session.rs
@@ -14,7 +14,7 @@ pub mod restore_authentication;
 #[derive(Debug, Error)]
 pub enum SessionError {
     #[error(transparent)]
-    Nats(#[from] si_data::NatsTxnError),
+    Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error(transparent)]

--- a/lib/sdf/src/server/service/signup.rs
+++ b/lib/sdf/src/server/service/signup.rs
@@ -13,7 +13,7 @@ pub mod create_account;
 #[derive(Debug, Error)]
 pub enum SignupError {
     #[error(transparent)]
-    Nats(#[from] si_data::NatsTxnError),
+    Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error("billing account error: {0}")]

--- a/lib/sdf/src/server/service/test.rs
+++ b/lib/sdf/src/server/service/test.rs
@@ -13,7 +13,7 @@ mod signup;
 #[derive(Debug, Error)]
 pub enum TestError {
     #[error(transparent)]
-    Nats(#[from] si_data::NatsTxnError),
+    Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error("billing account error: {0}")]

--- a/lib/si-data/Cargo.toml
+++ b/lib/si-data/Cargo.toml
@@ -1,19 +1,27 @@
 [package]
 name = "si-data"
 version = "0.1.0"
-authors = ["Adam Jacob <adam@systeminit.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+
+event-log-fs = []
+nats = []
+pg = []
 
 [dependencies]
-async-nats = "0.10.1"
 bytes = "1.0.1"
+crossbeam-channel = "0.5.1"
 deadpool = "0.8.1"
 deadpool-postgres = "0.9.0"
+futures = "0.3.17"
 lazy_static = "1.4.0"
+nats-client = { package = "nats", version = "0.15.2" }
 num_cpus = "1.13.0"
+opentelemetry = "0.16.0"
 refinery = { version = "0.6.0", features = ["tokio-postgres", "tokio"] }
 serde = "1.0.123"
 serde_json = "1.0.64"
@@ -23,3 +31,8 @@ thiserror = "1.0.24"
 tokio = { version = "1.2.0", features = ["full"] }
 tokio-postgres = { version ="0.7.0", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
 tracing = "0.1.26"
+
+[dev-dependencies]
+nkeys = "0.1.0"
+tokio-test = "0.4.2"
+tracing-subscriber = { version = "0.2.19" }

--- a/lib/si-data/src/event_log_fs.rs
+++ b/lib/si-data/src/event_log_fs.rs
@@ -82,7 +82,7 @@ impl EventLogFS {
         let log_path = self.active_path.join(basename(event_log_id, stream));
 
         if !is_file(&log_path).await {
-            let _ = fs::File::create(&log_path).await?;
+            let _ignored = fs::File::create(&log_path).await?;
         }
         let file = BufWriter::new(fs::OpenOptions::new().append(true).open(log_path).await?);
 

--- a/lib/si-data/src/lib.rs
+++ b/lib/si-data/src/lib.rs
@@ -1,8 +1,32 @@
+#![warn(
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::missing_panics_doc,
+    clippy::panic_in_result_fn
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::module_inception,
+    clippy::module_name_repetitions
+)]
+
+#[cfg(feature = "event-log-fs")]
 pub mod event_log_fs;
+#[cfg(feature = "event-log-fs")]
 pub use event_log_fs::{EventLogFS, EventLogFSError, OutputLineStream};
+
+#[cfg(feature = "pg")]
 pub mod pg;
+#[cfg(feature = "pg")]
 pub use pg::{Error as PgError, PgPool, PgPoolConfig, PgPoolError, PgTxn};
+
+#[cfg(feature = "nats")]
 pub mod nats;
-pub use nats::{NatsConfig, NatsConn, NatsTxn, NatsTxnError};
+#[cfg(feature = "nats")]
+pub use nats::{Client as NatsClient, Error as NatsError, NatsConfig, NatsTxn};
+
 mod sensitive_string;
 pub use sensitive_string::SensitiveString;
+
+pub mod telemetry;

--- a/lib/si-data/src/nats.rs
+++ b/lib/si-data/src/nats.rs
@@ -1,158 +1,932 @@
-pub use async_nats::{Connection, Message, Subscription};
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use thiserror::Error;
-use tokio::sync::Mutex;
-use tracing::{info_span, instrument, Instrument, Span};
+use std::{fmt::Debug, io, sync::Arc, time::Duration};
 
-#[derive(Error, Debug)]
-pub enum NatsTxnError {
-    #[error("serde error: {0}")]
-    Serialization(#[from] serde_json::Error),
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
+use nats_client as nats;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::{
+    sync::Mutex,
+    task::{self, spawn_blocking},
+};
+use tracing::{debug, field::Empty, instrument, span, Level, Span};
+
+use crate::telemetry::{SpanExt, SpanKind};
+
+pub mod jetstream;
+mod message;
+mod options;
+mod subscription;
+
+pub use message::Message;
+pub use nats::{rustls, Headers};
+pub use options::Options;
+pub use subscription::Subscription;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("async runtime error")]
+    Async(#[from] task::JoinError),
+    #[error("nats client error")]
+    Nats(#[from] io::Error),
+    #[error("error serializing object")]
+    Serialize(#[source] serde_json::Error),
 }
 
-pub type NatsTxnResult<T> = Result<T, NatsTxnError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
 pub struct NatsConfig {
     pub url: String,
 }
 
 impl Default for NatsConfig {
     fn default() -> Self {
-        NatsConfig {
+        Self {
             url: "localhost".to_string(),
         }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct NatsConn {
-    conn: Connection,
+pub struct Client {
+    inner: nats::Connection,
+    metadata: Arc<ConnectionMetadata>,
 }
 
-impl NatsConn {
-    // TODO(fnichol): complete NatsConn instrumentation connection metadata
-    #[instrument(name = "natsconn.new", skip(settings))]
-    pub async fn new(settings: &NatsConfig) -> NatsTxnResult<Self> {
-        let conn = async_nats::connect(&settings.url).await?;
-
-        Ok(Self { conn })
+impl Client {
+    #[instrument(name = "client::new", skip_all)]
+    pub async fn new(config: &NatsConfig) -> Result<Self> {
+        Self::connect_with_options(&config.url, Options::default()).await
     }
 
-    // TODO(fnichol): add some form of `db.transaction` attribute
-    #[instrument(name = "natsconn.transaction", skip(self))]
+    #[instrument(
+        name = "client.transaction",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.transaction = Empty,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+        )
+    )]
     pub fn transaction(&self) -> NatsTxn {
-        NatsTxn::new(self.conn.clone(), Span::current())
+        NatsTxn::new(self.clone(), self.metadata.clone(), Span::current())
     }
 
-    #[instrument(name = "natsconn.subscribe", skip(self, subject))]
-    pub async fn subscribe(&self, subject: &str) -> std::io::Result<Subscription> {
-        self.conn.subscribe(subject).await
+    /// Establish a `Connection` with a NATS server.
+    ///
+    /// Multiple servers may be specified by separating them with commas.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Client::connect_with_options(
+    ///         "demo.nats.io",
+    ///         nats::Options::default(),
+    ///     ).await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    ///
+    /// In the below case, the second server is configured to use TLS but the first one is not.
+    /// Using the `tls_required` method can ensure that all servers are connected to with TLS, if
+    /// that is your intention.
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Client::connect_with_options(
+    ///         "nats://demo.nats.io:4222,tls://demo.nats.io:4443",
+    ///         nats::Options::default(),
+    ///     )
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client::connect_with_options",
+        skip_all,
+        fields(
+            messaging.protocol = Empty,
+            messaging.system = Empty,
+            messaging.url = Empty,
+            net.transport = Empty,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn connect_with_options(
+        nats_url: impl Into<String>,
+        options: Options,
+    ) -> Result<Self> {
+        let nats_url = nats_url.into();
+
+        let mut metadata = ConnectionMetadata {
+            messaging_consumer_id: String::with_capacity(0),
+            messaging_protocol: "nats",
+            messaging_system: "nats",
+            messaging_url: nats_url.clone(),
+            net_transport: "ip_tcp",
+        };
+
+        let span = Span::current();
+        span.record("messaging.protocol", &metadata.messaging_protocol);
+        span.record("messaging.system", &metadata.messaging_system);
+        span.record("messaging.url", &metadata.messaging_url.as_str());
+        span.record("net.transport", &metadata.net_transport);
+
+        let inner = spawn_blocking(move || options.inner.connect(&nats_url))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+        debug!("successfully connected to nats");
+
+        metadata.messaging_consumer_id = inner.client_id().to_string();
+
+        span.record_ok();
+        Ok(Self {
+            inner,
+            metadata: Arc::new(metadata),
+        })
     }
 
-    #[instrument(name = "natsconn.queue_subscribe", skip(self, subject, queue))]
+    /// Create a subscription for the given NATS connection.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let sub = nc.subscribe("foo").await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.subscribe",
+        skip_all,
+        fields(
+            messaging.consumer_id = %self.metadata.messaging_consumer_id,
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "receive",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Consumer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn subscribe(&self, subject: impl Into<String>) -> Result<Subscription> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} process", &subject).as_str());
+        let inner = self.inner.clone();
+        let sub = spawn_blocking(move || inner.subscribe(&subject))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        Ok(Subscription::new(sub, self.metadata.clone(), span))
+    }
+
+    /// Create a queue subscription for the given NATS connection.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let sub = nc.queue_subscribe("foo", "production").await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.queue_subscribe",
+        skip_all,
+        fields(
+            messaging.consumer_id = %self.metadata.messaging_consumer_id,
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "receive",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.subscription.queue = Empty,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Consumer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
     pub async fn queue_subscribe(
         &self,
-        subject: &str,
-        queue: &str,
-    ) -> std::io::Result<Subscription> {
-        self.conn.queue_subscribe(subject, queue).await
+        subject: impl Into<String>,
+        queue: impl Into<String>,
+    ) -> Result<Subscription> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let queue = queue.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("messaging.subscription.queue", &queue.as_str());
+        span.record("otel.name", &format!("{} process", &subject).as_str());
+        let inner = self.inner.clone();
+        let sub = spawn_blocking(move || inner.queue_subscribe(&subject, &queue))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        Ok(Subscription::new(sub, self.metadata.clone(), span))
     }
 
-    #[instrument(name = "natsconn.publish", skip(self))]
-    pub async fn publish(&self, subject: &str, message: &str) -> std::io::Result<()> {
-        self.conn.publish(subject, message).await
+    /// Publish a message on the given subject.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// nc.publish("foo", "Hello World!").await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub async fn publish(&self, subject: impl Into<String>, msg: impl Into<Vec<u8>>) -> Result<()> {
+        self.publish_with_reply_or_headers(subject, None::<String>, None, msg)
+            .await
     }
 
-    #[instrument(name = "natsconn.request_multi", skip(self))]
+    /// Publish a message on the given subject with a reply subject for responses.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let reply = nc.new_inbox();
+    /// let rsub = nc.subscribe(&reply).await?;
+    /// nc.publish_request("foo", &reply, "Help me!").await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.publish_request",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn publish_request(
+        &self,
+        subject: impl Into<String>,
+        reply: impl Into<String>,
+        msg: impl Into<Vec<u8>>,
+    ) -> Result<()> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let reply = reply.into();
+        let msg = msg.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} send", &subject).as_str());
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.publish_request(&subject, &reply, &msg))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Create a new globally unique inbox which can be used for replies.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let reply = nc.new_inbox();
+    /// let rsub = nc.subscribe(&reply).await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn new_inbox(&self) -> String {
+        self.inner.new_inbox()
+    }
+
+    /// Publish a message on the given subject as a request and receive the response.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use futures::{TryStreamExt};
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// # nc.subscribe("foo").await?.try_for_each(|m| async move { m.respond("ans=42").await });
+    /// # nc.subscribe("foo").await?;
+    /// let resp = nc.request("foo", "Help me?").await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.request",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn request(
+        &self,
+        subject: impl Into<String>,
+        msg: impl Into<Vec<u8>>,
+    ) -> Result<Message> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let msg = msg.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} send", &subject).as_str());
+        let inner = self.inner.clone();
+        let msg = spawn_blocking(move || inner.request(&subject, &msg))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(Message::new(msg, self.metadata.clone()))
+    }
+
+    /// Publish a message on the given subject as a request and receive the response.
+    ///
+    /// This call will return after the timeout duration if no response is received.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use futures::{TryStreamExt};
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// # nc.subscribe("foo").await?.try_for_each(|m| async move { m.respond("ans=42").await });
+    /// # nc.subscribe("foo").await?;
+    /// let resp = nc.request_timeout("foo", "Help me?", std::time::Duration::from_secs(2)).await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.request_timeout",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn request_timeout(
+        &self,
+        subject: impl Into<String>,
+        msg: impl Into<Vec<u8>>,
+        timeout: Duration,
+    ) -> Result<Message> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let msg = msg.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} send", &subject).as_str());
+        let inner = self.inner.clone();
+        let msg = spawn_blocking(move || inner.request_timeout(&subject, &msg, timeout))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(Message::new(msg, self.metadata.clone()))
+    }
+
+    /// Publish a message on the given subject as a request and allow multiple responses.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use futures::{TryStreamExt, StreamExt};
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// # nc.subscribe("foo").await?.try_for_each(|m| async move { m.respond("ans=42").await });
+    /// for msg in nc.request_multi("foo", "Help").await?.take(1).next().await {}
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.request_multi",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
     pub async fn request_multi(
         &self,
-        subject: &str,
-        message: &str,
-    ) -> std::io::Result<Subscription> {
-        self.conn.request_multi(subject, message).await
+        subject: impl Into<String>,
+        msg: impl Into<Vec<u8>>,
+    ) -> Result<Subscription> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let sub_span_subject = subject.clone();
+        let msg = msg.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} send", &subject).as_str());
+        let inner = self.inner.clone();
+        let sub = spawn_blocking(move || inner.request_multi(&subject, &msg))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        let sub_span = span!(
+            Level::INFO,
+            "client.request_multi.subscribe",
+            messaging.consumer_id = %self.metadata.messaging_consumer_id,
+            messaging.destination = %sub_span_subject,
+            messaging.destination_kind = "topic",
+            messaging.operation = "receive",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Consumer,
+            otel.name = %format!("{} receive", &sub_span_subject),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        );
+        sub_span.follows_from(&span);
+
+        span.record_ok();
+        Ok(Subscription::new(sub, self.metadata.clone(), sub_span))
+    }
+
+    /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
+    ///
+    /// Will fail with `TimedOut` if the server does not respond with in 10 seconds. Will fail with
+    /// `NotConnected` if the server is not currently connected. Will fail with `BrokenPipe` if the
+    /// connection to the server is lost.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// nc.flush().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.flush",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn flush(&self) -> Result<()> {
+        let span = Span::current();
+
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.flush())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Flush a NATS connection by sending a `PING` protocol and waiting for the responding `PONG`.
+    ///
+    /// Will fail with `TimedOut` if the server takes longer than this duration to respond. Will
+    /// fail with `NotConnected` if the server is not currently connected. Will fail with
+    /// `BrokenPipe` if the connection to the server is lost.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// nc.flush_timeout(std::time::Duration::from_secs(8)).await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.flush_timeout",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn flush_timeout(&self, duration: Duration) -> Result<()> {
+        let span = Span::current();
+
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.flush_timeout(duration))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Close a NATS connection. All clones of this `Connection` will also be closed, as the
+    /// backing IO threads are shared.
+    ///
+    /// If the client is currently connected to a server, the outbound write buffer will be flushed
+    /// in the process of shutting down.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// nc.close().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.close",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn close(self) -> Result<()> {
+        let span = Span::current();
+
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.close())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Calculates the round trip time between this client and the server, if the server is
+    /// currently connected.
+    ///
+    /// Fails with `TimedOut` if the server takes more than 10 seconds to respond.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// println!("server rtt: {:?}", nc.rtt().await);
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.rtt",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn rtt(&self) -> Result<Duration> {
+        let span = Span::current();
+
+        let inner = self.inner.clone();
+        let duration = spawn_blocking(move || inner.rtt())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(duration)
+    }
+
+    /// Returns the client IP as known by the server. Supported as of server version 2.1.6.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// println!("ip: {:?}", nc.client_ip());
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn client_ip(&self) -> Result<std::net::IpAddr> {
+        self.inner.client_ip().map_err(Into::into)
+    }
+
+    /// Returns the client ID as known by the most recently connected server.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// println!("ip: {:?}", nc.client_id());
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn client_id(&self) -> u64 {
+        self.inner.client_id()
+    }
+
+    /// Send an unsubscription for all subs then flush the connection, allowing any unprocessed
+    /// messages to be handled by a handler function if one is configured.
+    ///
+    /// After the flush returns, we know that a round-trip to the server has happened after it
+    /// received our unsubscription, so we shut down the subscriber afterwards.
+    ///
+    /// A similar method exists for the `Subscription` struct which will drain a single
+    /// `Subscription` without shutting down the entire connection afterward.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::sync::{Arc, atomic::{AtomicBool, Ordering::SeqCst}};
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let received = Arc::new(AtomicBool::new(false));
+    /// let received_2 = received.clone();
+    ///
+    /// nc.subscribe("test.drain").await?;
+    ///
+    /// nc.publish("test.drain", "message").await?;
+    /// nc.drain().await?;
+    ///
+    /// # std::thread::sleep(std::time::Duration::from_secs(1));
+    ///
+    /// assert!(received.load(SeqCst));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.drain",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn drain(&self) -> Result<()> {
+        let span = Span::current();
+
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.drain())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Publish a message which may have a reply subject or headers set.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use futures::StreamExt;
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let mut sub = nc.subscribe("foo.headers").await?;
+    /// let headers = [("header1", "value1"),
+    ///                ("header2", "value2")].iter().collect();
+    /// let reply_to = None::<String>;
+    /// nc.publish_with_reply_or_headers(
+    ///     "foo.headers",
+    ///     reply_to,
+    ///     Some(&headers),
+    ///     "Hello World!"
+    /// ).await?;
+    /// nc.flush().await?;
+    /// let message = sub.next().await.unwrap()?;
+    /// assert_eq!(message.headers().unwrap().len(), 2);
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "client.publish_with_reply_or_headers",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn publish_with_reply_or_headers(
+        &self,
+        subject: impl Into<String>,
+        reply: Option<impl Into<String>>,
+        headers: Option<&Headers>,
+        msg: impl Into<Vec<u8>>,
+    ) -> Result<()> {
+        let span = Span::current();
+
+        let subject = subject.into();
+        let headers = headers.map(Headers::clone);
+        let reply = reply.map(Into::into);
+        let msg = msg.into();
+        span.record("messaging.destination", &subject.as_str());
+        span.record("otel.name", &format!("{} send", &subject).as_str());
+        let inner = self.inner.clone();
+        spawn_blocking(move || {
+            inner.publish_with_reply_or_headers(&subject, reply.as_deref(), headers.as_ref(), &msg)
+        })
+        .await
+        .map_err(|err| span.record_err(Error::Async(err)))?
+        .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Returns the maximum payload size the most recently connected server will accept.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// println!("max payload: {:?}", nc.max_payload());
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn max_payload(&self) -> usize {
+        self.inner.max_payload()
     }
 }
 
-impl From<Connection> for NatsConn {
-    fn from(conn: Connection) -> Self {
-        NatsConn { conn }
-    }
+#[derive(Clone, Debug)]
+pub(crate) struct ConnectionMetadata {
+    messaging_consumer_id: String,
+    messaging_protocol: &'static str,
+    messaging_system: &'static str,
+    messaging_url: String,
+    net_transport: &'static str,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct NatsTxn {
-    pub connection: Connection,
-    object_list: Arc<Mutex<Vec<serde_json::Value>>>,
+    client: Client,
+    pending_publish: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
+    metadata: Arc<ConnectionMetadata>,
     tx_span: Span,
 }
 
 impl NatsTxn {
-    fn new(connection: Connection, tx_span: Span) -> Self {
-        NatsTxn {
-            connection,
-            object_list: Arc::new(Mutex::new(Vec::new())),
+    fn new(client: Client, metadata: Arc<ConnectionMetadata>, tx_span: Span) -> Self {
+        Self {
+            client,
+            pending_publish: Arc::new(Mutex::new(Vec::new())),
+            metadata,
             tx_span,
         }
     }
 
-    #[instrument(name = "natstxn.publish", skip(self, object))]
-    pub async fn publish<T: Serialize + std::fmt::Debug>(&self, object: &T) -> NatsTxnResult<()> {
-        let json: serde_json::Value = serde_json::to_value(object)?;
-        let mut object_list = self.object_list.lock().await;
-        object_list.push(json);
+    #[instrument(
+        name = "transaction.publish",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+        )
+    )]
+    pub async fn publish<T>(&self, subject: impl Into<String>, object: &T) -> Result<()>
+    where
+        T: Serialize + Debug,
+    {
+        let span = Span::current();
+        span.follows_from(&self.tx_span);
+
+        let subject = subject.into();
+        let json: serde_json::Value = serde_json::to_value(object)
+            .map_err(|err| span.record_err(self.tx_span.record_err(Error::Serialize(err))))?;
+        let mut pending_publish = self.pending_publish.lock().await;
+        pending_publish.push((subject, json));
+
         Ok(())
     }
 
-    #[instrument(name = "natstxn.delete", skip(self, object))]
-    pub async fn delete<T: Serialize + std::fmt::Debug>(&self, object: &T) -> NatsTxnResult<()> {
-        let json: serde_json::Value = serde_json::to_value(object)?;
-        let mut object_list = self.object_list.lock().await;
-        object_list.push(serde_json::json![{ "deleted": json }]);
-        Ok(())
-    }
+    #[instrument(
+        name = "transaction.commit",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+        )
+    )]
+    pub async fn commit(self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.tx_span);
 
-    // TODO(fnichol): record a transaction attribute as committed
-    #[instrument(name = "natstxn.commit", skip(self))]
-    pub async fn commit(self) -> NatsTxnResult<()> {
-        let mut object_list = self.object_list.lock().await;
-        for model_json in object_list.iter_mut() {
-            let mut model_body: serde_json::Value = model_json.clone();
-            if model_json["deleted"].is_object() {
-                model_body = model_json["deleted"].clone();
-            }
-            let mut subject_array: Vec<String> = Vec::new();
-            if let Some(tenant_ids_values) = model_body["siStorable"]["tenantIds"].as_array() {
-                for tenant_id_value in tenant_ids_values.iter() {
-                    let tenant_id = String::from(tenant_id_value.as_str().unwrap());
-                    subject_array.push(tenant_id);
-                }
-            } else {
-                match model_body["siStorable"]["billingAccountId"].as_str() {
-                    Some(billing_account_id) => subject_array.push(billing_account_id.into()),
-                    None => return Ok(()),
-                }
-            }
-            if !subject_array.is_empty() {
-                let subject: String = subject_array.join(".");
-                self.connection
-                    .publish(&subject, model_json.to_string())
-                    .instrument(info_span!(
-                        "publish",
-                        code.namespace = "async-nats::Connection"
-                    ))
-                    .await?;
-            } else {
-                dbg!(
-                    "tried to publish a model that has no tenancy; model_json={:?}",
-                    model_json
-                );
-            }
+        let mut pending_publish = self.pending_publish.lock_owned().await;
+        for (subject, object) in pending_publish.drain(0..) {
+            let msg = serde_json::to_vec(&object)
+                .map_err(|err| span.record_err(self.tx_span.record_err(Error::Serialize(err))))?;
+            self.client
+                .publish(subject, msg)
+                .await
+                .map_err(|err| span.record_err(self.tx_span.record_err(err)))?;
         }
+
+        self.tx_span.record_ok();
+        self.tx_span.record("messaging.transaction", &"commit");
+        span.record_ok();
+        Ok(())
+    }
+
+    #[instrument(
+        name = "transaction.rollback",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+        )
+    )]
+    pub async fn rollback(self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.tx_span);
+
+        // Nothing much to do, we want to drop the pending publishes which happens when this
+        // function returns (i.e. it consumes `self`).
+
+        self.tx_span.record_ok();
+        self.tx_span.record("messaging.transaction", &"rollback");
+        span.record_ok();
         Ok(())
     }
 }

--- a/lib/si-data/src/nats/jetstream.rs
+++ b/lib/si-data/src/nats/jetstream.rs
@@ -1,0 +1,12 @@
+use nats_client as nats;
+
+pub use super::{Client, Message};
+
+// Re-export JetStream types. Since this is a private module, we'll have to name them from
+// `nats::jetstream` :(
+pub use nats::jetstream::{
+    AccountInfo, AccountLimits, AckKind, AckPolicy, ApiStats, ClusterInfo, ConsumerConfig,
+    ConsumerInfo, DateTime, DeliverPolicy, DiscardPolicy, JetStreamMessageInfo, NextRequest,
+    PurgeResponse, ReplayPolicy, RetentionPolicy, SequencePair, StorageType, StreamConfig,
+    StreamInfo, StreamState,
+};

--- a/lib/si-data/src/nats/message.rs
+++ b/lib/si-data/src/nats/message.rs
@@ -1,0 +1,237 @@
+use std::{fmt, sync::Arc};
+
+use nats_client as nats;
+use tokio::task::spawn_blocking;
+use tracing::{field::Empty, instrument, Span};
+
+use super::{
+    jetstream::{AckKind, JetStreamMessageInfo},
+    ConnectionMetadata, Error, Headers, Result,
+};
+use crate::telemetry::{SpanExt, SpanKind};
+
+#[derive(Clone)]
+pub struct Message {
+    inner: nats::Message,
+    metadata: Arc<ConnectionMetadata>,
+}
+
+impl Message {
+    pub(crate) fn new(inner: nats::Message, metadata: Arc<ConnectionMetadata>) -> Self {
+        Self { inner, metadata }
+    }
+
+    /// Gets a reference to the subject of this message.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.inner.subject
+    }
+
+    /// Gets a reference to the reply of this message.
+    #[must_use]
+    pub fn reply(&self) -> Option<&str> {
+        self.inner.reply.as_deref()
+    }
+
+    /// Gets a reference to the message contents.
+    #[must_use]
+    pub fn data(&self) -> &[u8] {
+        &self.inner.data
+    }
+
+    /// Gets a reference to the headers of this message.
+    #[must_use]
+    pub fn headers(&self) -> Option<&Headers> {
+        self.inner.headers.as_ref()
+    }
+
+    /// Consumes the message and returns the inner data.
+    #[must_use]
+    pub fn into_data(self) -> Vec<u8> {
+        self.inner.data
+    }
+
+    /// Consumes the message and returns the inner data and reply subject.
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<u8>, Option<String>) {
+        (self.inner.data, self.inner.reply)
+    }
+
+    /// Respond to a request message.
+    #[instrument(
+        name = "message.respond",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn respond(&self, msg: impl Into<Vec<u8>>) -> Result<()> {
+        let span = Span::current();
+
+        let msg = msg.into();
+        if let Some(reply) = self.reply() {
+            span.record("messaging.destination", &reply);
+            span.record("otel.name", &format!("{} send", &reply).as_str());
+        }
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.respond(&msg))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Acknowledge a `JetStream` message with a default acknowledgement.
+    ///
+    /// See `AckKind` documentation for details of what other types of acks are available. If you
+    /// need to send a non-default ack, use the `ack_kind` method below. If you need to block until
+    /// the server acks your ack, use the `double_ack` method instead.
+    ///
+    /// Returns immediately if this message has already been double-acked.
+    #[instrument(
+        name = "message.ack",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn ack(&self) -> Result<()> {
+        let span = Span::current();
+
+        if let Some(reply) = self.reply() {
+            span.record("messaging.destination", &reply);
+            span.record("otel.name", &format!("{} send", &reply).as_str());
+        }
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.ack())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Acknowledge a `JetStream` message.
+    ///
+    /// See `AckKind` documentation for details of what each variant means. If you need to block
+    /// until the server acks your ack, use the `double_ack` method instead.
+    ///
+    /// Does not check whether this message has already been double-acked.
+    #[instrument(
+        name = "message.ack_kind",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn ack_kind(&self, ack_kind: AckKind) -> Result<()> {
+        let span = Span::current();
+
+        if let Some(reply) = self.reply() {
+            span.record("messaging.destination", &reply);
+            span.record("otel.name", &format!("{} send", &reply).as_str());
+        }
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.ack_kind(ack_kind))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Acknowledge a `JetStream` message and wait for acknowledgement from the server that it has
+    /// received our ack.
+    ///
+    /// Retry acknowledgement until we receive a response. See `AckKind` documentation for details
+    /// of what each variant means.
+    ///
+    /// Returns immediately if this message has already been double-acked.
+    #[instrument(
+        name = "message.double_ack",
+        skip_all,
+        fields(
+            messaging.destination = Empty,
+            messaging.destination_kind = "topic",
+            messaging.operation = "send",
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Producer,
+            otel.name = Empty,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn double_ack(&self, ack_kind: AckKind) -> Result<()> {
+        let span = Span::current();
+
+        if let Some(reply) = self.reply() {
+            span.record("messaging.destination", &reply);
+            span.record("otel.name", &format!("{} send", &reply).as_str());
+        }
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.double_ack(ack_kind))
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Returns the `JetStream` message ID if this is a `JetStream` message.
+    ///
+    /// Returns `None` if this is not a `JetStream` message with headers set.
+    #[must_use]
+    pub fn jetstream_message_info(&self) -> Option<JetStreamMessageInfo<'_>> {
+        self.inner.jetstream_message_info()
+    }
+}
+
+impl fmt::Debug for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/lib/si-data/src/nats/options.rs
+++ b/lib/si-data/src/nats/options.rs
@@ -1,0 +1,454 @@
+use std::{io, path::Path, time::Duration};
+
+use nats_client as nats;
+
+use super::{Client, Result};
+
+/// Connect options.
+#[derive(Debug, Default)]
+pub struct Options {
+    pub(crate) inner: nats::Options,
+}
+
+impl Options {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Authenticate with NATS using a token.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::with_token("t0k3n!")
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn with_token(token: &str) -> Self {
+        nats::Options::with_token(token).into()
+    }
+
+    /// Authenticate with NATS using a username and password.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::with_user_pass("derek", "s3cr3t!")
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn with_user_pass(user: &str, password: &str) -> Self {
+        nats::Options::with_user_pass(user, password).into()
+    }
+
+    /// Authenticate with NATS using a `.creds` file.
+    ///
+    /// This will open the provided file, load its creds, perform the desired authentication, and
+    /// then zero the memory used to store the creds before continuing.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::with_credentials("path/to/my.creds")
+    ///     .connect("connect.ngs.global")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn with_credentials(path: impl AsRef<Path>) -> Self {
+        nats::Options::with_credentials(path).into()
+    }
+
+    /// Authenticate with NATS using a static credential str, using the creds file format.
+    ///
+    /// Note that this is more hazardous than using the above `with_credentials` method because it
+    /// retains the secret in-memory for the lifetime of this client instead of zeroing the
+    /// credentials after holding them for a very short time, as the `with_credentials` method
+    /// does.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let creds =
+    /// "-----BEGIN NATS USER JWT-----
+    /// eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5...
+    /// ------END NATS USER JWT------
+    ///
+    /// ************************* IMPORTANT *************************
+    /// NKEY Seed printed below can be used sign and prove identity.
+    /// NKEYs are sensitive and should be treated as secrets.
+    ///
+    /// -----BEGIN USER NKEY SEED-----
+    /// SUAIO3FHUX5PNV2LQIIP7TZ3N4L7TX3W53MQGEIVYFIGA635OZCKEYHFLM
+    /// ------END USER NKEY SEED------
+    /// ";
+    ///
+    /// let nc = nats::Options::with_static_credentials(creds)
+    ///     .expect("failed to parse static creds")
+    ///     .connect("connect.ngs.global")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn with_static_credentials(creds: &str) -> Result<Self> {
+        Ok(nats::Options::with_static_credentials(creds)?.into())
+    }
+
+    /// Authenticate with a function that loads user JWT and a signature function.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let seed = "SUANQDPB2RUOE4ETUA26CNX7FUKE5ZZKFCQIIW63OX225F2CO7UEXTM7ZY";
+    /// let kp = nkeys::KeyPair::from_seed(seed).unwrap();
+    ///
+    /// fn load_jwt() -> std::io::Result<String> {
+    ///     todo!()
+    /// }
+    ///
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::with_jwt(load_jwt, move |nonce| kp.sign(nonce).unwrap())
+    ///     .connect("localhost")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn with_jwt<J, S>(jwt_cb: J, sig_cb: S) -> Self
+    where
+        J: Fn() -> io::Result<String> + Send + Sync + 'static,
+        S: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        nats::Options::with_jwt(jwt_cb, sig_cb).into()
+    }
+
+    /// Authenticate with NATS using a public key and a signature function.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let nkey = "UAMMBNV2EYR65NYZZ7IAK5SIR5ODNTTERJOBOF4KJLMWI45YOXOSWULM";
+    /// let seed = "SUANQDPB2RUOE4ETUA26CNX7FUKE5ZZKFCQIIW63OX225F2CO7UEXTM7ZY";
+    /// let kp = nkeys::KeyPair::from_seed(seed).unwrap();
+    ///
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::with_nkey(nkey, move |nonce| kp.sign(nonce).unwrap())
+    ///     .connect("localhost")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn with_nkey<F>(nkey: &str, sig_cb: F) -> Self
+    where
+        F: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        nats::Options::with_nkey(nkey, sig_cb).into()
+    }
+
+    /// Set client certificate and private key files.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .client_cert("client-cert.pem", "client-key.pem")
+    ///     .connect("nats://localhost:4443")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn client_cert(self, cert: impl AsRef<Path>, key: impl AsRef<Path>) -> Self {
+        self.inner.client_cert(cert, key).into()
+    }
+
+    /// Set the default TLS config that will be used for connections.
+    ///
+    /// Note that this is less secure than specifying TLS certificate file paths using the other
+    /// methods on `Options`, which will avoid keeping raw key material in-memory and will zero
+    /// memory buffers that temporarily contain key material during connection attempts.  This is
+    /// intended to be used as a method of last-resort when providing well-known file paths is not
+    /// feasible.
+    ///
+    /// To avoid version conflicts, the `rustls` version used by this crate is exported as
+    /// `nats::rustls`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let mut tls_client_config = nats::rustls::ClientConfig::default();
+    /// tls_client_config
+    ///     .set_single_client_cert(
+    ///         vec![nats::rustls::Certificate(b"MY_CERT".to_vec())],
+    ///         nats::rustls::PrivateKey(b"MY_KEY".to_vec()),
+    ///     );
+    /// let nc = nats::Options::new()
+    ///     .tls_client_config(tls_client_config)
+    ///     .connect("nats://localhost:4443")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn tls_client_config(self, tls_client_config: nats::rustls::ClientConfig) -> Self {
+        self.inner.tls_client_config(tls_client_config).into()
+    }
+
+    /// Add a name option to this configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .with_name("My App")
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn with_name(self, name: &str) -> Self {
+        self.inner.with_name(name).into()
+    }
+
+    /// Select option to not deliver messages that we have published.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .no_echo()
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn no_echo(self) -> Self {
+        self.inner.no_echo().into()
+    }
+
+    /// Set the maximum number of reconnect attempts.  If no servers remain that are under this
+    /// threshold, then no further reconnect shall be attempted.  The reconnect attempt for a
+    /// server is reset upon successful connection.
+    ///
+    /// If None then there is no maximum number of attempts.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .max_reconnects(3)
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn max_reconnects<T: Into<Option<usize>>>(self, max_reconnects: T) -> Self {
+        self.inner.max_reconnects(max_reconnects).into()
+    }
+
+    /// Set the maximum amount of bytes to buffer when accepting outgoing traffic in disconnected
+    /// mode.
+    ///
+    /// The default value is 8mb.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .reconnect_buffer_size(64 * 1024)
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn reconnect_buffer_size(self, reconnect_buffer_size: usize) -> Self {
+        self.inner
+            .reconnect_buffer_size(reconnect_buffer_size)
+            .into()
+    }
+
+    /// Establish a `Connection` with a NATS server.
+    ///
+    /// Multiple servers may be specified by separating them with commas.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    ///
+    /// In the below case, the second server is configured to use TLS but the first one is not.
+    /// Using the `tls_required` method can ensure that all servers are connected to with TLS, if
+    /// that is your intention.
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .connect("nats://demo.nats.io:4222,tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub async fn connect(self, nats_url: impl Into<String>) -> Result<Client> {
+        Client::connect_with_options(nats_url, self).await
+    }
+
+    /// Set a callback to be executed when connectivity to a server has been lost.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .disconnect_callback(|| println!("connection has been lost"))
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn disconnect_callback<F>(self, cb: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.inner.disconnect_callback(cb).into()
+    }
+
+    /// Set a callback to be executed when connectivity to a server has been reestablished.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .reconnect_callback(|| println!("connection has been reestablished"))
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn reconnect_callback<F>(self, cb: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.inner.reconnect_callback(cb).into()
+    }
+
+    /// Set a custom `JetStream` API prefix. This is useful when using `JetStream` through
+    /// exports/imports.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .jetstream_api_prefix("some_exported_prefix".to_string())
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// nc.drain().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn jetstream_api_prefix(self, jetstream_prefix: String) -> Self {
+        self.inner.jetstream_api_prefix(jetstream_prefix).into()
+    }
+
+    /// Set a callback to be executed when the client has been closed due to exhausting reconnect
+    /// retries to known servers or by completing a drain request.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .close_callback(|| println!("connection has been closed"))
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// nc.drain().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn close_callback<F>(self, cb: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.inner.close_callback(cb).into()
+    }
+
+    /// Set a callback to be executed for calculating the backoff duration to wait before a server
+    /// reconnection attempt.
+    ///
+    /// The function takes the number of reconnects as an argument and returns the `Duration` that
+    /// should be waited before making the next connection attempt.
+    ///
+    /// It is recommended that some random jitter is added to your returned `Duration`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # use std::time::Duration;
+    /// let nc = nats::Options::new()
+    ///     .reconnect_delay_callback(|c| {
+    ///         Duration::from_millis(std::cmp::min((c * 100) as u64, 8000))
+    ///     })
+    ///     .connect("demo.nats.io")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn reconnect_delay_callback<F>(self, cb: F) -> Self
+    where
+        F: Fn(usize) -> Duration + Send + Sync + 'static,
+    {
+        self.inner.reconnect_delay_callback(cb).into()
+    }
+
+    /// Setting this requires that TLS be set for all server connections.
+    ///
+    /// If you only want to use TLS for some server connections, you may declare them separately in
+    /// the connect string by prefixing them with `tls://host:port` instead of `nats://host:port`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .tls_required(true)
+    ///     .connect("tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[must_use]
+    pub fn tls_required(self, tls_required: bool) -> Self {
+        self.inner.tls_required(tls_required).into()
+    }
+
+    /// Adds a root certificate file.
+    ///
+    /// The file must be PEM encoded. All certificates in the file will be used.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// let nc = nats::Options::new()
+    ///     .add_root_certificate("my-certs.pem")
+    ///     .connect("tls://demo.nats.io:4443")
+    ///     .await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    pub fn add_root_certificate(self, path: impl AsRef<Path>) -> Self {
+        self.inner.add_root_certificate(path).into()
+    }
+}
+
+impl From<nats::Options> for Options {
+    fn from(inner: nats::Options) -> Self {
+        Self { inner }
+    }
+}

--- a/lib/si-data/src/nats/subscription.rs
+++ b/lib/si-data/src/nats/subscription.rs
@@ -1,0 +1,203 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, Stream};
+use nats_client as nats;
+use tokio::task::spawn_blocking;
+use tracing::{field::Empty, instrument, Span};
+
+use super::{ConnectionMetadata, Error, Message, Result};
+use crate::telemetry::{SpanExt, SpanKind};
+
+/// A `Subscription` receives `Message`s published to specific NATS `Subject`s.
+#[derive(Debug)]
+pub struct Subscription {
+    inner: nats::Subscription,
+    shutdown_tx: crossbeam_channel::Sender<()>,
+    shutdown_rx: crossbeam_channel::Receiver<()>,
+    metadata: Arc<ConnectionMetadata>,
+    sub_span: Span,
+}
+
+impl Subscription {
+    pub(crate) fn new(
+        inner: nats::Subscription,
+        metadata: Arc<ConnectionMetadata>,
+        sub_span: Span,
+    ) -> Self {
+        // We don't use the tx side explicitly, but rather rely on the behavior when this
+        // Subscription is dropped, then tx is closed and the rx side running in a thread will get
+        // its shutdown signal immediately afterwards. That way we don't keep a zombie task
+        // receiving from a subscription that is no longer valid.
+        //
+        // This strategy uses a crossbeam channel as it presents a blocking API which we need in
+        // our blocking thread work. Bounded with size zero roughly maps to a "oneshot" channel,
+        // but with cloneable tx and rx ends.
+        let (shutdown_tx, shutdown_rx) = crossbeam_channel::bounded(0);
+
+        Self {
+            inner,
+            shutdown_tx,
+            shutdown_rx,
+            metadata,
+            sub_span,
+        }
+    }
+
+    /// Unsubscribe a subscription immediately without draining.
+    ///
+    /// Use `drain` instead if you want any pending messages to be processed by a handler, if one
+    /// is configured.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let sub = nc.subscribe("foo").await?;
+    /// sub.unsubscribe().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "subscription.unsubscribe",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn unsubscribe(self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.sub_span);
+
+        spawn_blocking(move || self.inner.unsubscribe())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Close a subscription. Same as `unsubscribe`
+    ///
+    /// Use `drain` instead if you want any pending messages to be processed by a handler, if one
+    /// is configured.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let sub = nc.subscribe("foo").await?;
+    /// sub.close().await?;
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "subscription.close",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn close(self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.sub_span);
+
+        spawn_blocking(move || self.inner.close())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Send an unsubscription then flush the connection, allowing any unprocessed messages to be
+    /// handled by a handler function if one is configured.
+    ///
+    /// After the flush returns, we know that a round-trip to the server has happened after it
+    /// received our unsubscription, so we shut down the subscriber afterwards.
+    ///
+    /// A similar method exists on the `Connection` struct which will drain all subscriptions for
+    /// the NATS client, and transition the entire system into the closed state afterward.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use futures::StreamExt;
+    /// # use std::sync::{Arc, atomic::{AtomicBool, Ordering::SeqCst}};
+    /// # use std::thread;
+    /// # use std::time::Duration;
+    /// # use si_data::nats; tokio_test::block_on(async {
+    /// # let nc = nats::Options::default().connect("demo.nats.io").await?;
+    /// let mut sub = nc.subscribe("test.drain").await?;
+    ///
+    /// nc.publish("test.drain", "message").await?;
+    /// sub.drain().await?;
+    ///
+    /// let mut received = false;
+    /// while sub.next().await.is_some() {
+    ///     received = true;
+    /// }
+    ///
+    /// assert!(received);
+    /// # Ok::<(), Box<dyn std::error::Error + 'static>>(()) });
+    /// ```
+    #[instrument(
+        name = "subscription.drain",
+        skip_all,
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol,
+            messaging.system = %self.metadata.messaging_system,
+            messaging.url = %self.metadata.messaging_url,
+            net.transport = %self.metadata.net_transport,
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn drain(&self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.sub_span);
+
+        let inner = self.inner.clone();
+        spawn_blocking(move || inner.drain())
+            .await
+            .map_err(|err| span.record_err(Error::Async(err)))?
+            .map_err(|err| span.record_err(Error::Nats(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+}
+
+impl Stream for Subscription {
+    type Item = Result<Message>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let _enter = self.sub_span.enter();
+        let inner = self.inner.clone();
+        match spawn_blocking(move || inner.next()).poll_unpin(cx) {
+            Poll::Ready(Ok(ready)) => Poll::Ready(
+                Ok(ready.map(|msg| Message::new(msg, self.metadata.clone()))).transpose(),
+            ),
+            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(Error::Async(err)))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/lib/si-data/src/telemetry.rs
+++ b/lib/si-data/src/telemetry.rs
@@ -1,0 +1,61 @@
+use std::{fmt, ops::Deref};
+
+use tracing::Span;
+
+pub use opentelemetry::trace::SpanKind;
+
+pub trait SpanExt {
+    fn record_ok(&self);
+    fn record_err<E>(&self, err: E) -> E
+    where
+        E: std::error::Error;
+}
+
+impl SpanExt for Span {
+    fn record_ok(&self) {
+        self.record("otel.status_code", &StatusCode::Ok.as_str());
+    }
+
+    fn record_err<E>(&self, err: E) -> E
+    where
+        E: std::error::Error,
+    {
+        self.record("otel.status_code", &StatusCode::Error.as_str());
+        self.record("otel.status_message", &err.to_string().as_str());
+        err
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StatusCode {
+    /// The default status.
+    #[allow(dead_code)]
+    Unset,
+    /// OK is returned on success.
+    #[allow(dead_code)]
+    Ok,
+    /// The operation contains an error.
+    Error,
+}
+
+impl fmt::Display for StatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unset => f.write_str(opentelemetry::trace::StatusCode::Unset.as_str()),
+            Self::Ok => f.write_str(opentelemetry::trace::StatusCode::Ok.as_str()),
+            Self::Error => f.write_str(opentelemetry::trace::StatusCode::Error.as_str()),
+        }
+    }
+}
+
+impl Deref for StatusCode {
+    type Target = opentelemetry::trace::StatusCode;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            StatusCode::Unset => &opentelemetry::trace::StatusCode::Unset,
+            StatusCode::Ok => &opentelemetry::trace::StatusCode::Ok,
+            StatusCode::Error => &opentelemetry::trace::StatusCode::Error,
+        }
+    }
+}

--- a/lib/veritech/Cargo.toml
+++ b/lib/veritech/Cargo.toml
@@ -17,6 +17,7 @@ client = []
 server = [
   "derive_builder",
   "futures-lite",
+  "pin-project-lite",
 ]
 
 [dependencies]
@@ -25,8 +26,7 @@ futures = { version = "0.3.17"}
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 cyclone = { path = "../../lib/cyclone", default-features = false, features = ["client"] }
-si-data = { path = "../../lib/si-data" }
-# TODO(fnichol): I *think* we can boil this off?
+si-data = { path = "../../lib/si-data", features = ["nats"] }
 si-settings = { path = "../../lib/si-settings" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.2.0", features = ["full"] }
@@ -36,3 +36,4 @@ tracing = { version = "0.1" }
 # server only dependencies
 derive_builder = { version = "0.10.2", optional = true }
 futures-lite = { version = "1.12.0", optional = true }
+pin-project-lite = { version = "0.2.7", optional = true }

--- a/lib/veritech/src/server/publisher.rs
+++ b/lib/veritech/src/server/publisher.rs
@@ -1,8 +1,6 @@
-use std::io;
-
 use cyclone::resolver_function::{FunctionResult, OutputStream};
 use serde::Serialize;
-use si_data::NatsConn;
+use si_data::NatsClient;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -10,21 +8,21 @@ pub enum PublisherError {
     #[error("failed to serialize json message")]
     JSONSerialize(#[source] serde_json::Error),
     #[error("failed to publish message to nats subject: {1}")]
-    NatsPublish(#[source] io::Error, String),
+    NatsPublish(#[source] si_data::NatsError, String),
 }
 
 type Result<T> = std::result::Result<T, PublisherError>;
 
 #[derive(Debug)]
 pub struct Publisher<'a> {
-    nats_conn: &'a NatsConn,
+    nats: &'a NatsClient,
     reply_mailbox: &'a str,
 }
 
 impl<'a> Publisher<'a> {
-    pub fn new(nats_conn: &'a NatsConn, reply_mailbox: &'a str) -> Self {
+    pub fn new(nats: &'a NatsClient, reply_mailbox: &'a str) -> Self {
         Self {
-            nats_conn,
+            nats,
             reply_mailbox,
         }
     }
@@ -32,8 +30,8 @@ impl<'a> Publisher<'a> {
     pub async fn publish(&self, message: &impl Publishable) -> Result<()> {
         let nats_msg = serde_json::to_string(message).map_err(PublisherError::JSONSerialize)?;
 
-        self.nats_conn
-            .publish(self.reply_mailbox, &nats_msg)
+        self.nats
+            .publish(self.reply_mailbox, nats_msg)
             .await
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox.to_string()))
     }

--- a/lib/veritech/src/server/subscriber.rs
+++ b/lib/veritech/src/server/subscriber.rs
@@ -1,15 +1,15 @@
 use std::{
-    io,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 
 use cyclone::resolver_function::ResolverFunctionRequest;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use futures_lite::FutureExt;
+use pin_project_lite::pin_project;
 use serde::de::DeserializeOwned;
-use si_data::{nats, NatsConn};
+use si_data::{nats, NatsClient};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -17,11 +17,13 @@ pub enum SubscriberError {
     #[error("failed to deserialize json message")]
     JSONDeserialize(#[source] serde_json::Error),
     #[error("failed to drain from nats subscription")]
-    NatsDrain(#[source] io::Error),
+    NatsDrain(#[source] si_data::NatsError),
+    #[error("nats io error when reading from subscription")]
+    NatsIo(#[source] si_data::NatsError),
     #[error("failed to subscribe to nats topic")]
-    NatsSubscribe(#[source] io::Error),
+    NatsSubscribe(#[source] si_data::NatsError),
     #[error("failed to unsubscribe from nats subscription")]
-    NatsUnsubscribe(#[source] io::Error),
+    NatsUnsubscribe(#[source] si_data::NatsError),
     #[error("no return mailbox specified; bug! message data: {0:?}")]
     NoReplyMailbox(Vec<u8>),
 }
@@ -32,7 +34,7 @@ pub struct Subscriber;
 
 impl Subscriber {
     pub async fn resolver_function(
-        nats: &NatsConn,
+        nats: &NatsClient,
     ) -> Result<Subscription<ResolverFunctionRequest>> {
         let inner = nats
             .subscribe("veritech.function.resolver")
@@ -58,10 +60,13 @@ impl<T> Request<T> {
     }
 }
 
-#[derive(Debug)]
-pub struct Subscription<T> {
-    inner: nats::Subscription,
-    _phantom: PhantomData<T>,
+pin_project! {
+    #[derive(Debug)]
+    pub struct Subscription<T> {
+        #[pin]
+        inner: nats::Subscription,
+        _phantom: PhantomData<T>,
+    }
 }
 
 impl<T> Subscription<T> {
@@ -70,7 +75,7 @@ impl<T> Subscription<T> {
         self.inner.drain().await.map_err(SubscriberError::NatsDrain)
     }
 
-    pub async fn unsubscribe(&self) -> Result<()> {
+    pub async fn unsubscribe(self) -> Result<()> {
         self.inner
             .unsubscribe()
             .await
@@ -85,22 +90,21 @@ where
     type Item = Result<Request<T>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.inner.next().boxed().poll(cx) {
+        let mut this = self.project();
+
+        match this.inner.next().poll(cx) {
             // Convert this NATS message into the cyclone request type `T` and return any errors
             // for the caller to decide how to proceed (i.e. does the caller fail on first error,
             // ignore error items, etc.)
-            Poll::Ready(Some(nats_msg)) => {
-                let reply_mailbox = match nats_msg.reply {
+            Poll::Ready(Some(Ok(nats_msg))) => {
+                let (data, reply) = nats_msg.into_parts();
+                let reply_mailbox = match reply {
                     // We have a reply mailbox, good
                     Some(reply) => reply,
                     // No reply mailbox provided
-                    None => {
-                        return Poll::Ready(Some(Err(SubscriberError::NoReplyMailbox(
-                            nats_msg.data,
-                        ))))
-                    }
+                    None => return Poll::Ready(Some(Err(SubscriberError::NoReplyMailbox(data)))),
                 };
-                let cyclone_request: T = match serde_json::from_slice(&nats_msg.data) {
+                let cyclone_request: T = match serde_json::from_slice(&data) {
                     // Deserializing from JSON into a formal request type was successful
                     Ok(request) => request,
                     // Deserializing failed
@@ -116,6 +120,8 @@ where
                 // Return the request type
                 Poll::Ready(Some(Ok(request)))
             }
+            // A NATS error occured (async error or other i/o)
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(SubscriberError::NatsIo(err)))),
             // We see no more messages on the subject, so close the stream
             Poll::Ready(None) => Poll::Ready(None),
             // Not ready, so...not ready!


### PR DESCRIPTION
This change updates the underlying NATS client implementation to the
current upstream `nats` crate library from the older "async" version of
the upstream client which was later brought back into the main crate.
Unfortunately, the current `asynk` module version of the NATS client
isn't at full feature parity with the main blocking implementation of
the client, so it was easier to wrap the synchronous client to present
an async API and provide the API surface area to re-instrument the
client (via tracing/opentelemtry). Finally, the NATS `asynk`
implementation relies on the `blocking` crate to wrap each synchronous
call which run on a threadpool, but this pool is not configurable, nor
is there an easy way to cancel these thread tasks. Instead in this
implementation, we base it on tokio's `task::spawn_blocking`
implementation which allows us to configure and tune the worker pool
right alongside our main runtime.

This updated implementation gives us a tru true `futures::Stream`
implementation for NATS subscriptions and better OpenTelemetry span
naming and status closing around key tasks such as publishing a message,
reading from a subscription, etc.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>