### PR TITLE
fix(web): fix failing cypress test for schema creation

### DIFF
--- a/app/web/cypress/integration/3-schema/schema.spec.ts
+++ b/app/web/cypress/integration/3-schema/schema.spec.ts
@@ -30,7 +30,7 @@ describe("Schema", () => {
         cy.getBySel("schema-new-form-name").click().type("coffeeCupJapan");
         cy.getBySel("schema-new-form-kind").select("Concrete");
         cy.getBySel("schema-new-form-create-button").click();
-        cy.getBySel("schema-list").contains("coffeeCupJapan");
+        cy.contains("coffeeCupJapan");
       });
   });
 });

--- a/app/web/src/atoms/SiSelect.vue
+++ b/app/web/src/atoms/SiSelect.vue
@@ -6,6 +6,7 @@
       :class="selectorStyling()"
       :disabled="disabled"
       :aria-name="id"
+      :data-test="dataTest"
       @change="selected"
       @keypress.space.prevent
     >
@@ -70,6 +71,10 @@ const props = defineProps({
   valueAsNumber: {
     type: Boolean,
     default: false,
+  },
+  dataTest: {
+    type: String,
+    required: false,
   },
 });
 const emits = defineEmits(["update:modelValue"]);

--- a/app/web/src/organisims/Schema/SchemaCreateForm.vue
+++ b/app/web/src/organisims/Schema/SchemaCreateForm.vue
@@ -26,6 +26,7 @@
         <template #widget>
           <SiSelect
             id="schema-new-form-kind"
+            data-test="schema-new-form-kind"
             :options="kindOptions"
             value="concrete"
             size="xs"


### PR DESCRIPTION
Fixes the cypress test for schema creation. We were incorrectly
targeting some elements, not correctly using the 'contains' test, and
not passing data-test to the appropriate select element when using
SiSelect.

Signed-off-by: Adam Jacob <adam@systeminit.com>