### PR TITLE
feat(web,dal,sdf): add system to...the system

### DIFF
--- a/app/web/src/api/sdf/dal/system.ts
+++ b/app/web/src/api/sdf/dal/system.ts
@@ -1,0 +1,5 @@
+import { StandardModel } from "@/api/sdf/dal/standard_model";
+
+export interface System extends StandardModel {
+  name: string;
+}

--- a/app/web/src/observable/system.ts
+++ b/app/web/src/observable/system.ts
@@ -1,0 +1,10 @@
+import { ReplaySubject } from "rxjs";
+import { System } from "@/api/sdf/dal/system";
+import { persistToSession } from "@/observable/session_state";
+
+/**
+ * The currently logged in associated system, or null if there isn't one.
+ */
+export const system$ = new ReplaySubject<System | null>(1);
+system$.next(null);
+persistToSession("system", system$);

--- a/app/web/src/service/session/get_defaults.ts
+++ b/app/web/src/service/session/get_defaults.ts
@@ -2,13 +2,16 @@ import Bottle from "bottlejs";
 import { ApiResponse, SDF } from "@/api/sdf";
 import { Workspace } from "@/api/sdf/dal/workspace";
 import { Organization } from "@/api/sdf/dal/organization";
+import { System } from "@/api/sdf/dal/system";
 import { workspace$ } from "@/observable/workspace";
 import { organization$ } from "@/observable/organization";
+import { system$ } from "@/observable/system";
 import { Observable, tap } from "rxjs";
 
 interface GetDefaultsResponse {
   workspace: Workspace;
   organization: Organization;
+  system: System;
 }
 
 export function getDefaults(): Observable<ApiResponse<GetDefaultsResponse>> {
@@ -19,6 +22,7 @@ export function getDefaults(): Observable<ApiResponse<GetDefaultsResponse>> {
       if (!response.error) {
         workspace$.next(response.workspace);
         organization$.next(response.organization);
+        system$.next(response.system);
       }
     }),
   );

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -23,6 +23,7 @@ pub mod socket;
 pub mod standard_accessors;
 pub mod standard_model;
 pub mod standard_pk;
+pub mod system;
 pub mod tenancy;
 pub mod test_harness;
 pub mod timestamp;
@@ -57,6 +58,7 @@ pub use schema::{
 };
 pub use schematic::SchematicKind;
 pub use standard_model::{StandardModel, StandardModelError, StandardModelResult};
+pub use system::{System, SystemError, SystemId, SystemPk, SystemResult};
 pub use tenancy::{Tenancy, TenancyError};
 pub use timestamp::{Timestamp, TimestampError};
 pub use user::{User, UserClaim, UserError, UserId, UserResult};

