### PR TITLE
feat(web): Restore Resource sub-panel

### DIFF
--- a/app/web/src/api/sdf/dal/resource.ts
+++ b/app/web/src/api/sdf/dal/resource.ts
@@ -1,0 +1,30 @@
+export enum ResourceHealth {
+  Ok = "ok",
+  Warning = "warning",
+  Error = "error",
+  Unknown = "unknown",
+}
+
+export enum ResourceStatus {
+  Pending = "pending",
+  InProgress = "inProgress",
+  Created = "created",
+  Failed = "failed",
+  Deleted = "deleted",
+}
+
+export interface Resource {
+  id: number;
+  // unixTimestamp: string;
+  timestamp: string;
+  error?: string; // TODO: what is this?
+  data: unknown; // TODO: what is this?
+  // state: any;
+  // status: ResourceStatus;
+  health: ResourceHealth;
+  // systemId: string;
+  // nodeId: string;
+  // entityId: string;
+  entityType: string; // TODO: make it an enum?
+  // siStorable: ISiStorable;
+}

--- a/app/web/src/atoms/SiTextBox.vue
+++ b/app/web/src/atoms/SiTextBox.vue
@@ -18,7 +18,7 @@
       :type="type"
       :aria-required="required"
       :placeholder="placeholder"
-      :value="value"
+      :value="modelValue"
       :data-test="id"
       class="block w-full h-24 px-2 py-1 pr-8 leading-tight text-gray-400 border border-gray-800 border-solid shadow shadow-inner resize-y focus:outline-none bg-blueGray-700"
       @input="valueChanged"

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -33,6 +33,12 @@
         </button>
       </div>
 
+      <div class="min-w-max">
+        <button @click="setToResource">
+          <VueFeather type="box" stroke="grey" size="1.5rem" />
+        </button>
+      </div>
+
       <LockButton v-model="isPinned" />
     </template>
 
@@ -43,6 +49,10 @@
       />
       <QualificationViewer
         v-if="selectedComponentId && activeView === 'qualification'"
+        :component-id="selectedComponentId"
+      />
+      <ResourceViewer
+        v-if="selectedComponentId && activeView === 'resource'"
         :component-id="selectedComponentId"
       />
       <div
@@ -68,6 +78,7 @@ import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import AttributeViewer from "@/organisims/AttributeViewer.vue";
 import QualificationViewer from "@/organisims/QualificationViewer.vue";
+import ResourceViewer from "@/organisims/ResourceViewer.vue";
 import VueFeather from "vue-feather";
 import _ from "lodash";
 import cheechSvg from "@/assets/images/cheech-and-chong.svg";
@@ -86,6 +97,9 @@ const props = defineProps({
 });
 
 const activeView = ref<string>("attribute");
+const setToResource = () => {
+  activeView.value = "resource";
+};
 const setToAttribute = () => {
   activeView.value = "attribute";
 };

