### PR TITLE
fix(si-data): fix NATS subscription stream impl

### DIFF
--- a/lib/cyclone/src/client/resolver_function.rs
+++ b/lib/cyclone/src/client/resolver_function.rs
@@ -152,6 +152,10 @@ where
                     ResolverFunctionMessage::FunctionResult(function_result) => {
                         self.result = Some(function_result);
                         // TODO(fnichol): what is the right return here??
+                        // (future fnichol): hey buddy! pretty sure you can:
+                        // `cx.waker().wake_by_ref()` before returning Poll::Ready which immediatly
+                        // re-wakes this stream to maybe pop another item off. cool huh? I think
+                        // you're learning and that's great.
                         Poll::Ready(Some(Ok(ResolverFunctionExecutingMessage::Heartbeat)))
                         //Poll::Pending
                     }

--- a/lib/si-data/Cargo.toml
+++ b/lib/si-data/Cargo.toml
@@ -57,3 +57,11 @@ tokio-postgres = { version ="0.7.0", features = ["runtime", "with-chrono-0_4", "
 nkeys = "0.1.0"
 tokio-test = "0.4.2"
 tracing-subscriber = { version = "0.2.19" }
+
+[[example]]
+name = "nats-subscribe"
+required-features = ["nats"]
+
+[[example]]
+name = "nats-publish"
+required-features = ["nats"]

--- a/lib/si-data/examples/nats-publish.rs
+++ b/lib/si-data/examples/nats-publish.rs
@@ -1,0 +1,51 @@
+use std::env;
+
+use si_data::{NatsClient, NatsConfig};
+use telemetry::prelude::*;
+use tracing_subscriber::{
+    fmt::{self, format::FmtSpan},
+    prelude::*,
+    EnvFilter, Registry,
+};
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_publish=trace,si_data=trace,info";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
+        )
+        .try_init()?;
+
+    run().await
+}
+
+#[instrument(name = "main", skip_all)]
+async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    let subject = env::args()
+        .nth(1)
+        .expect("usage: nats-publish SUBJECT BODY");
+    let msg = env::args()
+        .nth(2)
+        .expect("usage: nats-publish SUBJECT BODY");
+    let config = NatsConfig::default();
+    let nats = NatsClient::new(&config).await?;
+
+    nats.publish(&subject, msg.clone()).await?;
+    info!(
+        msg = msg.as_str(),
+        subject = subject.as_str(),
+        "published message on subject"
+    );
+
+    Ok(())
+}

--- a/lib/si-data/examples/nats-subscribe.rs
+++ b/lib/si-data/examples/nats-subscribe.rs
@@ -1,6 +1,10 @@
-use futures::{StreamExt, TryStreamExt};
-use si_data::{NatsClient, NatsConfig};
 use std::env;
+
+use futures::TryStreamExt;
+use si_data::{
+    nats::{Message, Subscription},
+    NatsClient, NatsConfig,
+};
 use telemetry::prelude::*;
 use tracing_subscriber::{
     fmt::{self, format::FmtSpan},
@@ -8,31 +12,87 @@ use tracing_subscriber::{
     EnvFilter, Registry,
 };
 
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_subscribe=trace,si_data=trace,info";
+
 #[tokio::main]
 async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     Registry::default()
         .with(
-            EnvFilter::try_from_env("SI_LOG")
-                .unwrap_or_else(|_| EnvFilter::new("debug,si_data=trace")),
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
         )
         .with(
             fmt::layer()
                 .with_thread_ids(true)
                 .with_thread_names(true)
-                .with_span_events(FmtSpan::FULL),
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
         )
         .try_init()?;
 
-    let subject = env::args().skip(1).next().unwrap();
+    run().await
+}
+
+#[instrument(name = "main", skip_all)]
+async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    let subject = env::args()
+        .nth(1)
+        .expect("usage: nats-subscribe SUBJECT [MAX_READ]");
+    let max_read = env::args()
+        .nth(2)
+        .map(|i| i.parse::<u32>().expect("MAX_READ must be a positive int"));
+    if let Some(max) = max_read {
+        info!(
+            "reading maximum of {} messages on subject '{}'",
+            max, &subject
+        );
+    }
     let config = NatsConfig::default();
     let nats = NatsClient::new(&config).await?;
 
     let mut subscription = nats.subscribe(&subject).await?;
 
