### PR TITLE
feat(web,dal): return true validations

### DIFF
--- a/lib/dal/src/queries/validation_resolver_find_values_for_context.sql
+++ b/lib/dal/src/queries/validation_resolver_find_values_for_context.sql
@@ -24,11 +24,12 @@ WHERE in_tenancy_v1($1, validation_resolvers.tenancy_universal, validation_resol
     func_binding_return_values.visibility_edit_session_pk, 
     func_binding_return_values.visibility_deleted)
   AND validation_resolvers.prop_id = $3
-   AND (validation_resolvers.component_id = $4 OR validation_resolvers.component_id = -1)
+   AND validation_resolvers.component_id = $4
    AND (validation_resolvers.system_id = $5 OR validation_resolvers.system_id = -1)
 	ORDER BY validation_resolvers.id, 
       visibility_change_set_pk DESC, 
       visibility_edit_session_pk DESC, 
+      prop_id DESC,
       component_id DESC, 
       system_id DESC, 
       schema_variant_id DESC, 


### PR DESCRIPTION
This PR brings validations fully round trip with the frontend, in a way
that shows how it will work, but is a little janky. :) Essentially, we
create a new ValidationResolver for every property that asserts that the
string should be 'poop', or else have an error. The validation itself is
produced by a Func that returns a ValidationError, proving that we can
set validations for a given context, look them up, and return them to
the frontend.

It's kind of awesome, even if it's a bit of a hack.

Signed-off-by: Adam Jacob <adam@systeminit.com>
Co-authored-by: Jacob Helwig <jacob@systeminit.com>