### PR TITLE
feat(*): application create and list

### DIFF
--- a/app/old-web/organisims/ApplicationList.vue
+++ b/app/old-web/organisims/ApplicationList.vue
@@ -57,7 +57,7 @@ export default Vue.extend({
     return {
       errorMessage: "",
       isLoading: true,
-      applicationList: [],
+      applicationList: []o,
     };
   },
   components: {

--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -11,6 +11,7 @@
         "vue": "^3.2.16"
       },
       "devDependencies": {
+        "@types/chart.js": "^2.9.3",
         "@types/jsonwebtoken": "^8.5.5",
         "@types/lodash": "^4.14.175",
         "@types/node": "^16.10.9",
@@ -357,6 +358,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@types/chart.js": {
+      "version": "2.9.34",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.34.tgz",
+      "integrity": "sha512-CtZVk+kh1IN67dv+fB0CWmCLCRrDJgqOj15qPic2B1VCMovNO6B7Vhf/TgPpNscjhAL1j+qUntDMWb9A4ZmPTg==",
+      "dev": true,
+      "dependencies": {
+        "moment": "^2.10.2"
       }
     },
     "node_modules/@types/json-schema": {
@@ -6329,6 +6339,15 @@
       "requires": {
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
+      }
+    },
+    "@types/chart.js": {
+      "version": "2.9.34",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.34.tgz",
+      "integrity": "sha512-CtZVk+kh1IN67dv+fB0CWmCLCRrDJgqOj15qPic2B1VCMovNO6B7Vhf/TgPpNscjhAL1j+qUntDMWb9A4ZmPTg==",
+      "dev": true,
+      "requires": {
+        "moment": "^2.10.2"
       }
     },
     "@types/json-schema": {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -17,6 +17,7 @@
     "vue": "^3.2.16"
   },
   "devDependencies": {
+    "@types/chart.js": "^2.9.3",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/lodash": "^4.14.175",
     "@types/node": "^16.10.9",

--- a/app/web/src/atoms/SummaryCard.vue
+++ b/app/web/src/atoms/SummaryCard.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="flex flex-col w-full h-full px-2 py-2 shadow-xl details-panel">
+    <div class="w-full details-panel-title">
+      <slot name="title" />
+    </div>
+
+    <div class="flex w-full h-full mt-1">
+      <slot name="content" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.details-panel {
+  border: 1px solid #464753;
+  background-color: #101010;
+}
+
+.details-panel-title {
+  /* @apply font-normal text-xs; */
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+</style>

--- a/app/web/src/organisims/Application/ApplicationCard.vue
+++ b/app/web/src/organisims/Application/ApplicationCard.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="flex flex-col justify-center w-full application-card">
+    <div class="py-1 pl-2 card-header">
+      {{ application.name }}
+    </div>
+
+    <div class="flex w-full h-full">
+      <div class="w-1/5 py-2 mx-2">
+        <ApplicationActivitySummary
+          :application-id="application.id"
+          height="40px"
+        />
+      </div>
+
+      <div class="w-1/5 py-2 mx-2">
+        <ApplicationServicesSummary
+          :application-id="application.id"
+          :show-button="false"
+        />
+      </div>
+
+      <div class="w-1/5 py-2 mx-2">
+        <ApplicationComputingResourcesSummary
+          :application-id="application.id"
+          :show-button="false"
+        />
+      </div>
+
+      <div class="w-1/5 py-2 mx-2">
+        <ApplicationProviderSummary :application-id="application.id" />
+      </div>
+
+      <div class="w-1/5 py-2 mx-2">
+        <ApplicationChangesSummary
+          :application-id="application.id"
+          :show-selected-changeset-data="false"
+        />
+      </div>
+
+      <div class="self-center w-6">
+        <VueFeather type="chevron-right" class="button" size="2rem" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PropType } from "vue";
+import { Component } from "@/api/sdf/dal/component";
+import VueFeather from "vue-feather";
+import ApplicationActivitySummary from "./Summary/ApplicationActivitySummary.vue";
+import ApplicationServicesSummary from "./Summary/ApplicationServicesSummary.vue";
+import ApplicationComputingResourcesSummary from "@/organisims/Application/Summary/ApplicationComputingResourcesSummary.vue";
+import ApplicationProviderSummary from "@/organisims/Application/Summary/ApplicationProviderSummary.vue";
+import ApplicationChangesSummary from "@/organisims/Application/Summary/ApplicationChangesSummary.vue";
+
+defineProps({
+  application: {
+    type: Object as PropType<Component>,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.application-card {
+  @apply shadow-md;
+  background-color: #262626;
+}
+
+.card-header {
+  @apply text-white;
+  @apply text-sm;
+  @apply font-normal;
+  background-color: #3a3d40;
+}
+
+.visualization-card {
+  @apply bg-gray-900;
+  @apply border;
+  @apply border-gray-600;
+  width: 25%;
+}
+
+.visualization-title {
+  @apply text-xs;
+}
+
+.button {
+  color: #4a4b4c;
+}
+
+.button:hover {
+  @apply text-gray-400;
+}
+
+.button:active {
+  @apply text-gray-300;
+}
+</style>

--- a/app/web/src/organisims/Application/ApplicationCreateForm.vue
+++ b/app/web/src/organisims/Application/ApplicationCreateForm.vue
@@ -48,6 +48,7 @@ import SiButton from "@/atoms/SiButton.vue";
 import SiError from "@/atoms/SiError.vue";
 import SiTextBox from "@/atoms/SiTextBox.vue";
 import SiFormRow from "@/atoms/SiFormRow.vue";
+import { ApplicationService } from "@/service/application";
 
 const emit = defineEmits(["cancel", "create"]);
 
@@ -57,7 +58,15 @@ const form = ref({
 });
 
 const create = () => {
-  emit("create");
+  ApplicationService.createApplication({
+    name: form.value.applicationName,
+  }).subscribe((response) => {
+    if (response.error) {
+      errorMessage.value = response.error.message;
+    }
+    form.value.applicationName = "";
+    emit("create", response);
+  });
 };
 
 const onEnter = () => {

--- a/app/web/src/organisims/Application/Summary/ApplicationActivitySummary.vue
+++ b/app/web/src/organisims/Application/Summary/ApplicationActivitySummary.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="w-full h-full">
+    <SummaryCard>
+      <template #title>Activity</template>
+
+      <template #content>
+        <div class="w-full h-full">
+          <!--
+        <div :style="canvasStyle">
+          <canvas :id="canvasId" />
+          </div>
+          -->
+        </div>
+      </template>
+    </SummaryCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SummaryCard from "@/atoms/SummaryCard.vue";
+// import { ChartConfiguration, Chart } from "chart.js";
+
+defineProps({
+  showChartLabels: {
+    type: Boolean,
+    default: true,
+  },
+  height: {
+    type: String,
+    default: "60px",
+  },
+  applicationId: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.canvas-container {
+  height: 60px;
+  width: 100%;
+}
+
+.details-panel {
+  border: solid;
+  border-width: 1px;
+  border-color: #464753;
+  background-color: #101010;
+}
+
+.details-panel-title {
+  /* @apply font-normal text-xs; */
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.details-panel-background {
+  background-color: #171717;
+}
+</style>

--- a/app/web/src/organisims/Application/Summary/ApplicationChangesSummary.vue
+++ b/app/web/src/organisims/Application/Summary/ApplicationChangesSummary.vue
@@ -1,0 +1,102 @@
+<template>
+  <SummaryCard>
+    <template #title>Changes</template>
+
+    <template #content>
+      <!--
+      <div class="flex flex-col w-full h-full mx-1" v-if="changesData">
+        <div class="flex flex-row opened-indicator">
+          <div>Opened:</div>
+          <div class="ml-1">{{ changesData.openChangeSetCount }}</div>
+        </div>
+
+        <div
+          class="mt-1"
+          v-if="
+            showSelectedChangesetData &&
+              changesData.currentChangeSet &&
+              changeSet
+          "
+        >
+          <div class="flex flex-row changeset-indicator">
+            <div class="">{{ changeSet.name }}</div>
+          </div>
+
+          <div class="flex flex-row pl-2 edits-indicator">
+            <div>Nodes:</div>
+
+            <div class="ml-1 additions">+</div>
+            <div class="additions">
+              {{ changesData.currentChangeSet.newNodes }}
+            </div>
+
+            <div class="ml-1 removals">-</div>
+            <div class="removals">
+              {{ changesData.currentChangeSet.deletedNodes }}
+            </div>
+
+            <div class="ml-1 updates">u</div>
+            <div class="updates">
+              {{ changesData.currentChangeSet.modifiedNodes }}
+            </div>
+          </div>
+
+          <div class="flex flex-row pl-2 edits-indicator">
+            <div>Edits:</div>
+            <div class="ml-1 additions">+</div>
+            <div class="additions">
+              {{ changesData.currentChangeset.nodeEdits }}
+            </div>
+          </div>
+        </div>
+      </div> -->
+    </template>
+  </SummaryCard>
+</template>
+
+<script setup lang="ts">
+import SummaryCard from "@/atoms/SummaryCard.vue";
+
+defineProps({
+  showSelectedChangesetData: {
+    type: Boolean,
+    default: true,
+  },
+  applicationId: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.opened-indicator {
+  font-size: 10px;
+  font-weight: 400;
+  color: #b7b9c9;
+}
+
+.changeset-indicator {
+  font-size: 10px;
+  font-weight: 600;
+  color: #b7b9c9;
+}
+
+.edits-indicator {
+  font-size: 9px;
+  font-weight: 400;
+  color: #b7b9c9;
+}
+
+.additions {
+  color: #a6e2a5;
+}
+
+.removals {
+  color: #e2a5a5;
+}
+
+.updates {
+  color: #e2c8a5;
+}
+</style>

--- a/app/web/src/organisims/Application/Summary/ApplicationComputingResourcesSummary.vue
+++ b/app/web/src/organisims/Application/Summary/ApplicationComputingResourcesSummary.vue
@@ -1,0 +1,84 @@
+<template>
+  <SummaryCard>
+    <template #title>Computing Resources</template>
+
+    <template #content>
+      <div class="flex flex-col w-full h-full">
+        <div class="flex flex-row flex-wrap w-full h-full mx-1">
+          <!--
+          <div
+            class="mr-2"
+            v-for="resource in computingResourcesData"
+            :key="resource.id"
+          >
+            <ResourceVisualization :resource="resource" />
+          </div>
+          -->
+        </div>
+
+        <div v-show="showButton" class="flex justify-end mt-2">
+          <div class="flex items-center justify-center button">
+            <div class="mx-1 align-middle button-text">Sync</div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </SummaryCard>
+</template>
+
+<script setup lang="ts">
+import SummaryCard from "@/atoms/SummaryCard.vue";
+
+defineProps({
+  showButton: {
+    type: Boolean,
+    default: false,
+  },
+  applicationId: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.05;
+
+.details-panel {
+  border: solid;
+  border-width: 1px;
+  border-color: #464753;
+  background-color: #101010;
+}
+
+.details-panel-title {
+  /* @apply font-normal text-xs; */
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.button {
+  background-color: #5a7b7c;
+}
+
+.button-text {
+  @apply font-normal;
+  font-size: 11px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.button:hover {
+  filter: brightness($button-brightness);
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+</style>

--- a/app/web/src/organisims/Application/Summary/ApplicationProviderSummary.vue
+++ b/app/web/src/organisims/Application/Summary/ApplicationProviderSummary.vue
@@ -1,0 +1,68 @@
+<template>
+  <SummaryCard>
+    <template #title>Providers</template>
+
+    <template #content>
+      <div class="flex flex-col w-full h-full">
+        <div class="flex flex-row flex-wrap w-full h-full mx-1">
+          <!--
+          <div class="mr-2" v-for="resource in providerData" :key="resource.id">
+            <ResourceVisualization :resource="resource" />
+          </div>
+          -->
+        </div>
+      </div>
+    </template>
+  </SummaryCard>
+</template>
+
+<script setup lang="ts">
+import SummaryCard from "@/atoms/SummaryCard.vue";
+
+defineProps({
+  applicationId: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.05;
+
+.details-panel {
+  border: 1px solid #464753;
+  background-color: #101010;
+}
+
+.details-panel-title {
+  /* @apply font-normal text-xs; */
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.button {
+  background-color: #5a7b7c;
+}
+
+.button-text {
+  @apply font-normal;
+  font-size: 11px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.button:hover {
+  filter: brightness($button-brightness);
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+</style>

--- a/app/web/src/organisims/Application/Summary/ApplicationServicesSummary.vue
+++ b/app/web/src/organisims/Application/Summary/ApplicationServicesSummary.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="w-full h-full">
+    <SummaryCard>
+      <template #title>Services</template>
+
+      <template #content>
+        <div class="flex flex-col content-start w-full h-full">
+          <div class="flex flex-row flex-wrap w-full h-full mx-1">
+            boop
+            <!--
+            <div
+              v-for="resource in servicesData"
+              :key="resource.id"
+              class="mr-2"
+            >
+              <ServiceVisualization :resource="resource" />
+            </div>
+            -->
+          </div>
+
+          <div v-show="showButton" class="flex justify-end mt-2">
+            <div class="flex text-xs text-center align-middle button">
+              <div class="mx-1 button-text">Deploy</div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </SummaryCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SummaryCard from "@/atoms/SummaryCard.vue";
+import { ref } from "vue";
+
+const servicesData = ref([]);
+defineProps({
+  showButton: {
+    type: Boolean,
+    default: true,
+  },
+  applicationId: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.1;
+
+.button {
+  background-color: #5a8f91;
+}
+
+.button-text {
+  @apply font-normal;
+  font-size: 11px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.button:hover {
+  filter: brightness($button-brightness);
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+
+.button:disabled {
+  background-color: red;
+  color: red;
+}
+</style>

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -1,32 +1,32 @@
 <template>
   <EditFormField :show="show">
-    <template #name>{{editField.name}}</template>
+    <template #name>{{ editField.name }}</template>
     <template #edit>
       <input
+        v-model="currentValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         type="checkbox"
         placeholder="text"
-        v-model="currentValue"
         @change="onBlur"
         @focus="onFocus"
         @blur="onBlur"
       />
     </template>
     <template #show>
-      <span :class="textColor">{{editField.value}}</span>
+      <span :class="textColor">{{ editField.value }}</span>
     </template>
   </EditFormField>
 </template>
 
 <script setup lang="ts">
-import {computed, PropType, ref, watch} from "vue";
-import type {EditField, CheckboxWidgetDal} from "@/api/sdf/dal/edit_field";
-import {EditFieldService} from "@/service/edit_field";
+import { computed, PropType, ref, watch } from "vue";
+import type { EditField, CheckboxWidgetDal } from "@/api/sdf/dal/edit_field";
+import { EditFieldService } from "@/service/edit_field";
 import EditFormField from "./EditFormField.vue";
-import {GlobalErrorService} from "@/service/global_error";
-import {UpdateFromEditFieldResponse} from "@/service/edit_field/update_from_edit_field";
-import {ApiResponse} from "@/api/sdf";
+import { GlobalErrorService } from "@/service/global_error";
+import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
+import { ApiResponse } from "@/api/sdf";
 
 const props = defineProps({
   show: {
@@ -81,18 +81,18 @@ watch(
 const borderColor = computed(
   (): Record<string, boolean> => {
     if (props.editField.visibility_diff.kind != "None") {
-      return {"input-border-gold": true};
+      return { "input-border-gold": true };
     } else {
-      return {"input-border-grey": true};
+      return { "input-border-grey": true };
     }
   },
 );
 const textColor = computed(
   (): Record<string, boolean> => {
     if (props.editField.visibility_diff.kind != "None") {
-      return {"text-gold": true};
+      return { "text-gold": true };
     } else {
-      return {"text-gold": false};
+      return { "text-gold": false };
     }
   },
 );

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -5,13 +5,21 @@
     class="flex flex-row w-full"
   >
     <!-- eventually this will do the show/hide logic -->
-    <HeaderWidget v-if="editField.widget.kind === 'Header'" :show="true" :edit-field="editField" />
+    <HeaderWidget
+      v-if="editField.widget.kind === 'Header'"
+      :show="true"
+      :edit-field="editField"
+    />
     <ArrayWidget
       v-else-if="editField.widget.kind === 'Array'"
       :show="true"
       :edit-field="editField"
     />
-    <TextWidget v-else-if="editField.widget.kind === 'Text'" :show="true" :edit-field="editField" />
+    <TextWidget
+      v-else-if="editField.widget.kind === 'Text'"
+      :show="true"
+      :edit-field="editField"
+    />
     <CheckboxWidget
       v-else-if="editField.widget.kind === 'Checkbox'"
       :show="true"
@@ -26,8 +34,8 @@
 </template>
 
 <script setup lang="ts">
-import {PropType, ref} from "vue";
-import {EditFields} from "@/api/sdf/dal/edit_field";
+import { PropType, ref } from "vue";
+import { EditFields } from "@/api/sdf/dal/edit_field";
 import CheckboxWidget from "@/organisims/EditForm/CheckboxWidget.vue";
 import TextWidget from "@/organisims/EditForm/TextWidget.vue";
 import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";

--- a/app/web/src/service/application.ts
+++ b/app/web/src/service/application.ts
@@ -1,5 +1,7 @@
 import { createApplication } from "./application/create_application";
+import { listApplications } from "./application/list_application";
 
 export const ApplicationService = {
   createApplication,
+  listApplications,
 };

--- a/app/web/src/service/application/create_application.ts
+++ b/app/web/src/service/application/create_application.ts
@@ -11,12 +11,13 @@ import _ from "lodash";
 
 export interface CreateApplicationArgs {
   name: String;
-  workspaceId: number;
 }
 
 export interface CreateApplicationRequest
   extends CreateApplicationArgs,
-    Visibility {}
+    Visibility {
+  workspaceId: number;
+}
 
 export interface CreateApplicationResponse {
   application: Component;

--- a/app/web/src/service/application/list_application.ts
+++ b/app/web/src/service/application/list_application.ts
@@ -1,0 +1,69 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import {
+  combineLatest,
+  combineLatestWith,
+  from,
+  Observable,
+  share,
+} from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Component } from "@/api/sdf/dal/component";
+import { workspace$ } from "@/observable/workspace";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import _ from "lodash";
+
+export interface ListApplicationRequest extends Visibility {
+  workspaceId: number;
+}
+
+export interface ListApplicationItem {
+  application: Component;
+
+  // These populated the former card display
+  //servicesWithResources: [];
+  //systems: [];
+  //changeSetCounts: {
+  //  open: number;
+  //  closed: number;
+  //};
+}
+
+export interface ListApplicationResponse {
+  list: Array<ListApplicationItem>;
+}
+
+const applicationList$ = combineLatest([standardVisibilityTriggers$]).pipe(
+  combineLatestWith(workspace$),
+  switchMap(([[[visibility]], workspace]) => {
+    const bottle = Bottle.pop("default");
+    const sdf: SDF = bottle.container.SDF;
+    if (_.isNull(workspace)) {
+      return from([
+        {
+          error: {
+            statusCode: 10,
+            message: "cannot make call without a workspace; bug!",
+            code: 10,
+          },
+        },
+      ]);
+    }
+    const request: ListApplicationRequest = {
+      ...visibility,
+      workspaceId: workspace.id,
+    };
+    return sdf.get<ApiResponse<ListApplicationResponse>>(
+      "application/list_applications",
+      request,
+    );
+  }),
+  share(),
+);
+
+export function listApplications(): Observable<
+  ApiResponse<ListApplicationResponse>
+> {
+  return applicationList$;
+}

--- a/app/web/src/service/schema/list_schemas.ts
+++ b/app/web/src/service/schema/list_schemas.ts
@@ -1,6 +1,6 @@
 import { ApiResponse, SDF } from "@/api/sdf";
 import { Schema } from "@/api/sdf/dal/schema";
-import { combineLatest, Observable, shareReplay } from "rxjs";
+import { combineLatest, Observable, share } from "rxjs";
 import { standardVisibilityTriggers$ } from "@/observable/visibility";
 import Bottle from "bottlejs";
 import { switchMap } from "rxjs/operators";
@@ -18,7 +18,7 @@ const schemaList$ = combineLatest([standardVisibilityTriggers$]).pipe(
       visibility,
     );
   }),
-  shareReplay(1),
+  share(),
 );
 
 export function listSchemas(): Observable<ApiResponse<ListSchemaResponse>> {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -3,12 +3,13 @@ use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::schema::variant::SchemaVariantId;
+use crate::node::NodeKind;
+use crate::schema::variant::{SchemaVariantError, SchemaVariantId};
 use crate::schema::SchemaVariant;
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
-    HistoryActor, HistoryEventError, Schema, SchemaId, StandardModel, StandardModelError, Tenancy,
-    Timestamp, Visibility,
+    HistoryActor, HistoryEventError, Node, NodeError, Schema, SchemaId, StandardModel,
+    StandardModelError, Tenancy, Timestamp, Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -23,6 +24,14 @@ pub enum ComponentError {
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]
     StandardModelError(#[from] StandardModelError),
+    #[error("node error: {0}")]
+    NodeError(#[from] NodeError),
+    #[error("schema variant not found")]
+    SchemaVariantNotFound,
+    #[error("schema not found")]
+    SchemaNotFound,
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
 }
 
 pub type ComponentResult<T> = Result<T, ComponentError>;
@@ -79,6 +88,108 @@ impl Component {
         )
         .await?;
         Ok(object)
+    }
+
+    #[tracing::instrument(skip(txn, nats, name))]
+    pub async fn new_for_schema_variant_with_node(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+        schema_variant_id: &SchemaVariantId,
+    ) -> ComponentResult<(Self, Node)> {
+        let name = name.as_ref();
+
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
+        let schema_variant =
+            SchemaVariant::get_by_id(&txn, &schema_tenancy, &visibility, &schema_variant_id)
+                .await?
+                .ok_or(ComponentError::SchemaVariantNotFound)?;
+        let schema = schema_variant
+            .schema(&txn, &visibility)
+            .await?
+            .ok_or(ComponentError::SchemaNotFound)?;
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM component_create_v1($1, $2, $3)",
+                &[&tenancy, &visibility, &name],
+            )
+            .await?;
+
+        let component: Component = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        component
+            .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+            .await?;
+        component
+            .set_schema_variant(
+                &txn,
+                &nats,
+                &visibility,
+                &history_actor,
+                schema_variant.id(),
+            )
+            .await?;
+
+        let node = Node::new(
+            &txn,
+            &nats,
+            &tenancy,
+            &visibility,
+            &history_actor,
+            &NodeKind::Component,
+        )
+        .await?;
+        node.set_component(&txn, &nats, &visibility, &history_actor, component.id())
+            .await?;
+
+        Ok((component, node))
+    }
+
+    #[tracing::instrument(skip(txn, nats, name))]
+    pub async fn new_application_with_node(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+    ) -> ComponentResult<(Self, Node)> {
+        let universal_tenancy = Tenancy::new_universal();
+        let schemas = Schema::find_by_attr(
+            &txn,
+            &universal_tenancy,
+            &visibility,
+            "name",
+            &"application".to_string(),
+        )
+        .await?;
+        let schema = schemas.first().ok_or(ComponentError::SchemaNotFound)?;
+        let schema_variant_id = schema
+            .default_schema_variant_id()
+            .ok_or(ComponentError::SchemaVariantNotFound)?;
+        let (component, node) = Component::new_for_schema_variant_with_node(
+            &txn,
+            &nats,
+            &tenancy,
+            &visibility,
+            &history_actor,
+            name,
+            schema_variant_id,
+        )
+        .await?;
+        Ok((component, node))
     }
 
     standard_model_accessor!(name, String, ComponentResult);

--- a/lib/dal/src/migrations/U0031__schema.sql
+++ b/lib/dal/src/migrations/U0031__schema.sql
@@ -15,7 +15,8 @@ CREATE TABLE schemas
     kind                        text                     NOT NULL,
     ui_menu_name                text,
     ui_menu_category            ltree,
-    ui_hidden                   boolean                  NOT NULL DEFAULT false
+    ui_hidden                   boolean                  NOT NULL DEFAULT false,
+    default_schema_variant_id   bigint
 );
 SELECT standard_model_table_constraints_v1('schemas');
 SELECT many_to_many_table_create_v1('schema_many_to_many_billing_account', 'schemas', 'billing_accounts');

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -231,12 +231,13 @@ macro_rules! standard_model_has_many {
         pub async fn $lookup_fn(
             &self,
             txn: &si_data::PgTxn<'_>,
+            tenancy: &$crate::Tenancy,
             visibility: &$crate::Visibility,
         ) -> $result_type<Vec<$has_many>> {
             let r = $crate::standard_model::has_many(
                 &txn,
                 $table,
-                &self.tenancy(),
+                tenancy,
                 visibility,
                 $retrieve_table,
                 &self.id(),
@@ -711,7 +712,7 @@ macro_rules! standard_model_accessor {
     };
 
     ($column:ident, Option<$value_type:ident>, $result_type:ident $(,)?) => {
-        standard_model_accessor!(@get_column_as_option $column);
+        standard_model_accessor!(@get_column_as_option $column, $value_type);
         standard_model_accessor!(@set_column_with_option
             $column,
             $value_type,
@@ -719,4 +720,15 @@ macro_rules! standard_model_accessor {
             $result_type,
         );
     };
+
+    ($column:ident, OptionBigInt<$value_type:ident>, $result_type:ident $(,)?) => {
+        standard_model_accessor!(@get_column_as_option $column, $value_type);
+        standard_model_accessor!(@set_column_with_option
+            $column,
+            $value_type,
+            $crate::standard_model::TypeHint::BigInt,
+            $result_type,
+        );
+    };
+
 }

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -2,8 +2,8 @@ use crate::billing_account::BillingAccountSignup;
 use crate::jwt_key::JwtEncrypt;
 use crate::node::NodeKind;
 use crate::{
-    schema, socket, BillingAccount, ChangeSet, Component, EditSession, Group, HistoryActor, KeyPair, Node,
-    Schema, SchemaKind, StandardModel, Tenancy, User, Visibility, NO_CHANGE_SET_PK,
+    schema, socket, BillingAccount, ChangeSet, Component, EditSession, Group, HistoryActor,
+    KeyPair, Node, Schema, SchemaKind, StandardModel, Tenancy, User, Visibility, NO_CHANGE_SET_PK,
     NO_EDIT_SESSION_PK,
 };
 use anyhow::Result;

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -22,6 +22,41 @@ async fn new() {
 }
 
 #[tokio::test]
+async fn new_for_schema_variant_with_node() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema = create_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Concept,
+    )
+    .await;
+    let schema_variant =
+        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot set schema variant");
+
+    let _component = Component::new_for_schema_variant_with_node(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "mastodon",
+        schema_variant.id(),
+    )
+    .await
+    .expect("cannot create component");
+}
+
+#[tokio::test]
 async fn schema_relationships() {
     test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
     let tenancy = Tenancy::new_universal();

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -192,7 +192,7 @@ async fn ui_menus() {
         .await
         .expect("cannot set schema");
     let ui_menus = schema
-        .ui_menus(&txn, &visibility)
+        .ui_menus(&txn, schema.tenancy(), &visibility)
         .await
         .expect("cannot get ui menus");
     assert_eq!(ui_menus, vec![schema_ui_menu.clone()]);

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -54,6 +54,10 @@ pub fn routes(
     let mut router: Router = Router::new();
     router = router
         .route("/demo", get(handlers::demo))
+        .nest(
+            "/api/application",
+            crate::server::service::application::routes(),
+        )
         .nest("/api/signup", crate::server::service::signup::routes())
         .nest("/api/session", crate::server::service::session::routes())
         .nest(

--- a/lib/sdf/src/server/service/application/list_applications.rs
+++ b/lib/sdf/src/server/service/application/list_applications.rs
@@ -1,0 +1,64 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{Component, Schema, StandardModel, Tenancy, Visibility, Workspace, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use super::{ApplicationError, ApplicationResult};
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListApplicationRequest {
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListApplicationItem {
+    pub application: Component,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListApplicationResponse {
+    pub list: Vec<ListApplicationItem>,
+}
+
+pub async fn list_applications(
+    mut txn: PgRoTxn,
+    Query(request): Query<ListApplicationRequest>,
+    Authorization(claim): Authorization,
+) -> ApplicationResult<Json<ListApplicationResponse>> {
+    let txn = txn.start().await?;
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(ApplicationError::InvalidRequest)?;
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+
+    let universal_tenancy = Tenancy::new_universal();
+    let schemas = Schema::find_by_attr(
+        &txn,
+        &universal_tenancy,
+        &request.visibility,
+        "name",
+        &"application".to_string(),
+    )
+    .await?;
+    let schema = schemas.first().ok_or(ApplicationError::SchemaNotFound)?;
+    let list: Vec<ListApplicationItem> = schema
+        .components(&txn, &tenancy, &request.visibility)
+        .await?
+        .into_iter()
+        .map(|application| ListApplicationItem { application })
+        .collect();
+    let response = ListApplicationResponse { list };
+    Ok(Json(response))
+}

--- a/lib/sdf/tests/service_tests/application.rs
+++ b/lib/sdf/tests/service_tests/application.rs
@@ -1,0 +1,85 @@
+use axum::http::Method;
+
+use crate::service_tests::{api_request_auth_json_body, api_request_auth_query};
+use crate::test_setup;
+use dal::{Component, HistoryActor, StandardModel, Tenancy, Visibility};
+use sdf::service::application::create_application::{
+    CreateApplicationRequest, CreateApplicationResponse,
+};
+use sdf::service::application::list_applications::{ListApplicationRequest, ListApplicationResponse};
+
+#[tokio::test]
+async fn create_application() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        _txn,
+        _nats_conn,
+        _nats,
+        app,
+        nba,
+        auth_token
+    );
+    let visibility = Visibility::new_head(false);
+    let request = CreateApplicationRequest {
+        name: "fancyPants".to_string(),
+        visibility,
+        workspace_id: *nba.workspace.id(),
+    };
+    let response: CreateApplicationResponse = api_request_auth_json_body(
+        app,
+        Method::POST,
+        "/api/application/create_application",
+        &auth_token,
+        &request,
+    )
+    .await;
+    assert_eq!(response.application.name(), "fancyPants");
+}
+
+#[tokio::test]
+async fn list_applications() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        app,
+        nba,
+        auth_token
+    );
+    let visibility = Visibility::new_head(false);
+    let tenancy= Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    let history_actor = HistoryActor::SystemInit;
+
+    let (component, _node) = Component::new_application_with_node(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "poop",
+    )
+    .await
+    .expect("cannot create new application");
+    txn.commit().await.expect("cannot commit transaction");
+
+    let request = ListApplicationRequest {
+        visibility,
+        workspace_id: *nba.workspace.id(),
+    };
+    let response: ListApplicationResponse = api_request_auth_query(
+        app,
+        "/api/application/list_applications",
+        &auth_token,
+        &request,
+    )
+    .await;
+    assert_eq!(response.list.len(), 1);
+    assert_eq!(response.list[0].application.name(), component.name());
+}

--- a/lib/sdf/tests/service_tests/schema.rs
+++ b/lib/sdf/tests/service_tests/schema.rs
@@ -82,7 +82,7 @@ async fn list_schemas() {
     };
     let response: ListSchemaResponse =
         api_request_auth_query(app, "/api/schema/list_schemas", &auth_token, &request).await;
-    assert_eq!(response.list.len(), 2);
+    assert_eq!(response.list.len(), 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Restores application creation and list functionality. Much of the UI for list is unimplemented - the cards are back, and the boxes are back, but the actual data inside them is not.

Otherwise, this creates a new component, assigns it to the `default` variant for the application `schema`, and allows you to list the components that use the `application` schema. It really shows off the delta between the old code base and the new code base.

<img src="https://media1.giphy.com/media/l2Je9JGAXCWnSUwWQ/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>