### PR TITLE
refactor(cyclone,veritech): unify `OutputStream` & common types

### DIFF
--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -410,14 +410,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        qualification_check::{
-            Component, QualificationCheckExecutingMessage, QualificationCheckResult,
-        },
-        resolver_function::{
-            ResolverFunctionExecutingMessage, ResolverFunctionRequest, ResolverFunctionResult,
-        },
+        qualification_check::Component,
+        resolver_function::ResolverFunctionRequest,
         server::{Config, ConfigBuilder, UdsIncomingStream},
-        Server,
+        FunctionResult, ProgressMessage, Server,
     };
 
     fn rand_uds() -> TempPath {
@@ -670,7 +666,7 @@ mod tests {
 
         // Consume the output messages
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "i like")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -678,7 +674,7 @@ mod tests {
             None => panic!("output stream ended early"),
         };
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "my butt")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -688,7 +684,7 @@ mod tests {
         // TODO(fnichol): until we've determined how to handle processing the result server side,
         // we're going to see a heartbeat come back when a request is processed
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::Heartbeat)) => assert!(true),
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
             Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
             None => panic!("output stream ended early"),
@@ -700,11 +696,11 @@ mod tests {
         // Get the result
         let result = progress.finish().await.expect("failed to return result");
         match result {
-            ResolverFunctionResult::Success(success) => {
+            FunctionResult::Success(success) => {
                 assert_eq!(success.unset, false);
                 assert_eq!(success.data, json!({"a": "b"}));
             }
-            ResolverFunctionResult::Failure(failure) => {
+            FunctionResult::Failure(failure) => {
                 panic!("result should be success; failure={:?}", failure)
             }
         }
@@ -742,7 +738,7 @@ mod tests {
 
         // Consume the output messages
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "i like")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -750,7 +746,7 @@ mod tests {
             None => panic!("output stream ended early"),
         };
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "my butt")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -760,7 +756,7 @@ mod tests {
         // TODO(fnichol): until we've determined how to handle processing the result server side,
         // we're going to see a heartbeat come back when a request is processed
         match progress.next().await {
-            Some(Ok(ResolverFunctionExecutingMessage::Heartbeat)) => assert!(true),
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
             Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
             None => panic!("output stream ended early"),
@@ -772,11 +768,11 @@ mod tests {
         // Get the result
         let result = progress.finish().await.expect("failed to return result");
         match result {
-            ResolverFunctionResult::Success(success) => {
+            FunctionResult::Success(success) => {
                 assert_eq!(success.unset, false);
                 assert_eq!(success.data, json!({"a": "b"}));
             }
-            ResolverFunctionResult::Failure(failure) => {
+            FunctionResult::Failure(failure) => {
                 panic!("result should be success; failure={:?}", failure)
             }
         }
@@ -821,7 +817,7 @@ mod tests {
 
         // Consume the output messages
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "i like")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -829,7 +825,7 @@ mod tests {
             None => panic!("output stream ended early"),
         };
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "my butt")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -839,7 +835,7 @@ mod tests {
         // TODO(fnichol): until we've determined how to handle processing the result server side,
         // we're going to see a heartbeat come back when a request is processed
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::Heartbeat)) => assert!(true),
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
             Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
             None => panic!("output stream ended early"),
@@ -851,11 +847,11 @@ mod tests {
         // Get the result
         let result = progress.finish().await.expect("failed to return result");
         match result {
-            QualificationCheckResult::Success(success) => {
+            FunctionResult::Success(success) => {
                 assert_eq!(success.qualified, true);
                 assert_eq!(success.output, None);
             }
-            QualificationCheckResult::Failure(failure) => {
+            FunctionResult::Failure(failure) => {
                 panic!("result should be success; failure={:?}", failure)
             }
         }
@@ -902,7 +898,7 @@ mod tests {
 
         // Consume the output messages
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "i like")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -910,7 +906,7 @@ mod tests {
             None => panic!("output stream ended early"),
         };
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::OutputStream(output))) => {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(output.message, "my butt")
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -920,7 +916,7 @@ mod tests {
         // TODO(fnichol): until we've determined how to handle processing the result server side,
         // we're going to see a heartbeat come back when a request is processed
         match progress.next().await {
-            Some(Ok(QualificationCheckExecutingMessage::Heartbeat)) => assert!(true),
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
             Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
             None => panic!("output stream ended early"),
@@ -932,11 +928,11 @@ mod tests {
         // Get the result
         let result = progress.finish().await.expect("failed to return result");
         match result {
-            QualificationCheckResult::Success(success) => {
+            FunctionResult::Success(success) => {
                 assert_eq!(success.qualified, true);
                 assert_eq!(success.output, None);
             }
-            QualificationCheckResult::Failure(failure) => {
+            FunctionResult::Failure(failure) => {
                 panic!("result should be success; failure={:?}", failure)
             }
         }

--- a/lib/cyclone/src/client/qualification_check.rs
+++ b/lib/cyclone/src/client/qualification_check.rs
@@ -13,9 +13,9 @@ pub use tokio_tungstenite::tungstenite::{
     protocol::frame::CloseFrame as WebSocketCloseFrame, Message as WebSocketMessage,
 };
 
-use crate::qualification_check::{
-    QualificationCheckExecutingMessage, QualificationCheckMessage, QualificationCheckRequest,
-    QualificationCheckResult,
+use crate::{
+    FunctionResult, Message, ProgressMessage, QualificationCheckRequest,
+    QualificationCheckResultSuccess,
 };
 
 pub fn execute<T>(
@@ -38,7 +38,7 @@ pub enum QualificationCheckExecutionError {
     #[error("unexpected websocket message after finish was sent: {0}")]
     MessageAfterFinish(WebSocketMessage),
     #[error("unexpected qualification check message before start was sent: {0:?}")]
-    MessageBeforeStart(QualificationCheckMessage),
+    MessageBeforeStart(Message<QualificationCheckResultSuccess>),
     #[error("unexpected websocket message type: {0}")]
     UnexpectedMessageType(WebSocketMessage),
     #[error("websocket stream is closed, but finish was not sent")]
@@ -66,10 +66,10 @@ where
     pub async fn start(mut self) -> Result<QualificationCheckExecutionStarted<T>> {
         match self.stream.next().await {
             Some(Ok(WebSocketMessage::Text(json_str))) => {
-                let msg = QualificationCheckMessage::deserialize_from_str(&json_str)
+                let msg = Message::deserialize_from_str(&json_str)
                     .map_err(QualificationCheckExecutionError::JSONDeserialize)?;
                 match msg {
-                    QualificationCheckMessage::Start => {
+                    Message::Start => {
                         // received correct message, so proceed
                     }
                     unexpected => {
@@ -113,14 +113,14 @@ impl<T> From<QualificationCheckExecution<T>> for QualificationCheckExecutionStar
 #[derive(Debug)]
 pub struct QualificationCheckExecutionStarted<T> {
     stream: WebSocketStream<T>,
-    result: Option<QualificationCheckResult>,
+    result: Option<FunctionResult<QualificationCheckResultSuccess>>,
 }
 
 impl<T> QualificationCheckExecutionStarted<T>
 where
     T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
-    pub async fn finish(self) -> Result<QualificationCheckResult> {
+    pub async fn finish(self) -> Result<FunctionResult<QualificationCheckResultSuccess>> {
         QualificationCheckExecutionClosing::try_from(self)?
             .finish()
             .await
@@ -131,38 +131,34 @@ impl<T> Stream for QualificationCheckExecutionStarted<T>
 where
     T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
-    type Item = Result<QualificationCheckExecutingMessage>;
+    type Item = Result<ProgressMessage>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.stream.next()).poll(cx) {
             // We successfully got a websocket text message
             Poll::Ready(Some(Ok(WebSocketMessage::Text(json_str)))) => {
-                let msg = QualificationCheckMessage::deserialize_from_str(&json_str)
+                let msg = Message::deserialize_from_str(&json_str)
                     .map_err(QualificationCheckExecutionError::JSONDeserialize)?;
                 match msg {
                     // We got a heartbeat message, pass it on
-                    QualificationCheckMessage::Heartbeat => {
-                        Poll::Ready(Some(Ok(QualificationCheckExecutingMessage::Heartbeat)))
-                    }
+                    Message::Heartbeat => Poll::Ready(Some(Ok(ProgressMessage::Heartbeat))),
                     // We got an output message, pass it on
-                    QualificationCheckMessage::OutputStream(output_stream) => {
-                        Poll::Ready(Some(Ok(QualificationCheckExecutingMessage::OutputStream(
-                            output_stream,
-                        ))))
+                    Message::OutputStream(output_stream) => {
+                        Poll::Ready(Some(Ok(ProgressMessage::OutputStream(output_stream))))
                     }
                     // We got a funtion result message, save it and continue
-                    QualificationCheckMessage::Result(function_result) => {
+                    Message::Result(function_result) => {
                         self.result = Some(function_result);
                         // TODO(fnichol): what is the right return here??
                         // (future fnichol): hey buddy! pretty sure you can:
                         // `cx.waker().wake_by_ref()` before returning Poll::Ready which immediatly
                         // re-wakes this stream to maybe pop another item off. cool huh? I think
                         // you're learning and that's great.
-                        Poll::Ready(Some(Ok(QualificationCheckExecutingMessage::Heartbeat)))
+                        Poll::Ready(Some(Ok(ProgressMessage::Heartbeat)))
                         //Poll::Pending
                     }
                     // We got a finish message
-                    QualificationCheckMessage::Finish => {
+                    Message::Finish => {
                         if self.result.is_some() {
                             // If we have saved the result, then close this stream out
                             Poll::Ready(None)
@@ -200,7 +196,7 @@ where
 #[derive(Debug)]
 pub struct QualificationCheckExecutionClosing<T> {
     stream: WebSocketStream<T>,
-    result: QualificationCheckResult,
+    result: FunctionResult<QualificationCheckResultSuccess>,
 }
 
 impl<T> TryFrom<QualificationCheckExecutionStarted<T>> for QualificationCheckExecutionClosing<T> {
@@ -221,7 +217,7 @@ impl<T> QualificationCheckExecutionClosing<T>
 where
     T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
-    async fn finish(mut self) -> Result<QualificationCheckResult> {
+    async fn finish(mut self) -> Result<FunctionResult<QualificationCheckResultSuccess>> {
         match self.stream.next().await {
             Some(Ok(WebSocketMessage::Close(_))) | None => Ok(self.result),
             Some(Ok(unexpected)) => Err(QualificationCheckExecutionError::MessageAfterFinish(

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -13,12 +13,19 @@
 
 pub mod canonical_command;
 mod liveness;
-pub mod qualification_check;
+mod progress;
+mod qualification_check;
 mod readiness;
-pub mod resolver_function;
+mod resolver_function;
 
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
+pub use progress::{
+    FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,
+    ProgressMessage,
+};
+pub use qualification_check::{QualificationCheckRequest, QualificationCheckResultSuccess};
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
+pub use resolver_function::{ResolverFunctionRequest, ResolverFunctionResultSuccess};
 
 #[cfg(feature = "process")]
 pub mod process;

--- a/lib/cyclone/src/progress.rs
+++ b/lib/cyclone/src/progress.rs
@@ -1,0 +1,109 @@
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+
+/// A line of output, streamed from an executing function.
+///
+/// An instance of this type typically maps to a single line of output from a process--either on
+/// standard output or standard error.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OutputStream {
+    /// The stream name.
+    ///
+    /// Typically set to `stdout`/`stderr` for process oriented output, but currently remains
+    /// free-form.
+    pub stream: String,
+    /// An identifier for the execution of a particular function.
+    ///
+    /// Every function execution is given an indentifier, so that at least around execution time
+    /// (i.e. possibly not forever and for all time), all output with the same execution ID can be
+    /// reasonably assumed to be generated from the same function.
+    pub execution_id: String,
+    /// A "loglevel" tag for the output line.
+    ///
+    /// Level mimics the log level used in logging and tracing frameworks so level values such as
+    /// `"info"`, `"debug"` are suitable but currently remains free-form.
+    pub level: String,
+    /// An option tag to help group together output.
+    ///
+    /// Group can be used upstream (i.e. a frontend UI) to group sets of `OutputStream`s together.
+    pub group: Option<String>,
+    /// An optional bundle of lightly structured data.
+    ///
+    /// Data mimics the data parameter in JavaScript's `console.log()` function.
+    pub data: Option<Value>,
+    /// The contents of the output line.
+    pub message: String,
+    /// A timestamp in seconds since UNIX epoch.
+    ///
+    /// The timestamp generated locally when the message was created.
+    pub timestamp: u64,
+}
+
+/// A message produced as a function is executing.
+///
+/// A `ProgressMessage` is a way to track and follow how an execution is progressing. Such messages
+/// can be produced up until a result is generated.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ProgressMessage {
+    /// A heartbeat message.
+    ///
+    /// This message can be used to signal "execution presence" (that is, the producer of such
+    /// message is still alive and making progress).
+    Heartbeat,
+    /// An `OutputStream` message.
+    OutputStream(OutputStream),
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Message<R> {
+    Start,
+    Finish,
+    Heartbeat,
+    Fail(Fail),
+    OutputStream(OutputStream),
+    Result(FunctionResult<R>),
+}
+
+impl<R> Message<R>
+where
+    R: Serialize + DeserializeOwned,
+{
+    pub fn fail(message: impl Into<String>) -> Self {
+        Self::Fail(Fail {
+            message: message.into(),
+        })
+    }
+
+    pub fn deserialize_from_str(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+
+    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum FunctionResult<S> {
+    Success(S),
+    Failure(FunctionResultFailure),
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FunctionResultFailure {
+    pub execution_id: String,
+    pub error: FunctionResultFailureError,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FunctionResultFailureError {
+    pub kind: String,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Fail {
+    pub message: String,
+}

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -30,77 +30,9 @@ pub struct Component {
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum QualificationCheckMessage {
-    Start,
-    Finish,
-    Heartbeat,
-    Fail(Fail),
-    OutputStream(OutputStream),
-    Result(QualificationCheckResult),
-}
-
-impl QualificationCheckMessage {
-    pub fn fail(message: impl Into<String>) -> Self {
-        Self::Fail(Fail {
-            message: message.into(),
-        })
-    }
-
-    pub fn deserialize_from_str(s: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(s)
-    }
-
-    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(self)
-    }
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum QualificationCheckExecutingMessage {
-    Heartbeat,
-    OutputStream(OutputStream),
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct OutputStream {
-    pub stream: String,
-    pub execution_id: String,
-    pub level: String,
-    pub group: Option<String>,
-    pub data: Option<Value>,
-    pub message: String,
-    pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum QualificationCheckResult {
-    Success(QualificationCheckResultSuccess),
-    Failure(QualificationCheckResultFailure),
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QualificationCheckResultSuccess {
     pub execution_id: String,
     pub qualified: bool,
     pub output: Option<String>,
     pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct QualificationCheckResultFailure {
-    pub execution_id: String,
-    pub error: QualificationCheckResultFailureError,
-    pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct QualificationCheckResultFailureError {
-    pub kind: String,
-    pub message: String,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Fail {
-    pub message: String,
 }

--- a/lib/cyclone/src/resolver_function.rs
+++ b/lib/cyclone/src/resolver_function.rs
@@ -23,77 +23,9 @@ impl ResolverFunctionRequest {
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum ResolverFunctionMessage {
-    Start,
-    Finish,
-    Heartbeat,
-    Fail(Fail),
-    OutputStream(OutputStream),
-    Result(ResolverFunctionResult),
-}
-
-impl ResolverFunctionMessage {
-    pub fn fail(message: impl Into<String>) -> Self {
-        Self::Fail(Fail {
-            message: message.into(),
-        })
-    }
-
-    pub fn deserialize_from_str(s: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(s)
-    }
-
-    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(self)
-    }
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum ResolverFunctionExecutingMessage {
-    Heartbeat,
-    OutputStream(OutputStream),
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct OutputStream {
-    pub stream: String,
-    pub execution_id: String,
-    pub level: String,
-    pub group: Option<String>,
-    pub data: Option<Value>,
-    pub message: String,
-    pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum ResolverFunctionResult {
-    Success(ResolverFunctionResultSuccess),
-    Failure(ResolverFunctionResultFailure),
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ResolverFunctionResultSuccess {
     pub execution_id: String,
     pub data: Value,
     pub unset: bool,
     pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ResolverFunctionResultFailure {
-    pub execution_id: String,
-    pub error: ResolverFunctionResultFailureError,
-    pub timestamp: u64,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ResolverFunctionResultFailureError {
-    pub kind: String,
-    pub message: String,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Fail {
-    pub message: String,
 }

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -5,7 +5,7 @@ use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::mpsc;
-use veritech::{Client, OutputStream, ResolverFunctionRequest, ResolverFunctionResult};
+use veritech::{Client, FunctionResult, OutputStream, ResolverFunctionRequest};
 
 use crate::{edit_field::ToSelectWidget, label_list::ToLabelList};
 
@@ -189,7 +189,7 @@ impl FuncBackendJsString {
             .await
             .map_err(|err| span.record_err(err))?;
         let value = match result {
-            ResolverFunctionResult::Success(success) => {
+            FunctionResult::Success(success) => {
                 if success.unset {
                     return Err(span.record_err(FuncBackendError::UnexpectedUnset));
                 }
@@ -198,7 +198,7 @@ impl FuncBackendJsString {
                 }
                 success.data
             }
-            ResolverFunctionResult::Failure(failure) => {
+            FunctionResult::Failure(failure) => {
                 return Err(span.record_err(FuncBackendError::ResultFailure {
                     kind: failure.error.kind,
                     message: failure.error.message,

--- a/lib/deadpool-cyclone/examples/deadpool-cyclone-qualification-check-pool.rs
+++ b/lib/deadpool-cyclone/examples/deadpool-cyclone-qualification-check-pool.rs
@@ -4,7 +4,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use cyclone::qualification_check::{QualificationCheckExecutingMessage, QualificationCheckResult};
+use cyclone::{FunctionResult, ProgressMessage};
 use deadpool_cyclone::{
     client::{CycloneClient, QualificationCheckRequest},
     instance::{
@@ -115,8 +115,8 @@ async fn execute(
         .await?;
     while let Some(message) = progress.try_next().await? {
         match message {
-            QualificationCheckExecutingMessage::Heartbeat => info!("heartbeat"),
-            QualificationCheckExecutingMessage::OutputStream(output) => {
+            ProgressMessage::Heartbeat => info!("heartbeat"),
+            ProgressMessage::OutputStream(output) => {
                 info!(
                     execution_id = &output.execution_id.as_str(),
                     stream = &output.stream.as_str(),
@@ -130,13 +130,13 @@ async fn execute(
     }
     let result = progress.finish().await?;
     match result {
-        QualificationCheckResult::Success(success) => info!(
+        FunctionResult::Success(success) => info!(
                 execution_id = &success.execution_id.as_str(),
                 qualified = success.qualified,
                 output = ?success.output,
                 timestamp = success.timestamp,
         ),
-        QualificationCheckResult::Failure(failure) => error!(
+        FunctionResult::Failure(failure) => error!(
             execution_id = &failure.execution_id.as_str(),
             error_kind = &failure.error.kind.as_str(),
             error_message = &failure.error.message.as_str(),

--- a/lib/deadpool-cyclone/examples/deadpool-cyclone-resolver-function-pool.rs
+++ b/lib/deadpool-cyclone/examples/deadpool-cyclone-resolver-function-pool.rs
@@ -4,7 +4,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use cyclone::resolver_function::{ResolverFunctionExecutingMessage, ResolverFunctionResult};
+use cyclone::{FunctionResult, ProgressMessage};
 use deadpool_cyclone::{
     client::{CycloneClient, ResolverFunctionRequest},
     instance::{
@@ -111,8 +111,8 @@ async fn execute(
     let mut progress = instance.execute_resolver(request).await?.start().await?;
     while let Some(message) = progress.try_next().await? {
         match message {
-            ResolverFunctionExecutingMessage::Heartbeat => info!("heartbeat"),
-            ResolverFunctionExecutingMessage::OutputStream(output) => {
+            ProgressMessage::Heartbeat => info!("heartbeat"),
+            ProgressMessage::OutputStream(output) => {
                 info!(
                     execution_id = &output.execution_id.as_str(),
                     stream = &output.stream.as_str(),
@@ -126,13 +126,13 @@ async fn execute(
     }
     let result = progress.finish().await?;
     match result {
-        ResolverFunctionResult::Success(success) => info!(
+        FunctionResult::Success(success) => info!(
                 execution_id = &success.execution_id.as_str(),
                 data = ?success.data,
                 unset = success.unset,
                 timestamp = success.timestamp,
         ),
-        ResolverFunctionResult::Failure(failure) => error!(
+        FunctionResult::Failure(failure) => error!(
             execution_id = &failure.execution_id.as_str(),
             error_kind = &failure.error.kind.as_str(),
             error_message = &failure.error.message.as_str(),

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -13,9 +13,8 @@ use cyclone::{
         UnixStream, Watch, WatchError, WatchStarted,
     },
     process::{self, ShutdownError},
-    qualification_check::QualificationCheckRequest,
-    resolver_function::ResolverFunctionRequest,
-    Client, ClientError, CycloneClient, LivenessStatus, ReadinessStatus, UdsClient,
+    Client, ClientError, CycloneClient, LivenessStatus, QualificationCheckRequest, ReadinessStatus,
+    ResolverFunctionRequest, UdsClient,
 };
 use derive_builder::Builder;
 use futures::StreamExt;

--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -23,11 +23,8 @@ pub use self::instance::{Instance, Spec};
 
 pub use cyclone::{
     client::{self, ResolverFunctionExecutionError},
-    resolver_function::{
-        OutputStream, ResolverFunctionExecutingMessage, ResolverFunctionRequest,
-        ResolverFunctionResult,
-    },
-    CycloneClient,
+    CycloneClient, OutputStream, ProgressMessage, QualificationCheckRequest,
+    ResolverFunctionRequest,
 };
 
 /// [`Instance`] implementations.

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -24,9 +24,7 @@ pub mod client;
 #[cfg(feature = "client")]
 pub use client::{Client, ClientError, ClientResult};
 #[cfg(feature = "client")]
-pub use cyclone::resolver_function::{
-    OutputStream, ResolverFunctionRequest, ResolverFunctionResult, ResolverFunctionResultFailure,
-};
+pub use cyclone::{FunctionResult, OutputStream, ResolverFunctionRequest};
 
 pub(crate) const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";
 

--- a/lib/veritech/src/server/config.rs
+++ b/lib/veritech/src/server/config.rs
@@ -92,6 +92,7 @@ fn create_hardcoded_cyclone_spec() -> Result<CycloneSpec> {
             .try_lang_server_cmd_path(lang_server_cmd_path)
             .map_err(|err| ConfigError::CycloneSpecBuild(Box::new(err)))?
             .resolver()
+            .qualification()
             .build()
             .map_err(|err| ConfigError::CycloneSpecBuild(Box::new(err)))?,
     ))

--- a/lib/veritech/src/server/publisher.rs
+++ b/lib/veritech/src/server/publisher.rs
@@ -1,4 +1,5 @@
-use deadpool_cyclone::{OutputStream, ResolverFunctionResult};
+use cyclone::FunctionResult;
+use deadpool_cyclone::OutputStream;
 use serde::Serialize;
 use si_data::NatsClient;
 use thiserror::Error;
@@ -53,7 +54,10 @@ impl<'a> Publisher<'a> {
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_output.clone()))
     }
 
-    pub async fn publish_result(&self, result: &impl Resultable) -> Result<()> {
+    pub async fn publish_result<R>(&self, result: &FunctionResult<R>) -> Result<()>
+    where
+        R: Serialize,
+    {
         let nats_msg = serde_json::to_string(result).map_err(PublisherError::JSONSerialize)?;
 
         self.nats
@@ -62,6 +66,3 @@ impl<'a> Publisher<'a> {
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_result.clone()))
     }
 }
-
-pub trait Resultable: Serialize {}
-impl Resultable for ResolverFunctionResult {}

--- a/lib/veritech/src/server/server.rs
+++ b/lib/veritech/src/server/server.rs
@@ -1,6 +1,6 @@
 use deadpool_cyclone::{
-    instance::cyclone::LocalUdsInstanceSpec, CycloneClient, Manager, Pool,
-    ResolverFunctionExecutingMessage, ResolverFunctionRequest,
+    instance::cyclone::LocalUdsInstanceSpec, CycloneClient, Manager, Pool, ProgressMessage,
+    ResolverFunctionRequest,
 };
 use futures::StreamExt;
 use si_data::NatsClient;
@@ -134,10 +134,10 @@ async fn resolver_function_request(
 
     while let Some(msg) = progress.next().await {
         match msg {
-            Ok(ResolverFunctionExecutingMessage::OutputStream(output)) => {
+            Ok(ProgressMessage::OutputStream(output)) => {
                 publisher.publish_output(&output).await?;
             }
-            Ok(ResolverFunctionExecutingMessage::Heartbeat) => {
+            Ok(ProgressMessage::Heartbeat) => {
                 trace!("received heartbeat message");
             }
             Err(e) => todo!("deal with this: {:?}", e),


### PR DESCRIPTION
This change combines ResolverFunction and QualificationCheck
`OutputStream` types into a single type and unifies the notion of a
`ProgressMessage` and common result failure types.

The combined types are in `lib/cyclone/src/progress.rs` and most of the
changes are the fallout from there. ;)

References: add the veritech client server call to dispatch [sc-2117]

<img src="https://media1.giphy.com/media/pCt1CBOZJ3aMw/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>