### PR TITLE
feat(dal): Create "unset" function backend

### DIFF
--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -36,7 +36,7 @@ pub enum FuncBackendKind {
     //Array,
     //EmptyObject,
     //EmptyArray,
-    //Unset,
+    Unset,
     //Json,
     //Js,
 }
@@ -61,7 +61,7 @@ pub enum FuncBackendResponseType {
     //Boolean,
     //Object,
     //Array,
-    //Unset,
+    Unset,
     //Json,
 }
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -142,6 +142,7 @@ impl FuncBinding {
                 }
                 Some(return_value)
             }
+            FuncBackendKind::Unset => None,
         };
 
         let func = self


### PR DESCRIPTION
This function backend always returns "unset" as the value, which is useful for specifying that a property has no default value, and that it must be specified explicitly.

[sc-2015]