### PR TITLE
feat(connection): add connections API

### DIFF
--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
@@ -104,7 +104,13 @@ export class ConnectingManager {
       );
       this.clearInteractiveConnection(sceneManager);
       sceneManager.refreshConnections();
-      this.dataManager.connectionCreate$.next({ id: "a new connection" });
+      // FIXME(nick): these values are temporary.
+      this.dataManager.connectionCreate$.next({
+        sourceNodeId: 1,
+        sourceSocketId: 1,
+        destinationNodeId: 2,
+        destinationSocketId: 2,
+      });
     }
   }
 

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -7,9 +7,10 @@ import { SchematicKind } from "@/api/sdf/dal/schematic";
 import { SchematicService } from "@/service/schematic";
 import { GlobalErrorService } from "@/service/global_error";
 import { ApiResponse } from "@/api/sdf";
-import { SetNodeResponse } from "@/service/schematic/set_node";
 import { NodeCreate } from "./event";
 import { EditorContext } from "@/api/sdf/dal/schematic";
+import { CreateConnectionResponse } from "@/service/schematic/create_connection";
+import { SetNodePositionResponse } from "@/service/schematic/set_node_position";
 
 // import { schematicData$ as schematicDataGlobal$ } from "./observable";
 
@@ -19,7 +20,7 @@ export class SchematicDataManager {
   nodeUpdate$: Rx.ReplaySubject<NodeUpdate | null>;
   connectionCreate$: Rx.ReplaySubject<ConnectionCreate | null>;
   nodeCreate$: Rx.ReplaySubject<NodeCreate | null>;
-  editorContext: Rx.ReplaySubject<EditorContext | null>;
+  editorContext$: Rx.ReplaySubject<EditorContext | null>;
 
   constructor() {
     this.id = _.uniqueId();
@@ -50,7 +51,7 @@ export class SchematicDataManager {
     this.nodeCreate$.subscribe({ next: (d) => this.createNode(d) });
   }
 
-  async updateNodePosition(nodeUpdate: NodeUpdate | null): void {
+  async updateNodePosition(nodeUpdate: NodeUpdate | null): Promise<void> {
     const editorContext = await Rx.firstValueFrom(this.editorContext$);
     if (nodeUpdate && editorContext) {
       SchematicService.setNodePosition({
@@ -72,15 +73,20 @@ export class SchematicDataManager {
 
   createConnection(nodeUpdate: ConnectionCreate | null): void {
     if (nodeUpdate) {
-      SchematicService.createConnection({ name: "canoe" }).subscribe(
-        (response: ApiResponse<SetNodeResponse>) => {
-          if (response.error) {
-            GlobalErrorService.set(response);
-          }
-          // const d = schematicDataAfter;
-          // schematicDataGlobal$.next(d);
-        },
-      );
+      // FIXME(nick): these values are temporary.
+      SchematicService.createConnection({
+        headSocketId: 1,
+        headNodeId: 1,
+        tailSocketId: 2,
+        tailNodeId: 2,
+      }).subscribe((response: ApiResponse<CreateConnectionResponse>) => {
+        if (response.error) {
+          GlobalErrorService.set(response);
+        }
+        // const d = schematicDataAfter;
+        // this.schematicData$.next(d);
+        // schematicDataGlobal$.next(d);
+      });
     }
   }
 

--- a/app/web/src/organisims/SchematicViewer/model/connection.ts
+++ b/app/web/src/organisims/SchematicViewer/model/connection.ts
@@ -29,13 +29,17 @@ interface Destination {
 
 /**  A connection (from an output to an input) */
 export interface Connection extends SchematicObject {
-  id: string;
+  id: number;
   classification: ConnectionClassification;
   source: Source;
   destination: Destination;
+  // FIXME(nick): the backend is not returning or storing color at this time.
   display?: ConnectionDisplay;
 }
 
 export interface ConnectionCreate {
-  id: string;
+  sourceNodeId: number;
+  sourceSocketId: number;
+  destinationNodeId: number;
+  destinationSocketId: number;
 }

--- a/app/web/src/service/schematic/create_connection.ts
+++ b/app/web/src/service/schematic/create_connection.ts
@@ -1,21 +1,67 @@
 import { Visibility } from "@/api/sdf/dal/visibility";
-import { from, Observable } from "rxjs";
-import { ApiResponse } from "@/api/sdf";
+import { combineLatest, from, Observable, take, tap } from "rxjs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { Connection } from "@/organisims/SchematicViewer/model/connection";
+import { visibility$ } from "@/observable/visibility";
+import { workspace$ } from "@/observable/workspace";
+import { switchMap } from "rxjs/operators";
+import Bottle from "bottlejs";
+import _ from "lodash";
+import { editSessionWritten$ } from "@/observable/edit_session";
 
 export interface CreateConnectionArgs {
-  name: String;
+  headNodeId: number;
+  headSocketId: number;
+  tailNodeId: number;
+  tailSocketId: number;
 }
 
 export interface CreateConnectionRequest
   extends CreateConnectionArgs,
-    Visibility {}
+    Visibility {
+  workspaceId: number;
+}
 
 export interface CreateConnectionResponse {
-  schematic: string;
+  connection: Connection;
 }
 
 export function createConnection(
   args: CreateConnectionArgs,
 ): Observable<ApiResponse<CreateConnectionResponse>> {
-  return from([{ schematic: "connection created" }]);
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+  return combineLatest([visibility$, workspace$]).pipe(
+    take(1),
+    switchMap(([visibility, workspace]) => {
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      const request: CreateConnectionRequest = {
+        ...args,
+        ...visibility,
+        workspaceId: workspace.id,
+      };
+      return sdf
+        .post<ApiResponse<CreateConnectionResponse>>(
+          "schematic/create_connection",
+          request,
+        )
+        .pipe(
+          tap((response) => {
+            if (!response.error) {
+              editSessionWritten$.next(true);
+            }
+          }),
+        );
+    }),
+  );
 }

--- a/app/web/src/service/schematic/set_node_position.ts
+++ b/app/web/src/service/schematic/set_node_position.ts
@@ -11,7 +11,7 @@ import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
 
 export interface SetNodePositionArgs {
-  nodeId: number;
+  nodeId: string;
   schematicKind: SchematicKind;
   rootNodeId: number;
   systemId?: number;
@@ -49,7 +49,7 @@ export function setNodePosition(
           },
         ]);
       }
-      const request: SetPositionRequest = {
+      const request: SetNodePositionRequest = {
         ...args,
         ...visibility,
         workspaceId: workspace.id,

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -71,7 +71,7 @@ pub use qualification_check::{
 pub use schema::{
     Schema, SchemaError, SchemaId, SchemaKind, SchemaPk, SchemaVariant, SchemaVariantId,
 };
-pub use schematic::{Schematic, SchematicError, SchematicKind};
+pub use schematic::{Connection, Schematic, SchematicError, SchematicKind};
 pub use standard_model::{StandardModel, StandardModelError, StandardModelResult};
 pub use system::{System, SystemError, SystemId, SystemPk, SystemResult};
 pub use tenancy::{Tenancy, TenancyError};

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -31,6 +31,10 @@ pub enum NodeError {
     SchemaMissingDefaultVariant,
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
+    #[error("component is None")]
+    ComponentIsNone,
+    #[error("could not find node with ID: {0}")]
+    NotFound(NodeId),
 }
 
 pub type NodeResult<T> = Result<T, NodeError>;

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -11,6 +11,7 @@ use dal::{
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod create_connection;
 pub mod create_node;
 pub mod get_node_add_menu;
 pub mod get_node_template;
@@ -80,5 +81,9 @@ pub fn routes() -> Router {
         .route(
             "/set_node_position",
             post(set_node_position::set_node_position),
+        )
+        .route(
+            "/create_connection",
+            post(create_connection::create_connection),
         )
 }

--- a/lib/sdf/src/server/service/schematic/create_connection.rs
+++ b/lib/sdf/src/server/service/schematic/create_connection.rs
@@ -1,0 +1,65 @@
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+use crate::service::schematic::{SchematicError, SchematicResult};
+use axum::Json;
+use dal::node::NodeId;
+use dal::socket::SocketId;
+use dal::{Connection, HistoryActor, StandardModel, Tenancy, Visibility, Workspace, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateConnectionRequest {
+    pub head_node_id: NodeId,
+    pub head_socket_id: SocketId,
+    pub tail_node_id: NodeId,
+    pub tail_socket_id: SocketId,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateConnectionResponse {
+    pub connection: Connection,
+}
+
+pub async fn create_connection(
+    mut txn: PgRwTxn,
+    mut nats: NatsTxn,
+    Authorization(claim): Authorization,
+    Json(request): Json<CreateConnectionRequest>,
+) -> SchematicResult<Json<CreateConnectionResponse>> {
+    let txn = txn.start().await?;
+    let nats = nats.start().await?;
+
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let history_actor: HistoryActor = HistoryActor::from(claim.user_id);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(SchematicError::InvalidRequest)?;
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+
+    let connection = Connection::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &request.visibility,
+        &history_actor,
+        &request.head_node_id,
+        &request.head_socket_id,
+        &request.tail_node_id,
+        &request.tail_socket_id,
+    )
+    .await?;
+
+    txn.commit().await?;
+    nats.commit().await?;
+
+    Ok(Json(CreateConnectionResponse { connection }))
+}


### PR DESCRIPTION
- Create Connection API within schematic in dal [sc-2011]
- Add create connection API schematic route in sdf
- Shape Connection object to match app's shape of a connection, rather
  than the other way around
- Add create connection to service
- Fix misc ESLint errors
- Partially wire service to SchematicViewer with dummy data in the
  interaction manager (partially [sc-2018])
- Partially wire service to dataManager within SchematicViewer

<img src="https://media0.giphy.com/media/mfGkfzHM3KfdI0OmIW/giphy-downsized-medium.gif"/>