### PR TITLE
feat(dal,web): set value for a string from a function

### DIFF
--- a/app/web/src/api/sdf/dal/edit_field.ts
+++ b/app/web/src/api/sdf/dal/edit_field.ts
@@ -2,6 +2,7 @@ import { LabelList } from "@/api/sdf/dal/label_list";
 
 export enum EditFieldObjectKind {
   Component = "Component",
+  ComponentProp = "ComponentProp",
   Schema = "Schema",
 }
 
@@ -86,6 +87,7 @@ export interface EditField {
   value: any;
   visibility_diff: VisibilityDiff;
   validators: Array<Validator>;
+  baggage?: any;
 }
 
 export type EditFields = Array<EditField>;

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -66,6 +66,7 @@ const addToArray = () => {
     objectId: props.editField.object_id,
     editFieldId: props.editField.id,
     value: null,
+    baggage: props.editField.baggage,
   }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
     if (response.error) {
       GlobalErrorService.set(response);

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -60,6 +60,7 @@ const onBlur = () => {
       objectId: props.editField.object_id,
       editFieldId: props.editField.id,
       value: currentValue.value,
+      baggage: props.editField.baggage,
     }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
       if (response.error) {
         GlobalErrorService.set(response);

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -69,6 +69,7 @@ const onBlur = () => {
       objectId: props.editField.object_id,
       editFieldId: props.editField.id,
       value: currentValue.value,
+      baggage: props.editField.baggage,
     }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
       if (response.error) {
         GlobalErrorService.set(response);

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -56,6 +56,7 @@ const onBlur = () => {
       objectId: props.editField.object_id,
       editFieldId: props.editField.id,
       value: currentValue.value,
+      baggage: props.editField.baggage,
     }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
       if (response.error) {
         GlobalErrorService.set(response);

--- a/app/web/src/service/edit_field/update_from_edit_field.ts
+++ b/app/web/src/service/edit_field/update_from_edit_field.ts
@@ -14,6 +14,7 @@ export interface UpdateFromEditFieldArgs {
   objectId: number;
   editFieldId: string;
   value: any;
+  baggage?: any;
 }
 
 export interface UpdateFromEditFieldRequest
@@ -35,7 +36,10 @@ export function updateFromEditField(
     take(1),
     switchMap(([visibility, workspace]) => {
       let request: UpdateFromEditFieldRequest;
-      if (args.objectKind === EditFieldObjectKind.Component) {
+      if (
+        args.objectKind === EditFieldObjectKind.Component ||
+        args.objectKind === EditFieldObjectKind.ComponentProp
+      ) {
         if (_.isNull(workspace)) {
           return from([
             {

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -13,6 +13,7 @@ use self::backend::{FuncBackendKind, FuncBackendResponseType};
 pub mod backend;
 pub mod binding;
 pub mod binding_return_value;
+pub mod builtins;
 
 #[derive(Error, Debug)]
 pub enum FuncError {

--- a/lib/dal/src/func/builtins.rs
+++ b/lib/dal/src/func/builtins.rs
@@ -1,0 +1,77 @@
+use si_data::{NatsTxn, PgTxn};
+
+use crate::{
+    Func, FuncBackendKind, FuncBackendResponseType, FuncResult, HistoryActor, StandardModel,
+    Tenancy, Visibility,
+};
+
+pub async fn migrate(txn: &PgTxn<'_>, nats: &NatsTxn) -> FuncResult<()> {
+    let (tenancy, visibility, history_actor) = (
+        Tenancy::new_universal(),
+        Visibility::new_head(false),
+        HistoryActor::SystemInit,
+    );
+
+    si_set_string(txn, nats, &tenancy, &visibility, &history_actor).await?;
+    si_unset(txn, nats, &tenancy, &visibility, &history_actor).await?;
+
+    Ok(())
+}
+
+async fn si_set_string(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> FuncResult<()> {
+    let existing_func = Func::find_by_attr(
+        txn,
+        tenancy,
+        visibility,
+        "name",
+        &"si:setString".to_string(),
+    )
+    .await?;
+    if existing_func.is_empty() {
+        Func::new(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            "si:setString",
+            FuncBackendKind::String,
+            FuncBackendResponseType::String,
+        )
+        .await
+        .expect("cannot create func");
+    }
+    Ok(())
+}
+
+async fn si_unset(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> FuncResult<()> {
+    let existing_func =
+        Func::find_by_attr(txn, tenancy, visibility, "name", &"si:unset".to_string()).await?;
+    if existing_func.is_empty() {
+        Func::new(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            "si:unset",
+            FuncBackendKind::Unset,
+            FuncBackendResponseType::Unset,
+        )
+        .await
+        .expect("cannot create func");
+    }
+    Ok(())
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -101,6 +101,8 @@ pub enum ModelError {
     PgError(#[from] PgError),
     #[error("Schema error")]
     Schema(#[from] SchemaError),
+    #[error("Func error")]
+    Func(#[from] FuncError),
 }
 
 pub type ModelResult<T> = Result<T, ModelError>;
@@ -117,6 +119,7 @@ pub async fn migrate_builtin_schemas(pg: &PgPool, nats: &NatsClient) -> ModelRes
     let txn = conn.transaction().await?;
     let nats = nats.transaction();
     schema::builtins::migrate(&txn, &nats).await?;
+    func::builtins::migrate(&txn, &nats).await?;
     txn.commit().await?;
     nats.commit().await?;
     Ok(())

--- a/lib/dal/src/migrations/U0042__funcs.sql
+++ b/lib/dal/src/migrations/U0042__funcs.sql
@@ -124,6 +124,103 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL VOLATILE;
 
+-- There is a potential race condition in this function - if two bindings are created at the
+-- exact same time, there could wind up being two identical FuncBindings in the database. 
+-- We will account for this later, when we are reading the data back, by having a consistent
+-- ordering. (We order by `id` ASC, and limit 1)
+CREATE OR REPLACE FUNCTION func_binding_find_or_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_args jsonb,
+    this_backend_kind text,
+    OUT object json, OUT created bool) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_change_set_visibility jsonb;
+    this_head_visibility jsonb;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+    created := false;
+
+    SELECT 
+      row_to_json(func_bindings.*) FROM func_bindings WHERE 
+        func_bindings.args = this_args AND func_bindings.backend_kind = this_backend_kind 
+        AND in_tenancy_v1(this_tenancy, 
+          func_bindings.tenancy_universal, 
+          func_bindings.tenancy_billing_account_ids, 
+          func_bindings.tenancy_organization_ids,
+          func_bindings.tenancy_workspace_ids)
+        AND is_visible_v1(this_visibility, 
+          func_bindings.visibility_change_set_pk, 
+          func_bindings.visibility_edit_session_pk, 
+          func_bindings.visibility_deleted) 
+        ORDER BY id ASC
+        LIMIT 1
+        INTO object;
+
+    IF object IS NULL THEN
+      this_change_set_visibility := jsonb_build_object(
+        'visibility_change_set_pk', 
+        this_visibility_record.visibility_change_set_pk, 
+        'visibility_edit_session_pk', 
+        -1, 
+        'visibility_deleted', 
+        this_visibility_record.visibility_deleted);
+      
+      SELECT 
+        row_to_json(func_bindings.*) FROM func_bindings WHERE 
+          func_bindings.args = this_args AND func_bindings.backend_kind = this_backend_kind 
+          AND in_tenancy_v1(this_tenancy, 
+            func_bindings.tenancy_universal, 
+            func_bindings.tenancy_billing_account_ids, 
+            func_bindings.tenancy_organization_ids,
+            func_bindings.tenancy_workspace_ids)
+          AND is_visible_v1(this_change_set_visibility, 
+            func_bindings.visibility_change_set_pk, 
+            func_bindings.visibility_edit_session_pk, 
+            func_bindings.visibility_deleted)
+          ORDER BY id ASC
+          LIMIT 1
+          INTO object;
+    END IF;
+
+    IF object IS NULL THEN
+      this_head_visibility := jsonb_build_object(
+        'visibility_change_set_pk', 
+        -1,
+        'visibility_edit_session_pk', 
+        -1, 
+        'visibility_deleted', 
+        this_visibility_record.visibility_deleted);
+      
+      SELECT 
+        row_to_json(func_bindings.*) FROM func_bindings WHERE 
+          func_bindings.args = this_args AND func_bindings.backend_kind = this_backend_kind 
+          AND in_tenancy_v1(this_tenancy, 
+            func_bindings.tenancy_universal, 
+            func_bindings.tenancy_billing_account_ids, 
+            func_bindings.tenancy_organization_ids,
+            func_bindings.tenancy_workspace_ids)
+          AND is_visible_v1(this_head_visibility, 
+            func_bindings.visibility_change_set_pk, 
+            func_bindings.visibility_edit_session_pk, 
+            func_bindings.visibility_deleted)
+          ORDER BY id ASC
+          LIMIT 1
+          INTO object;
+    END IF;
+
+    IF object IS NULL THEN
+      created := true;
+      SELECT * FROM func_binding_create_v1(this_tenancy, this_visibility, this_args, this_backend_kind) INTO object;
+    END IF;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+
 CREATE OR REPLACE FUNCTION func_binding_return_value_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,

--- a/lib/dal/src/migrations/U0043__attribute_resolvers.sql
+++ b/lib/dal/src/migrations/U0043__attribute_resolvers.sql
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION attribute_resolver_create_v1(
     this_schema_id bigint,
     this_schema_variant_id bigint,
     this_system_id bigint,
-        OUT object json) AS
+    OUT object json) AS
 $$
 DECLARE
     this_tenancy_record    tenancy_record_v1;
@@ -44,39 +44,155 @@ BEGIN
     this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
     this_visibility_record := visibility_json_to_columns_v1(this_visibility);
 
-    INSERT INTO attribute_resolvers (
-      tenancy_universal,
-      tenancy_billing_account_ids,
-      tenancy_organization_ids,
-      tenancy_workspace_ids,
-      visibility_change_set_pk,
-      visibility_edit_session_pk,
-      visibility_deleted,
-      func_id,
-      func_binding_id,
-      prop_id,
-      component_id,
-      schema_id,
-      schema_variant_id,
-      system_id
-    ) VALUES (
-      this_tenancy_record.tenancy_universal,
-      this_tenancy_record.tenancy_billing_account_ids,
-      this_tenancy_record.tenancy_organization_ids,
-      this_tenancy_record.tenancy_workspace_ids,
-      this_visibility_record.visibility_change_set_pk,
-      this_visibility_record.visibility_edit_session_pk,
-      this_visibility_record.visibility_deleted, 
-      this_func_id,
-      this_func_binding_id, 
-      this_prop_id, 
-      this_component_id, 
-      this_schema_id, 
-      this_schema_variant_id,
-      this_system_id
-    ) RETURNING * INTO this_new_row;
+    INSERT INTO attribute_resolvers (tenancy_universal,
+                                     tenancy_billing_account_ids,
+                                     tenancy_organization_ids,
+                                     tenancy_workspace_ids,
+                                     visibility_change_set_pk,
+                                     visibility_edit_session_pk,
+                                     visibility_deleted,
+                                     func_id,
+                                     func_binding_id,
+                                     prop_id,
+                                     component_id,
+                                     schema_id,
+                                     schema_variant_id,
+                                     system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_func_id,
+            this_func_binding_id,
+            this_prop_id,
+            this_component_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);
 END;
 $$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION attribute_resolver_upsert_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id bigint,
+    this_func_binding_id bigint,
+    this_prop_id bigint,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    OUT object json, OUT created boolean) AS
+$$
+DECLARE
+    this_tenancy_record        tenancy_record_v1;
+    this_visibility_record     visibility_record_v1;
+    this_update_id             bigint;
+    this_change_set_visibility jsonb;
+    this_head_visibility       jsonb;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+    created := false;
+    this_change_set_visibility := jsonb_build_object(
+            'visibility_change_set_pk',
+            this_visibility_record.visibility_change_set_pk,
+            'visibility_edit_session_pk',
+            -1,
+            'visibility_deleted',
+            this_visibility_record.visibility_deleted);
+    this_head_visibility := jsonb_build_object(
+            'visibility_change_set_pk',
+            -1,
+            'visibility_edit_session_pk',
+            -1,
+            'visibility_deleted',
+            this_visibility_record.visibility_deleted);
+
+    -- If we have an ID at all in this query, its because something in our
+    -- possible visibilities has an AttributeResolver with our criteria!
+    SELECT id
+    FROM attribute_resolvers
+    WHERE in_tenancy_v1(
+            this_tenancy,
+            attribute_resolvers.tenancy_universal,
+            attribute_resolvers.tenancy_billing_account_ids,
+            attribute_resolvers.tenancy_organization_ids,
+            attribute_resolvers.tenancy_workspace_ids)
+      AND (
+            is_visible_v1(
+                    this_visibility,
+                    attribute_resolvers.visibility_change_set_pk,
+                    attribute_resolvers.visibility_edit_session_pk,
+                    attribute_resolvers.visibility_deleted)
+            OR
+            is_visible_v1(
+                    this_change_set_visibility,
+                    attribute_resolvers.visibility_change_set_pk,
+                    attribute_resolvers.visibility_edit_session_pk,
+                    attribute_resolvers.visibility_deleted)
+            OR
+            is_visible_v1(
+                    this_visibility,
+                    attribute_resolvers.visibility_change_set_pk,
+                    attribute_resolvers.visibility_edit_session_pk,
+                    attribute_resolvers.visibility_deleted)
+        )
+      AND attribute_resolvers.prop_id = this_prop_id
+      AND attribute_resolvers.component_id = this_component_id
+      AND attribute_resolvers.schema_id = this_schema_id
+      AND attribute_resolvers.schema_variant_id = this_schema_variant_id
+      AND attribute_resolvers.system_id = this_system_id
+    LIMIT 1
+    INTO this_update_id;
+
+    IF this_update_id IS NULL THEN
+        created := true;
+        SELECT *
+        FROM attribute_resolver_create_v1(
+                this_tenancy,
+                this_visibility,
+                this_func_id,
+                this_func_binding_id,
+                this_prop_id,
+                this_component_id,
+                this_schema_id,
+                this_schema_variant_id,
+                this_system_id
+            )
+        INTO object;
+    ELSE
+        PERFORM update_by_id_v1('attribute_resolvers', 'func_id', this_tenancy, this_visibility, this_update_id,
+                                this_func_id);
+        PERFORM update_by_id_v1('attribute_resolvers', 'func_binding_id', this_tenancy, this_visibility, this_update_id,
+                                this_func_binding_id);
+        SELECT row_to_json(attribute_resolvers.*)
+        FROM attribute_resolvers
+        WHERE in_tenancy_v1(
+                this_tenancy,
+                attribute_resolvers.tenancy_universal,
+                attribute_resolvers.tenancy_billing_account_ids,
+                attribute_resolvers.tenancy_organization_ids,
+                attribute_resolvers.tenancy_workspace_ids)
+          AND is_visible_v1(
+                this_visibility,
+                attribute_resolvers.visibility_change_set_pk,
+                attribute_resolvers.visibility_edit_session_pk,
+                attribute_resolvers.visibility_deleted)
+          AND attribute_resolvers.prop_id = this_prop_id
+          AND attribute_resolvers.component_id = this_component_id
+          AND attribute_resolvers.schema_id = this_schema_id
+          AND attribute_resolvers.schema_variant_id = this_schema_variant_id
+          AND attribute_resolvers.system_id = this_system_id
+        INTO object;
+    END IF;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
 

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -298,6 +298,55 @@ async fn docker_image(
         .set_default_schema_variant_id(txn, nats, visibility, history_actor, Some(*variant.id()))
         .await?;
 
+    let mut ui_menu = UiMenu::new(txn, nats, tenancy, visibility, history_actor).await?;
+    ui_menu
+        .set_name(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            Some(schema.name().to_string()),
+        )
+        .await?;
+
+    let application_name = "application".to_string();
+    ui_menu
+        .set_category(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            Some(application_name.clone()),
+        )
+        .await?;
+    ui_menu
+        .set_schematic_kind(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            SchematicKind::Deployment,
+        )
+        .await?;
+    ui_menu
+        .set_schema(txn, nats, visibility, history_actor, schema.id())
+        .await?;
+
+    let application_schema_results =
+        Schema::find_by_attr(txn, tenancy, visibility, "name", &application_name).await?;
+    let application_schema = application_schema_results
+        .first()
+        .ok_or(SchemaError::NotFoundByName(application_name))?;
+    ui_menu
+        .add_root_schematic(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            application_schema.id(),
+        )
+        .await?;
+
     let image_prop = Prop::new(
         txn,
         nats,

--- a/lib/dal/tests/integration_test/attribute_resolver.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver.rs
@@ -190,10 +190,8 @@ async fn find_value_for_prop_and_component() {
     .expect("cannot create attribute resolver");
     let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
         &txn,
-        &nats,
         &tenancy,
         &visibility,
-        &history_actor,
         *first_prop.id(),
         *component.id(),
         *nba.system.id(),
@@ -239,10 +237,8 @@ async fn find_value_for_prop_and_component() {
     .expect("cannot create attribute resolver");
     let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
         &txn,
-        &nats,
         &tenancy,
         &visibility,
-        &history_actor,
         *first_prop.id(),
         *component.id(),
         *nba.system.id(),
@@ -288,10 +284,8 @@ async fn find_value_for_prop_and_component() {
     .expect("cannot create attribute resolver");
     let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
         &txn,
-        &nats,
         &tenancy,
         &visibility,
-        &history_actor,
         *first_prop.id(),
         *component.id(),
         *nba.system.id(),
@@ -337,10 +331,8 @@ async fn find_value_for_prop_and_component() {
     .expect("cannot create attribute resolver");
     let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
         &txn,
-        &nats,
         &tenancy,
         &visibility,
-        &history_actor,
         *first_prop.id(),
         *component.id(),
         *nba.system.id(),
@@ -386,10 +378,8 @@ async fn find_value_for_prop_and_component() {
     .expect("cannot create attribute resolver");
     let func_binding_return_value = AttributeResolver::find_value_for_prop_and_component(
         &txn,
-        &nats,
         &tenancy,
         &visibility,
-        &history_actor,
         *first_prop.id(),
         *component.id(),
         *nba.system.id(),
@@ -399,5 +389,129 @@ async fn find_value_for_prop_and_component() {
     assert_eq!(
         func_binding_return_value.value(),
         Some(&serde_json::json!["prop_and_component"])
+    );
+}
+
+#[tokio::test]
+async fn upsert() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"docker_image".to_string(),
+    )
+    .await
+    .expect("cannot find docker image")
+    .pop()
+    .expect("no docker image found");
+
+    let default_variant = schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot find default variant");
+
+    let first_prop = default_variant
+        .props(&txn, &visibility)
+        .await
+        .expect("cannot get props")
+        .pop()
+        .expect("no prop found");
+
+    let component = create_component_for_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema.id(),
+    )
+    .await;
+
+    let func = Func::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "test:setString",
+        FuncBackendKind::String,
+        FuncBackendResponseType::String,
+    )
+    .await
+    .expect("cannot create func");
+
+    let args = FuncBackendStringArgs::new("gatecreeper".to_string());
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+
+    let mut attribute_resolver_context = AttributeResolverContext::new();
+    attribute_resolver_context.set_prop_id(*first_prop.id());
+    attribute_resolver_context.set_component_id(*component.id());
+    let _first_attribute_resolver = AttributeResolver::upsert(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *func_binding.id(),
+        attribute_resolver_context.clone(),
+    )
+    .await
+    .expect("cannot create new attribute resolver");
+
+    let second_args = FuncBackendStringArgs::new("bleed from within".to_string());
+    let second_func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(second_args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    second_func_binding
+        .execute(&txn, &nats)
+        .await
+        .expect("failed to execute func binding");
+    let second_attribute_resolver = AttributeResolver::upsert(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        *second_func_binding.id(),
+        attribute_resolver_context,
+    )
+    .await
+    .expect("cannot create new attribute resolver");
+
+    assert_eq!(
+        second_attribute_resolver.func_binding_id(),
+        *second_func_binding.id()
     );
 }

--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -35,6 +35,8 @@ pub enum EditFieldError {
     SchemaVariant(#[from] SchemaVariantError),
     #[error("socket error: {0}")]
     Socket(#[from] SocketError),
+    #[error("missing required baggage for edit field request; bug")]
+    MissingBaggage,
 }
 
 pub type EditFieldResult<T> = std::result::Result<T, EditFieldError>;

--- a/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
+++ b/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
@@ -45,6 +45,10 @@ pub async fn get_edit_fields(
             Component::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into())
                 .await?
         }
+        EditFieldObjectKind::ComponentProp => {
+            Component::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into())
+                .await?
+        }
         EditFieldObjectKind::Prop => {
             Prop::get_edit_fields(&txn, &tenancy, &request.visibility, &request.id.into()).await?
         }


### PR DESCRIPTION
This PR connects AttributeResolvers to the EditField implementation for
the Props of Components. It creates an appropriate FuncBinding, and then
ensures that the AttributeResolver is correctly configured for the
context the value is being set in. (In this case, it's directly on the
component).

Lots of future work expanding this - making it work for every prop type,
making it work with function backends, etc. But this gets the job done
for now.

Signed-off-by: Adam Jacob <adam@systeminit.com>
Co-authored-by: Fletcher Nichol <fletcher@systeminit.com>
Co-authored-by: Jacob Helwig <jhelwig@systeminit.com>