### PR TITLE
feat(dal): create a qualification resolver from a qualification prototype

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -11,7 +11,7 @@
     <template #menuButtons>
       <div class="flex flex-row items-center justify-between flex-grow">
         <div class="flex flex-row">
-          <div class="min-w-max">
+          <div v-if="componentNamesOnlyList" class="min-w-max">
             <SiSelect
               id="nodeSelect"
               v-model="selectedComponentId"

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -36,7 +36,7 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
     // service boots??
     //
     // See: https://app.shortcut.com/systeminit/story/1934/sdf-mutex-poison-panic-on-launch-with-opentelemetry-exporter
-    let disable_opentelemetry = args.disable_opentelemetry;
+    let _disable_opentelemetry = args.disable_opentelemetry;
     telemetry.disable_opentelemetry().await?;
     // if args.disable_opentelemetry {
     //     telemetry.disable_opentelemetry().await?;
@@ -71,9 +71,9 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
     }
 
     // TODO(fnichol): re-enable, which we shouldn't need in the long run
-    if !disable_opentelemetry {
-        telemetry.enable_opentelemetry().await?;
-    }
+    //if !disable_opentelemetry {
+    //    telemetry.enable_opentelemetry().await?;
+    //}
 
     start_tracing_level_signal_handler_task(&telemetry)?;
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 
 use serde_json::Value as JsonValue;
 use tokio::sync::mpsc;
-use veritech::{Client, QualificationCheckComponent, QualificationCheckResultSuccess};
+use veritech::{Client, QualificationCheckResultSuccess};
 
