### PR TITLE
feat(web): Add ValidationErrors component for displaying EditFormField errors

### DIFF
--- a/app/web/src/organisims/EditForm/EditFormField.vue
+++ b/app/web/src/organisims/EditForm/EditFormField.vue
@@ -22,18 +22,18 @@
           </div>
         </div>
       </div>
-      <!--
       <div class="flex flex-wrap">
         <ValidationErrors :errors="errors" class="p-2" />
       </div>
-      -->
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { refFrom } from "vuse-rx";
 import { ChangeSetService } from "@/service/change_set";
+import ValidationErrors from "@/organisims/EditForm/ValidationErrors.vue";
 
 defineProps({
   show: {
@@ -42,6 +42,7 @@ defineProps({
   },
 });
 const editMode = refFrom(ChangeSetService.currentEditMode());
+const errors = ref([{ message: "Aieeee!", link: "https://placekitten.com" }]);
 </script>
 
 <style scoped></style>

--- a/app/web/src/organisims/EditForm/ValidationErrors.vue
+++ b/app/web/src/organisims/EditForm/ValidationErrors.vue
@@ -1,0 +1,50 @@
+<template>
+  <ul :v-if="props.errors.length">
+    <li
+      v-for="(error, index) in props.errors"
+      :key="index"
+      class="text-red-400"
+    >
+      <div class="flex flex-row items-center">
+        <VueFeather
+          type="alert-triangle"
+          :stroke="strokeColorForLevel(error.level)"
+          size="1.5rem"
+        />
+        <div class="ml-1 text-xs">
+          {{ error.message }}
+        </div>
+        <div v-if="error.link" class="ml-1 align-top">
+          <a target="_blank" :href="error.link">
+            <VueFeather type="external-link" stroke="grey" size="1.5rem" />
+          </a>
+        </div>
+      </div>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import VueFeather from "vue-feather";
+
+const props = defineProps<{
+  errors: {
+    message: string;
+    level?: string;
+    kind?: string;
+    link?: string;
+  }[];
+}>();
+
+function strokeColorForLevel(level: string | undefined): string {
+  switch (level) {
+    case "warning":
+      return "yellow";
+    case "info":
+      return "grey";
+
+    default:
+      return "red";
+  }
+}
+</script>


### PR DESCRIPTION
This is not wired up to any real data yet, and is relying on a hard-coded error in `EditFormField` to display anything. We'll eventually wire this up to real data coming from SDF, but for now, this is sufficient to make sure that we're getting the styling correct for displaying the data that will be coming back through the API.

[sc-2008]