### PR TITLE
chore(*): backend of components and nodes

### DIFF
--- a/app/web/src/api/sdf.ts
+++ b/app/web/src/api/sdf.ts
@@ -3,6 +3,7 @@ import { SdfWs } from "@/api/sdf/ws";
 import { fromFetch } from "rxjs/fetch";
 import { from, mergeMap, Observable } from "rxjs";
 import _ from "lodash";
+import { SessionService } from "@/service/session";
 
 export class FetchError extends Error {
   response: Response;
@@ -170,7 +171,11 @@ export class SDF {
   send_request<T>(request: Request): Observable<ApiResponse<T>> {
     return fromFetch(request).pipe(
       mergeMap((response) => {
-        return from(response.json());
+        if (response.status === 401) {
+          return from(SessionService.logout());
+        } else {
+          return from(response.json());
+        }
       }),
     );
   }

--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -1,0 +1,5 @@
+import { StandardModel } from "@/api/sdf/dal/standard_model";
+
+export interface Component extends StandardModel {
+  name: string;
+}

--- a/app/web/src/api/sdf/ws.ts
+++ b/app/web/src/api/sdf/ws.ts
@@ -1,5 +1,5 @@
 import Bottle from "bottlejs";
-import { WsEvent } from "@/api/sdf/dal/ws_event";
+import { WsEvent, WsPayloadKinds } from "@/api/sdf/dal/ws_event";
 import { WsEventService } from "@/service/ws_event";
 
 export class SdfWs {
@@ -54,6 +54,6 @@ function onClose(ev: CloseEvent): any {
 }
 
 function onMessage(ev: MessageEvent) {
-  const wsEvent: WsEvent = JSON.parse(ev.data);
+  const wsEvent: WsEvent<WsPayloadKinds> = JSON.parse(ev.data);
   WsEventService.dispatch(wsEvent);
 }

--- a/app/web/src/observable/schema.ts
+++ b/app/web/src/observable/schema.ts
@@ -1,7 +1,7 @@
 import { ReplaySubject } from "rxjs";
 
 /**
- * Fired with the id of the new change set when one is canceled.
+ * Fired with the id of a schema when it is created
  */
 export const schemaCreated$ = new ReplaySubject<number | null>(1);
 schemaCreated$.next(null);

--- a/app/web/src/organisims/Application/ApplicationCreateForm.vue
+++ b/app/web/src/organisims/Application/ApplicationCreateForm.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="flex flex-col w-full">
+    <SiError :message="errorMessage" />
+    <SiFormRow>
+      <template #label>
+        <label>Application Name</label>
+      </template>
+      <template #widget>
+        <SiTextBox
+          id="applicationName"
+          v-model="form.applicationName"
+          name="applicationName"
+          placeholder="super dope"
+          required
+          size="sm"
+          @keyup.enter="onEnter"
+          @keyup.escape="cancel"
+        />
+      </template>
+    </SiFormRow>
+    <div class="flex justify-end w-full">
+      <div class="pr-2">
+        <SiButton
+          size="xs"
+          label="Cancel"
+          kind="cancel"
+          icon="null"
+          @click="cancel"
+        />
+      </div>
+      <div>
+        <SiButton
+          size="xs"
+          label="Create"
+          kind="save"
+          icon="null"
+          @click="create"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+import SiButton from "@/atoms/SiButton.vue";
+import SiError from "@/atoms/SiError.vue";
+import SiTextBox from "@/atoms/SiTextBox.vue";
+import SiFormRow from "@/atoms/SiFormRow.vue";
+
+const emit = defineEmits(["cancel", "create"]);
+
+const errorMessage = ref<string>("");
+const form = ref({
+  applicationName: "",
+});
+
+const create = () => {
+  emit("create");
+};
+
+const onEnter = () => {
+  if (form.value.applicationName.length > 0) {
+    create();
+  }
+};
+const cancel = () => {
+  form.value.applicationName = "";
+  emit("cancel");
+};
+</script>

--- a/app/web/src/organisims/Application/ApplicationList.vue
+++ b/app/web/src/organisims/Application/ApplicationList.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    id="applications"
+    class="flex flex-col w-full h-full select-none page-background"
+  >
+    <div
+      id="applications-header"
+      class="flex flex-row items-center justify-between flex-grow-0 flex-shrink-0 h-12 header-background"
+    >
+      <div class="mt-1 ml-8 font-medium align-middle">Applications</div>
+      <div class="mt-1 mr-8 align-middle">
+        <SiButton icon="plus" label="New" size="xs" @click="applicationNew()" />
+      </div>
+      <SiModal
+        v-model="applicationCreateModalShow"
+        name="newApplication"
+        :esc-to-close="true"
+      >
+        <template #title>Create new application</template>
+        <template #body>
+          <ApplicationCreateForm
+            @create="closeCreateModal"
+            @cancel="closeCreateModal"
+          />
+        </template>
+        <template #buttons>
+          <div></div>
+        </template>
+      </SiModal>
+    </div>
+
+    <div class="flex h-full mx-4 mt-4 overflow-auto">
+      <!-- <ApplicationList linkTo="applicationEditor" /> -->
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+import SiButton from "@/atoms/SiButton.vue";
+import SiModal from "@/molecules/SiModal.vue";
+import ApplicationCreateForm from "@/organisims/Application/ApplicationCreateForm.vue";
+
+const applicationCreateModalShow = ref<boolean>(false);
+const applicationNew = () => {
+  applicationCreateModalShow.value = true;
+};
+const closeCreateModal = () => {
+  applicationCreateModalShow.value = false;
+};
+</script>
+
+<style scoped>
+.page-background {
+  background-color: #1e1e1e;
+}
+
+.header-background {
+  background-color: #171717;
+}
+</style>

--- a/app/web/src/organisims/EditForm/EditFormField.vue
+++ b/app/web/src/organisims/EditForm/EditFormField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-row items-center w-full" v-if="show">
+  <div v-if="show" class="flex flex-row items-center w-full">
     <div class="flex flex-col w-full">
       <div class="flex flex-row items-center">
         <div class="flex-wrap self-start text-sm leading-tight text-right w-36">
@@ -7,8 +7,8 @@
         </div>
         <div class="flex w-full">
           <div
-            class="flex mx-2 text-sm leading-tight text-gray-400"
             v-if="editMode"
+            class="flex mx-2 text-sm leading-tight text-gray-400"
             @keyup.stop
             @keydown.stop
           >
@@ -35,7 +35,7 @@
 import { refFrom } from "vuse-rx";
 import { ChangeSetService } from "@/service/change_set";
 
-const props = defineProps({
+defineProps({
   show: {
     type: Boolean,
     required: true,

--- a/app/web/src/organisims/EditForm/HeaderWidget.vue
+++ b/app/web/src/organisims/EditForm/HeaderWidget.vue
@@ -1,8 +1,6 @@
 <template>
   <section>
-    <div
-      class="flex w-full pt-1 pb-1 mt-2 text-sm text-white"
-    >
+    <div class="flex w-full pt-1 pb-1 mt-2 text-sm text-white">
       <div v-if="open" class="flex">
         <VueFeather type="chevron-down" />
         {{ editField.name }}
@@ -40,7 +38,7 @@ const props = defineProps({
 
 const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
 const widget = computed<HeaderWidgetDal>(() => {
-  console.log({widget: JSON.stringify(props.editField.widget)});
+  console.log({ widget: JSON.stringify(props.editField.widget) });
   return props.editField.widget as HeaderWidgetDal;
 });
 

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -5,10 +5,10 @@
     </template>
     <template #edit>
       <select
+        v-model="currentValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         placeholder="text"
-        v-model="currentValue"
         @change="onBlur"
         @focus="onFocus"
         @blur="onBlur"

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -5,12 +5,12 @@
     </template>
     <template #edit>
       <input
+        v-model="currentValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         type="text"
         aria-label="name"
         placeholder="text"
-        v-model="currentValue"
         @keyup.enter="onKeyEnter($event)"
         @focus="onFocus"
         @blur="onBlur"

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="flex flex-row w-full" v-for="editField in editFields" :key="editField.id">
+  <div
+    v-for="editField in editFields"
+    :key="editField.id"
+    class="flex flex-row w-full"
+  >
     <!-- eventually this will do the show/hide logic -->
     <HeaderWidget v-if="editField.widget.kind === 'Header'" :show="true" :edit-field="editField" />
     <ArrayWidget

--- a/app/web/src/organisims/Nav.vue
+++ b/app/web/src/organisims/Nav.vue
@@ -49,14 +49,8 @@
           <!-- Applications Link -->
           <div class="container-link">
             <router-link
-              v-if="currentOrganization && currentWorkspace"
-              data-cy="application-nav-link"
               :to="{
-                name: 'application',
-                params: {
-                  organizationId: currentOrganization.id,
-                  workspaceId: currentWorkspace.id,
-                },
+                name: 'application-list',
               }"
             >
               <div class="flex items-center justify-start cursor-pointer">
@@ -136,13 +130,7 @@
             <router-link
               v-if="currentOrganization && currentWorkspace"
               data-cy="secret-nav-link"
-              :to="{
-                name: 'secret',
-                params: {
-                  organizationId: currentOrganization.id,
-                  workspaceId: currentWorkspace.id,
-                },
-              }"
+              to="notFound"
             >
               <div class="flex items-center justify-start cursor-pointer">
                 <VueFeather type="key" size="1.1rem" class="" />

--- a/app/web/src/organisims/PanelEmpty.vue
+++ b/app/web/src/organisims/PanelEmpty.vue
@@ -13,12 +13,9 @@
       <div
         class="flex flex-col items-center justify-center w-full h-full align-middle"
       >
-        {{panelContainerRef}}
-        {{panelRef}}
-        <img
-          width="300"
-          :src="cheechSvg"
-        />
+        {{ panelContainerRef }}
+        {{ panelRef }}
+        <img width="300" :src="cheechSvg" />
       </div>
     </template>
   </Panel>

--- a/app/web/src/organisims/PanelTree/PanelContainer.vue
+++ b/app/web/src/organisims/PanelTree/PanelContainer.vue
@@ -66,8 +66,9 @@ import {
 } from "./panel_types";
 import {
   createPanelContainerMaximizedObservable,
-  createPanelContainerSizeObservable, restorePanelContainerMaximizedObservable,
-  restorePanelContainerSizeObservable
+  createPanelContainerSizeObservable,
+  restorePanelContainerMaximizedObservable,
+  restorePanelContainerSizeObservable,
 } from "@/observable/editor";
 
 const props = defineProps({
@@ -105,7 +106,7 @@ onMounted(() => {
   );
   if (panelContainerMaximized) {
     maximizedData.value = panelContainerMaximized;
-  };
+  }
 });
 
 watch(

--- a/app/web/src/organisims/Schema/SchemaCreateForm.vue
+++ b/app/web/src/organisims/Schema/SchemaCreateForm.vue
@@ -8,9 +8,9 @@
         </template>
         <template #widget>
           <SiTextBox
-            data-test="schema-new-form-name"
             id="schemaName"
             v-model="form.name"
+            data-test="schema-new-form-name"
             size="xs"
             name="name"
             placeholder="schema name"

--- a/app/web/src/organisims/Schema/SchemaList.vue
+++ b/app/web/src/organisims/Schema/SchemaList.vue
@@ -42,9 +42,9 @@
           </div>
         </div>
         <div
-          data-test="schema-list"
           v-for="schema in schemaList"
           :key="schema.pk"
+          data-test="schema-list"
           class="flex flex-row row-item"
         >
           <div class="w-6/12 px-2 py-1 text-center">

--- a/app/web/src/pages/Home.vue
+++ b/app/web/src/pages/Home.vue
@@ -56,11 +56,7 @@ onMounted(async () => {
   isLoading.value = false;
   if (route.name == "home" && !defaults.error) {
     await router.push({
-      name: "workspace",
-      params: {
-        organizationId: defaults.organization.id,
-        workspaceId: defaults.workspace.id,
-      },
+      name: "application-list",
     });
   }
 });

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -10,6 +10,8 @@ import Schema from "@/templates/Schema.vue";
 import SchemaList from "@/organisims/Schema/SchemaList.vue";
 import SchemaNew from "@/organisims/Schema/SchemaNew.vue";
 import SchemaView from "@/organisims/Schema/SchemaView.vue";
+import Application from "@/templates/Application.vue";
+import ApplicationList from "@/organisims/Application/ApplicationList.vue";
 import Editor from "@/organisims/Editor.vue";
 import _ from "lodash";
 
@@ -20,28 +22,40 @@ const routes: RouteRecordRaw[] = [
     component: Home,
     children: [
       {
-        path: "o/:organizationId/w/:workspaceId",
-        props: true,
-        name: "workspace",
-        redirect: { name: "application" },
-      },
-      {
-        path: "o/:organizationId/w/:workspaceId/a",
+        path: "application",
         props: true,
         name: "application",
-        component: Editor, // Application
-      },
-      {
-        path: "o/:organizationId/w/:workspaceId/a/:applicationId",
-        props: true,
-        name: "applicationDetails",
-        component: Editor, // ApplicationDetails
-      },
-      {
-        path: "o/:organizationId/w/:workspaceId/s",
-        props: true,
-        name: "secret",
-        component: Editor, // Secret
+        component: Application,
+        redirect: { name: "application-list" },
+        children: [
+          {
+            name: "application-list",
+            path: "list",
+            component: ApplicationList,
+            props: { modal: true },
+          },
+          {
+            name: "application-new",
+            path: "new",
+            component: Editor,
+          },
+          {
+            name: "application-view",
+            path: ":applicationId",
+            props: (route) => {
+              let applicationId;
+              if (_.isArray(route.params.applicationId)) {
+                applicationId = Number.parseInt(route.params.applicationId[0]);
+              } else {
+                applicationId = Number.parseInt(route.params.applicationId);
+              }
+              return {
+                applicationId,
+              };
+            },
+            component: Editor,
+          },
+        ],
       },
       {
         path: "schema",
@@ -102,6 +116,7 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: "/404",
+    name: "notFound",
     component: NotFoundPage,
   },
   {

--- a/app/web/src/service/application.ts
+++ b/app/web/src/service/application.ts
@@ -1,0 +1,5 @@
+import { createApplication } from "./application/create_application";
+
+export const ApplicationService = {
+  createApplication,
+};

--- a/app/web/src/service/application/create_application.ts
+++ b/app/web/src/service/application/create_application.ts
@@ -1,0 +1,64 @@
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatestWith, from, Observable, take, tap } from "rxjs";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { visibility$ } from "@/observable/visibility";
+import { switchMap } from "rxjs/operators";
+import { editSessionWritten$ } from "@/observable/edit_session";
+import { Component } from "@/api/sdf/dal/component";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
+
+export interface CreateApplicationArgs {
+  name: String;
+  workspaceId: number;
+}
+
+export interface CreateApplicationRequest
+  extends CreateApplicationArgs,
+    Visibility {}
+
+export interface CreateApplicationResponse {
+  application: Component;
+}
+
+export function createApplication(
+  args: CreateApplicationArgs,
+): Observable<ApiResponse<CreateApplicationResponse>> {
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+  return visibility$.pipe(
+    take(1),
+    combineLatestWith(workspace$),
+    switchMap(([visibility, workspace]) => {
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot create an application without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      const request: CreateApplicationRequest = {
+        ...args,
+        ...visibility,
+        workspaceId: workspace.id,
+      };
+      return sdf
+        .post<ApiResponse<CreateApplicationResponse>>(
+          "application/create_application",
+          request,
+        )
+        .pipe(
+          tap((response) => {
+            if (!response.error) {
+              editSessionWritten$.next(true);
+            }
+          }),
+        );
+    }),
+  );
+}

--- a/app/web/src/service/schema/create_schema.ts
+++ b/app/web/src/service/schema/create_schema.ts
@@ -1,7 +1,6 @@
 import Bottle from "bottlejs";
 import { ApiResponse, SDF } from "@/api/sdf";
 import { Schema, SchemaKind } from "@/api/sdf/dal/schema";
-import { schemaCreated$ } from "@/observable/schema";
 import { Observable, take, tap } from "rxjs";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import { visibility$ } from "@/observable/visibility";
@@ -35,7 +34,6 @@ export function createSchema(
         .pipe(
           tap((response) => {
             if (!response.error) {
-              schemaCreated$.next(response.schema.pk);
               editSessionWritten$.next(true);
             }
           }),

--- a/app/web/src/service/schema/get_schema.ts
+++ b/app/web/src/service/schema/get_schema.ts
@@ -3,7 +3,6 @@ import { Schema } from "@/api/sdf/dal/schema";
 import { combineLatest, Observable, shareReplay } from "rxjs";
 import { standardVisibilityTriggers$ } from "@/observable/visibility";
 import Bottle from "bottlejs";
-import { schemaCreated$ } from "@/observable/schema";
 import { switchMap } from "rxjs/operators";
 import { Visibility } from "@/api/sdf/dal/visibility";
 
@@ -11,8 +10,7 @@ export interface GetSchemaArgs {
   schemaId: number;
 }
 
-export interface GetSchemaRequest extends GetSchemaArgs, Visibility {
-}
+export interface GetSchemaRequest extends GetSchemaArgs, Visibility {}
 
 export type GetSchemaResponse = Schema;
 
@@ -28,7 +26,6 @@ export function getSchema(
   }
   getSchemaCollection[args.schemaId] = combineLatest([
     standardVisibilityTriggers$,
-    schemaCreated$,
   ]).pipe(
     switchMap(([[visibility]]) => {
       const bottle = Bottle.pop("default");

--- a/app/web/src/templates/Application.vue
+++ b/app/web/src/templates/Application.vue
@@ -1,0 +1,14 @@
+<template>
+  <div
+    id="applications"
+    class="flex flex-col w-full h-full select-none page-background"
+  >
+    <router-view />
+  </div>
+</template>
+
+<style scoped>
+.page-background {
+  background-color: #1e1e1e;
+}
+</style>

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     },
     proxy: {
       "/api": {
-        target: "http://localhost:5156",
+        target: "http://127.0.0.1:5156",
         ws: true,
       },
     },

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::schema::variant::SchemaVariantId;
+use crate::schema::SchemaVariant;
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
+    HistoryActor, HistoryEventError, Schema, SchemaId, StandardModel, StandardModelError, Tenancy,
+    Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum ComponentError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type ComponentResult<T> = Result<T, ComponentError>;
+
+pk!(ComponentPk);
+pk!(ComponentId);
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Component {
+    pk: ComponentPk,
+    id: ComponentId,
+    name: String,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: Component,
+    pk: ComponentPk,
+    id: ComponentId,
+    table_name: "components",
+    history_event_label_base: "component",
+    history_event_message_name: "Component"
+}
+
+impl Component {
+    #[tracing::instrument(skip(txn, nats, name))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+    ) -> ComponentResult<Self> {
+        let name = name.as_ref();
+        let row = txn
+            .query_one(
+                "SELECT object FROM component_create_v1($1, $2, $3)",
+                &[&tenancy, &visibility, &name],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(name, String, ComponentResult);
+
+    standard_model_belongs_to!(
+        lookup_fn: schema,
+        set_fn: set_schema,
+        unset_fn: unset_schema,
+        table: "component_belongs_to_schema",
+        model_table: "schemas",
+        belongs_to_id: SchemaId,
+        returns: Schema,
+        result: ComponentResult,
+    );
+
+    standard_model_belongs_to!(
+        lookup_fn: schema_variant,
+        set_fn: set_schema_variant,
+        unset_fn: unset_schema_variant,
+        table: "component_belongs_to_schema_variant",
+        model_table: "schema_variants",
+        belongs_to_id: SchemaVariantId,
+        returns: SchemaVariant,
+        result: ComponentResult,
+    );
+}

--- a/lib/dal/src/migrations/U0035__components.sql
+++ b/lib/dal/src/migrations/U0035__components.sql
@@ -1,0 +1,51 @@
+CREATE TABLE components
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    name                        text                     NOT NULL
+);
+SELECT standard_model_table_constraints_v1('components');
+SELECT belongs_to_table_create_v1('component_belongs_to_schema', 'components', 'schemas');
+SELECT belongs_to_table_create_v1('component_belongs_to_schema_variant', 'components', 'schema_variants');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('components', 'model', 'component', 'Component'),
+       ('component_belongs_to_schema', 'belongs_to', 'component.schema', 'Component <> Schema'),
+       ('component_belongs_to_schema_variant', 'belongs_to', 'component.schema_variant', 'Component <> SchemaVariant');
+
+
+CREATE OR REPLACE FUNCTION component_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO components (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
+                          tenancy_workspace_ids,
+                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name)
+    VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted, this_name)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/migrations/U0036__nodes.sql
+++ b/lib/dal/src/migrations/U0036__nodes.sql
@@ -1,0 +1,48 @@
+CREATE TABLE nodes
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    kind                        text NOT NULL
+);
+SELECT standard_model_table_constraints_v1('nodes');
+SELECT belongs_to_table_create_v1('node_belongs_to_component', 'nodes', 'components');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('nodes', 'model', 'node', 'Node'),
+       ('node_belongs_to_component', 'belongs_to', 'node.component', 'Node <> Component');
+
+CREATE OR REPLACE FUNCTION node_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_kind text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           nodes%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO nodes (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
+                          tenancy_workspace_ids,
+                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, kind)
+    VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted, this_kind)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
+    Component, ComponentId, HistoryActor, HistoryEventError, StandardModel, StandardModelError,
+    Tenancy, Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum NodeError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type NodeResult<T> = Result<T, NodeError>;
+
+pk!(NodePk);
+pk!(NodeId);
+
+#[derive(
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::AsRefStr,
+    strum_macros::EnumIter,
+)]
+pub enum NodeKind {
+    Component,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Node {
+    pk: NodePk,
+    id: NodeId,
+    kind: NodeKind,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: Node,
+    pk: NodePk,
+    id: NodeId,
+    table_name: "nodes",
+    history_event_label_base: "node",
+    history_event_message_name: "Node"
+}
+
+impl Node {
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        kind: &NodeKind,
+    ) -> NodeResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM node_create_v1($1, $2, $3)",
+                &[&tenancy, &visibility, &kind.to_string()],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(kind, Enum(NodeKind), NodeResult);
+
+    standard_model_belongs_to!(
+        lookup_fn: component,
+        set_fn: set_component,
+        unset_fn: unset_component,
+        table: "node_belongs_to_component",
+        model_table: "components",
+        belongs_to_id: ComponentId,
+        returns: Component,
+        result: NodeResult,
+    );
+}

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -23,6 +23,7 @@ use crate::{
 pub use ui_menu::UiMenu;
 pub use variant::SchemaVariant;
 
+pub mod builtins;
 pub mod ui_menu;
 pub mod variant;
 

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -1,0 +1,30 @@
+use crate::schema::{SchemaResult, SchemaVariant};
+use crate::{HistoryActor, Schema, SchemaKind, StandardModel, Tenancy, Visibility};
+use si_data::{NatsTxn, PgTxn};
+
+pub async fn migrate(txn: &PgTxn<'_>, nats: &NatsTxn) -> SchemaResult<()> {
+    application(&txn, &nats).await?;
+    Ok(())
+}
+
+async fn application(txn: &PgTxn<'_>, nats: &NatsTxn) -> SchemaResult<()> {
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema = Schema::new(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "application",
+        &SchemaKind::Concept,
+    )
+    .await?;
+    let variant =
+        SchemaVariant::new(txn, nats, &tenancy, &visibility, &history_actor, "v0").await?;
+    variant
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await?;
+    Ok(())
+}

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -68,6 +68,24 @@ pub async fn get_by_id<ID: Send + Sync + ToSql, OBJECT: DeserializeOwned>(
     object_option_from_row_option(row_option)
 }
 
+#[instrument(skip(txn))]
+pub async fn find_by_attr<V: Send + Sync + ToSql, OBJECT: DeserializeOwned>(
+    txn: &PgTxn<'_>,
+    table: &str,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    attr_name: &str,
+    value: &V,
+) -> StandardModelResult<Option<OBJECT>> {
+    let row_option = txn
+        .query_opt(
+            "SELECT * FROM find_by_attr_v1($1, $2, $3, $4, $5)",
+            &[&table, &tenancy, &visibility, &attr_name, &value],
+        )
+        .await?;
+    object_option_from_row_option(row_option)
+}
+
 pub fn object_option_from_row_option<OBJECT: DeserializeOwned>(
     row_option: Option<tokio_postgres::Row>,
 ) -> StandardModelResult<Option<OBJECT>> {

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -1,10 +1,10 @@
 use crate::test_setup;
 use dal::test_harness::{
-    create_billing_account_with_name, create_change_set, create_edit_session,
-    create_visibility_edit_session, create_visibility_head,
+    create_billing_account, create_billing_account_with_name, create_change_set,
+    create_edit_session, create_visibility_edit_session, create_visibility_head,
 };
 use dal::{
-    BillingAccount, ChangeSet, ChangeSetStatus, HistoryActor, StandardModel, Tenancy,
+    BillingAccount, ChangeSet, ChangeSetStatus, HistoryActor, StandardModel, Tenancy, Visibility,
     NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
 };
 
@@ -89,8 +89,12 @@ async fn apply() {
 async fn list_open() {
     test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
 
-    let tenancy = Tenancy::new_universal();
+    let uv_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
+    let head_visibility = Visibility::new_head(false);
+    let billing_account =
+        create_billing_account(&txn, &nats, &uv_tenancy, &head_visibility, &history_actor).await;
+    let tenancy = Tenancy::new_billing_account(vec![*billing_account.id()]);
 
     let a_change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
     let b_change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -1,0 +1,69 @@
+use crate::test_setup;
+
+use dal::test_harness::{create_schema, create_schema_variant};
+use dal::{Component, HistoryActor, SchemaKind, StandardModel, Tenancy, Visibility};
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let _component = Component::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "mastodon",
+    )
+    .await
+    .expect("cannot create entity");
+}
+
+#[tokio::test]
+async fn schema_relationships() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema = create_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Implementation,
+    )
+    .await;
+    let schema_variant =
+        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot set schema variant to schema");
+    let component = Component::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "mastodon",
+    )
+    .await
+    .expect("cannot create entity");
+    component
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot set schema for entity");
+    component
+        .set_schema_variant(
+            &txn,
+            &nats,
+            &visibility,
+            &history_actor,
+            schema_variant.id(),
+        )
+        .await
+        .expect("cannot set schema for entity");
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,11 +1,13 @@
 mod billing_account;
 mod capability;
 mod change_set;
+mod component;
 mod edit_session;
 mod group;
 mod history_event;
 mod jwt_key;
 mod key_pair;
+mod node;
 mod organization;
 mod schema;
 mod socket;

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -1,0 +1,51 @@
+use crate::test_setup;
+
+use dal::node::NodeKind;
+use dal::test_harness::{create_component_and_schema, create_node};
+use dal::{HistoryActor, Node, StandardModel, Tenancy, Visibility};
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let _node = Node::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &NodeKind::Component,
+    )
+    .await
+    .expect("cannot create node");
+}
+
+#[tokio::test]
+async fn component_relationships() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let component =
+        create_component_and_schema(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let node = create_node(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &NodeKind::Component,
+    )
+    .await;
+    node.set_component(&txn, &nats, &visibility, &history_actor, component.id())
+        .await
+        .expect("cannot associate node with component");
+    let retrieved_component = node
+        .component(&txn, &visibility)
+        .await
+        .expect("cannot retrieve component for node")
+        .expect("no component set for node");
+    assert_eq!(&retrieved_component, &component);
+}

--- a/lib/sdf/src/server/service.rs
+++ b/lib/sdf/src/server/service.rs
@@ -1,3 +1,4 @@
+pub mod application;
 pub mod change_set;
 pub mod edit_field;
 pub mod schema;

--- a/lib/sdf/src/server/service/application.rs
+++ b/lib/sdf/src/server/service/application.rs
@@ -1,0 +1,56 @@
+use axum::body::{Bytes, Full};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{post};
+use axum::Json;
+use axum::Router;
+use dal::{ComponentError as DalComponentError, NodeError, StandardModelError};
+use std::convert::Infallible;
+use thiserror::Error;
+
+pub mod create_application;
+
+#[derive(Debug, Error)]
+pub enum ApplicationError {
+    #[error(transparent)]
+    Nats(#[from] si_data::NatsError),
+    #[error(transparent)]
+    Pg(#[from] si_data::PgError),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+    #[error("entity error: {0}")]
+    Component(#[from] DalComponentError),
+    #[error("not found")]
+    NotFound,
+    #[error("invalid request")]
+    InvalidRequest,
+    #[error("node error")]
+    Node(#[from] NodeError),
+}
+
+pub type ApplicationResult<T> = std::result::Result<T, ApplicationError>;
+
+impl IntoResponse for ApplicationError {
+    type Body = Full<Bytes>;
+    type BodyError = Infallible;
+
+    fn into_response(self) -> hyper::Response<Self::Body> {
+        let (status, error_message) = match self {
+            ApplicationError::NotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
+
+        let body = Json(
+            serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),
+        );
+
+        (status, body).into_response()
+    }
+}
+
+pub fn routes() -> Router {
+    Router::new().route(
+        "/create_application",
+        post(create_application::create_application),
+    )
+}

--- a/lib/sdf/src/server/service/application/create_application.rs
+++ b/lib/sdf/src/server/service/application/create_application.rs
@@ -1,0 +1,76 @@
+use super::{ApplicationError, ApplicationResult};
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+use axum::Json;
+use dal::node::NodeKind;
+use dal::{
+    Component, HistoryActor, Node, StandardModel, Tenancy, Visibility,
+    Workspace, WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateApplicationRequest {
+    pub name: String,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateApplicationResponse {
+    pub application: Component,
+}
+
+pub async fn create_application(
+    mut txn: PgRwTxn,
+    mut nats: NatsTxn,
+    Authorization(claim): Authorization,
+    Json(request): Json<CreateApplicationRequest>,
+) -> ApplicationResult<Json<CreateApplicationResponse>> {
+    let txn = txn.start().await?;
+    let nats = nats.start().await?;
+
+    // Create the workspace tenancy
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let history_actor: HistoryActor = HistoryActor::from(claim.user_id);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(ApplicationError::InvalidRequest)?;
+
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+    // You can only create applications directly to head? This feels wrong, but..
+    let visibility = Visibility::new_head(false);
+    let component = Component::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &request.name,
+    )
+    .await?;
+    let node = Node::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &NodeKind::Component,
+    )
+    .await?;
+    node.set_component(&txn, &nats, &visibility, &history_actor, component.id())
+        .await?;
+
+    txn.commit().await?;
+    nats.commit().await?;
+    Ok(Json(CreateApplicationResponse {
+        application: component,
+    }))
+}

--- a/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
+++ b/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
@@ -32,7 +32,9 @@ pub async fn get_edit_fields(
     Query(request): Query<GetEditFieldsRequest>,
 ) -> EditFieldResult<Json<GetEditFieldsResponse>> {
     let txn = txn.start().await?;
-    let tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    // TODO: This needs to be something we can control - it's a security problem now - Adam
+    tenancy.universal = true;
 
     let edit_fields = match request.object_kind {
         EditFieldObjectKind::Schema => {

--- a/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
@@ -35,7 +35,8 @@ pub async fn update_from_edit_field(
 ) -> EditFieldResult<Json<UpdateFromEditFieldResponse>> {
     let txn = txn.start().await?;
     let nats = nats.start().await?;
-    let tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.universal = true;
     let history_actor: HistoryActor = HistoryActor::from(claim.user_id);
 
     match request.object_kind {

--- a/lib/sdf/src/server/service/schema/get_schema.rs
+++ b/lib/sdf/src/server/service/schema/get_schema.rs
@@ -21,7 +21,8 @@ pub async fn get_schema(
     Query(request): Query<GetSchemaRequest>,
 ) -> SchemaResult<Json<GetSchemaResponse>> {
     let txn = txn.start().await?;
-    let tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.universal = true;
     let response = Schema::get_by_id(&txn, &tenancy, &request.visibility, &request.schema_id)
         .await?
         .ok_or(SchemaError::SchemaNotFound)?;

--- a/lib/sdf/src/server/service/schema/list_schemas.rs
+++ b/lib/sdf/src/server/service/schema/list_schemas.rs
@@ -24,7 +24,8 @@ pub async fn list_schemas(
     Authorization(claim): Authorization,
 ) -> SchemaResult<Json<ListSchemaResponse>> {
     let txn = txn.start().await?;
-    let tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.universal = true;
     let list = Schema::list(&txn, &tenancy, &request.visibility).await?;
     let response = ListSchemaResponse { list };
     Ok(Json(response))


### PR DESCRIPTION
This PR includes the backend of components (the object formerly known as an entity) and nodes. They're pretty thin right this second - as we flesh out more, we will round them out.

Also in this PR:

* Some lint cleanup
* SDF now immediately logs the user out if it receives a 401 for any reason.
* Vite's proxy config now uses 127.0.0.1 instead of localhost, to avoid ipv6 shenangians.
* The errant test failure with change_sets is fixed through the proper use of tenancy.
* The application schema is now created by default when the server starts. It's probably not quite right yet :)

It's worth a quick review and a merge, so that Fletcher and I can parallelize.

![](https://media3.giphy.com/media/l0HlTEbRoQKBgFmNO/giphy.gif)

Signed-off-by: Adam Jacob <adam@systeminit.com>