### PR TITLE
feat(dal,web): Reactively refresh resource viewer on sync

### DIFF
--- a/app/web/src/api/sdf/dal/ws_event.ts
+++ b/app/web/src/api/sdf/dal/ws_event.ts
@@ -1,4 +1,5 @@
 import { HistoryActor } from "@/api/sdf/dal/history_actor";
+import { ResourceSyncId } from "@/observable/resource";
 
 export interface WsEvent<Payload extends WsPayload> {
   version: number;
@@ -32,8 +33,14 @@ export interface WsEditSessionSaved extends WsPayload {
   data: number;
 }
 
+export interface WsResourceSynced extends WsPayload {
+  kind: "ResourceSynced";
+  data: ResourceSyncId;
+}
+
 export type WsPayloadKinds =
   | WsEditSessionSaved
   | WsChangeSetCreated
   | WsChangeSetApplied
-  | WsChangeSetCanceled;
+  | WsChangeSetCanceled
+  | WsResourceSynced;

--- a/app/web/src/observable/resource.ts
+++ b/app/web/src/observable/resource.ts
@@ -1,0 +1,15 @@
+import { ReplaySubject } from "rxjs";
+import { WsResourceSyncedSaved, WsEvent } from "@/api/sdf/dal/ws_event";
+
+export interface ResourceSyncId {
+  componentId: number;
+  resourceId: number;
+}
+
+/**
+ * Fired with the ids of the component and the system
+ */
+export const eventResourceSynced$ = new ReplaySubject<WsEvent<WsResourceSynced> | null>(
+  1,
+);
+eventResourceSynced$.next(null);

--- a/app/web/src/service/ws_event.ts
+++ b/app/web/src/service/ws_event.ts
@@ -6,6 +6,7 @@ import {
   eventChangeSetCreated$,
 } from "@/observable/change_set";
 import { eventEditSessionSaved$ } from "@/observable/edit_session";
+import { eventResourceSynced$ } from "@/observable/resource";
 
 const eventMap: {
   [E in WsPayloadKinds["kind"]]: BehaviorSubject<any> | ReplaySubject<any>;
@@ -14,6 +15,7 @@ const eventMap: {
   ChangeSetApplied: eventChangeSetApplied$,
   ChangeSetCanceled: eventChangeSetCanceled$,
   EditSessionSaved: eventEditSessionSaved$,
+  ResourceSynced: eventResourceSynced$,
 };
 
 export function dispatch(wsEvent: WsEvent<WsPayloadKinds>) {

--- a/lib/dal/src/queries/component_get_workspace.sql
+++ b/lib/dal/src/queries/component_get_workspace.sql
@@ -1,0 +1,9 @@
+SELECT DISTINCT ON (workspaces.id) workspaces.id,
+                              workspaces.visibility_change_set_pk,
+                              workspaces.visibility_edit_session_pk,
+                              row_to_json(workspaces.*) AS object
+FROM workspaces
+WHERE workspaces.id = $1
+  AND is_visible_v1($2, workspaces.visibility_change_set_pk, workspaces.visibility_edit_session_pk, workspaces.visibility_deleted)
+ORDER BY id DESC, visibility_change_set_pk DESC, visibility_edit_session_pk DESC
+LIMIT 1;

--- a/lib/dal/src/resource.rs
+++ b/lib/dal/src/resource.rs
@@ -8,9 +8,10 @@ use thiserror::Error;
 
 use crate::func::binding_return_value::FuncBindingReturnValue;
 use crate::{
-    impl_standard_model, pk, standard_model, standard_model_belongs_to, Component, ComponentId,
-    HistoryActor, HistoryEventError, StandardModel, StandardModelError, System, SystemId, Tenancy,
-    Timestamp, Visibility,
+    impl_standard_model, pk, standard_model, standard_model_belongs_to,
+    ws_event::{WsEvent, WsPayload},
+    BillingAccountId, Component, ComponentId, HistoryActor, HistoryEventError, StandardModel,
+    StandardModelError, System, SystemId, Tenancy, Timestamp, Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -219,5 +220,30 @@ impl From<(Resource, Option<FuncBindingReturnValue>)> for ResourceView {
                 entity_type: "idk bro".to_owned(),
             }
         }
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSyncId {
+    component_id: ComponentId,
+    system_id: SystemId,
+}
+
+impl WsEvent {
+    pub fn resource_synced(
+        component_id: ComponentId,
+        system_id: SystemId,
+        billing_account_ids: Vec<BillingAccountId>,
+        history_actor: &HistoryActor,
+    ) -> Self {
+        WsEvent::new(
+            billing_account_ids,
+            history_actor.clone(),
+            WsPayload::ResourceSynced(ResourceSyncId {
+                component_id,
+                system_id,
+            }),
+        )
     }
 }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 use si_data::{NatsError, NatsTxn};
 
+use crate::resource::ResourceSyncId;
 use crate::{BillingAccountId, ChangeSetPk, HistoryActor, SchemaPk, Tenancy};
 
 #[derive(Error, Debug)]
@@ -23,6 +24,7 @@ pub enum WsPayload {
     ChangeSetCanceled(ChangeSetPk),
     EditSessionSaved(ChangeSetPk),
     SchemaCreated(SchemaPk),
+    ResourceSynced(ResourceSyncId),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
Backend sends websocket message that resource was synced with the component_id and the system_id.

When the frontend receives it, if the ResourceViewer is opened to that component in that system we fetch the resource.

We use a very bad hack to access the BillingAccountIds from a Component, we need to fix Component belongs_to Workspace in the future.