### PR TITLE
chore(web): add proxy support, htpasswd, and fix up docker-compose

### DIFF
--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -33,3 +33,4 @@ FROM nginx:$NGINX_VERSION-alpine as final
 RUN rm -rf /etc/nginx/conf.d/default.conf /usr/share/nginx/html/*
 COPY --from=builder /usr/src/app/web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/web/dist /usr/share/nginx/html
+COPY --from=builder /usr/src/app/web/htpasswd /htpasswd

--- a/app/web/htpasswd
+++ b/app/web/htpasswd
@@ -1,0 +1,1 @@
+max:$2y$05$IjSLp2MNV4Xbq2H3r4sc.eSmMyCS.SVKAC./QghlA.KvLwRp2Avw.

--- a/app/web/nginx.conf
+++ b/app/web/nginx.conf
@@ -1,5 +1,12 @@
+upstream sdf {
+  server sdf:5156;
+}
+
 server {
     listen       80;
+
+    auth_basic           "S00perS3kret Authentication";
+    auth_basic_user_file /htpasswd;
 
     location / {
         root   /usr/share/nginx/html;
@@ -11,5 +18,24 @@ server {
 
     location = /50x.html {
       root   /usr/share/nginx/html;
+    }
+
+    location /api/ws {
+      auth_basic off;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
+      proxy_pass http://sdf;
+    }
+
+    location /api {
+      auth_basic off;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-NginX-Proxy true;
+      proxy_pass http://sdf;
+      proxy_redirect off;
     }
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,3 +50,9 @@ services:
     ports:
       - "4317:4317"
       - "55679:55679"
+
+  web:
+    image: "systeminit/web:stable"
+    ports:
+      - "80:80"
+


### PR DESCRIPTION
This PR adds proxy support to the web nginx config when it is in a
container, along with adding an htpasswd for authentication. Things are
almost working!!

Love,
Fletcher and Adam