### PR TITLE
feat(dal): Add ability to include a component in a system

### DIFF
--- a/lib/dal/src/migrations/U0036__nodes.sql
+++ b/lib/dal/src/migrations/U0036__nodes.sql
@@ -15,10 +15,12 @@ CREATE TABLE nodes
 );
 SELECT standard_model_table_constraints_v1('nodes');
 SELECT belongs_to_table_create_v1('node_belongs_to_component', 'nodes', 'components');
+SELECT belongs_to_table_create_v1('node_belongs_to_system', 'nodes', 'systems');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
 VALUES ('nodes', 'model', 'node', 'Node'),
-       ('node_belongs_to_component', 'belongs_to', 'node.component', 'Node <> Component');
+       ('node_belongs_to_component', 'belongs_to', 'node.component', 'Node <> Component'),
+       ('node_belongs_to_system', 'belongs_to', 'node.system', 'Node <> System');
 
 CREATE OR REPLACE FUNCTION node_create_v1(
     this_tenancy jsonb,

--- a/lib/dal/src/migrations/U0038__systems.sql
+++ b/lib/dal/src/migrations/U0038__systems.sql
@@ -15,10 +15,14 @@ CREATE TABLE systems
 );
 SELECT standard_model_table_constraints_v1('systems');
 SELECT belongs_to_table_create_v1('system_belongs_to_workspace', 'systems', 'workspaces');
+SELECT belongs_to_table_create_v1('system_belongs_to_schema', 'systems', 'schemas');
+SELECT belongs_to_table_create_v1('system_belongs_to_schema_variant', 'systems', 'schema_variants');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
 VALUES ('systems', 'model', 'system', 'System'),
