### PR TITLE
Validate Fedora and require non-root for bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,26 @@ This is a monolithic repository containing the source for System Initiative (SI)
 
 ## Supported Developer Environments
 
-| OS         | OS Type   | amd64 | arm64 (aarch64) |
-|------------|-----------|-------|-----------------|
-| Arch Linux | linux-gnu | ✅     | 🚫️             |
-| Fedora     | linux-gnu | ⚠️    | ⚠️              |
-| macOS      | darwin    | ✅     | ✅               |           |
+* Arch Linux `(x86_64 / amd64)`
+* Fedora `(x86_64 / amd64)`
+* macOS `(arm64 / aarch64)`
+* macOS `(x86_64 / amd64)`
 
-> **Legend:**
-> - ✅: validated manually or automatically
-> - ⚠️: not yet validated, but likely supported
-> - 🚫: not yet validated, decidedly unsupported, and/or yet to be supported
+> If your preferred environment is not listed, please feel free to add it once the following conditions have been met:
+>
+> 1. It's been added to the idempotent [bootstrap script](./scripts/bootstrap.sh)
+> 2. The aforementioned script has been tested and remains idempotent
+> 3. Running the **Quickstart** steps below is successful and the UI is fully functional
+>
+> _Please note:_ adding your preferred environment will also add you as a maintainer of its functionality throughout this repository.
 
