### PR TITLE
chore(cyclone,dal,telemetry): make `lang-js` logging configurable

### DIFF
--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -30,9 +30,11 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
 
     start_tracing_level_signal_handler_task(&telemetry)?;
 
+    let telemetry = Box::new(telemetry);
+
     match config.incoming_stream() {
-        IncomingStream::HTTPSocket(_) => Server::http(config)?.run().await?,
-        IncomingStream::UnixDomainSocket(_) => Server::uds(config).await?.run().await?,
+        IncomingStream::HTTPSocket(_) => Server::http(config, telemetry)?.run().await?,
+        IncomingStream::UnixDomainSocket(_) => Server::uds(config, telemetry).await?.run().await?,
     }
 
     Ok(())

--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -447,7 +447,9 @@ mod tests {
             .build()
             .expect("failed to build config");
 
-        Server::uds(config).await.expect("failed to init server")
+        Server::uds(config, Box::new(telemetry::NoopClient))
+            .await
+            .expect("failed to init server")
     }
 
     async fn uds_client_for_running_server(
@@ -469,7 +471,7 @@ mod tests {
             .build()
             .expect("failed to build config");
 
-        Server::http(config).expect("failed to init server")
+        Server::http(config, Box::new(telemetry::NoopClient)).expect("failed to init server")
     }
 
     async fn http_client_for_running_server(builder: &mut ConfigBuilder) -> HttpClient {

--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -24,5 +24,6 @@ pub use application::{
 mod library;
 #[cfg(feature = "library")]
 pub use library::{
-    prelude, Client, ClientError, TelemetryClient, TracingLevel, UpdateOpenTelemetry, Verbosity,
+    prelude, Client, ClientError, NoopClient, TelemetryClient, TelemetryLevel, TracingLevel,
+    UpdateOpenTelemetry, Verbosity,
 };


### PR DESCRIPTION
Yes, yes, a task to configure a logging level for `lang-js`...by
changing no code in `lang-js` you say?

Well, `lang-js` is doing just fine, thanks for asking. Right now, a
Cyclone server will spawn a process of `lang-js` and before this change
it was unconditionally setting the output to debug level. This change
threads through a notion of a `TelemetryLevel`, which is a trait in
our `tracing` crate for any type that can answer if it is in debug
level logging or lower (that is, trace, etc.).

Now by default, if a Cyclone server is running a debug or lower logging
level, then any `lang-js` that is spun up will also be at a debug level
of logging.

In our testing code, Cyclone servers and Veritech servers can be
spawned, both of which will ultimately spawn `lang-js` instances.  By
default in tests, these processes will log at their standard info levels
so far less output is seen mixed in with the Rust tests. If you wish to
see `lang-js` output then set the `SI_TEST_VERBOSE` environment variable
to some non-empty value when running tests like `env SI_TEST_VERBOSE=1
cargo test`.

Note that Cyclone and Veritech servers may still be emitting their log
output during tests, but that's the topic of another batch of changes.
Until next time!

<img src="https://media0.giphy.com/media/13JvTLd46G8v5K/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>