### PR TITLE
fix(build): restore full Rust project build

### DIFF
--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -10,7 +10,7 @@ name = "cyclone"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "3.0.0-beta.4" }
+clap = { version = "3.0.0-beta.5" }
 color-eyre = { version = "0.5.11" }
 cyclone = { path = "../../lib/cyclone", features = ["server"] }
 thiserror = { version = "1.0" }

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -1,7 +1,9 @@
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use clap::{AppSettings, ArgSettings, Clap};
+use clap::{ArgSettings, Parser};
 use cyclone::{Config, ConfigError, IncomingStream};
+
+const NAME: &str = "cyclone";
 
 /// Parse, validate, and return the CLI arguments as a typed struct.
 pub(crate) fn parse() -> Args {
@@ -12,13 +14,8 @@ pub(crate) fn parse() -> Args {
 ///
 /// Cyclone is a software component of the System Initiative which handles requested execution of
 /// small functions in a backing language server.
-#[derive(Clap, Debug)]
-#[clap(
-    name = "cyclone",
-    global_setting = AppSettings::ColoredHelp,
-    global_setting = AppSettings::UnifiedHelpMessage,
-    max_term_width = 100,
-)]
+#[derive(Debug, Parser)]
+#[clap(name = NAME, max_term_width = 100)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct Args {
     /// Sets the verbosity mode.

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Parser};
+use clap::Parser;
 use sdf::{Config, ConfigError, ConfigFile, MigrationMode, StandardConfigFile};
 
 const NAME: &str = "sdf";

--- a/bin/veritech/Cargo.toml
+++ b/bin/veritech/Cargo.toml
@@ -10,7 +10,7 @@ name = "veritech"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "3.0.0-beta.4" }
+clap = { version = "3.0.0-beta.5" }
 color-eyre = { version = "0.5.11" }
 # TODO(fnichol): I *think* we can boil this off?
 si-settings = { path = "../../lib/si-settings" }

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use clap::{AppSettings, Clap};
+use clap::Parser;
 use si_settings::StandardConfigFile;
 use veritech::{
     server::{Config, ConfigError},
@@ -14,13 +14,8 @@ pub(crate) fn parse() -> Args {
     Args::parse()
 }
 
-#[derive(Clap, Debug)]
-#[clap(
-    name = NAME,
-    global_setting = AppSettings::ColoredHelp,
-    global_setting = AppSettings::UnifiedHelpMessage,
-    max_term_width = 100,
-)]
+#[derive(Debug, Parser)]
+#[clap(name = NAME, max_term_width = 100)]
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///

--- a/lib/sdf/src/server/service/session/restore_authentication.rs
+++ b/lib/sdf/src/server/service/session/restore_authentication.rs
@@ -1,8 +1,8 @@
 use super::SessionResult;
-use crate::server::extract::{Authorization, JwtSigningKey, NatsTxn, PgRoTxn, PgRwTxn};
+use crate::server::extract::{Authorization, PgRoTxn};
 use crate::server::service::session::SessionError;
 use axum::Json;
-use dal::{BillingAccount, StandardModel, Tenancy, User, UserClaim, Visibility};
+use dal::{BillingAccount, StandardModel, Tenancy, User, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]


### PR DESCRIPTION
Only 2 small issues that are dealt with:

* Upgrade `cyclone` and `veritech` to clap 3.0.0.beta.5
* Remove a couple of unused imports

Confirmed entire project builds with:

```sh
time { cargo check && cargo build && cargo test && cargo doc; }
```

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>