-## Quick Start
+We recommend using the latest stable Rust toolchain and latest LTS Node toolchain for your environment.
+If unsure, the following tools are recommended to help manage your toolchains:
+
+* [**rustup**](https://rustup.rs) 🦀: Rust, `cargo`, etc.
+* [**volta**](https://volta.sh) ⚡: `node`, `npm`, etc.
+
+## Quickstart
 
 To get ready to run this repository, you should run the following script:
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,13 +1,59 @@
 #!/usr/bin/env bash
 set -e
 
+SI_USER="unknown"
 SI_OS="unknown"
 SI_LINUX="unknown"
 SI_WSL2="unknown"
 SI_ARCH="unknown"
 
+function error-and-exit {
+    if [ "$1" = "" ]; then
+        error-and-exit "must provide argument <error-message>"
+    fi
+    echo "error: $1"
+    exit 1
+}
+
+function determine-user {
+    if [ $EUID -eq 0 ]; then
+        error-and-exit "must run as non-root"
+    fi
+    SI_USER=$(whoami)
+    sudo -v
+}
+
+function set-config {
+    # Since arm64 has many names, we standardize on one to reduce verbosity within this script.
+    SI_ARCH="$(uname -m)"
+    if [ "$SI_ARCH" = "aarch64" ]; then
+        SI_ARCH="arm64"
+    fi
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        SI_OS="darwin"
+        SI_LINUX="false"
+        SI_WSL2="false"
+    elif [ "$(uname -s)" = "Linux" ]; then
+        SI_LINUX="true"
+
+        if [ -f /etc/os-release ]; then
+            SI_OS=$(grep '^ID=' /etc/os-release | sed 's/^ID=//' | tr -d '"')
+        else
+            error-and-exit "file \"/etc/os-release\" not found"
+        fi
+
+        SI_WSL2="false"
+        if [ -f /proc/sys/kernel/osrelease ] && [ $(grep "WSL2" /proc/sys/kernel/osrelease) ]; then
+            SI_WSL2="true"
+        fi
+    else
+        error-and-exit "detected OS is neither Darwin nor Linux"
+    fi
+}
+
 function arch-bootstrap {
-    pacman -Syu --noconfirm base-devel make sudo git
+    sudo pacman -Syu --noconfirm base-devel make git
 }
 
 function darwin-bootstrap {
@@ -18,70 +64,27 @@ function darwin-bootstrap {
 }
 
 function fedora-bootstrap {
-    echo "error: fedora not yet supported, but will likely be soon"
-    exit 1
-    dnf upgrade -y --refresh
-    dnf autoremove -y
-    dnf install -y @development-tools make sudo git
-}
-
-function determine-architecture {
-    # Since arm64 has many names, we standardize on one to reduce verbosity within this script.
-    SI_ARCH="$(uname -m)"
-    if [ "$SI_ARCH" = "aarch64" ]; then
-        SI_ARCH="arm64"
-    fi
-
-    if [ "$SI_ARCH" != "x86_64" ] && [ "$SI_ARCH" != "arm64" ]; then
-        echo "error: detected architecture \"$SI_ARCH\" has not yet been validated"
-        exit 1
-    fi
+    sudo dnf upgrade -y --refresh
+    sudo dnf autoremove -y
+    sudo dnf install -y @development-tools make git lld
 }
 
 function perform-bootstrap {
-    determine-architecture
-
-    if [ "$(uname -s)" = "Darwin" ]; then
-        SI_OS="darwin"
-        SI_LINUX="false"
-        SI_WSL2="false"
+    if [ "$SI_OS" = "darwin" ] && ( [ "$SI_ARCH" = "x86_64" ] || [ "$SI_ARCH" = "arm64" ] ); then
         darwin-bootstrap
-    elif [ "$(uname -s)" = "Linux" ]; then
-        SI_LINUX="true"
-
-        if [ -f /etc/os-release ]; then
-            SI_OS=$(grep '^ID=' /etc/os-release | sed 's/^ID=//' | tr -d '"')
-
-            # Arch Linux only officially supports amd64.
-            if [ "$SI_OS" = "arch" ] && [ "$SI_ARCH" = "x86_64" ]; then
-                arch-bootstrap
-            elif [ "$SI_OS" = "fedora" ]; then
-                fedora-bootstrap
-            else
-                echo "error: detected distro \"$SI_OS\" and architecture \"$SI_ARCH\" combination have not yet been validated"
-                exit 1
-            fi
-        else
-           echo "error: file \"/etc/os-release\" not found"
-           exit 1
-        fi
-
-        if [ -f /proc/sys/kernel/osrelease ] && [ $(grep "WSL2" /proc/sys/kernel/osrelease) ]; then
-            SI_WSL2="true"
-        else
-            SI_WSL2="false"
-        fi
+    elif [ "$SI_OS" = "arch" ] && [ "$SI_ARCH" = "x86_64" ]; then
+        arch-bootstrap
+    elif [ "$SI_OS" = "fedora" ] && [ "$SI_ARCH" = "x86_64" ]; then
+        fedora-bootstrap
     else
-        echo "error: detected OS is neither Darwin nor Linux"
-        exit 1
+        error-and-exit "detected distro \"$SI_OS\" and architecture \"$SI_ARCH\" combination have not yet been validated"
     fi
 }
 
 function check-binaries {
     for BINARY in "cargo" "node" "npm" "docker"; do
         if ! [ "$(command -v ${BINARY})" ]; then
-            echo "error: \"$BINARY\" must be installed and in PATH"
-            exit 1
+            error-and-exit "\"$BINARY\" must be installed and in PATH"
         fi
     done
 }
@@ -89,8 +92,7 @@ function check-binaries {
 function check-node {
     # Check added due to vercel/pkg requirement: https://github.com/vercel/pkg/issues/838
     if [ "$(node -pe process.release.lts)" = "undefined" ] && [ "$SI_OS" = "darwin"] && [ "$SI_ARCH" = "arm64"]; then
-        echo "error: must use an LTS release of node for \"$SI_OS\" on \"$SI_ARCH\""
-        exit 1
+        error-and-exit "must use an LTS release of node for \"$SI_OS\" on \"$SI_ARCH\""
     fi
 }
 
@@ -99,6 +101,7 @@ function print-success {
     echo ""
     echo "Success! Ready to build System Initiative with your config 🦀:"
     echo ""
+    echo "user  : $SI_USER"
     echo "os    : $SI_OS"
     echo "arch  : $SI_ARCH"
     echo "linux : $SI_LINUX"
@@ -106,6 +109,8 @@ function print-success {
     echo ""
 }
 
+determine-user
+set-config
 perform-bootstrap
 check-binaries
 check-node


### PR DESCRIPTION
- Validate Fedora on amd64 machines
- Require non-root user for execution of bootstrapper
- Replace compatibility table with list to reduce confusion
- Add recommended toolchain management tools
- Add environment addition steps
- Refactor bootstrapper to split bootstrap functions from variable
  determination steps