### PR TITLE
feat(dal): track function execution, and record any output

### DIFF
--- a/lib/cyclone/src/progress.rs
+++ b/lib/cyclone/src/progress.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 ///
 /// An instance of this type typically maps to a single line of output from a process--either on
 /// standard output or standard error.
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct OutputStream {
     /// The stream name.
     ///
@@ -90,14 +90,14 @@ pub enum FunctionResult<S> {
     Failure(FunctionResultFailure),
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct FunctionResultFailure {
     pub execution_id: String,
     pub error: FunctionResultFailureError,
     pub timestamp: u64,
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct FunctionResultFailureError {
     pub kind: String,
     pub message: String,

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -14,6 +14,7 @@ pub mod backend;
 pub mod binding;
 pub mod binding_return_value;
 pub mod builtins;
+pub mod execution;
 
 #[derive(Error, Debug)]
 pub enum FuncError {

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -1,0 +1,223 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::sync::mpsc::Receiver;
+use veritech::{FunctionResultFailure, OutputStream};
+
+use crate::{
+    pk, Func, FuncBackendKind, FuncBackendResponseType, HistoryEventError, StandardModel,
+    StandardModelError, Tenancy, Timestamp,
+};
+
+use super::{
+    binding::{FuncBinding, FuncBindingId},
+    binding_return_value::{FuncBindingReturnValue, FuncBindingReturnValueId},
+    FuncId,
+};
+
+#[derive(Error, Debug)]
+pub enum FuncExecutionError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type FuncExecutionResult<T> = Result<T, FuncExecutionError>;
+
+pk!(FuncExecutionPk);
+pk!(FuncExecutionId);
+
+// Are these the right states? -- Adam
+#[derive(
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    strum_macros::EnumString,
+    strum_macros::Display,
+    Copy,
+)]
+pub enum FuncExecutionState {
+    Create,
+    Dispatch,
+    Start,
+    Run,
+    Success,
+    Failure,
+}
+
+/// FuncExecutions record that a function has executed, all the
+/// various context required to understand the execution, and
+/// contains the log of the output stream for the function.
+///
+/// It is not part of the 'standard model' - it doesn't participate
+/// in change sets, and is only used for reference. Essentially the
+/// func equivalent of a `HistoryEvent`
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct FuncExecution {
+    pk: FuncExecutionPk,
+    state: FuncExecutionState,
+    func_id: FuncId,
+    func_binding_id: FuncBindingId,
+    func_binding_args: serde_json::Value,
+    backend_kind: FuncBackendKind,
+    backend_response_type: FuncBackendResponseType,
+    func_binding_return_value_id: Option<FuncBindingReturnValueId>,
+    handler: Option<String>,
+    code_base64: Option<String>,
+    unprocessed_value: Option<serde_json::Value>,
+    value: Option<serde_json::Value>,
+    output_stream: Option<Vec<OutputStream>>,
+    function_failure: Option<FunctionResultFailure>,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+}
+
+impl FuncExecution {
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        func: &Func,
+        func_binding: &FuncBinding,
+    ) -> FuncExecutionResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM func_execution_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[
+                    &tenancy,
+                    &FuncExecutionState::Start.to_string(),
+                    &func.id(),
+                    &func_binding.id(),
+                    &func_binding.args(),
+                    &func_binding.backend_kind().to_string(),
+                    &func.backend_response_type().to_string(),
+                    &func.handler(),
+                    &func.code_base64(),
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        // This needs to be some kind of 'immediate mode' publish.
+        nats.publish("funcExecution", &json).await?;
+        let object: FuncExecution = serde_json::from_value(json)?;
+        Ok(object)
+    }
+
+    pub fn state(&self) -> FuncExecutionState {
+        self.state
+    }
+
+    pub async fn set_state(
+        &mut self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        state: FuncExecutionState,
+    ) -> FuncExecutionResult<()> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM func_execution_set_state_v1($1, $2)",
+                &[&self.pk, &state.to_string()],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        // This needs to be some kind of 'immediate mode' publish.
+        nats.publish("funcExecution", &json).await?;
+        let mut object: FuncExecution = serde_json::from_value(json)?;
+        std::mem::swap(self, &mut object);
+        Ok(())
+    }
+
+    /// Takes the receiver stream from a Veritech function execution, and stores the output.
+    pub async fn process_output(
+        &mut self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        mut rx: Receiver<OutputStream>,
+    ) -> FuncExecutionResult<()> {
+        // Right now, we consume everything. This should really be happening in a separate thread altogether, and
+        // persisting the output lines as they come in.  But this works for now, and should be easy enough to
+        // refactor.
+        let mut output = Vec::new();
+        while let Some(output_stream) = rx.recv().await {
+            output.push(output_stream);
+        }
+        self.set_output_stream(txn, nats, output).await
+    }
+
+    pub fn output_stream(&self) -> Option<&Vec<OutputStream>> {
+        self.output_stream.as_ref()
+    }
+
+    pub async fn set_output_stream(
+        &mut self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        output_stream: Vec<OutputStream>,
+    ) -> FuncExecutionResult<()> {
+        let output_stream_json = serde_json::to_value(&output_stream)?;
+        let row = txn
+            .query_one(
+                "SELECT object FROM func_execution_set_output_stream_v1($1, $2)",
+                &[&self.pk, &output_stream_json],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish("funcExecution", &json).await?;
+        let mut object: FuncExecution = serde_json::from_value(json)?;
+        std::mem::swap(self, &mut object);
+        Ok(())
+    }
+
+    /// Take the return value of a function binding, and store its results.
+    pub async fn process_return_value(
+        &mut self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        func_binding_return_value: &FuncBindingReturnValue,
+    ) -> FuncExecutionResult<()> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM func_execution_set_return_value_v1($1, $2, $3, $4)",
+                &[
+                    &self.pk,
+                    &func_binding_return_value.id(),
+                    &func_binding_return_value.value(),
+                    &func_binding_return_value.unprocessed_value(),
+                ],
+            )
+            .await?;
+        let json: serde_json::Value = row.try_get("object")?;
+        nats.publish("funcExecution", &json).await?;
+        let mut object: FuncExecution = serde_json::from_value(json)?;
+        std::mem::swap(self, &mut object);
+
+        Ok(())
+    }
+
+    pub fn func_binding_return_value_id(&self) -> Option<FuncBindingReturnValueId> {
+        self.func_binding_return_value_id
+    }
+
+    pub fn value(&self) -> Option<&serde_json::Value> {
+        self.value.as_ref()
+    }
+
+    pub fn unprocessed_value(&self) -> Option<&serde_json::Value> {
+        self.unprocessed_value.as_ref()
+    }
+}

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -39,6 +39,9 @@ impl From<&HistoryActor> for HistoryActor {
 
 pk!(HistoryEventPk);
 
+/// HistoryEvents are the audit trail for things in SI. They track
+/// that a specific actor did something, and optionally store data
+/// associated with the activity for posterity.
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct HistoryEvent {
     pub pk: HistoryEventPk,

--- a/lib/dal/src/migrations/U0046__func_executions.sql
+++ b/lib/dal/src/migrations/U0046__func_executions.sql
@@ -1,0 +1,123 @@
+CREATE TABLE func_executions
+(
+    pk                           bigserial             PRIMARY KEY,
+    state              text                     NOT NULL,
+    func_id                      bigint                   NOT NULL,
+    func_binding_id              bigint                   NOT NULL,
+    func_binding_args            jsonb                    NOT NULL,
+    backend_kind                 text                     NOT NULL,
+    backend_response_type        text                     NOT NULL,
+    func_binding_return_value_id bigint,
+    handler                      text, 
+    code_base64                  text,
+    unprocessed_value            jsonb,
+    value                        jsonb,
+    output_stream                jsonb,
+    function_failure             jsonb, 
+    tenancy_universal            bool,
+    tenancy_billing_account_ids  bigint[],
+    tenancy_organization_ids     bigint[],
+    tenancy_workspace_ids        bigint[],
+    created_at                   timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                   timestamp with time zone NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION func_execution_create_v1(
+    this_tenancy                      jsonb,
+    this_state                        text,
+    this_func_id                      bigint,
+    this_func_binding_id              bigint,
+    this_func_binding_args            jsonb,
+    this_backend_kind                 text,
+    this_backend_response_type        text,
+    this_handler                      text, 
+    this_code_base64                  text,
+  OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record tenancy_record_v1;
+    this_new_row        func_executions%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+
+    INSERT INTO func_executions (
+      tenancy_universal, 
+      tenancy_billing_account_ids,
+      tenancy_organization_ids,
+      tenancy_workspace_ids,
+      state,
+      func_id,
+      func_binding_id,
+      func_binding_args,
+      backend_kind,
+      backend_response_type,
+      handler, 
+      code_base64
+    )
+    VALUES (
+      this_tenancy_record.tenancy_universal, 
+      this_tenancy_record.tenancy_billing_account_ids,
+      this_tenancy_record.tenancy_organization_ids,
+      this_tenancy_record.tenancy_workspace_ids,
+      this_state,
+      this_func_id,
+      this_func_binding_id,
+      this_func_binding_args,
+      this_backend_kind,
+      this_backend_response_type,
+      this_handler, 
+      this_code_base64
+    )
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION func_execution_set_state_v1(
+    this_pk bigint,
+    this_state text,
+  OUT object json) AS
+$$
+BEGIN
+  UPDATE func_executions 
+    SET state = this_state, updated_at = now() 
+    WHERE pk = this_pk 
+    RETURNING row_to_json(func_executions.*) 
+    INTO object;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION func_execution_set_output_stream_v1(
+    this_pk bigint,
+    this_output_stream jsonb,
+  OUT object json) AS
+$$
+BEGIN
+  UPDATE func_executions 
+    SET output_stream = this_output_stream, updated_at = now() 
+    WHERE pk = this_pk 
+    RETURNING row_to_json(func_executions.*) 
+    INTO object;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION func_execution_set_return_value_v1(
+    this_pk bigint,
+    this_func_binding_return_value_id bigint,
+    this_value jsonb,
+    this_unprocessed_value jsonb,
+  OUT object json) AS
+$$
+BEGIN
+  UPDATE func_executions 
+    SET func_binding_return_value_id = this_func_binding_return_value_id,
+        value = this_value,
+        unprocessed_value = this_unprocessed_value,
+        updated_at = now()
+    WHERE pk = this_pk 
+    RETURNING row_to_json(func_executions.*) 
+    INTO object;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -1,0 +1,159 @@
+use crate::test_setup;
+use dal::func::execution::FuncExecutionState;
+use dal::{func::execution::FuncExecution, StandardModel};
+
+use dal::{
+    func::backend::FuncBackendStringArgs,
+    test_harness::{create_func, create_func_binding, create_visibility_head},
+    HistoryActor, Tenancy,
+};
+use veritech::OutputStream;
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = create_visibility_head();
+    let history_actor = HistoryActor::SystemInit;
+    let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let args = FuncBackendStringArgs::new("slayer".to_string());
+    let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+    let func_binding = create_func_binding(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        args_json,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await;
+    let execution = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+        .await
+        .expect("cannot create a new func execution");
+    assert_eq!(execution.state(), FuncExecutionState::Start);
+}
+
+#[tokio::test]
+async fn set_state() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = create_visibility_head();
+    let history_actor = HistoryActor::SystemInit;
+    let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let args = FuncBackendStringArgs::new("slayer".to_string());
+    let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+    let func_binding = create_func_binding(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        args_json,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await;
+    let mut execution = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+        .await
+        .expect("cannot create a new func execution");
+    assert_eq!(execution.state(), FuncExecutionState::Start);
+    execution
+        .set_state(&txn, &nats, FuncExecutionState::Dispatch)
+        .await
+        .expect("cannot set state");
+    assert_eq!(execution.state(), FuncExecutionState::Dispatch);
+}
+
+#[tokio::test]
+async fn set_output_stream() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = create_visibility_head();
+    let history_actor = HistoryActor::SystemInit;
+    let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let args = FuncBackendStringArgs::new("slayer".to_string());
+    let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+    let func_binding = create_func_binding(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        args_json,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await;
+    let mut execution = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+        .await
+        .expect("cannot create a new func execution");
+
+    execution
+        .set_output_stream(
+            &txn,
+            &nats,
+            vec![
+                (OutputStream {
+                    stream: "stdout".to_string(),
+                    execution_id: "foo".to_string(),
+                    level: "info".to_string(),
+                    group: None,
+                    data: None,
+                    message: "worm shepherd".to_string(),
+                    timestamp: 1865,
+                }),
+            ],
+        )
+        .await
+        .expect("cannot set output stream");
+    let output_stream = execution.output_stream().expect("has an output stream");
+    assert_eq!(output_stream.len(), 1);
+}
+
+#[tokio::test]
+async fn process_return_value() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    let tenancy = Tenancy::new_universal();
+    let visibility = create_visibility_head();
+    let history_actor = HistoryActor::SystemInit;
+    let veritech = veritech::Client::new(nats_conn.clone());
+
+    let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let args = FuncBackendStringArgs::new("slayer".to_string());
+    let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+    let func_binding = create_func_binding(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        args_json,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await;
+    let func_binding_return_value = func_binding
+        .execute(&txn, &nats, veritech)
+        .await
+        .expect("cannot execute binding");
+
+    let mut execution = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+        .await
+        .expect("cannot create a new func execution");
+
+    execution
+        .process_return_value(&txn, &nats, &func_binding_return_value)
+        .await
+        .expect("cannot process return value");
+    assert_eq!(
+        execution.func_binding_return_value_id(),
+        Some(*func_binding_return_value.id())
+    );
+    assert_eq!(execution.value(), func_binding_return_value.value(),);
+    assert_eq!(
+        execution.unprocessed_value(),
+        func_binding_return_value.unprocessed_value(),
+    );
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -6,6 +6,7 @@ mod component;
 mod edge;
 mod edit_session;
 mod func;
+mod func_execution;
 mod group;
 mod history_event;
 mod jwt_key;

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -27,8 +27,8 @@ pub mod client;
 pub use client::{Client, ClientError, ClientResult};
 #[cfg(feature = "client")]
 pub use cyclone::{
-    FunctionResult, OutputStream, QualificationCheckComponent, QualificationCheckRequest,
-    ResolverFunctionRequest,
+    FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
+    QualificationCheckRequest, ResolverFunctionRequest,
 };
 
 pub(crate) const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";


### PR DESCRIPTION
Adds a `FuncExecution` module, which is used to track the execution of a
given function. It's analogous to the `HistoryEvent` module, which
tracks user (or system) events for recording their history, except it
does so for function executions.

It will also keep track of the output of a function as it is executing,
and push it down NATS to be consumed by the browser. It does so in a
deeply un-optimized way.

We will eventually revisit how this is factored, I think, as we add more
FuncBackends and put streaming output in the frontend.

<img src="https://media1.giphy.com/media/OoxzFYCmEiELda33Xg/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>