### PR TITLE
feat(*): improve qualification output, show validation qualification

### DIFF
--- a/app/web/src/api/sdf/dal/qualification.ts
+++ b/app/web/src/api/sdf/dal/qualification.ts
@@ -7,7 +7,13 @@ export interface Qualification {
 }
 
 export interface QualificationResult {
-  errors: Array<QualificationError>;
+  title?: string;
+  link?: string;
+  sub_checks?: Array<{
+    status: "Success" | "Failure" | "Unknown";
+    description: string;
+  }>;
+  output?: Array<string>;
   success: boolean;
 }
 

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -33,84 +33,6 @@
 
       <div class="flex w-full h-full pt-2 pb-4 overflow-auto background-color">
         <div class="flex flex-col w-full">
-          <!-- NOTE(nick): this was not present in old-web, but we need to account for null qualifications since they
-          are collected inside the viewer rather than by attribute panel (old-web behavior). Essentially, this
-          div is only rendered we either have no qualifications (default square) or if we know they are all valid
-          (happy face with all fields valid). This needs to appears BEFORE the other qualifications are displayed
-          iteratively. I'm sure we can _smush_ it back together and ensure "allFieldsValid" is frontloaded in the
-          future, but this works for the time being.
-          -->
-          <div
-            v-if="
-              !allQualifications ||
-              allQualifications.length < 1 ||
-              allFieldsValid
-            "
-            class="flex flex-col py-1 mx-2 mt-2 text-sm border qualification-section"
-          >
-            <div class="flex flex-row items-center w-full pl-4 my-1">
-              <div class="flex">
-                <VueFeather
-                  v-if="allFieldsValid"
-                  type="smile"
-                  class="text-green-300"
-                  size="1.1em"
-                />
-                <VueFeather
-                  v-else
-                  type="square"
-                  class="text-gray-700"
-                  size="1.1em"
-                />
-              </div>
-              <!-- NOTE(nick): there does not exist 1:1 behavior with old-web here, but the appearance should be the
-              same, barring the chevron icon being remove. This is because we won't have any descriptions or outputs
-              to display.
-              -->
-              <div class="flex flex-row text-xs w-full pl-4 my-1 text-gray-300">
-                All fields are valid
-              </div>
-
-              <!-- NOTE(nick): We only render the button div if all fields are valid. -->
-              <div
-                v-if="allFieldsValid"
-                class="flex justify-end flex-grow pr-4"
-              >
-                <button
-                  class="focus:outline-none"
-                  @click="toggleShowDescription('allFieldsValid')"
-                >
-                  <VueFeather
-                    v-if="showDescriptionMap['allFieldsValid'] === true"
-                    type="chevron-down"
-                    size="1.1em"
-                  />
-                  <VueFeather v-else type="chevron-right" size="1.1em" />
-                </button>
-              </div>
-            </div>
-
-            <div
-              v-if="
-                allFieldsValid && showDescriptionMap['allFieldsValid'] === true
-              "
-              class="flex flex-col w-full"
-            >
-              <div class="flex flex-col w-full">
-                <div class="mt-1">
-                  <QualificationOutput
-                    :kind="'allFieldsValid'"
-                    :data="'i liketh my buttocks'"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- NOTE(nick): okay, you with me? This is where we iterate over all qualifications found. Unlike old-web,
-          this DOES NOT include "allFieldsValid" because we collect qualifications within the viewer. Let's go through
-          them all and display as needed.
-          -->
           <div
             v-for="q in allQualifications"
             :key="q.name"
@@ -182,10 +104,7 @@
             >
               <div v-if="q.result" class="flex flex-col w-full">
                 <div class="mt-1">
-                  <QualificationOutput
-                    :kind="q.name"
-                    :data="qualificationResultMessage(q.result)"
-                  />
+                  <QualificationOutput :result="q.result" />
                 </div>
               </div>
             </div>
