### PR TITLE
feat(editFields): wire validation errors from DAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ For instance, you can tidy up your Rust code before opening a pull request by ex
 ( cd ci; make tidy )
 ```
 
+To verify that all lints will pass in CI, execute the following target:
+
+```bash
+( cd ci; make ci-lint )
+```
+
 You can also run individual tests before bringing up the entire SI stack, as neeeded.
 This can be done in the root of the repository:
 

--- a/app/web/src/api/sdf/dal/edit_field.ts
+++ b/app/web/src/api/sdf/dal/edit_field.ts
@@ -86,8 +86,17 @@ export interface EditField {
   widget: Widget;
   value: any;
   visibility_diff: VisibilityDiff;
-  validators: Array<Validator>;
+  validation_errors: ValidationErrors;
   baggage?: any;
 }
 
 export type EditFields = Array<EditField>;
+
+export type ValidationErrors = Array<ValidationError>;
+
+export interface ValidationError {
+  message: string;
+  level?: string;
+  kind?: string;
+  link?: string;
+}

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <EditFormField :show="show">
+  <EditFormField :show="show" :validation-errors="editField.validation_errors">
     <template #name>
       {{ editField.name }}
     </template>

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <EditFormField :show="show">
+  <EditFormField :show="show" :validation-errors="editField.validation_errors">
     <template #name>{{ editField.name }}</template>
     <template #edit>
       <input

--- a/app/web/src/organisims/EditForm/EditFormField.vue
+++ b/app/web/src/organisims/EditForm/EditFormField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show" class="flex flex-row items-center w-full">
+  <div v-if="props.show" class="flex flex-row items-center w-full">
     <div class="flex flex-col w-full">
       <div class="flex flex-row items-center">
         <div class="flex-wrap self-start text-sm leading-tight text-right w-36">
@@ -23,26 +23,24 @@
         </div>
       </div>
       <div class="flex flex-wrap">
-        <ValidationErrors :errors="errors" class="p-2" />
+        <ValidationErrorsWidget :errors="props.validationErrors" class="p-2" />
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
 import { refFrom } from "vuse-rx";
 import { ChangeSetService } from "@/service/change_set";
-import ValidationErrors from "@/organisims/EditForm/ValidationErrors.vue";
+import ValidationErrorsWidget from "@/organisims/EditForm/ValidationErrorsWidget.vue";
+import type { ValidationErrors } from "@/api/sdf/dal/edit_field";
 
-defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  validationErrors: ValidationErrors;
+}>();
+
 const editMode = refFrom(ChangeSetService.currentEditMode());
-const errors = ref([{ message: "Aieeee!", link: "https://placekitten.com" }]);
 </script>
 
 <style scoped></style>

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <EditFormField :show="show">
+  <EditFormField :show="show" :validation-errors="editField.validation_errors">
     <template #name>
       {{ editField.name }}
     </template>

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <EditFormField :show="show">
+  <EditFormField :show="show" :validation-errors="editField.validation_errors">
     <template #name>
       {{ editField.name }}
     </template>

--- a/app/web/src/organisims/EditForm/ValidationErrorsWidget.vue
+++ b/app/web/src/organisims/EditForm/ValidationErrorsWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul :v-if="props.errors.length">
+  <ul v-if="props.errors.length">
     <li
       v-for="(error, index) in props.errors"
       :key="index"
@@ -26,23 +26,18 @@
 
 <script setup lang="ts">
 import VueFeather from "vue-feather";
+import type { ValidationErrors } from "@/api/sdf/dal/edit_field";
 
 const props = defineProps<{
-  errors: {
-    message: string;
-    level?: string;
-    kind?: string;
-    link?: string;
-  }[];
+  errors: ValidationErrors;
 }>();
 
-function strokeColorForLevel(level: string | undefined): string {
+function strokeColorForLevel(level: string): string {
   switch (level) {
     case "warning":
       return "yellow";
     case "info":
       return "grey";
-
     default:
       return "red";
   }

--- a/app/web/src/service/edit_field/get_edit_fields.ts
+++ b/app/web/src/service/edit_field/get_edit_fields.ts
@@ -70,11 +70,10 @@ export function getEditFields(
           ...visibility,
         };
       }
-      const response = sdf.get<ApiResponse<GetEditFieldsResponse>>(
+      return sdf.get<ApiResponse<GetEditFieldsResponse>>(
         "edit_field/get_edit_fields",
         request,
       );
-      return response;
     }),
     shareReplay(1),
   );

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -10,7 +10,9 @@ boostrap:
 # This target does not compose down beforehand.
 partial: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
+		docker-compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			-f $(MAKEPATH)/docker-compose.env.yml \
 		up -d nats pg otel
 
 # Run this target alongside local developer builds of web.
@@ -18,27 +20,37 @@ partial: init
 # without having to build backend components.
 backend: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
+	REPOPATH=$(REPOPATH) \
+		docker-compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			-f $(MAKEPATH)/docker-compose.env.yml \
+			-f $(MAKEPATH)/docker-compose.backend.yml \
 		up -d nats pg otel sdf veritech
 
 # Run interactively and compose down beforehand. This target is meant to be run iteratively for
 # local development and testing.
 dev: down init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
+		docker-compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			-f $(MAKEPATH)/docker-compose.env.yml \
 		up
 
 # Run in a detached state and do not compose down beforehand.
 # This is the target to run in production.
 prod: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
+		docker-compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			-f $(MAKEPATH)/docker-compose.env.yml \
 		up -d
 
 ci: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) REPOPATH=$(REPOPATH) \
-		docker-compose -f $(MAKEPATH)/docker-compose.yml -f $(MAKEPATH)/docker-compose.env.yml \
-		-f $(MAKEPATH)/docker-compose.ci.yml \
+		docker-compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			-f $(MAKEPATH)/docker-compose.env.yml \
+			-f $(MAKEPATH)/docker-compose.ci.yml \
 		up -d
 
 down:
@@ -49,5 +61,4 @@ init:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
-	docker-compose -f $(MAKEPATH)/docker-compose.yml \
-		pull
+	docker-compose -f $(MAKEPATH)/docker-compose.yml pull

--- a/deploy/docker-compose.backend.yml
+++ b/deploy/docker-compose.backend.yml
@@ -1,0 +1,5 @@
+version: "3"
+services:
+  sdf:
+    volumes:
+      - "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin:ro"

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -10,6 +10,7 @@ use crate::edit_field::{
     EditFieldBaggage, EditFieldBaggageComponentProp, EditFieldDataType, EditFieldError,
     EditFieldObjectKind, EditFields, TextWidget, Widget,
 };
+use crate::func::backend::validation::ValidationError;
 use crate::func::backend::FuncBackendStringArgs;
 use crate::func::binding::{FuncBinding, FuncBindingError};
 use crate::func::binding_return_value::FuncBindingReturnValue;
@@ -336,7 +337,11 @@ impl Component {
             Widget::Text(TextWidget::new()),
             value,
             visibility_diff,
-            vec![], // TODO: actually validate to generate ValidationErrors
+            vec![ValidationError {
+                message: "Aieeee! This name SUCKS!".to_string(),
+                link: Some("https://placekitten.com".to_string()),
+                ..ValidationError::default()
+            }], // TODO: actually validate to generate ValidationErrors
         ))
     }
 


### PR DESCRIPTION
- Wire validation errors from DAL through EditFields [sc-2090]
  - Pass through validation errors from EditField object through widgets
  - Update widgets using EditFormField with validation objects
- Ensure "backend" deploy target has dev JWT key [sc-2091]
  - Add docker compose file for backend target
- Move dummy validation error from frontend to DAL upon name field
  creation
- Add note to README on linting everything when preparing changes