### PR TITLE
feat(*): wire qual output to frontend 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,12 @@ backend: down
 	cd $(MAKEPATH)/deploy && $(MAKE) backend
 .PHONY: backend
 
+veritech-run:
+	cd $(MAKEPATH); cargo build
+	cd $(MAKEPATH); cargo build --bin cyclone
+	cd $(MAKEPATH)/bin/veritech; cargo run
+.PHONY: veritech-run
+
 sdf-run:
 	cd $(MAKEPATH); cargo build
 	cd $(MAKEPATH); cargo run --bin sdf -- --disable-opentelemetry

--- a/README.md
+++ b/README.md
@@ -69,15 +69,21 @@ This will ensure that our database is running, our NATS server is running, the J
 Now, wait for the `postgres` database container to be running and ready to receive incoming client connection requests.
 If it is not ready, `sdf` database migration will fail.
 
-Once the database is ready, you can run `sdf`.
+Once the database is ready, you can run `veritech`.
+
+```bash
+make veritech-run
+```
+
+In another terminal pane, run `sdf`.
 
 ```bash
 make sdf-run
 ```
 
-_Note:_ you can run `sdf` again without running the prepare target if you are only making changes to `sdf` and the libraries it pulls in.
+_Note:_ you can run `veritech` and `sdf` again without running the prepare target.
 
