### PR TITLE
chore(dal): Add a JS qualification that always passes

### DIFF
--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -52,6 +52,7 @@ pub enum FuncBackendKind {
     Unset,
     //Json,
     //Js,
+    JsQualification,
     JsString,
     ValidateStringValue,
 }
@@ -78,6 +79,7 @@ pub enum FuncBackendResponseType {
     //Array,
     Unset,
     //Json,
+    Qualification,
     Validation,
 }
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -207,6 +207,8 @@ impl FuncBinding {
                 Some(return_value)
             }
             FuncBackendKind::Unset => None,
+            // TODO: Gonna need to ship this off to veritech to be handled externally.
+            FuncBackendKind::JsQualification => unimplemented!(),
             FuncBackendKind::ValidateStringValue => {
                 let args: FuncBackendValidateStringValueArgs =
                     serde_json::from_value(self.args.clone())?;


### PR DESCRIPTION
This isn't terribly useful, but it does allow us to test fully round-tripping qualifications through the system,  including running JS code.