### PR TITLE
feat(web,sdf,dal): create nodes from the schematic panel

### DIFF
--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
@@ -206,6 +206,7 @@ export class InteractionManager {
 
     // Adding a node
     if (ST.isAddingNode(this.stateService)) {
+      this.nodeAddManager.afterAddNode();
       ST.deactivateNodeAdd(this.stateService);
     }
   }

--- a/app/web/src/service/schematic.ts
+++ b/app/web/src/service/schematic.ts
@@ -4,6 +4,7 @@ import { setNode } from "./schematic/set_node";
 import { createConnection } from "./schematic/create_connection";
 import { getNodeAddMenu } from "./schematic/get_node_add_menu";
 import { getNodeTemplate } from "./schematic/get_node_template";
+import { createNode } from "./schematic/create_node";
 
 export const SchematicService = {
   getSchematic,
@@ -12,4 +13,5 @@ export const SchematicService = {
   getNodeTemplate,
   setNode,
   createConnection,
+  createNode,
 };

--- a/app/web/src/service/schematic/create_node.ts
+++ b/app/web/src/service/schematic/create_node.ts
@@ -1,0 +1,62 @@
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { Schema, SchemaKind } from "@/api/sdf/dal/schema";
+import { combineLatest, from, Observable, take, tap } from "rxjs";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { visibility$ } from "@/observable/visibility";
+import { switchMap } from "rxjs/operators";
+import { editSessionWritten$ } from "@/observable/edit_session";
+import { Node } from "@/organisims/SchematicViewer/model/node";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
+
+// Note: eventually, this needs to include the name and the position. For now, just the ID is good enough.
+export interface CreateNodeArgs {
+  schemaId: number;
+}
+
+export interface CreateNodeRequest extends CreateNodeArgs, Visibility {
+  workspaceId: number;
+}
+
+export interface CreateNodeResponse {
+  node: Node;
+}
+
+export function createNode(
+  args: CreateNodeArgs,
+): Observable<ApiResponse<CreateNodeResponse>> {
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+
+  return combineLatest([visibility$, workspace$]).pipe(
+    take(1),
+    switchMap(([visibility, workspace]) => {
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot create workspace without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      const request: CreateNodeRequest = {
+        ...args,
+        ...visibility,
+        workspaceId: workspace.id,
+      };
+      return sdf
+        .post<ApiResponse<CreateNodeResponse>>("schematic/create_node", request)
+        .pipe(
+          tap((response) => {
+            if (!response.error) {
+              editSessionWritten$.next(true);
+            }
+          }),
+        );
+    }),
+  );
+}

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -4,10 +4,13 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use dal::{NodeError, NodeMenuError, SchemaError as DalSchemaError, StandardModelError};
+use dal::{
+    ComponentError, NodeError, NodeMenuError, SchemaError as DalSchemaError, StandardModelError,
+};
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod create_node;
 pub mod get_node_add_menu;
 pub mod get_node_template;
 pub mod get_schematic;
@@ -29,6 +32,10 @@ pub enum SchematicError {
     NodeMenu(#[from] NodeMenuError),
     #[error("node error: {0}")]
     Node(#[from] NodeError),
+    #[error("invalid request")]
+    InvalidRequest,
+    #[error("component error: {0}")]
+    ComponentError(#[from] ComponentError),
 }
 
 pub type SchematicResult<T> = std::result::Result<T, SchematicError>;
@@ -63,4 +70,5 @@ pub fn routes() -> Router {
             "/get_node_template",
             get(get_node_template::get_node_template),
         )
+        .route("/create_node", post(create_node::create_node))
 }

--- a/lib/sdf/src/server/service/schematic/create_node.rs
+++ b/lib/sdf/src/server/service/schematic/create_node.rs
@@ -1,0 +1,77 @@
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+use crate::service::schematic::{SchematicError, SchematicResult};
+use axum::Json;
+use dal::node::{NodeTemplate, NodeView};
+use dal::{
+    generate_name, Component, HistoryActor, SchemaId, StandardModel, Tenancy, Visibility,
+    Workspace, WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNodeRequest {
+    pub schema_id: SchemaId,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNodeResponse {
+    pub node: NodeView,
+}
+
+pub async fn create_node(
+    mut txn: PgRwTxn,
+    mut nats: NatsTxn,
+    Authorization(claim): Authorization,
+    Json(request): Json<CreateNodeRequest>,
+) -> SchematicResult<Json<CreateNodeResponse>> {
+    let txn = txn.start().await?;
+    let nats = nats.start().await?;
+
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let history_actor: HistoryActor = HistoryActor::from(claim.user_id);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(SchematicError::InvalidRequest)?;
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+
+    let name = generate_name(None);
+
+    let (component, node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        &tenancy,
+        &request.visibility,
+        &history_actor,
+        &name,
+        &request.schema_id,
+    )
+    .await?;
+
+    let mut schema_tenancy = tenancy.clone();
+    schema_tenancy.universal = true;
+
+    let node_template = NodeTemplate::new_from_schema_id(
+        &txn,
+        &schema_tenancy,
+        &request.visibility,
+        request.schema_id,
+    )
+    .await?;
+
+    let node_view = NodeView::new(component.name(), node, node_template);
+
+    txn.commit().await?;
+    nats.commit().await?;
+
+    Ok(Json(CreateNodeResponse { node: node_view }))
+}


### PR DESCRIPTION
Restores creating new nodes from the schematic panel. When the user clicks to drop the new node on the schematic, we trigger a call to create the node (and its attendent component) on the backend.

It also introduces the idea of a `NodeView` on the backend. This object is responsible for taking the data that is persisted to the `Node` in the DAL, along with the data for a `NodeTemplate` in the frontend that comes from the Schema (currently populated as a `NodeTemplate`). This will allow us to create that view for the frontend from any combination of information that makes sense.

Caveats:

* We do not take the position as an argument, since that code was in flight when this was written. Adding it is a good follow-up PR.
* We do not have test coverage for the schematic api endpoints. I assume they will change (perhaps greatly) after Alex updates things. Once they stabilize, we should add tests.
* The actual code to do the create is in the wrong place in the Schematic code. Alex will refactor it.

Co-authored-by: Paulo Cabral <paulo@systeminit.com>
Signed-off-by: Adam Jacob <adam@systeminit.com>