### PR TITLE
feat: implement minimal js string function dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "url",
+ "veritech",
 ]
 
 [[package]]
@@ -2558,6 +2559,7 @@ dependencies = [
  "tokio-tungstenite",
  "tower",
  "tower-http",
+ "veritech",
 ]
 
 [[package]]
@@ -3542,6 +3544,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "cyclone",
+ "deadpool-cyclone",
  "derive_builder",
  "futures",
  "futures-lite",
@@ -3551,9 +3554,12 @@ dependencies = [
  "si-data",
  "si-settings",
  "telemetry",
+ "test-env-log",
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -68,6 +68,8 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
         trace!("migration mode is skip, not running migrations");
     }
 
+    let veritech = Server::create_veritech_client(nats.clone());
+
     // TODO(fnichol): re-enable, which we shouldn't need in the long run
     if !disable_opentelemetry {
         telemetry.enable_opentelemetry().await?;
@@ -77,12 +79,12 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
 
     match config.incoming_stream() {
         IncomingStream::HTTPSocket(_) => {
-            Server::http(config, telemetry, pg_pool, nats, jwt_secret_key)?
+            Server::http(config, telemetry, pg_pool, nats, veritech, jwt_secret_key)?
                 .run()
                 .await?;
         }
         IncomingStream::UnixDomainSocket(_) => {
-            Server::uds(config, telemetry, pg_pool, nats, jwt_secret_key)
+            Server::uds(config, telemetry, pg_pool, nats, veritech, jwt_secret_key)
                 .await?
                 .run()
                 .await?;

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -1,6 +1,6 @@
 use color_eyre::Result;
 use telemetry::{start_tracing_level_signal_handler_task, tracing::debug, TelemetryClient};
-use veritech::{Config, CycloneStream, Server};
+use veritech::{Config, CycloneSpec, Server};
 
 mod args;
 
@@ -30,11 +30,11 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
 
     start_tracing_level_signal_handler_task(&telemetry)?;
 
-    match config.cyclone_stream() {
-        CycloneStream::HttpSocket(_) => {
+    match config.cyclone_spec() {
+        CycloneSpec::LocalHttp(_) => {
             Server::for_cyclone_http(config).await?.run().await?;
         }
-        CycloneStream::UnixDomainSocket(_) => {
+        CycloneSpec::LocalUds(_) => {
             Server::for_cyclone_uds(config).await?.run().await?;
         }
     }

--- a/lib/cyclone/Cargo.toml
+++ b/lib/cyclone/Cargo.toml
@@ -10,39 +10,60 @@ publish = false
 # to the features they desire.
 default = []
 
+process = [
+  "nix",
+  "tokio",
+]
+
 # The client implementation for a cyclone server.
 client = [
+  "async-trait",
+  "futures",
   "futures-lite",
   "http",
+  "hyper",
   "hyperlocal",
+  "tokio",
   "tokio-tungstenite",
+  "uuid",
 ]
 
 # The server side implementation of cyclone, as a library.
 server = [
+  "async-trait",
   "axum",
   "bytes-lines-codec",
   "chrono",
   "derive_builder",
+  "futures",
+  "hyper",
+  "nix",
   "pin-project-lite",
+  "process",
+  "tokio",
   "tokio-serde",
   "tokio-util",
   "tower",
   "tower-http",
+  "uuid",
 ]
 
 [dependencies]
-# server and client
-async-trait = { version = "0.1.51" }
-futures = { version = "0.3.17" }
-hyper = { version = "0.14", features = ["client", "http1", "runtime", "server"] }
-nix = { version = "0.23.0" }
+# for common types shared between client and server
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+
+# for process shutdown behavior
+nix = { version = "0.23.0", optional = true }
+
+# server and/or client
+async-trait = { version = "0.1.51", optional = true }
+futures = { version = "0.3.17", optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "runtime", "server"], optional = true }
+tokio = { version = "1.12.0", features = ["full"], optional = true }
+uuid = { version = "0.8.2", features = ["serde", "v4"], optional = true }
 
 # client only
 futures-lite = { version = "1.12.0", optional = true }

--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -397,6 +397,7 @@ impl Default for ClientConfig {
     }
 }
 
+#[allow(clippy::panic)]
 #[cfg(test)]
 mod tests {
     use std::{borrow::Cow, collections::HashMap, env, path::Path};

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -13,13 +13,15 @@
 
 pub mod canonical_command;
 mod liveness;
-pub mod process;
 pub mod qualification_check;
 mod readiness;
 pub mod resolver_function;
 
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
+
+#[cfg(feature = "process")]
+pub mod process;
 
 #[cfg(feature = "server")]
 mod server;

--- a/lib/cyclone/src/process.rs
+++ b/lib/cyclone/src/process.rs
@@ -5,9 +5,9 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::{process::Child, time};
 
-const CHILD_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(10);
-
 pub use nix::sys::signal::Signal;
+
+const CHILD_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Error)]
 pub enum ShutdownError {

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -36,6 +36,7 @@ derive_more = "0.99.16"
 postgres-types = { version = "0.2.2", features = ["derive"] }
 paste = "1.0"
 async-trait = "0.1.51"
+veritech = { path = "../../lib/veritech", features = ["client"] }
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -349,6 +349,7 @@ impl Component {
     pub async fn update_prop_from_edit_field(
         txn: &PgTxn<'_>,
         nats: &NatsTxn,
+        veritech: veritech::Client,
         tenancy: &Tenancy,
         visibility: &Visibility,
         history_actor: &HistoryActor,
@@ -395,7 +396,7 @@ impl Component {
                 // think about execution time. Probably higher up than this? But just
                 // an FYI.
                 if created {
-                    func_binding.execute(txn, nats).await?;
+                    func_binding.execute(txn, nats, veritech).await?;
                 }
                 (func, func_binding)
             }

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -1,17 +1,28 @@
-pub mod validation;
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
 use thiserror::Error;
+use tokio::sync::mpsc;
+use veritech::{Client, OutputStream, ResolverFunctionRequest, ResolverFunctionResult};
 
 use crate::{edit_field::ToSelectWidget, label_list::ToLabelList};
 
+pub mod validation;
+
 #[derive(Error, Debug)]
 pub enum FuncBackendError {
-    #[error("error serializing/deserializing json: {0}")]
-    SerdeJson(#[from] serde_json::Error),
     #[error("invalid data - expected a string, got: {0}")]
     InvalidStringData(serde_json::Value),
+    #[error("result failure: kind={kind}, message={message}")]
+    ResultFailure { kind: String, message: String },
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("invalid data - got unset when not expected")]
+    UnexpectedUnset,
+    #[error("veritech client error: {0}")]
+    VeritechClient(#[from] veritech::ClientError),
 }
 
 pub type FuncBackendResult<T> = Result<T, FuncBackendError>;
@@ -41,6 +52,7 @@ pub enum FuncBackendKind {
     Unset,
     //Json,
     //Js,
+    JsString,
     ValidateStringValue,
 }
 
@@ -93,18 +105,109 @@ impl FuncBackendString {
         Self { args }
     }
 
-    pub fn response_type(&self) -> FuncBackendResponseType {
-        FuncBackendResponseType::String
-    }
+    #[instrument(
+        name = "funcbackendstring.execute",
+        skip_all,
+        level = "debug",
+        fields(
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.func.result = Empty
+        )
+    )]
+    pub async fn execute(self) -> FuncBackendResult<serde_json::Value> {
+        let span = Span::current();
 
-    pub fn execute(&self) -> FuncBackendResult<serde_json::Value> {
         let value = serde_json::to_value(&self.args.value)?;
         // You can be damn sure this is a string, really - because
         // the inner type there is a string. But hey - better safe
         // than sorry!
         if !value.is_string() {
-            return Err(FuncBackendError::InvalidStringData(value));
+            return Err(span.record_err(FuncBackendError::InvalidStringData(value)));
         }
+
+        span.record_ok();
+        span.record("si.func.result", &tracing::field::debug(&value));
+        Ok(value)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendJsStringArgs {
+    pub arguments: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug)]
+pub struct FuncBackendJsString {
+    veritech: Client,
+    output_tx: mpsc::Sender<OutputStream>,
+    request: ResolverFunctionRequest,
+}
+
+impl FuncBackendJsString {
+    pub fn new(
+        veritech: Client,
+        output_tx: mpsc::Sender<OutputStream>,
+        handler: impl Into<String>,
+        args: HashMap<String, serde_json::Value>,
+        code_base64: impl Into<String>,
+    ) -> Self {
+        let request = ResolverFunctionRequest {
+            // Once we start tracking the state of these executions, then this id will be useful,
+            // but for now it's passed along and back, and is opaue
+            execution_id: "tomcruise".to_string(),
+            handler: handler.into(),
+            parameters: Some(args),
+            code_base64: code_base64.into(),
+        };
+
+        Self {
+            veritech,
+            output_tx,
+            request,
+        }
+    }
+
+    #[instrument(
+        name = "funcbackendjsstring.execute",
+        skip_all,
+        level = "debug",
+        fields(
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.func.result = Empty
+        )
+    )]
+    pub async fn execute(self) -> FuncBackendResult<serde_json::Value> {
+        let span = Span::current();
+
+        let result = self
+            .veritech
+            .execute_resolver_function("veritech.function.resolver", self.output_tx, &self.request)
+            .await
+            .map_err(|err| span.record_err(err))?;
+        let value = match result {
+            ResolverFunctionResult::Success(success) => {
+                if success.unset {
+                    return Err(span.record_err(FuncBackendError::UnexpectedUnset));
+                }
+                if !success.data.is_string() {
+                    return Err(span.record_err(FuncBackendError::InvalidStringData(success.data)));
+                }
+                success.data
+            }
+            ResolverFunctionResult::Failure(failure) => {
+                return Err(span.record_err(FuncBackendError::ResultFailure {
+                    kind: failure.error.kind,
+                    message: failure.error.message,
+                }));
+            }
+        };
+
+        span.record_ok();
+        span.record("si.func.result", &tracing::field::debug(&value));
         Ok(value)
     }
 }

--- a/lib/dal/tests/integration_test/attribute_resolver.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver.rs
@@ -10,10 +10,11 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -76,7 +77,7 @@ async fn new() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
 
@@ -101,12 +102,13 @@ async fn new() {
 // nuts.
 #[tokio::test]
 async fn find_value_for_prop_and_component() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let _unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
@@ -171,7 +173,7 @@ async fn find_value_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut attribute_resolver_context = AttributeResolverContext::new();
@@ -217,7 +219,7 @@ async fn find_value_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut attribute_resolver_context = AttributeResolverContext::new();
@@ -264,7 +266,7 @@ async fn find_value_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut attribute_resolver_context = AttributeResolverContext::new();
@@ -311,7 +313,7 @@ async fn find_value_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut attribute_resolver_context = AttributeResolverContext::new();
@@ -358,7 +360,7 @@ async fn find_value_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     let mut attribute_resolver_context = AttributeResolverContext::new();
@@ -394,10 +396,11 @@ async fn find_value_for_prop_and_component() {
 
 #[tokio::test]
 async fn upsert() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -460,7 +463,7 @@ async fn upsert() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
 
@@ -494,7 +497,7 @@ async fn upsert() {
     .await
     .expect("cannot create function binding");
     second_func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     let second_attribute_resolver = AttributeResolver::upsert(

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -264,10 +264,11 @@ async fn func_binding_return_value_new() {
 
 #[tokio::test]
 async fn func_binding_execute() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
     let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let args = serde_json::to_value(FuncBackendStringArgs::new("funky".to_string()))
         .expect("cannot serialize args to json");
@@ -285,7 +286,7 @@ async fn func_binding_execute() {
     .await;
 
     let return_value = func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     assert_eq!(return_value.value(), Some(&serde_json::json!["funky"]));
@@ -297,10 +298,11 @@ async fn func_binding_execute() {
 
 #[tokio::test]
 async fn func_binding_execute_unset() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
     let name = dal::test_harness::generate_fake_name();
     let func = Func::new(
         &txn,
@@ -329,7 +331,7 @@ async fn func_binding_execute_unset() {
     .await;
 
     let return_value = func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     assert_eq!(return_value.value(), None);

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -13,10 +13,11 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -80,7 +81,7 @@ async fn new() {
     .await
     .expect("cannot create function binding");
     func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
 
@@ -104,12 +105,13 @@ async fn new() {
 
 #[tokio::test]
 async fn find_values_for_prop_and_component() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
@@ -175,7 +177,7 @@ async fn find_values_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     first_func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut validation_resolver_context = ValidationResolverContext::new();
@@ -210,7 +212,7 @@ async fn find_values_for_prop_and_component() {
     .await
     .expect("cannot create function binding");
     second_func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     let mut validation_resolver_context = ValidationResolverContext::new();
@@ -247,12 +249,13 @@ async fn find_values_for_prop_and_component() {
 
 #[tokio::test]
 async fn find_values_for_prop_and_component_override() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
 
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
@@ -318,7 +321,7 @@ async fn find_values_for_prop_and_component_override() {
     .await
     .expect("cannot create function binding");
     first_func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech.clone())
         .await
         .expect("failed to execute func binding");
     let mut validation_resolver_context = ValidationResolverContext::new();
@@ -353,7 +356,7 @@ async fn find_values_for_prop_and_component_override() {
     .await
     .expect("cannot create function binding");
     second_func_binding
-        .execute(&txn, &nats)
+        .execute(&txn, &nats, veritech)
         .await
         .expect("failed to execute func binding");
     let mut validation_resolver_context = ValidationResolverContext::new();

--- a/lib/deadpool-cyclone/Cargo.toml
+++ b/lib/deadpool-cyclone/Cargo.toml
@@ -13,7 +13,7 @@ deadpool = { version = "0.9.0", features = ["rt_tokio_1"] }
 derive_builder = { version = "0.10.2" }
 futures = { version = "0.3.17" }
 nix = { version = "0.23.0" }
-cyclone = { path = "../cyclone", features = ["client"] }
+cyclone = { path = "../cyclone", features = ["client", "process"] }
 tempfile = { version = "3.2.0" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
@@ -195,7 +195,7 @@ impl LocalHttpInstance {
 }
 
 /// The [`Spec`] for [`LocalHttpInstance`]
-#[derive(Builder, Debug)]
+#[derive(Builder, Clone, Debug, Eq, PartialEq)]
 pub struct LocalHttpInstanceSpec {
     /// Canonical path to the `cyclone` program.
     #[builder(try_setter, setter(into))]
@@ -344,7 +344,7 @@ impl LocalHttpInstanceSpecBuilder {
 }
 
 /// Socket strategy when spawning [`Instance`]s using a TCP socket.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum LocalHttpSocketStrategy {
     /// Randomly assign a port.
     Random,

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -203,7 +203,7 @@ impl LocalUdsInstance {
 }
 
 /// The [`Spec`] for [`LocalUdsInstance`]
-#[derive(Builder, Debug)]
+#[derive(Builder, Clone, Debug, Eq, PartialEq)]
 pub struct LocalUdsInstanceSpec {
     /// Canonical path to the `cyclone` program.
     #[builder(try_setter, setter(into))]
@@ -353,7 +353,7 @@ impl LocalUdsInstanceSpecBuilder {
 }
 
 /// Socket strategy when spawning [`Instance`]s using a local Unix domain socket.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum LocalUdsSocketStrategy {
     /// Randomly assign a socket from a temp file.
     Random,

--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -19,9 +19,16 @@ use async_trait::async_trait;
 use deadpool::managed;
 use thiserror::Error;
 
-use self::instance::{Instance, Spec};
+pub use self::instance::{Instance, Spec};
 
-pub use cyclone::client;
+pub use cyclone::{
+    client::{self, ResolverFunctionExecutionError},
+    resolver_function::{
+        OutputStream, ResolverFunctionExecutingMessage, ResolverFunctionRequest,
+        ResolverFunctionResult,
+    },
+    CycloneClient,
+};
 
 /// [`Instance`] implementations.
 pub mod instance;

--- a/lib/sdf/Cargo.toml
+++ b/lib/sdf/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.12.0", features = ["full"] }
 tokio-tungstenite = "0.15.0"
 tower = { version = "0.4.10" }
 tower-http = { version = "0.1", features = ["trace"] }
+veritech = { path = "../../lib/veritech", features = ["client"] }
 
 [dev-dependencies]
 serde_url_params = "0.2.1"

--- a/lib/sdf/src/server/extract.rs
+++ b/lib/sdf/src/server/extract.rs
@@ -124,6 +124,23 @@ impl NatsTxn {
     }
 }
 
+pub struct Veritech(pub veritech::Client);
+
+#[async_trait]
+impl<P> FromRequest<P> for Veritech
+where
+    P: Send,
+{
+    type Rejection = (StatusCode, Json<InternalError>);
+
+    async fn from_request(req: &mut RequestParts<P>) -> Result<Self, Self::Rejection> {
+        let Extension(veritech) = Extension::<veritech::Client>::from_request(req)
+            .await
+            .map_err(internal_error)?;
+        Ok(Self(veritech))
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct InternalError {
     error: String,

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -45,6 +45,7 @@ pub fn routes(
     telemetry: impl TelemetryClient,
     pg_pool: pg::PgPool,
     nats: nats::Client,
+    veritech: veritech::Client,
     jwt_secret_key: JwtSecretKey,
     shutdown_tx: mpsc::Sender<ShutdownSource>,
     shutdown_broadcast_tx: broadcast::Sender<()>,
@@ -84,6 +85,7 @@ pub fn routes(
         .layer(AddExtensionLayer::new(telemetry))
         .layer(AddExtensionLayer::new(pg_pool))
         .layer(AddExtensionLayer::new(nats))
+        .layer(AddExtensionLayer::new(veritech))
         .layer(AddExtensionLayer::new(jwt_secret_key))
         .layer(AddExtensionLayer::new(ShutdownBroadcast(
             shutdown_broadcast_tx,

--- a/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field/update_from_edit_field.rs
@@ -8,7 +8,7 @@ use dal::{
 use serde::{Deserialize, Serialize};
 
 use super::{EditFieldError, EditFieldResult};
-use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn, Veritech};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +32,7 @@ pub struct UpdateFromEditFieldResponse {
 pub async fn update_from_edit_field(
     mut txn: PgRwTxn,
     mut nats: NatsTxn,
+    Veritech(veritech): Veritech,
     Authorization(claim): Authorization,
     Json(request): Json<UpdateFromEditFieldRequest>,
 ) -> EditFieldResult<Json<UpdateFromEditFieldResponse>> {
@@ -67,6 +68,7 @@ pub async fn update_from_edit_field(
             Component::update_prop_from_edit_field(
                 &txn,
                 &nats,
+                veritech,
                 &tenancy,
                 &request.visibility,
                 &history_actor,

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -182,12 +182,14 @@ macro_rules! test_setup {
         let ($pg, $nats_conn, $jwt_secret_key) = $ctx.entries();
         let telemetry = $ctx.telemetry();
         let $nats = $nats_conn.transaction();
+        let veritech = veritech::Client::new($nats_conn.clone());
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
         let $pgtxn = $pgconn.transaction().await.expect("cannot create txn");
         let ($app, _) = sdf::build_service(
             telemetry,
             $pg.clone(),
             $nats_conn.clone(),
+            veritech,
             $jwt_secret_key.clone(),
         )
         .expect("cannot build new server");

--- a/lib/sdf/tests/service_tests/signup.rs
+++ b/lib/sdf/tests/service_tests/signup.rs
@@ -12,9 +12,16 @@ async fn create_account() {
     one_time_setup().await.expect("cannot setup tests");
     let ctx = TestContext::init().await;
     let (pg, nats, jwt_secret_key) = ctx.entries();
+    let veritech = veritech::Client::new(nats.clone());
     let telemetry = ctx.telemetry();
-    let (app, _) = sdf::build_service(telemetry, pg.clone(), nats.clone(), jwt_secret_key.clone())
-        .expect("cannot build new server");
+    let (app, _) = sdf::build_service(
+        telemetry,
+        pg.clone(),
+        nats.clone(),
+        veritech,
+        jwt_secret_key.clone(),
+    )
+    .expect("cannot build new server");
     let app: Router = app;
 
     let request = signup::create_account::CreateAccountRequest {

--- a/lib/veritech/Cargo.toml
+++ b/lib/veritech/Cargo.toml
@@ -11,10 +11,15 @@ publish = false
 default = []
 
 # The client implementation for a veritech service.
-client = []
+client = [
+  "cyclone",
+  "futures-lite",
+  "pin-project-lite",
+]
 
 # The server side implementation of veritech, as a library.
 server = [
+  "deadpool-cyclone",
   "derive_builder",
   "futures-lite",
   "pin-project-lite",
@@ -23,10 +28,13 @@ server = [
 [dependencies]
 # server and client dependencies
 base64 = "0.13.0"
+deadpool-cyclone = { path = "../../lib/deadpool-cyclone", optional = true }
 futures = { version = "0.3.17"}
 serde = "1.0.123"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
-cyclone = { path = "../../lib/cyclone", default-features = false, features = ["client"] }
+cyclone = { path = "../../lib/cyclone", optional = true }
+futures-lite = { version = "1.12.0", optional = true }
+pin-project-lite = { version = "0.2.7", optional = true }
 si-data = { path = "../../lib/si-data", features = ["nats"] }
 si-settings = { path = "../../lib/si-settings" }
 telemetry = { path = "../../lib/telemetry-rs" }
@@ -36,5 +44,8 @@ toml = "0.5"
 
 # server only dependencies
 derive_builder = { version = "0.10.2", optional = true }
-futures-lite = { version = "1.12.0", optional = true }
-pin-project-lite = { version = "0.2.7", optional = true }
+
+[dev-dependencies]
+test-env-log = { version = "0.2.7", default-features = false, features = ["trace"] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.2.19", default-features = false, features = ["env-filter", "fmt"] }

--- a/lib/veritech/src/client.rs
+++ b/lib/veritech/src/client.rs
@@ -1,58 +1,301 @@
-use futures::StreamExt;
+use cyclone::resolver_function::{OutputStream, ResolverFunctionRequest, ResolverFunctionResult};
+use futures::{StreamExt, TryStreamExt};
 use si_data::NatsClient;
 use telemetry::prelude::*;
 use thiserror::Error;
+use tokio::sync::mpsc;
 
-use crate::{ResolverFunctionRequest, ResolverFunctionResult};
+use self::subscription::{Subscription, SubscriptionError};
+use crate::{reply_mailbox_for_output, reply_mailbox_for_result};
 
 #[derive(Error, Debug)]
-pub enum VeritechClientError {
-    #[error("serde error")]
-    SerdeJson(#[from] serde_json::Error),
-    #[error("nats io error")]
+pub enum ClientError {
+    #[error("failed to serialize json message")]
+    JSONSerialize(#[source] serde_json::Error),
+    #[error("nats error")]
     Nats(#[from] si_data::NatsError),
     #[error("no function result from cyclone; bug!")]
     NoResult,
+    #[error("result error")]
+    Result(#[from] SubscriptionError),
 }
 
-pub type VeritechClientResult<T> = Result<T, VeritechClientError>;
+pub type ClientResult<T> = Result<T, ClientError>;
 
-#[instrument(name = "veritech.client.run_function", skip(nats, _kind, code))]
-pub async fn run_function(
-    nats: &NatsClient,
-    _kind: impl Into<String>,
-    code: impl Into<String>,
-) -> VeritechClientResult<ResolverFunctionResult> {
-    let code = code.into();
-    let request = ResolverFunctionRequest {
-        // TODO(jhelwig): Something will need to own generating a real execution_id at some point, but we don't have that place or a definition of exactly what the execution_id is yet.
-        execution_id: "TODO".into(),
-        // TODO(jhelwig): This should be the name of the function to call in the base64 encoded code block, but we don't have a way to know that yet.
-        handler: "TODO".into(),
-        parameters: None,
-        code_base64: base64::encode(&code),
+#[derive(Clone, Debug)]
+pub struct Client {
+    nats: NatsClient,
+}
+
+impl Client {
+    pub fn new(nats: NatsClient) -> Self {
+        Self { nats }
+    }
+
+    #[instrument(name = "client.execute_resolver_function", skip_all)]
+    pub async fn execute_resolver_function(
+        &self,
+        subject: impl Into<String>,
+        output_tx: mpsc::Sender<OutputStream>,
+        request: &ResolverFunctionRequest,
+    ) -> ClientResult<ResolverFunctionResult> {
+        let msg = serde_json::to_vec(request).map_err(ClientError::JSONSerialize)?;
+        let reply_mailbox_root = self.nats.new_inbox();
+
+        // Construct a subscription stream for the result
+        let mut result_subscription: Subscription<ResolverFunctionResult> = Subscription::new(
+            self.nats
+                .subscribe(reply_mailbox_for_result(&reply_mailbox_root))
+                .await?,
+        );
+
+        // Construct a subscription stream for output messages
+        let output_subscription = Subscription::new(
+            self.nats
+                .subscribe(reply_mailbox_for_output(&reply_mailbox_root))
+                .await?,
+        );
+        // Spawn a task to forward output to the sender provided by the caller
+        tokio::spawn(forward_output_task(output_subscription, output_tx));
+
+        // Submit the request message
+        self.nats
+            .publish_with_reply_or_headers(subject, Some(reply_mailbox_root.as_str()), None, msg)
+            .await?;
+
+        // Wait for one message on the result reply mailbox
+        let result = result_subscription
+            .try_next()
+            .await?
+            .ok_or(ClientError::NoResult)?;
+        result_subscription.unsubscribe().await?;
+
+        Ok(result)
+    }
+}
+
+async fn forward_output_task(
+    mut output_subscription: Subscription<OutputStream>,
+    output_tx: mpsc::Sender<OutputStream>,
+) {
+    while let Some(msg) = output_subscription.next().await {
+        match msg {
+            Ok(output) => {
+                if let Err(err) = output_tx.send(output).await {
+                    warn!(error = ?err, "output forwarder failed to send message on channel");
+                }
+            }
+            Err(err) => {
+                warn!(error = ?err, "output forwarder received an error on its subscription")
+            }
+        }
+    }
+    if let Err(err) = output_subscription.unsubscribe().await {
+        warn!(error = ?err, "error when unsubscribing from output subscription");
+    }
+}
+
+mod subscription {
+    use std::{
+        marker::PhantomData,
+        pin::Pin,
+        task::{Context, Poll},
     };
-    let mut reply_sub = nats
-        .request_multi(
-            "veritech.function.resolver",
-            serde_json::to_string(&request)?,
-        )
-        .await?;
 
-    let mut result: Option<ResolverFunctionResult> = None;
-    // TODO - We will eventually want this to timeout if we don't receive the
-    // payload in time. Lots of fanciness can ensue.
-    while let Some(msg) = reply_sub.next().await.transpose()? {
-        let json_payload: serde_json::Value = serde_json::from_slice(msg.data())?;
-        // Then it is output
-        if json_payload["stream"].is_null() {
-            let function_result: ResolverFunctionResult = serde_json::from_value(json_payload)?;
-            result = Some(function_result);
-            break;
+    use futures::{Stream, StreamExt};
+    use futures_lite::FutureExt;
+    use pin_project_lite::pin_project;
+    use serde::de::DeserializeOwned;
+    use si_data::nats;
+    use telemetry::prelude::*;
+    use thiserror::Error;
+
+    use crate::FINAL_MESSAGE_HEADER_KEY;
+
+    #[derive(Error, Debug)]
+    pub enum SubscriptionError {
+        #[error("failed to deserialize json message")]
+        JSONDeserialize(#[source] serde_json::Error),
+        #[error("nats io error when reading from subscription")]
+        NatsIo(#[source] si_data::NatsError),
+        #[error("failed to unsubscribe from nats subscription")]
+        NatsUnsubscribe(#[source] si_data::NatsError),
+        #[error("the nats subscription closed before seeing a final message")]
+        UnexpectedNatsSubscriptionClosed,
+    }
+
+    pin_project! {
+        #[derive(Debug)]
+        pub struct Subscription<T> {
+            #[pin]
+            inner: nats::Subscription,
+            _phantom: PhantomData<T>,
+        }
+    }
+
+    impl<T> Subscription<T> {
+        pub fn new(inner: nats::Subscription) -> Self {
+            Subscription {
+                inner,
+                _phantom: PhantomData,
+            }
         }
 
-        // TODO: We should do something here with output!
-        dbg!(json_payload);
+        pub async fn unsubscribe(self) -> Result<(), SubscriptionError> {
+            self.inner
+                .unsubscribe()
+                .await
+                .map_err(SubscriptionError::NatsUnsubscribe)
+        }
     }
-    result.ok_or(VeritechClientError::NoResult)
+
+    impl<T> Stream for Subscription<T>
+    where
+        T: DeserializeOwned,
+    {
+        type Item = Result<T, SubscriptionError>;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let mut this = self.project();
+
+            match this.inner.next().poll(cx) {
+                // Convert this NATS message into the cyclone request type `T` and return any
+                // errors for the caller to decide how to proceed (i.e. does the caller fail on
+                // first error, ignore error items, etc.)
+                Poll::Ready(Some(Ok(nats_msg))) => {
+                    // If the NATS message has a final message header, then treat this as an
+                    // end-of-stream marker and close our stream.
+                    if let Some(headers) = nats_msg.headers() {
+                        if headers.keys().any(|key| key == FINAL_MESSAGE_HEADER_KEY) {
+                            trace!(
+                                "{} header detected in NATS message, closing stream",
+                                FINAL_MESSAGE_HEADER_KEY
+                            );
+                            return Poll::Ready(None);
+                        }
+                    }
+
+                    let data = nats_msg.into_data();
+                    match serde_json::from_slice::<T>(&data) {
+                        // Deserializing from JSON into the target type was successful
+                        Ok(msg) => Poll::Ready(Some(Ok(msg))),
+                        // Deserializing failed
+                        Err(err) => Poll::Ready(Some(Err(SubscriptionError::JSONDeserialize(err)))),
+                    }
+                }
+                // A NATS error occurred (async error or other i/o)
+                Poll::Ready(Some(Err(err))) => {
+                    Poll::Ready(Some(Err(SubscriptionError::NatsIo(err))))
+                }
+                // We see no more messages on the subject, but we haven't seen a "final message"
+                // yet, so this is an unexpected problem
+                Poll::Ready(None) => Poll::Ready(Some(Err(
+                    SubscriptionError::UnexpectedNatsSubscriptionClosed,
+                ))),
+                // Not ready, so...not ready!
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}
+
+#[allow(clippy::panic)]
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, env};
+
+    use deadpool_cyclone::{instance::cyclone::LocalUdsInstance, Instance};
+    use si_data::NatsConfig;
+    use si_settings::StandardConfig;
+    use test_env_log::test;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+    use crate::{Config, CycloneSpec, Server, ServerError};
+
+    fn nats_config() -> NatsConfig {
+        let mut config = NatsConfig::default();
+        if let Ok(value) = env::var("SI_TEST_NATS_URL") {
+            config.url = value;
+        }
+        config
+    }
+
+    async fn nats() -> NatsClient {
+        NatsClient::new(&nats_config())
+            .await
+            .expect("failed to connect to NATS")
+    }
+
+    async fn server_for_uds_cyclone() -> Server {
+        let cyclone_spec = CycloneSpec::LocalUds(
+            LocalUdsInstance::spec()
+                .try_cyclone_cmd_path("../../target/debug/cyclone")
+                .expect("failed to setup cyclone_cmd_path")
+                .try_lang_server_cmd_path("../../bin/lang-js/target/lang-js")
+                .expect("failed to setup lang_js_cmd_path")
+                .resolver()
+                .build()
+                .expect("failed to build cyclone spec"),
+        );
+        let config = Config::builder()
+            .nats(nats_config())
+            .cyclone_spec(cyclone_spec)
+            .build()
+            .expect("failed to build spec");
+        Server::for_cyclone_uds(config)
+            .await
+            .expect("failed to create server")
+    }
+
+    async fn client() -> Client {
+        Client::new(nats().await)
+    }
+
+    async fn run_server_for_uds_cyclone() -> JoinHandle<Result<(), ServerError>> {
+        tokio::spawn(server_for_uds_cyclone().await.run())
+    }
+
+    #[ignore = "at the moment this test blocks at the end and does not terminate"]
+    #[test(tokio::test)]
+    async fn executes_simple_resolver_function() {
+        run_server_for_uds_cyclone().await;
+        let client = client().await;
+
+        // Not going to check output here--we aren't emitting anything
+        let (tx, mut rx) = mpsc::channel(64);
+        tokio::spawn(async move {
+            while let Some(output) = rx.recv().await {
+                info!("output: {:?}", output)
+            }
+        });
+
+        let mut parameters = HashMap::new();
+        parameters.insert("value".to_string(), serde_json::json!("waffles_are_neat"));
+
+        let request = ResolverFunctionRequest {
+            execution_id: "1234".to_string(),
+            handler: "upperCaseString".to_string(),
+            parameters: Some(parameters),
+            code_base64: base64::encode(
+                "function upperCaseString(params) { return params.value.toUpperCase(); }",
+            ),
+        };
+
+        let result = client
+            .execute_resolver_function("veritech.function.resolver", tx, &request)
+            .await
+            .expect("failed to execute resolver function");
+
+        match result {
+            ResolverFunctionResult::Success(success) => {
+                assert_eq!(success.execution_id, "1234");
+                assert_eq!(success.data, serde_json::json!("WAFFLES_ARE_NEAT"));
+                assert!(!success.unset);
+            }
+            ResolverFunctionResult::Failure(failure) => {
+                panic!("function did not succeed and should have: {:?}", failure)
+            }
+        }
+    }
 }

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -11,15 +11,29 @@
     clippy::module_name_repetitions
 )]
 
-pub use cyclone::resolver_function::*;
-
 #[cfg(feature = "server")]
 pub mod server;
 #[cfg(feature = "server")]
 pub use server::{
-    Config, ConfigBuilder, ConfigError, ConfigFile, CycloneStream, Server, StandardConfig,
-    StandardConfigFile,
+    Config, ConfigBuilder, ConfigError, ConfigFile, CycloneSpec, CycloneStream, Server,
+    ServerError, StandardConfig, StandardConfigFile,
 };
 
 #[cfg(feature = "client")]
 pub mod client;
+#[cfg(feature = "client")]
+pub use client::{Client, ClientError, ClientResult};
+#[cfg(feature = "client")]
+pub use cyclone::resolver_function::{
+    OutputStream, ResolverFunctionRequest, ResolverFunctionResult, ResolverFunctionResultFailure,
+};
+
+pub(crate) const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";
+
+pub(crate) fn reply_mailbox_for_output(reply_mailbox: &str) -> String {
+    format!("{reply_mailbox}.output")
+}
+
+pub(crate) fn reply_mailbox_for_result(reply_mailbox: &str) -> String {
+    format!("{reply_mailbox}.result")
+}

--- a/lib/veritech/src/server.rs
+++ b/lib/veritech/src/server.rs
@@ -1,9 +1,9 @@
 pub use self::config::{
-    Config, ConfigBuilder, ConfigError, ConfigFile, CycloneStream, StandardConfig,
+    Config, ConfigBuilder, ConfigError, ConfigFile, CycloneSpec, CycloneStream, StandardConfig,
     StandardConfigFile,
 };
 pub(crate) use self::publisher::{Publisher, PublisherError};
-pub use self::server::Server;
+pub use self::server::{Server, ServerError};
 pub(crate) use self::subscriber::{Request, Subscriber, SubscriberError};
 
 mod config;

--- a/lib/veritech/src/server/subscriber.rs
+++ b/lib/veritech/src/server/subscriber.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use cyclone::resolver_function::ResolverFunctionRequest;
+use deadpool_cyclone::ResolverFunctionRequest;
 use futures::{Stream, StreamExt};
 use futures_lite::FutureExt;
 use pin_project_lite::pin_project;


### PR DESCRIPTION
To try this out:

```sh
 # ensure that lang-js is built
(cd bin/lang-js && npm install && npm run package)
 # build the project, most importantly cyclone
cargo build
 # run the test from lib/veritech
cd lib/veritech
 # test is currently ignored as it doesn't terminate correctly
env RUST_LOG=debug cargo test --all-features -- --nocapture --ignored
```
References: add a javscript function call that returns [sc-2016]

<img src="https://media2.giphy.com/media/YtbH63GKxLwYw/giphy.gif"/>