### PR TITLE
feat(lang-js,cyclone,dal,veritech): implement FuncBackendJsResourceSync

### DIFF
--- a/app/web/src/service/component/get_resource.ts
+++ b/app/web/src/service/component/get_resource.ts
@@ -43,7 +43,7 @@ export function getResource(
         {
           ...args,
           ...visibility,
-          systemId: system.id,
+          systemId: system?.id,
           workspaceId: workspace.id,
         },
       );

--- a/app/web/src/service/component/sync_resource.ts
+++ b/app/web/src/service/component/sync_resource.ts
@@ -42,7 +42,7 @@ export function syncResource(
         {
           ...args,
           ...visibility,
-          systemId: system.id,
+          systemId: system?.id,
           workspaceId: workspace.id,
         },
       );

--- a/bin/lang-js/examples/resourceSyncTest.json
+++ b/bin/lang-js/examples/resourceSyncTest.json
@@ -1,5 +1,9 @@
 {
   "executionId": "9012",
   "handler": "sync",
-  "codeBase64": "Ly8gRW5jb2RlIHRoaXMgaW50byBCYXNlNjQgd2l0aDoKLy8KLy8gYGBgc2gKLy8gY2F0IGV4YW1wbGVzL3Jlc291cmNlU3luY1Rlc3RDb2RlLmpzIHwgYmFzZTY0IHwgdHIgLWQgJ1xuJwovLyBgYGAKCmZ1bmN0aW9uIHN5bmMoKSB7CiAgY29uc29sZS5sb2coInN5bmNpbmcgc29tZXRoaW5nLCByaWdodD8iKTsKICByZXR1cm4ge307Cn0K"
+  "component": {
+    "name": "jane",
+    "properties": {}
+  },
+  "codeBase64": "Ly8gRW5jb2RlIHRoaXMgaW50byBCYXNlNjQgd2l0aDoKLy8KLy8gYGBgc2gKLy8gY2F0IGV4YW1wbGVzL3Jlc291cmNlU3luY1Rlc3RDb2RlLmpzIHwgYmFzZTY0IHwgdHIgLWQgJ1xuJwovLyBgYGAKCmZ1bmN0aW9uIHN5bmMoY29tcG9uZW50KSB7CiAgY29uc29sZS5sb2coSlNPTi5zdHJpbmdpZnkoY29tcG9uZW50KSk7CiAgY29uc29sZS5sb2coInN5bmNpbmcgc29tZXRoaW5nLCByaWdodD8iKTsKICByZXR1cm4ge307Cn0K"
 }

--- a/bin/lang-js/examples/resourceSyncTestCode.js
+++ b/bin/lang-js/examples/resourceSyncTestCode.js
@@ -4,7 +4,8 @@
 // cat examples/resourceSyncTestCode.js | base64 | tr -d '\n'
 // ```
 
