### PR TITLE
fix(dal): in Schematic::find, filter out NodeKind:System nodes

### DIFF
--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -198,18 +198,26 @@ impl Schematic {
                     )
                 }
                 NodeKind::System => {
-                    let system = node
-                        .system(txn, visibility)
-                        .await?
-                        .ok_or(SchematicError::SystemNotFound)?;
-                    let mut tenancy = tenancy.clone();
-                    tenancy.universal = true;
-                    let schema = system
-                        .schema_with_tenancy(txn, &tenancy, visibility)
-                        .await?
-                        .ok_or(SchematicError::SchemaNotFound)?;
+                    // We're going to skip all `NodeKind::System` nodes
+                    continue;
 
-                    (schema, system.name().to_owned(), SchematicKind::System)
+                    // TODO(fnichol): We were failing in `node.system()` with an `Error: dal
+                    // schematic error: system not found` error. For the moment we're going to
+                    // filter out system-backed nodes, but ultimately we might want to return all
+                    // node kinds back to the frontend for use.
+                    //
+                    // let system = node
+                    //     .system(txn, visibility)
+                    //     .await?
+                    //     .ok_or(SchematicError::SystemNotFound)?;
+                    // let mut tenancy = tenancy.clone();
+                    // tenancy.universal = true;
+                    // let schema = system
+                    //     .schema_with_tenancy(txn, &tenancy, visibility)
+                    //     .await?
+                    //     .ok_or(SchematicError::SchemaNotFound)?;
+
+                    // (schema, system.name().to_owned(), SchematicKind::System)
                 }
             };
 


### PR DESCRIPTION
This is likely not the right long term solution, but when logging in to
a new billing account I was getting a error of:

`Error: dal schematic error: system not found`

It's looking like the call of `node.system(...)` is returning `None`
which may mean that the association of node <> system isn't quite 100%.

Also, for this second we don't need system nodes to come back in the
schematic. I presume that we will want all of these nodes eventually, so
this will need to be fixed.

If this solution is too hacky, we can resolve the commented out body
instead (granted I'm looking for a real quick fix so we can use the
interface and am open to alternatives).

<img src="https://media0.giphy.com/media/3o7btNRptqBgLSKR2w/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>