### PR TITLE
feat(web,sdf): restore the node add menu

### DIFF
--- a/app/web/src/api/sdf/dal/schematic.ts
+++ b/app/web/src/api/sdf/dal/schematic.ts
@@ -1,3 +1,47 @@
 export interface Schematic {
   poop: string;
 }
+
+export enum SchematicKind {
+  Deployment = "deployment",
+  Component = "component",
+}
+
+export function schematicKindFromString(s: string): SchematicKind {
+  switch (s) {
+    case "deployment":
+      return SchematicKind.Deployment;
+    case "component":
+      return SchematicKind.Component;
+    default:
+      throw Error(`Unknown SchematicKind member: ${s}`);
+  }
+}
+
+export interface MenuFilter {
+  schematicKind: SchematicKind;
+  rootComponentId: number;
+}
+
+export interface Category {
+  kind: "category";
+  name: string;
+  items: MenuItem[];
+}
+
+export interface Item {
+  kind: "item";
+  name: string;
+  entityType: string;
+  links?: LinkNodeItem[];
+}
+
+export interface LinkNodeItem {
+  kind: "link";
+  entityType: string;
+  nodeId: string;
+  entityId: string;
+  name: string;
+}
+
+export type MenuItem = Category | Item | LinkNodeItem;

--- a/app/web/src/atoms/LockButton.vue
+++ b/app/web/src/atoms/LockButton.vue
@@ -1,0 +1,30 @@
+<template>
+  <button class="pl-4 text-sm focus:outline-none" @click="toggle()">
+    <VueFeather v-if="modelValue" size="1rem" type="lock" class="locked" />
+    <VueFeather v-else size="1rem" type="unlock" class="unlocked" />
+  </button>
+</template>
+
+<script setup lang="ts">
+import VueFeather from "vue-feather";
+
+const props = defineProps({
+  modelValue: { type: Boolean, required: true },
+});
+
+const emits = defineEmits(["update:modelValue"]);
+
+const toggle = () => {
+  emits("update:modelValue", !props.modelValue);
+};
+</script>
+
+<style scoped>
+.unlocked {
+  color: #c6c6c6;
+}
+
+.locked {
+  color: #e3ddba;
+}
+</style>

