### PR TITLE
feat(dal): qualification metadata

### DIFF
--- a/lib/dal/src/migrations/U0048__qualification_prototypes.sql
+++ b/lib/dal/src/migrations/U0048__qualification_prototypes.sql
@@ -13,6 +13,8 @@ CREATE TABLE qualification_prototypes
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     func_id                     bigint                   NOT NULL,
     args                        jsonb                    NOT NULL,
+    title                       text                     NOT NULL,
+    link                        text,
     component_id                bigint                   NOT NULL,
     schema_id                   bigint                   NOT NULL,
     schema_variant_id           bigint                   NOT NULL,
@@ -32,6 +34,7 @@ CREATE OR REPLACE FUNCTION qualification_prototype_create_v1(
     this_schema_id bigint,
     this_schema_variant_id bigint,
     this_system_id bigint,
+    this_title text,
     OUT object json) AS
 $$
 DECLARE
@@ -51,6 +54,7 @@ BEGIN
                                        visibility_deleted,
                                        func_id,
                                        args,
+                                       title,
                                        component_id,
                                        schema_id,
                                        schema_variant_id,
@@ -64,6 +68,7 @@ BEGIN
             this_visibility_record.visibility_deleted,
             this_func_id,
             this_args,
+            this_title,
             this_component_id,
             this_schema_id,
             this_schema_variant_id,

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -24,10 +24,28 @@ pub struct QualificationResult {
     pub errors: Vec<QualificationErrorMessage>,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub enum QualificationSubCheckStatus {
+    Success,
+    Failure,
+    Unknown,
+}
+
+impl Default for QualificationSubCheckStatus {
+    fn default() -> Self {
+        QualificationSubCheckStatus::Unknown
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct QualificationSubCheck {
+    pub description: String,
+    pub status: QualificationSubCheckStatus,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct QualificationView {
-    pub message: String,
-    pub title: Option<String>,
+    pub title: String,
     pub description: Option<String>,
     pub link: Option<String>,
     pub result: Option<QualificationResult>,
@@ -40,8 +58,7 @@ impl TryFrom<FuncBindingReturnValue> for QualificationView {
         if let Some(qual_result_json) = fbrv.value() {
             let result = serde_json::from_value(qual_result_json.clone())?;
             Ok(QualificationView {
-                message: "did it".to_string(),
-                title: None,
+                title: "Unknown (no title provided)".to_string(),
                 description: None,
                 link: None,
                 result: Some(result),

--- a/lib/dal/src/qualification_prototype.rs
+++ b/lib/dal/src/qualification_prototype.rs
@@ -110,6 +110,8 @@ pub struct QualificationPrototype {
     id: QualificationPrototypeId,
     func_id: FuncId,
     args: serde_json::Value,
+    title: String,
+    link: Option<String>,
     #[serde(flatten)]
     context: QualificationPrototypeContext,
     #[serde(flatten)]
@@ -131,7 +133,7 @@ impl_standard_model! {
 
 impl QualificationPrototype {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(txn, nats))]
+    #[tracing::instrument(skip(txn, nats, title))]
     pub async fn new(
         txn: &PgTxn<'_>,
         nats: &NatsTxn,
@@ -141,10 +143,12 @@ impl QualificationPrototype {
         func_id: FuncId,
         args: serde_json::Value,
         context: QualificationPrototypeContext,
+        title: impl Into<String>,
     ) -> QualificationPrototypeResult<Self> {
+        let title = title.into();
         let row = txn
             .query_one(
-                "SELECT object FROM qualification_prototype_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+                "SELECT object FROM qualification_prototype_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                 &[
                     &tenancy,
                     &visibility,
@@ -154,6 +158,7 @@ impl QualificationPrototype {
                     &context.schema_id(),
                     &context.schema_variant_id(),
                     &context.system_id(),
+                    &title,
                 ],
             )
             .await?;
@@ -171,6 +176,8 @@ impl QualificationPrototype {
 
     standard_model_accessor!(func_id, Pk(FuncId), QualificationPrototypeResult);
     standard_model_accessor!(args, Json<JsonValue>, QualificationPrototypeResult);
+    standard_model_accessor!(title, String, QualificationPrototypeResult);
+    standard_model_accessor!(link, Option<String>, QualificationPrototypeResult);
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_component(

--- a/lib/dal/src/queries/component_list_qualifications.sql
+++ b/lib/dal/src/queries/component_list_qualifications.sql
@@ -1,12 +1,16 @@
 SELECT DISTINCT ON (qualification_resolvers.id) qualification_resolvers.id,
                               qualification_resolvers.visibility_change_set_pk,
                               qualification_resolvers.visibility_edit_session_pk,
+                              qualification_prototypes.title as title,
+                              qualification_prototypes.link as link,
                               row_to_json(func_binding_return_values.*) AS object
 FROM qualification_resolvers
 INNER JOIN func_binding_return_value_belongs_to_func_binding ON 
   func_binding_return_value_belongs_to_func_binding.belongs_to_id = qualification_resolvers.func_binding_id
 INNER JOIN func_binding_return_values ON 
   func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+INNER JOIN qualification_prototypes ON
+  qualification_prototypes.id = qualification_resolvers.qualification_prototype_id
 WHERE in_tenancy_v1($1, qualification_resolvers.tenancy_universal, qualification_resolvers.tenancy_billing_account_ids, qualification_resolvers.tenancy_organization_ids,
                     qualification_resolvers.tenancy_workspace_ids)
   AND is_visible_v1($2, qualification_resolvers.visibility_change_set_pk, qualification_resolvers.visibility_edit_session_pk, qualification_resolvers.visibility_deleted)

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -621,7 +621,7 @@ async fn docker_image(
     let mut qual_prototype_context = QualificationPrototypeContext::new();
     qual_prototype_context.set_schema_variant_id(*variant.id());
 
-    let _prototype = QualificationPrototype::new(
+    let mut prototype = QualificationPrototype::new(
         txn,
         nats,
         tenancy,
@@ -630,8 +630,18 @@ async fn docker_image(
         *qual_func.id(),
         qual_args_json,
         qual_prototype_context,
+        "docker image name must match the component name",
     )
     .await?;
+    prototype
+        .set_link(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            "http://docker.com".into(),
+        )
+        .await?;
 
     // Resource Prototype
     let resource_sync_func_name = "si:resourceSyncHammer".to_string();

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -62,6 +62,7 @@ async fn new() {
         *func.id(),
         serde_json::to_value(&args).expect("serialization failed"),
         prototype_context,
+        "docker image name must match component name",
     )
     .await
     .expect("cannot create new prototype");


### PR DESCRIPTION
Adds the qualification metadata. Currently, we use the information
supplied when the Qualification Prototype is created.

Eventually, we want to support changing the metadata from the
qualification function itself, but that is for a separate PR.

We also lay some groundwork for sending the sub-check information that
is required by several of our custom qualification checks in the v0.4
implementation (in particular the way we custom render field validations
and kubeeval checks). (See the `QualificationSubCheck`)

Excelsior!

Signed-off-by: Adam Jacob <adam@systeminit.com>