### PR TITLE
feat(dal): add qualification prototype to docker image

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -881,4 +881,12 @@ impl ComponentQualificationView {
 
         Ok(qualification_view)
     }
+
+    /// Create an empty componenent qualification view; useful for qualification prototypes.
+    pub fn empty() -> ComponentQualificationView {
+        ComponentQualificationView {
+            name: "".to_string(),
+            properties: HashMap::new(),
+        }
+    }
 }

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -18,8 +18,8 @@ use crate::{
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
     AttributeResolverError, BillingAccount, BillingAccountId, Component, HistoryActor,
     HistoryEventError, LabelEntry, LabelList, Organization, OrganizationId, PropError,
-    StandardModel, StandardModelError, Tenancy, Timestamp, ValidationPrototypeError, Visibility,
-    Workspace, WorkspaceId, WsEventError,
+    QualificationPrototypeError, StandardModel, StandardModelError, Tenancy, Timestamp,
+    ValidationPrototypeError, Visibility, Workspace, WorkspaceId, WsEventError,
 };
 
 use crate::socket::SocketError;
@@ -68,6 +68,10 @@ pub enum SchemaError {
     AttributeResolver(#[from] AttributeResolverError),
     #[error("func binding error: {0}")]
     FuncBinding(#[from] FuncBindingError),
+    #[error("func not found: {0}")]
+    FuncNotFound(String),
+    #[error("qaulification prototype error: {0}")]
+    Qualification(#[from] QualificationPrototypeError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;


### PR DESCRIPTION
This PR adds a qualification prototype to the dockerImage's default
schema variant. It should complete [sc-2154].

Signed-off-by: Adam Jacob <adam@systeminit.com>