### PR TITLE
feat(dal,sdf): return qualification results via sdf

### DIFF
--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -16,7 +16,7 @@ use crate::{
         FuncBackendString, FuncBackendStringArgs,
     },
     impl_standard_model, pk,
-    qualification::{QualificationError, QualificationResult},
+    qualification::{QualificationErrorMessage, QualificationResult},
     standard_model, standard_model_accessor, standard_model_belongs_to, Func, FuncBackendError,
     FuncBackendKind, HistoryActor, HistoryEvent, HistoryEventError, StandardModel,
     StandardModelError, Tenancy, Timestamp, Visibility,
@@ -274,7 +274,7 @@ impl FuncBinding {
                 let mut errors = vec![];
                 if !veritech_result.qualified {
                     // TODO(paulo): veritech doesn't actually give us multiple errors, but we might execute multiple QualificationResolvers and concatenate their result (?), kinda hacky, but it seems better than having a QualificationResultList to collect all of them?
-                    errors = vec![QualificationError {
+                    errors = vec![QualificationErrorMessage {
                         message: veritech_result.message.unwrap_or_else(|| "🥸".to_owned()),
                     }]
                 }

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -1,14 +1,27 @@
+use std::convert::TryFrom;
+
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::func::binding_return_value::FuncBindingReturnValue;
+
+#[derive(Error, Debug)]
+pub enum QualificationError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("no value returned in qualification function result")]
+    NoValue,
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
-pub struct QualificationError {
+pub struct QualificationErrorMessage {
     pub message: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct QualificationResult {
     pub success: bool,
-    pub errors: Vec<QualificationError>,
+    pub errors: Vec<QualificationErrorMessage>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -18,4 +31,23 @@ pub struct QualificationView {
     pub description: Option<String>,
     pub link: Option<String>,
     pub result: Option<QualificationResult>,
+}
+
+impl TryFrom<FuncBindingReturnValue> for QualificationView {
+    type Error = QualificationError;
+
+    fn try_from(fbrv: FuncBindingReturnValue) -> Result<Self, Self::Error> {
+        if let Some(qual_result_json) = fbrv.value() {
+            let result = serde_json::from_value(qual_result_json.clone())?;
+            Ok(QualificationView {
+                message: "did it".to_string(),
+                title: None,
+                description: None,
+                link: None,
+                result: Some(result),
+            })
+        } else {
+            Err(QualificationError::NoValue)
+        }
+    }
 }

--- a/lib/dal/src/qualification_resolver.rs
+++ b/lib/dal/src/qualification_resolver.rs
@@ -176,16 +176,22 @@ impl QualificationResolver {
         QualificationResolverResult
     );
 
-    pub async fn find_for_prototype(
+    pub async fn find_for_prototype_and_component(
         txn: &PgTxn<'_>,
         tenancy: &Tenancy,
         visibility: &Visibility,
         qualification_prototype_id: &QualificationPrototypeId,
+        component_id: &ComponentId,
     ) -> QualificationResolverResult<Vec<Self>> {
         let rows = txn
             .query(
                 FIND_FOR_PROTOTYPE,
-                &[&tenancy, &visibility, qualification_prototype_id],
+                &[
+                    &tenancy,
+                    &visibility,
+                    qualification_prototype_id,
+                    component_id,
+                ],
             )
             .await?;
         let object = objects_from_rows(rows)?;

--- a/lib/dal/src/queries/component_list_qualifications.sql
+++ b/lib/dal/src/queries/component_list_qualifications.sql
@@ -1,0 +1,25 @@
+SELECT DISTINCT ON (qualification_resolvers.id) qualification_resolvers.id,
+                              qualification_resolvers.visibility_change_set_pk,
+                              qualification_resolvers.visibility_edit_session_pk,
+                              row_to_json(func_binding_return_values.*) AS object
+FROM qualification_resolvers
+INNER JOIN func_binding_return_value_belongs_to_func_binding ON 
+  func_binding_return_value_belongs_to_func_binding.belongs_to_id = qualification_resolvers.func_binding_id
+INNER JOIN func_binding_return_values ON 
+  func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+WHERE in_tenancy_v1($1, qualification_resolvers.tenancy_universal, qualification_resolvers.tenancy_billing_account_ids, qualification_resolvers.tenancy_organization_ids,
+                    qualification_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, qualification_resolvers.visibility_change_set_pk, qualification_resolvers.visibility_edit_session_pk, qualification_resolvers.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_edit_session_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_values.visibility_change_set_pk, 
+    func_binding_return_values.visibility_edit_session_pk, 
+    func_binding_return_values.visibility_deleted)
+  AND qualification_resolvers.component_id = $3
+   AND (qualification_resolvers.system_id = $4 OR qualification_resolvers.system_id = -1)
+	ORDER BY qualification_resolvers.id, 
+      visibility_change_set_pk DESC, 
+      visibility_edit_session_pk DESC;

--- a/lib/dal/src/queries/qualification_resolver_find_for_prototype.sql
+++ b/lib/dal/src/queries/qualification_resolver_find_for_prototype.sql
@@ -11,6 +11,7 @@ WHERE in_tenancy_v1($1, qualification_resolvers.tenancy_universal, qualification
                     qualification_resolvers.tenancy_workspace_ids)
   AND is_visible_v1($2, qualification_resolvers.visibility_change_set_pk, qualification_resolvers.visibility_edit_session_pk, qualification_resolvers.visibility_deleted)
   AND qualification_resolvers.qualification_prototype_id = $3
+  AND qualification_resolvers.component_id = $4
 ORDER BY qualification_resolvers.id,
          visibility_change_set_pk DESC,
          visibility_edit_session_pk DESC,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -1,9 +1,10 @@
 use crate::test_setup;
 
+use dal::qualification_resolver::UNSET_ID_VALUE;
 use dal::test_harness::{create_schema, create_schema_variant};
 use dal::{
-    Component, ComponentQualificationView, HistoryActor, Prop, PropKind, SchemaKind, StandardModel,
-    Tenancy, Visibility,
+    Component, ComponentQualificationView, HistoryActor, Prop, PropKind, Schema, SchemaKind,
+    StandardModel, Tenancy, Visibility,
 };
 use serde_json::json;
 
@@ -225,4 +226,157 @@ async fn qualification_view() {
             }
         }),
     );
+}
+
+// NOTE: This test is brittle. It's going to rely on the existing configuration of the dockerImage, but it's going
+// to prove what we want right now. Figuring out a test that is less brittle is a great idea, but I'm choosing
+// expediency.
+#[tokio::test]
+async fn list_qualifications() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema = create_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Implementation,
+    )
+    .await;
+
+    let schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"docker_image".to_string(),
+    )
+    .await
+    .expect("cannot find docker image schema")
+    .pop()
+    .expect("no docker image schema found");
+    let (mut component, node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech.clone(),
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "ash",
+        schema.id(),
+    )
+    .await
+    .expect("cannot create docker_image component");
+
+    component
+        .set_name(&txn, &nats, &visibility, &history_actor, "chvrches")
+        .await
+        .expect("cannot set name");
+    component
+        .check_qualifications(
+            &txn,
+            &nats,
+            veritech.clone(),
+            &tenancy,
+            &visibility,
+            &history_actor,
+            UNSET_ID_VALUE.into(),
+        )
+        .await
+        .expect("cannot check qualifications");
+    let qualifications = component
+        .list_qualifications(&txn, &tenancy, &visibility, UNSET_ID_VALUE.into())
+        .await
+        .expect("cannot list qualifications");
+    assert_eq!(qualifications.len(), 1);
+}
+
+// Also brittle, same reason
+#[tokio::test]
+async fn list_qualifications_by_component_id() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema = create_schema(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Implementation,
+    )
+    .await;
+
+    let schema = Schema::find_by_attr(
+        &txn,
+        &tenancy,
+        &visibility,
+        "name",
+        &"docker_image".to_string(),
+    )
+    .await
+    .expect("cannot find docker image schema")
+    .pop()
+    .expect("no docker image schema found");
+    let (mut component, node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech.clone(),
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "ash",
+        schema.id(),
+    )
+    .await
+    .expect("cannot create docker_image component");
+
+    component
+        .set_name(&txn, &nats, &visibility, &history_actor, "chvrches")
+        .await
+        .expect("cannot set name");
+    component
+        .check_qualifications(
+            &txn,
+            &nats,
+            veritech.clone(),
+            &tenancy,
+            &visibility,
+            &history_actor,
+            UNSET_ID_VALUE.into(),
+        )
+        .await
+        .expect("cannot check qualifications");
+    let qualifications = Component::list_qualifications_by_component_id(
+        &txn,
+        &tenancy,
+        &visibility,
+        *component.id(),
+        UNSET_ID_VALUE.into(),
+    )
+    .await
+    .expect("cannot list qualifications");
+    assert_eq!(qualifications.len(), 1);
 }


### PR DESCRIPTION
Wire qualification checks through to the frontend. This PR links
actually checking the qualification by looking for the
QualificationPrototypes for a given Schema/SchemaVariant, and creating
or updating QualificationResolvers for a given component as appropriate.

It also transforms the FuncBindingResultValue into a QualificationView
suitable for use in the frontend.

It includes some test coverage for qualifications that is fragile - it
depends on the current implementation of the `docker_image` schema. What
it does do is confirm that the full behavior works as expected.

Signed-off-by: Adam Jacob <adam@systeminit.com>