### PR TITLE
chore(otel): pass otel credentials to the compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/automerge
 /support/dev/k8s/**/dockerconfig.json
 /support/dev/k8s/**/web-htpasswd
 /tmp/
+deploy/docker-compose.env.yml

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,22 +37,30 @@ services:
       - "PGPASSWORD=bugbear"
       - "POSTGRES_USER=si"
       - "POSTGRES_DB=si"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "5432:5432"
 
   nats:
     image: "systeminit/nats:stable"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "4222:4222"
 
   otel:
     image: "systeminit/otelcol:stable"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "4317:4317"
       - "55679:55679"
 
   web:
     image: "systeminit/web:stable"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "80:80"
 


### PR DESCRIPTION
We now require a docker-compose.env.yml to exist, which should not be
checked in to the respository, which will contain the environment
variables that inject credentials into the otel collector container.

It also removes the use of sudo from run.sh, and adds the web and support
containers to watchtower (because we should update them if we release
them)

Signed-off-by: Adam Jacob <adam@systeminit.com>