### PR TITLE
feat(attribute): add node picker to attr panel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ WATCHABLE = $(patsubst %,watch//%,$(RUNNABLE_COMPONENTS))
 BUILDABLE_REGEX = $(shell echo $(COMPONENTS) | tr " " "|")
 RELEASEABLE_REGEX = $(shell echo $(RELEASEABLE_COMPONENTS) | tr " " "|")
 
-.DEFAULT_GOAL := sdf-prepare
+.DEFAULT_GOAL := prepare
 
 .PHONY: $(BUILDABLE) $(TESTABLE) $(RELEASEABLE) $(IMAGEABLE) image release
 
@@ -209,12 +209,12 @@ clean-containers: clean-dev-deps
 # Vue 2 to Vue 3 rewrite. These targets should be merged into existing ones once the transition is
 # complete.
 
-sdf-prepare:
+prepare:
 	-cd $(MAKEPATH)/deploy && $(MAKE) down
 	cd $(MAKEPATH)/bin/lang-js; npm install
 	cd $(MAKEPATH)/bin/lang-js; npm run package
 	cd $(MAKEPATH)/deploy && $(MAKE) partial
-.PHONY: sdf-prepare
+.PHONY: prepare
 
 sdf-run:
 	cd $(MAKEPATH); cargo build

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In one terminal pane (e.g. using a terminal multiplexer, such as `tmux`, or tabs
 **Services:** docker-compose deploys a postgresql service, an open-telemetry service, a nats service and an watchtower service, using the default ports, so if some of those already are running on the host machine a conflict will happen, for now just disable the host's service and let the docker one do its job
 
 ```bash
-make sdf-prepare
+make prepare
 ```
 
 This will ensure that our database is running, our NATS server is running, the JS language server is built, and all crates are built.
@@ -75,6 +75,20 @@ Now, you have SI running!
 
 Navigate to the `Makefile` in the [ci](./ci) directory to see local development targets.
 These targets include code linting, formating, running CI locally, etc.
+For instance, you can tidy up your Rust code before opening a pull request by executing the following:
+
+```bash
+( cd ci; make tidy )
+```
+
+You can also run individual tests before bringing up the entire SI stack, as neeeded.
+This can be done in the root of the repository:
+
+```bash
+make prepare
+cargo build
+RUST_BACKTRACE=1 cargo test <your-test-name>
+``
 
 ## Architecture
 

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -8,20 +8,37 @@
     :is-visible="isVisible"
     :is-maximized-container-enabled="isMaximizedContainerEnabled"
   >
-    <template #content>
-      I like my butt
+    <template #menuButtons>
+      <div class="min-w-max" v-if="componentNamesOnlyList">
+        <SiSelect
+          id="nodeSelect"
+          size="xs"
+          name="nodeSelect"
+          class="pl-1"
+          :options="componentNamesOnlyList"
+        />
+      </div>
+
+      <LockButton
+        v-model="isPinned"
+      />
     </template>
   </Panel>
 </template>
 
 <script setup lang="ts">
 import Panel from "@/molecules/Panel.vue";
-// import ViewerAttribute from "@/organisims/PanelAttribute/ViewerAttribute.vue";
+import LockButton from "@/atoms/LockButton.vue";
+import SiSelect from "@/atoms/SiSelect.vue";
+import { ref } from "vue";
+import { LabelList } from "@/api/sdf/dal/label_list";
+import { refFrom } from "vuse-rx";
+import { switchMap } from "rxjs/operators";
+import { from } from "rxjs";
+import { ComponentService } from "@/service/component";
+import { GlobalErrorService } from "@/service/global_error";
 
-// import { GlobalErrorService } from "@/service/global_error";
-// import { ApiResponse } from "@/api/sdf";
-
-// TODO: Nick, here is your panel. The switcher is fucked, but otherwise, should be good to port.
+const isPinned = ref<boolean>(false);
 
 defineProps({
   panelIndex: { type: Number, required: true },
@@ -32,6 +49,19 @@ defineProps({
   isVisible: Boolean,
   isMaximizedContainerEnabled: Boolean,
 });
+
+const componentNamesOnlyList = refFrom<LabelList<number>>(
+  ComponentService.listComponentsNamesOnly().pipe(
+    switchMap((response) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+        return from([[]]);
+      } else {
+        return from([response.list]);
+      }
+    }),
+  ),
+);
 
 </script>
 

--- a/app/web/src/service/component.ts
+++ b/app/web/src/service/component.ts
@@ -1,0 +1,5 @@
+import { listComponentsNamesOnly } from "./component/list_components_names_only";
+
+export const ComponentService = {
+  listComponentsNamesOnly,
+};

--- a/app/web/src/service/component/list_components_names_only.ts
+++ b/app/web/src/service/component/list_components_names_only.ts
@@ -1,0 +1,57 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import {
+  combineLatest,
+  combineLatestWith,
+  from,
+  Observable,
+  share,
+} from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { workspace$ } from "@/observable/workspace";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import _ from "lodash";
+import { LabelList } from "@/api/sdf/dal/label_list";
+
+export interface ListComponentNamesOnlyRequest extends Visibility {
+  workspaceId: number;
+}
+
+export interface ListComponentNamesOnlyResponse {
+  list: LabelList<number>;
+}
+
+const componentNamesOnlyList$ = combineLatest([standardVisibilityTriggers$]).pipe(
+  combineLatestWith(workspace$),
+  switchMap(([[[visibility]], workspace]) => {
+    const bottle = Bottle.pop("default");
+    const sdf: SDF = bottle.container.SDF;
+    if (_.isNull(workspace)) {
+      return from([
+        {
+          error: {
+            statusCode: 10,
+            message: "cannot make call without a workspace; bug!",
+            code: 10,
+          },
+        },
+      ]);
+    }
+    const request: ListComponentNamesOnlyRequest = {
+      ...visibility,
+      workspaceId: workspace.id,
+    };
+    return sdf.get<ApiResponse<ListComponentNamesOnlyResponse>>(
+      "component/list_components_names_only",
+      request,
+    );
+  }),
+  share(),
+);
+
+export function listComponentsNamesOnly(): Observable<
+  ApiResponse<ListComponentNamesOnlyResponse>
+> {
+  return componentNamesOnlyList$;
+}

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -50,8 +50,8 @@ teardown:
 .PHONY: teardown
 
 # TODO(nick): consider adding --all-targets --all-features to clippy
-prepare:
+tidy:
 	cd $(REPOPATH); cargo fix --edition-idioms --allow-dirty --allow-staged
 	cd $(REPOPATH); cargo fmt --all
 	cd $(REPOPATH); cargo clippy
-.PHONY: prepare
+.PHONY: tidy

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -8,26 +8,26 @@ boostrap:
 
 # Run this target alongside local developer builds of web, sdf, etc.
 # This target does not compose down beforehand.
-partial: check-env
+partial: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
 		up -d nats pg otel
 
 # Run interactively and compose down beforehand. This target is meant to be run iteratively for
 # local development and testing.
-dev: down check-env
+dev: down init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
 		up
 
 # Run in a detached state and do not compose down beforehand.
 # This is the target to run in production.
-prod: check-env
+prod: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
 		up -d
 
-ci: check-env
+ci: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) REPOPATH=$(REPOPATH) \
 		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
 		-f $(MAKEPATH)/docker-compose.ci.yml \
@@ -37,7 +37,9 @@ down:
 	-docker-compose -f $(MAKEPATH)/docker-compose.yml \
 		down
 
-check-env:
+init:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
+	docker-compose -f $(MAKEPATH)/docker-compose.yml \
+		pull

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -58,6 +58,10 @@ pub fn routes(
             "/api/application",
             crate::server::service::application::routes(),
         )
+        .nest(
+            "/api/component",
+            crate::server::service::component::routes(),
+        )
         .nest("/api/signup", crate::server::service::signup::routes())
         .nest("/api/session", crate::server::service::session::routes())
         .nest(

--- a/lib/sdf/src/server/service.rs
+++ b/lib/sdf/src/server/service.rs
@@ -1,5 +1,6 @@
 pub mod application;
 pub mod change_set;
+pub mod component;
 pub mod edit_field;
 pub mod schema;
 pub mod schematic;

--- a/lib/sdf/src/server/service/component/list_components_names_only.rs
+++ b/lib/sdf/src/server/service/component/list_components_names_only.rs
@@ -1,0 +1,64 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{
+    Component, ComponentId, LabelEntry, LabelList, StandardModel, Tenancy, Visibility, Workspace,
+    WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{ComponentError, ComponentResult};
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListComponentNamesOnlyRequest {
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListComponentNamesOnlyItem {
+    pub id: ComponentId,
+    pub name: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListComponentNamesOnlyResponse {
+    pub list: LabelList<ComponentId>,
+}
+
+// NOTE(nick): this name is long and cumbersome, but the hole has been dug for this dummy data
+// provider. Future changes to this code should consider renaming this (and its route, TS client,
+// etc.) to something more readable, such as "list_component_names".
+pub async fn list_components_names_only(
+    mut txn: PgRoTxn,
+    Query(request): Query<ListComponentNamesOnlyRequest>,
+    Authorization(claim): Authorization,
+) -> ComponentResult<Json<ListComponentNamesOnlyResponse>> {
+    let txn = txn.start().await?;
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(ComponentError::InvalidRequest)?;
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+
+    let components = Component::list(&txn, &tenancy, &request.visibility).await?;
+    let label_entries: Vec<LabelEntry<ComponentId>> = components
+        .into_iter()
+        .map(|component| LabelEntry {
+            label: component.name().to_string(),
+            value: *component.id(),
+        })
+        .collect();
+    let list = LabelList::from(label_entries);
+    let response = ListComponentNamesOnlyResponse { list };
+    Ok(Json(response))
+}

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -1,0 +1,67 @@
+use std::collections::HashSet;
+
+use crate::service_tests::api_request_auth_query;
+use crate::test_setup;
+use dal::{Component, HistoryActor, StandardModel, Tenancy, Visibility};
+use sdf::service::component::list_components_names_only::{
+    ListComponentNamesOnlyRequest, ListComponentNamesOnlyResponse,
+};
+
+#[tokio::test]
+async fn list_components_names_only() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        app,
+        nba,
+        auth_token
+    );
+    let visibility = Visibility::new_head(false);
+    let tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    let history_actor = HistoryActor::SystemInit;
+
+    let component_name1 = "poop";
+    let component_name2 = "ilikemybutt";
+    for name in vec![component_name1, component_name2] {
+        let _component = Component::new(&txn, &nats, &tenancy, &visibility, &history_actor, &name)
+            .await
+            .expect("cannot create new component");
+    }
+    txn.commit().await.expect("cannot commit transaction");
+
+    let request = ListComponentNamesOnlyRequest {
+        visibility,
+        workspace_id: *nba.workspace.id(),
+    };
+    let response: ListComponentNamesOnlyResponse = api_request_auth_query(
+        app,
+        "/api/component/list_components_names_only",
+        &auth_token,
+        &request,
+    )
+    .await;
+
+    let filtered_components_names_only: HashSet<String> = response
+        .list
+        .iter()
+        .filter_map(|list_item| match &list_item.label {
+            component_name
+                if component_name == component_name1 || component_name == component_name2 =>
+            {
+                Some(component_name.to_string())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        filtered_components_names_only,
+        vec![component_name1.to_string(), component_name2.to_string()]
+            .into_iter()
+            .collect()
+    );
+}

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -7,6 +7,7 @@ use tower::ServiceExt;
 
 mod application;
 mod change_set;
+mod component;
 mod schema;
 mod session;
 mod signup;


### PR DESCRIPTION
## Details

- Add node picker (component picker) to attribute panel [sc-1974]
- Use all components' names and IDs only as dummy data for the picker
- Default components' names may be empty, so the node picker's selection
  might be as well (known issue with the dummy data)
- Add list components names only routes to DAL, including client calls
  in TS and an SDF service test
- Ensure docker-compose pulls latest images (fixes an issue where
  existing images were not updated, causing cargo tests to fail for
  local development [sc-1987]
- Rename existing CI-related targets for local development (prepare and
  init) and include their usages in README

## Note to Reviewers

I do not _love_ the `list_components_names_only` naming scheme that persists through this PR.
However, I think a refactor around something like `list_component_names` might not be worth the cycles.
We should likely look at this next time we run into it (to a significant degree).