### PR TITLE
feat(sdf,dal): implement simple resource sync scheduler

### DIFF
--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -77,6 +77,8 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
 
     start_tracing_level_signal_handler_task(&telemetry)?;
 
+    Server::start_resource_sync_scheduler(pg_pool.clone(), nats.clone(), veritech.clone()).await;
+
     match config.incoming_stream() {
         IncomingStream::HTTPSocket(_) => {
             Server::http(config, telemetry, pg_pool, nats, veritech, jwt_secret_key)?

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -85,6 +85,7 @@ pub enum ComponentError {
 pub type ComponentResult<T> = Result<T, ComponentError>;
 
 const LIST_QUALIFICATIONS: &str = include_str!("./queries/component_list_qualifications.sql");
+const LIST_FOR_RESOURCE_SYNC: &str = include_str!("./queries/component_list_for_resource_sync.sql");
 
 pk!(ComponentPk);
 pk!(ComponentId);
@@ -755,6 +756,21 @@ impl Component {
         }
 
         Ok(qualification_view)
+    }
+
+    #[tracing::instrument(skip(txn))]
+    pub async fn list_for_resource_sync(txn: &PgTxn<'_>) -> ComponentResult<Vec<Component>> {
+        let visibility = Visibility::new_head(false);
+        let rows = txn.query(LIST_FOR_RESOURCE_SYNC, &[&visibility]).await?;
+        let results = standard_model::objects_from_rows(rows)?;
+        Ok(results)
+    }
+
+    // TODO: Make this actully sync the resource, by looking up the protoype, building resolvers, etc.!
+    #[tracing::instrument]
+    pub async fn sync_resource(&self) -> ComponentResult<()> {
+        tracing::warn!("checking resource: {:?}", self);
+        Ok(())
     }
 }
 

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -27,6 +27,7 @@ pub mod qualification_check;
 pub mod qualification_prototype;
 pub mod qualification_resolver;
 pub mod resource;
+pub mod resource_scheduler;
 pub mod schema;
 pub mod schematic;
 pub mod socket;
@@ -83,6 +84,7 @@ pub use qualification_resolver::{
     QualificationResolver, QualificationResolverError, QualificationResolverId,
 };
 pub use resource::{Resource, ResourceError};
+pub use resource_scheduler::{ResourceScheduler, ResourceSchedulerError};
 pub use schema::{
     Schema, SchemaError, SchemaId, SchemaKind, SchemaPk, SchemaVariant, SchemaVariantId,
 };

--- a/lib/dal/src/queries/component_list_for_resource_sync.sql
+++ b/lib/dal/src/queries/component_list_for_resource_sync.sql
@@ -1,0 +1,8 @@
+SELECT row_to_json(components.*) AS object
+  FROM components
+  WHERE is_visible_v1(
+      $1, 
+      components.visibility_change_set_pk, 
+      components.visibility_edit_session_pk, 
+      components.visibility_deleted
+    );

--- a/lib/dal/src/resource_scheduler.rs
+++ b/lib/dal/src/resource_scheduler.rs
@@ -1,0 +1,98 @@
+use std::time::Duration;
+
+use si_data::{NatsClient, NatsError, PgError, PgPool, PgPoolError};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::time;
+
+use crate::{Component, ComponentError, HistoryEventError, StandardModelError};
+
+#[derive(Error, Debug)]
+pub enum ResourceSchedulerError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg pool error: {0}")]
+    PgPool(#[from] PgPoolError),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+    #[error("component")]
+    Component(#[from] ComponentError),
+}
+
+pub type ResourceSchedulerResult<T> = Result<T, ResourceSchedulerError>;
+
+/// The resource scheduler handles looking up all the components, and scheduling
+/// them to refresh their resources. Eventually, it should become smart enough to
+/// parallelize, it might be extracted to a fully separate service, etc etc. For now,
+/// it is the dumbest thing that could possibly work - no more often than every 30
+/// seconds, it will ask a component to sync_resource.
+// TODO: Remove this dead_code call once we implement the rest...
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ResourceScheduler {
+    pg_pool: PgPool,
+    nats: NatsClient,
+    veritech: veritech::Client,
+}
+
+impl ResourceScheduler {
+    pub fn new(pg_pool: PgPool, nats: NatsClient, veritech: veritech::Client) -> ResourceScheduler {
+        ResourceScheduler {
+            pg_pool,
+            nats,
+            veritech,
+        }
+    }
+
+    /// Starts the scheduler. It returns the join handle to the spawned scheduler, and
+    /// consumes itself. The caller should check for errors and restart the scheduler if
+    /// it ever returns an error.
+    #[tracing::instrument]
+    pub async fn start(self) {
+        tokio::spawn(async move { self.start_task().await });
+    }
+
+    /// The internal task spawned by `start`. No more frequently than every 30
+    /// seconds, it will iterate over all the components in the database and
+    /// schedule them to sync their resources.
+    #[tracing::instrument]
+    async fn start_task(&self) {
+        let mut interval = time::interval(Duration::from_secs(30));
+        'schedule: loop {
+            interval.tick().await;
+            let components = match self.components_to_check().await {
+                Ok(r) => r,
+                Err(error) => {
+                    tracing::error!(
+                        ?error,
+                        "Failed to fetch components; aborting scheduled interval check"
+                    );
+                    continue 'schedule;
+                }
+            };
+            'check: for component in components.into_iter() {
+                // likely we are passing in a transaction, etc here.
+                if let Err(error) = component.sync_resource().await {
+                    tracing::error!(?error, "Failed to sync component, moving to the next.");
+                    continue 'check;
+                }
+            }
+        }
+    }
+
+    /// Gets a list of all the components in the database.
+    #[tracing::instrument]
+    async fn components_to_check(&self) -> ResourceSchedulerResult<Vec<Component>> {
+        let mut conn = self.pg_pool.get().await?;
+        let txn = conn.transaction().await?;
+        let components = Component::list_for_resource_sync(&txn).await?;
+        txn.commit().await?;
+        Ok(components)
+    }
+}


### PR DESCRIPTION
Adds a very simple resource sync scheduler. When the sdf binary is
started, it will automatically start a scheduler task. That task will,
no more than every 30 seconds, query for all the components in the
database, and then execute a `sync_resource` call on them. The guts of
`sync_resource` remain to be implemented, but when we are ready, they'll
get called.

There is no test coverage of the scheduler yet, because it's unclear
exactly how to write one. I suspect when we see everything back in
place, it will be much more obvious.

<img src="https://media4.giphy.com/media/l2SpZz83lbE37iu2c/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>