### PR TITLE
chore(web): first step to restore css in qual

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -9,57 +9,93 @@
     :is-maximized-container-enabled="props.isMaximizedContainerEnabled"
   >
     <template #menuButtons>
-      <div v-if="componentNamesOnlyList" class="min-w-max">
-        <SiSelect
-          id="nodeSelect"
-          v-model="selectedComponentId"
-          size="xs"
-          name="nodeSelect"
-          class="pl-1"
-          :value-as-number="true"
-          :options="componentNamesOnlyList"
-        />
-      </div>
+      <div class="flex flex-row items-center justify-between flex-grow">
+        <div class="flex flex-row">
+          <div class="min-w-max">
+            <SiSelect
+              id="nodeSelect"
+              v-model="selectedComponentId"
+              size="xs"
+              name="nodeSelect"
+              class="pl-1"
+              :value-as-number="true"
+              :options="componentNamesOnlyList"
+            />
+          </div>
+          <LockButton v-model="isPinned" />
+        </div>
 
-      <div class="min-w-max">
-        <button @click="setToAttribute">
-          <VueFeather type="home" stroke="grey" size="1.5rem" />
-        </button>
-      </div>
+        <div class="flex flex-row items-center">
+          <button class="pl-1 focus:outline-none" @click="setToAttribute">
+            <VueFeather
+              v-if="activeView === 'attribute'"
+              type="disc"
+              stroke="cyan"
+              size="1.5rem"
+            />
+            <VueFeather
+              v-else
+              type="disc"
+              class="text-gray-300"
+              size="1.5rem"
+            />
+          </button>
+          <button class="pl-1 focus:outline-none" @click="setToQualification">
+            <VueFeather
+              v-if="activeView === 'qualification'"
+              type="check-square"
+              stroke="cyan"
+              size="1.5rem"
+            />
+            <VueFeather
+              v-else
+              type="check-square"
+              class="text-gray-300"
+              size="1.5rem"
+            />
+          </button>
+        </div>
 
-      <div class="min-w-max">
-        <button @click="setToQualification">
-          <VueFeather type="crosshair" stroke="grey" size="1.5rem" />
-        </button>
+        <div class="flex items-center">
+          <button
+            class="pl-1 text-white focus:outline-none"
+            @click="setToResource"
+          >
+            <VueFeather
+              v-if="activeView === 'resource'"
+              type="box"
+              stroke="cyan"
+              size="1.5rem"
+            />
+            <VueFeather v-else type="box" class="text-gray-300" size="1.5rem" />
+          </button>
+        </div>
       </div>
-
-      <div class="min-w-max">
-        <button @click="setToResource">
-          <VueFeather type="box" stroke="grey" size="1.5rem" />
-        </button>
-      </div>
-
-      <LockButton v-model="isPinned" />
     </template>
 
     <template #content>
-      <AttributeViewer
-        v-if="selectedComponentId && activeView === 'attribute'"
-        :component-id="selectedComponentId"
-      />
-      <QualificationViewer
-        v-if="selectedComponentId && activeView === 'qualification'"
-        :component-id="selectedComponentId"
-      />
-      <ResourceViewer
-        v-if="selectedComponentId && activeView === 'resource'"
-        :component-id="selectedComponentId"
-      />
       <div
-        v-if="!selectedComponentId"
-        class="flex flex-col items-center justify-center w-full h-full align-middle"
+        v-if="selectedComponentId != null && selectedComponentId > -1"
+        class="flex flex-row w-full h-full"
       >
-        <img width="300" :src="cheechSvg" />
+        <AttributeViewer
+          v-if="activeView === 'attribute'"
+          :component-id="selectedComponentId"
+        />
+        <QualificationViewer
+          v-else-if="activeView === 'qualification'"
+          :component-id="selectedComponentId"
+        />
+        <ResourceViewer
+          v-if="activeView === 'resource'"
+          :component-id="selectedComponentId"
+        />
+        <div
+          v-else
+          class="flex flex-col items-center justify-center w-full h-full align-middle"
+        >
+          <img width="300" :src="cheechSvg" alt="Cheech and Chong!" />
+        </div>
       </div>
     </template>
   </Panel>
