### PR TITLE
chore(dal): converts raw panics to errors in edit field trait impls

### DIFF
--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -10,14 +10,26 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum EditFieldError {
+    #[error("invalid edit field name: {0}")]
+    InvalidField(String),
+    #[error("value is not expected type: {0}")]
+    InvalidValueType(&'static str),
     #[error("label list error: {0}")]
     LabelList(#[from] LabelListError),
+    #[error("value for edit field not provided, cannot set value")]
+    MissingValue,
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("missing head value in visibility diff calculation")]
     VisibilityDiffMissingHeadValue,
     #[error("missing change set value in visibility diff calculation")]
     VisibilityDiffMissingChangeSetValue,
+}
+
+impl EditFieldError {
+    pub fn invalid_field(field_name: impl Into<String>) -> Self {
+        Self::InvalidField(field_name.into())
+    }
 }
 
 pub type EditFieldResult<T> = Result<T, EditFieldError>;

--- a/lib/dal/src/qualification_check.rs
+++ b/lib/dal/src/qualification_check.rs
@@ -190,17 +190,16 @@ impl EditFieldAble for QualificationCheck {
         match edit_field_id.as_ref() {
             "name" => match value {
                 Some(json_value) => {
-                    let value = json_value
-                        .as_str()
-                        .map(|s| s.to_string())
-                        .expect("TODO: value is not a string");
+                    let value = json_value.as_str().map(|s| s.to_string()).ok_or(
+                        Self::Error::EditField(EditFieldError::InvalidValueType("string")),
+                    )?;
                     object
                         .set_name(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
-            invalid => panic!("TODO: invalid field name: {}", invalid),
+            invalid => return Err(EditFieldError::invalid_field(invalid).into()),
         }
 
         Ok(())

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -8,8 +8,8 @@ use super::{Schema, SchemaId, SchemaResult};
 use crate::{
     edit_field::{
         value_and_visiblity_diff, value_and_visiblity_diff_option, EditField, EditFieldAble,
-        EditFieldDataType, EditFieldObjectKind, EditFields, RequiredValidator, SelectWidget,
-        TextWidget, Validator, Widget,
+        EditFieldDataType, EditFieldError, EditFieldObjectKind, EditFields, RequiredValidator,
+        SelectWidget, TextWidget, Validator, Widget,
     },
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
     standard_model_many_to_many, HistoryActor, LabelList, SchemaError, SchematicKind,
@@ -213,7 +213,7 @@ impl EditFieldAble for UiMenu {
                         .set_name(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("cannot set the value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "category" => match value {
                 Some(json_value) => {
@@ -222,7 +222,7 @@ impl EditFieldAble for UiMenu {
                         .set_category(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("cannot set the value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "schematic_kind" => match value {
                 Some(json_value) => {
@@ -232,9 +232,9 @@ impl EditFieldAble for UiMenu {
                         .set_schematic_kind(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("cannot set the value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
-            _ => {}
+            invalid => return Err(EditFieldError::invalid_field(invalid).into()),
         }
         Ok(())
     }

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -250,15 +250,14 @@ impl EditFieldAble for SchemaVariant {
         match edit_field_id.as_ref() {
             "name" => match value {
                 Some(json_value) => {
-                    let value = json_value
-                        .as_str()
-                        .map(|s| s.to_string())
-                        .expect("TODO: value is not a string");
+                    let value = json_value.as_str().map(|s| s.to_string()).ok_or(
+                        Self::Error::EditField(EditFieldError::InvalidValueType("string")),
+                    )?;
                     object
                         .set_name(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "connections.sockets" => {
                 // TODO(fnichol): we're sticking in arbitrary default values--these become required
@@ -278,7 +277,7 @@ impl EditFieldAble for SchemaVariant {
                     .add_type(txn, nats, visibility, history_actor, object.id())
                     .await?;
             }
-            invalid => panic!("TODO: invalid field name: {}", invalid),
+            invalid => return Err(EditFieldError::invalid_field(invalid).into()),
         }
 
         Ok(())

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -326,46 +326,52 @@ impl EditFieldAble for Socket {
         match edit_field_id.as_ref() {
             "name" => match value {
                 Some(json_value) => {
-                    let value = json_value
-                        .as_str()
-                        .map(|s| s.to_string())
-                        .expect("TODO: value is not a string");
+                    let value = json_value.as_str().map(|s| s.to_string()).ok_or(
+                        Self::Error::EditField(EditFieldError::InvalidValueType("string")),
+                    )?;
                     object
                         .set_name(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "edge_kind" => match value {
                 Some(json_value) => {
-                    let value: SocketEdgeKind = serde_json::from_value(json_value)
-                        .expect("TODO: value is not a SocketEdgeKind");
+                    let value: SocketEdgeKind =
+                        serde_json::from_value(json_value).map_err(|_| {
+                            Self::Error::EditField(EditFieldError::InvalidValueType(
+                                "SocketEdgeKind",
+                            ))
+                        })?;
                     object
                         .set_edge_kind(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "arity" => match value {
                 Some(json_value) => {
-                    let value: SocketArity = serde_json::from_value(json_value)
-                        .expect("TODO: value is not a SocketArity");
+                    let value: SocketArity = serde_json::from_value(json_value).map_err(|_| {
+                        Self::Error::EditField(EditFieldError::InvalidValueType("SocketArity"))
+                    })?;
                     object
                         .set_arity(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
             "required" => match value {
                 Some(json_value) => {
-                    let value = json_value.as_bool().expect("TODO: value is not a bool");
+                    let value = json_value.as_bool().ok_or(Self::Error::EditField(
+                        EditFieldError::InvalidValueType("boolean"),
+                    ))?;
                     object
                         .set_required(txn, nats, visibility, history_actor, value)
                         .await?;
                 }
-                None => panic!("TODO: value for name not provided, cannot set value"),
+                None => return Err(EditFieldError::MissingValue.into()),
             },
-            invalid => panic!("TODO: invalid field name: {}", invalid),
+            invalid => return Err(EditFieldError::invalid_field(invalid).into()),
         }
 
         Ok(())


### PR DESCRIPTION
This change removes the temporary/YOLO match arm logic when returning
edit fields or updating from an edit field. Nice, clean error types,
ahhhh...

![tenor-153120129](https://user-images.githubusercontent.com/261548/145889714-c41e2009-c309-45f2-8160-780a1fcffcdd.gif)
>