### PR TITLE
feat(dal): validation from schema variant's props

### DIFF
--- a/bin/lang-js/package-lock.json
+++ b/bin/lang-js/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lang-js",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -34,6 +34,7 @@ pub mod tenancy;
 pub mod test_harness;
 pub mod timestamp;
 pub mod user;
+pub mod validation_prototype;
 pub mod validation_resolver;
 pub mod visibility;
 pub mod workspace;
@@ -80,6 +81,9 @@ pub use system::{System, SystemError, SystemId, SystemPk, SystemResult};
 pub use tenancy::{Tenancy, TenancyError};
 pub use timestamp::{Timestamp, TimestampError};
 pub use user::{User, UserClaim, UserError, UserId, UserResult};
+pub use validation_prototype::{
+    ValidationPrototype, ValidationPrototypeError, ValidationPrototypeId,
+};
 pub use validation_resolver::{ValidationResolver, ValidationResolverError, ValidationResolverId};
 pub use visibility::{Visibility, VisibilityError};
 pub use workspace::{Workspace, WorkspaceError, WorkspaceId, WorkspacePk, WorkspaceResult};
@@ -120,8 +124,8 @@ pub async fn migrate_builtin_schemas(pg: &PgPool, nats: &NatsClient) -> ModelRes
     let mut conn = pg.get().await?;
     let txn = conn.transaction().await?;
     let nats = nats.transaction();
-    schema::builtins::migrate(&txn, &nats).await?;
     func::builtins::migrate(&txn, &nats).await?;
+    schema::builtins::migrate(&txn, &nats).await?;
     txn.commit().await?;
     nats.commit().await?;
     Ok(())

