### PR TITLE
feat(dal): Create basic FuncBackendValidateStringValue

### DIFF
--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -41,6 +41,7 @@ pub enum FuncBackendKind {
     Unset,
     //Json,
     //Js,
+    ValidateStringValue,
 }
 
 #[derive(
@@ -65,6 +66,7 @@ pub enum FuncBackendResponseType {
     //Array,
     Unset,
     //Json,
+    Validation,
 }
 
 impl ToLabelList for FuncBackendKind {}

--- a/lib/dal/src/func/backend/validation.rs
+++ b/lib/dal/src/func/backend/validation.rs
@@ -1,5 +1,19 @@
 use serde::{Deserialize, Serialize};
 
+use crate::func::backend::FuncBackendResult;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendValidateStringValueArgs {
+    pub value: String,
+    pub expected: String,
+}
+
+impl FuncBackendValidateStringValueArgs {
+    pub fn new(value: String, expected: String) -> Self {
+        Self { value, expected }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct ValidationError {
     pub message: String,
@@ -8,4 +22,30 @@ pub struct ValidationError {
     /// This really should be an enum at some point, but we need to figure out the set of values it should be first.
     pub kind: Option<String>,
     pub link: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendValidateStringValue {
+    args: FuncBackendValidateStringValueArgs,
+}
+
+impl FuncBackendValidateStringValue {
+    pub fn new(args: FuncBackendValidateStringValueArgs) -> Self {
+        Self { args }
+    }
+
+    pub fn execute(&self) -> FuncBackendResult<serde_json::Value> {
+        let value = self.args.value.clone();
+        let expected = self.args.expected.clone();
+        let mut validation_errors = vec![];
+
+        if value != expected {
+            validation_errors.push(ValidationError {
+                message: format!("value ({value}) does not match expected ({expected})"),
+                ..ValidationError::default()
+            });
+        }
+
+        Ok(serde_json::to_value(validation_errors)?)
+    }
 }

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -187,6 +187,7 @@ impl FuncBinding {
                 Some(return_value)
             }
             FuncBackendKind::Unset => None,
+            FuncBackendKind::ValidateStringValue => unimplemented!(),
         };
 
         let func = self


### PR DESCRIPTION
This is a very basic validation backend that makes sure its two arguments have the same string value. There is nothing that will execute the backend yet. That will be handled in a follow-on task.

Co-authored-by: Adam Jacob <adam@opscode.com>