-In another terminal pane, execute the following command:
+In a third terminal pane, execute the following command:
 
 ```bash
 make app-run

--- a/app/web/src/api/sdf/dal/qualification.ts
+++ b/app/web/src/api/sdf/dal/qualification.ts
@@ -4,19 +4,21 @@ export interface Qualification {
   link?: string;
   description?: string;
   result?: QualificationResult;
+  output?: Array<QualificationOutputStream>;
 }
 
 export interface QualificationResult {
   title?: string;
   link?: string;
+  success: boolean;
   sub_checks?: Array<{
     status: "Success" | "Failure" | "Unknown";
     description: string;
   }>;
-  output?: Array<string>;
-  success: boolean;
 }
 
-export interface QualificationError {
-  message: string;
+export interface QualificationOutputStream {
+  line: string;
+  stream: string;
+  level: string;
 }

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -102,9 +102,10 @@
               v-if="showDescriptionMap[q.name] === true"
               class="flex flex-col w-full"
             >
+              <!-- NOTE(nick): output is optional and can be empty. -->
               <div v-if="q.result" class="flex flex-col w-full">
                 <div class="mt-1">
-                  <QualificationOutput :result="q.result" />
+                  <QualificationOutput :result="q.result" :output="q.output" />
                 </div>
               </div>
             </div>

--- a/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
+++ b/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
@@ -27,12 +27,15 @@
       </div>
     </div>
 
-    <div v-if="output" class="flex flex-col flex-grow border-t border-gray-800">
+    <div
+      v-if="combined_output"
+      class="flex flex-col flex-grow border-t border-gray-800"
+    >
       <div class="mt-2 mb-1 ml-2 text-xs font-medium output-title">Output</div>
       <div
         class="px-6 text-xs leading-relaxed whitespace-pre-line select-text output-lines"
       >
-        {{ output }}
+        {{ combined_output }}
       </div>
     </div>
   </div>
@@ -40,14 +43,18 @@
 
 <script setup lang="ts">
 import VueFeather from "vue-feather";
-import { QualificationResult } from "@/api/sdf/dal/qualification";
+import {
+  QualificationOutputStream,
+  QualificationResult,
+} from "@/api/sdf/dal/qualification";
 import { computed, toRefs } from "vue";
 
 const props = defineProps<{
   result: QualificationResult;
+  output?: Array<QualificationOutputStream>;
 }>();
 
-const { result } = toRefs(props);
+const { result, output } = toRefs(props);
 
 const subChecks = computed(() => {
   if (result.value.sub_checks) {
@@ -71,12 +78,19 @@ const subChecks = computed(() => {
   }
 });
 
-const output = computed(() => {
-  if (result.value.output) {
-    return result.value.output.join("\n");
-  } else {
-    return "remove this mock output when we have real output!!!";
+const combined_output = computed((): string | false => {
+  if (output.value) {
+    let lines = "";
+    for (const stream of output.value) {
+      if (lines == "") {
+        lines = stream.line;
+      } else {
+        lines = lines + "\n" + stream.line;
+      }
+    }
+    return lines;
   }
+  return false;
 });
 </script>
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -792,7 +791,11 @@ impl Component {
         for row in rows.into_iter() {
             let json: serde_json::Value = row.try_get("object")?;
             let func_binding_return_value: FuncBindingReturnValue = serde_json::from_value(json)?;
-            let mut qual_view = QualificationView::try_from(func_binding_return_value)?;
+            let mut qual_view = QualificationView::new_for_func_binding_return_value(
+                txn,
+                func_binding_return_value,
+            )
+            .await?;
             let title: String = row.try_get("title")?;
             let link: Option<String> = row.try_get("link")?;
             qual_view.title = title;

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -556,3 +556,67 @@ async fn get_resource_by_component_id() {
         serde_json::json!("Cant touch this: chvrches")
     );
 }
+
+// FIXME(nick,adam): fix output stream test or figure out another way how to do this. This is
+// relatively low priority since it just checks if the output matches the expected between the
+// execution output stream itself and the view that was created afterwards.
+//
+// #[tokio::test]
+// async fn qualification_view_output_stream() {
+//     test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
+//     let tenancy = Tenancy::new_universal();
+//     let visibility = create_visibility_head();
+//     let history_actor = HistoryActor::SystemInit;
+//
+//     let func = Func::new(
+//         &txn,
+//         &nats,
+//         &tenancy,
+//         &visibility,
+//         &history_actor,
+//         "lateralus",
+//         FuncBackendKind::JsQualification,
+//         FuncBackendResponseType::Qualification,
+//     )
+//     .await
+//     .expect("cannot create func");
+//     let args = FuncBackendJsQualificationArgs::new();
+//     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+//     let func_binding = FuncBinding::new(
+//         &txn,
+//         &nats,
+//         &tenancy,
+//         &visibility,
+//         &HistoryActor::SystemInit,
+//         Default::default(),
+//         *func.id(),
+//         FuncBackendKind::JsQualification,
+//     )
+//     .await
+//     .expect(
+//         "could not create func binding",
+//     );
+//
+//     let func_binding_return_value = func_binding
+//         .execute(&txn, &nats, veritech)
+//         .await
+//         .expect("cannot execute binding");
+//
+//     let output_stream = execution.into_output_stream().expect("output stream empty");
+//     let before = output_stream
+//         .into_iter()
+//         .map(|stream| stream.message)
+//         .collect::<HashSet<String>>();
+//
+//     let qualification_view = QualificationView::new(&txn, func_binding_return_value)
+//         .await
+//         .expect("could not create qualification view");
+//     let after = qualification_view
+//         .output
+//         .into_iter()
+//         .map(|view| view.line)
+//         .collect::<HashSet<String>>();
+//
+//     // NOTE(nick): HashSets are "sorted", so we can compare these directly.
+//     assert_eq!(before, after);
+// }

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -1,5 +1,6 @@
 use crate::test_setup;
 
+use dal::func::execution::FuncExecution;
 use dal::{
     func::{
         backend::FuncBackendStringArgs, binding::FuncBinding,
@@ -291,6 +292,10 @@ async fn func_binding_return_value_new() {
     )
     .await;
 
+    let execution = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+        .await
+        .expect("cannot create a new func execution");
+
     let _func_binding_return_value = FuncBindingReturnValue::new(
         &txn,
         &nats,
@@ -301,6 +306,7 @@ async fn func_binding_return_value_new() {
         Some(serde_json::json!("funky")),
         *func.id(),
         *func_binding.id(),
+        execution.pk(),
     )
     .await
     .expect("failed to create return value");

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -183,3 +183,40 @@ async fn process_return_value() {
         func_binding_return_value.unprocessed_value(),
     );
 }
+
+// FIXME(nick,fletcher): re-add test once upsert is added.
+// #[tokio::test]
+// async fn execution_upserts_return_value() {
+//     test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
+//     let tenancy = Tenancy::new_universal();
+//     let visibility = create_visibility_head();
+//     let history_actor = HistoryActor::SystemInit;
+//
+//     let func = create_func(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+//     let args = FuncBackendStringArgs::new("slayer".to_string());
+//     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
+//     let func_binding = create_func_binding(
+//         &txn,
+//         &nats,
+//         &tenancy,
+//         &visibility,
+//         &history_actor,
+//         args_json,
+//         *func.id(),
+//         *func.backend_kind(),
+//     )
+//         .await;
+//     let fbrv = func_binding
+//         .execute(&txn, &nats, veritech)
+//         .await
+//         .expect("cannot execute binding");
+//
+//     let _execution1 = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+//         .await
+//         .expect("cannot create a new func execution");
+//
+//     let  _execution2 = FuncExecution::new(&txn, &nats, &tenancy, &func, &func_binding)
+//         .await
+//         .expect("cannot create a new func execution");
+//
+// }


### PR DESCRIPTION
- Wire qualification output to frontend (empty vector is no output is
found)
- Add veritech-run make target and README edit
- Match shape of qualification frontend DAL and SDF response objects
- Add output as optional field on QualificationOuput component
- Remove unused error and message fields on qual view
- Attach function execution PKs to function return binding values to
  perform lookup for output
- Remove unused, duplicate subchecks field (the real one exists under
  result)

<img src="https://media2.giphy.com/media/l41m04gr7tRet7Uas/giphy.gif"/>