@@ -84,7 +120,7 @@ import _ from "lodash";
 import cheechSvg from "@/assets/images/cheech-and-chong.svg";
 
 const isPinned = ref<boolean>(false);
-const selectedComponentId = ref<number | "">("");
+const selectedComponentId = ref<number>(-1);
 
 const props = defineProps({
   panelIndex: { type: Number, required: true },
@@ -97,14 +133,14 @@ const props = defineProps({
 });
 
 const activeView = ref<string>("attribute");
-const setToResource = () => {
-  activeView.value = "resource";
-};
 const setToAttribute = () => {
   activeView.value = "attribute";
 };
 const setToQualification = () => {
   activeView.value = "qualification";
+};
+const setToResource = () => {
+  activeView.value = "resource";
 };
 
 const componentNamesOnlyList = refFrom<LabelList<number | "">>(
@@ -122,3 +158,21 @@ const componentNamesOnlyList = refFrom<LabelList<number | "">>(
   ),
 );
 </script>
+
+<style scoped>
+.menu-button-active {
+  color: #69e3d2;
+}
+
+.menu-button-inactive {
+  color: #c6c6c6;
+}
+
+.unlocked {
+  color: #c6c6c6;
+}
+
+.locked {
+  color: #e3ddba;
+}
+</style>

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -1,55 +1,105 @@
 <template>
-  <div v-if="componentId" class="flex flex-col w-full">
-    <div class="flex">
-      <div>
-        <div>Component ID {{ props.componentId }} Qualifications</div>
+  <div v-if="props.componentId" class="flex flex-col w-full">
+    <div
+      class="relative flex flex-row items-center justify-between h-10 pt-2 pb-2 pl-6 pr-6 text-white property-section-bg-color"
+    >
+      <div class="text-lg">
+        Component number {{ props.componentId }}'s qualifications
       </div>
 
       <div class="flex">
-        <button><VueFeather type="refresh-cw" size="1.5rem" /></button>
-        <VueFeather type="check-square" size="1.5rem" />
+        <button v-if="editMode" class="pl-1 focus:outline-none sync-button">
+          <VueFeather
+            ref="sync"
+            type="refresh-cw"
+            size="1.5rem"
+            class="text-sm"
+            :class="refreshButtonClasses()"
+          />
+        </button>
+        <VueFeather
+          v-else
+          type="check-square"
+          class="text-base text-sm text-gray-300"
+          size="1.5rem"
+          :class="refreshButtonClasses()"
+        />
       </div>
     </div>
 
-    <div class="flex flex-col">
-      <div>QualificationChecks Here!</div>
+    <div class="flex flex-col mx-4 mt-2 border qualification-card">
+      <div class="px-2 py-2 text-xs font-medium align-middle title">
+        Qualification Checks
+      </div>
 
-      <div class="flex">
-        <div class="flex flex-col">
+      <div
+        v-if="schema"
+        class="flex w-full h-full pt-2 pb-4 overflow-auto background-color"
+      >
+        <div class="flex flex-col w-full">
           <div
             v-for="q in allQualifications"
             :key="q.name"
-            class="flex flex-col"
+            class="flex flex-col py-1 mx-2 mt-2 text-sm border qualification-section"
           >
-            <div class="flex flex-row">
-              <div v-if="showQualificationStarting" class="flex">
+            <div class="flex flex-row items-center w-full pl-4 my-1">
+              <div v-if="qualificationStarting(q.name)" class="flex">
+                <VueLoading
+                  class="inline-flex"
+                  type="cylon"
+                  :size="{ width: '14px', height: '14px' }"
+                />
+              </div>
+              <div v-else-if="q.result" class="flex">
                 <VueFeather
-                  type="rotate-cw"
-                  animation="spin"
-                  animation-speed="slow"
+                  v-if="qualificationResultQualified(q)"
+                  type="smile"
+                  class="text-green-300"
+                  size="1.5rem"
+                />
+                <VueFeather
+                  v-else
+                  type="frown"
+                  class="text-xs error"
                   size="1.5rem"
                 />
               </div>
-              <div v-else-if="showQualificationResult" class="flex">
-                <VueFeather type="smile" color="green" size="1.5rem" />
-                <VueFeather type="frown" color="red" size="1.5rem" />
-              </div>
               <div v-else class="flex">
-                <VueFeather type="square" size="1.5rem" />
+                <VueFeather type="square" class="text-gray-700" size="1.5rem" />
               </div>
-              <div class="flex">title: {{ q.title }}</div>
-              <div v-if="showQualificationLink" class="flex">
+
+              <div
+                v-if="q.title"
+                class="flex ml-2 text-xs qualification-check-title"
+              >
+                {{ q.title }}
+              </div>
+              <div v-if="q.link" class="flex ml-2">
                 <a target="_blank" :href="q.link">
-                  <VueFeather type="link" size="1.5rem" />
+                  <VueFeather type="link" class="info-button" size="1.5rem" />
                 </a>
               </div>
-              <div class="flex flex-grow"></div>
+              <div class="flex justify-end flex-grow pr-4">
+                <button
+                  class="focus:outline-none"
+                  @click="setShowDescription(q.description)"
+                >
+                  <VueFeather
+                    v-if="showDescription"
+                    type="chevron-up"
+                    size="1.5rem"
+                  />
+                  <VueFeather v-else type="chevron-down" size="1.5rem" />
+                </button>
+              </div>
             </div>
 
-            <!-- NOTE(nick): showing description should be toggleable. -->
-            <div v-if="q.description" class="flex flex-col">
-              <div v-if="q.result" class="flex flex-col">
-                <div class="border border-solid border-slate-100">
+            <div
+              v-if="showDescription && q.description"
+              class="flex flex-col w-full"
+            >
+              <div v-if="q.result" class="flex flex-col w-full">
+                <div class="mt-1">
                   <QualificationOutput :result="q.result" />
                 </div>
               </div>
@@ -69,11 +119,49 @@ import { refFrom } from "vuse-rx";
 import { from, switchMap } from "rxjs";
 import { GlobalErrorService } from "@/service/global_error";
 import { Qualification } from "@/api/sdf/dal/qualification";
+import { VueLoading } from "vue-loading-template";
+import { ref } from "vue";
+import { ChangeSetService } from "@/service/change_set";
 //import { ListQualificationsResponse } from "@/service/component/list_qualifications";
 
-const showQualificationResult = true;
-const showQualificationStarting = true;
-const showQualificationLink = true;
+const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
+
+// TODO(nick): replace mock data and functions.
+const schema = true;
+
+// FIXME(nick): implement active state.
+function isQualifying() {
+  return false;
+}
+
+// FIXME(nick): implement active state.
+function qualificationStarting(_qualification_name: string) {
+  return false;
+}
+
+function qualificationResultQualified(qualification: Qualification) {
+  if (qualification.result) {
+    return qualification.result?.success;
+  }
+  return false;
+}
+
+function isQualified(qualifications: Array<Qualification>): boolean {
+  qualifications.forEach((q) => {
+    // Do nothing if the result is qualified or does not exist.
+    if (q.result && !q.result.success) {
+      return false;
+    }
+  });
+
+  // All results are qualified, do not have an attached result, or a mixture of the two.
+  return true;
+}
+
+const showDescription = ref<boolean>(false);
+function setShowDescription(description: string) {
+  showDescription.value = description !== "";
+}
 
 const props = defineProps<{
   componentId: number;
@@ -93,4 +181,84 @@ const allQualifications = refFrom<Array<Qualification>>(
     }),
   ),
 );
