### PR TITLE
feat(veritech): impl resource sync on server & client

### DIFF
--- a/lib/veritech/src/server/subscriber.rs
+++ b/lib/veritech/src/server/subscriber.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use cyclone::ResourceSyncRequest;
 use deadpool_cyclone::{QualificationCheckRequest, ResolverFunctionRequest};
 use futures::{Stream, StreamExt};
 use futures_lite::FutureExt;
@@ -33,6 +34,20 @@ type Result<T> = std::result::Result<T, SubscriberError>;
 pub struct Subscriber;
 
 impl Subscriber {
+    pub async fn qualification_check(
+        nats: &NatsClient,
+    ) -> Result<Subscription<QualificationCheckRequest>> {
+        let inner = nats
+            .subscribe("veritech.function.qualification")
+            .await
+            .map_err(SubscriberError::NatsSubscribe)?;
+
+        Ok(Subscription {
+            inner,
+            _phantom: PhantomData,
+        })
+    }
+
     pub async fn resolver_function(
         nats: &NatsClient,
     ) -> Result<Subscription<ResolverFunctionRequest>> {
@@ -47,11 +62,9 @@ impl Subscriber {
         })
     }
 
-    pub async fn qualification_check(
-        nats: &NatsClient,
-    ) -> Result<Subscription<QualificationCheckRequest>> {
+    pub async fn resource_sync(nats: &NatsClient) -> Result<Subscription<ResourceSyncRequest>> {
         let inner = nats
-            .subscribe("veritech.function.qualification")
+            .subscribe("veritech.function.sync")
             .await
             .map_err(SubscriberError::NatsSubscribe)?;
 


### PR DESCRIPTION
This work was easiest to implement together as the verification of the
Veritech server was delivered by a client implementation and test. Also,
I forgot that I hadn't implemented the server before starting on the
client and seeing that my test was failing. Ha.

References: Add resource sync handling to Veritech server [sc-2163]
References: Add resource sync handling to Veritech client [sc-2171]

<img src="https://media3.giphy.com/media/kcs5CvQIBJtsgE0aBE/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>