--- a/lib/dal/src/migrations/U0045__validation_prototypes.sql
+++ b/lib/dal/src/migrations/U0045__validation_prototypes.sql
@@ -1,0 +1,75 @@
+CREATE TABLE validation_prototypes
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    func_id                     bigint                   NOT NULL,
+    args                        jsonb                    NOT NULL,
+    prop_id                     bigint                   NOT NULL,
+    schema_id                   bigint,
+    schema_variant_id           bigint,
+    system_id                   bigint
+);
+SELECT standard_model_table_constraints_v1('validation_prototypes');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('validation_prototypes', 'model', 'validation_prototype', 'Validation Prototype');
+
+CREATE OR REPLACE FUNCTION validation_prototype_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id bigint,
+    this_args jsonb,
+    this_prop_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           validation_prototypes%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO validation_prototypes (tenancy_universal,
+                                     tenancy_billing_account_ids,
+                                     tenancy_organization_ids,
+                                     tenancy_workspace_ids,
+                                     visibility_change_set_pk,
+                                     visibility_edit_session_pk,
+                                     visibility_deleted,
+                                     func_id,
+                                     args,
+                                     prop_id,
+                                     schema_id,
+                                     schema_variant_id,
+                                     system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_func_id,
+            this_args,
+            this_prop_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/validation_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/validation_prototype_find_for_context.sql
@@ -1,0 +1,22 @@
+SELECT DISTINCT ON (validation_prototypes.id) validation_prototypes.id,
+                              validation_prototypes.prop_id,
+                              validation_prototypes.schema_id,
+                              validation_prototypes.schema_variant_id,
+                              validation_prototypes.system_id,
+                              validation_prototypes.visibility_change_set_pk,
+                              validation_prototypes.visibility_edit_session_pk,
+                              row_to_json(validation_prototypes.*) AS object
+FROM validation_prototypes
+WHERE in_tenancy_v1($1, validation_prototypes.tenancy_universal, validation_prototypes.tenancy_billing_account_ids, validation_prototypes.tenancy_organization_ids,
+                    validation_prototypes.tenancy_workspace_ids)
+  AND is_visible_v1($2, validation_prototypes.visibility_change_set_pk, validation_prototypes.visibility_edit_session_pk, validation_prototypes.visibility_deleted)
+  AND validation_prototypes.prop_id = $3
+  AND (validation_prototypes.system_id = $4 OR validation_prototypes.system_id = -1)
+  ORDER BY validation_prototypes.id,
+           visibility_change_set_pk DESC,
+           visibility_edit_session_pk DESC,
+           prop_id DESC,
+           func_id DESC,
+           system_id DESC,
+           schema_variant_id DESC,
+           schema_id DESC;

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -17,7 +17,7 @@ use crate::{
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
     BillingAccount, BillingAccountId, Component, HistoryActor, HistoryEventError, LabelEntry,
     LabelList, Organization, OrganizationId, PropError, StandardModel, StandardModelError, Tenancy,
-    Timestamp, Visibility, Workspace, WorkspaceId, WsEventError,
+    Timestamp, ValidationPrototypeError, Visibility, Workspace, WorkspaceId, WsEventError,
 };
 
 use crate::socket::SocketError;
@@ -58,6 +58,10 @@ pub enum SchemaError {
     Variant(#[from] SchemaVariantError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
+    #[error("missing a func in attribute update: {0} not found")]
+    MissingFunc(String),
+    #[error("validation prototype error: {0}")]
+    ValidationPrototype(#[from] ValidationPrototypeError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;

--- a/lib/dal/src/validation_prototype.rs
+++ b/lib/dal/src/validation_prototype.rs
@@ -1,0 +1,196 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::FuncId,
+    impl_standard_model, pk,
+    standard_model::{self, objects_from_rows},
+    standard_model_accessor, HistoryActor, HistoryEventError, PropId, SchemaId, SchemaVariantId,
+    StandardModel, StandardModelError, SystemId, Tenancy, Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum ValidationPrototypeError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type ValidationPrototypeResult<T> = Result<T, ValidationPrototypeError>;
+
+pub const UNSET_ID_VALUE: i64 = -1;
+const FIND_VALUES_FOR_CONTEXT: &str =
+    include_str!("./queries/validation_prototype_find_for_context.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ValidationPrototypeContext {
+    prop_id: PropId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+}
+
+// Hrm - is this a universal resolver context? -- Adam
+impl Default for ValidationPrototypeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ValidationPrototypeContext {
+    pub fn new() -> Self {
+        Self {
+            prop_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    pub fn prop_id(&self) -> PropId {
+        self.prop_id
+    }
+
+    pub fn set_prop_id(&mut self, prop_id: PropId) {
+        self.prop_id = prop_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(ValidationPrototypePk);
+pk!(ValidationPrototypeId);
+
+// An ValidationPrototype joins a `Func` to the context in which
+// the component that is created with it can use to generate a ValidationResolver.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ValidationPrototype {
+    pk: ValidationPrototypePk,
+    id: ValidationPrototypeId,
+    func_id: FuncId,
+    args: serde_json::Value,
+    #[serde(flatten)]
+    context: ValidationPrototypeContext,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: ValidationPrototype,
+    pk: ValidationPrototypePk,
+    id: ValidationPrototypeId,
+    table_name: "validation_prototypes",
+    history_event_label_base: "validation_prototype",
+    history_event_message_name: "Validation Prototype"
+}
+
+impl ValidationPrototype {
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        func_id: FuncId,
+        args: serde_json::Value,
+        context: ValidationPrototypeContext,
+    ) -> ValidationPrototypeResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM validation_prototype_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    &tenancy,
+                    &visibility,
+                    &func_id,
+                    &args,
+                    &context.prop_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(func_id, Pk(FuncId), ValidationPrototypeResult);
+    standard_model_accessor!(args, Json<JsonValue>, ValidationPrototypeResult);
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_for_prop(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        prop_id: PropId,
+        system_id: SystemId,
+    ) -> ValidationPrototypeResult<Vec<Self>> {
+        let rows = txn
+            .query(
+                FIND_VALUES_FOR_CONTEXT,
+                &[&tenancy, &visibility, &prop_id, &system_id],
+            )
+            .await?;
+        let object = objects_from_rows(rows)?;
+        Ok(object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ValidationPrototypeContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = ValidationPrototypeContext::new();
+        c.set_prop_id(22.into());
+        assert_eq!(c.prop_id(), 22.into());
+    }
+}


### PR DESCRIPTION
Creates a ValidationPrototype that is associated with a schema's variant's prop,
then a ValidationResolver can actually be dynamically created on field update