+
+function refreshButtonClasses(): Record<string, any> {
+  let classes: Record<string, any> = {};
+  if (allQualifications.value && allQualifications.value.length > 0) {
+    if (isQualifying()) {
+      classes["animation"] = "spin";
+      classes["success"] = false;
+      classes["error"] = false;
+      classes["qualifying"] = true;
+    }
+
+    if (isQualified(allQualifications.value)) {
+      classes["success"] = true;
+    } else {
+      classes["error"] = true;
+    }
+  } else {
+    classes["unknown"] = true;
+  }
+  return classes;
+}
 </script>
+
+<style scoped>
+.background-color {
+  background-color: #151515;
+}
+
+.title {
+  background-color: #1f2122;
+  color: #e9f2fe;
+}
+
+.qualification-card {
+  border-color: #1f2122;
+}
+
+.qualification-check-title {
+  color: #d4d4d4;
+}
+
+.qualification-section {
+  border-color: #2d3032;
+}
+
+.info-button {
+  color: #8fc8ff;
+}
+
+.success {
+  color: #86f0ad;
+}
+
+.error {
+  color: #f08686;
+}
+
+.unknown {
+  color: #bbbbbb;
+}
+
+.qualifying {
+  color: #bbbbbb;
+}
+
+.sync-button {
+  color: #a8cc5f;
+}
+
+/*.sync-button:hover {*/
+/*  filter: brightness($button-brightness);*/
+/*}*/
+
+.sync-button:focus {
+  outline: none;
+}
+
+/*.sync-button:active {*/
+/*  filter: saturate(1.5) brightness($button-brightness);*/
+/*}*/
+</style>

