### PR TITLE
feat(cyclone) impl resource sync endpoint on server

### DIFF
--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -56,6 +56,14 @@ pub(crate) struct Args {
     #[clap(long, group = "ping")]
     pub(crate) disable_ping: bool,
 
+    /// Enables qualification endpoint.
+    #[clap(long, group = "qualification")]
+    pub(crate) enable_qualification: bool,
+
+    /// Disables qualification endpoint.
+    #[clap(long, group = "qualification")]
+    pub(crate) disable_qualification: bool,
+
     /// Enables resolver endpoint.
     #[clap(long, group = "resolver")]
     pub(crate) enable_resolver: bool,
@@ -64,13 +72,13 @@ pub(crate) struct Args {
     #[clap(long, group = "resolver")]
     pub(crate) disable_resolver: bool,
 
-    /// Enables qualification endpoint.
-    #[clap(long, group = "qualification")]
-    pub(crate) enable_qualification: bool,
+    /// Enables sync endpoint.
+    #[clap(long, group = "sync")]
+    pub(crate) enable_sync: bool,
 
-    /// Disables qualification endpoint.
-    #[clap(long, group = "qualification")]
-    pub(crate) disable_qualification: bool,
+    /// Disables sync endpoint.
+    #[clap(long, group = "sync")]
+    pub(crate) disable_sync: bool,
 
     /// Path to the lang server program.
     #[clap(long, env = "SI_LANG_SERVER", setting = ArgSettings::HideEnvValues)]
@@ -110,16 +118,22 @@ impl TryFrom<Args> for Config {
             builder.enable_ping(false);
         }
 
+        if args.enable_qualification {
+            builder.enable_qualification(true);
+        } else if args.disable_qualification {
+            builder.enable_qualification(false);
+        }
+
         if args.enable_resolver {
             builder.enable_resolver(true);
         } else if args.disable_resolver {
             builder.enable_resolver(false);
         }
 
-        if args.enable_qualification {
-            builder.enable_qualification(true);
-        } else if args.disable_qualification {
-            builder.enable_qualification(false);
+        if args.enable_sync {
+            builder.enable_sync(true);
+        } else if args.disable_sync {
+            builder.enable_sync(false);
         }
 
         if args.lang_server.is_file() {

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -17,6 +17,7 @@ mod progress;
 mod qualification_check;
 mod readiness;
 mod resolver_function;
+mod resource_sync;
 
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use progress::{
@@ -28,6 +29,7 @@ pub use qualification_check::{
 };
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
 pub use resolver_function::{ResolverFunctionRequest, ResolverFunctionResultSuccess};
+pub use resource_sync::{ResourceSyncRequest, ResourceSyncResultSuccess};
 
 #[cfg(feature = "process")]
 pub mod process;

--- a/lib/cyclone/src/resource_sync.rs
+++ b/lib/cyclone/src/resource_sync.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSyncRequest {
+    pub execution_id: String,
+    pub handler: String,
+    pub code_base64: String,
+}
+
+impl ResourceSyncRequest {
+    pub fn deserialize_from_str(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+
+    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ResourceSyncResultSuccess {
+    pub execution_id: String,
+    pub timestamp: u64,
+}

--- a/lib/cyclone/src/server.rs
+++ b/lib/cyclone/src/server.rs
@@ -10,6 +10,7 @@ pub(crate) mod extract;
 mod handlers;
 pub mod qualification_check;
 pub mod resolver_function;
+pub mod resource_sync;
 mod routes;
 mod server;
 pub(crate) mod tower;

--- a/lib/cyclone/src/server/config.rs
+++ b/lib/cyclone/src/server/config.rs
@@ -30,10 +30,13 @@ pub struct Config {
     enable_ping: bool,
 
     #[builder(default = "true")]
+    enable_qualification: bool,
+
+    #[builder(default = "true")]
     enable_resolver: bool,
 
     #[builder(default = "true")]
-    enable_qualification: bool,
+    enable_sync: bool,
 
     #[builder(default = "IncomingStream::default()")]
     incoming_stream: IncomingStream,
@@ -64,16 +67,22 @@ impl Config {
         self.enable_ping
     }
 
+    /// Gets a reference to the config's enable qualification.
+    #[must_use]
+    pub fn enable_qualification(&self) -> bool {
+        self.enable_qualification
+    }
+
     /// Gets a reference to the config's enable resolver.
     #[must_use]
     pub fn enable_resolver(&self) -> bool {
         self.enable_resolver
     }
 
-    /// Gets a reference to the config's enable qualification.
+    /// Gets a reference to the config's enable sync.
     #[must_use]
-    pub fn enable_qualification(&self) -> bool {
-        self.enable_qualification
+    pub fn enable_sync(&self) -> bool {
+        self.enable_sync
     }
 
     /// Gets a reference to the config's incoming stream.

--- a/lib/cyclone/src/server/handlers.rs
+++ b/lib/cyclone/src/server/handlers.rs
@@ -15,9 +15,9 @@ use super::{
     routes::{State, WatchKeepalive},
 };
 use crate::{
-    server::{qualification_check, resolver_function, watch},
+    server::{qualification_check, resolver_function, resource_sync, watch},
     LivenessStatus, Message, QualificationCheckResultSuccess, ReadinessStatus,
-    ResolverFunctionResultSuccess,
+    ResolverFunctionResultSuccess, ResourceSyncResultSuccess,
 };
 
 #[allow(clippy::unused_async)]
@@ -193,6 +193,67 @@ async fn fail_qualification_check(
     message: impl Into<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let msg = Message::<QualificationCheckResultSuccess>::fail(message).serialize_to_string()?;
+    socket.send(ws::Message::Text(msg)).await?;
+    socket.close().await?;
+    Ok(())
+}
+
+#[allow(clippy::unused_async)]
+pub async fn ws_execute_sync(
+    wsu: WebSocketUpgrade,
+    Extension(state): Extension<Arc<State>>,
+    Extension(telemetry_level): Extension<Arc<Box<dyn TelemetryLevel>>>,
+    limit_request_guard: LimitRequestGuard,
+) -> impl IntoResponse {
+    async fn handle_socket(
+        mut socket: WebSocket,
+        state: Arc<State>,
+        lang_server_debugging: bool,
+        _limit_request_guard: LimitRequestGuard,
+    ) {
+        let proto = match resource_sync::execute(state.lang_server_path(), lang_server_debugging)
+            .start(&mut socket)
+            .await
+        {
+            Ok(started) => started,
+            Err(err) => {
+                warn!(error = ?err, "failed to start protocol");
+                if let Err(err) = fail_resource_sync(socket, "failed to start protocol").await {
+                    warn!(error = ?err, "failed to fail execute sync");
+                };
+                return;
+            }
+        };
+        let proto = match proto.process(&mut socket).await {
+            Ok(processed) => processed,
+            Err(err) => {
+                warn!(error = ?err, "failed to process protocol");
+                if let Err(err) = fail_resource_sync(socket, "failed to process protocol").await {
+                    warn!(error = ?err, "failed to fail execute sync");
+                };
+                return;
+            }
+        };
+        if let Err(err) = proto.finish(socket).await {
+            warn!(error = ?err, "failed to finish protocol");
+        }
+    }
+
+    wsu.on_upgrade(move |socket| {
+        handle_socket(
+            socket,
+            state,
+            telemetry_level.is_debug_or_lower(),
+            limit_request_guard,
+        )
+    })
+}
+
+async fn fail_resource_sync(
+    mut socket: WebSocket,
+    message: impl Into<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let msg = Message::<ResourceSyncResultSuccess>::fail(message).serialize_to_string()?;
     socket.send(ws::Message::Text(msg)).await?;
     socket.close().await?;
     Ok(())

--- a/lib/cyclone/src/server/resource_sync.rs
+++ b/lib/cyclone/src/server/resource_sync.rs
@@ -1,0 +1,354 @@
+use std::{io, path::PathBuf, process::Stdio, time::Duration};
+
+use axum::extract::ws::WebSocket;
+use bytes_lines_codec::BytesLinesCodec;
+use chrono::Utc;
+use futures::{SinkExt, StreamExt, TryStreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{
+    process::{Child, ChildStdin, ChildStdout, Command},
+    time,
+};
+use tokio_serde::{
+    formats::{Json, SymmetricalJson},
+    Framed, SymmetricallyFramed,
+};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use crate::{
+    process::{self, ShutdownError},
+    server::WebSocketMessage,
+    FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,
+    ResourceSyncRequest, ResourceSyncResultSuccess,
+};
+
+const TX_TIMEOUT_SECS: Duration = Duration::from_secs(2);
+
+pub fn execute(
+    lang_server_path: impl Into<PathBuf>,
+    lang_server_debugging: bool,
+) -> ResourceSyncExecution {
+    ResourceSyncExecution {
+        lang_server_path: lang_server_path.into(),
+        lang_server_debugging,
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ResourceSyncError {
+    #[error("failed to consume the {0} stream for the child process")]
+    ChildIO(&'static str),
+    #[error("failed to receive child process message")]
+    ChildRecvIO(#[source] io::Error),
+    #[error("failed to send child process message")]
+    ChildSendIO(#[source] io::Error),
+    #[error("failed to spawn child process; program={0}")]
+    ChildSpawn(#[source] io::Error, PathBuf),
+    #[error(transparent)]
+    ChildShutdown(#[from] ShutdownError),
+    #[error("failed to deserialize json message")]
+    JSONDeserialize(#[source] serde_json::Error),
+    #[error("failed to serialize json message")]
+    JSONSerialize(#[source] serde_json::Error),
+    #[error("send timeout")]
+    SendTimeout(#[source] tokio::time::error::Elapsed),
+    #[error("failed to close websocket")]
+    WSClose(#[source] axum::Error),
+    #[error("failed to receive websocket message--stream is closed")]
+    WSRecvClosed,
+    #[error("failed to receive websocket message")]
+    WSRecvIO(#[source] axum::Error),
+    #[error("failed to send websocket message")]
+    WSSendIO(#[source] axum::Error),
+    #[error("unexpected websocket message type: {0:?}")]
+    UnexpectedMessageType(WebSocketMessage),
+}
+
+type Result<T> = std::result::Result<T, ResourceSyncError>;
+
+#[derive(Debug)]
+pub struct ResourceSyncExecution {
+    lang_server_path: PathBuf,
+    lang_server_debugging: bool,
+}
+
+impl ResourceSyncExecution {
+    pub async fn start(self, ws: &mut WebSocket) -> Result<ResourceSyncServerExecutionStarted> {
+        Self::ws_send_start(ws).await?;
+        let request = Self::read_request(ws).await?;
+
+        let mut command = Command::new(&self.lang_server_path);
+        command
+            .arg("resourceSync")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped());
+        if self.lang_server_debugging {
+            command.env("DEBUG", "*").env("DEBUG_DEPTH", "5");
+        }
+        debug!(cmd = ?command, "spawning child process");
+        let mut child = command
+            .spawn()
+            .map_err(|err| ResourceSyncError::ChildSpawn(err, self.lang_server_path.clone()))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(ResourceSyncError::ChildIO("stdin"))?;
+        Self::child_send_function_request(stdin, request).await?;
+
+        let stdout = {
+            let stdout = child
+                .stdout
+                .take()
+                .ok_or(ResourceSyncError::ChildIO("stdout"))?;
+            let codec = FramedRead::new(stdout, BytesLinesCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+
+        Ok(ResourceSyncServerExecutionStarted { child, stdout })
+    }
+
+    async fn read_request(ws: &mut WebSocket) -> Result<ResourceSyncRequest> {
+        let request = match ws.next().await {
+            Some(Ok(WebSocketMessage::Text(json_str))) => {
+                ResourceSyncRequest::deserialize_from_str(&json_str)
+                    .map_err(ResourceSyncError::JSONDeserialize)?
+            }
+            Some(Ok(unexpected)) => {
+                return Err(ResourceSyncError::UnexpectedMessageType(unexpected))
+            }
+            Some(Err(err)) => return Err(ResourceSyncError::WSRecvIO(err)),
+            None => return Err(ResourceSyncError::WSRecvClosed),
+        };
+        Ok(request)
+    }
+
+    async fn ws_send_start(ws: &mut WebSocket) -> Result<()> {
+        let msg = Message::<ResourceSyncResultSuccess>::Start
+            .serialize_to_string()
+            .map_err(ResourceSyncError::JSONSerialize)?;
+
+        time::timeout(TX_TIMEOUT_SECS, ws.send(WebSocketMessage::Text(msg)))
+            .await
+            .map_err(ResourceSyncError::SendTimeout)?
+            .map_err(ResourceSyncError::WSSendIO)?;
+        Ok(())
+    }
+
+    async fn child_send_function_request(
+        stdin: ChildStdin,
+        request: ResourceSyncRequest,
+    ) -> Result<()> {
+        let codec = FramedWrite::new(stdin, BytesLinesCodec::new());
+        let mut stdin = SymmetricallyFramed::new(codec, SymmetricalJson::default());
+
+        time::timeout(TX_TIMEOUT_SECS, stdin.send(request))
+            .await
+            .map_err(ResourceSyncError::SendTimeout)?
+            .map_err(ResourceSyncError::ChildSendIO)?;
+        time::timeout(TX_TIMEOUT_SECS, stdin.close())
+            .await
+            .map_err(ResourceSyncError::SendTimeout)?
+            .map_err(ResourceSyncError::ChildSendIO)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ResourceSyncServerExecutionStarted {
+    child: Child,
+    stdout: Framed<
+        FramedRead<ChildStdout, BytesLinesCodec>,
+        LangServerResourceSyncMessage,
+        LangServerResourceSyncMessage,
+        Json<LangServerResourceSyncMessage, LangServerResourceSyncMessage>,
+    >,
+}
+
+impl ResourceSyncServerExecutionStarted {
+    pub async fn process(self, ws: &mut WebSocket) -> Result<ResourceSyncServerExecutionClosing> {
+        let mut stream = self
+            .stdout
+            .map(|ls_result| match ls_result {
+                Ok(ls_msg) => match ls_msg {
+                    LangServerResourceSyncMessage::Output(output) => {
+                        Ok(Message::OutputStream(output.into()))
+                    }
+                    LangServerResourceSyncMessage::Result(result) => {
+                        Ok(Message::Result(result.into()))
+                    }
+                },
+                Err(err) => Err(ResourceSyncError::ChildRecvIO(err)),
+            })
+            .map(|msg_result: Result<_>| match msg_result {
+                Ok(msg) => match msg
+                    .serialize_to_string()
+                    .map_err(ResourceSyncError::JSONSerialize)
+                {
+                    Ok(json_str) => Ok(WebSocketMessage::Text(json_str)),
+                    Err(err) => Err(err),
+                },
+                Err(err) => Err(err),
+            });
+
+        while let Some(msg) = stream.try_next().await? {
+            ws.send(msg).await.map_err(ResourceSyncError::WSSendIO)?;
+        }
+
+        Ok(ResourceSyncServerExecutionClosing { child: self.child })
+    }
+}
+
+#[derive(Debug)]
+pub struct ResourceSyncServerExecutionClosing {
+    child: Child,
+}
+
+impl ResourceSyncServerExecutionClosing {
+    pub async fn finish(mut self, mut ws: WebSocket) -> Result<()> {
+        let finished = Self::ws_send_finish(&mut ws).await;
+        let closed = Self::ws_close(ws).await;
+        let shutdown =
+            process::child_shutdown(&mut self.child, Some(process::Signal::SIGTERM), None)
+                .await
+                .map_err(Into::into);
+        drop(self.child);
+
+        match (finished, closed, shutdown) {
+            // Everything succeeds, great!
+            (Ok(_), Ok(_), Ok(_)) => Ok(()),
+
+            // One of the steps failed, return its error
+            (Ok(_), Ok(_), Err(err)) | (Ok(_), Err(err), Ok(_)) | (Err(err), Ok(_), Ok(_)) => {
+                Err(err)
+            }
+
+            // 2/3 steps errored so warn about the lower priority error and return the highest
+            // priority
+            (Ok(_), Err(err), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                Err(err)
+            }
+            (Err(err), Ok(_), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                Err(err)
+            }
+            (Err(err), Err(closed), Ok(_)) => {
+                warn!(error = ?closed, "failed to cleanly close websocket");
+                Err(err)
+            }
+
+            // All steps failed so warn about the lower priorities and return the highest priority
+            (Err(err), Err(closed), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                warn!(error = ?closed, "failed to cleanly close websocket");
+                Err(err)
+            }
+        }
+    }
+
+    async fn ws_send_finish(ws: &mut WebSocket) -> Result<()> {
+        let msg = Message::<ResourceSyncResultSuccess>::Finish
+            .serialize_to_string()
+            .map_err(ResourceSyncError::JSONSerialize)?;
+        time::timeout(TX_TIMEOUT_SECS, ws.send(WebSocketMessage::Text(msg)))
+            .await
+            .map_err(ResourceSyncError::SendTimeout)?
+            .map_err(ResourceSyncError::WSSendIO)?;
+
+        Ok(())
+    }
+
+    async fn ws_close(ws: WebSocket) -> Result<()> {
+        ws.close().await.map_err(ResourceSyncError::WSClose)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "protocol", rename_all = "camelCase")]
+enum LangServerResourceSyncMessage {
+    Output(LangServerOutput),
+    Result(LangServerResult),
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerOutput {
+    execution_id: String,
+    stream: String,
+    level: String,
+    group: Option<String>,
+    message: String,
+    data: Option<Value>,
+}
+
+impl From<LangServerOutput> for OutputStream {
+    fn from(value: LangServerOutput) -> Self {
+        Self {
+            execution_id: value.execution_id,
+            stream: value.stream,
+            level: value.level,
+            group: value.group,
+            data: value.data,
+            message: value.message,
+            timestamp: timestamp(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+enum LangServerResult {
+    Success(LangServerSuccess),
+    Failure(LangServerFailure),
+}
+
+impl From<LangServerResult> for FunctionResult<ResourceSyncResultSuccess> {
+    fn from(value: LangServerResult) -> Self {
+        match value {
+            LangServerResult::Success(success) => Self::Success(ResourceSyncResultSuccess {
+                execution_id: success.execution_id,
+                timestamp: timestamp(),
+            }),
+            LangServerResult::Failure(failure) => Self::Failure(FunctionResultFailure {
+                execution_id: failure.execution_id,
+                error: FunctionResultFailureError {
+                    kind: failure.error.kind,
+                    message: failure.error.message,
+                },
+                timestamp: timestamp(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerSuccess {
+    execution_id: String,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerFailure {
+    #[serde(default)]
+    execution_id: String,
+    error: LangServerFailureError,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerFailureError {
+    kind: String,
+    message: String,
+}
+
+fn timestamp() -> u64 {
+    // We're going eat any timestamp values that are negative (it is an `i64`) and replace them
+    // with 0, which will then safely fit in a `u64` without overflow/underflow
+    u64::try_from(std::cmp::max(Utc::now().timestamp(), 0)).expect("timestamp not be negative")
+}

--- a/lib/cyclone/src/server/routes.rs
+++ b/lib/cyclone/src/server/routes.rs
@@ -104,16 +104,22 @@ fn execute_routes(config: &Config, shutdown_tx: mpsc::Sender<ShutdownSource>) ->
             .or(Router::new().route("/ping", get(handlers::ws_execute_ping)))
             .boxed();
     }
+    if config.enable_qualification() {
+        debug!("enabling qualification endpoint");
+        router = router
+            .or(Router::new().route("/qualification", get(handlers::ws_execute_qualification)))
+            .boxed();
+    }
     if config.enable_resolver() {
         debug!("enabling resolver endpoint");
         router = router
             .or(Router::new().route("/resolver", get(handlers::ws_execute_resolver)))
             .boxed();
     }
-    if config.enable_qualification() {
-        debug!("enabling qualification endpoint");
+    if config.enable_sync() {
+        debug!("enabling sync endpoint");
         router = router
-            .or(Router::new().route("/qualification", get(handlers::ws_execute_qualification)))
+            .or(Router::new().route("/sync", get(handlers::ws_execute_sync)))
             .boxed();
     }
 


### PR DESCRIPTION
If you would like to try this out, there are a few of set up steps:

1. Ensure that the `lang-js` binary is built and up to date (with `cd
   bin/lang-js && npm run package`)
2. Ensure that the `jq` program is installed on your system
   (<https://stedolan.github.io/jq/>)
3. Ensure that the `websocat` program is installed on your system to act
   as the client side of the WebSocket session
   (<https://github.com/vi/websocat>, available on Arch via `sudo pacman
   -S websocat`)

With that out of the way, run a Cyclone server instance from the root of
the repo as this helps to specify the path to the `lang-js` program
(note that specifying a relative path is also totally okay and
works--the server will canonicalize the `--lang-server` argument to an
absolute path either way):
```sh
cargo run --bin cyclone -- \
    --enable-sync \
    --lang-server ./bin/lang-js/target/lang-js
```

This enables the `execute/sync` endpoint and will use our compiled
`lang-js` as the language server backend.

In another terminal, again from the root of the repo, you can run the
following which will create a resource sync request using an example in
our source tree and use `websocat` to run the request session to
completion:

```sh
jq -c -r . < bin/lang-js/examples/resourceSyncTest.json \
    | websocat --text ws://127.0.0.1:5157/execute/sync
```

Assuming it all goes to plan, the `websocat` terminal will emit output
like the following:

```console
"Start"
{"OutputStream":{"stream":"stdout","execution_id":"9012","level":"info","group":"log","data":null,"message":"syncing something, right?","timestamp":1643144105}}
{"Result":{"Success":{"execution_id":"9012","timestamp":1643144105}}}
"Finish"
```

References: Add resourceSync endpoint to Cyclone server [sc-2152]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>