### PR TITLE
feat(cyclone,deadpool-cyclone): impl resource sync on client

### DIFF
--- a/lib/cyclone/src/client/resource_sync.rs
+++ b/lib/cyclone/src/client/resource_sync.rs
@@ -1,0 +1,220 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Future, SinkExt, Stream, StreamExt};
+use hyper::client::connect::Connection;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_tungstenite::WebSocketStream;
+
+use crate::{
+    FunctionResult, Message, ProgressMessage, ResourceSyncRequest, ResourceSyncResultSuccess,
+};
+
+pub use tokio_tungstenite::tungstenite::{
+    protocol::frame::CloseFrame as WebSocketCloseFrame, Message as WebSocketMessage,
+};
+
+pub fn execute<T>(
+    stream: WebSocketStream<T>,
+    request: ResourceSyncRequest,
+) -> ResourceSyncExecution<T> {
+    ResourceSyncExecution { stream, request }
+}
+
+#[derive(Debug, Error)]
+pub enum ResourceSyncExecutionError {
+    #[error("closing execution stream without a result")]
+    ClosingWithoutResult,
+    #[error("finish message received before result message was received")]
+    FinishBeforeResult,
+    #[error("failed to deserialize json message")]
+    JSONDeserialize(#[source] serde_json::Error),
+    #[error("failed to serialize json message")]
+    JSONSerialize(#[source] serde_json::Error),
+    #[error("unexpected websocket message after finish was sent: {0}")]
+    MessageAfterFinish(WebSocketMessage),
+    #[error("unexpected qualification check message before start was sent: {0:?}")]
+    MessageBeforeStart(Message<ResourceSyncResultSuccess>),
+    #[error("unexpected websocket message type: {0}")]
+    UnexpectedMessageType(WebSocketMessage),
+    #[error("websocket stream is closed, but finish was not sent")]
+    WSClosedBeforeFinish,
+    #[error("websocket stream is closed, but start was not sent")]
+    WSClosedBeforeStart,
+    #[error("failed to read websocket message")]
+    WSReadIO(#[source] tokio_tungstenite::tungstenite::Error),
+    #[error("failed to send websocket message")]
+    WSSendIO(#[source] tokio_tungstenite::tungstenite::Error),
+}
+
+type Result<T> = std::result::Result<T, ResourceSyncExecutionError>;
+
+#[derive(Debug)]
+pub struct ResourceSyncExecution<T> {
+    stream: WebSocketStream<T>,
+    request: ResourceSyncRequest,
+}
+
+impl<T> ResourceSyncExecution<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    pub async fn start(mut self) -> Result<ResourceSyncExecutionStarted<T>> {
+        match self.stream.next().await {
+            Some(Ok(WebSocketMessage::Text(json_str))) => {
+                let msg = Message::deserialize_from_str(&json_str)
+                    .map_err(ResourceSyncExecutionError::JSONDeserialize)?;
+                match msg {
+                    Message::Start => {
+                        // received correct message, so proceed
+                    }
+                    unexpected => {
+                        return Err(ResourceSyncExecutionError::MessageBeforeStart(unexpected))
+                    }
+                }
+            }
+            Some(Ok(unexpected)) => {
+                return Err(ResourceSyncExecutionError::UnexpectedMessageType(
+                    unexpected,
+                ))
+            }
+            Some(Err(err)) => return Err(ResourceSyncExecutionError::WSReadIO(err)),
+            None => return Err(ResourceSyncExecutionError::WSClosedBeforeStart),
+        }
+
+        let msg = self
+            .request
+            .serialize_to_string()
+            .map_err(ResourceSyncExecutionError::JSONSerialize)?;
+        self.stream
+            .send(WebSocketMessage::Text(msg))
+            .await
+            .map_err(ResourceSyncExecutionError::WSSendIO)?;
+
+        Ok(self.into())
+    }
+}
+
+impl<T> From<ResourceSyncExecution<T>> for ResourceSyncExecutionStarted<T> {
+    fn from(value: ResourceSyncExecution<T>) -> Self {
+        Self {
+            stream: value.stream,
+            result: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ResourceSyncExecutionStarted<T> {
+    stream: WebSocketStream<T>,
+    result: Option<FunctionResult<ResourceSyncResultSuccess>>,
+}
+
+impl<T> ResourceSyncExecutionStarted<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    pub async fn finish(self) -> Result<FunctionResult<ResourceSyncResultSuccess>> {
+        ResourceSyncExecutionClosing::try_from(self)?.finish().await
+    }
+}
+
+impl<T> Stream for ResourceSyncExecutionStarted<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    type Item = Result<ProgressMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream.next()).poll(cx) {
+            // We successfully got a websocket text message
+            Poll::Ready(Some(Ok(WebSocketMessage::Text(json_str)))) => {
+                let msg = Message::deserialize_from_str(&json_str)
+                    .map_err(ResourceSyncExecutionError::JSONDeserialize)?;
+                match msg {
+                    // We got a heartbeat message, pass it on
+                    Message::Heartbeat => Poll::Ready(Some(Ok(ProgressMessage::Heartbeat))),
+                    // We got an output message, pass it on
+                    Message::OutputStream(output_stream) => {
+                        Poll::Ready(Some(Ok(ProgressMessage::OutputStream(output_stream))))
+                    }
+                    // We got a funtion result message, save it and continue
+                    Message::Result(function_result) => {
+                        self.result = Some(function_result);
+                        // TODO(fnichol): what is the right return here??
+                        // (future fnichol): hey buddy! pretty sure you can:
+                        // `cx.waker().wake_by_ref()` before returning Poll::Ready which immediatly
+                        // re-wakes this stream to maybe pop another item off. cool huh? I think
+                        // you're learning and that's great.
+                        Poll::Ready(Some(Ok(ProgressMessage::Heartbeat)))
+                        //Poll::Pending
+                    }
+                    // We got a finish message
+                    Message::Finish => {
+                        if self.result.is_some() {
+                            // If we have saved the result, then close this stream out
+                            Poll::Ready(None)
+                        } else {
+                            // Otherwise we got a finish before seeing the result
+                            Poll::Ready(Some(Err(ResourceSyncExecutionError::FinishBeforeResult)))
+                        }
+                    }
+                    // We got an unexpected message
+                    unexpected => Poll::Ready(Some(Err(
+                        ResourceSyncExecutionError::MessageBeforeStart(unexpected),
+                    ))),
+                }
+            }
+            // We successfully got an unexpected websocket message type that was not text
+            Poll::Ready(Some(Ok(unexpected))) => Poll::Ready(Some(Err(
+                ResourceSyncExecutionError::UnexpectedMessageType(unexpected),
+            ))),
+            // We failed to get the next websocket message
+            Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(ResourceSyncExecutionError::WSReadIO(err))))
+            }
+            // We see the end of the websocket stream, but finish was never sent
+            Poll::Ready(None) => {
+                Poll::Ready(Some(Err(ResourceSyncExecutionError::WSClosedBeforeFinish)))
+            }
+            // Not ready, so...not ready!
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ResourceSyncExecutionClosing<T> {
+    stream: WebSocketStream<T>,
+    result: FunctionResult<ResourceSyncResultSuccess>,
+}
+
+impl<T> TryFrom<ResourceSyncExecutionStarted<T>> for ResourceSyncExecutionClosing<T> {
+    type Error = ResourceSyncExecutionError;
+
+    fn try_from(value: ResourceSyncExecutionStarted<T>) -> Result<Self> {
+        match value.result {
+            Some(result) => Ok(Self {
+                stream: value.stream,
+                result,
+            }),
+            None => Err(Self::Error::ClosingWithoutResult),
+        }
+    }
+}
+
+impl<T> ResourceSyncExecutionClosing<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    async fn finish(mut self) -> Result<FunctionResult<ResourceSyncResultSuccess>> {
+        match self.stream.next().await {
+            Some(Ok(WebSocketMessage::Close(_))) | None => Ok(self.result),
+            Some(Ok(unexpected)) => Err(ResourceSyncExecutionError::MessageAfterFinish(unexpected)),
+            Some(Err(err)) => Err(ResourceSyncExecutionError::WSReadIO(err)),
+        }
+    }
+}

--- a/lib/deadpool-cyclone/examples/deadpool-cyclone-resource-sync-pool.rs
+++ b/lib/deadpool-cyclone/examples/deadpool-cyclone-resource-sync-pool.rs
@@ -1,0 +1,143 @@
+use std::{
+    env, io,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use cyclone::{FunctionResult, ProgressMessage};
+use deadpool_cyclone::{
+    client::{CycloneClient, ResourceSyncRequest},
+    instance::{
+        cyclone::{LocalUdsInstance, LocalUdsInstanceSpec},
+        Instance,
+    },
+    Manager, Pool,
+};
+use futures::{stream, StreamExt, TryStreamExt};
+use tokio::signal;
+use tracing::{error, info};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env("SI_LOG")
+                .unwrap_or_else(|_| EnvFilter::new("info,deadpool_cyclone=trace,cyclone=trace")),
+        )
+        .with(fmt::layer())
+        .try_init()?;
+
+    let concurrency = match env::args().nth(1) {
+        Some(arg) => usize::from_str(&arg)?,
+        None => 4,
+    };
+
+    let spec = LocalUdsInstance::spec()
+        .try_cyclone_cmd_path("../../target/debug/cyclone")?
+        .try_lang_server_cmd_path("../../bin/lang-js/target/lang-js")?
+        .sync()
+        .build()?;
+    let manager = Manager::new(spec);
+    let pool = Pool::builder(manager).max_size(64).build()?;
+
+    let ctrl_c = signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    info!("waiting for request on stdin...");
+    let request: ResourceSyncRequest = serde_json::from_reader(io::stdin())?;
+    info!(request = ?request);
+    info!("running executions");
+
+    let count = AtomicU64::new(0);
+
+    let concurrent_executions = stream::repeat_with(|| execute(&pool, &request))
+        .map(Ok)
+        .try_for_each_concurrent(concurrency, |execution_task| async {
+            let result = execution_task.await;
+            count.fetch_add(1, Ordering::SeqCst);
+            result
+        });
+
+    loop {
+        tokio::select! {
+            _ = &mut ctrl_c => {
+                info!("received ctrl-c signal, shutting down");
+                break
+            }
+            result = concurrent_executions => {
+                match result {
+                    Ok(_) => {
+                        info!("finished executions");
+                        break
+                    }
+                    Err(err) => {
+                        error!(error = ?err, "found error in execution stream");
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    info!("closing the pool");
+    pool.close();
+
+    info!(
+        "program complete; executions={}",
+        count.load(Ordering::Relaxed)
+    );
+    Ok(())
+}
+
+async fn execute(
+    pool: &Pool<LocalUdsInstanceSpec>,
+    request: &ResourceSyncRequest,
+) -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    // Generate a random execution_id
+    let mut request = (*request).clone();
+    request.execution_id = Uuid::new_v4().to_string();
+
+    info!(status = ?pool.status(), "Getting an instance from the pool");
+    let mut instance = pool.get().await?;
+    info!("Checking if instance is healthy");
+    instance.ensure_healthy().await?;
+
+    info!(
+        execution_id = &request.execution_id.as_str(),
+        "Executing resource sync"
+    );
+    let mut progress = instance.execute_sync(request).await?.start().await?;
+    while let Some(message) = progress.try_next().await? {
+        match message {
+            ProgressMessage::Heartbeat => info!("heartbeat"),
+            ProgressMessage::OutputStream(output) => {
+                info!(
+                    execution_id = &output.execution_id.as_str(),
+                    stream = &output.stream.as_str(),
+                    level = &output.level.as_str(),
+                    message = &output.message.as_str(),
+                    data = ?output.data,
+                    timestamp = output.timestamp,
+                );
+            }
+        }
+    }
+    let result = progress.finish().await?;
+    match result {
+        FunctionResult::Success(success) => info!(
+            execution_id = &success.execution_id.as_str(),
+            // TODO(fnichol): show more fields when we have them
+            timestamp = success.timestamp,
+        ),
+        FunctionResult::Failure(failure) => error!(
+            execution_id = &failure.execution_id.as_str(),
+            error_kind = &failure.error.kind.as_str(),
+            error_message = &failure.error.message.as_str(),
+            timestamp = failure.timestamp,
+        ),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
There are 2 more tests in `lib/cyclone/client.rs` which exercise the
client call/protocol.

The `deadpool-cyclone` client is also updated to handle this request and
so a third example program is provided to exercise this code path. To
run the pooling test (i.e. watch a lot of output stream by and your
machine get hot), you'll need:

* An up-to-date `lang-js` binary (via: `cd bin/lang-js && npm run
  package`)
* An up-to-date `cyclone` binary (via `cargo build --bin cyclone`)

Finally, you'll need to be in the `lib/deadpool-cyclone` directory (I
know, I know, there's some inconsistency here) and run the example by
piping it the same testing request on `stdin`:

```sh
cd lib/deadpool-cyclone
cat ../../bin/lang-js/examples/resourceSyncTest.json \
    | cargo run --example deadpool-cyclone-resource-sync-pool 8
```

Hitting `Ctrl+c` will terminate the running program and in the last few
lines should report how many requests it serviced. In the invocation
above the `8` refers to how many requests to run in a worker pool
concurrently, so if you want to push this number up, especially on a
large multi-core system, feel free to bump it and re-try.

References: Add resourceSync endpoint to Cyclone client [sc-2153]

<img src="https://media1.giphy.com/media/gfrAjxfuhnaKwB2AbF/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>