### PR TITLE
feat(web,sdf): persist node position after moving

### DIFF
--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -190,6 +190,7 @@ export default defineComponent({
 
     const dataManager = new SchematicDataManager();
     this.dataManager = dataManager;
+    this.dataManager.editorContext$.next(this.editorContext);
 
     dataManager.schematicData$.subscribe({
       next: (d) => this.loadSchematicData(d),

--- a/app/web/src/service/schematic.ts
+++ b/app/web/src/service/schematic.ts
@@ -5,6 +5,7 @@ import { createConnection } from "./schematic/create_connection";
 import { getNodeAddMenu } from "./schematic/get_node_add_menu";
 import { getNodeTemplate } from "./schematic/get_node_template";
 import { createNode } from "./schematic/create_node";
+import { setNodePosition } from "./schematic/set_node_position";
 
 export const SchematicService = {
   getSchematic,
@@ -14,4 +15,5 @@ export const SchematicService = {
   setNode,
   createConnection,
   createNode,
+  setNodePosition,
 };

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -196,6 +196,7 @@ impl NodeTemplate {
 // This maps to the typescript node, and can go from the database
 // representation of a node, combined with the schema data.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct NodeView {
     id: NodeId,
     kind: NodeKind,

--- a/lib/sdf/src/server/service/schematic/set_node_position.rs
+++ b/lib/sdf/src/server/service/schematic/set_node_position.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct SetNodePositionRequest {
     pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
     pub visibility: Visibility,
     pub node_id: NodeId,
     pub schematic_kind: SchematicKind,


### PR DESCRIPTION
Stores the new position of the node after the dragging ends. There is a
catch tho, we reload the entire schematic after each move which is
expensive. We should think about sending the diff in the websocket to
avoid that (or ignore requests for refreshs that our actions triggered)