### PR TITLE
feat(web): global error service

### DIFF
--- a/app/web/src/api/sdf.ts
+++ b/app/web/src/api/sdf.ts
@@ -41,7 +41,7 @@ export class SDF {
   }
 
   async startUpdate() {
-    if (!this.ws) {
+    if (!this.ws && this.token) {
       await this.setupUpdate();
     }
   }

--- a/app/web/src/api/sdf/ws.ts
+++ b/app/web/src/api/sdf/ws.ts
@@ -1,8 +1,4 @@
 import Bottle from "bottlejs";
-import {
-  eventChangeSetApplied$,
-  eventChangeSetCreated$,
-} from "@/observable/change_set";
 import { WsEvent } from "@/api/sdf/dal/ws_event";
 import { WsEventService } from "@/service/ws_event";
 

--- a/app/web/src/observable/change_set.ts
+++ b/app/web/src/observable/change_set.ts
@@ -42,6 +42,10 @@ eventChangeSetApplied$.next(null);
 export const eventChangeSetCanceled$ = new ReplaySubject<number | null>(1);
 eventChangeSetCanceled$.next(null);
 
+/**
+ * The list of open change sets, refreshed when the right events trigger, debounced, and
+ * shared. Always populated once it's been called, if there are subscribers.
+ */
 export const changeSetsOpenList$ = combineLatest([
   eventChangeSetCreated$,
   eventChangeSetApplied$,

--- a/app/web/src/organisims/ChangeSetWidget.vue
+++ b/app/web/src/organisims/ChangeSetWidget.vue
@@ -118,7 +118,6 @@ import {
   revision$,
 } from "@/observable/change_set";
 
-import { globalErrorMessage$ } from "@/observable/global";
 import { editMode$ } from "@/observable/edit_mode";
 
 import SiSelect from "@/atoms/SiSelect.vue";
@@ -136,6 +135,7 @@ import { ChangeSet } from "@/api/sdf/dal/change_set";
 
 import { tap } from "rxjs";
 import _ from "lodash";
+import { GlobalErrorService } from "@/service/global_error";
 
 const CHANGE_SET_NONE = -2;
 const CHANGE_SET_NEW = -3;
@@ -188,7 +188,7 @@ const _openChangeSetsList$ = refFrom(
         { label: ": new :", value: CHANGE_SET_NEW },
       ];
       if (response.error) {
-        globalErrorMessage$.next(response);
+        GlobalErrorService.set(response);
         openChangeSetsList.value = always;
       } else {
         openChangeSetsList.value = _.concat(response.list, always);
@@ -221,7 +221,7 @@ const changeSetSelected = async () => {
       pk: selectedChangeSetPk.value,
     });
     if (response.error) {
-      globalErrorMessage$.next(response);
+      GlobalErrorService.set(response);
     }
   }
 };
@@ -249,7 +249,7 @@ const changeSetCreate = async () => {
 const changeSetApply = async () => {
   let response = await ChangeSetService.applyChangeSet();
   if (response.error) {
-    globalErrorMessage$.next(response);
+    GlobalErrorService.set(response);
   } else {
     selectedChangeSetPk.value = CHANGE_SET_NONE;
   }
@@ -258,13 +258,13 @@ const changeSetApply = async () => {
 const editSessionCancel = async () => {
   let response = await ChangeSetService.cancelEditSession();
   if (response.error) {
-    globalErrorMessage$.next(response);
+    GlobalErrorService.set(response);
   }
 };
 const editSessionSave = async () => {
   let response = await ChangeSetService.saveEditSession();
   if (response.error) {
-    globalErrorMessage$.next(response);
+    GlobalErrorService.set(response);
   }
 };
 const editSessionStart = async () => {
@@ -272,7 +272,7 @@ const editSessionStart = async () => {
     changeSetPk: selectedChangeSetPk.value,
   });
   if (response.error) {
-    globalErrorMessage$.next(response);
+    GlobalErrorService.set(response);
   }
 };
 </script>

--- a/app/web/src/organisims/Schema/SchemaList.vue
+++ b/app/web/src/organisims/Schema/SchemaList.vue
@@ -2,10 +2,11 @@
   <div
     class="flex flex-row items-center justify-between flex-grow-0 flex-shrink-0 h-12 header-background"
   >
-    <div class="mt-1 ml-8 font-medium align-middle">Schema</div>
+    <div class="mt-1 ml-8 font-medium align-middle">Schema
+      <SiButton class="ml-2" icon="plus" label="New" size="xs" @click="schemaNew()" />
+    </div>
     <div class="mt-1 mr-8 align-middle">
       <ChangeSetWidget />
-      <SiButton icon="plus" label="New" size="xs" @click="schemaNew()" />
     </div>
   </div>
 </template>

--- a/app/web/src/pages/Home.vue
+++ b/app/web/src/pages/Home.vue
@@ -28,6 +28,7 @@ import { useRouter, useRoute } from "vue-router";
 import { globalErrorMessage$ } from "@/observable/global";
 import { refFrom } from "vuse-rx";
 import { map } from "rxjs/operators";
+import { GlobalErrorService } from "@/service/global_error";
 
 const route = useRoute();
 const router = useRouter();
@@ -46,7 +47,7 @@ const isLoading = ref(true);
 const navIsVisible = ref(true);
 
 const clearErrorMessage = () => {
-  globalErrorMessage$.next(null);
+  GlobalErrorService.clear();
 };
 
 onMounted(async () => {

--- a/app/web/src/service/global_error.ts
+++ b/app/web/src/service/global_error.ts
@@ -1,0 +1,24 @@
+import { globalErrorMessage$ } from "@/observable/global";
+import { ApiResponseError } from "@/api/sdf";
+
+/**
+ * Clear the global error message
+ */
+export function clear() {
+  globalErrorMessage$.next(null);
+}
+
+/**
+ * Set the global error message
+ */
+export function set(error: ApiResponseError) {
+  globalErrorMessage$.next(error);
+}
+
+/**
+ * Manages the global error display
+ */
+export const GlobalErrorService = {
+  clear,
+  set,
+};


### PR DESCRIPTION
This introduces a GlobalErrorService, which handles updating the state for the global error display. (that gets mounted in the Home page.)

It also fixes a small bug in the websocket being created when there is no current authentication token (which isn't a thing), and moves a button around in the change set.