### PR TITLE
feat(lang-js): create initial resourceSync function kind

### DIFF
--- a/bin/lang-js/examples/resourceSyncTest.json
+++ b/bin/lang-js/examples/resourceSyncTest.json
@@ -1,0 +1,5 @@
+{
+  "executionId": "9012",
+  "handler": "sync",
+  "codeBase64": "Ly8gRW5jb2RlIHRoaXMgaW50byBCYXNlNjQgd2l0aDoKLy8KLy8gYGBgc2gKLy8gY2F0IGV4YW1wbGVzL3Jlc291cmNlU3luY1Rlc3RDb2RlLmpzIHwgYmFzZTY0IHwgdHIgLWQgJ1xuJwovLyBgYGAKCmZ1bmN0aW9uIHN5bmMoKSB7CiAgY29uc29sZS5sb2coInN5bmNpbmcgc29tZXRoaW5nLCByaWdodD8iKTsKICByZXR1cm4ge307Cn0K"
+}

--- a/bin/lang-js/examples/resourceSyncTestCode.js
+++ b/bin/lang-js/examples/resourceSyncTestCode.js
@@ -1,0 +1,10 @@
+// Encode this into Base64 with:
+//
+// ```sh
+// cat examples/resourceSyncTestCode.js | base64 | tr -d '\n'
+// ```
+
+function sync() {
+  console.log("syncing something, right?");
+  return {};
+}

--- a/bin/lang-js/src/function.ts
+++ b/bin/lang-js/src/function.ts
@@ -1,10 +1,15 @@
 export enum FunctionKind {
   QualificationCheck = "qualificationcheck",
   ResolverFunction = "resolverfunction",
+  ResourceSync = "resourceSync",
 }
 
 export function function_kinds(): Array<string> {
-  return [FunctionKind.QualificationCheck, FunctionKind.ResolverFunction];
+  return [
+    FunctionKind.QualificationCheck,
+    FunctionKind.ResolverFunction,
+    FunctionKind.ResourceSync,
+  ];
 }
 
 export type Parameters = Record<string, unknown>;

--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -4,9 +4,10 @@ import fs from "fs";
 import { Command } from "commander";
 import Debug from "debug";
 import { failureExecution, FunctionKind, function_kinds } from "./function";
-import { executeResolverFunction } from "./resolver_function";
 import { makeConsole } from "./sandbox/console";
 import { executeQualificationCheck } from "./qualification_check";
+import { executeResolverFunction } from "./resolver_function";
+import { executeResourceSync } from "./resource_sync";
 
 const debug = Debug("langJs");
 
@@ -52,6 +53,9 @@ function main() {
         break;
       case FunctionKind.ResolverFunction:
         executeResolverFunction(request);
+        break;
+      case FunctionKind.ResourceSync:
+        executeResourceSync(request);
         break;
       default:
         throw Error(`Unknown Kind variant: ${kind}`);

--- a/bin/lang-js/src/resource_sync.ts
+++ b/bin/lang-js/src/resource_sync.ts
@@ -1,0 +1,84 @@
+import Debug from "debug";
+import _ from "lodash";
+import { VM, VMScript } from "vm2";
+import { base64Decode } from "./base64";
+import {
+  failureExecution,
+  FunctionKind,
+  Request,
+  ResultFailure,
+  ResultSuccess,
+} from "./function";
+import { createSandbox } from "./sandbox";
+import { createVm } from "./vm";
+
+const debug = Debug("langJs:resourceSync");
+
+export interface ResourceSyncRequest extends Request {
+  handler: string;
+  codeBase64: string;
+}
+
+export type ResourceSyncResult =
+  | ResourceSyncResultSuccess
+  | ResourceSyncResultFailure;
+
+export interface ResourceSyncResultSuccess extends ResultSuccess {
+  something?: string;
+}
+
+export interface ResourceSyncResultFailure extends ResultFailure {
+  something?: never;
+}
+
+export function executeResourceSync(request: ResourceSyncRequest): void {
+  const code = base64Decode(request.codeBase64);
+  debug({ code });
+  const compiledCode = new VMScript(wrapCode(code, request.handler)).compile();
+  debug({ code: compiledCode.code });
+  const sandbox = createSandbox(FunctionKind.ResourceSync, request.executionId);
+  const vm = createVm(sandbox);
+
+  const result = execute(vm, compiledCode, request.executionId);
+  debug({ result });
+
+  console.log(JSON.stringify(result));
+}
+
+function execute(
+  vm: VM,
+  code: VMScript,
+  executionId: string
+): ResourceSyncResult {
+  let resourceSyncResult;
+  try {
+    resourceSyncResult = vm.run(code);
+  } catch (err) {
+    return failureExecution(err, executionId);
+  }
+
+  if (_.isUndefined(resourceSyncResult) || _.isNull(resourceSyncResult)) {
+    return {
+      protocol: "result",
+      status: "failure",
+      executionId,
+      error: {
+        kind: "InvalidReturnType",
+        message: "Return type must not be null or undefined",
+      },
+    };
+  }
+
+  // TODO(fnichol): minimum checking of other result fields here...
+
+  const result: ResourceSyncResultSuccess = {
+    protocol: "result",
+    status: "success",
+    executionId,
+  };
+  return result;
+}
+
+function wrapCode(code: string, handle: string): string {
+  return code + `\n${handle}();\n`;
+}

--- a/bin/lang-js/src/sandbox.ts
+++ b/bin/lang-js/src/sandbox.ts
@@ -22,6 +22,8 @@ function commonSandbox(executionId: string): Sandbox {
 
 const resolverFunctionSandbox = {};
 
+const resourceSyncSandbox = {};
+
 const qualificationCheckSandbox = {};
 
 export function createSandbox(
@@ -38,6 +40,11 @@ export function createSandbox(
       return {
         ...commonSandbox(executionId),
         ...qualificationCheckSandbox,
+      };
+    case FunctionKind.ResourceSync:
+      return {
+        ...commonSandbox(executionId),
+        ...resourceSyncSandbox,
       };
     default:
       throw new UnknownSandboxKind(kind);


### PR DESCRIPTION
Currently the request/response types are created but do not have any
special fields in them (i.e. the request requires no special parameters
and it returns nothing but an empty object).

Further work can fill these types in to flow back upstream.

References: add the resource sync capability to lang [sc-2147]

<img src="https://media2.giphy.com/media/RJVdIhqjpB3b7IXa63/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>