### PR TITLE
feat(web,sdf,dal): node add menu data fetched from schemas

### DIFF
--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -14,7 +14,7 @@ jwt-simple = "0.10.1"
 names = { version = "0.12.0", default-features = false }
 rand = "0.8.3"
 refinery = "0.6.0"
-serde = "1.0.123"
+serde = { version = "1.0.123", features = ["rc"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 serde-aux = "3.0.1"
 si-data = { path = "../../lib/si-data", features = ["nats", "pg"] }

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -1,4 +1,8 @@
-use std::collections::HashMap;
+//! This module is responsible for creating NodeMenus. At the moment, it only really makes
+//! the node add menu. It creates a tree for the menu, and can create it from the Schema's
+//! menu items based on the schematic context for the menu.
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -7,8 +11,8 @@ use si_data::{PgError, PgTxn};
 
 use crate::schema::UiMenu;
 use crate::{
-    standard_model, ComponentId, SchemaError, SchemaId, SchematicKind, StandardModelError, Tenancy,
-    Visibility,
+    standard_model, ComponentId, SchemaError, SchemaId, SchematicKind, StandardModel,
+    StandardModelError, Tenancy, Visibility,
 };
 
 const UI_MENUS_FOR_NODE_MENU: &str = include_str!("./queries/ui_menus_for_node_menu.sql");
@@ -23,6 +27,10 @@ pub enum NodeMenuError {
     StandardModel(#[from] StandardModelError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
+    #[error("cannot find menu entry; path does not exist: {0}")]
+    PathDoesNotExist(String),
+    #[error("cannot get inner category for non category menu item")]
+    NoInnerCategory,
 }
 
 pub type NodeMenuResult<T> = Result<T, NodeMenuError>;
@@ -30,14 +38,27 @@ pub type NodeMenuResult<T> = Result<T, NodeMenuError>;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Category {
     pub name: String,
-    pub items: Vec<MenuItem>,
+    // Whoa! I'm pretty sure this can be refactored to be
+    // less intense. But it's working, and I'm a tired of looking
+    // at it. So lets take care of that in a refactor the next
+    // time we find a problem with this code, eh?
+    //
+    // Love,
+    // Adam
+    pub items: Arc<RefCell<Vec<Arc<RefCell<MenuItem>>>>>,
 }
 
 impl Category {
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
-        let items = Vec::new();
+        let items = Arc::new(RefCell::new(Vec::new()));
         Category { name, items }
+    }
+
+    pub fn push(&self, menu_item: MenuItem) {
+        self.items
+            .borrow_mut()
+            .push(Arc::new(RefCell::new(menu_item)));
     }
 }
 
@@ -62,16 +83,34 @@ pub enum MenuItem {
 }
 
 impl MenuItem {
-    pub fn add_item_if_category(&mut self, item: MenuItem) {
-        if let MenuItem::Category(c) = self {
-            c.items.push(item);
+    pub fn category(name: impl Into<String>) -> MenuItem {
+        MenuItem::Category(Category::new(name))
+    }
+
+    pub fn item(name: impl Into<String>, schema_id: SchemaId) -> MenuItem {
+        MenuItem::Item(Item::new(name, schema_id))
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            MenuItem::Category(c) => &c.name,
+            MenuItem::Item(i) => &i.name,
+        }
+    }
+
+    pub fn inner_category(&self) -> NodeMenuResult<&Category> {
+        match self {
+            MenuItem::Category(c) => Ok(c),
+            _ => Err(NodeMenuError::NoInnerCategory),
         }
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MenuItems {
-    list: Vec<MenuItem>,
+    // Same thing here - we probably need some of these, but
+    // likely not all of them? -- Adam
+    list: Arc<RefCell<Vec<Arc<RefCell<MenuItem>>>>>,
 }
 
 impl Default for MenuItems {
@@ -82,17 +121,86 @@ impl Default for MenuItems {
 
 impl MenuItems {
     pub fn new() -> Self {
-        MenuItems { list: Vec::new() }
+        MenuItems {
+            list: Arc::new(RefCell::new(Vec::new())),
+        }
     }
 
-    pub async fn update_from_ui_menu(
-        &mut self,
-        txn: &PgTxn<'_>,
-        visibility: &Visibility,
-        ui_menu: UiMenu,
-    ) -> NodeMenuResult<()> {
-        if ui_menu.usable_in_menu(txn, visibility).await? {}
+    /// Search the list of menu items for the path given, and return the menu item
+    /// when it is found.
+    pub fn item_for_path(&self, path: &[String]) -> NodeMenuResult<Arc<RefCell<MenuItem>>> {
+        let mut current_list = self.list.clone();
+        let final_path_index = if path.is_empty() { 0 } else { path.len() - 1 };
+        for (path_idx, path_part) in path.iter().enumerate() {
+            let ref_list = current_list.clone();
+            if let Some(menu_item) = ref_list
+                .borrow()
+                .iter()
+                .find(|i| i.borrow().name() == *path_part)
+            {
+                if path_idx == final_path_index {
+                    return Ok(menu_item.clone());
+                } else {
+                    current_list = menu_item.clone().borrow().inner_category()?.items.clone();
+                }
+            } else {
+                return Err(NodeMenuError::PathDoesNotExist(path.join(".")));
+            }; // <- ensures the borrow above doesn't live too long
+        }
+        Err(NodeMenuError::PathDoesNotExist(path.join(".")))
+    }
+
+    /// Insert a new menu item into the list, creating any categories that might not exist along
+    /// the way, and eventually adding the `menu_item` to the list for the correct categories.
+    pub fn insert_menu_item(&self, path: &[String], menu_item: MenuItem) -> NodeMenuResult<()> {
+        let fallback_path = vec![menu_item.name().to_string()];
+        let path_to_check = if path.is_empty() {
+            path
+        } else {
+            &fallback_path
+        };
+        match self.item_for_path(path_to_check) {
+            Ok(parent) => {
+                let pb = parent.borrow();
+                let f = pb.inner_category()?;
+                f.push(menu_item);
+            }
+            Err(NodeMenuError::PathDoesNotExist(_)) => {
+                if path.is_empty() {
+                    self.list
+                        .borrow_mut()
+                        .push(Arc::new(RefCell::new(menu_item)));
+                } else {
+                    let mut insert_into = self.list.clone();
+                    for (path_idx, path_part) in path.iter().enumerate() {
+                        match self.item_for_path(&path[0..=path_idx].to_vec()) {
+                            Ok(parent) => {
+                                insert_into = parent.borrow().inner_category()?.items.clone();
+                            }
+                            _ => {
+                                let new_category =
+                                    Arc::new(RefCell::new(MenuItem::category(path_part.clone())));
+                                insert_into.borrow_mut().push(new_category.clone());
+                                insert_into = new_category.borrow().inner_category()?.items.clone();
+                            }
+                        }
+                    }
+                    insert_into
+                        .borrow_mut()
+                        .push(Arc::new(RefCell::new(menu_item)));
+                }
+            }
+            _ => {}
+        }
         Ok(())
+    }
+
+    pub fn list(&self) -> Arc<RefCell<Vec<Arc<RefCell<MenuItem>>>>> {
+        self.list.clone()
+    }
+
+    pub fn to_json_value(&self) -> NodeMenuResult<serde_json::Value> {
+        Ok(serde_json::to_value(self.list.clone())?)
     }
 }
 
@@ -103,12 +211,59 @@ pub struct MenuFilter {
     pub root_component_id: ComponentId,
 }
 
-pub async fn get_node_menu(
+impl MenuFilter {
+    pub fn new(schematic_kind: SchematicKind, root_component_id: ComponentId) -> Self {
+        MenuFilter {
+            schematic_kind,
+            root_component_id,
+        }
+    }
+}
+
+// Why is there a lock and an Arc here? Because otherwise the
+// handler complained about it. It *might* be good to remove
+// now, if we're careful about using things across await points.
+// But I'm leaving it in, because the cost is pretty low, and
+// it's working. -- Adam
+#[derive(Deserialize, Serialize, Debug)]
+pub struct GenerateMenuItem(Arc<Mutex<MenuItems>>);
+
+impl GenerateMenuItem {
+    pub fn new() -> Self {
+        GenerateMenuItem(Arc::new(Mutex::new(MenuItems::new())))
+    }
+
+    pub fn create_menu_json(
+        self,
+        items: Vec<(Vec<String>, Item)>,
+    ) -> NodeMenuResult<serde_json::Value> {
+        let result = {
+            let menu_items = self
+                .0
+                .lock()
+                .expect("cannot get lock on async menu item; bug");
+            for (path, item) in items.into_iter() {
+                menu_items.insert_menu_item(&path, MenuItem::Item(item))?;
+            }
+            menu_items.to_json_value()
+        };
+        result
+    }
+}
+
+impl Default for GenerateMenuItem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub async fn get_node_menu_items(
     txn: &PgTxn<'_>,
-    visibility: &Visibility,
     tenancy: &Tenancy,
+    visibility: &Visibility,
     filter: &MenuFilter,
-) -> NodeMenuResult<Vec<MenuItem>> {
+) -> NodeMenuResult<Vec<(Vec<String>, Item)>> {
+    let mut item_list = Vec::new();
     let rows = txn
         .query(
             UI_MENUS_FOR_NODE_MENU,
@@ -120,42 +275,90 @@ pub async fn get_node_menu(
             ],
         )
         .await?;
-    let _result: Vec<UiMenu> = standard_model::objects_from_rows(rows)?;
-    let _categories: HashMap<String, Category> = HashMap::new();
-    //for menu_entry in result.into_iter() {
-    //    if menu_entry.name().is_none() {
-    //        dbg!("skipping menu entry with no name", &menu_entry);
-    //        continue;
-    //    }
-    //    if let Some(category_full) = menu_entry.category() {
-    //        let category_parts: Vec<&str> = category_full.split('.').collect();
-    //        let category_parts_count = category_parts.len();
-    //        for (category_parts_index, category_name) in category_parts.into_iter().enumerate() {
-    //            let category_path = category_parts[0..=category_parts_index];
-    //            let category = categories
-    //                .entry(category_parts[0..=category_parts_index].join("."))
-    //                .or_insert(Category::new(category_name));
+    let result: Vec<UiMenu> = standard_model::objects_from_rows(rows)?;
+    for ui_menu in result.into_iter() {
+        if ui_menu.usable_in_menu(txn, visibility).await? {
+            if let Some(schema) = ui_menu.schema(txn, visibility).await? {
+                item_list.push((
+                    ui_menu.category_path(),
+                    Item::new(
+                        ui_menu
+                            .name()
+                            .expect("name does not exist; bug in usable_in_menu"),
+                        *schema.id(),
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(item_list)
+}
 
-    //            if category_parts_index == category_parts_count - 1 {
-    //                if let Some(schema) = menu_entry.schema(&txn, &visibility).await? {
-    //                    category.items.push(MenuItem::Item(Item::new(
-    //                        menu_entry.name().unwrap(),
-    //                        *schema.id(),
-    //                    )));
-    //                } else {
-    //                    dbg!("skipping menu entry with no schema");
-    //                    dbg!(&menu_entry);
-    //                }
-    //            }
-    //        }
-    //    }
-    //}
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    // TODO: Walk the resulting menu entries, translating them into the right shape.
-    //
-    // 1. Create all the categories, and populate sub-categories.
-    // 2. Add all the items to the categories
-    //Ok(result)
+    #[test]
+    fn menu_item_for_top_level_path() {
+        let menu_items = MenuItems::new();
+        menu_items
+            .insert_menu_item(&Vec::new(), MenuItem::category("application"))
+            .expect("cannot insert menu item");
+        let item = menu_items
+            .item_for_path(&vec!["application".to_string()])
+            .expect("cannot find application in menu");
+        assert_eq!(item.borrow().name(), "application");
+    }
 
-    todo!()
+    #[test]
+    fn nested_menu_items_for_top_level_path() {
+        let menu_items = MenuItems::new();
+        menu_items
+            .insert_menu_item(
+                &vec!["application".to_string(), "snakes".to_string()],
+                MenuItem::item("ninjas", 1.into()),
+            )
+            .expect("cannot insert menu item");
+        let item = menu_items
+            .item_for_path(&vec![
+                "application".to_string(),
+                "snakes".to_string(),
+                "ninjas".to_string(),
+            ])
+            .expect("cannot find application.snakes in menu");
+        assert_eq!(item.borrow().name(), "ninjas".to_string());
+    }
+
+    #[test]
+    fn multiple_nested_menu_items_for_top_level_path() {
+        let menu_items = MenuItems::new();
+        menu_items
+            .insert_menu_item(
+                &vec!["application".to_string(), "snakes".to_string()],
+                MenuItem::item("ninjas", 1.into()),
+            )
+            .expect("cannot insert menu item");
+        menu_items
+            .insert_menu_item(
+                &vec!["application".to_string(), "snakes".to_string()],
+                MenuItem::item("dragons", 1.into()),
+            )
+            .expect("cannot insert menu item");
+        let ninjas = menu_items
+            .item_for_path(&vec![
+                "application".to_string(),
+                "snakes".to_string(),
+                "ninjas".to_string(),
+            ])
+            .expect("cannot find application.snakes in menu");
+        assert_eq!(ninjas.borrow().name(), "ninjas".to_string());
+        let dragons = menu_items
+            .item_for_path(&vec![
+                "application".to_string(),
+                "snakes".to_string(),
+                "dragons".to_string(),
+            ])
+            .expect("cannot find application.snakes in menu");
+        assert_eq!(dragons.borrow().name(), "dragons".to_string());
+    }
 }

--- a/lib/dal/src/queries/ui_menus_for_node_menu.sql
+++ b/lib/dal/src/queries/ui_menus_for_node_menu.sql
@@ -3,14 +3,14 @@ SELECT schema_ui_menus.id                       AS id,
        schema_ui_menus.visibility_edit_session_pk AS visibility_edit_session_pk,
        row_to_json(schema_ui_menus.*) AS object
 FROM component_belongs_to_schema
-         INNER JOIN schema_ui_menu_belongs_to_schema
-                    ON component_belongs_to_schema.belongs_to_id = schema_ui_menu_belongs_to_schema.belongs_to_id
+         INNER JOIN schema_ui_menu_root_schematic_many_to_many_schematic
+                    ON component_belongs_to_schema.belongs_to_id = schema_ui_menu_root_schematic_many_to_many_schematic.right_object_id
                         AND is_visible_v1($2
-                           , schema_ui_menu_belongs_to_schema.visibility_change_set_pk
-                           , schema_ui_menu_belongs_to_schema.visibility_edit_session_pk
-                           , schema_ui_menu_belongs_to_schema.visibility_deleted)
+                           , schema_ui_menu_root_schematic_many_to_many_schematic.visibility_change_set_pk
+                           , schema_ui_menu_root_schematic_many_to_many_schematic.visibility_edit_session_pk
+                           , schema_ui_menu_root_schematic_many_to_many_schematic.visibility_deleted)
          INNER JOIN schema_ui_menus
-                    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
+                    ON schema_ui_menus.id = schema_ui_menu_root_schematic_many_to_many_schematic.left_object_id
                         AND schema_ui_menus.schematic_kind = $4
                         AND is_visible_v1($2
                            , schema_ui_menus.visibility_change_set_pk

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -23,7 +23,7 @@ pk!(UiMenuId);
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct UiMenu {
-    pk: UiMenuPk,
+    pub pk: UiMenuPk,
     id: UiMenuId,
     name: Option<String>,
     category: Option<String>,
@@ -118,9 +118,9 @@ impl UiMenu {
         }
     }
 
-    pub fn category_path(&self) -> Vec<&str> {
+    pub fn category_path(&self) -> Vec<String> {
         match self.category() {
-            Some(category) => category.split('.').collect(),
+            Some(category) => category.split('.').map(|f| f.to_string()).collect(),
             None => Vec::new(),
         }
     }

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -8,6 +8,7 @@ mod history_event;
 mod jwt_key;
 mod key_pair;
 mod node;
+mod node_menu;
 mod organization;
 mod qualification_check;
 mod schema;

--- a/lib/dal/tests/integration_test/node_menu.rs
+++ b/lib/dal/tests/integration_test/node_menu.rs
@@ -1,0 +1,52 @@
+use dal::node_menu::get_node_menu_items;
+use dal::test_harness::{billing_account_signup, create_component_for_schema};
+use dal::{node_menu::MenuFilter, Schema, SchematicKind};
+use dal::{HistoryActor, StandardModel, Tenancy, Visibility};
+
+use crate::test_setup;
+
+#[tokio::test]
+async fn get_node_menu() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let (nba, _key) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let visibility = Visibility::new_head(false);
+    let tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    let history_actor = HistoryActor::SystemInit;
+
+    let tenancy_uni = Tenancy::new_universal();
+
+    let application_schema = Schema::find_by_attr(
+        &txn,
+        &tenancy_uni,
+        &visibility,
+        "name",
+        &String::from("application"),
+    )
+    .await
+    .expect("cannot query for built in application")
+    .first()
+    .expect("no built in application found")
+    .clone();
+
+    let application = create_component_for_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &application_schema.id(),
+    )
+    .await;
+
+    let items = get_node_menu_items(
+        &txn,
+        &tenancy,
+        &visibility,
+        &MenuFilter::new(SchematicKind::Deployment, *application.id()),
+    )
+    .await
+    .expect("cannot get items");
+
+    let service_item = items.iter().find(|(_path, item)| item.name == "service");
+    assert!(service_item.is_some(), "menu must include the service item");
+}

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -4,7 +4,7 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use dal::{SchemaError as DalSchemaError, StandardModelError};
+use dal::{NodeMenuError, SchemaError as DalSchemaError, StandardModelError};
 use std::convert::Infallible;
 use thiserror::Error;
 
@@ -24,6 +24,8 @@ pub enum SchematicError {
     Schema(#[from] DalSchemaError),
     #[error("schema not found")]
     SchemaNotFound,
+    #[error("node menu error: {0}")]
+    NodeMenu(#[from] NodeMenuError),
 }
 
 pub type SchematicResult<T> = std::result::Result<T, SchematicError>;

--- a/lib/sdf/src/server/service/schematic/get_node_add_menu.rs
+++ b/lib/sdf/src/server/service/schematic/get_node_add_menu.rs
@@ -1,14 +1,16 @@
 use axum::Json;
-use dal::{MenuFilter, Visibility};
+use dal::node_menu::{get_node_menu_items, GenerateMenuItem};
+use dal::{MenuFilter, Tenancy, Visibility, WorkspaceId};
 use serde::{Deserialize, Serialize};
 
 use super::SchematicResult;
-use crate::server::extract::{Authorization, PgRoTxn};
+use crate::server::extract::{Authorization, PgRwTxn};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetNodeAddMenuRequest {
     pub menu_filter: MenuFilter,
+    pub workspace_id: WorkspaceId,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -16,24 +18,19 @@ pub struct GetNodeAddMenuRequest {
 pub type GetNodeAddMenuResponse = serde_json::Value;
 
 pub async fn get_node_add_menu(
-    _txn: PgRoTxn,
-    Authorization(_claim): Authorization,
-    Json(_request): Json<GetNodeAddMenuRequest>,
+    mut txn: PgRwTxn,
+    Authorization(claim): Authorization,
+    Json(request): Json<GetNodeAddMenuRequest>,
 ) -> SchematicResult<Json<GetNodeAddMenuResponse>> {
-    let response = serde_json::json![
-     [
-       {
-         "kind": "category",
-         "name": "Snoopy",
-         "items": [
-           {
-             "kind": "item",
-             "name": "floopy",
-             "entityType": "floopy",
-           },
-         ],
-       },
-     ]
-    ];
+    let txn = txn.start().await?;
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.workspace_ids = vec![request.workspace_id];
+    tenancy.universal = true;
+    let items =
+        get_node_menu_items(&txn, &tenancy, &request.visibility, &request.menu_filter).await?;
+    let response = {
+        let gmi = GenerateMenuItem::new();
+        gmi.create_menu_json(items)?
+    };
     Ok(Json(response))
 }


### PR DESCRIPTION
The node add menu now returns real data calculated from the schemas,
according to the context provided from the frontend. The bulk of the
work is in the `node_menu.rs` module, which is responsible for creating
the `node menu` structure required by the frontend.

It also has an implementation that I'm either proud of or horrified by -
it creates the data structure the frontend needs directly, using a lot
of Arc<RefCell<_>> and one cleverly placed Arc<Mutex<_>>. It does work,
it has test coverage, and I'm pretty sure it can be cleaned up more than
a little bit.

But it's fast enough, and it's time to move on. :)

Special shout out to Fletcher and Jacob, who talked through with me my
options toward the end of the day.

<img src="https://media2.giphy.com/media/3b8GDuWKKGZIyACVM0/giphy-downsized-medium.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>