@@ -217,21 +136,6 @@ const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
 // FIXME(nick): implement active state. Default to not starting for now.
 const qualificationStarting = (_qualification_name: string) => {
   return false;
-};
-
-// FIXME(nick): concatenate the message of each error for now.
-const qualificationResultMessage = (result: QualificationResult) => {
-  let data = "";
-  result.errors.forEach((e) => {
-    if (e.message !== "") {
-      if (data === "") {
-        data = e.message;
-      } else {
-        data = data + "\n" + e.message;
-      }
-    }
-  });
-  return data;
 };
 
 enum QualifiedState {
@@ -275,25 +179,6 @@ const refreshButtonClasses = computed(() => {
     classes["unknown"] = true;
   }
   return classes;
-});
-
-// Every qualification must produce a result and must be successful for this to be true. No ifs,
-// ands or buts.
-const allFieldsValid = computed((): boolean => {
-  if (allQualifications.value && allQualifications.value.length > 0) {
-    for (const q of allQualifications.value) {
-      if (q.result) {
-        if (!q.result.success) {
-          return false;
-        }
-      } else {
-        return false;
-      }
-    }
-    return true;
-  } else {
-    return false;
-  }
 });
 
 const qualificationResultQualified = (result: QualificationResult) => {

--- a/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
+++ b/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
@@ -1,65 +1,38 @@
 <template>
   <div class="w-full pb-1">
-    <div v-if="parseKubevalOutput">
-      <div class="text-xs">Not yet implemented: parseKubevalOutput</div>
-    </div>
-
-    <div
-      v-else-if="parseValidFieldsOutput"
-      class="pt-3 pb-4 border-t border-gray-800"
-    >
+    <div class="pt-3 pb-4 border-t border-gray-800">
       <div
-        v-for="(validation, fieldName) in parseValidFieldsOutput"
-        :key="fieldName"
+        v-for="(subCheck, index) in subChecks"
+        :key="index"
         class="flex flex-col flex-grow"
       >
         <div class="flex flex-row items-center px-6 pt-1 text-xs output-lines">
           <div class="w-4">
-            <VueFeather
-              v-if="validation === 'success'"
-              type="check"
-              size="1.1em"
-              class="mr-2 text-xs"
-            />
+            <VueFeather type="check" size="1.1em" class="mr-2 text-xs" />
           </div>
           <div class="flex flex-row">
-            <div class="ml-1">field {{ fieldName }}</div>
+            <div class="ml-1">{{ subCheck.description }}</div>
 
             <div class="ml-1 text-xs">(</div>
-            <span v-if="validation === 'success'" class="success">success</span>
-            <span v-else class="error">failure</span>
+            <span v-if="subCheck.status === 'Success'" class="success">
+              success
+            </span>
+            <span v-else-if="subCheck.status === 'Failure'" class="error">
+              failure
+            </span>
+            <span v-else class="unknown">unknown</span>
             <div class="">)</div>
           </div>
         </div>
-        <template v-if="validation && validation !== 'success'">
-          <div
-            v-for="e in validation"
-            :key="e.message"
-            class="flex flex-col pl-10 mt-1 mb-1 ml-2 text-xs select-text output-lines"
-          >
-            <div class="flex flex-row items-center">
-              <VueFeather type="alert-triangle" size="1.1em" class="error" />
-              <div class="ml-2 error">
-                {{ e.message }}
-              </div>
-            </div>
-          </div>
-        </template>
       </div>
     </div>
 
-    <!-- NOTE(nick): remove "v-else" directive for now. Always render data, even if empty.
-    The only exception to this is the special "allFieldsValid" box.
-    -->
-    <div
-      v-if="!allFieldsValid"
-      class="flex flex-col flex-grow border-t border-gray-800"
-    >
+    <div v-if="output" class="flex flex-col flex-grow border-t border-gray-800">
       <div class="mt-2 mb-1 ml-2 text-xs font-medium output-title">Output</div>
       <div
         class="px-6 text-xs leading-relaxed whitespace-pre-line select-text output-lines"
       >
-        {{ data }}
+        {{ output }}
       </div>
     </div>
   </div>
@@ -67,50 +40,44 @@
 
 <script setup lang="ts">
 import VueFeather from "vue-feather";
-import { computed } from "vue";
+import { QualificationResult } from "@/api/sdf/dal/qualification";
+import { computed, toRefs } from "vue";
 
 const props = defineProps<{
-  kind: string;
-  // NOTE(nick): data can come in as empty. This might be true if we only have a description to display, but not a
-  // result. We should account for that scenario as we move past old-web parity.
-  data: string;
-  // TODO(nick): we need to display descriptions at some point. This was not in old-web.
-  description?: string;
+  result: QualificationResult;
 }>();
 
-interface ValidFieldsOutput {
-  [fieldPath: string]: "success" | { message: string }[];
-}
+const { result } = toRefs(props);
 
-const allFieldsValid = computed((): boolean => {
-  return props.kind == "allFieldsValid";
+const subChecks = computed(() => {
+  if (result.value.sub_checks) {
+    return result.value.sub_checks;
+  } else {
+    if (result.value.success) {
+      return [
+        {
+          status: "Success",
+          description: "Qualification check succeeded",
+        },
+      ];
+    } else {
+      return [
+        {
+          status: "Failure",
+          description: "Qualification check failed",
+        },
+      ];
+    }
+  }
 });
 
-// FIXME(nick): we hardcode this value for now to showcase the UI.
-const parseValidFieldsOutput = computed((): ValidFieldsOutput | false => {
-  if (props.data === "") {
-    return false;
+const output = computed(() => {
+  if (result.value.output) {
+    return result.value.output.join("\n");
+  } else {
+    return "remove this mock output when we have real output!!!";
   }
-  if (props.kind === "allFieldsValid") {
-    return {
-      success: "success",
-    };
-  }
-  return {
-    someFieldPath: [{ message: props.data }],
-  };
 });
-
-// FIXME(nick): re-introduce this once we have the ability to concatenate validations.
-// const parseValidFieldsOutput = computed(() => {
-//   if (props.kind === "allFieldsValid") {
-//     return JSON.parse(props.data) as ValidFieldsOutput;
-//   }
-//   return null;
-// });
-
-// TODO(nick): remove dummy values.
-const parseKubevalOutput = false;
 </script>
 
 <style scoped>

--- a/bin/lang-js/src/qualification_check.ts
+++ b/bin/lang-js/src/qualification_check.ts
@@ -32,6 +32,12 @@ export type QualificationCheckResult =
 
 export interface QualificationCheckResultSuccess extends ResultSuccess {
   qualified: boolean;
+  title?: string;
+  link?: string;
+  subChecks?: Array<{
+    status: "Success" | "Failure" | "Unknown",
+    description: string,
+  }>,
   message?: string;
 }
 
@@ -119,6 +125,9 @@ function execute(
     protocol: "result",
     status: "success",
     executionId,
+    title: qualificationCheckResult["title"],
+    link: qualificationCheckResult["link"],
+    subChecks: qualificationCheckResult["subChecks"],
     qualified: qualificationCheckResult["qualified"],
   };
   if (qualificationCheckResult["message"]) {

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -26,6 +26,7 @@ pub use progress::{
 };
 pub use qualification_check::{
     QualificationCheckComponent, QualificationCheckRequest, QualificationCheckResultSuccess,
+    QualificationSubCheck, QualificationSubCheckStatus,
 };
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
 pub use resolver_function::{ResolverFunctionRequest, ResolverFunctionResultSuccess};

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -29,10 +29,35 @@ pub struct QualificationCheckComponent {
     pub properties: HashMap<String, Value>,
 }
 
+// Note: these map 1:1 to the DAL qualificationsubcheck data in the qualification view.
+//       perhaps they should live permanently here, and be exported via veritech?
+//       for now I'm duplicating, so we can experiement with it.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub enum QualificationSubCheckStatus {
+    Success,
+    Failure,
+    Unknown,
+}
+
+impl Default for QualificationSubCheckStatus {
+    fn default() -> Self {
+        QualificationSubCheckStatus::Unknown
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct QualificationSubCheck {
+    pub description: String,
+    pub status: QualificationSubCheckStatus,
+}
+
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QualificationCheckResultSuccess {
     pub execution_id: String,
     pub qualified: bool,
+    pub title: Option<String>,
+    pub link: Option<String>,
     pub message: Option<String>,
+    pub sub_checks: Option<Vec<QualificationSubCheck>>,
     pub timestamp: u64,
 }

--- a/lib/cyclone/src/server/qualification_check.rs
+++ b/lib/cyclone/src/server/qualification_check.rs
@@ -20,6 +20,7 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 
 use crate::{
     process::{self, ShutdownError},
+    qualification_check::QualificationSubCheck,
     server::WebSocketMessage,
     FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,
     QualificationCheckRequest, QualificationCheckResultSuccess,
@@ -321,6 +322,9 @@ impl From<LangServerResult> for FunctionResult<QualificationCheckResultSuccess> 
                 execution_id: success.execution_id,
                 qualified: success.qualified,
                 message: success.message,
+                title: success.title,
+                link: success.link,
+                sub_checks: success.sub_checks,
                 timestamp: timestamp(),
             }),
             LangServerResult::Failure(failure) => Self::Failure(FunctionResultFailure {
@@ -340,6 +344,9 @@ impl From<LangServerResult> for FunctionResult<QualificationCheckResultSuccess> 
 struct LangServerSuccess {
     execution_id: String,
     qualified: bool,
+    title: Option<String>,
+    link: Option<String>,
+    sub_checks: Option<Vec<QualificationSubCheck>>,
     message: Option<String>,
 }
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -284,6 +284,9 @@ impl FuncBinding {
 
                 let qual_result = QualificationResult {
                     success: veritech_result.qualified,
+                    title: veritech_result.title,
+                    link: veritech_result.link,
+                    sub_checks: veritech_result.sub_checks,
                     errors,
                 };
 

--- a/lib/dal/src/func/builtins/qualificationDockerImageNameEqualsComponentName.js
+++ b/lib/dal/src/func/builtins/qualificationDockerImageNameEqualsComponentName.js
@@ -1,10 +1,23 @@
 function dockerImageNameEqualsComponentName(component) {
-    const result = component.name === component.properties.image;
-    if (result) {
-        return {
-            qualified: result,
-            message: "dockerImageName (" + component.properties.image + ") is not equal to componentName (" + component.name + ")"
-        };
-    }
-    return { qualified: result };
+  const result = component.name === component.properties.image;
+  if (result) {
+    return {
+      qualified: result,
+      subChecks: [
+        {
+          status: "Success",
+          description: "dockerImageName (" + component.properties.image + ") is not equal to componentName (" + component.name + ")"
+        }
+      ],
+    };
+  }
+  return {
+    qualified: result,
+    subChecks: [
+      {
+        status: "Failure",
+        description: "dockerImageName (" + component.properties.image + ") is not equal to componentName (" + component.name + ")"
+      }
+    ],
+  };
 }

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -3,7 +3,12 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::func::binding_return_value::FuncBindingReturnValue;
+use crate::{
+    func::{backend::validation::ValidationError, binding_return_value::FuncBindingReturnValue},
+    Prop,
+};
+
+use veritech::QualificationSubCheck;
 
 #[derive(Error, Debug)]
 pub enum QualificationError {
@@ -21,26 +26,11 @@ pub struct QualificationErrorMessage {
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct QualificationResult {
     pub success: bool,
+    pub title: Option<String>,
+    pub link: Option<String>,
+    pub sub_checks: Option<Vec<QualificationSubCheck>>,
+    // Pretty sure this field is no longer relevant.
     pub errors: Vec<QualificationErrorMessage>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-pub enum QualificationSubCheckStatus {
-    Success,
-    Failure,
-    Unknown,
-}
-
-impl Default for QualificationSubCheckStatus {
-    fn default() -> Self {
-        QualificationSubCheckStatus::Unknown
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
-pub struct QualificationSubCheck {
-    pub description: String,
-    pub status: QualificationSubCheckStatus,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -48,7 +38,41 @@ pub struct QualificationView {
     pub title: String,
     pub description: Option<String>,
     pub link: Option<String>,
+    pub sub_checks: Option<Vec<QualificationSubCheck>>,
     pub result: Option<QualificationResult>,
+}
+
+impl QualificationView {
+    pub fn new_for_validation_errors(
+        prop_validation_errors: Vec<(Prop, Vec<ValidationError>)>,
+    ) -> QualificationView {
+        let mut sub_checks: Vec<QualificationSubCheck> = Vec::new();
+        let mut success = true;
+        for (prop, validation_errors) in prop_validation_errors.into_iter() {
+            for validation_error in validation_errors.into_iter() {
+                let description =
+                    format!("field {} failed: {}", prop.name(), validation_error.message);
+                sub_checks.push(QualificationSubCheck {
+                    description,
+                    status: veritech::QualificationSubCheckStatus::Failure,
+                });
+                success = false;
+            }
+        }
+        QualificationView {
+            title: "All fields are valid".into(),
+            description: None,
+            link: None,
+            sub_checks: None,
+            result: Some(QualificationResult {
+                success,
+                title: None,
+                link: None,
+                sub_checks: Some(sub_checks),
+                errors: Vec::new(),
+            }),
+        }
+    }
 }
 
 impl TryFrom<FuncBindingReturnValue> for QualificationView {
@@ -61,6 +85,7 @@ impl TryFrom<FuncBindingReturnValue> for QualificationView {
                 title: "Unknown (no title provided)".to_string(),
                 description: None,
                 link: None,
+                sub_checks: None,
                 result: Some(result),
             })
         } else {

--- a/lib/dal/src/queries/validation_resolver_find_values_for_component.sql
+++ b/lib/dal/src/queries/validation_resolver_find_values_for_component.sql
@@ -1,0 +1,37 @@
+SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
+                              validation_resolvers.prop_id,
+                              validation_resolvers.visibility_change_set_pk,
+                              validation_resolvers.visibility_edit_session_pk,
+                              validation_resolvers.component_id,
+                              validation_resolvers.schema_id,
+                              validation_resolvers.schema_variant_id,
+                              validation_resolvers.system_id,
+                              row_to_json(func_binding_return_values.*) AS object
+FROM validation_resolvers
+INNER JOIN func_binding_return_value_belongs_to_func_binding ON 
+  func_binding_return_value_belongs_to_func_binding.belongs_to_id = validation_resolvers.func_binding_id
+INNER JOIN func_binding_return_values ON 
+  func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+WHERE in_tenancy_v1($1, validation_resolvers.tenancy_universal, validation_resolvers.tenancy_billing_account_ids, validation_resolvers.tenancy_organization_ids,
+                    validation_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, validation_resolvers.visibility_change_set_pk, validation_resolvers.visibility_edit_session_pk, validation_resolvers.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_edit_session_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_values.visibility_change_set_pk, 
+    func_binding_return_values.visibility_edit_session_pk, 
+    func_binding_return_values.visibility_deleted)
+   AND validation_resolvers.component_id = $3
+   AND (validation_resolvers.system_id = $4 OR validation_resolvers.system_id = -1)
+	ORDER BY validation_resolvers.id, 
+      visibility_change_set_pk DESC, 
+      visibility_edit_session_pk DESC, 
+      prop_id DESC,
+      component_id DESC, 
+      system_id DESC, 
+      schema_variant_id DESC, 
+      schema_id DESC;
+
+

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -319,7 +319,7 @@ async fn list_qualifications() {
         .list_qualifications(&txn, &tenancy, &visibility, UNSET_ID_VALUE.into())
         .await
         .expect("cannot list qualifications");
-    assert_eq!(qualifications.len(), 1);
+    assert_eq!(qualifications.len(), 2);
 }
 
 // Also brittle, same reason
@@ -390,7 +390,7 @@ async fn list_qualifications_by_component_id() {
     )
     .await
     .expect("cannot list qualifications");
-    assert_eq!(qualifications.len(), 1);
+    assert_eq!(qualifications.len(), 2);
 }
 
 // Also brittle, same reason

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -28,8 +28,9 @@ pub use client::{Client, ClientError, ClientResult};
 #[cfg(feature = "client")]
 pub use cyclone::{
     FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
-    QualificationCheckRequest, QualificationCheckResultSuccess, ResolverFunctionRequest,
-    ResourceSyncComponent, ResourceSyncRequest, ResourceSyncResultSuccess,
+    QualificationCheckRequest, QualificationCheckResultSuccess, QualificationSubCheck,
+    QualificationSubCheckStatus, ResolverFunctionRequest, ResourceSyncComponent,
+    ResourceSyncRequest, ResourceSyncResultSuccess,
 };
 
 const NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT: &str = "veritech.fn.qualificationcheck";


### PR DESCRIPTION
This PR improves qualifications by allowing the internal functions to
return "subChecks", which then render in the UI. It also paves the way
for returning output.

It also returns a universal "all fields valid" qualification, which is
generated by looking at all the qualification results for a component.

Signed-off-by: Adam Jacob <adam@systeminit.com>