### PR TITLE
feat(*): add schema creation

### DIFF
--- a/app/web/.eslintrc.js
+++ b/app/web/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   env: {
     node: true,
   },
+  globals: { defineProps: "readonly", defineEmits: "readonly", },
   extends: [
     "eslint:recommended",
     "plugin:vue/vue3-recommended",
@@ -10,7 +11,7 @@ module.exports = {
     "@vue/prettier",
   ],
   rules: {
-    "camelcase": "off",
+    camelcase: "off",
     "no-console": "off",
     "no-debugger": "off",
     "no-alert": "error",

--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -6,8 +6,6 @@ export enum SchemaKind {
   Concrete = "concrete",
 }
 
-export type SchemaKindStrings = keyof typeof SchemaKind;
-
 export interface Schema extends StandardModel {
   name: string;
   kind: SchemaKind;

--- a/app/web/src/api/sdf/dal/ws_event.ts
+++ b/app/web/src/api/sdf/dal/ws_event.ts
@@ -16,8 +16,13 @@ export interface WsChangeSetCanceled {
   kind: "ChangeSetCanceled";
   data: number;
 }
+export interface WsSchemaCreated {
+  kind: "SchemaCreated";
+  data: number;
+}
 
 export type WsPayload =
+  | WsSchemaCreated
   | WsChangeSetCreated
   | WsChangeSetApplied
   | WsChangeSetCanceled;

--- a/app/web/src/atoms/SiError.vue
+++ b/app/web/src/atoms/SiError.vue
@@ -3,7 +3,7 @@
     <div v-if="message" :data-test="test" class="bg-red-500 text-white flex">
       <span class="flex-grow">Error: {{ message }}</span>
       <button class="flex-grow-0" @click="clear">
-        <VueFeather type="xicon" />
+        <VueFeather type="x" />
       </button>
     </div>
     <div

--- a/app/web/src/observable/change_set.ts
+++ b/app/web/src/observable/change_set.ts
@@ -1,13 +1,7 @@
 import {
-  combineLatest,
-  debounceTime,
-  from,
   ReplaySubject,
-  shareReplay,
 } from "rxjs";
-import { switchMap } from "rxjs/operators";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
-import { ChangeSetService } from "@/service/change_set";
 import { persistToSession } from "@/observable/session_state";
 
 /**
@@ -41,25 +35,3 @@ eventChangeSetApplied$.next(null);
  */
 export const eventChangeSetCanceled$ = new ReplaySubject<number | null>(1);
 eventChangeSetCanceled$.next(null);
-
-/**
- * The list of open change sets, refreshed when the right events trigger, debounced, and
- * shared. Always populated once it's been called, if there are subscribers.
- */
-export const changeSetsOpenList$ = combineLatest([
-  eventChangeSetCreated$,
-  eventChangeSetApplied$,
-  eventChangeSetCanceled$,
-]).pipe(
-  switchMap(
-    ([
-      _eventChangeSetCreated,
-      _eventChangeSetApplied,
-      _eventChangeSetCanceled,
-    ]) => {
-      return from(ChangeSetService.listOpenChangeSets());
-    },
-  ),
-  debounceTime(100),
-  shareReplay(1),
-);

--- a/app/web/src/observable/schema.ts
+++ b/app/web/src/observable/schema.ts
@@ -1,7 +1,7 @@
-import { BehaviorSubject } from "rxjs";
+import { ReplaySubject } from "rxjs";
 
 /**
- * Triggered when a list of schemas needs to be refreshed, either because of
- * local action or remote behavior.
+ * Fired with the id of the new change set when one is canceled.
  */
-export const schemaListRefresh$ = new BehaviorSubject<boolean>(true);
+export const eventSchemaCreated$ = new ReplaySubject<number | null>(1);
+eventSchemaCreated$.next(null);

--- a/app/web/src/observable/visibility.ts
+++ b/app/web/src/observable/visibility.ts
@@ -1,0 +1,37 @@
+import {
+  BehaviorSubject,
+  combineLatest,
+  debounceTime,
+  from,
+  shareReplay,
+} from "rxjs";
+import { changeSet$ } from "@/observable/change_set";
+import { editSession$ } from "@/observable/edit_session";
+import { switchMap } from "rxjs/operators";
+import {
+  NO_CHANGE_SET_PK,
+  NO_EDIT_SESSION_PK,
+  Visibility,
+} from "@/api/sdf/dal/visibility";
+
+export const showDeleted$ = new BehaviorSubject<boolean>(false);
+
+export const visibility$ = combineLatest([
+  changeSet$,
+  editSession$,
+  showDeleted$,
+]).pipe(
+  debounceTime(10),
+  switchMap(([changeSet, editSession, showDeleted]) => {
+    const visibility_change_set_pk = changeSet?.pk || NO_CHANGE_SET_PK;
+    const visibility_edit_session_pk = editSession?.pk || NO_EDIT_SESSION_PK;
+    const visibility_deleted = showDeleted;
+    const visibility: Visibility = {
+      visibility_change_set_pk,
+      visibility_edit_session_pk,
+      visibility_deleted,
+    };
+    return from([visibility]);
+  }),
+  shareReplay(1),
+);

--- a/app/web/src/organisims/LoginForm.vue
+++ b/app/web/src/organisims/LoginForm.vue
@@ -122,15 +122,14 @@ export default defineComponent({
     goToSignUp() {
       this.$emit("signup");
     },
-    async login() {
-      const reply = await SessionService.login(this.form);
-      if (reply.error) {
-        this.errorMessage = "Login error; please try again!";
-      } else {
-        //user$.next(reply.user);
-        //billingAccount$.next(reply.billingAccount);
-        this.$emit("success");
-      }
+    login() {
+      SessionService.login(this.form).subscribe((response) => {
+        if (response.error) {
+          this.errorMessage = "Login error; please try again!";
+        } else {
+          this.$emit("success");
+        }
+      });
     },
     inputStyling(inputKind: string): Record<string, any> {
       let classes: Record<string, any> = {};

--- a/app/web/src/organisims/Schema/SchemaCreateForm.vue
+++ b/app/web/src/organisims/Schema/SchemaCreateForm.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="flex flex-col">
+    <SiError :message="errorMessage" />
+    <div class="flex flex-col mt-4">
+      <SiFormRow>
+        <template #label>
+          <label>Schema Name:</label>
+        </template>
+        <template #widget>
+          <SiTextBox
+            id="schemaName"
+            v-model="form.name"
+            size="xs"
+            name="name"
+            placeholder="schema name"
+            :is-show-type="false"
+            required
+          />
+        </template>
+      </SiFormRow>
+      <SiFormRow>
+        <template #label>
+          <label>Schema Kind:</label>
+        </template>
+        <template #widget>
+          <SiSelect
+            id="schemaKind"
+            :options="kindOptions"
+            value="concrete"
+            size="xs"
+          />
+        </template>
+      </SiFormRow>
+      <div class="flex justify-end w-full">
+        <div class="pr-2">
+          <SiButton
+            size="xs"
+            label="Cancel"
+            kind="cancel"
+            icon="null"
+            @click="cancel"
+          />
+        </div>
+        <div>
+          <SiButton
+            size="xs"
+            label="Create"
+            kind="save"
+            icon="null"
+            @click="create"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SiTextBox from "@/atoms/SiTextBox.vue";
+import SiSelect from "@/atoms/SiSelect.vue";
+import SiButton from "@/atoms/SiButton.vue";
+import SiFormRow from "@/atoms/SiFormRow.vue";
+import SiError from "@/atoms/SiError.vue";
+
+import { ref } from "vue";
+import { SchemaKind } from "@/api/sdf/dal/schema";
+import { SchemaService } from "@/service/schema";
+import { enumKeys } from "@/utils/enumKeys";
+
+const emit = defineEmits(["cancel", "create"]);
+
+const kindOptionsArray: Array<{ label: string; value: string }> = [];
+for (const value of enumKeys(SchemaKind)) {
+  kindOptionsArray.push({ label: value, value: SchemaKind[value] });
+}
+const kindOptions = ref(kindOptionsArray);
+
+const form = ref({
+  name: "",
+  kind: SchemaKind.Concrete,
+});
+
+const errorMessage = ref("");
+
+const create = () => {
+  SchemaService.createSchema(form.value).subscribe((response) => {
+    if (response.error) {
+      errorMessage.value = response.error.message;
+    }
+    emit("create", response);
+  });
+};
+
+const cancel = () => {
+  form.value.name = "";
+  form.value.kind = SchemaKind.Concrete;
+  emit("cancel");
+};
+</script>
+
+<style scoped>
+.page-background {
+  background-color: #1e1e1e;
+}
+
+.header-background {
+  background-color: #171717;
+}
+</style>

--- a/app/web/src/organisims/Schema/SchemaList.vue
+++ b/app/web/src/organisims/Schema/SchemaList.vue
@@ -1,25 +1,119 @@
 <template>
-  <div
-    class="flex flex-row items-center justify-between flex-grow-0 flex-shrink-0 h-12 header-background"
-  >
-    <div class="mt-1 ml-8 font-medium align-middle">Schema
-      <SiButton class="ml-2" icon="plus" label="New" size="xs" @click="schemaNew()" />
+  <div class="flex flex-col">
+    <div
+      class="flex flex-row items-center justify-between flex-grow-0 flex-shrink-0 h-12 header-background"
+    >
+      <div class="mt-1 ml-8 font-medium align-middle">
+        Schema
+        <SiButton
+          class="ml-2"
+          icon="plus"
+          label="New"
+          size="xs"
+          :disabled="!editMode"
+          @click="schemaNew()"
+        />
+      </div>
+      <SiModal
+        v-if="modal"
+        v-model="schemaCreateModalShow"
+        name="schemaCreate"
+        :esc-to-close="true"
+      >
+        <template #title>Create Schema</template>
+        <template #body>
+          <SchemaCreateForm
+            @create="closeCreateSchemaModal"
+            @cancel="closeCreateSchemaModal"
+          />
+        </template>
+        <template #buttons>
+          <div></div>
+        </template>
+      </SiModal>
+      <div class="mt-1 mr-8 align-middle">
+        <ChangeSetWidget />
+      </div>
     </div>
-    <div class="mt-1 mr-8 align-middle">
-      <ChangeSetWidget />
+    <div class="flex flex-row mt-5 page-background w-full">
+      <div class="flex flex-col w-full">
+        <div class="flex flex-row">
+          <div class="w-6/12 px-2 py-1 text-center align-middle table-border">
+            Name
+          </div>
+          <div class="w-6/12 px-2 py-1 text-center align-middle table-border">
+            Kind
+          </div>
+        </div>
+        <div
+          v-for="schema in schemaList"
+          :key="schema.pk"
+          class="flex flex-row row-item"
+        >
+          <div class="w-6/12 px-2 py-1 text-center">
+            {{ schema.name }}
+          </div>
+          <div class="w-6/12 px-2 py-1 text-center align-middle">
+            {{ schema.kind }}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import SiButton from "@/atoms/SiButton.vue";
+import SiModal from "@/molecules/SiModal.vue";
 import ChangeSetWidget from "@/organisims/ChangeSetWidget.vue";
+import SchemaCreateForm from "./SchemaCreateForm.vue";
+
+import { Schema } from "@/api/sdf/dal/schema";
+import { GlobalErrorService } from "@/service/global_error";
+
 import { useRouter } from "vue-router";
+import { ref } from "vue";
+import { refFrom, untilUnmounted } from "vuse-rx";
+import { from } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import { SchemaService } from "@/service/schema";
+import { ChangeSetService } from "@/service/change_set";
 
 const router = useRouter();
 
+const schemaCreateModalShow = ref(false);
+
+const props = defineProps({
+  modal: {
+    type: Boolean,
+    default: true,
+  },
+});
+
+const editMode = refFrom(ChangeSetService.currentEditMode());
+const schemaList = refFrom<Array<Schema>>(
+  SchemaService.listSchemas().pipe(
+    switchMap((response) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+        return from([[]]);
+      } else {
+        return from([response.list]);
+      }
+    }),
+  ),
+);
+
 const schemaNew = async () => {
-  await router.push({ name: "schema-new" });
+  if (props.modal.valueOf()) {
+    schemaCreateModalShow.value = true;
+  } else {
+    await router.push({ name: "schema-new" });
+  }
+};
+
+const closeCreateSchemaModal = () => {
+  schemaCreateModalShow.value = false;
 };
 </script>
 
@@ -30,5 +124,17 @@ const schemaNew = async () => {
 
 .header-background {
   background-color: #171717;
+}
+
+.row-item {
+  background-color: #262626;
+}
+
+.row-item:nth-child(odd) {
+  background-color: #2c2c2c;
+}
+
+.table-border {
+  border-bottom: 1px solid #46494d;
 }
 </style>

--- a/app/web/src/organisims/Schema/SchemaNew.vue
+++ b/app/web/src/organisims/Schema/SchemaNew.vue
@@ -13,106 +13,33 @@
         Create Schema
       </div>
     </div>
-    <div class="flex flex-row page-background">
-      <SiError :message="errorMessage" />
-      <div class="flex flex-col mt-4">
-        <SiFormRow>
-          <template #label>
-            <label>Schema Name:</label>
-          </template>
-          <template #widget>
-            <SiTextBox
-              id="schemaName"
-              v-model="form.name"
-              size="xs"
-              name="name"
-              placeholder="schema name"
-              :is-show-type="false"
-              required
-            />
-          </template>
-        </SiFormRow>
-        <SiFormRow>
-          <template #label>
-            <label>Schema Kind:</label>
-          </template>
-          <template #widget>
-            <SiSelect
-              id="schemaKind"
-              :options="kindOptions"
-              value="concrete"
-              size="xs"
-            />
-          </template>
-        </SiFormRow>
-        <div class="flex justify-end w-full">
-          <div class="pr-2">
-            <SiButton
-              size="xs"
-              label="Cancel"
-              kind="cancel"
-              icon="null"
-              @click="cancel"
-            />
-          </div>
-          <div>
-            <SiButton
-              size="xs"
-              label="Create"
-              kind="save"
-              icon="null"
-              @click="create"
-            />
-          </div>
-        </div>
-      </div>
+    <div class="flex flex-row">
+      <SchemaCreateForm @create="create" @cancel="cancel" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import VueFeather from "vue-feather";
-import SiTextBox from "@/atoms/SiTextBox.vue";
-import SiSelect from "@/atoms/SiSelect.vue";
-import SiButton from "@/atoms/SiButton.vue";
-import SiFormRow from "@/atoms/SiFormRow.vue";
-import SiError from "@/atoms/SiError.vue";
+import SchemaCreateForm from "./SchemaCreateForm.vue";
 
 import { useRouter } from "vue-router";
-import { ref } from "vue";
-import { SchemaKind } from "@/api/sdf/dal/schema";
-import { SchemaService } from "@/service/schema";
-import { enumKeys } from "@/utils/enumKeys";
+import { GlobalErrorService } from "@/service/global_error";
+import { ApiResponse } from "@/api/sdf";
+import { CreateSchemaResponse } from "@/service/schema/create_schema";
 
 const router = useRouter();
-
-const kindOptionsArray: Array<{ label: string; value: string }> = [];
-for (const value of enumKeys(SchemaKind)) {
-  kindOptionsArray.push({ label: value, value: SchemaKind[value] });
-}
-const kindOptions = ref(kindOptionsArray);
-
-const form = ref({
-  name: "",
-  kind: SchemaKind.Concrete,
-});
 
 const cancel = async () => {
   await router.push({ name: "schema-list" });
 };
 
-const errorMessage = ref("");
-const create = async () => {
-  let result = await SchemaService.createSchema(form.value);
+const create = async (result: ApiResponse<CreateSchemaResponse>) => {
   if (result.error) {
-    errorMessage.value = result.error.message;
+    GlobalErrorService.set(result);
   } else {
     await router.push({ name: "schema-list" });
   }
-};
-
-const _schemaNew = async () => {
-  await router.push({ name: "schema-new" });
 };
 </script>
 

--- a/app/web/src/organisims/SignupForm.vue
+++ b/app/web/src/organisims/SignupForm.vue
@@ -117,6 +117,7 @@ import {
   SignupService,
 } from "@/service/signup";
 import { ApiResponse } from "@/api/sdf";
+import { take, tap } from "rxjs";
 
 enum InputKind {
   BillingAccount = "billingAccount",
@@ -145,15 +146,14 @@ export default defineComponent({
     };
   },
   methods: {
-    async createAccount() {
-      let reply: ApiResponse<CreateAccountResponse> = await SignupService.createAccount(
-        this.form,
-      );
-      if (reply.error) {
-        this.errorMessage = reply.error.message;
-      } else {
-        this.$emit("success");
-      }
+    createAccount() {
+      SignupService.createAccount(this.form).subscribe((response) => {
+        if (response.error) {
+          this.errorMessage = response.error.message;
+        } else {
+          this.$emit("success");
+        }
+      });
     },
     async backToLogin() {
       this.$emit("back-to-login");

--- a/app/web/src/pages/Home.vue
+++ b/app/web/src/pages/Home.vue
@@ -29,6 +29,7 @@ import { globalErrorMessage$ } from "@/observable/global";
 import { refFrom } from "vuse-rx";
 import { map } from "rxjs/operators";
 import { GlobalErrorService } from "@/service/global_error";
+import { firstValueFrom, tap } from "rxjs";
 
 const route = useRoute();
 const router = useRouter();
@@ -51,7 +52,7 @@ const clearErrorMessage = () => {
 };
 
 onMounted(async () => {
-  const defaults = await SessionService.getDefaults();
+  const defaults = await firstValueFrom(SessionService.getDefaults());
   isLoading.value = false;
   if (route.name == "home" && !defaults.error) {
     await router.push({

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -51,6 +51,7 @@ const routes: RouteRecordRaw[] = [
             name: "schema-list",
             path: "list",
             component: SchemaList,
+            props: { modal: true },
           },
           {
             name: "schema-new",

--- a/app/web/src/service/change_set.ts
+++ b/app/web/src/service/change_set.ts
@@ -7,8 +7,12 @@ import { startEditSession } from "./change_set/start_edit_session";
 import { cancelEditSession } from "./change_set/cancel_edit_session";
 import { saveEditSession } from "./change_set/save_edit_session";
 import { switchToHead } from "./change_set/switch_to_head";
+import { currentChangeSet } from "./change_set/current_change_set";
+import { currentEditMode } from "./change_set/current_edit_mode";
 
 export const ChangeSetService = {
+  currentEditMode,
+  currentChangeSet,
   listOpenChangeSets,
   createChangeSet,
   applyChangeSet,

--- a/app/web/src/service/change_set/cancel_edit_session.ts
+++ b/app/web/src/service/change_set/cancel_edit_session.ts
@@ -3,7 +3,7 @@ import { ApiResponse, SDF } from "@/api/sdf";
 import { EditSession } from "@/api/sdf/dal/edit_session";
 import { editSession$ } from "@/observable/edit_session";
 import { editMode$ } from "@/observable/edit_mode";
-import { firstValueFrom, from, mergeMap, take, tap } from "rxjs";
+import { from, mergeMap, Observable, take, tap } from "rxjs";
 
 /**
  * Returns the edit session that has been cancelled, or null if no
@@ -13,36 +13,32 @@ interface CancelEditSessionResponse {
   editSession: EditSession | null;
 }
 
-export async function cancelEditSession(): Promise<
+export function cancelEditSession(): Observable<
   ApiResponse<CancelEditSessionResponse>
 > {
-  return firstValueFrom(
-    editSession$.pipe(
-      take(1),
-      mergeMap((editSession) => {
-        if (editSession) {
-          const bottle = Bottle.pop("default");
-          const sdf: SDF = bottle.container.SDF;
-          return from(
-            sdf.post<CancelEditSessionResponse>(
-              "change_set/cancel_edit_session",
-              { editSessionPk: editSession.pk },
-            ),
-          );
-        } else {
-          const response: ApiResponse<CancelEditSessionResponse> = {
-            editSession: null,
-          };
-          return from([response]);
-        }
-      }),
-      tap((response) => {
-        if (!response.error) {
-          editSession$.next(null);
-          editMode$.next(false);
-        }
-      }),
-      take(1),
-    ),
+  return editSession$.pipe(
+    take(1),
+    mergeMap((editSession) => {
+      if (editSession) {
+        const bottle = Bottle.pop("default");
+        const sdf: SDF = bottle.container.SDF;
+        return sdf.post<ApiResponse<CancelEditSessionResponse>>(
+          "change_set/cancel_edit_session",
+          { editSessionPk: editSession.pk },
+        );
+      } else {
+        const response: ApiResponse<CancelEditSessionResponse> = {
+          editSession: null,
+        };
+        return from([response]);
+      }
+    }),
+    tap((response) => {
+      if (!response.error) {
+        editSession$.next(null);
+        editMode$.next(false);
+      }
+    }),
+    take(1),
   );
 }

--- a/app/web/src/service/change_set/current_change_set.ts
+++ b/app/web/src/service/change_set/current_change_set.ts
@@ -1,0 +1,9 @@
+import { changeSet$ } from "@/observable/change_set";
+
+/**
+ * An observable stream of the currently selected changeset, if
+ * there is any.
+ */
+export function currentChangeSet(): typeof changeSet$ {
+  return changeSet$;
+}

--- a/app/web/src/service/change_set/current_edit_mode.ts
+++ b/app/web/src/service/change_set/current_edit_mode.ts
@@ -1,0 +1,5 @@
+import { editMode$ } from "@/observable/edit_mode";
+
+export function currentEditMode(): typeof editMode$ {
+  return editMode$;
+}

--- a/app/web/src/service/change_set/list_open_change_sets.ts
+++ b/app/web/src/service/change_set/list_open_change_sets.ts
@@ -1,21 +1,45 @@
 import Bottle from "bottlejs";
 import { ApiResponse, SDF } from "@/api/sdf";
 import { LabelList } from "@/api/sdf/dal/label_list";
+import { combineLatest, Observable, shareReplay } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import {
+  eventChangeSetApplied$,
+  eventChangeSetCanceled$,
+  eventChangeSetCreated$,
+} from "@/observable/change_set";
 
 interface ListOpenChangesetsResponse {
   list: LabelList<number>;
 }
 
-export async function listOpenChangeSets(): Promise<
+/**
+ * The list of open change sets, refreshed when the right events trigger, debounced, and
+ * shared. Always populated once it's been called, if there are subscribers.
+ */
+export const changeSetsOpenList$ = combineLatest([
+  eventChangeSetCreated$,
+  eventChangeSetApplied$,
+  eventChangeSetCanceled$,
+]).pipe(
+  switchMap(
+    ([
+      _eventChangeSetCreated,
+      _eventChangeSetApplied,
+      _eventChangeSetCanceled,
+    ]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      return sdf.get<ApiResponse<ListOpenChangesetsResponse>>(
+        "change_set/list_open_change_sets",
+      );
+    },
+  ),
+  shareReplay(1),
+);
+
+export function listOpenChangeSets(): Observable<
   ApiResponse<ListOpenChangesetsResponse>
 > {
-  const bottle = Bottle.pop("default");
-  const sdf: SDF = bottle.container.SDF;
-  const result: ApiResponse<ListOpenChangesetsResponse> = await sdf.get(
-    "change_set/list_open_change_sets",
-  );
-  if (result.error) {
-    return result;
-  }
-  return result;
+  return changeSetsOpenList$;
 }

--- a/app/web/src/service/change_set/save_edit_session.ts
+++ b/app/web/src/service/change_set/save_edit_session.ts
@@ -3,7 +3,7 @@ import { ApiResponse, SDF } from "@/api/sdf";
 import { EditSession } from "@/api/sdf/dal/edit_session";
 import { editSession$ } from "@/observable/edit_session";
 import { editMode$ } from "@/observable/edit_mode";
-import { firstValueFrom, from, mergeMap, take, tap } from "rxjs";
+import { from, mergeMap, Observable, take, tap } from "rxjs";
 
 /**
  * Returns the edit session that has been saved, or null if no
@@ -13,35 +13,33 @@ interface SaveEditSessionResponse {
   editSession: EditSession | null;
 }
 
-export async function saveEditSession(): Promise<
+export function saveEditSession(): Observable<
   ApiResponse<SaveEditSessionResponse>
 > {
-  return firstValueFrom(
-    editSession$.pipe(
-      take(1),
-      mergeMap((editSession) => {
-        if (editSession) {
-          const bottle = Bottle.pop("default");
-          const sdf: SDF = bottle.container.SDF;
-          return from(
-            sdf.post<SaveEditSessionResponse>("change_set/save_edit_session", {
-              editSessionPk: editSession.pk,
-            }),
-          );
-        } else {
-          const response: ApiResponse<SaveEditSessionResponse> = {
-            editSession: null,
-          };
-          return from([response]);
-        }
-      }),
-      tap((response) => {
-        if (!response.error) {
-          editSession$.next(null);
-          editMode$.next(false);
-        }
-      }),
-      take(1),
-    ),
+  return editSession$.pipe(
+    take(1),
+    mergeMap((editSession) => {
+      if (editSession) {
+        const bottle = Bottle.pop("default");
+        const sdf: SDF = bottle.container.SDF;
+        return from(
+          sdf.post<SaveEditSessionResponse>("change_set/save_edit_session", {
+            editSessionPk: editSession.pk,
+          }),
+        );
+      } else {
+        const response: ApiResponse<SaveEditSessionResponse> = {
+          editSession: null,
+        };
+        return from([response]);
+      }
+    }),
+    tap((response) => {
+      if (!response.error) {
+        editSession$.next(null);
+        editMode$.next(false);
+      }
+    }),
+    take(1),
   );
 }

--- a/app/web/src/service/change_set/start_edit_session.ts
+++ b/app/web/src/service/change_set/start_edit_session.ts
@@ -3,6 +3,7 @@ import { ApiResponse, SDF } from "@/api/sdf";
 import { EditSession } from "@/api/sdf/dal/edit_session";
 import { editSession$ } from "@/observable/edit_session";
 import { editMode$ } from "@/observable/edit_mode";
+import { Observable, tap } from "rxjs";
 
 interface StartEditSessionRequest {
   changeSetPk: number;
@@ -12,19 +13,22 @@ interface StartEditSessionResponse {
   editSession: EditSession;
 }
 
-export async function startEditSession(
+export function startEditSession(
   request: StartEditSessionRequest,
-): Promise<ApiResponse<StartEditSessionResponse>> {
+): Observable<ApiResponse<StartEditSessionResponse>> {
   const bottle = Bottle.pop("default");
   const sdf: SDF = bottle.container.SDF;
-  const response: ApiResponse<StartEditSessionResponse> = await sdf.post(
-    "change_set/start_edit_session",
-    request,
-  );
-  if (response.error) {
-    return response;
-  }
-  editSession$.next(response.editSession);
-  editMode$.next(true);
-  return response;
+  return sdf
+    .post<ApiResponse<StartEditSessionResponse>>(
+      "change_set/start_edit_session",
+      request,
+    )
+    .pipe(
+      tap((response) => {
+        if (!response.error) {
+          editSession$.next(response.editSession);
+          editMode$.next(true);
+        }
+      }),
+    );
 }

--- a/app/web/src/service/global_error.ts
+++ b/app/web/src/service/global_error.ts
@@ -1,5 +1,6 @@
 import { globalErrorMessage$ } from "@/observable/global";
-import { ApiResponseError } from "@/api/sdf";
+import { ApiResponse, ApiResponseError } from "@/api/sdf";
+import { Observable } from "rxjs";
 
 /**
  * Clear the global error message
@@ -16,9 +17,21 @@ export function set(error: ApiResponseError) {
 }
 
 /**
+ * Set the global error message if the observable requires it
+ */
+export function setIfError<T>(obs: Observable<ApiResponse<T>>) {
+  obs.subscribe((response) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
+}
+
+/**
  * Manages the global error display
  */
 export const GlobalErrorService = {
   clear,
   set,
+  setIfError,
 };

--- a/app/web/src/service/schema.ts
+++ b/app/web/src/service/schema.ts
@@ -1,6 +1,8 @@
 export * from "./schema/create_schema";
 import { createSchema } from "./schema/create_schema";
+import { listSchemas } from "./schema/list_schemas";
 
 export const SchemaService = {
   createSchema,
+  listSchemas,
 };

--- a/app/web/src/service/schema/create_schema.ts
+++ b/app/web/src/service/schema/create_schema.ts
@@ -1,29 +1,43 @@
 import Bottle from "bottlejs";
 import { ApiResponse, SDF } from "@/api/sdf";
 import { Schema, SchemaKind } from "@/api/sdf/dal/schema";
-import { schemaListRefresh$ } from "@/observable/schema";
+import { eventSchemaCreated$ } from "@/observable/schema";
+import { combineLatest, Observable, take, tap } from "rxjs";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { visibility$ } from "@/observable/visibility";
+import { switchMap } from "rxjs/operators";
 
-interface CreateSchemaRequest {
+export interface CreateSchemaArgs {
   name: String;
   kind: SchemaKind;
 }
 
-interface CreateSchemaResponse {
+export interface CreateSchemaRequest extends CreateSchemaArgs, Visibility {}
+
+export interface CreateSchemaResponse {
   schema: Schema;
 }
 
-export async function createSchema(
-  request: CreateSchemaRequest,
-): Promise<ApiResponse<CreateSchemaResponse>> {
+export function createSchema(
+  args: CreateSchemaArgs,
+): Observable<ApiResponse<CreateSchemaResponse>> {
   const bottle = Bottle.pop("default");
   const sdf: SDF = bottle.container.SDF;
-  const result: ApiResponse<CreateSchemaResponse> = await sdf.post(
-    "schema/create_schema",
-    request,
+  return combineLatest([visibility$]).pipe(
+    take(1),
+    switchMap(([visibility]) => {
+      return sdf
+        .post<ApiResponse<CreateSchemaResponse>>("schema/create_schema", {
+          ...args,
+          ...visibility,
+        })
+        .pipe(
+          tap((response) => {
+            if (!response.error) {
+              eventSchemaCreated$.next(response.schema.pk);
+            }
+          }),
+        );
+    }),
   );
-  if (result.error) {
-    return result;
-  }
-  schemaListRefresh$.next(true);
-  return result;
 }

--- a/app/web/src/service/schema/list_schemas.ts
+++ b/app/web/src/service/schema/list_schemas.ts
@@ -1,0 +1,30 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { Schema } from "@/api/sdf/dal/schema";
+import { combineLatest, Observable, shareReplay } from "rxjs";
+import { visibility$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { eventSchemaCreated$ } from "@/observable/schema";
+import { switchMap } from "rxjs/operators";
+
+export interface ListSchemaResponse {
+  list: Array<Schema>;
+}
+
+export const schemaList$ = combineLatest([
+  visibility$,
+  eventSchemaCreated$,
+]).pipe(
+  switchMap(([visibility, _eventSchemaCreated]) => {
+    const bottle = Bottle.pop("default");
+    const sdf: SDF = bottle.container.SDF;
+    return sdf.get<ApiResponse<ListSchemaResponse>>(
+      "schema/list_schemas",
+      visibility,
+    );
+  }),
+  shareReplay(1),
+);
+
+export function listSchemas(): Observable<ApiResponse<ListSchemaResponse>> {
+  return schemaList$;
+}

--- a/app/web/src/service/session/get_defaults.ts
+++ b/app/web/src/service/session/get_defaults.ts
@@ -4,22 +4,22 @@ import { Workspace } from "@/api/sdf/dal/workspace";
 import { Organization } from "@/api/sdf/dal/organization";
 import { workspace$ } from "@/observable/workspace";
 import { organization$ } from "@/observable/organization";
+import { Observable, tap } from "rxjs";
 
 interface GetDefaultsResponse {
   workspace: Workspace;
   organization: Organization;
 }
 
-export async function getDefaults(): Promise<ApiResponse<GetDefaultsResponse>> {
+export function getDefaults(): Observable<ApiResponse<GetDefaultsResponse>> {
   const bottle = Bottle.pop("default");
   const sdf: SDF = bottle.container.SDF;
-  const result: ApiResponse<GetDefaultsResponse> = await sdf.get(
-    "session/get_defaults",
+  return sdf.get<ApiResponse<GetDefaultsResponse>>("session/get_defaults").pipe(
+    tap((response) => {
+      if (!response.error) {
+        workspace$.next(response.workspace);
+        organization$.next(response.organization);
+      }
+    }),
   );
-  if (result.error) {
-    return result;
-  }
-  workspace$.next(result.workspace);
-  organization$.next(result.organization);
-  return result;
 }

--- a/app/web/src/service/session/is_authenticated.ts
+++ b/app/web/src/service/session/is_authenticated.ts
@@ -22,8 +22,8 @@ export async function isAuthenticated(): Promise<ApiResponse<boolean>> {
     const user = await firstValueFrom(user$);
     const billingAccount = await firstValueFrom(billingAccount$);
     if (!user && !billingAccount) {
-      const result: ApiResponse<RestoreAuthenticationResponse> = await sdf.get(
-        "session/restore_authentication",
+      const result: ApiResponse<RestoreAuthenticationResponse> = await firstValueFrom(
+        sdf.get("session/restore_authentication"),
       );
       if (result.error) {
         console.log("failed to restore authentication state", result);

--- a/app/web/src/service/signup/create_account.ts
+++ b/app/web/src/service/signup/create_account.ts
@@ -1,5 +1,6 @@
-import { ApiResponse } from "@/api/sdf";
+import { ApiResponse, SDF } from "@/api/sdf";
 import Bottle from "bottlejs";
+import { Observable } from "rxjs";
 
 export interface CreateAccountRequest {
   billingAccountName: string;
@@ -12,12 +13,14 @@ export interface CreateAccountResponse {
   success: boolean;
 }
 
-export async function createAccount(
+export function createAccount(
   request: CreateAccountRequest,
-): Promise<ApiResponse<CreateAccountResponse>> {
+): Observable<ApiResponse<CreateAccountResponse>> {
   const bottle = Bottle.pop("default");
-  const sdf = bottle.container.SDF;
+  const sdf: SDF = bottle.container.SDF;
 
-  const response = await sdf.post("signup/create_account", request);
-  return response;
+  return sdf.post<ApiResponse<CreateAccountResponse>>(
+    "signup/create_account",
+    request,
+  );
 }

--- a/app/web/src/service/ws_event.ts
+++ b/app/web/src/service/ws_event.ts
@@ -5,6 +5,7 @@ import {
   eventChangeSetCanceled$,
   eventChangeSetCreated$,
 } from "@/observable/change_set";
+import { eventSchemaCreated$ } from "@/observable/schema";
 
 const eventMap: {
   [E in WsEvent["payload"]["kind"]]: BehaviorSubject<any> | ReplaySubject<any>;
@@ -12,6 +13,7 @@ const eventMap: {
   ChangeSetCreated: eventChangeSetCreated$,
   ChangeSetApplied: eventChangeSetApplied$,
   ChangeSetCanceled: eventChangeSetCanceled$,
+  SchemaCreated: eventSchemaCreated$,
 };
 
 export function dispatch(wsEvent: WsEvent) {

--- a/lib/dal/src/standard_pk.rs
+++ b/lib/dal/src/standard_pk.rs
@@ -15,6 +15,15 @@ macro_rules! pk {
         )]
         pub struct $name(i64);
 
+        impl std::str::FromStr for $name {
+            type Err = std::num::ParseIntError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let x = s.parse::<i64>()?;
+                Ok($name(x))
+            }
+        }
+
         impl<'a> postgres_types::FromSql<'a> for $name {
             fn from_sql(
                 ty: &postgres_types::Type,

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -1,9 +1,6 @@
 use crate::billing_account::BillingAccountSignup;
 use crate::jwt_key::JwtEncrypt;
-use crate::{
-    BillingAccount, ChangeSet, EditSession, Group, HistoryActor, KeyPair, StandardModel, Tenancy,
-    User, Visibility, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
-};
+use crate::{BillingAccount, ChangeSet, EditSession, Group, HistoryActor, KeyPair, StandardModel, Tenancy, User, Visibility, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK, Schema, SchemaKind};
 use anyhow::Result;
 use async_trait::async_trait;
 use lazy_static::lazy_static;
@@ -339,3 +336,26 @@ pub async fn billing_account_signup(
         .expect("cannot log in newly created user");
     (nba, auth_token)
 }
+
+pub async fn create_schema(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    kind: &SchemaKind,
+) -> Schema {
+    let name = generate_fake_name();
+    Schema::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &name,
+        &kind,
+    )
+        .await
+        .expect("cannot create schema")
+}
+

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -1,4 +1,4 @@
-use crate::{BillingAccountId, ChangeSet, ChangeSetPk, StandardModel, Tenancy};
+use crate::{BillingAccountId, ChangeSetPk, SchemaPk, StandardModel, Tenancy};
 use serde::{Deserialize, Serialize};
 use si_data::{NatsError, NatsTxn};
 use thiserror::Error;
@@ -19,6 +19,7 @@ pub enum WsPayload {
     ChangeSetCreated(ChangeSetPk),
     ChangeSetApplied(ChangeSetPk),
     ChangeSetCanceled(ChangeSetPk),
+    SchemaCreated(SchemaPk),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]

--- a/lib/sdf/src/server/service/schema.rs
+++ b/lib/sdf/src/server/service/schema.rs
@@ -1,7 +1,7 @@
 use axum::body::{Bytes, Full};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
 use dal::{SchemaError as DalSchemaError, StandardModelError};
@@ -9,6 +9,7 @@ use std::convert::Infallible;
 use thiserror::Error;
 
 pub mod create_schema;
+pub mod list_schemas;
 
 #[derive(Debug, Error)]
 pub enum SchemaError {
@@ -43,4 +44,5 @@ impl IntoResponse for SchemaError {
 
 pub fn routes() -> Router {
     Router::new().route("/create_schema", post(create_schema::create_schema))
+        .route("/list_schemas", get(list_schemas::list_schemas))
 }

--- a/lib/sdf/src/server/service/schema/list_schemas.rs
+++ b/lib/sdf/src/server/service/schema/list_schemas.rs
@@ -1,0 +1,29 @@
+use super::SchemaResult;
+use crate::server::extract::{Authorization, NatsTxn, PgRoTxn, QueryVisibility};
+use axum::Json;
+use dal::{HistoryActor, Schema, SchemaKind, StandardModel, Tenancy, Visibility};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ListSchemaRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSchemaResponse {
+    pub list: Vec<Schema>,
+}
+
+pub async fn list_schemas(
+    mut txn: PgRoTxn,
+    Authorization(claim): Authorization,
+    QueryVisibility(visibility): QueryVisibility,
+) -> SchemaResult<Json<ListSchemaResponse>> {
+    let txn = txn.start().await?;
+    let tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let list = Schema::list(&txn, &tenancy, &visibility).await?;
+    let response = ListSchemaResponse { list };
+    Ok(Json(response))
+}

--- a/lib/sdf/tests/service_tests/schema.rs
+++ b/lib/sdf/tests/service_tests/schema.rs
@@ -1,8 +1,10 @@
-use crate::service_tests::api_request_auth_json_body;
+use crate::service_tests::{api_request_auth_json_body, api_request_auth_query};
 use crate::test_setup;
 use axum::http::Method;
-use dal::SchemaKind;
+use dal::{HistoryActor, SchemaKind, StandardModel, Tenancy, Visibility};
 use sdf::service::schema::create_schema::{CreateSchemaRequest, CreateSchemaResponse};
+use dal::test_harness::create_schema as dal_create_schema;
+use sdf::service::schema::list_schemas::{ListSchemaRequest, ListSchemaResponse};
 
 #[tokio::test]
 async fn create_schema() {
@@ -32,4 +34,29 @@ async fn create_schema() {
     .await;
     assert_eq!(response.schema.name(), "fancyPants");
     assert_eq!(response.schema.kind(), &SchemaKind::Concrete);
+}
+
+#[tokio::test]
+async fn list_schemas() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        app,
+        nba,
+        auth_token
+    );
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema_one = dal_create_schema(&txn, &nats, &tenancy, &visibility, &history_actor, &SchemaKind::Concrete).await;
+    let schema_two = dal_create_schema(&txn, &nats, &tenancy, &visibility, &history_actor, &SchemaKind::Concrete).await;
+    txn.commit().await.expect("cannot commit txn");
+    let request = ListSchemaRequest { visibility: visibility.clone() };
+    let response: ListSchemaResponse = api_request_auth_query(app, "/api/schema/list_schemas", &auth_token, &request).await;
+    assert_eq!(response.list.len(), 2);
 }


### PR DESCRIPTION
You can now list and create schemas from the frontend. This PR also includes cleaning up the pattern in the web app to always access state through "services", which wrap the actual application state.

![](https://media4.giphy.com/media/XathaB5ILqSME/giphy.gif)