### PR TITLE
feat(dal): Create an "Includes" edge between all created components and the "production" system

### DIFF
--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -150,10 +150,14 @@ impl Edge {
         component_id: &ComponentId,
         system_id: &SystemId,
     ) -> EdgeResult<Self> {
+        // TODO: We're creating a universal tenancy here, to make sure the DB function can find the schemas System Initiative has created, but that might not actually be the right thing to do here long term.
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
+
         let row = txn
             .query_one(
                 "SELECT object FROM edge_include_component_in_system_v1($1, $2, $3, $4)",
-                &[&tenancy, &visibility, component_id, system_id],
+                &[&schema_tenancy, &visibility, component_id, system_id],
             )
             .await?;
 

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -2,6 +2,7 @@ use crate::test_setup;
 
 use dal::func::backend::FuncBackendJsQualificationArgs;
 use dal::qualification_prototype::QualificationPrototypeContext;
+use dal::test_harness::find_or_create_production_system;
 use dal::{
     qualification_prototype::UNSET_ID_VALUE, test_harness::billing_account_signup, Component, Func,
     HistoryActor, QualificationPrototype, Schema, StandardModel, Tenancy, Visibility,
@@ -13,6 +14,8 @@ async fn new() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
 
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)

--- a/lib/dal/tests/integration_test/resource_prototype.rs
+++ b/lib/dal/tests/integration_test/resource_prototype.rs
@@ -2,6 +2,7 @@ use crate::test_setup;
 
 use dal::func::backend::FuncBackendJsResourceSyncArgs;
 use dal::resource_prototype::ResourcePrototypeContext;
+use dal::test_harness::find_or_create_production_system;
 use dal::{
     resource_prototype::UNSET_ID_VALUE, test_harness::billing_account_signup, Component, Func,
     HistoryActor, ResourcePrototype, Schema, StandardModel, Tenancy, Visibility,
@@ -13,6 +14,8 @@ async fn new() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
 
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -1,7 +1,7 @@
 use crate::test_setup;
 use dal::{
-    Component, Connection, HistoryActor, NodePosition, Schema, Schematic, SchematicKind,
-    StandardModel, SystemId, Tenancy, Visibility,
+    test_harness::find_or_create_production_system, Component, Connection, HistoryActor,
+    NodePosition, Schema, Schematic, SchematicKind, StandardModel, SystemId, Tenancy, Visibility,
 };
 
 #[tokio::test]
@@ -10,6 +10,8 @@ async fn get_schematic() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
 
     let application_schema = Schema::find_by_attr(
         &txn,
@@ -100,6 +102,8 @@ async fn create_connection() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
 
     let service_schema =
         Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &"service".to_string())

--- a/lib/sdf/tests/service_tests/application.rs
+++ b/lib/sdf/tests/service_tests/application.rs
@@ -31,6 +31,7 @@ async fn create_application() {
         visibility,
         workspace_id: *nba.workspace.id(),
     };
+
     let response: CreateApplicationResponse = api_request_auth_json_body(
         app,
         Method::POST,
@@ -72,6 +73,7 @@ async fn list_applications() {
     )
     .await
     .expect("cannot create new application");
+    // TODO This commit is important to the test. We should probably figure out a way of doing this without requiring committing to the test DB.
     txn.commit().await.expect("cannot commit transaction");
 
     let request = ListApplicationRequest {


### PR DESCRIPTION
Long-term, we'll want to be smarter about picking which `System` we use for the `Edge`, but for now, we're YOLOing everything into "production".

This also consolidates the "create a `System` with a `Node`, and all the supporting relations into `System::new_with_node` similar to how we have `Component::new_with_schema_variant_with_node`.