-    while let Some(msg) = subscription.async_next().await? {
-        info!(message = ?msg, "new message");
+    let mut count = 0;
+    while let Some(message) = subscription.try_next().await? {
+        count += 1;
+
+        process_message(message, count, &subscription);
+
+        if let Some(max) = max_read {
+            if count >= max {
+                debug!("hit max read, closing subscription and ending");
+                subscription.close().await?;
+                break;
+            }
+        }
     }
-    info!("ALL DONE");
+    info!("subscription stream completed");
 
     Ok(())
+}
+
+#[instrument(
+    skip_all,
+    level = "debug",
+    fields(
+        messaging.consumer_id = sub.metadata().messaging_consumer_id(),
+        messaging.destination = sub.metadata().messaging_destination(),
+        messaging.destination_kind = sub.metadata().messaging_destination_kind(),
+        messaging.operation = sub.metadata().messaging_operation(),
+        messaging.protocol = sub.metadata().messaging_protocol(),
+        messaging.system = sub.metadata().messaging_system(),
+        messaging.url = sub.metadata().messaging_url(),
+        messaging.subject = sub.metadata().messaging_subject(),
+        net.transport = sub.metadata().net_transport(),
+        otel.kind = sub.metadata().process_otel_kind(),
+        otel.name = sub.metadata().process_otel_name(),
+        otel.status_code = Empty,
+        otel.status_message = Empty,
+    )
+)]
+fn process_message(message: Message, count: u32, sub: &Subscription) {
+    Span::current().follows_from(sub.span());
+
+    let data = String::from_utf8_lossy(message.data());
+    info!(message = ?message, data = data.as_ref(), count);
 }

--- a/lib/si-data/src/nats/message.rs
+++ b/lib/si-data/src/nats/message.rs
@@ -60,6 +60,7 @@ impl Message {
     #[instrument(
         name = "message.respond",
         skip_all,
+        level = "debug",
         fields(
             messaging.destination = Empty,
             messaging.destination_kind = "topic",
@@ -102,6 +103,7 @@ impl Message {
     #[instrument(
         name = "message.ack",
         skip_all,
+        level = "debug",
         fields(
             messaging.destination = Empty,
             messaging.destination_kind = "topic",
@@ -142,6 +144,7 @@ impl Message {
     #[instrument(
         name = "message.ack_kind",
         skip_all,
+        level = "debug",
         fields(
             messaging.destination = Empty,
             messaging.destination_kind = "topic",
@@ -183,6 +186,7 @@ impl Message {
     #[instrument(
         name = "message.double_ack",
         skip_all,
+        level = "debug",
         fields(
             messaging.destination = Empty,
             messaging.destination_kind = "topic",


### PR DESCRIPTION
This change fixes the `Subscription` streaming implementation, which
wraps over the upstream blocking NATS client API. Prior to this change,
calling `.next()`/`try_next()` on a `Subscription` stream would sit and
never yield a message, despite messages appearing on the target subject.

The issue here, was the prior version was inadvertently spawning a new
blocking task which was waiting on the next message on each call to
`.poll_next()`. The initial call would correctly immediately return a
`Poll::Pending` (i.e. the blocking task was still making progress), but
that future would never be polled again. Instead a *new* blocking task
would be spawned on the second `.poll_next()` call, and so on.

The fix here was to stash the running blocking task's `JoinHandle`, so
we can re-poll it on the next `.poll_next()` call, driving it to
completion.

Bonus Content
-------------

In addition to this fix the following improvements/tweaks are included:

- Update the `nats-subscribe` example to optionally provide a count of
  the maximum number of messages to process before closing the
  subscription.
- Add a `nats-publish` example to pair with `nats-subscribe` and behave
  a bit like `nats pub`.
- Add NATS subscription-specific metadata to each `Subscription` so that
  message-processing code can better instrument themselves. An example
  is provided in the `nats-subscibe` example, which will give us spans
  and timings of not only the total subscription receive time, but each
  message's processing timing.
- Update the instrumentation spans for the NATS client to be `debug`
  rather than the default of `info`. It's possible that `trace` might be
  the right level, although I think that could be reserved for lower
  level network/framing concerns. If this proves about right, then we
  should update the Posgres implementation's instrumentation levels as
  well.

![tenor-217142525](https://user-images.githubusercontent.com/261548/142520423-7511695f-7216-467a-b5ef-1fd81b3d0e81.gif)