--- a/app/web/src/molecules/NodeAddMenu.vue
+++ b/app/web/src/molecules/NodeAddMenu.vue
@@ -1,0 +1,153 @@
+<template>
+  <div
+    class="relative w-auto menu-root"
+    @mouseleave="onMouseLeave"
+    @mouseenter="cancelClose"
+  >
+    <button
+      class="w-full focus:outline-none"
+      data-cy="editor-schematic-node-add-button"
+      :disabled="disabled"
+      @click="isOpen = !isOpen"
+    >
+      <div
+        class="items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
+        :class="{
+          'text-gray-200': !isOpen,
+          'menu-selected': isOpen,
+          'text-gray-600': disabled,
+        }"
+      >
+        Add
+      </div>
+    </button>
+
+    <NodeAddMenuCategory
+      :is-open="isOpen"
+      :menu-items="menuItems"
+      root-menu
+      class="menu-root"
+      @selected="onSelect"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MenuFilter, MenuItem } from "@/api/sdf/dal/schematic";
+import NodeAddMenuCategory from "./NodeAddMenu/NodeAddMenuCategory.vue";
+import { computed, onBeforeUnmount, PropType, ref } from "vue";
+import { refFrom } from "vuse-rx";
+import _ from "lodash";
+import { SchematicService } from "@/service/schematic";
+import { GlobalErrorService } from "@/service/global_error";
+import { tap } from "rxjs";
+import { GetNodeAddMenuResponse } from "@/service/schematic/get_node_add_menu";
+import { ApiResponse } from "@/api/sdf";
+
+const props = defineProps({
+  disabled: { type: Boolean, default: false },
+  filter: {
+    type: Object as PropType<MenuFilter>,
+    required: true,
+  },
+});
+const emits = defineEmits(["selected"]);
+
+const isOpen = ref<boolean>(false);
+
+const onSelect = (entityType: string, event: MouseEvent) => {
+  event.preventDefault();
+  emits("selected", entityType, event);
+  isOpen.value = false;
+};
+
+const debounceIsOpen = _.debounce((component: any, isOpen: boolean) => {
+  component.value = isOpen;
+}, 500);
+const onMouseLeave = () => {
+  debounceIsOpen(isOpen, false);
+};
+const cancelClose = () => {
+  debounceIsOpen.cancel();
+};
+
+const menuItems = refFrom(
+  SchematicService.getNodeAddMenu({ menuFilter: props.filter }).pipe(
+    tap((response: ApiResponse<GetNodeAddMenuResponse>) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+      }
+    }),
+  ),
+);
+
+//    computed<MenuItem[]>(() => {
+//  return [
+//    {
+//      kind: "category",
+//      name: "Snoopy",
+//      items: [
+//        {
+//          kind: "item",
+//          name: "floopy",
+//          entityType: "floopy",
+//        },
+//      ],
+//    },
+//  ];
+//});
+
+const handleEscape = (e: any) => {
+  if (e.key === "Esc" || e.key === "Escape") {
+    if (isOpen.value) {
+      isOpen.value = false;
+    }
+  }
+};
+document.addEventListener("keydown", handleEscape);
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", handleEscape);
+});
+</script>
+
+<style>
+.menu-root {
+  z-index: 999;
+}
+
+.menu {
+  background-color: #2d3748;
+  border-color: #485359;
+}
+
+.menu-selected {
+  background-color: #edf2f8;
+  color: #000000;
+}
+
+.menu-not-selected {
+  color: red;
+}
+
+.options {
+  background-color: #1f2631;
+  border-color: #485359;
+}
+
+.options:hover {
+  background-color: #3d4b62;
+  border-color: #454d3e;
+}
+
+.menu-category .category-items {
+  /*  visibility: hidden; */
+  position: absolute;
+  left: 100%;
+  top: auto;
+  margin-top: -1.305rem;
+}
+
+.menu-category:hover .category-items {
+  /* visibility: visible; */
+}
+</style>

--- a/app/web/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
+++ b/app/web/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
@@ -1,0 +1,89 @@
+<template>
+  <ul v-show="isOpen" :class="listClasses">
+    <template v-for="item in menuItems">
+      <li
+        v-if="item.kind === 'category'"
+        :key="item.name"
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 cursor-pointer options menu-category whitespace-nowrap"
+        @mouseenter="open(item.name)"
+        @mouseleave="close(item.name)"
+      >
+        <div class="whitespace-no-wrap hover:text-white">
+          {{ item.name }}
+        </div>
+        <NodeAddMenuCategory
+          :menu-items="item.items"
+          :is-open="isCategoryOpen(item.name)"
+          @selected="selectedType"
+        />
+      </li>
+      <li
+        v-if="item.kind === 'item'"
+        :key="item.name"
+        class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
+        @click="selectedType(item.entityType, $event)"
+      >
+        <div class="whitespace-no-wrap">
+          {{ item.name }}
+        </div>
+      </li>
+    </template>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref } from "vue";
+import { MenuItem } from "@/molecules/NodeAddMenu.vue";
+
+interface OpenCategories {
+  [category: string]: boolean;
+}
+
+const props = defineProps({
+  menuItems: {
+    type: Array as PropType<MenuItem[]>,
+    required: true,
+  },
+  rootMenu: { type: Boolean, default: false },
+  isOpen: { type: Boolean, default: false },
+});
+
+const emits = defineEmits(["selected"]);
+
+const openCategories = ref<OpenCategories>({});
+
+const listClasses = computed(() => {
+  if (props.rootMenu) {
+    return {
+      absolute: true,
+      "w-auto": true,
+      "text-gray-200": true,
+      border: true,
+      "shadow-md": true,
+      options: true,
+    };
+  } else {
+    return {
+      relative: true,
+      "w-auto": true,
+      border: true,
+      "shadow-md": true,
+      "category-items": true,
+      options: true,
+    };
+  }
+});
+
+const selectedType = (entityType: string, event: MouseEvent) => {
+  emits("selected", entityType, event);
+};
+const open = (category: string) => {
+  openCategories.value[category] = true;
+};
+const close = (category: string) => {
+  openCategories.value[category] = false;
+};
+const isCategoryOpen = (category: string) => {
+  return openCategories.value[category];
+};
+</script>

