### PR TITLE
feat(web,sdf,dal): node template from schema in node add

### DIFF
--- a/app/web/src/api/sdf/dal/node.ts
+++ b/app/web/src/api/sdf/dal/node.ts
@@ -1,0 +1,14 @@
+import { Socket } from "@/organisims/SchematicViewer/model/socket";
+import {
+  NodeLabel,
+  NodeClassification,
+  NodeDisplay,
+} from "@/organisims/SchematicViewer/model/node";
+
+export interface NodeTemplate {
+  label: NodeLabel;
+  classification: NodeClassification;
+  input: Socket[];
+  output: Socket[];
+  display?: NodeDisplay;
+}

--- a/app/web/src/api/sdf/dal/schematic.ts
+++ b/app/web/src/api/sdf/dal/schematic.ts
@@ -32,10 +32,11 @@ export interface Category {
 export interface Item {
   kind: "item";
   name: string;
-  entityType: string;
+  schema_id: number;
   links?: LinkNodeItem[];
 }
 
+// TODO: This entire thing is wrong now, but should look like item eventually. -- Adam
 export interface LinkNodeItem {
   kind: "link";
   entityType: string;

--- a/app/web/src/molecules/NodeAddMenu.vue
+++ b/app/web/src/molecules/NodeAddMenu.vue
@@ -55,9 +55,9 @@ const emits = defineEmits(["selected"]);
 
 const isOpen = ref<boolean>(false);
 
-const onSelect = (entityType: string, event: MouseEvent) => {
+const onSelect = (schemaId: number, event: MouseEvent) => {
   event.preventDefault();
-  emits("selected", entityType, event);
+  emits("selected", schemaId, event);
   isOpen.value = false;
 };
 

--- a/app/web/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
+++ b/app/web/src/molecules/NodeAddMenu/NodeAddMenuCategory.vue
@@ -21,7 +21,7 @@
         v-if="item.kind === 'item'"
         :key="item.name"
         class="w-full px-4 text-sm subpixel-antialiased font-light tracking-tight text-left text-gray-300 whitespace-no-wrap cursor-pointer options"
-        @click="selectedType(item.entityType, $event)"
+        @click="selectedType(item.schema_id, $event)"
       >
         <div class="whitespace-no-wrap">
           {{ item.name }}
@@ -75,8 +75,8 @@ const listClasses = computed(() => {
   }
 });
 
-const selectedType = (entityType: string, event: MouseEvent) => {
-  emits("selected", entityType, event);
+const selectedType = (schemaId: number, event: MouseEvent) => {
+  emits("selected", schemaId, event);
 };
 const open = (category: string) => {
   openCategories.value[category] = true;

--- a/app/web/src/organisims/PanelSchematic.vue
+++ b/app/web/src/organisims/PanelSchematic.vue
@@ -86,7 +86,7 @@ import { ChangeSetService } from "@/service/change_set";
 
 // TODO: Alex, here is your panel. The switcher is fucked, but otherwise, should be good to port.
 
-const schematicViewer = ref(null);
+const schematicViewer = ref<typeof SchematicViewer | null>(null);
 
 defineProps({
   panelIndex: { type: Number, required: true },
@@ -162,9 +162,11 @@ const addMenuEnabled = computed(() => {
   }
 });
 
-const addNode = (nodeType: string) => {
-  // @ts-ignore
-  schematicViewer.value.addNode(nodeType);
+const addNode = (schemaId: number, _event: MouseEvent) => {
+  console.log("poop canoe", { schemaId });
+  if (schematicViewer.value) {
+    schematicViewer.value.addNode(schemaId);
+  }
 };
 
 // const getSchematic = () => {

--- a/app/web/src/organisims/SchematicViewer.vue
+++ b/app/web/src/organisims/SchematicViewer.vue
@@ -48,7 +48,7 @@ import { Schematic } from "./SchematicViewer/model";
 const componentName = "SchematicViewer";
 const componentId = _.uniqueId();
 
-const viewer = ref(null);
+const viewer = ref<typeof Viewer | null>(null);
 const viewerId = componentName + "-" + componentId;
 const viewerState = new ViewerStateMachine();
 
@@ -71,9 +71,10 @@ const getSchematic = () => {
   );
 };
 
-function addNode(nodeType: string) {
-  // @ts-ignore
-  viewer.value.handleNodeAdd(nodeType);
+function addNode(schemaId: number) {
+  if (viewer.value) {
+    viewer.value.handleNodeAdd(schemaId);
+  }
 }
 
 defineExpose({

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -258,14 +258,14 @@ export default defineComponent({
       }
     },
 
-    handleNodeAdd(nodeType: string): void {
+    async handleNodeAdd(schemaId: number): Promise<void> {
       this.activateComponent();
       if (this.component.isActive) {
         console.log("component is active");
 
         if (this.interactionManager) {
+          await this.interactionManager.nodeAddManager.addNode(schemaId);
           this.send(ViewerEventKind.ACTIVATE_NODEADD);
-          this.interactionManager.nodeAddManager.addNode(nodeType);
           console.log("activated NodeAdd and added node");
         }
       }

--- a/app/web/src/organisims/SchematicViewer/model/node.ts
+++ b/app/web/src/organisims/SchematicViewer/model/node.ts
@@ -1,7 +1,8 @@
 import { Color, SchematicObject, Position } from "./common";
 import { Socket } from "./socket";
+import {NodeTemplate} from "@/api/sdf/dal/node";
 
-interface NodeLabel {
+export interface NodeLabel {
   title: string;
   name: string;
 }
@@ -24,7 +25,7 @@ export enum SchematicLevel {
  *
  * This will evolve over time as we grow the list of component
  * */
-interface NodeClassification {
+export interface NodeClassification {
   component: ComponentType; // update to correct value
   kind: string; // update to correct value
   type: string; // update to correct value
@@ -84,7 +85,7 @@ interface NodeStatus {
 }
 
 /**  Display properties */
-interface NodeDisplay {
+export interface NodeDisplay {
   color?: Color;
 }
 
@@ -114,6 +115,37 @@ export interface NodePositionUpdate {
 export interface NodeUpdate {
   nodeId: string;
   position: NodePositionUpdate;
+}
+
+export function fakeNodeFromTemplate(
+  template: NodeTemplate,
+): Node {
+  const node: Node = {
+    id: "A:1",
+    label: template.label,
+    classification: template.classification,
+    position: {
+      ctx: [
+        {
+          id: "A:1",
+          position: {
+            x: 0,
+            y: 0,
+          },
+        },
+      ],
+    },
+    input: template.input,
+    output: template.output,
+    display: template.display,
+    lastUpdated: new Date(Date.now()),
+    checksum: "j4j4j4j4j4j4j4j4j4j4j4",
+    schematic: {
+      deployment: false,
+      component: true,
+    },
+  };
+  return node;
 }
 
 export function generateNode(

--- a/app/web/src/service/schematic.ts
+++ b/app/web/src/service/schematic.ts
@@ -3,11 +3,13 @@ import { setSchematic } from "./schematic/set_schematic";
 import { setNode } from "./schematic/set_node";
 import { createConnection } from "./schematic/create_connection";
 import { getNodeAddMenu } from "./schematic/get_node_add_menu";
+import { getNodeTemplate } from "./schematic/get_node_template";
 
 export const SchematicService = {
   getSchematic,
   setSchematic,
   getNodeAddMenu,
+  getNodeTemplate,
   setNode,
   createConnection,
 };

--- a/app/web/src/service/schematic/get_node_template.ts
+++ b/app/web/src/service/schematic/get_node_template.ts
@@ -1,0 +1,65 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, from, Observable, shareReplay } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
+import { NodeTemplate } from "@/api/sdf/dal/node";
+
+export interface GetNodeTemplateArgs {
+  schemaId: number;
+}
+
+export interface GetNodeTemplateRequest
+  extends GetNodeTemplateArgs,
+    Visibility {
+  workspaceId: number;
+}
+
+export type GetNodeTemplateResponse = NodeTemplate;
+
+const getNodeTemplateCollection: {
+  [key: string]: Observable<ApiResponse<GetNodeTemplateResponse>>;
+} = {};
+
+export function getNodeTemplate(
+  args: GetNodeTemplateArgs,
+): Observable<ApiResponse<GetNodeTemplateResponse>> {
+  const key = args.schemaId;
+  if (getNodeTemplateCollection[key]) {
+    return getNodeTemplateCollection[key];
+  }
+  getNodeTemplateCollection[key] = combineLatest([
+    standardVisibilityTriggers$,
+    workspace$,
+  ]).pipe(
+    switchMap(([[visibility], workspace]) => {
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot get node template without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      const request: GetNodeTemplateRequest = {
+        ...args,
+        ...visibility,
+        workspaceId: workspace.id,
+      };
+      return sdf.get<ApiResponse<GetNodeTemplateResponse>>(
+        "schematic/get_node_template",
+        request,
+      );
+    }),
+    shareReplay(1),
+  );
+  return getNodeTemplateCollection[key];
+}

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -4,11 +4,12 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use dal::{NodeMenuError, SchemaError as DalSchemaError, StandardModelError};
+use dal::{NodeError, NodeMenuError, SchemaError as DalSchemaError, StandardModelError};
 use std::convert::Infallible;
 use thiserror::Error;
 
 pub mod get_node_add_menu;
+pub mod get_node_template;
 pub mod get_schematic;
 pub mod set_schematic;
 
@@ -26,6 +27,8 @@ pub enum SchematicError {
     SchemaNotFound,
     #[error("node menu error: {0}")]
     NodeMenu(#[from] NodeMenuError),
+    #[error("node error: {0}")]
+    Node(#[from] NodeError),
 }
 
 pub type SchematicResult<T> = std::result::Result<T, SchematicError>;
@@ -55,5 +58,9 @@ pub fn routes() -> Router {
         .route(
             "/get_node_add_menu",
             post(get_node_add_menu::get_node_add_menu),
+        )
+        .route(
+            "/get_node_template",
+            get(get_node_template::get_node_template),
         )
 }

--- a/lib/sdf/src/server/service/schematic/get_node_template.rs
+++ b/lib/sdf/src/server/service/schematic/get_node_template.rs
@@ -1,0 +1,36 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::node::NodeTemplate;
+use dal::{SchemaId, Tenancy, Visibility, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use super::SchematicResult;
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetNodeTemplateRequest {
+    pub schema_id: SchemaId,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub type GetNodeTemplateResponse = NodeTemplate;
+
+pub async fn get_node_template(
+    mut txn: PgRoTxn,
+    Authorization(claim): Authorization,
+    Query(request): Query<GetNodeTemplateRequest>,
+) -> SchematicResult<Json<GetNodeTemplateResponse>> {
+    let txn = txn.start().await?;
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.workspace_ids = vec![request.workspace_id];
+    tenancy.universal = true;
+
+    let response =
+        NodeTemplate::new_from_schema_id(&txn, &tenancy, &request.visibility, request.schema_id)
+            .await?;
+
+    Ok(Json(response))
+}


### PR DESCRIPTION
This integrates the backend Schema information with the hypothetical
node that needs to be created by the Schematic Viewer when a new node is
created.

When a menu item is selected, we then ask the backend for the correct
`Node Template`, which contains all the information you need to render
the node on the schematic, but does not actually create a node (or the
attendant component). The data in the `Node Template` is pulled from the
schema.

There are currently no sockets defined in the schema, nor are we
differentiating between input and output sockets. But we can fix that
when we get to edge integration.

<img src="https://media3.giphy.com/media/ZB95y3XSFbljaNu7mT/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>
Co-authored-by: Paulo Cabral <paulo@systeminit.com>