### PR TITLE
fix(sdf): add missing match arm variants for EditFieldObjectKind

### DIFF
--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -6,7 +6,8 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    schema::variant::SchemaVariantError, socket::SocketError, SchemaError, StandardModelError,
+    schema::variant::SchemaVariantError, socket::SocketError, QualificationCheckError, SchemaError,
+    StandardModelError,
 };
 use std::convert::Infallible;
 use thiserror::Error;
@@ -20,6 +21,8 @@ pub enum EditFieldError {
     Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
+    #[error("qualification check error: {0}")]
+    QualificationChec(#[from] QualificationCheckError),
     #[error(transparent)]
     StandardModel(#[from] StandardModelError),
     #[error("schema error: {0}")]

--- a/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
+++ b/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
@@ -4,7 +4,7 @@ use dal::{
     edit_field::{EditFieldAble, EditFieldObjectKind, EditFields},
     schema,
     socket::Socket,
-    Schema, Tenancy, Visibility,
+    QualificationCheck, Schema, Tenancy, Visibility,
 };
 use serde::{Deserialize, Serialize};
 
@@ -37,6 +37,15 @@ pub async fn get_edit_fields(
     tenancy.universal = true;
 
     let edit_fields = match request.object_kind {
+        EditFieldObjectKind::QualificationCheck => {
+            QualificationCheck::get_edit_fields(
+                &txn,
+                &tenancy,
+                &request.visibility,
+                &request.id.into(),
+            )
+            .await?
+        }
         EditFieldObjectKind::Schema => {
             Schema::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into()).await?
         }

--- a/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
@@ -3,7 +3,7 @@ use dal::{
     edit_field::{EditFieldAble, EditFieldObjectKind},
     schema::{self, SchemaVariant},
     socket::Socket,
-    HistoryActor, Schema, Tenancy, Visibility,
+    HistoryActor, QualificationCheck, Schema, Tenancy, Visibility,
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +40,19 @@ pub async fn update_from_edit_field(
     let history_actor: HistoryActor = HistoryActor::from(claim.user_id);
 
     match request.object_kind {
+        EditFieldObjectKind::QualificationCheck => {
+            QualificationCheck::update_from_edit_field(
+                &txn,
+                &nats,
+                &tenancy,
+                &request.visibility,
+                &history_actor,
+                request.object_id.into(),
+                request.edit_field_id,
+                request.value,
+            )
+            .await?
+        }
         EditFieldObjectKind::Schema => {
             Schema::update_from_edit_field(
                 &txn,


### PR DESCRIPTION
This looks like it was missed as the PRs merged on top of each other.
CI's going to catch this stuff moving forward ;)

![tenor-129104374](https://user-images.githubusercontent.com/261548/145889184-c6193c98-202f-4f9f-ba5f-1369816dc8da.gif)