### PR TITLE
bug(sdf): fix the build of the sdf binary

### DIFF
--- a/lib/sdf/Cargo.toml
+++ b/lib/sdf/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1.12.0", features = ["full"] }
 tokio-tungstenite = "0.15.0"
 tower = { version = "0.4.10" }
 tower-http = { version = "0.1", features = ["trace"] }
-veritech = { path = "../../lib/veritech", features = ["client"] }
+veritech = { path = "../../lib/veritech", features = ["client", "server"] }
 
 [dev-dependencies]
 serde_url_params = "0.2.1"


### PR DESCRIPTION
We broke the build of the sdf binary, by not including every feature we
needed for veritech.