### PR TITLE
fix(dal): Fix get_schematic test

### DIFF
--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -250,4 +250,12 @@ impl NodeView {
             }],
         }
     }
+
+    pub fn id(&self) -> &NodeId {
+        &self.id
+    }
+
+    pub fn positions(&self) -> &[NodePosition] {
+        &self.position
+    }
 }

--- a/lib/dal/src/node_position.rs
+++ b/lib/dal/src/node_position.rs
@@ -101,6 +101,9 @@ impl NodePosition {
         root_node_id: NodeId,
         node_id: NodeId,
     ) -> NodePositionResult<Option<Self>> {
+        // Note: This query is broken if system_id is None, we spent quite some
+        // time trying to fix, but since right now the system_id always is
+        // set we decided to leave it as future work - Paulo & Fletcher
         let row = txn
             .query_opt(
                 FIND_NODE_POSITION_BY_NODE_ID,

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -101,4 +101,8 @@ impl Schematic {
             connections,
         })
     }
+
+    pub fn nodes(&self) -> &[NodeView] {
+        &self.nodes
+    }
 }

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -16,6 +16,7 @@ mod organization;
 mod prop;
 mod qualification_check;
 mod schema;
+mod schematic;
 mod socket;
 mod standard_model;
 mod system;

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -1,39 +1,84 @@
-use dal::{
-    node::NodeKind, test_harness::create_node, HistoryActor, NodePosition, SchematicKind,
-    StandardModel, Tenancy, Visibility,
-};
-
 use crate::test_setup;
+use dal::{
+    Component, HistoryActor, NodePosition, Schema, Schematic, SchematicKind, StandardModel,
+    SystemId, Tenancy, Visibility,
+};
 
 #[tokio::test]
 async fn get_schematic() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, conn, txn, _nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let root_node = create_node(
+
+    let application_schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"application".to_string(),
+    )
+    .await
+    .expect("cannot find application schema")
+    .pop()
+    .expect("no application schema found");
+    let (_component, root_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
         &tenancy,
         &visibility,
         &history_actor,
-        &NodeKind::Component,
+        "sc-component-root-get_schematic",
+        application_schema.id(),
     )
-    .await;
-    let node_position = NodePosition::new(
+    .await
+    .expect("unable to create component for schema");
+
+    let service_schema =
+        Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"service".to_string())
+            .await
+            .expect("cannot find service schema")
+            .pop()
+            .expect("no service schema found");
+    let (_component, node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "sc-component-get_schematic",
+        service_schema.id(),
+    )
+    .await
+    .expect("unable to create component for schema");
+
+    let node_position = NodePosition::upsert_by_node_id(
         &txn,
         &nats,
         &tenancy,
         &visibility,
         &history_actor,
         SchematicKind::Component,
+        &Some(SystemId::from(1)),
         *root_node.id(),
+        *node.id(),
         "123",
         "-10",
     )
     .await
-    .expect("cannot create node position");
+    .expect("cannot upsert node position");
 
-    let schematic = Schematic::find(&txn, &tenancy, &visibility, None, *root_node.id()).await.expect("cannot find schematic");
-    assert_eq!(schematic.nodes.first().expect("no node found on schematic").id() == node.id());
+    let schematic = Schematic::find(
+        &txn,
+        &tenancy,
+        &visibility,
+        Some(SystemId::from(1)),
+        *root_node.id(),
+    )
+    .await
+    .expect("cannot find schematic");
+    assert_eq!(schematic.nodes()[0].id(), root_node.id());
+    assert_eq!(schematic.nodes()[1].id(), node.id());
+    assert_eq!(schematic.nodes()[1].positions()[0].x(), node_position.x());
+    assert_eq!(schematic.nodes()[1].positions()[0].y(), node_position.y());
 }


### PR DESCRIPTION
There is an issue tho, if Option<SystemId> is None the SQL query is
going to fail because `data = NULL` doesn't work in PostgreSQL, so we
are assuming a Option<SystemId> always exists and moving the problem
into the future