### PR TITLE
feat(dal): implement FuncBindingReturnValue upsert

### DIFF
--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -328,7 +328,7 @@ impl FuncBinding {
             }
         };
 
-        let fbrv = FuncBindingReturnValue::new(
+        let fbrv = FuncBindingReturnValue::upsert(
             txn,
             nats,
             &tenancy,

--- a/lib/dal/src/migrations/U0004__standard_model.sql
+++ b/lib/dal/src/migrations/U0004__standard_model.sql
@@ -198,6 +198,27 @@ CREATE OR REPLACE FUNCTION update_by_id_v1(this_table_text text,
                                            this_tenancy jsonb,
                                            this_visibility jsonb,
                                            this_id bigint,
+                                           this_value jsonb,
+                                           OUT updated_at timestamp with time zone)
+AS
+$$
+BEGIN
+    SELECT update_by_id_v1(this_table_text,
+                           this_column,
+                           this_tenancy,
+                           this_visibility,
+                           this_id,
+                           CAST(this_value as text))
+    INTO updated_at;
+END ;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+-- update_by_id_v1 (BOOL)
+CREATE OR REPLACE FUNCTION update_by_id_v1(this_table_text text,
+                                           this_column text,
+                                           this_tenancy jsonb,
+                                           this_visibility jsonb,
+                                           this_id bigint,
                                            this_value bool,
                                            OUT updated_at timestamp with time zone)
 AS

--- a/lib/dal/src/queries/func_binding_return_value_get_for_func_binding.sql
+++ b/lib/dal/src/queries/func_binding_return_value_get_for_func_binding.sql
@@ -1,0 +1,23 @@
+SELECT DISTINCT ON (func_binding_return_values.id) func_binding_return_values.id,
+                                             func_binding_return_values.visibility_change_set_pk,
+                                             func_binding_return_values.visibility_edit_session_pk,
+                                             func_binding_return_values.unprocessed_value,
+                                             func_binding_return_values.value,
+                                             row_to_json(func_binding_return_values.*) as object
+FROM func_binding_return_values
+INNER JOIN func_binding_return_value_belongs_to_func_binding ON 
+  func_binding_return_value_belongs_to_func_binding.object_id = func_binding_return_values.id
+WHERE in_tenancy_v1($1, func_binding_return_values.tenancy_universal, func_binding_return_values.tenancy_billing_account_ids, func_binding_return_values.tenancy_organization_ids,
+                    func_binding_return_values.tenancy_workspace_ids)
+  AND is_visible_v1($2, func_binding_return_values.visibility_change_set_pk, func_binding_return_values.visibility_edit_session_pk, func_binding_return_values.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_edit_session_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_deleted)
+  AND func_binding_return_value_belongs_to_func_binding.belongs_to_id = $3
+ORDER BY func_binding_return_values.id,
+         visibility_change_set_pk DESC,
+         visibility_edit_session_pk DESC,
+         func_binding_return_value_belongs_to_func_binding.belongs_to_id DESC,
+         func_binding_return_value_belongs_to_func_binding.object_id DESC
+LIMIT 1;

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -746,7 +746,7 @@ macro_rules! standard_model_accessor {
         standard_model_accessor!(@set_column_with_option
             $column,
             $value_type,
-            $crate::standard_model::TypeHint::Text,
+            $crate::standard_model::TypeHint::JsonB,
             $result_type,
         );
     };
@@ -756,7 +756,7 @@ macro_rules! standard_model_accessor {
         standard_model_accessor!(@set_column
             $column,
             $value_type,
-            $crate::standard_model::TypeHint::Text,
+            $crate::standard_model::TypeHint::JsonB,
             $result_type,
         );
     };

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -35,6 +35,7 @@ pub enum TypeHint {
     Integer,
     SmallInt,
     Text,
+    JsonB,
 }
 
 #[instrument(skip(txn))]


### PR DESCRIPTION
Avoids FuncBindingReturnValue flooding the server because of non-idempotent runs (like syncing components every 30 seconds)

FuncExecution currently is created every time, so it might still flood the server, but it's a different context (as it exists to audit all executions)