### PR TITLE
chore(deploy,bootstrap): fix missing compose env file error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If unsure, the following tools are recommended to help manage your toolchains:
 
 ## Quickstart
 
-To get ready to run this repository, you should run the following script:
+**Bootstrap:** to get ready to run this repository, you should run the following script:
 
 ```bash
 ./scripts/bootstrap.sh
@@ -34,7 +34,9 @@ To get ready to run this repository, you should run the following script:
 The bootstrapper is idempotent, so feel free to run it as many times as you like!
 However, it _will_ upgrade existing packages without confirmations, so ensure that you are ready to do so.
 
-With all dependencies installed and required binaries in `PATH`, we are ready to go!
+**Login:** now, we need to ensure that we are [logged into Docker locally](https://docs.docker.com/engine/reference/commandline/login/) and that the corrresponding account can pull images from our [private repositories](https://hub.docker.com/orgs/systeminit/repositories).
+
+**Make:** with all dependencies installed and required binaries in `PATH`, we are ready to go!
 In one terminal pane (e.g. using a terminal multiplexer, such as `tmux`, or tabs/windows), execute the following:
 
 ```bash

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -38,17 +38,6 @@ down:
 		down
 
 check-env:
-	@if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
-		echo "Missing docker-compose.env.yml - must be included for use!"; \
-		echo "A sample file appears below, for your convenience. ;)"; \
-		echo "---"; \
-		echo "sdf:"; \
-		echo "  volumes:"; \
-		echo "    - /etc/jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin"; \
-		echo "otel:"; \
-		echo "  environment:"; \
-		echo "    - HONEYCOMB_TOKEN=the_token"; \
-		echo "    - HONEYCOMB_DATASET=the_dataset"; \
-		echo "---"; \
-		exit 1; \
+	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
+		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,26 @@
+# Deploying SI
+
+When using the `Makefile` within this directory (`./deploy/`), a file named `docker-compose.env.yml` needs to exist.
+Make targets will automatically create an minimal version of this file if it does not exist, but you can customize it further.
+Here is an example:
+
+```yaml
+version: "3"
+services:
+  sdf:
+    volumes:
+      - /<path>/<to>/jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin
+  otel:
+    environment:
+      - HONEYCOMB_TOKEN=<token>
+      - HONEYCOMB_DATASET=<dataset>
+```
+
+By default, the file will be created with the following contents:
+
+```yaml
+version: "3"
+```
+
+_Note:_ the `docker-compose.env.yml` file within this directory has been added to `.gitignore`.
+This is because enviroment overrides may include tokens used for local development.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,9 +7,9 @@ SI_LINUX="unknown"
 SI_WSL2="unknown"
 SI_ARCH="unknown"
 
-function error-and-exit {
+function die {
     if [ "$1" = "" ]; then
-        error-and-exit "must provide argument <error-message>"
+        die "must provide argument <error-message>"
     fi
     echo "error: $1"
     exit 1
@@ -17,7 +17,7 @@ function error-and-exit {
 
 function determine-user {
     if [ $EUID -eq 0 ]; then
-        error-and-exit "must run as non-root"
+        die "must run as non-root"
     fi
     SI_USER=$(whoami)
     sudo -v
@@ -40,7 +40,7 @@ function set-config {
         if [ -f /etc/os-release ]; then
             SI_OS=$(grep '^ID=' /etc/os-release | sed 's/^ID=//' | tr -d '"')
         else
-            error-and-exit "file \"/etc/os-release\" not found"
+            die "file \"/etc/os-release\" not found"
         fi
 
         SI_WSL2="false"
@@ -48,7 +48,7 @@ function set-config {
             SI_WSL2="true"
         fi
     else
-        error-and-exit "detected OS is neither Darwin nor Linux"
+        die "detected OS is neither Darwin nor Linux"
     fi
 }
 
@@ -77,14 +77,14 @@ function perform-bootstrap {
     elif [ "$SI_OS" = "fedora" ] && [ "$SI_ARCH" = "x86_64" ]; then
         fedora-bootstrap
     else
-        error-and-exit "detected distro \"$SI_OS\" and architecture \"$SI_ARCH\" combination have not yet been validated"
+        die "detected distro \"$SI_OS\" and architecture \"$SI_ARCH\" combination have not yet been validated"
     fi
 }
 
 function check-binaries {
-    for BINARY in "cargo" "node" "npm" "docker"; do
+    for BINARY in "cargo" "node" "npm" "docker" "docker-compose"; do
         if ! [ "$(command -v ${BINARY})" ]; then
-            error-and-exit "\"$BINARY\" must be installed and in PATH"
+            die "\"$BINARY\" must be installed and in PATH"
         fi
     done
 }
@@ -92,7 +92,7 @@ function check-binaries {
 function check-node {
     # Check added due to vercel/pkg requirement: https://github.com/vercel/pkg/issues/838
     if [ "$(node -pe process.release.lts)" = "undefined" ] && [ "$SI_OS" = "darwin"] && [ "$SI_ARCH" = "arm64"]; then
-        error-and-exit "must use an LTS release of node for \"$SI_OS\" on \"$SI_ARCH\""
+        die "must use an LTS release of node for \"$SI_OS\" on \"$SI_ARCH\""
     fi
 }
 


### PR DESCRIPTION
- Originally, the missing compose env file check was meant to ensure
  you manually created the file
- In hindsight, the error can be difficult to parse, and we should
  create a minimal file silently
- The old error message is now in its own README
- Bootstrapper now checks for "docker-compose"

<img src="https://media4.giphy.com/media/xT5LMtYEfxlFnXC7XW/giphy.gif"/>