--- a/lib/dal/src/migrations/U0038__systems.sql
+++ b/lib/dal/src/migrations/U0038__systems.sql
@@ -1,0 +1,49 @@
+CREATE TABLE systems
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    name                        text                     NOT NULL
+);
+SELECT standard_model_table_constraints_v1('systems');
+SELECT belongs_to_table_create_v1('system_belongs_to_workspace', 'systems', 'workspaces');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('systems', 'model', 'system', 'System'),
+       ('system_belongs_to_workspace', 'belongs_to', 'system.workspace', 'System <> Workspace');
+
+CREATE OR REPLACE FUNCTION system_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           systems%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO systems (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
+                     tenancy_workspace_ids,
+                     visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted,
+                     name)
+    VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
+        this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
+        this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
+        this_visibility_record.visibility_deleted, this_name)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/system.rs
+++ b/lib/dal/src/system.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsTxn, PgError, PgTxn};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
+    HistoryActor, HistoryEventError, StandardModel, StandardModelError, Tenancy, Timestamp,
+    Visibility, Workspace, WorkspaceId,
+};
+
+#[derive(Error, Debug)]
+pub enum SystemError {
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type SystemResult<T> = Result<T, SystemError>;
+
+pk!(SystemPk);
+pk!(SystemId);
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct System {
+    pk: SystemPk,
+    id: SystemId,
+    name: String,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: System,
+    pk: SystemPk,
+    id: SystemId,
+    table_name: "systems",
+    history_event_label_base: "system",
+    history_event_message_name: "System"
+}
+
+impl System {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+    ) -> SystemResult<Self> {
+        let name = name.as_ref();
+        let row = txn
+            .query_one(
+                "SELECT object FROM system_create_v1($1, $2, $3)",
+                &[tenancy, visibility, &name],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+
+        Ok(object)
+    }
+
+    standard_model_accessor!(name, String, SystemResult);
+
+    standard_model_belongs_to!(
+        lookup_fn: workspace,
+        set_fn: set_workspace,
+        unset_fn: unset_workspace,
+        table: "system_belongs_to_workspace",
+        model_table: "workspaces",
+        belongs_to_id: WorkspaceId,
+        returns: Workspace,
+        result: SystemResult,
+    );
+}

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -10,8 +10,8 @@ use telemetry::{ClientError, TelemetryClient, Verbosity};
 use crate::{
     billing_account::BillingAccountSignup, jwt_key::JwtSecretKey, node::NodeKind, schema, socket,
     BillingAccount, ChangeSet, Component, EditSession, Group, HistoryActor, KeyPair, Node,
-    QualificationCheck, Schema, SchemaKind, StandardModel, Tenancy, User, Visibility,
-    NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
+    Organization, QualificationCheck, Schema, SchemaKind, StandardModel, System, Tenancy, User,
+    Visibility, Workspace, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
 };
 
 #[derive(Debug)]
@@ -243,6 +243,32 @@ pub async fn create_billing_account(
         .expect("cannot create billing_account")
 }
 
+pub async fn create_organization(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> Organization {
+    let name = generate_fake_name();
+    Organization::new(txn, nats, tenancy, visibility, history_actor, &name)
+        .await
+        .expect("cannot create organization")
+}
+
+pub async fn create_workspace(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> Workspace {
+    let name = generate_fake_name();
+    Workspace::new(txn, nats, tenancy, visibility, history_actor, &name)
+        .await
+        .expect("cannot create workspace")
+}
+
 pub async fn create_key_pair(
     txn: &PgTxn<'_>,
     nats: &NatsTxn,
@@ -439,4 +465,17 @@ pub async fn create_qualification_check(
     QualificationCheck::new(txn, nats, tenancy, visibility, history_actor, name)
         .await
         .expect("cannot create qualification check")
+}
+
+pub async fn create_system(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> System {
+    let name = generate_fake_name();
+    System::new(txn, nats, tenancy, visibility, history_actor, name)
+        .await
+        .expect("cannot create system")
 }

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
-    HistoryActor, HistoryEventError, Organization, OrganizationId, StandardModel,
-    StandardModelError, Tenancy, Timestamp, Visibility,
+    standard_model_has_many, HistoryActor, HistoryEventError, Organization, OrganizationId,
+    StandardModel, StandardModelError, System, SystemResult, Tenancy, Timestamp, Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -80,6 +80,7 @@ impl Workspace {
     }
 
     standard_model_accessor!(name, String, WorkspaceResult);
+
     standard_model_belongs_to!(
         lookup_fn: organization,
         set_fn: set_organization,
@@ -89,5 +90,13 @@ impl Workspace {
         belongs_to_id: OrganizationId,
         returns: Organization,
         result: WorkspaceResult,
+    );
+
+    standard_model_has_many!(
+        lookup_fn: systems,
+        table: "system_belongs_to_workspace",
+        model_table: "systems",
+        returns: System,
+        result: SystemResult,
     );
 }

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -13,6 +13,7 @@ mod qualification_check;
 mod schema;
 mod socket;
 mod standard_model;
+mod system;
 mod tenancy;
 mod user;
 mod visibility;

--- a/lib/dal/tests/integration_test/system.rs
+++ b/lib/dal/tests/integration_test/system.rs
@@ -1,0 +1,47 @@
+use dal::{
+    test_harness::{create_system, create_workspace},
+    HistoryActor, StandardModel, System, Tenancy, Visibility,
+};
+
+use crate::test_setup;
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let system = System::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "jonas-brothers-why-oh-why",
+    )
+    .await
+    .expect("cannot create system");
+    assert_eq!(system.name(), "jonas-brothers-why-oh-why");
+}
+
+#[tokio::test]
+async fn set_workspace() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let system = create_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let workspace = create_workspace(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+
+    system
+        .set_workspace(&txn, &nats, &visibility, &history_actor, workspace.id())
+        .await
+        .expect("cannot associate system with workspace");
+
+    let associated_workspace = system
+        .workspace(&txn, &visibility)
+        .await
+        .expect("failed to get a workspace")
+        .expect("workspace was none");
+    assert_eq!(associated_workspace, workspace);
+}

--- a/lib/sdf/src/server/service/session/get_defaults.rs
+++ b/lib/sdf/src/server/service/session/get_defaults.rs
@@ -2,7 +2,7 @@ use super::SessionResult;
 use crate::server::extract::{Authorization, PgRoTxn};
 use axum::Json;
 use dal::billing_account::BillingAccountDefaults;
-use dal::{BillingAccount, Organization, Tenancy, Visibility, Workspace};
+use dal::{BillingAccount, Organization, System, Tenancy, Visibility, Workspace};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct GetDefaultsResponse {
     pub workspace: Workspace,
     pub organization: Organization,
+    pub system: System,
 }
 
 impl From<BillingAccountDefaults> for GetDefaultsResponse {
@@ -17,6 +18,7 @@ impl From<BillingAccountDefaults> for GetDefaultsResponse {
         GetDefaultsResponse {
             workspace: defaults.workspace,
             organization: defaults.organization,
+            system: defaults.system,
         }
     }
 }


### PR DESCRIPTION
This change adds an initial implementation of System to SI. It's pretty
simple so far:

* has a name
* belongs to a Workspace
* a System called `"production"` is created and associated during
  `BillingAccount::signup`
* this initial System (called `"production"`) is returned in the
  `/session/get_defaults` API call from SDF
* the initial System is set in a new frontend observable called
  `system$` on session login and is persisted to session storage (same
  as Organization and Workspace) and cleared on logout

References: Create the backend notion of system [sc-1965]

<img src="https://media2.giphy.com/media/74e5YIHDbqWT6/giphy.gif"/>

(this is System of a Down, huh? huh?)