-       ('system_belongs_to_workspace', 'belongs_to', 'system.workspace', 'System <> Workspace');
+       ('system_belongs_to_workspace', 'belongs_to', 'system.workspace', 'System <> Workspace'),
+       ('system_belongs_to_schema', 'belongs_to', 'system.schema', 'System <> Schema'),
+       ('system_belongs_to_schema_variant', 'belongs_to', 'system.schema_variant', 'System <> Schema Variant');
 
 CREATE OR REPLACE FUNCTION system_create_v1(
     this_tenancy jsonb,

--- a/lib/dal/src/migrations/U0041__edges.sql
+++ b/lib/dal/src/migrations/U0041__edges.sql
@@ -64,3 +64,209 @@ BEGIN
     object := row_to_json(this_new_row);
 END;
 $$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION edge_include_component_in_system_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id bigint,
+    this_system_id bigint,
+        OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record      tenancy_record_v1;
+    this_visibility_record   visibility_record_v1;
+    this_component_node_id   bigint;
+    this_component_socket_id bigint;
+    this_system_node_id      bigint;
+    this_system_socket_id    bigint;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    SELECT
+        nodes.id,
+        sockets.id
+    -- Using "STRICT" to ensure that this entire query must return _exactly_ one (1) row,
+    -- since there should ever only be one "includes" socket for the component.
+    INTO STRICT
+        this_component_node_id,
+        this_component_socket_id
+    FROM components
+            -- We're making sure the tenancy & visibility match the component's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the component that we're interested in.
+            INNER JOIN component_belongs_to_schema_variant
+                        ON components.id = component_belongs_to_schema_variant.object_id
+                            AND components.tenancy_universal = component_belongs_to_schema_variant.tenancy_universal
+                            AND components.tenancy_billing_account_ids =
+                                component_belongs_to_schema_variant.tenancy_billing_account_ids
+                            AND components.tenancy_organization_ids =
+                                component_belongs_to_schema_variant.tenancy_organization_ids
+                            AND components.tenancy_workspace_ids = component_belongs_to_schema_variant.tenancy_workspace_ids
+                            AND components.visibility_change_set_pk =
+                                component_belongs_to_schema_variant.visibility_change_set_pk
+                            AND components.visibility_edit_session_pk =
+                                component_belongs_to_schema_variant.visibility_edit_session_pk
+                            AND components.visibility_deleted = component_belongs_to_schema_variant.visibility_deleted
+            -- We're making sure the tenancy & visibility match the component's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the component that we're interested in.
+            INNER JOIN node_belongs_to_component
+                        ON components.id = node_belongs_to_component.belongs_to_id
+                            AND components.tenancy_universal = node_belongs_to_component.tenancy_universal
+                            AND
+                        components.tenancy_billing_account_ids = node_belongs_to_component.tenancy_billing_account_ids
+                            AND components.tenancy_organization_ids = node_belongs_to_component.tenancy_organization_ids
+                            AND components.tenancy_workspace_ids = node_belongs_to_component.tenancy_workspace_ids
+                            AND components.visibility_change_set_pk = node_belongs_to_component.visibility_change_set_pk
+                            AND components.visibility_edit_session_pk = node_belongs_to_component.visibility_edit_session_pk
+                            AND components.visibility_deleted = node_belongs_to_component.visibility_deleted
+            -- We're making sure the tenancy & visibility match the component's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the component that we're interested in.
+            INNER JOIN nodes
+                        ON nodes.id = node_belongs_to_component.object_id
+                            AND nodes.tenancy_universal = components.tenancy_universal
+                            AND nodes.tenancy_billing_account_ids = components.tenancy_billing_account_ids
+                            AND nodes.tenancy_organization_ids = components.tenancy_organization_ids
+                            AND nodes.tenancy_workspace_ids = components.tenancy_workspace_ids
+                            AND nodes.visibility_change_set_pk = node_belongs_to_component.visibility_change_set_pk
+                            AND nodes.visibility_edit_session_pk = node_belongs_to_component.visibility_edit_session_pk
+                            AND nodes.visibility_deleted = node_belongs_to_component.visibility_deleted
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the schema_variant might not
+            -- exist in the _exact_ same tenancy/visibility as the component, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN schema_variants
+                        ON schema_variants.id = component_belongs_to_schema_variant.belongs_to_id
+                            AND in_tenancy_v1(this_tenancy, schema_variants.tenancy_universal, schema_variants.tenancy_billing_account_ids,
+                                            schema_variants.tenancy_organization_ids,
+                                            schema_variants.tenancy_workspace_ids)
+                            AND is_visible_v1(this_visibility, schema_variants.visibility_change_set_pk, schema_variants.visibility_edit_session_pk,
+                                            schema_variants.visibility_deleted)
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the schema_variant might not
+            -- exist in the _exact_ same tenancy/visibility as the component, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN socket_many_to_many_schema_variants
+                        ON schema_variants.id = socket_many_to_many_schema_variants.right_object_id
+                            AND in_tenancy_v1(this_tenancy, socket_many_to_many_schema_variants.tenancy_universal,
+                                            socket_many_to_many_schema_variants.tenancy_billing_account_ids,
+                                            socket_many_to_many_schema_variants.tenancy_organization_ids,
+                                            socket_many_to_many_schema_variants.tenancy_workspace_ids)
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the socket might not
+            -- exist in the _exact_ same tenancy/visibility as the component, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN sockets
+                        ON sockets.id = socket_many_to_many_schema_variants.left_object_id
+                            AND sockets.tenancy_universal = socket_many_to_many_schema_variants.tenancy_universal
+                            AND sockets.tenancy_billing_account_ids =
+                                socket_many_to_many_schema_variants.tenancy_billing_account_ids
+                            AND
+                        sockets.tenancy_organization_ids = socket_many_to_many_schema_variants.tenancy_organization_ids
+                            AND sockets.tenancy_workspace_ids = socket_many_to_many_schema_variants.tenancy_workspace_ids
+                            AND sockets.edge_kind = 'includes'
+    WHERE in_tenancy_v1(this_tenancy, components.tenancy_universal, components.tenancy_billing_account_ids, components.tenancy_organization_ids,
+                        components.tenancy_workspace_ids)
+    AND is_visible_v1(this_visibility, components.visibility_change_set_pk, components.visibility_edit_session_pk, components.visibility_deleted)
+    AND components.id = this_component_id;
+
+    SELECT
+        nodes.id,
+        sockets.id
+    -- Using "STRICT" to ensure that this entire query must return _exactly_ one (1) row,
+    -- since there should ever only be one "includes" socket for the system.
+    INTO STRICT
+        this_system_node_id,
+        this_system_socket_id
+    FROM systems
+            -- We're making sure the tenancy & visibility match the system's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the system that we're interested in.
+            INNER JOIN system_belongs_to_schema_variant
+                        ON systems.id = system_belongs_to_schema_variant.object_id
+                            AND systems.tenancy_universal = system_belongs_to_schema_variant.tenancy_universal
+                            AND systems.tenancy_billing_account_ids =
+                                system_belongs_to_schema_variant.tenancy_billing_account_ids
+                            AND systems.tenancy_organization_ids =
+                                system_belongs_to_schema_variant.tenancy_organization_ids
+                            AND systems.tenancy_workspace_ids = system_belongs_to_schema_variant.tenancy_workspace_ids
+                            AND systems.visibility_change_set_pk =
+                                system_belongs_to_schema_variant.visibility_change_set_pk
+                            AND systems.visibility_edit_session_pk =
+                                system_belongs_to_schema_variant.visibility_edit_session_pk
+                            AND systems.visibility_deleted = system_belongs_to_schema_variant.visibility_deleted
+            -- We're making sure the tenancy & visibility match the system's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the system that we're interested in.
+            INNER JOIN node_belongs_to_system
+                        ON systems.id = node_belongs_to_system.belongs_to_id
+                            AND systems.tenancy_universal = node_belongs_to_system.tenancy_universal
+                            AND
+                        systems.tenancy_billing_account_ids = node_belongs_to_system.tenancy_billing_account_ids
+                            AND systems.tenancy_organization_ids = node_belongs_to_system.tenancy_organization_ids
+                            AND systems.tenancy_workspace_ids = node_belongs_to_system.tenancy_workspace_ids
+                            AND systems.visibility_change_set_pk = node_belongs_to_system.visibility_change_set_pk
+                            AND systems.visibility_edit_session_pk = node_belongs_to_system.visibility_edit_session_pk
+                            AND systems.visibility_deleted = node_belongs_to_system.visibility_deleted
+            -- We're making sure the tenancy & visibility match the system's _exactly_ here, to ensure that
+            -- we are getting the _exact_ join record for _this_ version of the system that we're interested in.
+            INNER JOIN nodes
+                        ON nodes.id = node_belongs_to_system.object_id
+                            AND nodes.tenancy_universal = node_belongs_to_system.tenancy_universal
+                            AND nodes.tenancy_billing_account_ids = node_belongs_to_system.tenancy_billing_account_ids
+                            AND nodes.tenancy_organization_ids = node_belongs_to_system.tenancy_organization_ids
+                            AND nodes.tenancy_workspace_ids = node_belongs_to_system.tenancy_workspace_ids
+                            AND nodes.visibility_change_set_pk = node_belongs_to_system.visibility_change_set_pk
+                            AND nodes.visibility_edit_session_pk = node_belongs_to_system.visibility_edit_session_pk
+                            AND nodes.visibility_deleted = node_belongs_to_system.visibility_deleted
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the schema_variant might not
+            -- exist in the _exact_ same tenancy/visibility as the system, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN schema_variants
+                        ON schema_variants.id = system_belongs_to_schema_variant.belongs_to_id
+                            AND in_tenancy_v1(this_tenancy, schema_variants.tenancy_universal, schema_variants.tenancy_billing_account_ids,
+                                            schema_variants.tenancy_organization_ids,
+                                            schema_variants.tenancy_workspace_ids)
+                            AND is_visible_v1(this_visibility, schema_variants.visibility_change_set_pk, schema_variants.visibility_edit_session_pk,
+                                            schema_variants.visibility_deleted)
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the schema_variant might not
+            -- exist in the _exact_ same tenancy/visibility as the system, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN socket_many_to_many_schema_variants
+                        ON schema_variants.id = socket_many_to_many_schema_variants.right_object_id
+                            AND in_tenancy_v1(this_tenancy, socket_many_to_many_schema_variants.tenancy_universal,
+                                            socket_many_to_many_schema_variants.tenancy_billing_account_ids,
+                                            socket_many_to_many_schema_variants.tenancy_organization_ids,
+                                            socket_many_to_many_schema_variants.tenancy_workspace_ids)
+            -- We're using the in_tenancy_v1, and is_visible_v1 helpers here, because the socket might not
+            -- exist in the _exact_ same tenancy/visibility as the system, so we need to be able to do the
+            -- fallback/lookup logic here.
+            INNER JOIN sockets
+                        ON sockets.id = socket_many_to_many_schema_variants.left_object_id
+                            AND sockets.tenancy_universal = socket_many_to_many_schema_variants.tenancy_universal
+                            AND sockets.tenancy_billing_account_ids =
+                                socket_many_to_many_schema_variants.tenancy_billing_account_ids
+                            AND
+                        sockets.tenancy_organization_ids = socket_many_to_many_schema_variants.tenancy_organization_ids
+                            AND sockets.tenancy_workspace_ids = socket_many_to_many_schema_variants.tenancy_workspace_ids
+                            AND sockets.edge_kind = 'output'
+    WHERE in_tenancy_v1(this_tenancy, systems.tenancy_universal, systems.tenancy_billing_account_ids, systems.tenancy_organization_ids,
+                        systems.tenancy_workspace_ids)
+    AND is_visible_v1(this_visibility, systems.visibility_change_set_pk, systems.visibility_edit_session_pk, systems.visibility_deleted)
+    AND systems.id = this_system_id;
+
+    SELECT
+        *
+    INTO
+        object
+    FROM
+        edge_create_v1(
+            this_tenancy,
+            this_visibility,
+            'includes',
+            this_component_node_id,
+            'component',
+            this_component_id,
+            this_component_socket_id,
+            this_system_node_id,
+            'system',
+            this_system_id,
+            this_system_socket_id
+        );
+
+END;
+$$ LANGUAGE plpgsql VOLATILE;

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -9,8 +9,8 @@ use crate::socket::{Socket, SocketEdgeKind};
 use crate::{
     generate_name, impl_standard_model, pk, standard_model, standard_model_accessor,
     standard_model_belongs_to, Component, ComponentId, HistoryActor, HistoryEventError,
-    NodePosition, Schema, SchemaId, SchemaVariant, StandardModel, StandardModelError, Tenancy,
-    Timestamp, Visibility,
+    NodePosition, Schema, SchemaId, SchemaVariant, StandardModel, StandardModelError, System,
+    SystemId, Tenancy, Timestamp, Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -56,6 +56,7 @@ pk!(NodeId);
 )]
 pub enum NodeKind {
     Component,
+    System,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
@@ -118,6 +119,17 @@ impl Node {
         model_table: "components",
         belongs_to_id: ComponentId,
         returns: Component,
+        result: NodeResult,
+    );
+
+    standard_model_belongs_to!(
+        lookup_fn: system,
+        set_fn: set_system,
+        unset_fn: unset_system,
+        table: "node_belongs_to_system",
+        model_table: "systems",
+        belongs_to_id: SystemId,
+        returns: System,
         result: NodeResult,
     );
 }

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -59,6 +59,7 @@ pub enum SocketEdgeKind {
     Component,
     Configures,
     Deployment,
+    Includes,
     Output,
 }
 

