### PR TITLE
feat(cd): manual deployment make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,3 +235,7 @@ app-run:
 cargo-clean:
 	cd $(MAKEPATH); cargo clean
 .PHONY: clean-cargo
+
+deploy-prod:
+	@$(MAKEPATH)/scripts/deploy-prod.sh
+.PHONY: deploy-prod

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,29 @@
+# Production
+
+The production environment is running on a single ec2 instance, which you can reach if you are on the tailscale
+network. You need to have the `si_key` from 1password in your keychain.
+
+## Interactive
+
+You can log in interactively with:
+
+```
+$ ssh fedora@prod-1
+```
+
+The environment is running via docker-compose out of the `deploy` directory.
+
+## Updates
+
+Updates are applied to production automatically, as new containers are tagged `stable`. If production is up and running, there should be nnothing to do in the common case.
+
+## Deploy manually
+
+If, for some reason, you need to deploy the system manually, you can. Use the top level make target:
+
+```
+$ make deploy-prod
+```
+
+You must have `rsync` installed on your workstation, and the ssh-key loaded.
+

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+
+echo "*** Deploying production ***"
+
+echo "*** Rsync ***"
+rsync -vaP $SCRIPT_PATH/../deploy --exclude 'docker-compose.env.yml' fedora@prod-1:~
+
+echo "*** Deployment ***"
+ssh fedora@prod-1 '(cd ~/deploy && make down; make prod)'


### PR DESCRIPTION
You can now manually deploy production with:

```
$ make deploy-prod
```

This will tear down the environment and redeploy it, after rsync-ing the
udpated deployment code.

Signed-off-by: Adam Jacob <adam@systeminit.com>