-function sync() {
+function sync(component) {
+  console.log(JSON.stringify(component));
   console.log("syncing something, right?");
   return {};
 }

--- a/bin/lang-js/src/resource_sync.ts
+++ b/bin/lang-js/src/resource_sync.ts
@@ -16,7 +16,14 @@ const debug = Debug("langJs:resourceSync");
 
 export interface ResourceSyncRequest extends Request {
   handler: string;
+  component: Component;
   codeBase64: string;
+}
+
+export interface Component {
+  name: string;
+  // TODO(fnichol): Highly, highly, highly TBD!
+  properties: Record<string, unknown>;
 }
 
 export type ResourceSyncResult =
@@ -34,7 +41,7 @@ export interface ResourceSyncResultFailure extends ResultFailure {
 export function executeResourceSync(request: ResourceSyncRequest): void {
   const code = base64Decode(request.codeBase64);
   debug({ code });
-  const compiledCode = new VMScript(wrapCode(code, request.handler)).compile();
+  const compiledCode = new VMScript(wrapCode(code, request.handler, request.component)).compile();
   debug({ code: compiledCode.code });
   const sandbox = createSandbox(FunctionKind.ResourceSync, request.executionId);
   const vm = createVm(sandbox);
@@ -79,6 +86,6 @@ function execute(
   return result;
 }
 
-function wrapCode(code: string, handle: string): string {
-  return code + `\n${handle}();\n`;
+function wrapCode(code: string, handle: string, component: Component): string {
+  return code + `\n${handle}(${JSON.stringify(component)});\n`;
 }

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -29,7 +29,7 @@ pub use qualification_check::{
 };
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
 pub use resolver_function::{ResolverFunctionRequest, ResolverFunctionResultSuccess};
-pub use resource_sync::{ResourceSyncRequest, ResourceSyncResultSuccess};
+pub use resource_sync::{ResourceSyncComponent, ResourceSyncRequest, ResourceSyncResultSuccess};
 
 #[cfg(feature = "process")]
 pub mod process;

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -22,7 +22,7 @@ impl QualificationCheckRequest {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct QualificationCheckComponent {
     pub name: String,

--- a/lib/cyclone/src/resource_sync.rs
+++ b/lib/cyclone/src/resource_sync.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceSyncRequest {
     pub execution_id: String,
     pub handler: String,
+    pub component: ResourceSyncComponent,
     pub code_base64: String,
 }
 
@@ -16,6 +20,13 @@ impl ResourceSyncRequest {
     pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSyncComponent {
+    pub name: String,
+    pub properties: HashMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -50,7 +50,7 @@ pub use billing_account::{
 };
 pub use capability::{Capability, CapabilityError, CapabilityId, CapabilityPk, CapabilityResult};
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetPk, ChangeSetStatus, NO_CHANGE_SET_PK};
-pub use component::{Component, ComponentError, ComponentId, ComponentQualificationView};
+pub use component::{Component, ComponentError, ComponentId};
 pub use edge::{Edge, EdgeError, EdgeResult};
 pub use edit_session::{
     EditSession, EditSessionError, EditSessionPk, EditSessionStatus, NO_EDIT_SESSION_PK,

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -6,10 +6,9 @@ use crate::socket::{Socket, SocketArity, SocketEdgeKind};
 use crate::{
     attribute_resolver::AttributeResolverContext, func::binding::FuncBinding,
     validation_prototype::ValidationPrototypeContext, AttributeResolver, Func, HistoryActor, Prop,
-    PropKind, Schema, SchemaError, SchemaKind, SchematicKind, StandardModel, Tenancy,
-    ValidationPrototype, Visibility,
+    PropKind, QualificationPrototype, Schema, SchemaError, SchemaKind, SchematicKind,
+    StandardModel, Tenancy, ValidationPrototype, Visibility,
 };
-use crate::{ComponentQualificationView, QualificationPrototype};
 use si_data::{NatsTxn, PgTxn};
 
 pub async fn migrate(
@@ -500,7 +499,7 @@ async fn docker_image(
         .pop()
         .ok_or(SchemaError::FuncNotFound(qual_func_name))?;
     let qual_args = FuncBackendJsQualificationArgs {
-        component: ComponentQualificationView::empty(),
+        component: veritech::QualificationCheckComponent::default(),
     };
     let qual_args_json = serde_json::to_value(&qual_args)?;
     let mut qual_prototype_context = QualificationPrototypeContext::new();

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -3,8 +3,7 @@ use crate::test_setup;
 use dal::qualification_resolver::UNSET_ID_VALUE;
 use dal::test_harness::{create_schema, create_schema_variant};
 use dal::{
-    Component, ComponentQualificationView, HistoryActor, Prop, PropKind, Schema, SchemaKind,
-    StandardModel, Tenancy, Visibility,
+    Component, HistoryActor, Prop, PropKind, Schema, SchemaKind, StandardModel, Tenancy, Visibility,
 };
 use serde_json::json;
 
@@ -211,14 +210,14 @@ async fn qualification_view() {
     .await
     .expect("cannot add schema variant for prop");
 
-    let component_qualification_view =
-        ComponentQualificationView::new(&txn, &tenancy, &visibility, component.id())
-            .await
-            .expect("cannot create ComponentQualificationView");
+    let qualification_check_component = component
+        .veritech_qualification_check_component(&txn, &tenancy, &visibility)
+        .await
+        .expect("cannot create QualificationCheckComponent");
 
     assert_eq!(
-        serde_json::to_value(&component_qualification_view)
-            .expect("cannot serialize ComponentQualificationView"),
+        serde_json::to_value(&qualification_check_component)
+            .expect("cannot serialize QualificationCheckComponent"),
         json!({
             "name": "mastodon",
             "properties": {

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -3,9 +3,8 @@ use crate::test_setup;
 use dal::func::backend::FuncBackendJsQualificationArgs;
 use dal::qualification_prototype::QualificationPrototypeContext;
 use dal::{
-    qualification_prototype::UNSET_ID_VALUE, test_harness::billing_account_signup, Component,
-    ComponentQualificationView, Func, HistoryActor, QualificationPrototype, Schema, StandardModel,
-    Tenancy, Visibility,
+    qualification_prototype::UNSET_ID_VALUE, test_harness::billing_account_signup, Component, Func,
+    HistoryActor, QualificationPrototype, Schema, StandardModel, Tenancy, Visibility,
 };
 
 #[tokio::test]
@@ -43,7 +42,8 @@ async fn new() {
         .expect("Missing builtin function si:qualificationDockerImageNameEqualsComponentName");
 
     let args = FuncBackendJsQualificationArgs {
-        component: ComponentQualificationView::new(&txn, &tenancy, &visibility, component.id())
+        component: component
+            .veritech_qualification_check_component(&txn, &tenancy, &visibility)
             .await
             .expect("could not create component qualification view"),
     };

--- a/lib/dal/tests/integration_test/qualification_resolver.rs
+++ b/lib/dal/tests/integration_test/qualification_resolver.rs
@@ -20,7 +20,7 @@
 //     func::binding::FuncBinding,
 //     qualification_resolver::{QualificationResolverContext, UNSET_ID_VALUE},
 //     test_harness::{billing_account_signup, create_component_for_schema},
-//     ComponentQualificationView, Func, HistoryActor, QualificationResolver, Schema, StandardModel,
+//     Func, HistoryActor, QualificationResolver, Schema, StandardModel,
 //     Tenancy, Visibility,
 // };
 //
@@ -57,7 +57,7 @@
 //         .expect("Missing builtin function si:qualificationDockerImageNameEqualsComponentName");
 //
 //     let args = FuncBackendJsQualificationArgs {
-//         component: ComponentQualificationView::new(&txn, &tenancy, &visibility, component.id())
+//         component: component.veritech_qualification_check_component(&txn, &tenancy, &visibility, component.id())
 //             .await
 //             .expect("could not create component qualification view"),
 //     };
@@ -130,7 +130,7 @@
 //         .expect("Missing builtin function si:qualificationDockerImageNameEqualsComponentName");
 //
 //     let args = FuncBackendJsQualificationArgs {
-//         component: ComponentQualificationView::new(&txn, &tenancy, &visibility, component.id())
+//         component: component.veritech_qualification_check_component(&txn, &tenancy, &visibility, component.id())
 //             .await
 //             .expect("could not create component qualification view"),
 //     };

--- a/lib/veritech/src/client.rs
+++ b/lib/veritech/src/client.rs
@@ -327,7 +327,7 @@ mod subscription {
 mod tests {
     use std::{collections::HashMap, env};
 
-    use cyclone::QualificationCheckComponent;
+    use cyclone::{QualificationCheckComponent, ResourceSyncComponent};
     use deadpool_cyclone::{instance::cyclone::LocalUdsInstance, Instance};
     use indoc::indoc;
     use si_data::NatsConfig;
@@ -529,10 +529,16 @@ mod tests {
             }
         });
 
+        let mut properties = HashMap::new();
+        properties.insert("pkg".to_string(), serde_json::json!("cider"));
         let request = ResourceSyncRequest {
             execution_id: "7867".to_string(),
             handler: "syncItOut".to_string(),
-            code_base64: base64::encode("function syncItOut() { return {}; }"),
+            component: ResourceSyncComponent {
+                name: "cider".to_string(),
+                properties,
+            },
+            code_base64: base64::encode("function syncItOut(component) { return {}; }"),
         };
 
         let result = client

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -29,6 +29,7 @@ pub use client::{Client, ClientError, ClientResult};
 pub use cyclone::{
     FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
     QualificationCheckRequest, QualificationCheckResultSuccess, ResolverFunctionRequest,
+    ResourceSyncComponent, ResourceSyncRequest, ResourceSyncResultSuccess,
 };
 
 const NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT: &str = "veritech.fn.qualificationcheck";


### PR DESCRIPTION
Implement support for the ResourceSyncComponent parameter to ResourceSyncs in lang-js & cyclone & veritech.

Fix lang-js and cyclone ResourceSync tests.

Remove sdf's version of QualificationCheckComponent and use the cyclone's one directly.

Keep ResourceSyncComponent as a different struct than QualificationCheckComponent as we don't know if they will stay the same in the future.

Implement the FuncBackendJsResourceSync and make it executable.

Note: we aren't testing the backend yet, FuncBackends generally are tested in the Resolver/Prototype, we will implement those later today, so this might be slightly broken, but it's an easy fix for when we are actually plugging things together.

We don't actually know what the ResourceSync's return type will be, so it's a dummy for now, and we don't do anything with it yet.

<img src="https://media2.giphy.com/media/9J8PGEd27f1SjaAhAX/giphy.gif"/>