### PR TITLE
feat(qualification,bootstrap): add qual service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,32 @@ This is a monolithic repository containing the source for System Initiative (SI)
 
 ## Supported Developer Environments
 
-* Arch Linux `(x86_64 / amd64)`
-* Fedora `(x86_64 / amd64)`
-* macOS `(arm64 / aarch64)`
-* macOS `(x86_64 / amd64)`
-* Ubuntu `(x86_64 / amd64)`
-* WSL2 `(x86_64 / amd64)`
-
-> If your preferred environment is not listed, please feel free to add it once the following conditions have been met:
->
-> 1. It's been added to the idempotent [bootstrap script](./scripts/bootstrap.sh)
-> 2. The aforementioned script has been tested and remains idempotent
-> 3. Running the **Quickstart** steps below is successful and the UI is fully functional
->
-> _Please note:_ adding your preferred environment will also add you as a maintainer of its functionality throughout this repository.
-> If unsure where to start, you can look at a [PR from the past](https://github.com/systeminit/si/pull/589) to help.
+Environment | `x84_64 (amd64)` | `aarch64 (arm64)` | Validated On
+--- | --- | --- | ---
+Arch Linux | ✅ | 🚫 | desktop
+Fedora | ✅ | 🚫 | server-side (EC2)
+macOS | ✅ | ✅ | desktop
+Pop!_OS | ✅ | 🚫 | desktop
+Ubuntu | ✅ | 🚫 | desktop
+WSL2 | ✅ | 🚫 | desktop
 
 We recommend using the latest stable Rust toolchain and latest LTS Node toolchain for your environment.
 If unsure, the following tools are recommended to help manage your toolchains:
 
 * [**rustup**](https://rustup.rs) 🦀: Rust, `cargo`, etc.
 * [**volta**](https://volta.sh) ⚡: `node`, `npm`, etc.
+
+### Preferred Environment Not Listed
+
+If your preferred environment is not listed, please feel free to add it once the following conditions have been met:
+
+1. It's been added to the idempotent [bootstrap script](./scripts/bootstrap.sh)
+2. The aforementioned script has been tested and remains idempotent
+3. Running the **Quickstart** steps below is successful and the UI is fully functional
+
+_Please note:_ adding your preferred environment will also add you as a maintainer of its functionality throughout this repository.
+If unsure where to start, you can look at a [PR from the past](https://github.com/systeminit/si/pull/589) to help.
+If you are no longer using the environment, and you are the sole maintainer of the environment, you must remove it from the bootstrapper and the table above.
 
 ## Quickstart
 
@@ -90,7 +95,7 @@ make down
 ## Prepare Your Changes
 
 Navigate to the `Makefile` in the [ci](./ci) directory to see local development targets.
-These targets include code linting, formating, running CI locally, etc.
+These targets include code linting, formatting, running CI locally, etc.
 For instance, you can tidy up your Rust code before opening a pull request by executing the following:
 
 ```bash
@@ -189,4 +194,5 @@ Welcome to the team! A few handy links:
 
 * [Engineering Team Onboarding](https://docs.google.com/presentation/d/1Ypesl1iZ5KXI9KBxXINYPlo5TexAuln6Dg26yPXEqbM) - the foundation of our team
 * [Engineering Process](https://docs.google.com/document/d/1T3pMkTUX5fhzkBpG4NR3x6DrhZ18xXIjnSYl0g6Ld4o) - how we work together 
+* [Engineering Maxims](https://docs.google.com/document/d/1l-YCyMbXaVAG6VVDucZVJlO7VbJeTAAwt4jB-1usSQA) - some maxims we try to follow
 

--- a/app/web/src/api/sdf/dal/qualification.ts
+++ b/app/web/src/api/sdf/dal/qualification.ts
@@ -1,0 +1,16 @@
+export interface Qualification {
+  name: string;
+  title?: string;
+  link?: string;
+  description?: string;
+  result?: QualificationResult;
+}
+
+export interface QualificationResult {
+  errors: Array<QualificationError>;
+  success: boolean;
+}
+
+export interface QualificationError {
+  message: string;
+}

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -20,16 +20,29 @@
         />
       </div>
 
+      <div class="min-w-max">
+        <button @click="setToAttribute">
+          <VueFeather type="home" stroke="grey" size="1.5rem" />
+        </button>
+      </div>
+
+      <div class="min-w-max">
+        <button @click="setToQualification">
+          <VueFeather type="crosshair" stroke="grey" size="1.5rem" />
+        </button>
+      </div>
+
       <LockButton v-model="isPinned" />
     </template>
 
     <template #content>
+      <!-- FIXME(nick): there is a bug unrelated to the viewer buttons where EditFields will be undefined despite the component ID being valid -->
       <AttributeViewer
-        v-if="selectedComponentId"
+        v-if="selectedComponentId && activeView === 'attribute'"
         :component-id="selectedComponentId"
       />
       <QualificationViewer
-        v-if="selectedComponentId"
+        v-if="selectedComponentId && activeView === 'qualification'"
         :component-id="selectedComponentId"
       />
     </template>
@@ -49,10 +62,10 @@ import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import AttributeViewer from "@/organisims/AttributeViewer.vue";
 import QualificationViewer from "@/organisims/QualificationViewer.vue";
+import VueFeather from "vue-feather";
 
 const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | undefined>(undefined);
-// const attributeViewer = ref<typeof AttributeViewer | null>(null);
 
 defineProps({
   panelIndex: { type: Number, required: true },
@@ -63,6 +76,14 @@ defineProps({
   isVisible: Boolean,
   isMaximizedContainerEnabled: Boolean,
 });
+
+const activeView = ref<string>("attribute");
+const setToAttribute = () => {
+  activeView.value = "attribute";
+};
+const setToQualification = () => {
+  activeView.value = "qualification";
+};
 
 const componentNamesOnlyList = refFrom<LabelList<number>>(
   ComponentService.listComponentsNamesOnly().pipe(
@@ -77,13 +98,3 @@ const componentNamesOnlyList = refFrom<LabelList<number>>(
   ),
 );
 </script>
-
-<style scoped>
-.unlocked {
-  color: #c6c6c6;
-}
-
-.locked {
-  color: #e3ddba;
-}
-</style>

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -1,51 +1,58 @@
 <template>
   <div v-if="componentId" class="flex flex-col w-full">
-    <div
-      class="relative flex flex-row items-center justify-between h-10 pt-2 pb-2 pl-6 pr-6 text-white property-section-bg-color"
-    >
-      <div class="text-lg">COMPONENT_NAME Qualifications</div>
+    <div class="flex">
+      <div>
+        <div>Component ID {{ props.componentId }} Qualifications</div>
+      </div>
+
+      <div class="flex">
+        <button><VueFeather type="refresh-cw" size="1.5rem" /></button>
+        <VueFeather type="check-square" size="1.5rem" />
+      </div>
     </div>
 
-    <div class="flex">RefreshCwIcon CheckSquareIcon</div>
-  </div>
+    <div class="flex flex-col">
+      <div>QualificationChecks Here!</div>
 
-  <div class="flex flex-col mx-4 mt-2 border qualification-card">
-    <div class="px-2 py-2 text-xs font-medium align-middle title">
-      QualificationChecks
-    </div>
+      <div v-if="isSchema" class="flex">
+        <div class="flex flex-col">
+          <div
+            v-for="q in allQualifications"
+            :key="q.name"
+            class="flex flex-col"
+          >
+            <div class="flex flex-row">
+              <div v-if="showQualificationStarting" class="flex">
+                <VueFeather
+                  type="rotate-cw"
+                  animation="spin"
+                  animation-speed="slow"
+                  size="1.5rem"
+                />
+              </div>
+              <div v-else-if="showQualificationResult" class="flex">
+                <VueFeather type="smile" color="green" size="1.5rem" />
+                <VueFeather type="frown" color="red" size="1.5rem" />
+              </div>
+              <div v-else class="flex">
+                <VueFeather type="square" size="1.5rem" />
+              </div>
+              <div class="flex">title: {{ q.title }}</div>
+              <div v-if="showQualificationLink" class="flex">
+                <a target="_blank" :href="q.link">
+                  <VueFeather type="link" size="1.5rem" />
+                </a>
+              </div>
+              <div class="flex flex-grow"></div>
+            </div>
 
-    <div
-      v-if="!schemaEmpty"
-      class="flex w-full h-full pt-2 pb-4 overflow-auto background-color"
-    >
-      <div class="flex flex-col w-full">
-        <div
-          v-for="q in allQualifications"
-          :key="q.name"
-          class="flex flex-col py-1 mx-2 mt-2 text-sm border qualification-section"
-        >
-          <div class="flex flex-row items-center w-full pl-4 my-1">
-            <div v-if="showQualificationStarting" class="flex">VueLoading</div>
-            <div v-else-if="showQualificationResult" class="flex">
-              SmileOrFrownIcon
-            </div>
-            <div v-else class="flex">SquareIcon</div>
-            <div class="flex ml-2 text-xs qualification-check-title">
-              QualificationCheckTitle
-            </div>
-            <div v-if="showQualificationLink" class="flex ml-2">
-              <a target="_blank" :href="link"> InfoIcon </a>
-            </div>
-            <div class="flex justify-end flex-grow pr-4">
-              ToggleDescriptionButton
-            </div>
-          </div>
-        </div>
-
-        <div v-if="showDescription[q.name]" class="flex flex-col w-full">
-          <div v-if="showQualificationResult" class="flex flex-col w-full">
-            <div class="mt-1">
-              <QualificationOutput />
+            <!-- NOTE(nick): showing description should be toggleable. -->
+            <div v-if="q.description" class="flex flex-col">
+              <div v-if="q.result" class="flex flex-col">
+                <div class="border border-solid border-slate-100">
+                  <QualificationOutput :result="q.result" />
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -55,23 +62,20 @@
 </template>
 
 <script setup lang="ts">
-const showDescription = true;
+import { QualificationService } from "@/service/qualification";
+import QualificationOutput from "./QualificationViewer/QualificationOutput.vue";
+import VueFeather from "vue-feather";
+
 const showQualificationResult = true;
 const showQualificationStarting = true;
 const showQualificationLink = true;
-const schemaEmpty = true;
-const link = "https://bit.ly/3qHuTNh";
-
-const allQualifications = [
-  {
-    name: "foo",
-  },
-  {
-    name: "bar",
-  },
-];
+const isSchema = true;
 
 const props = defineProps<{
   componentId: number;
 }>();
+
+const allQualifications = QualificationService.listQualifications(
+  props.componentId,
+);
 </script>

--- a/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
+++ b/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
@@ -1,89 +1,37 @@
 <template>
-  <div class="w-full pb-1">
-    <div v-if="showParseKubeValOutput">
-      <div
-        v-for="o in parseKubevalOutput"
-        :key="o.filename"
-        class="flex flex-col flex-grow"
-      >
-        <div
-          class="flex flex-row items-center px-6 pt-3 pb-1 border-t border-gray-800"
-        >
-          <div class="w-4">CheckIcon</div>
-          <div class="text-xs output-lines">Kind and Status</div>
-        </div>
-        <div
-          v-for="e in o.errors"
-          :key="e"
-          class="flex flex-col pl-10 mb-1 ml-1 text-xs select-text output-lines"
-        >
-          <div class="flex flex-row items-center">
-            AlertTriangleIcon
-            <div class="ml-2 text-xs error">
-              {{ e }}
-            </div>
-          </div>
+  <div>
+    <div v-if="props.result">
+      <div class="flex flex-row">
+        <div><VueFeather type="check" size="1.5rem" /></div>
+        <div class="flex flex-row">
+          <div>Qualification status: (</div>
+          <span v-if="props.result.success">success</span>
+          <span v-else>failure</span>
+          <div>)</div>
         </div>
       </div>
-    </div>
-    <div
-      v-else-if="parseValidFieldsOutput"
-      class="pt-3 pb-4 border-t border-gray-800"
-    >
+
       <div
-        v-for="(validation, fieldName) in parseValidFieldsOutput"
-        :key="fieldName"
+        v-for="error in props.result.errors"
+        :key="error.message"
         class="flex flex-col flex-grow"
       >
-        <div class="flex flex-row items-center px-6 pt-1 text-xs output-lines">
-          <div class="w-4">CheckIcon</div>
+        <div v-if="!props.result.success">
           <div class="flex flex-row">
-            <div class="ml-1">field {{ fieldName }}</div>
-
-            <div class="ml-1 text-xs">(</div>
-            <span v-if="showSuccess" class="success">success</span>
-            <span v-else class="error">failure</span>
-            <div class="">)</div>
+            <VueFeather type="alert-triangle" size="1.5rem" />
+            <div>{{ error.message }}</div>
           </div>
         </div>
-
-        <template v-if="validation && showSuccess">
-          <div
-            v-for="e in validation"
-            :key="e.message"
-            class="flex flex-col pl-10 mt-1 mb-1 ml-2 text-xs select-text output-lines"
-          >
-            <div class="flex flex-row items-center">
-              AlertTriangleIcon
-              <div class="ml-2 error">
-                {{ e.message }}
-              </div>
-            </div>
-          </div>
-        </template>
-      </div>
-    </div>
-
-    <div v-else class="flex flex-col flex-grow border-t border-gray-800">
-      <div class="mt-2 mb-1 ml-2 text-xs font-medium output-title">Output</div>
-      <div
-        class="px-6 text-xs leading-relaxed whitespace-pre-line select-text output-lines"
-      >
-        Data
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-const parseKubevalOutput = [
-  { filename: "foo", errors: [{ message: "poop" }] },
-  { filename: "bar", errors: [{ message: "canoe" }] },
-];
-const parseValidFieldsOutput = [
-  { validation: "success", fieldName: "i like" },
-  { validation: "failure", fieldName: "my butt" },
-];
-const showParseKubeValOutput = true;
-const showSuccess = true;
+import { QualificationResult } from "@/api/sdf/dal/qualification";
+import VueFeather from "vue-feather";
+
+const props = defineProps<{
+  result: QualificationResult;
+}>();
 </script>

--- a/app/web/src/service/qualification.ts
+++ b/app/web/src/service/qualification.ts
@@ -1,0 +1,5 @@
+import { listQualifications } from "./qualification/list_qualifications";
+
+export const QualificationService = {
+  listQualifications,
+};

--- a/app/web/src/service/qualification/list_qualifications.ts
+++ b/app/web/src/service/qualification/list_qualifications.ts
@@ -1,0 +1,16 @@
+import { Qualification } from "@/api/sdf/dal/qualification";
+
+export function listQualifications(componentId: number): Array<Qualification> {
+  console.log(componentId);
+  const qualification = {
+    name: "ilikemybutt",
+    title: "I LIKE MY BUTT",
+    link: "https://bit.ly/3qHuTNh",
+    description: "description of i like my butt",
+    result: {
+      success: false,
+      errors: [{ message: "there's a snake in my boot!" }],
+    },
+  };
+  return [qualification];
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -77,12 +77,16 @@ function ubuntu-bootstrap {
 }
 
 function perform-bootstrap {
-    if [ "$SI_OS" = "darwin" ] && ( [ "$SI_ARCH" = "x86_64" ] || [ "$SI_ARCH" = "arm64" ] ); then
+    if [ "$SI_OS" = "darwin" ] && [ "$SI_ARCH" = "x86_64" ]; then
+        darwin-bootstrap
+    elif [ "$SI_OS" = "darwin" ] && [ "$SI_ARCH" = "arm64" ]; then
         darwin-bootstrap
     elif [ "$SI_OS" = "arch" ] && [ "$SI_ARCH" = "x86_64" ]; then
         arch-bootstrap
     elif [ "$SI_OS" = "fedora" ] && [ "$SI_ARCH" = "x86_64" ]; then
         fedora-bootstrap
+    elif [ "$SI_OS" = "pop" ] && [ "$SI_ARCH" = "x86_64" ]; then
+        ubuntu-bootstrap
     elif [ "$SI_OS" = "ubuntu" ] && [ "$SI_ARCH" = "x86_64" ]; then
         ubuntu-bootstrap
     else


### PR DESCRIPTION
- Add QualificationService with mock data for the viewer to use [sc-2115]
- Add pop-os to bootstrapper and demote Fedora to server-only (I was the only maintainer for Fedora desktop)
- Add subpanel buttons to toggle between attribute viewer and qualification viewer (default to attribute viewer)
- Load QualificationOutput within QualificationViewer
- Use table for supported developer environments
- Use vue-feather for icons