### PR TITLE
feat(dal): add AttributeResolver

### DIFF
--- a/lib/dal/src/attribute_resolver.rs
+++ b/lib/dal/src/attribute_resolver.rs
@@ -1,0 +1,214 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::{binding::FuncBindingId, binding_return_value::FuncBindingReturnValue, FuncId},
+    impl_standard_model, pk, standard_model, ComponentId, HistoryActor, HistoryEventError, PropId,
+    SchemaId, SchemaVariantId, StandardModel, StandardModelError, SystemId, Tenancy, Timestamp,
+    Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum AttributeResolverError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type AttributeResolverResult<T> = Result<T, AttributeResolverError>;
+
+pub const UNSET_ID_VALUE: i64 = -1;
+const FIND_VALUE_FOR_CONTEXT: &str =
+    include_str!("./queries/attribute_resolver_find_value_for_context.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct AttributeResolverContext {
+    prop_id: PropId,
+    component_id: ComponentId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+}
+
+impl Default for AttributeResolverContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttributeResolverContext {
+    pub fn new() -> Self {
+        AttributeResolverContext {
+            prop_id: UNSET_ID_VALUE.into(),
+            component_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    pub fn prop_id(&self) -> PropId {
+        self.prop_id
+    }
+
+    pub fn set_prop_id(&mut self, prop_id: PropId) {
+        self.prop_id = prop_id;
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(AttributeResolverPk);
+pk!(AttributeResolverId);
+
+// An AttributeResolver joins a `FuncBinding` to the context in which
+// its corresponding `FuncBindingResultValue` is consumed.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct AttributeResolver {
+    pk: AttributeResolverPk,
+    id: AttributeResolverId,
+    func_id: FuncId,
+    func_binding_id: FuncBindingId,
+    #[serde(flatten)]
+    context: AttributeResolverContext,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: AttributeResolver,
+    pk: AttributeResolverPk,
+    id: AttributeResolverId,
+    table_name: "attribute_resolvers",
+    history_event_label_base: "attribute_resolver",
+    history_event_message_name: "Attribute Resolver"
+}
+
+impl AttributeResolver {
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        func_id: FuncId,
+        func_binding_id: FuncBindingId,
+        context: AttributeResolverContext,
+    ) -> AttributeResolverResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM attribute_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[
+                    &tenancy,
+                    &visibility,
+                    &func_id,
+                    &func_binding_id,
+                    &context.prop_id(),
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_value_for_prop_and_component(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        prop_id: PropId,
+        component_id: ComponentId,
+        system_id: SystemId,
+    ) -> AttributeResolverResult<FuncBindingReturnValue> {
+        let row = txn
+            .query_one(
+                FIND_VALUE_FOR_CONTEXT,
+                &[&tenancy, &visibility, &prop_id, &component_id, &system_id],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::AttributeResolverContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = AttributeResolverContext::new();
+        c.set_component_id(15.into());
+        c.set_prop_id(22.into());
+        assert_eq!(c.component_id(), 15.into());
+        assert_eq!(c.prop_id(), 22.into());
+    }
+}

--- a/lib/dal/src/billing_account.rs
+++ b/lib/dal/src/billing_account.rs
@@ -311,6 +311,7 @@ impl BillingAccount {
             admin_group,
             organization,
             workspace,
+            system,
         })
     }
 
@@ -367,6 +368,7 @@ pub struct BillingAccountSignup {
     pub admin_group: Group,
     pub organization: Organization,
     pub workspace: Workspace,
+    pub system: System,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -3,6 +3,7 @@ use si_data::{NatsClient, NatsError, PgError, PgPool, PgPoolError};
 use telemetry::prelude::*;
 use thiserror::Error;
 
+pub mod attribute_resolver;
 pub mod billing_account;
 pub mod capability;
 pub mod change_set;
@@ -37,6 +38,7 @@ pub mod visibility;
 pub mod workspace;
 pub mod ws_event;
 
+pub use attribute_resolver::{AttributeResolver, AttributeResolverError, AttributeResolverId};
 pub use billing_account::{
     BillingAccount, BillingAccountDefaults, BillingAccountError, BillingAccountId, BillingAccountPk,
 };

--- a/lib/dal/src/migrations/U0043__attribute_resolvers.sql
+++ b/lib/dal/src/migrations/U0043__attribute_resolvers.sql
@@ -1,0 +1,82 @@
+CREATE TABLE attribute_resolvers
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    func_id                     bigint                   NOT NULL,
+    func_binding_id             bigint                   NOT NULL,
+    prop_id                     bigint,
+    component_id                bigint,
+    schema_id                   bigint,
+    schema_variant_id           bigint,
+    system_id                   bigint
+);
+SELECT standard_model_table_constraints_v1('attribute_resolvers');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('attribute_resolvers', 'model', 'attribute_resolver', 'Attribute Resolver');
+
+CREATE OR REPLACE FUNCTION attribute_resolver_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id bigint,
+    this_func_binding_id bigint,
+    this_prop_id bigint,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+        OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           attribute_resolvers%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO attribute_resolvers (
+      tenancy_universal,
+      tenancy_billing_account_ids,
+      tenancy_organization_ids,
+      tenancy_workspace_ids,
+      visibility_change_set_pk,
+      visibility_edit_session_pk,
+      visibility_deleted,
+      func_id,
+      func_binding_id,
+      prop_id,
+      component_id,
+      schema_id,
+      schema_variant_id,
+      system_id
+    ) VALUES (
+      this_tenancy_record.tenancy_universal,
+      this_tenancy_record.tenancy_billing_account_ids,
+      this_tenancy_record.tenancy_organization_ids,
+      this_tenancy_record.tenancy_workspace_ids,
+      this_visibility_record.visibility_change_set_pk,
+      this_visibility_record.visibility_edit_session_pk,
+      this_visibility_record.visibility_deleted, 
+      this_func_id,
+      this_func_binding_id, 
+      this_prop_id, 
+      this_component_id, 
+      this_schema_id, 
+      this_schema_variant_id,
+      this_system_id
+    ) RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+

--- a/lib/dal/src/queries/attribute_resolver_find_value_for_context.sql
+++ b/lib/dal/src/queries/attribute_resolver_find_value_for_context.sql
@@ -1,0 +1,36 @@
+SELECT DISTINCT ON (attribute_resolvers.prop_id) attribute_resolvers.id,
+                              attribute_resolvers.prop_id,
+                              attribute_resolvers.visibility_change_set_pk,
+                              attribute_resolvers.visibility_edit_session_pk,
+                              attribute_resolvers.component_id,
+                              attribute_resolvers.schema_id,
+                              attribute_resolvers.schema_variant_id,
+                              attribute_resolvers.system_id,
+                              row_to_json(func_binding_return_values.*) AS object
+FROM attribute_resolvers
+INNER JOIN func_binding_return_value_belongs_to_func_binding ON 
+  func_binding_return_value_belongs_to_func_binding.belongs_to_id = attribute_resolvers.func_binding_id
+INNER JOIN func_binding_return_values ON 
+  func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+WHERE in_tenancy_v1($1, attribute_resolvers.tenancy_universal, attribute_resolvers.tenancy_billing_account_ids, attribute_resolvers.tenancy_organization_ids,
+                    attribute_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, attribute_resolvers.visibility_change_set_pk, attribute_resolvers.visibility_edit_session_pk, attribute_resolvers.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_edit_session_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_values.visibility_change_set_pk, 
+    func_binding_return_values.visibility_edit_session_pk, 
+    func_binding_return_values.visibility_deleted)
+  AND attribute_resolvers.prop_id = $3
+   AND (attribute_resolvers.component_id = $4 OR attribute_resolvers.component_id = -1)
+   AND (attribute_resolvers.system_id = $5 OR attribute_resolvers.system_id = -1)
+	ORDER BY prop_id, 
+      visibility_change_set_pk DESC, 
+      visibility_edit_session_pk DESC, 
+      component_id DESC, 
+      system_id DESC, 
+      schema_variant_id DESC, 
+      schema_id DESC
+  LIMIT 1;

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -53,10 +53,7 @@ impl WsEvent {
 
     pub async fn publish(&self, nats: &NatsTxn) -> WsEventResult<()> {
         for billing_account_id in self.billing_account_ids.iter() {
-            let subject = format!(
-                "si.billing_account_id.{}.event",
-                billing_account_id.to_string()
-            );
+            let subject = format!("si.billing_account_id.{}.event", billing_account_id);
             nats.publish(subject, &self).await?;
         }
         Ok(())

--- a/lib/dal/tests/integration_test/attribute_resolver.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver.rs
@@ -1,0 +1,403 @@
+use crate::test_setup;
+
+use dal::{
+    attribute_resolver::{AttributeResolverContext, UNSET_ID_VALUE},
+    func::{backend::FuncBackendStringArgs, binding::FuncBinding},
+    test_harness::{billing_account_signup, create_component_for_schema},
+    AttributeResolver, Func, FuncBackendKind, FuncBackendResponseType, HistoryActor, Schema,
+    StandardModel, SystemId, Tenancy, Visibility,
+};
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"docker_image".to_string(),
+    )
+    .await
+    .expect("cannot find docker image")
+    .pop()
+    .expect("no docker image found");
+
+    let default_variant = schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot find default variant");
+
+    let first_prop = default_variant
+        .props(&txn, &visibility)
+        .await
+        .expect("cannot get props")
+        .pop()
+        .expect("no prop found");
+
+    let component = create_component_for_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema.id(),
+    )
+    .await;
+
+    let func = Func::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "test:setString",
+        FuncBackendKind::String,
+        FuncBackendResponseType::String,
+    )
+    .await
+    .expect("cannot create func");
+
+    let args = FuncBackendStringArgs::new("gatecreeper".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_component_id(*component.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create new attribute resolver");
+}
+
+// TODO: Flesh out the full precedence for attributes, and refactor this test so that it is less
+// nuts.
+#[tokio::test]
+async fn find_value_for_prop_and_component() {
+    test_setup!(ctx, secret_key, pg, _conn, txn, _nats_conn, nats);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    tenancy.universal = true;
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let _unset_system_id: SystemId = UNSET_ID_VALUE.into();
+
+    let schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"docker_image".to_string(),
+    )
+    .await
+    .expect("cannot find docker image")
+    .pop()
+    .expect("no docker image found");
+
+    let default_variant = schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot find default variant");
+
+    let first_prop = default_variant
+        .props(&txn, &visibility)
+        .await
+        .expect("cannot get props")
+        .pop()
+        .expect("no prop found");
+
+    let component = create_component_for_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema.id(),
+    )
+    .await;
+
+    let func = Func::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "test:setString",
+        FuncBackendKind::String,
+        FuncBackendResponseType::String,
+    )
+    .await
+    .expect("cannot create func");
+
+    let args = FuncBackendStringArgs::new("prop".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create attribute resolver");
+    let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *first_prop.id(),
+        *component.id(),
+        *nba.system.id(),
+    )
+    .await
+    .expect("cannot get return value for prop and component");
+    assert_eq!(
+        func_binding_return_value.value(),
+        Some(&serde_json::json!["prop"])
+    );
+
+    let args = FuncBackendStringArgs::new("prop_and_schema".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_schema_id(*schema.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create attribute resolver");
+    let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *first_prop.id(),
+        *component.id(),
+        *nba.system.id(),
+    )
+    .await
+    .expect("cannot get return value for prop and component");
+    assert_eq!(
+        func_binding_return_value.value(),
+        Some(&serde_json::json!["prop_and_schema"])
+    );
+
+    let args = FuncBackendStringArgs::new("prop_and_schema_variant".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_schema_variant_id(*default_variant.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create attribute resolver");
+    let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *first_prop.id(),
+        *component.id(),
+        *nba.system.id(),
+    )
+    .await
+    .expect("cannot get return value for prop and component");
+    assert_eq!(
+        func_binding_return_value.value(),
+        Some(&serde_json::json!["prop_and_schema_variant"])
+    );
+
+    let args = FuncBackendStringArgs::new("prop_and_schema_variant".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_schema_variant_id(*default_variant.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create attribute resolver");
+    let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *first_prop.id(),
+        *component.id(),
+        *nba.system.id(),
+    )
+    .await
+    .expect("cannot get return value for prop and component");
+    assert_eq!(
+        func_binding_return_value.value(),
+        Some(&serde_json::json!["prop_and_schema_variant"])
+    );
+
+    let args = FuncBackendStringArgs::new("prop_and_component".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_component_id(*component.id());
+    let _attribute_resolver = AttributeResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create attribute resolver");
+    let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *first_prop.id(),
+        *component.id(),
+        *nba.system.id(),
+    )
+    .await
+    .expect("cannot get return value for prop and component");
+    assert_eq!(
+        func_binding_return_value.value(),
+        Some(&serde_json::json!["prop_and_component"])
+    );
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,3 +1,4 @@
+mod attribute_resolver;
 mod billing_account;
 mod capability;
 mod change_set;

--- a/lib/sdf/src/server/service/ws/billing_account_updates.rs
+++ b/lib/sdf/src/server/service/ws/billing_account_updates.rs
@@ -115,10 +115,7 @@ mod billing_account_updates {
 
     impl BillingAccountUpdates {
         pub async fn start(self) -> Result<BillingAccountUpdatesStarted> {
-            let subject = format!(
-                "si.billing_account_id.{}.>",
-                self.billing_account_id.to_string()
-            );
+            let subject = format!("si.billing_account_id.{}.>", self.billing_account_id);
             let subscription = self
                 .nats
                 .subscribe(&subject)


### PR DESCRIPTION
This adds AttributeResolver back into the system. It allows you to take
a FuncBinding and say that it should be used to resolve the value of a
given Prop in a particular Context. It features a spiffy function to
look up a FuncBindingResultValue, choosing the correct value based on
the precedence of the various AttributeResolvers contexts that are
relevant for the prop.

It stops short of the full precedence - I suspect we also need to add
systems to the mix. But it's good enough to unblock everyone!

<img src="https://media1.giphy.com/media/FqeFrKjxruhTEr3R1x/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>