### PR TITLE
feat(attribute): add attribute panel

### DIFF
--- a/app/web/src/atoms/SiSelect.vue
+++ b/app/web/src/atoms/SiSelect.vue
@@ -32,8 +32,8 @@ import { PropType, defineProps, defineEmits, computed } from "vue";
 import VueFeather from "vue-feather";
 
 export interface SelectPropsOption {
-  value: string | null | Object | number;
-  label: string;
+  value: unknown;
+  label: unknown;
 }
 
 export interface SelectProps {

--- a/app/web/src/molecules/Panel.vue
+++ b/app/web/src/molecules/Panel.vue
@@ -96,7 +96,7 @@ const props = defineProps({
   panelIndex: { type: Number, required: true },
   panelRef: { type: String, required: true },
   panelContainerRef: { type: String, required: true },
-  initialPanelType: { type: String as PropType<PanelType>, required: true },
+  initialPanelType: { type: String as PropType<PanelType>, default: PanelType.Empty },
   initialMaximizedFull: Boolean,
   initialMaximizedContainer: Boolean,
   isVisible: { type: Boolean, default: true },
@@ -225,13 +225,15 @@ div.inactive-panel-menu > * {
   filter: brightness(90%);
 }
 
+/*
 div.active-panel {
-  /* border: solid;
+  border: solid;
   border-color: #323536;
-  border-width: 0.1em; */
+  border-width: 0.1em;
 }
 
 div.inactive-panel > * {
-  /* filter: brightness(98%); */
+  filter: brightness(98%);
 }
+*/
 </style>

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, ref } from "vue";
+import { PropType } from "vue";
 import { EditFields } from "@/api/sdf/dal/edit_field";
 import CheckboxWidget from "@/organisims/EditForm/CheckboxWidget.vue";
 import TextWidget from "@/organisims/EditForm/TextWidget.vue";
@@ -42,13 +42,13 @@ import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
 import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
 import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
 
-const props = defineProps({
+defineProps({
   editFields: {
     type: Array as PropType<EditFields>,
     required: true,
   },
 });
 
-type TreeOpenState = Record<string, boolean>;
-const treeOpenState = ref<TreeOpenState>({});
+// type TreeOpenState = Record<string, boolean>;
+// const treeOpenState = ref<TreeOpenState>({});
 </script>

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -1,0 +1,46 @@
+<template>
+  <Panel
+    :panel-index="panelIndex"
+    :panel-ref="panelRef"
+    :panel-container-ref="panelContainerRef"
+    :initial-maximized-container="initialMaximizedContainer"
+    :initial-maximized-full="initialMaximizedFull"
+    :is-visible="isVisible"
+    :is-maximized-container-enabled="isMaximizedContainerEnabled"
+  >
+    <template #content>
+      I like my butt
+    </template>
+  </Panel>
+</template>
+
+<script setup lang="ts">
+import Panel from "@/molecules/Panel.vue";
+// import ViewerAttribute from "@/organisims/PanelAttribute/ViewerAttribute.vue";
+
+// import { GlobalErrorService } from "@/service/global_error";
+// import { ApiResponse } from "@/api/sdf";
+
+// TODO: Nick, here is your panel. The switcher is fucked, but otherwise, should be good to port.
+
+defineProps({
+  panelIndex: { type: Number, required: true },
+  panelRef: { type: String, required: true },
+  panelContainerRef: { type: String, required: true },
+  initialMaximizedFull: Boolean,
+  initialMaximizedContainer: Boolean,
+  isVisible: Boolean,
+  isMaximizedContainerEnabled: Boolean,
+});
+
+</script>
+
+<style scoped>
+.unlocked {
+  color: #c6c6c6;
+}
+
+.locked {
+  color: #e3ddba;
+}
+</style>

--- a/app/web/src/organisims/PanelSchematic.vue
+++ b/app/web/src/organisims/PanelSchematic.vue
@@ -1,6 +1,5 @@
 <template>
   <Panel
-    initial-panel-type="empty"
     :panel-index="panelIndex"
     :panel-ref="panelRef"
     :panel-container-ref="panelContainerRef"

--- a/app/web/src/organisims/PanelTree/PanelSelector.vue
+++ b/app/web/src/organisims/PanelTree/PanelSelector.vue
@@ -8,6 +8,7 @@
       :panel-container-ref="panelContainerRef"
       :initial-maximized-full="maximizedFull"
       :initial-maximized-container="maximizedContainer"
+      :initial-panel-type="panelType"
       :is-maximized-container-enabled="isMaximizedContainerEnabled"
       @change-panel="changePanelType"
       @panel-maximize-full="setMaximizedFullTrue($event)"
@@ -22,6 +23,8 @@
 import { computed, PropType, ref } from "vue";
 import { PanelMaximized, PanelType } from "./panel_types";
 import PanelEmpty from "@/organisims/PanelEmpty.vue";
+
+import PanelAttribute from "@/organisims/PanelAttribute.vue";
 import PanelSchematic from "@/organisims/PanelSchematic.vue";
 
 const props = defineProps({
@@ -43,7 +46,9 @@ const emit = defineEmits([
 const panelType = ref<PanelType>(props.initialPanelType);
 
 const whichComponent = computed<any>(() => {
-  if (panelType.value == "schematic") {
+  if (panelType.value == "attribute") {
+    return PanelAttribute;
+  } else if (panelType.value == "schematic") {
     return PanelSchematic;
   } else {
     return PanelEmpty;


### PR DESCRIPTION
- Add attribute panel [sc-1950]
- Fix bug where panel name was not displaying correctly
  - Short version: the panel type was being emitted correctly but the
    value passed down to the SiSelect component was... well, not
    happening
  - Observably, if you set the panel to its same type again, the value
    miraculously worked, but this is purely because Vue cached the
    component rather than re-creating it
  - Thus, the fallback value was "Empty", which was observed in the bug
- Move default panel type value to the panel declaration rather than per
  panel settings
- Fix typecasting for LabelList<PanelType> for panel

<img src="https://media4.giphy.com/media/wbipxAHsNf2Wk/giphy.gif"/>