--- a/lib/dal/src/system.rs
+++ b/lib/dal/src/system.rs
@@ -5,7 +5,8 @@ use thiserror::Error;
 
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
-    HistoryActor, HistoryEventError, StandardModel, StandardModelError, Tenancy, Timestamp,
+    standard_model_has_many, HistoryActor, HistoryEventError, Node, Schema, SchemaId,
+    SchemaVariant, SchemaVariantId, StandardModel, StandardModelError, Tenancy, Timestamp,
     Visibility, Workspace, WorkspaceId,
 };
 
@@ -78,6 +79,28 @@ impl System {
     standard_model_accessor!(name, String, SystemResult);
 
     standard_model_belongs_to!(
+        lookup_fn: schema,
+        set_fn: set_schema,
+        unset_fn: unset_schema,
+        table: "system_belongs_to_schema",
+        model_table: "schemas",
+        belongs_to_id: SchemaId,
+        returns: Schema,
+        result: SystemResult,
+    );
+
+    standard_model_belongs_to!(
+        lookup_fn: schema_variant,
+        set_fn: set_schema_variant,
+        unset_fn: unset_schema_variant,
+        table: "system_belongs_to_schema_variant",
+        model_table: "schema_variants",
+        belongs_to_id: SchemaVariantId,
+        returns: SchemaVariant,
+        result: SystemResult,
+    );
+
+    standard_model_belongs_to!(
         lookup_fn: workspace,
         set_fn: set_workspace,
         unset_fn: unset_workspace,
@@ -85,6 +108,14 @@ impl System {
         model_table: "workspaces",
         belongs_to_id: WorkspaceId,
         returns: Workspace,
+        result: SystemResult,
+    );
+
+    standard_model_has_many!(
+        lookup_fn: node,
+        table: "node_belongs_to_system",
+        model_table: "nodes",
+        returns: Node,
         result: SystemResult,
     );
 }

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -1,7 +1,12 @@
 use crate::test_setup;
 
 use dal::edge::{EdgeKind, VertexObjectKind};
-use dal::{Component, Edge, HistoryActor, Schema, StandardModel, Tenancy, Visibility};
+use dal::test_harness::{
+    create_change_set, create_edit_session, create_system, create_visibility_edit_session,
+};
+use dal::{
+    Component, Edge, HistoryActor, Node, NodeKind, Schema, StandardModel, Tenancy, Visibility,
+};
 
 #[tokio::test]
 async fn new() {
@@ -90,4 +95,229 @@ async fn new() {
     )
     .await
     .expect("cannot create new edge");
+}
+
+#[tokio::test]
+async fn include_component_in_system() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let system_schema =
+        Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"system".to_string())
+            .await
+            .expect("cannot find system schema")
+            .pop()
+            .expect("no system schema found");
+    let system_schema_variant = system_schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot get default schema variant");
+
+    let service_schema =
+        Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"service".to_string())
+            .await
+            .expect("cannot find service schema")
+            .pop()
+            .expect("no service schema found");
+
+    let _service_schema_variant = service_schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot get default schema variant");
+
+    let system = create_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    system
+        .set_schema(&txn, &nats, &visibility, &history_actor, system_schema.id())
+        .await
+        .expect("cannot set schema for system");
+    system
+        .set_schema_variant(
+            &txn,
+            &nats,
+            &visibility,
+            &history_actor,
+            system_schema_variant.id(),
+        )
+        .await
+        .expect("cannot set schema variant for system");
+
+    let system_node = Node::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &NodeKind::System,
+    )
+    .await
+    .expect("cannot create node for system");
+    system_node
+        .set_system(&txn, &nats, &visibility, &history_actor, system.id())
+        .await
+        .expect("cannot assign system to node");
+
+    let (first_component, first_component_node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech.clone(),
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "first",
+        service_schema.id(),
+    )
+    .await
+    .expect("cannot create component and node for service");
+
+    let (_second_component, _second_component_node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "second",
+        service_schema.id(),
+    )
+    .await
+    .expect("cannot create component and node for service");
+
+    let edge = Edge::include_component_in_system(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        first_component.id(),
+        system.id(),
+    )
+    .await
+    .expect("cannot create new edge");
+
+    assert_eq!(edge.head_node_id(), *first_component_node.id(),);
+}
+
+#[tokio::test]
+async fn include_component_in_system_with_edit_sessions() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
+    let edit_session = create_edit_session(&txn, &nats, &history_actor, &change_set).await;
+    let edit_session_visibility = create_visibility_edit_session(&change_set, &edit_session);
+
+    let system_schema =
+        Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"system".to_string())
+            .await
+            .expect("cannot find system schema")
+            .pop()
+            .expect("no system schema found");
+    let system_schema_variant = system_schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot get default schema variant");
+
+    let service_schema =
+        Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"service".to_string())
+            .await
+            .expect("cannot find service schema")
+            .pop()
+            .expect("no service schema found");
+
+    let _service_schema_variant = service_schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot get default schema variant");
+
+    let system = create_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    system
+        .set_schema(&txn, &nats, &visibility, &history_actor, system_schema.id())
+        .await
+        .expect("cannot set schema for system");
+    system
+        .set_schema_variant(
+            &txn,
+            &nats,
+            &visibility,
+            &history_actor,
+            system_schema_variant.id(),
+        )
+        .await
+        .expect("cannot set schema variant for system");
+
+    let system_node = Node::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &NodeKind::System,
+    )
+    .await
+    .expect("cannot create node for system");
+    system_node
+        .set_system(&txn, &nats, &visibility, &history_actor, system.id())
+        .await
+        .expect("cannot assign system to node");
+
+    let (first_component, first_component_node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech.clone(),
+        &tenancy,
+        &edit_session_visibility,
+        &history_actor,
+        "first",
+        service_schema.id(),
+    )
+    .await
+    .expect("cannot create component and node for service");
+
+    let (_second_component, _second_component_node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech,
+        &tenancy,
+        &edit_session_visibility,
+        &history_actor,
+        "second",
+        service_schema.id(),
+    )
+    .await
+    .expect("cannot create component and node for service");
+
+    let edge = Edge::include_component_in_system(
+        &txn,
+        &nats,
+        &tenancy,
+        &edit_session_visibility,
+        &history_actor,
+        first_component.id(),
+        system.id(),
+    )
+    .await
+    .expect("cannot create new edge");
+
+    assert_eq!(edge.head_node_id(), *first_component_node.id(),);
 }


### PR DESCRIPTION
There are several steps to be able to do this:

  * Systems now have schemas, schema variants, and nodes.
  * There is an `Includes` socket type that represents that the head is included in the tail of the edge connecting to that socket.
  * All builtin schema variants get the new "Includes" socket.
  * There is a new PLPGSQL function `edge_include_component_in_system_v1` that takes a `component_id`, and a `system_id` to find the appropriate nodes/sockets, generate the edge between them, and return the created Edge.