--- a/app/web/src/organisims/PanelTree/PanelSelector.vue
+++ b/app/web/src/organisims/PanelTree/PanelSelector.vue
@@ -9,6 +9,7 @@
       :initial-maximized-full="maximizedFull"
       :initial-maximized-container="maximizedContainer"
       :is-maximized-container-enabled="isMaximizedContainerEnabled"
+      :initial-panel-type="panelType"
       @change-panel="changePanelType"
       @panel-maximize-full="setMaximizedFullTrue($event)"
       @panel-minimize-full="setMaximizedFullFalse($event)"

--- a/app/web/src/service/schematic.ts
+++ b/app/web/src/service/schematic.ts
@@ -2,10 +2,12 @@ import { getSchematic } from "./schematic/get_schematic";
 import { setSchematic } from "./schematic/set_schematic";
 import { setNode } from "./schematic/set_node";
 import { createConnection } from "./schematic/create_connection";
+import { getNodeAddMenu } from "./schematic/get_node_add_menu";
 
 export const SchematicService = {
   getSchematic,
   setSchematic,
+  getNodeAddMenu,
   setNode,
   createConnection,
 };

--- a/app/web/src/service/schematic/get_node_add_menu.ts
+++ b/app/web/src/service/schematic/get_node_add_menu.ts
@@ -1,0 +1,45 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, Observable, shareReplay } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { MenuFilter, MenuItem } from "@/api/sdf/dal/schematic";
+
+export interface GetNodeAddMenuArgs {
+  menuFilter: MenuFilter;
+}
+
+export interface GetNodeAddMenuRequest extends GetNodeAddMenuArgs, Visibility {}
+
+export type GetNodeAddMenuResponse = MenuItem[];
+
+const getNodeAddMenuCollection: {
+  [key: string]: Observable<ApiResponse<GetNodeAddMenuResponse>>;
+} = {};
+
+export function getNodeAddMenu(
+  args: GetNodeAddMenuArgs,
+): Observable<ApiResponse<GetNodeAddMenuResponse>> {
+  const key = `${args.menuFilter.schematicKind}:${args.menuFilter.rootComponentId}`;
+  if (getNodeAddMenuCollection[key]) {
+    return getNodeAddMenuCollection[key];
+  }
+  getNodeAddMenuCollection[key] = combineLatest([
+    standardVisibilityTriggers$,
+  ]).pipe(
+    switchMap(([[visibility]]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      return sdf.post<ApiResponse<GetNodeAddMenuResponse>>(
+        "schematic/get_node_add_menu",
+        {
+          ...args,
+          ...visibility,
+        },
+      );
+    }),
+    shareReplay(1),
+  );
+  return getNodeAddMenuCollection[key];
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -15,6 +15,7 @@ pub mod jwt_key;
 pub mod key_pair;
 pub mod label_list;
 pub mod node;
+pub mod node_menu;
 pub mod organization;
 pub mod qualification_check;
 pub mod schema;
@@ -46,6 +47,7 @@ pub use jwt_key::{create_jwt_key_if_missing, JwtSecretKey};
 pub use key_pair::{KeyPair, KeyPairError, KeyPairResult};
 pub use label_list::{LabelEntry, LabelList, LabelListError};
 pub use node::{Node, NodeError};
+pub use node_menu::{MenuFilter, NodeMenuError};
 pub use organization::{
     Organization, OrganizationError, OrganizationId, OrganizationPk, OrganizationResult,
 };

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use si_data::{PgError, PgTxn};
+
+use crate::schema::UiMenu;
+use crate::{
+    standard_model, ComponentId, SchemaError, SchemaId, SchematicKind, StandardModelError, Tenancy,
+    Visibility,
+};
+
+const UI_MENUS_FOR_NODE_MENU: &str = include_str!("./queries/ui_menus_for_node_menu.sql");
+
+#[derive(Error, Debug)]
+pub enum NodeMenuError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model: {0}")]
+    StandardModel(#[from] StandardModelError),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
+}
+
+pub type NodeMenuResult<T> = Result<T, NodeMenuError>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Category {
+    pub name: String,
+    pub items: Vec<MenuItem>,
+}
+
+impl Category {
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let items = Vec::new();
+        Category { name, items }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Item {
+    pub name: String,
+    pub schema_id: SchemaId,
+}
+
+impl Item {
+    pub fn new(name: impl Into<String>, schema_id: SchemaId) -> Self {
+        let name = name.into();
+        Item { name, schema_id }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum MenuItem {
+    Category(Category),
+    Item(Item),
+}
+
+impl MenuItem {
+    pub fn add_item_if_category(&mut self, item: MenuItem) {
+        if let MenuItem::Category(c) = self {
+            c.items.push(item);
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MenuItems {
+    list: Vec<MenuItem>,
+}
+
+impl Default for MenuItems {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MenuItems {
+    pub fn new() -> Self {
+        MenuItems { list: Vec::new() }
+    }
+
+    pub async fn update_from_ui_menu(
+        &mut self,
+        txn: &PgTxn<'_>,
+        visibility: &Visibility,
+        ui_menu: UiMenu,
+    ) -> NodeMenuResult<()> {
+        if ui_menu.usable_in_menu(txn, visibility).await? {}
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MenuFilter {
+    pub schematic_kind: SchematicKind,
+    pub root_component_id: ComponentId,
+}
+
+pub async fn get_node_menu(
+    txn: &PgTxn<'_>,
+    visibility: &Visibility,
+    tenancy: &Tenancy,
+    filter: &MenuFilter,
+) -> NodeMenuResult<Vec<MenuItem>> {
+    let rows = txn
+        .query(
+            UI_MENUS_FOR_NODE_MENU,
+            &[
+                &tenancy,
+                &visibility,
+                &filter.root_component_id,
+                &filter.schematic_kind.to_string(),
+            ],
+        )
+        .await?;
+    let _result: Vec<UiMenu> = standard_model::objects_from_rows(rows)?;
+    let _categories: HashMap<String, Category> = HashMap::new();
+    //for menu_entry in result.into_iter() {
+    //    if menu_entry.name().is_none() {
+    //        dbg!("skipping menu entry with no name", &menu_entry);
+    //        continue;
+    //    }
+    //    if let Some(category_full) = menu_entry.category() {
+    //        let category_parts: Vec<&str> = category_full.split('.').collect();
+    //        let category_parts_count = category_parts.len();
+    //        for (category_parts_index, category_name) in category_parts.into_iter().enumerate() {
+    //            let category_path = category_parts[0..=category_parts_index];
+    //            let category = categories
+    //                .entry(category_parts[0..=category_parts_index].join("."))
+    //                .or_insert(Category::new(category_name));
+
+    //            if category_parts_index == category_parts_count - 1 {
+    //                if let Some(schema) = menu_entry.schema(&txn, &visibility).await? {
+    //                    category.items.push(MenuItem::Item(Item::new(
+    //                        menu_entry.name().unwrap(),
+    //                        *schema.id(),
+    //                    )));
+    //                } else {
+    //                    dbg!("skipping menu entry with no schema");
+    //                    dbg!(&menu_entry);
+    //                }
+    //            }
+    //        }
+    //    }
+    //}
+
+    // TODO: Walk the resulting menu entries, translating them into the right shape.
+    //
+    // 1. Create all the categories, and populate sub-categories.
+    // 2. Add all the items to the categories
+    //Ok(result)
+
+    todo!()
+}

--- a/lib/dal/src/queries/ui_menus_for_node_menu.sql
+++ b/lib/dal/src/queries/ui_menus_for_node_menu.sql
@@ -1,0 +1,30 @@
+SELECT schema_ui_menus.id                       AS id,
+       schema_ui_menus.visibility_change_set_pk AS visibility_change_set_pk,
+       schema_ui_menus.visibility_edit_session_pk AS visibility_edit_session_pk,
+       row_to_json(schema_ui_menus.*) AS object
+FROM component_belongs_to_schema
+         INNER JOIN schema_ui_menu_belongs_to_schema
+                    ON component_belongs_to_schema.belongs_to_id = schema_ui_menu_belongs_to_schema.belongs_to_id
+                        AND is_visible_v1($2
+                           , schema_ui_menu_belongs_to_schema.visibility_change_set_pk
+                           , schema_ui_menu_belongs_to_schema.visibility_edit_session_pk
+                           , schema_ui_menu_belongs_to_schema.visibility_deleted)
+         INNER JOIN schema_ui_menus
+                    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
+                        AND schema_ui_menus.schematic_kind = $4
+                        AND is_visible_v1($2
+                           , schema_ui_menus.visibility_change_set_pk
+                           , schema_ui_menus.visibility_edit_session_pk
+                           , schema_ui_menus.visibility_deleted)
+WHERE component_belongs_to_schema.object_id = $3
+  AND in_tenancy_v1($1
+    , component_belongs_to_schema.tenancy_universal
+    , component_belongs_to_schema.tenancy_billing_account_ids
+    , component_belongs_to_schema.tenancy_organization_ids
+    , component_belongs_to_schema.tenancy_workspace_ids)
+  AND is_visible_v1($2
+    , component_belongs_to_schema.visibility_change_set_pk
+    , component_belongs_to_schema.visibility_edit_session_pk
+    , component_belongs_to_schema.visibility_deleted)
+;
+

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -49,6 +49,8 @@ pub enum SchemaError {
     EditField(#[from] EditFieldError),
     #[error("schema variant error: {0}")]
     Variant(#[from] SchemaVariantError),
+    #[error("schema not found by name: {0}")]
+    NotFoundByName(String),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;
@@ -122,6 +124,7 @@ impl Schema {
 
     standard_model_accessor!(name, String, SchemaResult);
     standard_model_accessor!(kind, Enum(SchemaKind), SchemaResult);
+    standard_model_accessor!(ui_hidden, bool, SchemaResult);
     standard_model_accessor!(
         default_schema_variant_id,
         OptionBigInt<SchemaVariantId>,

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -8,6 +8,7 @@ use dal::{SchemaError as DalSchemaError, StandardModelError};
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod get_node_add_menu;
 pub mod get_schematic;
 pub mod set_schematic;
 
@@ -49,4 +50,8 @@ pub fn routes() -> Router {
     Router::new()
         .route("/get_schematic", get(get_schematic::get_schematic))
         .route("/set_schematic", post(set_schematic::set_schematic))
+        .route(
+            "/get_node_add_menu",
+            post(get_node_add_menu::get_node_add_menu),
+        )
 }

--- a/lib/sdf/src/server/service/schematic/get_node_add_menu.rs
+++ b/lib/sdf/src/server/service/schematic/get_node_add_menu.rs
@@ -1,0 +1,39 @@
+use axum::Json;
+use dal::{MenuFilter, Visibility};
+use serde::{Deserialize, Serialize};
+
+use super::SchematicResult;
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetNodeAddMenuRequest {
+    pub menu_filter: MenuFilter,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub type GetNodeAddMenuResponse = serde_json::Value;
+
+pub async fn get_node_add_menu(
+    _txn: PgRoTxn,
+    Authorization(_claim): Authorization,
+    Json(_request): Json<GetNodeAddMenuRequest>,
+) -> SchematicResult<Json<GetNodeAddMenuResponse>> {
+    let response = serde_json::json![
+     [
+       {
+         "kind": "category",
+         "name": "Snoopy",
+         "items": [
+           {
+             "kind": "item",
+             "name": "floopy",
+             "entityType": "floopy",
+           },
+         ],
+       },
+     ]
+    ];
+    Ok(Json(response))
+}


### PR DESCRIPTION
This brings the node add menu back, but with false data. It also contains 1/2 of the implementation of generating the menu accurately, which will come in a separate PR.

<img src="https://media1.giphy.com/media/Vw2bmCg1kHBLV73kzp/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>