### PR TITLE
fix(data): ensure a NATS subscription can be closed

### DIFF
--- a/lib/si-data/src/nats.rs
+++ b/lib/si-data/src/nats.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, io, sync::Arc, time::Duration};
 
+use crossbeam_channel::RecvError;
 use nats_client as nats;
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
@@ -25,6 +26,8 @@ pub enum Error {
     Async(#[from] task::JoinError),
     #[error("nats client error")]
     Nats(#[from] io::Error),
+    #[error("crossbeam select error")]
+    CrossBeamChannel(#[from] RecvError),
     #[error("error serializing object")]
     Serialize(#[source] serde_json::Error),
 }


### PR DESCRIPTION
This change fixes an issue with our Subscription::next_message
implementation. Before this change, the subscription would block (in a
worker thread pool) waiting for the next NATS message, but we forgot to
also expect a shutdown signal which would tell this blocking thread to
abort/quit/end.

The fix was ported from the upstream `nats` crate from the `asynk`
module (which is their async wrapper over their blocking client).

<img src="https://media4.giphy.com/media/3oKIPchYaXx2YQybcY/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>