### PR TITLE
feat(web): Fix icons size and use flex display

### DIFF
--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -28,4 +28,7 @@ export default {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+.vue-feather {
+  display: flex !important;
+}
 </style>

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -31,27 +31,22 @@
               v-if="activeView === 'attribute'"
               type="disc"
               stroke="cyan"
-              size="1.5rem"
+              size="1.1em"
             />
-            <VueFeather
-              v-else
-              type="disc"
-              class="text-gray-300"
-              size="1.5rem"
-            />
+            <VueFeather v-else type="disc" class="text-gray-300" size="1.1em" />
           </button>
           <button class="pl-1 focus:outline-none" @click="setToQualification">
             <VueFeather
               v-if="activeView === 'qualification'"
               type="check-square"
               stroke="cyan"
-              size="1.5rem"
+              size="1.1em"
             />
             <VueFeather
               v-else
               type="check-square"
               class="text-gray-300"
-              size="1.5rem"
+              size="1.1em"
             />
           </button>
         </div>
@@ -68,9 +63,9 @@
               v-if="activeView === 'resource'"
               type="box"
               stroke="cyan"
-              size="1.5rem"
+              size="1.1em"
             />
-            <VueFeather v-else type="box" class="text-gray-300" size="1.5rem" />
+            <VueFeather v-else type="box" class="text-gray-300" size="1.1em" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
Vue-Feather changed from specifying size with 1.1x to 1.1em

Also they are now setting all vue-feather icons to `display: inline-block`, which overrides flex alignment we were depending on.

We have more space between the icons because we tell flex display to use all of the parent element's width and we have less icons

<img width="554" alt="image" src="https://user-images.githubusercontent.com/6289779/151077528-d989799e-cd27-4820-b285-3d8204f059b3.png">

<img width="556" alt="image" src="https://user-images.githubusercontent.com/6289779/151077535-f0391573-6cf6-4dbc-8b10-cc1b5e9335ad.png">

<img src="https://media2.giphy.com/media/13FrpeVH09Zrb2/giphy.gif"/>