### PR TITLE
feat(dal): Set default Prop value through a JS function

### DIFF
--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -55,8 +55,10 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
 
     let pg_pool = Server::create_pg_pool(config.pg_pool()).await?;
 
+    let veritech = Server::create_veritech_client(nats.clone());
+
     if let MigrationMode::Run | MigrationMode::RunAndQuit = config.migration_mode() {
-        Server::migrate_database(&pg_pool, &nats, &jwt_secret_key).await?;
+        Server::migrate_database(&pg_pool, &nats, &jwt_secret_key, veritech.clone()).await?;
         if let MigrationMode::RunAndQuit = config.migration_mode() {
             info!(
                 "migration mode is {}, shutting down",
@@ -67,8 +69,6 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
     } else {
         trace!("migration mode is skip, not running migrations");
     }
-
-    let veritech = Server::create_veritech_client(nats.clone());
 
     // TODO(fnichol): re-enable, which we shouldn't need in the long run
     if !disable_opentelemetry {

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -40,3 +40,4 @@ veritech = { path = "../../lib/veritech", features = ["client"] }
 
 [dev-dependencies]
 insta = "1.8.0"
+veritech = { path = "../../lib/veritech", features = ["client", "server"] }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -120,12 +120,16 @@ pub async fn migrate(pg: &PgPool) -> ModelResult<()> {
 }
 
 #[instrument(skip_all)]
-pub async fn migrate_builtin_schemas(pg: &PgPool, nats: &NatsClient) -> ModelResult<()> {
+pub async fn migrate_builtin_schemas(
+    pg: &PgPool,
+    nats: &NatsClient,
+    veritech: veritech::Client,
+) -> ModelResult<()> {
     let mut conn = pg.get().await?;
     let txn = conn.transaction().await?;
     let nats = nats.transaction();
     func::builtins::migrate(&txn, &nats).await?;
-    schema::builtins::migrate(&txn, &nats).await?;
+    schema::builtins::migrate(&txn, &nats, veritech).await?;
     txn.commit().await?;
     nats.commit().await?;
     Ok(())

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -12,12 +12,14 @@ use crate::{
         EditFieldObjectKind, EditFields, HeaderWidget, SelectWidget, TextWidget, VisibilityDiff,
         Widget,
     },
+    func::binding::FuncBindingError,
     impl_standard_model, pk,
     schema::ui_menu::UiMenuId,
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
-    BillingAccount, BillingAccountId, Component, HistoryActor, HistoryEventError, LabelEntry,
-    LabelList, Organization, OrganizationId, PropError, StandardModel, StandardModelError, Tenancy,
-    Timestamp, ValidationPrototypeError, Visibility, Workspace, WorkspaceId, WsEventError,
+    AttributeResolverError, BillingAccount, BillingAccountId, Component, HistoryActor,
+    HistoryEventError, LabelEntry, LabelList, Organization, OrganizationId, PropError,
+    StandardModel, StandardModelError, Tenancy, Timestamp, ValidationPrototypeError, Visibility,
+    Workspace, WorkspaceId, WsEventError,
 };
 
 use crate::socket::SocketError;
@@ -62,6 +64,10 @@ pub enum SchemaError {
     MissingFunc(String),
     #[error("validation prototype error: {0}")]
     ValidationPrototype(#[from] ValidationPrototypeError),
+    #[error("attribute resolver error: {0}")]
+    AttributeResolver(#[from] AttributeResolverError),
+    #[error("func binding error: {0}")]
+    FuncBinding(#[from] FuncBindingError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;

--- a/lib/dal/tests/integration_test/attribute_resolver.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver.rs
@@ -133,7 +133,8 @@ async fn find_value_for_prop_and_component() {
         .props(&txn, &visibility)
         .await
         .expect("cannot get props")
-        .pop()
+        .first()
+        .cloned()
         .expect("no prop found");
 
     let component = create_component_for_schema(

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -7,7 +7,7 @@ use dal::{
     },
     test_harness::{
         create_change_set, create_edit_session, create_func, create_func_binding,
-        create_visibility_change_set, create_visibility_edit_session,
+        create_visibility_edit_session,
     },
     Func, FuncBackendKind, FuncBackendResponseType, HistoryActor, StandardModel, Tenancy,
     Visibility, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
@@ -104,7 +104,6 @@ async fn func_binding_find_or_create_head() {
 async fn func_binding_find_or_create_edit_session() {
     test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
     let tenancy = Tenancy::new_universal();
-    let head_visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
     let mut change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
     let mut edit_session = create_edit_session(&txn, &nats, &history_actor, &change_set).await;

--- a/lib/dal/tests/integration_test/validation_prototype.rs
+++ b/lib/dal/tests/integration_test/validation_prototype.rs
@@ -153,5 +153,5 @@ async fn find_for_prop() {
     .await
     .expect("cannot find values");
 
-    assert_eq!(validation_results.len(), 4);
+    assert_eq!(validation_results.len(), 2);
 }

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -1,14 +1,11 @@
 use crate::test_setup;
 
 use dal::{
-    func::{
-        backend::{validation::FuncBackendValidateStringValueArgs, FuncBackendStringArgs},
-        binding::FuncBinding,
-    },
+    func::{backend::validation::FuncBackendValidateStringValueArgs, binding::FuncBinding},
     test_harness::{billing_account_signup, create_component_for_schema},
     validation_resolver::{ValidationResolverContext, UNSET_ID_VALUE},
-    AttributeResolver, Func, FuncBackendKind, FuncBackendResponseType, HistoryActor, Schema,
-    StandardModel, SystemId, Tenancy, ValidationResolver, Visibility,
+    Func, FuncBackendKind, FuncBackendResponseType, HistoryActor, Schema, StandardModel, SystemId,
+    Tenancy, ValidationResolver, Visibility,
 };
 
 #[tokio::test]
@@ -112,8 +109,6 @@ async fn find_for_prototype() {
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
     let veritech = veritech::Client::new(nats_conn.clone());
-
-    let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
     let schema = Schema::find_by_attr(
         &txn,

--- a/lib/sdf/src/server/server.rs
+++ b/lib/sdf/src/server/server.rs
@@ -138,9 +138,10 @@ impl Server<(), ()> {
         pg: &PgPool,
         nats: &NatsClient,
         jwt_secret_key: &JwtSecretKey,
+        veritech: veritech::Client,
     ) -> Result<()> {
         migrate(pg).await?;
-        migrate_builtin_schemas(pg, nats).await?;
+        migrate_builtin_schemas(pg, nats, veritech).await?;
 
         let mut conn = pg.get().await?;
         let txn = conn.transaction().await?;

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -14,6 +14,8 @@
 #[cfg(feature = "server")]
 pub mod server;
 #[cfg(feature = "server")]
+pub use deadpool_cyclone::{instance::cyclone::LocalUdsInstance, Instance};
+#[cfg(feature = "server")]
 pub use server::{
     Config, ConfigBuilder, ConfigError, ConfigFile, CycloneSpec, CycloneStream, Server,
     ServerError, StandardConfig, StandardConfigFile,

--- a/lib/veritech/src/server/server.rs
+++ b/lib/veritech/src/server/server.rs
@@ -1,11 +1,10 @@
-use std::io;
-
 use deadpool_cyclone::{
     instance::cyclone::LocalUdsInstanceSpec, CycloneClient, Manager, Pool, ProgressMessage,
     QualificationCheckRequest, ResolverFunctionRequest,
 };
 use futures::{channel::oneshot, join, StreamExt};
 use si_data::NatsClient;
+use std::io;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::{


### PR DESCRIPTION
Create default AttributeResolver for a Prop that runs a custom Js function using veritech

This assumes functions are idempotent as it only runs the FuncBinding during the migration. In the future we will want to copy the Prop's AttributeResolver during Component creation to support non-pure functions