### PR TITLE
maint(veritech): Match new shape of ResolverFunctionRequest in cyclone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
 name = "veritech"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "cyclone",
  "derive_builder",
  "futures",

--- a/lib/veritech/Cargo.toml
+++ b/lib/veritech/Cargo.toml
@@ -22,6 +22,7 @@ server = [
 
 [dependencies]
 # server and client dependencies
+base64 = "0.13.0"
 futures = { version = "0.3.17"}
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }

--- a/lib/veritech/src/client.rs
+++ b/lib/veritech/src/client.rs
@@ -17,19 +17,20 @@ pub enum VeritechClientError {
 
 pub type VeritechClientResult<T> = Result<T, VeritechClientError>;
 
-#[instrument(name = "veritech.client.run_function", skip(nats, kind, code))]
+#[instrument(name = "veritech.client.run_function", skip(nats, _kind, code))]
 pub async fn run_function(
     nats: &NatsClient,
-    kind: impl Into<String>,
+    _kind: impl Into<String>,
     code: impl Into<String>,
 ) -> VeritechClientResult<ResolverFunctionResult> {
-    let kind = kind.into();
     let code = code.into();
     let request = ResolverFunctionRequest {
-        kind,
-        code,
-        container_image: "foo".to_string(),
-        container_tag: "latest".to_string(),
+        // TODO(jhelwig): Something will need to own generating a real execution_id at some point, but we don't have that place or a definition of exactly what the execution_id is yet.
+        execution_id: "TODO".into(),
+        // TODO(jhelwig): This should be the name of the function to call in the base64 encoded code block, but we don't have a way to know that yet.
+        handler: "TODO".into(),
+        parameters: None,
+        code_base64: base64::encode(&code),
     };
     let mut reply_sub = nats
         .request_multi(


### PR DESCRIPTION
The shape of ResolverFunctionRequest changed, but we didn't notice due to this code being behind a feature flag in veritech. The shape now matches, even though the code is wrong. To get it to not be wrong would involve a lot more changes than we really need right now to get other parts of the system working, so fixing the implementation is left as TODOs.

[sc-1978]