### PR TITLE
feat(web,sdf): Implement get/sync resource mock routes

### DIFF
--- a/app/web/src/service/component.ts
+++ b/app/web/src/service/component.ts
@@ -1,7 +1,11 @@
 import { listComponentsNamesOnly } from "./component/list_components_names_only";
 import { listQualifications } from "./component/list_qualifications";
+import { getResource } from "./component/get_resource";
+import { syncResource } from "./component/sync_resource";
 
 export const ComponentService = {
   listComponentsNamesOnly,
   listQualifications,
+  getResource,
+  syncResource,
 };

--- a/app/web/src/service/component/get_resource.ts
+++ b/app/web/src/service/component/get_resource.ts
@@ -1,0 +1,52 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, from, Observable } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { workspace$ } from "@/observable/workspace";
+import { system$ } from "@/observable/system";
+import { Resource } from "@/api/sdf/dal/resource";
+import _ from "lodash";
+
+export interface GetResourceArgs {
+  componentId: number;
+}
+
+export interface GetResourceRequest extends GetResourceArgs, Visibility {
+  systemId?: number;
+  workspaceId: number;
+}
+
+export type GetResourceResponse = { resource: Resource };
+
+export function getResource(
+  args: GetResourceArgs,
+): Observable<ApiResponse<GetResourceResponse>> {
+  return combineLatest([standardVisibilityTriggers$, system$, workspace$]).pipe(
+    switchMap(([[visibility], system, workspace]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      return sdf.get<ApiResponse<GetResourceResponse>>(
+        "component/get_resource",
+        {
+          ...args,
+          ...visibility,
+          systemId: system.id,
+          workspaceId: workspace.id,
+        },
+      );
+    }),
+  );
+}

--- a/app/web/src/service/resource.ts
+++ b/app/web/src/service/resource.ts
@@ -1,5 +1,0 @@
-import { syncResource } from "./resource/sync_resource";
-
-export const ResourceService = {
-  syncResource,
-};

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -1,15 +1,17 @@
 use axum::body::{Bytes, Full};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
 use dal::{ComponentError as DalComponentError, SchemaError, StandardModelError, WsEventError};
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod get_resource;
 pub mod list_components_names_only;
 pub mod list_qualifications;
+pub mod sync_resource;
 
 #[derive(Debug, Error)]
 pub enum ComponentError {
@@ -64,4 +66,6 @@ pub fn routes() -> Router {
             "/list_qualifications",
             get(list_qualifications::list_qualifications),
         )
+        .route("/get_resource", get(get_resource::get_resource))
+        .route("/sync_resource", post(sync_resource::sync_resource))
 }

--- a/lib/sdf/src/server/service/component/get_resource.rs
+++ b/lib/sdf/src/server/service/component/get_resource.rs
@@ -1,0 +1,43 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{ComponentId, SystemId, Visibility, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use super::ComponentResult;
+use crate::server::extract::{Authorization, PgRoTxn};
+use chrono::Utc;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetResourceRequest {
+    pub component_id: ComponentId,
+    pub system_id: Option<SystemId>,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetResourceResponse {
+    pub resource: serde_json::Value,
+}
+
+pub async fn get_resource(
+    mut txn: PgRoTxn,
+    Query(_request): Query<GetResourceRequest>,
+    Authorization(_claim): Authorization,
+) -> ComponentResult<Json<GetResourceResponse>> {
+    let txn = txn.start().await?;
+
+    let resource = serde_json::json!({
+        "id": "-1",
+        "timestamp": u64::try_from(std::cmp::max(Utc::now().timestamp(), 0)).expect("Timestamp will never be negative").to_string(),
+        "error": "Boto Cor de Rosa Spotted",
+        "data": { "Saci-Pererê": { "Its just a prank bro": 3 } },
+        "health": "warning",
+        "entityType": "Eat Acarajé with Shrimps & Vatapa & Caruru & a lot of hot sauce",
+    });
+    txn.commit().await?;
+    Ok(Json(GetResourceResponse { resource }))
+}

--- a/lib/sdf/src/server/service/component/sync_resource.rs
+++ b/lib/sdf/src/server/service/component/sync_resource.rs
@@ -1,0 +1,38 @@
+use axum::Json;
+use dal::{ComponentId, SystemId, Visibility, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use super::ComponentResult;
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncResourceRequest {
+    pub component_id: ComponentId,
+    pub system_id: Option<SystemId>,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncResourceResponse {
+    pub success: bool,
+}
+
+pub async fn sync_resource(
+    mut txn: PgRwTxn,
+    mut nats: NatsTxn,
+    Authorization(_claim): Authorization,
+    Json(_request): Json<SyncResourceRequest>,
+) -> ComponentResult<Json<SyncResourceResponse>> {
+    let txn = txn.start().await?;
+    let nats = nats.start().await?;
+
+    // TODO
+
+    txn.commit().await?;
+    nats.commit().await?;
+    Ok(Json(SyncResourceResponse { success: true }))
+}


### PR DESCRIPTION
We only want to sync when the user clicks (if not in edit mode).

So we fixed the reactivity and implemented a new route to fetch the last sync result.

Both routes are mocked right now, but it makes the frontend pretty close to the old demo and when we actually implement the routes in the sdf nothing in the frontend ideally should be changed.

There is a catch tho, the way we display the date seems different, we will have to check on how to format the date of the last sync depending on how it comes from the database