### PR TITLE
bug(web): fix reactivity in attribute panel

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -59,7 +59,7 @@
         "vue-loading-template": "^1.3.2",
         "vue-router": "^4.0.11",
         "vue-tsc": "^0.3.0",
-        "vuse-rx": "^0.13.1"
+        "vuse-rx": "systeminit/vuse-rx#bug/fix-options"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6803,9 +6803,9 @@
     },
     "node_modules/vuse-rx": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/vuse-rx/-/vuse-rx-0.13.1.tgz",
-      "integrity": "sha512-Jg0BjqUObKTIrm8HmGmyj/h5tEb5UxVvp5wqVZu2GviUAsSDyMrV2nWZsJ5z/1cjNRmm9KkZH+eJNQS8ihLEUg==",
+      "resolved": "git+ssh://git@github.com/systeminit/vuse-rx.git#26fcfc6fbea5a749e84dd2a97812affa99e64eb4",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "rxjs": "^7.1.0",
         "vue": "^3.0.5"
@@ -11981,10 +11981,9 @@
       }
     },
     "vuse-rx": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/vuse-rx/-/vuse-rx-0.13.1.tgz",
-      "integrity": "sha512-Jg0BjqUObKTIrm8HmGmyj/h5tEb5UxVvp5wqVZu2GviUAsSDyMrV2nWZsJ5z/1cjNRmm9KkZH+eJNQS8ihLEUg==",
+      "version": "git+ssh://git@github.com/systeminit/vuse-rx.git#26fcfc6fbea5a749e84dd2a97812affa99e64eb4",
       "dev": true,
+      "from": "vuse-rx@systeminit/vuse-rx#bug/fix-options",
       "requires": {}
     },
     "which": {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -68,7 +68,7 @@
     "vue-loading-template": "^1.3.2",
     "vue-router": "^4.0.11",
     "vue-tsc": "^0.3.0",
-    "vuse-rx": "^0.13.1",
+    "vuse-rx": "systeminit/vuse-rx#bug/fix-options",
     "faker": "^5.5.3"
   },
   "eslintConfig": {

--- a/app/web/src/atoms/SiSelect.vue
+++ b/app/web/src/atoms/SiSelect.vue
@@ -47,7 +47,7 @@ export interface SelectProps {
 
 const props = defineProps({
   styling: {
-    type: Object as PropType<Record<string, any>>,
+    type: Object as PropType<Record<string, unknown>>,
     default: null,
   },
   id: {

--- a/app/web/src/organisims/EditForm.vue
+++ b/app/web/src/organisims/EditForm.vue
@@ -1,15 +1,15 @@
 <template>
-  <Widgets :edit-fields="editFields" />
+  <Widgets v-if="editFields" :edit-fields="editFields" />
 </template>
 
 <script setup lang="ts">
 import { PropType } from "vue";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
-import { refFrom, fromRef } from "vuse-rx";
+import { fromRef, refFrom } from "vuse-rx";
 import { EditFieldService } from "@/service/edit_field";
 import { GlobalErrorService } from "@/service/global_error";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
-import { from } from "rxjs";
+import { combineLatest, from } from "rxjs";
 import { switchMap } from "rxjs/operators";
 
 const props = defineProps({
@@ -23,11 +23,11 @@ const props = defineProps({
   },
 });
 
-const props$ = fromRef(props);
+const props$ = fromRef(props, { immediate: true, deep: true });
 
 const editFields = refFrom<EditFields>(
-  props$.pipe(
-    switchMap((props) => {
+  combineLatest([props$]).pipe(
+    switchMap(([props]) => {
       return EditFieldService.getEditFields({
         id: props.objectId,
         objectKind: props.objectKind,

--- a/app/web/src/service/component/list_components_names_only.ts
+++ b/app/web/src/service/component/list_components_names_only.ts
@@ -1,14 +1,8 @@
 import { ApiResponse, SDF } from "@/api/sdf";
-import {
-  combineLatest,
-  combineLatestWith,
-  from,
-  Observable,
-  share,
-} from "rxjs";
+import { combineLatest, combineLatestWith, from, Observable } from "rxjs";
 import { standardVisibilityTriggers$ } from "@/observable/visibility";
 import Bottle from "bottlejs";
-import { switchMap } from "rxjs/operators";
+import { shareReplay, switchMap } from "rxjs/operators";
 import { workspace$ } from "@/observable/workspace";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import _ from "lodash";
@@ -49,7 +43,7 @@ const componentNamesOnlyList$ = combineLatest([
       request,
     );
   }),
-  share(),
+  shareReplay({ bufferSize: 1, refCount: true }),
 );
 
 export function listComponentsNamesOnly(): Observable<


### PR DESCRIPTION
Fixes a number of reactivity bugs in the attribute panel. The first was
our SiSelect component not being told to return the values as numbers,
and therefore it emitted values as strings.

The second (and more pernicious) issue was related to when the
observable to fetch the attribute data would fire when it was being fed
property information. It showed itself in two ways:

1. When a component should be reactive to property changes, and that
   reactivity happens from within an observable call (for example, using
   a `service` object to call sdf), the property that you wish to
   observe must be independently turned in to a Ref. (For background,
   the props object itself is reactive, but not *deeply* reactive). This
   can be done with `fromRef(props, { immediate: true, deep: true })`,
   or from otherwise destructuring the props to make them reactive.

2. When trying to use the property value in an observable, there was a
   bug in vuse-rx. The documentation said that calls to `fromRef` could
   take options (as the example above shows). Unfortunately, while the
   types themselves said the function would accept options, the options
   were never passed to the underlying `watch`. The result is that no
   matter what set of options were passed to `fromRef`, the first
   emission would not trigger the watch.

I have patched the upstream library and sent a pull request. When it is
merged and a new release is cut, we can upgrade our dependency. Until
then, we are pointing to a branch with the bugfix in it.

Signed-off-by: Adam Jacob <adam@systeminit.com>