### PR TITLE
feat(dal,sdf): a `Prop` to system, associated with a `SchemaVariant`

### DIFF
--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -58,6 +58,7 @@ pub enum Widget {
 #[derive(AsRefStr, Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
 pub enum EditFieldObjectKind {
     Component,
+    Prop,
     QualificationCheck,
     Schema,
     SchemaUiMenu,

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -19,6 +19,7 @@ pub mod node;
 pub mod node_menu;
 pub mod node_position;
 pub mod organization;
+pub mod prop;
 pub mod qualification_check;
 pub mod schema;
 pub mod schematic;
@@ -58,6 +59,7 @@ pub use node_position::{
 pub use organization::{
     Organization, OrganizationError, OrganizationId, OrganizationPk, OrganizationResult,
 };
+pub use prop::{Prop, PropError, PropId, PropKind, PropPk, PropResult};
 pub use qualification_check::{
     QualificationCheck, QualificationCheckError, QualificationCheckId, QualificationCheckPk,
 };

--- a/lib/dal/src/migrations/U0040__props.sql
+++ b/lib/dal/src/migrations/U0040__props.sql
@@ -1,0 +1,57 @@
+CREATE TABLE props
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    name                        text                     NOT NULL,
+    kind                        text                     NOT NULL
+);
+SELECT standard_model_table_constraints_v1('props');
+SELECT many_to_many_table_create_v1('prop_many_to_many_schema_variants', 'props',
+                                    'schema_variants');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('props', 'model', 'prop', 'Prop'),
+       ('prop_many_to_many_schema_variants', 'many_to_many', 'prop.schema_variant', 'Prop <> Schema Variant');
+
+-- Limit values of props.kind to a known set of variants. Is this required? No! But such a constraint
+-- might be useful elsewhere
+ALTER TABLE props
+    ADD CONSTRAINT valid_kind_check CHECK (kind IN ('array', 'boolean', 'map', 'number', 'object', 'string'));
+
+CREATE OR REPLACE FUNCTION prop_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    this_kind text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           props%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO props (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
+                                tenancy_workspace_ids,
+                                visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted,
+                                name, kind)
+    VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted, this_name, this_kind)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1,0 +1,264 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use si_data::{NatsTxn, PgError, PgTxn};
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    edit_field::{
+        value_and_visiblity_diff, EditField, EditFieldAble, EditFieldDataType, EditFieldError,
+        EditFieldObjectKind, EditFields, RequiredValidator, TextWidget, ToSelectWidget, Validator,
+        Widget,
+    },
+    impl_standard_model,
+    label_list::ToLabelList,
+    pk, standard_model, standard_model_accessor, standard_model_many_to_many, HistoryActor,
+    HistoryEventError, SchemaVariant, SchemaVariantId, StandardModel, StandardModelError, Tenancy,
+    Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum PropError {
+    #[error(transparent)]
+    EditField(#[from] EditFieldError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("prop not found: {0} ({1:?})")]
+    NotFound(PropId, Visibility),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type PropResult<T> = Result<T, PropError>;
+
+pk!(PropPk);
+pk!(PropId);
+
+#[derive(
+    AsRefStr, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum PropKind {
+    String,
+}
+
+impl ToLabelList for PropKind {}
+impl ToSelectWidget for PropKind {}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Prop {
+    pk: PropPk,
+    id: PropId,
+    name: String,
+    kind: PropKind,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: Prop,
+    pk: PropPk,
+    id: PropId,
+    table_name: "props",
+    history_event_label_base: "prop",
+    history_event_message_name: "Prop"
+}
+
+impl Prop {
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+        kind: PropKind,
+    ) -> PropResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM prop_create_v1($1, $2, $3, $4)",
+                &[tenancy, visibility, &name.as_ref(), &kind.as_ref()],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+
+        Ok(object)
+    }
+
+    standard_model_accessor!(name, String, PropResult);
+    standard_model_accessor!(kind, Enum(PropKind), PropResult);
+
+    standard_model_many_to_many!(
+        lookup_fn: schema_variants,
+        associate_fn: add_schema_variant,
+        disassociate_fn: remove_schema_variant,
+        table_name: "prop_many_to_many_schema_variants",
+        left_table: "props",
+        left_id: PropId,
+        right_table: "schema_variants",
+        right_id: SchemaVariantId,
+        which_table_is_this: "left",
+        returns: SchemaVariant,
+        result: PropResult,
+    );
+
+    fn edit_field_object_kind() -> EditFieldObjectKind {
+        EditFieldObjectKind::Prop
+    }
+
+    fn name_edit_field(
+        visibility: &Visibility,
+        object: &Self,
+        head_object: &Option<Self>,
+        change_set_object: &Option<Self>,
+    ) -> PropResult<EditField> {
+        let field_name = "name";
+        let target_fn = Self::name;
+
+        let (value, visibility_diff) = value_and_visiblity_diff(
+            visibility,
+            Some(object),
+            target_fn,
+            head_object.as_ref(),
+            change_set_object.as_ref(),
+        )?;
+
+        Ok(EditField::new(
+            field_name,
+            vec![],
+            Self::edit_field_object_kind(),
+            object.id,
+            EditFieldDataType::String,
+            Widget::Text(TextWidget::new()),
+            value,
+            visibility_diff,
+            vec![Validator::Required(RequiredValidator)],
+        ))
+    }
+
+    fn kind_edit_field(
+        visibility: &Visibility,
+        object: &Self,
+        head_object: &Option<Self>,
+        change_set_object: &Option<Self>,
+    ) -> PropResult<EditField> {
+        let field_name = "kind";
+        let target_fn = Self::kind;
+
+        let (value, visibility_diff) = value_and_visiblity_diff(
+            visibility,
+            Some(object),
+            target_fn,
+            head_object.as_ref(),
+            change_set_object.as_ref(),
+        )?;
+
+        Ok(EditField::new(
+            field_name,
+            vec![],
+            Self::edit_field_object_kind(),
+            object.id,
+            EditFieldDataType::String,
+            Widget::Select(PropKind::to_select_widget_with_no_default()?),
+            value,
+            visibility_diff,
+            vec![Validator::Required(RequiredValidator)],
+        ))
+    }
+}
+
+#[async_trait]
+impl EditFieldAble for Prop {
+    type Id = PropId;
+    type Error = PropError;
+
+    async fn get_edit_fields(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        id: &Self::Id,
+    ) -> Result<EditFields, Self::Error> {
+        let object = Self::get_by_id(txn, tenancy, visibility, id)
+            .await?
+            .ok_or(Self::Error::NotFound(*id, *visibility))?;
+        let head_object = if visibility.in_change_set() {
+            let head_visibility = visibility.to_head();
+            Self::get_by_id(txn, tenancy, &head_visibility, id).await?
+        } else {
+            None
+        };
+        let change_set_object = if visibility.in_change_set() {
+            let change_set_visibility = visibility.to_change_set();
+            Self::get_by_id(txn, tenancy, &change_set_visibility, id).await?
+        } else {
+            None
+        };
+
+        let edit_fields = vec![
+            Self::name_edit_field(visibility, &object, &head_object, &change_set_object)?,
+            Self::kind_edit_field(visibility, &object, &head_object, &change_set_object)?,
+        ];
+
+        Ok(edit_fields)
+    }
+
+    #[instrument(skip_all)]
+    async fn update_from_edit_field(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        id: Self::Id,
+        edit_field_id: String,
+        value: Option<serde_json::Value>,
+    ) -> Result<(), Self::Error> {
+        let mut object = Self::get_by_id(txn, tenancy, visibility, &id)
+            .await?
+            .ok_or(Self::Error::NotFound(id, *visibility))?;
+
+        match edit_field_id.as_ref() {
+            "name" => match value {
+                Some(json_value) => {
+                    let value = json_value.as_str().map(|s| s.to_string()).ok_or(
+                        Self::Error::EditField(EditFieldError::InvalidValueType("string")),
+                    )?;
+                    object
+                        .set_name(txn, nats, visibility, history_actor, value)
+                        .await?;
+                }
+                None => return Err(EditFieldError::MissingValue.into()),
+            },
+            "kind" => match value {
+                Some(json_value) => {
+                    let value: PropKind = serde_json::from_value(json_value).map_err(|_| {
+                        Self::Error::EditField(EditFieldError::InvalidValueType("PropKind"))
+                    })?;
+                    object
+                        .set_kind(txn, nats, visibility, history_actor, value)
+                        .await?;
+                }
+                None => return Err(EditFieldError::MissingValue.into()),
+            },
+            invalid => return Err(EditFieldError::invalid_field(invalid).into()),
+        }
+
+        Ok(())
+    }
+}

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -16,8 +16,8 @@ use crate::{
     schema::ui_menu::UiMenuId,
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
     BillingAccount, BillingAccountId, Component, HistoryActor, HistoryEventError, LabelEntry,
-    LabelList, Organization, OrganizationId, StandardModel, StandardModelError, Tenancy, Timestamp,
-    Visibility, Workspace, WorkspaceId, WsEventError,
+    LabelList, Organization, OrganizationId, PropError, StandardModel, StandardModelError, Tenancy,
+    Timestamp, Visibility, Workspace, WorkspaceId, WsEventError,
 };
 
 use crate::socket::SocketError;
@@ -30,32 +30,34 @@ pub mod variant;
 
 #[derive(Error, Debug)]
 pub enum SchemaError {
-    #[error("error serializing/deserializing json: {0}")]
-    SerdeJson(#[from] serde_json::Error),
-    #[error("pg error: {0}")]
-    Pg(#[from] PgError),
-    #[error("nats txn error: {0}")]
-    Nats(#[from] NatsError),
-    #[error("history event error: {0}")]
-    HistoryEvent(#[from] HistoryEventError),
-    #[error("standard model error: {0}")]
-    StandardModel(#[from] StandardModelError),
-    #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
-    #[error("schema not found: {0}")]
-    NotFound(SchemaId),
-    #[error("ui menu not found: {0}")]
-    UiMenuNotFound(UiMenuId),
     #[error("edit field error: {0}")]
     EditField(#[from] EditFieldError),
-    #[error("schema variant error: {0}")]
-    Variant(#[from] SchemaVariantError),
-    #[error("schema not found by name: {0}")]
-    NotFoundByName(String),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
     #[error("no default variant for schema id: {0}")]
     NoDefaultVariant(SchemaId),
+    #[error("schema not found: {0}")]
+    NotFound(SchemaId),
+    #[error("schema not found by name: {0}")]
+    NotFoundByName(String),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("prop error: {0}")]
+    Prop(#[from] PropError),
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
     #[error("socket error: {0}")]
     Socket(#[from] SocketError),
+    #[error("standard model error: {0}")]
+    StandardModel(#[from] StandardModelError),
+    #[error("ui menu not found: {0}")]
+    UiMenuNotFound(UiMenuId),
+    #[error("schema variant error: {0}")]
+    Variant(#[from] SchemaVariantError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] WsEventError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -1,8 +1,8 @@
 use crate::schema::{SchemaResult, SchemaVariant, UiMenu};
 use crate::socket::{Socket, SocketArity, SocketEdgeKind};
 use crate::{
-    HistoryActor, Schema, SchemaError, SchemaKind, SchematicKind, StandardModel, Tenancy,
-    Visibility,
+    HistoryActor, Prop, PropKind, Schema, SchemaError, SchemaKind, SchematicKind, StandardModel,
+    Tenancy, Visibility,
 };
 use si_data::{NatsTxn, PgTxn};
 
@@ -298,6 +298,20 @@ async fn docker_image(
         .set_default_schema_variant_id(txn, nats, visibility, history_actor, Some(*variant.id()))
         .await?;
 
+    let image_prop = Prop::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        "image",
+        PropKind::String,
+    )
+    .await?;
+    image_prop
+        .add_schema_variant(txn, nats, visibility, history_actor, variant.id())
+        .await?;
+
     // Note: This is not right; each schema needs its own socket types.
     //       Also, they should clearly inherit from the core schema? Something
     //       for later.
@@ -330,7 +344,6 @@ async fn docker_image(
     variant
         .add_socket(txn, nats, visibility, history_actor, output_socket.id())
         .await?;
-
     Ok(())
 }
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -11,8 +11,8 @@ use telemetry::{ClientError, TelemetryClient, Verbosity};
 use crate::{
     billing_account::BillingAccountSignup, jwt_key::JwtSecretKey, node::NodeKind, schema, socket,
     BillingAccount, ChangeSet, Component, EditSession, Group, HistoryActor, KeyPair, Node,
-    Organization, QualificationCheck, Schema, SchemaId, SchemaKind, StandardModel, System, Tenancy,
-    User, Visibility, Workspace, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
+    Organization, Prop, PropKind, QualificationCheck, Schema, SchemaId, SchemaKind, StandardModel,
+    System, Tenancy, User, Visibility, Workspace, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
 };
 
 #[derive(Debug)]
@@ -498,4 +498,25 @@ pub async fn create_system(
     System::new(txn, nats, tenancy, visibility, history_actor, name)
         .await
         .expect("cannot create system")
+}
+
+pub async fn create_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> Prop {
+    let name = generate_fake_name();
+    Prop::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        name,
+        PropKind::String,
+    )
+    .await
+    .expect("cannot create prop")
 }

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -12,6 +12,7 @@ mod node;
 mod node_menu;
 mod node_position;
 mod organization;
+mod prop;
 mod qualification_check;
 mod schema;
 mod socket;

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -1,0 +1,70 @@
+use dal::{
+    test_harness::{create_prop, create_schema_variant},
+    HistoryActor, Prop, PropKind, StandardModel, Tenancy, Visibility,
+};
+
+use crate::test_setup;
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let prop = Prop::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "coolness",
+        PropKind::String,
+    )
+    .await
+    .expect("cannot create prop");
+    assert_eq!(prop.name(), "coolness");
+    assert_eq!(prop.kind(), &PropKind::String);
+}
+
+#[tokio::test]
+async fn schema_variants() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema_variant =
+        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let prop = create_prop(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+
+    prop.add_schema_variant(
+        &txn,
+        &nats,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await
+    .expect("cannot add schema variant");
+
+    let relations = prop
+        .schema_variants(&txn, &visibility)
+        .await
+        .expect("cannot get schema variants");
+    assert_eq!(relations, vec![schema_variant.clone()]);
+
+    prop.remove_schema_variant(
+        &txn,
+        &nats,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await
+    .expect("cannot remove schema variant");
+
+    let relations = prop
+        .schema_variants(&txn, &visibility)
+        .await
+        .expect("cannot get schema variants");
+    assert_eq!(relations, vec![]);
+}

--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -6,7 +6,7 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    schema::variant::SchemaVariantError, socket::SocketError, ComponentError,
+    schema::variant::SchemaVariantError, socket::SocketError, ComponentError, PropError,
     QualificationCheckError, SchemaError, StandardModelError,
 };
 use std::convert::Infallible;
@@ -23,6 +23,8 @@ pub enum EditFieldError {
     Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
+    #[error("prop error: {0}")]
+    Prop(#[from] PropError),
     #[error("qualification check error: {0}")]
     QualificationChec(#[from] QualificationCheckError),
     #[error(transparent)]

--- a/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
+++ b/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
@@ -4,7 +4,7 @@ use dal::{
     edit_field::{EditFieldAble, EditFieldObjectKind, EditFields},
     schema,
     socket::Socket,
-    Component, QualificationCheck, Schema, Tenancy, Visibility, WorkspaceId,
+    Component, Prop, QualificationCheck, Schema, Tenancy, Visibility, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +44,9 @@ pub async fn get_edit_fields(
         EditFieldObjectKind::Component => {
             Component::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into())
                 .await?
+        }
+        EditFieldObjectKind::Prop => {
+            Prop::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into()).await?
         }
         EditFieldObjectKind::QualificationCheck => {
             QualificationCheck::get_edit_fields(

--- a/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
@@ -3,7 +3,7 @@ use dal::{
     edit_field::{EditFieldAble, EditFieldObjectKind},
     schema::{self, SchemaVariant},
     socket::Socket,
-    Component, HistoryActor, QualificationCheck, Schema, Tenancy, Visibility, WorkspaceId,
+    Component, HistoryActor, Prop, QualificationCheck, Schema, Tenancy, Visibility, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -46,6 +46,19 @@ pub async fn update_from_edit_field(
     match request.object_kind {
         EditFieldObjectKind::Component => {
             Component::update_from_edit_field(
+                &txn,
+                &nats,
+                &tenancy,
+                &request.visibility,
+                &history_actor,
+                request.object_id.into(),
+                request.edit_field_id,
+                request.value,
+            )
+            .await?
+        }
+        EditFieldObjectKind::Prop => {
+            Prop::update_from_edit_field(
                 &txn,
                 &nats,
                 &tenancy,

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -27,7 +27,7 @@ async fn list_components_names_only() {
 
     let component_name1 = "poop";
     let component_name2 = "ilikemybutt";
-    for name in vec![component_name1, component_name2] {
+    for name in &[component_name1, component_name2] {
         let _component = Component::new(&txn, &nats, &tenancy, &visibility, &history_actor, &name)
             .await
             .expect("cannot create new component");


### PR DESCRIPTION
Now `Prop`s get added to `SchemaVariant`s *and* you can edit it in the
frontend schema editor!!

One note: there is an error when interactively adding a new prop in the
schema editor. I bet it's a quick fix, but this is out of scope for this
story right this second, so...sorry?

<img src="https://media1.giphy.com/media/1zkaY6ncg4DwjncG7O/giphy.gif"/>