### PR TITLE
chore(dal,sdf): everyone who wants a Veritech client, gets one!

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -134,10 +134,12 @@ impl Component {
         Ok(object)
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(txn, nats, name))]
     pub async fn new_for_schema_with_node(
         txn: &PgTxn<'_>,
         nats: &NatsTxn,
+        veritech: veritech::Client,
         tenancy: &Tenancy,
         visibility: &Visibility,
         history_actor: &HistoryActor,
@@ -198,7 +200,6 @@ impl Component {
                 .await?
                 .ok_or_else(|| ComponentError::MissingFunc(prototype.func_id().to_string()))?;
 
-            // NOTE(nick): func cannot be executed without veritech client.
             let (func_binding, created) = FuncBinding::find_or_create(
                 txn,
                 nats,
@@ -212,8 +213,7 @@ impl Component {
             .await?;
 
             if created {
-                // TODO(paulo): we need to pass veritech client to this function (like we do with update_prop_...
-                //func_binding.execute(txn, nats, veritech.clone()).await?;
+                func_binding.execute(txn, nats, veritech.clone()).await?;
 
                 let mut existing_resolvers = QualificationResolver::find_for_prototype(
                     txn,
@@ -605,7 +605,6 @@ impl Component {
                 .await?
                 .ok_or_else(|| ComponentError::MissingFunc(prototype.func_id().to_string()))?;
 
-            // NOTE(nick): func cannot be executed without veritech client.
             let (func_binding, created) = FuncBinding::find_or_create(
                 txn,
                 nats,
@@ -619,8 +618,7 @@ impl Component {
             .await?;
 
             if created {
-                // TODO(paulo): FuncBinding execute is failing here, it's friday and it's late, I don't think we will be able to fix this now (nor should)
-                //func_binding.execute(txn, nats, veritech).await?;
+                func_binding.execute(txn, nats, veritech.clone()).await?;
 
                 let mut existing_resolvers = QualificationResolver::find_for_prototype(
                     txn,

--- a/lib/dal/tests/integration_test/attribute_resolver.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver.rs
@@ -10,11 +10,10 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -102,13 +101,12 @@ async fn new() {
 // nuts.
 #[tokio::test]
 async fn find_value_for_prop_and_component() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let _unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
@@ -397,11 +395,10 @@ async fn find_value_for_prop_and_component() {
 
 #[tokio::test]
 async fn upsert() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,

--- a/lib/dal/tests/integration_test/billing_account.rs
+++ b/lib/dal/tests/integration_test/billing_account.rs
@@ -41,7 +41,7 @@ async fn new() {
 
 #[tokio::test]
 async fn get_by_pk() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -169,7 +169,7 @@ async fn set_description() {
 
 #[tokio::test]
 async fn find_by_name() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let visibility = create_visibility_head();
@@ -188,7 +188,7 @@ async fn find_by_name() {
 
 #[tokio::test]
 async fn get_defaults() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let (nba, _auth_token) = billing_account_signup(&txn, &nats, secret_key).await;
     let visibility = create_visibility_head();
     let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);

--- a/lib/dal/tests/integration_test/capability.rs
+++ b/lib/dal/tests/integration_test/capability.rs
@@ -5,7 +5,7 @@ use dal::{Capability, HistoryActor, Tenancy};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -10,7 +10,7 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -35,7 +35,7 @@ async fn new() {
 
 #[tokio::test]
 async fn apply() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -87,7 +87,7 @@ async fn apply() {
 
 #[tokio::test]
 async fn list_open() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let uv_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -135,7 +135,7 @@ async fn list_open() {
 
 #[tokio::test]
 async fn get_by_pk() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -9,7 +9,16 @@ use serde_json::json;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -27,7 +36,16 @@ async fn new() {
 
 #[tokio::test]
 async fn new_for_schema_variant_with_node() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -62,7 +80,16 @@ async fn new_for_schema_variant_with_node() {
 
 #[tokio::test]
 async fn schema_relationships() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -109,7 +136,16 @@ async fn schema_relationships() {
 
 #[tokio::test]
 async fn qualification_view() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -5,7 +5,16 @@ use dal::{Component, Edge, HistoryActor, Schema, StandardModel, Tenancy, Visibil
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -40,6 +49,7 @@ async fn new() {
     let (head_component, head_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech.clone(),
         &tenancy,
         &visibility,
         &history_actor,
@@ -52,6 +62,7 @@ async fn new() {
     let (tail_component, tail_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/edit_session.rs
+++ b/lib/dal/tests/integration_test/edit_session.rs
@@ -102,7 +102,7 @@ async fn save() {
 
 #[tokio::test]
 async fn get_by_pk() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -117,7 +117,7 @@ async fn get_by_pk() {
 
 #[tokio::test]
 async fn cancel() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -15,7 +15,16 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -35,7 +44,16 @@ async fn new() {
 
 #[tokio::test]
 async fn func_binding_new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -58,7 +76,16 @@ async fn func_binding_new() {
 
 #[tokio::test]
 async fn func_binding_find_or_create_head() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -102,7 +129,16 @@ async fn func_binding_find_or_create_head() {
 
 #[tokio::test]
 async fn func_binding_find_or_create_edit_session() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let mut change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
@@ -226,7 +262,16 @@ async fn func_binding_find_or_create_edit_session() {
 
 #[tokio::test]
 async fn func_binding_return_value_new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -263,11 +308,10 @@ async fn func_binding_return_value_new() {
 
 #[tokio::test]
 async fn func_binding_execute() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech,);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
     let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let args = serde_json::to_value(FuncBackendStringArgs::new("funky".to_string()))
         .expect("cannot serialize args to json");
@@ -297,11 +341,10 @@ async fn func_binding_execute() {
 
 #[tokio::test]
 async fn func_binding_execute_unset() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech,);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
     let name = dal::test_harness::generate_fake_name();
     let func = Func::new(
         &txn,

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -11,7 +11,16 @@ use veritech::OutputStream;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = create_visibility_head();
     let history_actor = HistoryActor::SystemInit;
@@ -37,7 +46,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_state() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = create_visibility_head();
     let history_actor = HistoryActor::SystemInit;
@@ -68,7 +86,16 @@ async fn set_state() {
 
 #[tokio::test]
 async fn set_output_stream() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = create_visibility_head();
     let history_actor = HistoryActor::SystemInit;
@@ -114,11 +141,10 @@ async fn set_output_stream() {
 
 #[tokio::test]
 async fn process_return_value() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = create_visibility_head();
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let args = FuncBackendStringArgs::new("slayer".to_string());

--- a/lib/dal/tests/integration_test/group.rs
+++ b/lib/dal/tests/integration_test/group.rs
@@ -8,7 +8,7 @@ use dal::{Group, HistoryActor, StandardModel, Tenancy};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
@@ -21,7 +21,7 @@ async fn new() {
 
 #[tokio::test]
 async fn add_user() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let universal_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &universal_tenancy, &history_actor).await;
@@ -45,7 +45,7 @@ async fn add_user() {
 
 #[tokio::test]
 async fn remove_user() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let universal_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &universal_tenancy, &history_actor).await;
@@ -77,7 +77,7 @@ async fn remove_user() {
 
 #[tokio::test]
 async fn users() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let universal_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &universal_tenancy, &history_actor).await;

--- a/lib/dal/tests/integration_test/key_pair.rs
+++ b/lib/dal/tests/integration_test/key_pair.rs
@@ -9,7 +9,7 @@ use dal::{BillingAccount, HistoryActor, KeyPair, StandardModel, Tenancy};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
@@ -22,7 +22,7 @@ async fn new() {
 
 #[tokio::test]
 async fn belongs_to() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
@@ -67,7 +67,7 @@ async fn belongs_to() {
 
 #[tokio::test]
 async fn public_key_get_current() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -33,7 +33,16 @@ mod workspace;
 
 #[macro_export]
 macro_rules! test_setup {
-    ($ctx:ident, $secret_key:ident, $pg:ident, $pgconn:ident, $pgtxn:ident, $nats_conn:ident, $nats:ident) => {
+    (
+        $ctx:ident,
+        $secret_key:ident,
+        $pg:ident,
+        $pgconn:ident,
+        $pgtxn:ident,
+        $nats_conn:ident,
+        $nats:ident,
+        $veritech:ident $(,)?
+    ) => {
         dal::test_harness::one_time_setup()
             .await
             .expect("one time setup failed");
@@ -42,5 +51,6 @@ macro_rules! test_setup {
         let $nats = $nats_conn.transaction();
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
         let $pgtxn = $pgconn.transaction().await.expect("cannot create txn");
+        let $veritech = veritech::Client::new($nats_conn.clone());
     };
 }

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -8,7 +8,16 @@ use dal::{HistoryActor, Node, SchemaKind, StandardModel, Tenancy, Visibility};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -26,7 +35,16 @@ async fn new() {
 
 #[tokio::test]
 async fn component_relationships() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -54,7 +72,16 @@ async fn component_relationships() {
 
 #[tokio::test]
 async fn new_node_template() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/node_menu.rs
+++ b/lib/dal/tests/integration_test/node_menu.rs
@@ -7,7 +7,7 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn get_node_menu() {
-    test_setup!(ctx, secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(ctx, secret_key, _pg, _conn, txn, _nats_conn, nats, _veritech);
     let (nba, _key) = billing_account_signup(&txn, &nats, &secret_key).await;
     let visibility = Visibility::new_head(false);
     let tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);

--- a/lib/dal/tests/integration_test/node_position.rs
+++ b/lib/dal/tests/integration_test/node_position.rs
@@ -7,7 +7,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -39,7 +48,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_node() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -94,7 +112,16 @@ async fn set_node() {
 
 #[tokio::test]
 async fn set_node_position() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/organization.rs
+++ b/lib/dal/tests/integration_test/organization.rs
@@ -5,7 +5,7 @@ use dal::{HistoryActor, Organization, Tenancy};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -7,7 +7,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -28,7 +37,16 @@ async fn new() {
 
 #[tokio::test]
 async fn schema_variants() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/qualification_check.rs
+++ b/lib/dal/tests/integration_test/qualification_check.rs
@@ -7,7 +7,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -26,7 +35,16 @@ async fn new() {
 
 #[tokio::test]
 async fn schema_variants() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -10,7 +10,7 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech,);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -24,6 +24,7 @@ async fn new() {
     let (component, _node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &visibility,
         &history_actor,
@@ -65,7 +66,7 @@ async fn new() {
 
 #[tokio::test]
 async fn find_for_component_id() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
@@ -81,6 +82,7 @@ async fn find_for_component_id() {
     let (component, _node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/qualification_resolver.rs
+++ b/lib/dal/tests/integration_test/qualification_resolver.rs
@@ -26,11 +26,10 @@
 //
 // #[tokio::test]
 // async fn new() {
-//     test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+//     test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
 //     let tenancy = Tenancy::new_universal();
 //     let visibility = Visibility::new_head(false);
 //     let history_actor = HistoryActor::SystemInit;
-//     let veritech = veritech::Client::new(nats_conn.clone());
 //
 //     let name = "docker_image".to_string();
 //     let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)
@@ -98,13 +97,12 @@
 //
 // #[tokio::test]
 // async fn find_for_prototype() {
-//     test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+//     test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
 //     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
 //     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
 //     tenancy.universal = true;
 //     let visibility = Visibility::new_head(false);
 //     let history_actor = HistoryActor::SystemInit;
-//     let veritech = veritech::Client::new(nats_conn.clone());
 //
 //     let name = "docker_image".to_string();
 //     let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -9,7 +9,16 @@ pub mod variant;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -28,7 +37,7 @@ async fn new() {
 
 #[tokio::test]
 async fn billing_accounts() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -80,7 +89,7 @@ async fn billing_accounts() {
 
 #[tokio::test]
 async fn organizations() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -132,7 +141,7 @@ async fn organizations() {
 
 #[tokio::test]
 async fn workspaces() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -172,7 +181,7 @@ async fn workspaces() {
 
 #[tokio::test]
 async fn ui_menus() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -6,7 +6,16 @@ use dal::{schema::UiMenu, HistoryActor, SchematicKind, StandardModel, Tenancy, V
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -20,7 +29,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_schema() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -60,7 +78,16 @@ async fn set_schema() {
 
 #[tokio::test]
 async fn root_schematics() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -8,7 +8,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -20,7 +29,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_schema() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -6,7 +6,7 @@ use dal::{
 
 #[tokio::test]
 async fn get_schematic() {
-    test_setup!(ctx, _secret_key, _pg, conn, txn, _nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, conn, txn, _nats_conn, nats, veritech,);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -25,6 +25,7 @@ async fn get_schematic() {
     let (_component, root_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech.clone(),
         &tenancy,
         &visibility,
         &history_actor,
@@ -43,6 +44,7 @@ async fn get_schematic() {
     let (_component, node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &visibility,
         &history_actor,
@@ -85,7 +87,16 @@ async fn get_schematic() {
 
 #[tokio::test]
 async fn create_connection() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -120,6 +131,7 @@ async fn create_connection() {
     let (_head_component, head_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech.clone(),
         &tenancy,
         &visibility,
         &history_actor,
@@ -132,6 +144,7 @@ async fn create_connection() {
     let (_tail_component, tail_node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -8,7 +8,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -31,7 +40,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_required() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -11,7 +11,7 @@ use dal::{
 
 #[tokio::test]
 async fn get_by_pk() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -37,7 +37,7 @@ async fn get_by_pk() {
 
 #[tokio::test]
 async fn get_by_id() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -143,7 +143,7 @@ async fn get_by_id() {
 
 #[tokio::test]
 async fn list() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -286,7 +286,7 @@ async fn list() {
 
 #[tokio::test]
 async fn update() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -319,7 +319,7 @@ async fn update() {
 
 #[tokio::test]
 async fn delete() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -351,7 +351,7 @@ async fn delete() {
 
 #[tokio::test]
 async fn delete_with_bad_tenancy() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -381,7 +381,7 @@ async fn delete_with_bad_tenancy() {
 
 #[tokio::test]
 async fn undelete() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -425,7 +425,7 @@ async fn undelete() {
 
 #[tokio::test]
 async fn set_belongs_to() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -478,7 +478,7 @@ async fn set_belongs_to() {
 
 #[tokio::test]
 async fn unset_belongs_to() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -521,7 +521,7 @@ async fn unset_belongs_to() {
 
 #[tokio::test]
 async fn belongs_to() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -655,7 +655,7 @@ async fn belongs_to() {
 
 #[tokio::test]
 async fn has_many() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -743,7 +743,7 @@ async fn has_many() {
 
 #[tokio::test]
 async fn associate_many_to_many() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -777,7 +777,7 @@ async fn associate_many_to_many() {
 
 #[tokio::test]
 async fn disassociate_many_to_many() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -821,7 +821,7 @@ async fn disassociate_many_to_many() {
 
 #[tokio::test]
 async fn many_to_many() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -961,7 +961,7 @@ async fn many_to_many() {
 
 #[tokio::test]
 async fn associate_many_to_many_no_repeat_entries() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
@@ -994,7 +994,7 @@ async fn associate_many_to_many_no_repeat_entries() {
 
 #[tokio::test]
 async fn find_by_attr() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
 
     let universal_tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/system.rs
+++ b/lib/dal/tests/integration_test/system.rs
@@ -7,7 +7,16 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -26,7 +35,16 @@ async fn new() {
 
 #[tokio::test]
 async fn set_workspace() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, _nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;

--- a/lib/dal/tests/integration_test/tenancy.rs
+++ b/lib/dal/tests/integration_test/tenancy.rs
@@ -3,7 +3,7 @@ use dal::Tenancy;
 
 #[tokio::test]
 async fn check_universal() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_universal();
     let check_tenancy = tenancy.clone();
@@ -17,7 +17,7 @@ async fn check_universal() {
 
 #[tokio::test]
 async fn check_empty_always_fails() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_empty();
     let check_tenancy = tenancy.clone();
@@ -31,7 +31,7 @@ async fn check_empty_always_fails() {
 
 #[tokio::test]
 async fn check_billing_account_pk_identical() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_billing_account(vec![1.into()]);
     let check_tenancy = tenancy.clone();
@@ -45,7 +45,7 @@ async fn check_billing_account_pk_identical() {
 
 #[tokio::test]
 async fn check_billing_account_pk_overlapping() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_billing_account(vec![
         1.into(),
@@ -66,7 +66,7 @@ async fn check_billing_account_pk_overlapping() {
 
 #[tokio::test]
 async fn check_billing_account_pk_mismatched() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_billing_account(vec![1.into()]);
     let check_tenancy = Tenancy::new_billing_account(vec![2.into()]);
@@ -80,7 +80,7 @@ async fn check_billing_account_pk_mismatched() {
 
 #[tokio::test]
 async fn check_billing_account_pk_mismatched_level() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_billing_account(vec![1.into()]);
     let check_tenancy = Tenancy::new_organization(vec![1.into()]);
@@ -94,7 +94,7 @@ async fn check_billing_account_pk_mismatched_level() {
 
 #[tokio::test]
 async fn check_organization_pk_identical() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_organization(vec![1.into()]);
     let check_tenancy = tenancy.clone();
@@ -108,7 +108,7 @@ async fn check_organization_pk_identical() {
 
 #[tokio::test]
 async fn check_organization_pk_overlapping() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_organization(vec![
         1.into(),
@@ -129,7 +129,7 @@ async fn check_organization_pk_overlapping() {
 
 #[tokio::test]
 async fn check_organization_pk_mismatched() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_organization(vec![1.into()]);
     let check_tenancy = Tenancy::new_organization(vec![2.into()]);
@@ -143,7 +143,7 @@ async fn check_organization_pk_mismatched() {
 
 #[tokio::test]
 async fn check_workspace_pk_identical() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_workspace(vec![1.into()]);
     let check_tenancy = tenancy.clone();
@@ -157,7 +157,7 @@ async fn check_workspace_pk_identical() {
 
 #[tokio::test]
 async fn check_workspace_pk_overlapping() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_workspace(vec![
         1.into(),
@@ -178,7 +178,7 @@ async fn check_workspace_pk_overlapping() {
 
 #[tokio::test]
 async fn check_workspace_pk_mismatched() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let tenancy = Tenancy::new_workspace(vec![1.into()]);
     let check_tenancy = Tenancy::new_workspace(vec![2.into()]);

--- a/lib/dal/tests/integration_test/user.rs
+++ b/lib/dal/tests/integration_test/user.rs
@@ -8,7 +8,7 @@ use dal::{HistoryActor, StandardModel, Tenancy, User};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
@@ -30,7 +30,7 @@ async fn new() {
 
 #[tokio::test]
 async fn login() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let visibility = create_visibility_head();
@@ -58,7 +58,7 @@ async fn login() {
 
 #[tokio::test]
 async fn find_by_email() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let visibility = create_visibility_head();
@@ -99,7 +99,7 @@ async fn find_by_email() {
 
 #[tokio::test]
 async fn authorize() {
-    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let history_actor = HistoryActor::SystemInit;
     let visibility = create_visibility_head();
 

--- a/lib/dal/tests/integration_test/validation_prototype.rs
+++ b/lib/dal/tests/integration_test/validation_prototype.rs
@@ -9,7 +9,16 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        nats_conn,
+        nats,
+        _veritech,
+    );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
@@ -67,7 +76,7 @@ async fn new() {
 
 #[tokio::test]
 async fn find_for_prop() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, _veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -10,11 +10,10 @@ use dal::{
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech,);
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -102,13 +101,12 @@ async fn new() {
 
 #[tokio::test]
 async fn find_for_prototype() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let schema = Schema::find_by_attr(
         &txn,
@@ -237,13 +235,12 @@ async fn find_for_prototype() {
 
 #[tokio::test]
 async fn find_values_for_prop_and_component() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
@@ -380,13 +377,12 @@ async fn find_values_for_prop_and_component() {
 
 #[tokio::test]
 async fn find_values_for_prop_and_component_override() {
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let veritech = veritech::Client::new(nats_conn.clone());
 
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 

--- a/lib/dal/tests/integration_test/visibility.rs
+++ b/lib/dal/tests/integration_test/visibility.rs
@@ -3,7 +3,7 @@ use dal::Visibility;
 
 #[tokio::test]
 async fn head_is_visibile_to_head() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_head(false);
     let check_visibility = visibility;
@@ -17,7 +17,7 @@ async fn head_is_visibile_to_head() {
 
 #[tokio::test]
 async fn head_is_visible_to_change_set() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_head(false);
     let check_visibility = Visibility::new_change_set(1.into(), false);
@@ -31,7 +31,7 @@ async fn head_is_visible_to_change_set() {
 
 #[tokio::test]
 async fn head_is_visible_to_edit_session() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_head(false);
     let check_visibility = Visibility::new_edit_session(1.into(), 2.into(), false);
@@ -45,7 +45,7 @@ async fn head_is_visible_to_edit_session() {
 
 #[tokio::test]
 async fn head_is_invisibile_to_deleted_head() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_head(true);
     let check_visibility = Visibility::new_head(false);
@@ -59,7 +59,7 @@ async fn head_is_invisibile_to_deleted_head() {
 
 #[tokio::test]
 async fn delted_head_is_visibile_to_deleted_head() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_head(true);
     let check_visibility = Visibility::new_head(true);
@@ -73,7 +73,7 @@ async fn delted_head_is_visibile_to_deleted_head() {
 
 #[tokio::test]
 async fn change_set_is_not_visible_to_head() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_head(false);
@@ -87,7 +87,7 @@ async fn change_set_is_not_visible_to_head() {
 
 #[tokio::test]
 async fn change_set_is_visible_to_change_set() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_change_set(1.into(), false);
@@ -101,7 +101,7 @@ async fn change_set_is_visible_to_change_set() {
 
 #[tokio::test]
 async fn change_set_is_invisible_to_different_change_set() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_change_set(2.into(), false);
@@ -115,7 +115,7 @@ async fn change_set_is_invisible_to_different_change_set() {
 
 #[tokio::test]
 async fn change_set_is_visible_to_edit_session() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_edit_session(1.into(), 1.into(), false);
@@ -129,7 +129,7 @@ async fn change_set_is_visible_to_edit_session() {
 
 #[tokio::test]
 async fn edit_session_is_visible_to_edit_session() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_edit_session(1.into(), 1.into(), false);
     let check_visibility = Visibility::new_edit_session(1.into(), 1.into(), false);
@@ -143,7 +143,7 @@ async fn edit_session_is_visible_to_edit_session() {
 
 #[tokio::test]
 async fn edit_session_is_invisible_change_set() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_edit_session(1.into(), 1.into(), false);
     let check_visibility = Visibility::new_change_set(1.into(), false);
@@ -157,7 +157,7 @@ async fn edit_session_is_invisible_change_set() {
 
 #[tokio::test]
 async fn edit_session_is_invisible_to_different_edit_session() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, _nats, _veritech);
 
     let visibility = Visibility::new_edit_session(1.into(), 1.into(), false);
     let check_visibility = Visibility::new_edit_session(1.into(), 2.into(), false);

--- a/lib/dal/tests/integration_test/workspace.rs
+++ b/lib/dal/tests/integration_test/workspace.rs
@@ -5,7 +5,7 @@ use dal::{HistoryActor, Tenancy, Workspace};
 
 #[tokio::test]
 async fn new() {
-    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats);
+    test_setup!(ctx, _secret_key, pg, conn, txn, nats_conn, nats, _veritech);
     let tenancy = Tenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
     let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;

--- a/lib/sdf/src/server/service/schematic/create_node.rs
+++ b/lib/sdf/src/server/service/schematic/create_node.rs
@@ -1,4 +1,4 @@
-use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn, Veritech};
 use crate::service::schematic::{SchematicError, SchematicResult};
 use axum::Json;
 use dal::{
@@ -29,6 +29,7 @@ pub struct CreateNodeResponse {
 pub async fn create_node(
     mut txn: PgRwTxn,
     mut nats: NatsTxn,
+    Veritech(veritech): Veritech,
     Authorization(claim): Authorization,
     Json(request): Json<CreateNodeRequest>,
 ) -> SchematicResult<Json<CreateNodeResponse>> {
@@ -52,6 +53,7 @@ pub async fn create_node(
     let (component, node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
+        veritech,
         &tenancy,
         &request.visibility,
         &history_actor,

--- a/lib/sdf/tests/service_tests/application.rs
+++ b/lib/sdf/tests/service_tests/application.rs
@@ -20,6 +20,7 @@ async fn create_application() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -51,6 +52,7 @@ async fn list_applications() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token

--- a/lib/sdf/tests/service_tests/change_set.rs
+++ b/lib/sdf/tests/service_tests/change_set.rs
@@ -32,6 +32,7 @@ async fn list_open_change_sets() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -61,6 +62,7 @@ async fn create_change_set() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         _nba,
         auth_token
@@ -93,6 +95,7 @@ async fn get_change_set() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -118,6 +121,7 @@ async fn start_edit_session() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -150,6 +154,7 @@ async fn cancel_edit_session() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -183,6 +188,7 @@ async fn save_edit_session() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -216,6 +222,7 @@ async fn apply_change_set() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -17,6 +17,7 @@ async fn list_components_names_only() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -165,16 +165,19 @@ pub async fn api_request_raw<Req: Serialize>(
 
 #[macro_export]
 macro_rules! test_setup {
-    ($ctx:ident,
-     $jwt_secret_key:ident,
-     $pg:ident,
-     $pgconn:ident,
-     $pgtxn:ident,
-     $nats_conn:ident,
-     $nats:ident,
-     $app:ident,
-     $nba:ident,
-     $auth_token:ident) => {
+    (
+        $ctx:ident,
+        $jwt_secret_key:ident,
+        $pg:ident,
+        $pgconn:ident,
+        $pgtxn:ident,
+        $nats_conn:ident,
+        $nats:ident,
+        $veritech:ident,
+        $app:ident,
+        $nba:ident,
+        $auth_token:ident $(,)?
+    ) => {
         dal::test_harness::one_time_setup()
             .await
             .expect("one time setup failed");
@@ -182,14 +185,14 @@ macro_rules! test_setup {
         let ($pg, $nats_conn, $jwt_secret_key) = $ctx.entries();
         let telemetry = $ctx.telemetry();
         let $nats = $nats_conn.transaction();
-        let veritech = veritech::Client::new($nats_conn.clone());
+        let $veritech = veritech::Client::new($nats_conn.clone());
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
         let $pgtxn = $pgconn.transaction().await.expect("cannot create txn");
         let ($app, _) = sdf::build_service(
             telemetry,
             $pg.clone(),
             $nats_conn.clone(),
-            veritech,
+            $veritech.clone(),
             $jwt_secret_key.clone(),
         )
         .expect("cannot build new server");

--- a/lib/sdf/tests/service_tests/schema.rs
+++ b/lib/sdf/tests/service_tests/schema.rs
@@ -21,6 +21,7 @@ async fn create_schema() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         _nba,
         auth_token
@@ -53,6 +54,7 @@ async fn list_schemas() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -115,6 +117,7 @@ async fn get_schemas() {
         txn,
         _nats_conn,
         nats,
+        _veritech,
         app,
         nba,
         auth_token

--- a/lib/sdf/tests/service_tests/session.rs
+++ b/lib/sdf/tests/service_tests/session.rs
@@ -15,6 +15,7 @@ async fn login() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         nba,
         _auth_token
@@ -68,6 +69,7 @@ async fn restore_authentication() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         nba,
         auth_token
@@ -94,6 +96,7 @@ async fn get_defaults() {
         _txn,
         _nats_conn,
         _nats,
+        _veritech,
         app,
         nba,
         auth_token


### PR DESCRIPTION
This change threads through a `veritech::Client` struct to a couple of
DAL model calls that now require it.

As a consequence of having more Veritech clients in our lives moving
forward, this change also backfills a couple of testing macros (namely
`test_setup!` in `dal` and `sdf`) to include a ready-to-go Veritech
client.

<img src="https://media3.giphy.com/media/Z0ieYDOUC9oorHu4Pn/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>