--- a/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
+++ b/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
@@ -1,27 +1,22 @@
 <template>
-  <div>
-    <div v-if="props.result">
-      <div class="flex flex-row">
-        <div><VueFeather type="check" size="1.5rem" /></div>
-        <div class="flex flex-row">
-          <div>Qualification status: (</div>
-          <span v-if="props.result.success">success</span>
-          <span v-else>failure</span>
-          <div>)</div>
-        </div>
-      </div>
+  <div class="w-full pb-1">
+    <div v-if="parseKubevalOutput">
+      <div class="text-xs">TODO(nick): implement parseKubevalOutput</div>
+    </div>
 
+    <div
+      v-else-if="parseValidFieldsOutput"
+      class="pt-3 pb-4 border-t border-gray-800"
+    >
+      <div class="text-xs">TODO(nick): implement parseValidFieldsOutput</div>
+    </div>
+
+    <div v-else class="flex flex-col flex-grow border-t border-gray-800">
+      <div class="mt-2 mb-1 ml-2 text-xs font-medium output-title">Output</div>
       <div
-        v-for="error in props.result.errors"
-        :key="error.message"
-        class="flex flex-col flex-grow"
+        class="px-6 text-xs leading-relaxed whitespace-pre-line select-text output-lines"
       >
-        <div v-if="!props.result.success">
-          <div class="flex flex-row">
-            <VueFeather type="alert-triangle" size="1.5rem" />
-            <div>{{ error.message }}</div>
-          </div>
-        </div>
+        {{ data }}
       </div>
     </div>
   </div>
@@ -29,9 +24,48 @@
 
 <script setup lang="ts">
 import { QualificationResult } from "@/api/sdf/dal/qualification";
-import VueFeather from "vue-feather";
+import { computed } from "vue";
+
+// TODO(nick): remove dummy values.
+const parseKubevalOutput = false;
+const parseValidFieldsOutput = false;
+
+// TODO(nick): determine how to handle multiple errors since veritech only returns one error message (currently).
+const data = computed(() => {
+  let data = "";
+  for (let error of props.result.errors) {
+    if (data === "") {
+      data = error.message;
+    } else {
+      data = data + "\n" + error.message;
+    }
+  }
+  return data;
+});
 
 const props = defineProps<{
   result: QualificationResult;
 }>();
 </script>
+
+<style scoped>
+.success {
+  color: #4bde80;
+}
+
+.error {
+  color: #fb7185;
+}
+
+.unknown {
+  color: #969696;
+}
+
+.output-lines {
+  color: #e5decf;
+}
+
+.output-title {
+  color: #e5e5e5;
+}
+</style>


### PR DESCRIPTION
- First step to restore css and icons in qualifications components
[sc-2146]
- Three components were changed: PanelAttribute, QualificationViewer,
and QualificationOutput
- The Tailwind CSS classes were validated and derived from the demo
- The icons were chosen with the closest possible matches from the demo

<img src="https://media1.giphy.com/media/daD1h5mKuTLlBnr7jr/giphy.gif"/>