--- a/app/web/src/organisims/ResourceViewer.vue
+++ b/app/web/src/organisims/ResourceViewer.vue
@@ -1,0 +1,125 @@
+<template>
+  <div v-if="props.componentId" class="flex flex-col w-full">
+    <div
+      class="flex flex-row items-center justify-between h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
+    >
+      <div>
+        <div>Component ID {{ props.componentId }} Resources</div>
+      </div>
+
+      <div class="flex pl-1">
+        <button
+          v-if="!editMode"
+          ref="sync"
+          class="flex items-center focus:outline-none button"
+          @click="runSync()"
+        >
+          <VueFeather type="refresh-cw" :stroke="healthColor()" size="1.5rem" />
+        </button>
+        <VueFeather v-else type="box" :stroke="healthColor()" size="1.5rem" />
+      </div>
+    </div>
+
+    <div class="flex flex-row">
+      <div class="w-full h-full pt-2">
+        <SiTextBox
+          v-if="resource"
+          id="resourceJson"
+          name="resourceJson"
+          :placeholder="JSON.stringify(resource)"
+          :is-text-area="true"
+          :model-value="JSON.stringify(resource)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, defineProps } from "vue";
+import { Resource, ResourceHealth } from "@/api/sdf/dal/resource";
+import SiTextBox from "@/atoms/SiTextBox.vue";
+import { ResourceService } from "@/service/resource";
+import { GlobalErrorService } from "@/service/global_error";
+import { ChangeSetService } from "@/service/change_set";
+import { refFrom } from "vuse-rx";
+import VueFeather from "vue-feather";
+
+const props = defineProps<{
+  componentId: number;
+}>();
+const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
+const sync = ref<HTMLElement | null>(null);
+const resource = ref<Resource | null>(null);
+import { firstValueFrom } from "rxjs";
+
+const healthColor = () => {
+  if (resource.value) {
+    if (resource.value.health == ResourceHealth.Ok) {
+      return "#86f0ad";
+    } else if (resource.value.health == ResourceHealth.Warning) {
+      return "#f0d286";
+    } else if (resource.value.health == ResourceHealth.Error) {
+      return "#f08686";
+    } else if (resource.value.health == ResourceHealth.Unknown) {
+      return "#bbbbbb";
+    }
+  }
+  return "#bbbbbb";
+};
+
+const animateSyncButton = () => {
+  const button = sync.value;
+  if (button) {
+    button.animate(
+      [{ transform: "rotate(0deg)" }, { transform: "rotate(720deg)" }],
+      {
+        duration: 2500,
+        easing: "linear",
+      },
+    );
+  }
+};
+
+const runSync = async () => {
+  animateSyncButton();
+  const reply = await firstValueFrom(
+    ResourceService.syncResource({ componentId: props.componentId }),
+  );
+  if (reply.error) {
+    GlobalErrorService.set(reply);
+  } else {
+    resource.value = reply.resource;
+  }
+};
+runSync();
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.1;
+
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+
+.header-background {
+  background-color: #1f2122;
+}
+
+.button:hover {
+  filter: brightness($button-brightness);
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+
+.sync-button-invert {
+  transform: scaleX(-1);
+}
+</style>

--- a/app/web/src/service/resource.ts
+++ b/app/web/src/service/resource.ts
@@ -1,0 +1,5 @@
+import { syncResource } from "./resource/sync_resource";
+
+export const ResourceService = {
+  syncResource,
+};

--- a/app/web/src/service/resource/sync_resource.ts
+++ b/app/web/src/service/resource/sync_resource.ts
@@ -1,0 +1,65 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, from, Observable } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { workspace$ } from "@/observable/workspace";
+import { system$ } from "@/observable/system";
+import { Resource, ResourceHealth } from "@/api/sdf/dal/resource";
+import _ from "lodash";
+
+export interface SyncResourceArgs {
+  componentId: number;
+}
+
+export interface SyncResourceRequest extends SyncResourceArgs, Visibility {
+  systemId?: number;
+  workspaceId: number;
+}
+
+export type SyncResourceResponse = { resource: Resource };
+
+export function syncResource(
+  args: SyncResourceArgs,
+): Observable<ApiResponse<SyncResourceResponse>> {
+  return combineLatest([standardVisibilityTriggers$, system$, workspace$]).pipe(
+    switchMap(([[_visibility], _system, workspace]) => {
+      const bottle = Bottle.pop("default");
+      const _sdf: SDF = bottle.container.SDF;
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      return from([
+        {
+          resource: {
+            id: args.componentId,
+            timestamp: "0",
+            error: "Boto Cor de Rosa Spotted",
+            data: { "Saci-Pererê": { "Its just a prank bro": 3 } },
+            health: ResourceHealth.Warning,
+            entityType:
+              "Eat Acarajé with Shrimps & Vatapa & Caruru & a lot of hot sauce",
+          },
+        },
+      ]);
+      //return sdf.get<ApiResponse<SyncResourceResponse>>(
+      //  "resource/sync_resource",
+      //  {
+      //    ...args,
+      //    ...visibility,
+      //    systemId: system.id,
+      //    workspaceId: workspace.id,
+      //  },
+      //);
+    }),
+  );
+}


### PR DESCRIPTION
This restores a basic ResourceViewer that just dumps the JSON on the screen, without all the specialized sub viewers we used to have. So we can use this to create a generic viewer, that renders any kind of JSON dynamically.

This also creates a mock ResourceService that returns dummy value, to be replaced by an actual SDF call.