### PR TITLE
chore(dal,veritech): create default NATS subjects with optional prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "url",
+ "uuid",
  "veritech",
 ]
 
@@ -3576,6 +3577,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.2.0", features = ["full"] }
 tokio-postgres = { version ="0.7.0", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.3"
 url = "2.2.2"
+uuid = { version = "0.8.2", features = ["v4"] }
 petgraph = "0.6.0"
 anyhow = "1.0.40"
 lazy_static = "1.4.0"

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -191,7 +191,7 @@ impl FuncBackendJsString {
 
         let result = self
             .veritech
-            .execute_resolver_function("veritech.function.resolver", self.output_tx, &self.request)
+            .execute_resolver_function(self.output_tx, &self.request)
             .await
             .map_err(|err| span.record_err(err))?;
         let value = match result {
@@ -270,11 +270,7 @@ impl FuncBackendJsQualification {
 
         let result = self
             .veritech
-            .execute_qualification_check(
-                "veritech.function.qualification",
-                self.output_tx,
-                &self.request,
-            )
+            .execute_qualification_check(self.output_tx, &self.request)
             .await
             .map_err(|err| span.record_err(err))?;
         let value = match result {

--- a/lib/dal/tests/integration_test/billing_account.rs
+++ b/lib/dal/tests/integration_test/billing_account.rs
@@ -10,7 +10,7 @@ use dal::{BillingAccount, HistoryActor, StandardModel, Tenancy};
 async fn new() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
@@ -69,7 +69,7 @@ async fn get_by_pk() {
 async fn get_by_id() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
@@ -100,7 +100,7 @@ async fn get_by_id() {
 async fn set_name() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
@@ -133,7 +133,7 @@ async fn set_name() {
 async fn set_description() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");

--- a/lib/dal/tests/integration_test/edit_session.rs
+++ b/lib/dal/tests/integration_test/edit_session.rs
@@ -13,7 +13,7 @@ use dal::{
 async fn new() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
@@ -48,7 +48,7 @@ async fn new() {
 async fn save() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");

--- a/lib/dal/tests/integration_test/history_event.rs
+++ b/lib/dal/tests/integration_test/history_event.rs
@@ -5,7 +5,7 @@ use dal::{HistoryActor, HistoryEvent, Tenancy};
 async fn new() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, nats_conn, _secret_key) = ctx.entries();
+    let (pg, nats_conn, _veritech, _secret_key) = ctx.entries();
     let nats = nats_conn.transaction();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");

--- a/lib/dal/tests/integration_test/jwt_key.rs
+++ b/lib/dal/tests/integration_test/jwt_key.rs
@@ -8,7 +8,7 @@ use jwt_simple::algorithms::RSAKeyPairLike;
 async fn get_jwt_signing_key() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, _nats_conn, secret_key) = ctx.entries();
+    let (pg, _nats_conn, _veritech, secret_key) = ctx.entries();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
 
@@ -21,7 +21,7 @@ async fn get_jwt_signing_key() {
 async fn get_jwt_validation_key() {
     one_time_setup().await.expect("one time setup failed");
     let ctx = TestContext::init().await;
-    let (pg, _nats_conn, secret_key) = ctx.entries();
+    let (pg, _nats_conn, _veritech, secret_key) = ctx.entries();
     let mut conn = pg.get().await.expect("cannot connect to pg");
     let txn = conn.transaction().await.expect("cannot create txn");
 

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -48,10 +48,9 @@ macro_rules! test_setup {
             .await
             .expect("one time setup failed");
         let $ctx = dal::test_harness::TestContext::init().await;
-        let ($pg, $nats_conn, $secret_key) = $ctx.entries();
+        let ($pg, $nats_conn, $veritech, $secret_key) = $ctx.entries();
         let $nats = $nats_conn.transaction();
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
         let $pgtxn = $pgconn.transaction().await.expect("cannot create txn");
-        let $veritech = veritech::Client::new($nats_conn.clone());
     };
 }

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -182,10 +182,9 @@ macro_rules! test_setup {
             .await
             .expect("one time setup failed");
         let $ctx = dal::test_harness::TestContext::init().await;
-        let ($pg, $nats_conn, $jwt_secret_key) = $ctx.entries();
+        let ($pg, $nats_conn, $veritech, $jwt_secret_key) = $ctx.entries();
         let telemetry = $ctx.telemetry();
         let $nats = $nats_conn.transaction();
-        let $veritech = veritech::Client::new($nats_conn.clone());
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
         let $pgtxn = $pgconn.transaction().await.expect("cannot create txn");
         let ($app, _) = sdf::build_service(

--- a/lib/sdf/tests/service_tests/signup.rs
+++ b/lib/sdf/tests/service_tests/signup.rs
@@ -11,7 +11,7 @@ use tower::ServiceExt;
 async fn create_account() {
     one_time_setup().await.expect("cannot setup tests");
     let ctx = TestContext::init().await;
-    let (pg, nats, jwt_secret_key) = ctx.entries();
+    let (pg, nats, _veritech, jwt_secret_key) = ctx.entries();
     let veritech = veritech::Client::new(nats.clone());
     let telemetry = ctx.telemetry();
     let (app, _) = sdf::build_service(

--- a/lib/veritech/Cargo.toml
+++ b/lib/veritech/Cargo.toml
@@ -50,3 +50,4 @@ indoc = "1.0.3"
 test-env-log = { version = "0.2.7", default-features = false, features = ["trace"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.2.19", default-features = false, features = ["env-filter", "fmt"] }
+uuid = { version = "0.8.2", features = ["v4"] }

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -31,6 +31,10 @@ pub use cyclone::{
     QualificationCheckRequest, QualificationCheckResultSuccess, ResolverFunctionRequest,
 };
 
+const NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT: &str = "veritech.fn.qualificationcheck";
+const NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT: &str = "veritech.fn.resolverfunction";
+const NATS_RESOURCE_SYNC_DEFAULT_SUBJECT: &str = "veritech.fn.resourcesync";
+
 pub(crate) const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";
 
 pub(crate) fn reply_mailbox_for_output(reply_mailbox: &str) -> String {
@@ -39,4 +43,24 @@ pub(crate) fn reply_mailbox_for_output(reply_mailbox: &str) -> String {
 
 pub(crate) fn reply_mailbox_for_result(reply_mailbox: &str) -> String {
     format!("{reply_mailbox}.result")
+}
+
+pub(crate) fn nats_qualification_check_subject(prefix: Option<&str>) -> String {
+    nats_subject(prefix, NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT)
+}
+
+pub(crate) fn nats_resolver_function_subject(prefix: Option<&str>) -> String {
+    nats_subject(prefix, NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT)
+}
+
+pub(crate) fn nats_resource_sync_subject(prefix: Option<&str>) -> String {
+    nats_subject(prefix, NATS_RESOURCE_SYNC_DEFAULT_SUBJECT)
+}
+
+pub(crate) fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
+    let suffix = suffix.as_ref();
+    match prefix {
+        Some(prefix) => format!("{prefix}.{suffix}"),
+        None => suffix.to_string(),
+    }
 }

--- a/lib/veritech/src/server/config.rs
+++ b/lib/veritech/src/server/config.rs
@@ -36,6 +36,9 @@ pub struct Config {
     #[builder(default = "NatsConfig::default()")]
     nats: NatsConfig,
 
+    #[builder(setter(into, strip_option), default)]
+    subject_prefix: Option<String>,
+
     cyclone_spec: CycloneSpec,
 }
 
@@ -108,6 +111,11 @@ impl Config {
     #[must_use]
     pub fn nats(&self) -> &NatsConfig {
         &self.nats
+    }
+
+    /// Gets a reference to the config's subject prefix.
+    pub fn subject_prefix(&self) -> Option<&str> {
+        self.subject_prefix.as_deref()
     }
 }
 


### PR DESCRIPTION
This change adds some more convention around the Veritech server and
client agreeing on the various NATS subjects to use when transmitting
function executions requests. A set of shared functions in the
`veritech` crate are now responsible for building these topics so there
should be very little chance of "mis-wiring" an agreed upon subject over
which to communicate.

This change updates the following:

* Adds a `subject_prefix()` which is optional on the
  `veritech::Config::builder()` (the server's Config). This is used by
  our test suites to inject per-test unique prefixes.
* Adds a `veritech::Client::with_subject_prefix()` alternate constructor
  to configure the client side--this is also used by the test suites.
* Removes the formerly required subject strings on each
  `veritech::Client` method such as `execute_resolver_function()`, etc.
  There are net-new alternate methods such as
  `execute_resolver_function_with_subject()` which take a custom subject
  allowing the caller to override the conventional default.
* The Veritech client has a `subject_prefix()` method, allowing a user
  to determine how the client is set up.
* The Veritech server has a `shutdown_handle()` method which returns a
  type holding a shutdown tx and has a single `shutdown()` method on it.
  The test suite uses this on initial setup to explicitly shut down the
  server used in migrations (more detail below).

Now that we can have concurrently running Veritech with their own
subject namespaces, the dal and sdf test suites can essentially give
each test its own Veritech server instance and pre-configured client
which are wired together. In the `one_time_setup()` function--which is
executed fully only one time at the start of a test suite--a dedicated
Veritech server is spun up to assist with any database and object code
migrations. After the migrations, this server is explicitly asked to
shutdown so the currently running test that ran these migrations doesn't
end up with 2 Veritech servers spawned as tasks in its own tokio
reactor.

This'll be fun...

<img src="https://media2.giphy.com/media/5kFWWtxR0UCHgLaM4O/giphy.gif"/>

<img src="https://media4.giphy.com/media/1n4iuWZFnTeN6qvdpD/giphy.gif"/>

References: Add default configurable NATS subjects in [sc-2172]

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>