-use crate::func::backend::FuncBackendJsQualification;
+use crate::func::backend::{FuncBackendJsQualification, FuncBackendJsQualificationArgs};
 use crate::{
     func::backend::{
         validation::{FuncBackendValidateStringValue, FuncBackendValidateStringValueArgs},
@@ -258,13 +258,13 @@ impl FuncBinding {
                     .code_base64()
                     .ok_or(FuncBindingError::JsFuncNotFound(self.pk))?;
 
-                // NOTE(nick): deserialize value directly into the component that veritech expects.
-                let component = QualificationCheckComponent::deserialize(&self.args)?;
+                let backend_args: FuncBackendJsQualificationArgs =
+                    serde_json::from_value(self.args.clone())?;
                 let return_value = FuncBackendJsQualification::new(
                     veritech,
                     tx,
                     handler.to_owned(),
-                    component,
+                    backend_args.component.into(),
                     code_base64.to_owned(),
                 )
                 .execute()

--- a/lib/dal/src/qualification_prototype.rs
+++ b/lib/dal/src/qualification_prototype.rs
@@ -25,6 +25,14 @@ pub enum QualificationPrototypeError {
     HistoryEvent(#[from] HistoryEventError),
     #[error("standard model error: {0}")]
     StandardModelError(#[from] StandardModelError),
+    #[error("component not found: {0}")]
+    ComponentNotFound(ComponentId),
+    #[error("component error: {0}")]
+    Component(String),
+    #[error("schema not found")]
+    SchemaNotFound,
+    #[error("schema variant not found")]
+    SchemaVariantNotFound,
 }
 
 pub type QualificationPrototypeResult<T> = Result<T, QualificationPrototypeError>;
@@ -165,17 +173,26 @@ impl QualificationPrototype {
     standard_model_accessor!(args, Json<JsonValue>, QualificationPrototypeResult);
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn find_for_component_id(
+    pub async fn find_for_component(
         txn: &PgTxn<'_>,
         tenancy: &Tenancy,
         visibility: &Visibility,
         component_id: ComponentId,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
         system_id: SystemId,
     ) -> QualificationPrototypeResult<Vec<Self>> {
         let rows = txn
             .query(
                 FIND_FOR_CONTEXT,
-                &[&tenancy, &visibility, &component_id, &system_id],
+                &[
+                    &tenancy,
+                    &visibility,
+                    &component_id,
+                    &system_id,
+                    &schema_variant_id,
+                    &schema_id,
+                ],
             )
             .await?;
         let object = objects_from_rows(rows)?;

--- a/lib/dal/src/qualification_resolver.rs
+++ b/lib/dal/src/qualification_resolver.rs
@@ -8,7 +8,7 @@ use crate::{
     func::{binding::FuncBindingId, FuncId},
     impl_standard_model, pk,
     standard_model::{self, objects_from_rows},
-    standard_model_accessor, ComponentId, HistoryActor, HistoryEventError, PropId,
+    standard_model_accessor, ComponentId, HistoryActor, HistoryEventError,
     QualificationPrototypeId, SchemaId, SchemaVariantId, StandardModel, StandardModelError,
     SystemId, Tenancy, Timestamp, Visibility,
 };
@@ -35,7 +35,6 @@ const FIND_FOR_PROTOTYPE: &str =
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct QualificationResolverContext {
-    prop_id: PropId,
     component_id: ComponentId,
     schema_id: SchemaId,
     schema_variant_id: SchemaVariantId,
@@ -52,20 +51,11 @@ impl Default for QualificationResolverContext {
 impl QualificationResolverContext {
     pub fn new() -> Self {
         QualificationResolverContext {
-            prop_id: UNSET_ID_VALUE.into(),
             component_id: UNSET_ID_VALUE.into(),
             schema_id: UNSET_ID_VALUE.into(),
             schema_variant_id: UNSET_ID_VALUE.into(),
             system_id: UNSET_ID_VALUE.into(),
         }
-    }
-
-    pub fn prop_id(&self) -> PropId {
-        self.prop_id
-    }
-
-    pub fn set_prop_id(&mut self, prop_id: PropId) {
-        self.prop_id = prop_id;
     }
 
     pub fn component_id(&self) -> ComponentId {
@@ -148,14 +138,13 @@ impl QualificationResolver {
     ) -> QualificationResolverResult<Self> {
         let row = txn
             .query_one(
-                "SELECT object FROM qualification_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+                "SELECT object FROM qualification_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                 &[
                     &tenancy,
                     &visibility,
                     &qualification_prototype_id,
                     &func_id,
                     &func_binding_id,
-                    &context.prop_id(),
                     &context.component_id(),
                     &context.schema_id(),
                     &context.schema_variant_id(),
@@ -212,8 +201,6 @@ mod test {
     fn context_builder() {
         let mut c = QualificationResolverContext::new();
         c.set_component_id(15.into());
-        c.set_prop_id(22.into());
         assert_eq!(c.component_id(), 15.into());
-        assert_eq!(c.prop_id(), 22.into());
     }
 }

--- a/lib/dal/src/queries/qualification_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/qualification_prototype_find_for_context.sql
@@ -10,7 +10,9 @@ FROM qualification_prototypes
 WHERE in_tenancy_v1($1, qualification_prototypes.tenancy_universal, qualification_prototypes.tenancy_billing_account_ids, qualification_prototypes.tenancy_organization_ids,
     qualification_prototypes.tenancy_workspace_ids)
   AND is_visible_v1($2, qualification_prototypes.visibility_change_set_pk, qualification_prototypes.visibility_edit_session_pk, qualification_prototypes.visibility_deleted)
-  AND qualification_prototypes.component_id = $3
+  AND (qualification_prototypes.schema_id = $6
+          OR qualification_prototypes.schema_variant_id = $5
+          OR qualification_prototypes.component_id = $3)
   AND (qualification_prototypes.system_id = $4 OR qualification_prototypes.system_id = -1)
 ORDER BY qualification_prototypes.id,
     visibility_change_set_pk DESC,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -221,7 +221,6 @@ async fn qualification_view() {
         json!({
             "name": "mastodon",
             "properties": {
-                "some_property": null,
                 "name": "mastodon"
             }
         }),

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -65,7 +65,11 @@ async fn new() {
 }
 
 #[tokio::test]
-async fn find_for_component_id() {
+async fn find_for_component() {
+    // TODO: This test is brittle, because it relies on the behavior of docker_image. I'm okay
+    // with that for now, but not for long. If it breaks before we fix it - future person, I'm
+    // sorry. ;)
+
     test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
@@ -79,6 +83,10 @@ async fn find_for_component_id() {
         .expect("cannot find docker image")
         .pop()
         .expect("no docker image found");
+    let default_schema_variant_id = schema
+        .default_schema_variant_id()
+        .expect("cannot get default schema variant id");
+
     let (component, _node) = Component::new_for_schema_with_node(
         &txn,
         &nats,
@@ -86,46 +94,19 @@ async fn find_for_component_id() {
         &tenancy,
         &visibility,
         &history_actor,
-        &name,
+        "silverado",
         schema.id(),
     )
     .await
-    .expect("could not create component");
+    .expect("cannot create new component");
 
-    let func_name = "si:qualificationDockerImageNameEqualsComponentName".to_string();
-    let mut funcs = Func::find_by_attr(&txn, &tenancy, &visibility, "name", &func_name)
-        .await
-        .expect("Error fetching builtin function");
-    let func = funcs
-        .pop()
-        .expect("Missing builtin function si:qualificationDockerImageNameEqualsComponentName");
-
-    let args = FuncBackendJsQualificationArgs {
-        component: ComponentQualificationView::new(&txn, &tenancy, &visibility, component.id())
-            .await
-            .expect("could not create component qualification view"),
-    };
-
-    let mut prototype_context = QualificationPrototypeContext::new();
-    prototype_context.set_component_id(*component.id());
-    let created = QualificationPrototype::new(
-        &txn,
-        &nats,
-        &tenancy,
-        &visibility,
-        &history_actor,
-        *func.id(),
-        serde_json::to_value(&args).expect("serialization failed"),
-        prototype_context,
-    )
-    .await
-    .expect("cannot create new attribute prototype");
-
-    let mut found_prototypes = QualificationPrototype::find_for_component_id(
+    let mut found_prototypes = QualificationPrototype::find_for_component(
         &txn,
         &tenancy,
         &visibility,
         *component.id(),
+        *schema.id(),
+        *default_schema_variant_id,
         UNSET_ID_VALUE.into(),
     )
     .await
@@ -134,5 +115,4 @@ async fn find_for_component_id() {
     let found = found_prototypes
         .pop()
         .expect("found no qualification prototypes");
-    assert_eq!(created, found);
 }


### PR DESCRIPTION
Ensures that qualification resolvers get created from the associated
qualification prototypes. It's lightly tested at best right now, but it
does seem to be working.

Signed-off-by: Adam Jacob <adam@systeminit.com>