### PR TITLE
feat(webapp) create script to clean vite's cache

### DIFF
--- a/app/web/script/clean-vite-cache.sh
+++ b/app/web/script/clean-vite-cache.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+rm -r $SCRIPTPATH/../node_modules/.vite


### PR DESCRIPTION
Sometimes vite fails to clean it's own cache and ignores any changes made, so we created this tiny script to clean vite's cache to avoid getting stuck with this issue. Ideally we should debug vite and provide a PR, but for now we need to focus on other stuff so it's a quick gambiarra (brazilian hack).

I am not experiencing this bug so it's hard for me to ensure the fix works, but as Adam has already gone through it I'm assuming it does. And it's not clear if it's the best bash code ever, I just wanted to ensure we don't accidentally delete something else.