### PR TITLE
chore(dal): Make function binding return value `unprocessed_value` and `value` optional

### DIFF
--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -140,7 +140,7 @@ impl FuncBinding {
                 if !return_value.is_string() {
                     return Err(FuncBindingError::IncorrectReturnValueType("String"));
                 }
-                return_value
+                Some(return_value)
             }
         };
 

--- a/lib/dal/src/func/binding_return_value.rs
+++ b/lib/dal/src/func/binding_return_value.rs
@@ -41,9 +41,9 @@ pub struct FuncBindingReturnValue {
     // The unprocessed return value is the "real" result, unprocessed for any other behavior
     // This is useful when a function binding result is used as a generator for other
     // results - it lets us see where things came from.
-    unprocessed_value: serde_json::Value,
+    unprocessed_value: Option<serde_json::Value>,
     // The processed return value.
-    value: serde_json::Value,
+    value: Option<serde_json::Value>,
     #[serde(flatten)]
     tenancy: Tenancy,
     #[serde(flatten)]
@@ -75,8 +75,8 @@ impl FuncBindingReturnValue {
         tenancy: &Tenancy,
         visibility: &Visibility,
         history_actor: &HistoryActor,
-        unprocessed_value: serde_json::Value,
-        value: serde_json::Value,
+        unprocessed_value: Option<serde_json::Value>,
+        value: Option<serde_json::Value>,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
     ) -> FuncBindingReturnValueResult<Self> {
@@ -107,10 +107,10 @@ impl FuncBindingReturnValue {
 
     standard_model_accessor!(
         unprocessed_value,
-        Json<JsonValue>,
+        OptionJson<JsonValue>,
         FuncBindingReturnValueResult
     );
-    standard_model_accessor!(value, Json<JsonValue>, FuncBindingReturnValueResult);
+    standard_model_accessor!(value, OptionJson<JsonValue>, FuncBindingReturnValueResult);
 
     standard_model_belongs_to!(
         lookup_fn: func,

--- a/lib/dal/src/migrations/U0042__funcs.sql
+++ b/lib/dal/src/migrations/U0042__funcs.sql
@@ -49,8 +49,8 @@ CREATE TABLE func_binding_return_values
     visibility_deleted          bool,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
-    unprocessed_value           jsonb                    NOT NULL,
-    value                       jsonb                    NOT NULL
+    unprocessed_value           jsonb,
+    value                       jsonb
 );
 SELECT standard_model_table_constraints_v1('func_binding_return_values');
 SELECT belongs_to_table_create_v1('func_binding_return_value_belongs_to_func', 'func_binding_return_values', 'funcs');

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -741,6 +741,16 @@ macro_rules! standard_model_accessor {
         );
     };
 
+    ($column:ident, OptionJson<$value_type:ident>, $result_type:ident $(,)?) => {
+        standard_model_accessor!(@get_column_as_option $column, $value_type);
+        standard_model_accessor!(@set_column_with_option
+            $column,
+            $value_type,
+            $crate::standard_model::TypeHint::Text,
+            $result_type,
+        );
+    };
+
     ($column:ident, Json<$value_type:ident>, $result_type:ident $(,)?) => {
         standard_model_accessor!(@get_column $column, $value_type);
         standard_model_accessor!(@set_column

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -81,8 +81,8 @@ async fn func_binding_return_value_new() {
         &tenancy,
         &visibility,
         &history_actor,
-        serde_json::json!("funky"),
-        serde_json::json!("funky"),
+        Some(serde_json::json!("funky")),
+        Some(serde_json::json!("funky")),
         *func.id(),
         *func_binding.id(),
     )
@@ -116,9 +116,9 @@ async fn func_binding_execute() {
         .execute(&txn, &nats)
         .await
         .expect("failed to execute func binding");
-    assert_eq!(return_value.value(), &serde_json::json!["funky"]);
+    assert_eq!(return_value.value(), Some(&serde_json::json!["funky"]));
     assert_eq!(
         return_value.unprocessed_value(),
-        &serde_json::json!["funky"]
+        Some(&serde_json::json!["funky"])
     );
 }


### PR DESCRIPTION
In order to be able to represent the value for a `FuncBackendKind::Unset`, we need to be able to store a "nothing" value. Before this change, we were requiring that `unprocessed_value` and `value` were a valid JSON object, which would have meant reserving a value that could have been valid from another backend as our special "unset" value.

For now, we're loosening the constraint in the DB that `unprocessed_value` and `value` be present, so that we can use a DB `null` value to represent "unset". On the Rust side "unset" will be represented by an `Option::None`, and all other values become an `Option::Some<T>`.

By explicitly storing the "unset" as a `null` in the value, we are still able to differentiate between "this binding has been executed, and it explicitly has no value" and "this binding has yet to be executed, so we don't know what the value is yet".