### PR TITLE
feat(dal): Create FuncBackendKind::Integer

### DIFF
--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -13,10 +13,13 @@ use veritech::{
 
 use crate::{edit_field::ToSelectWidget, label_list::ToLabelList};
 
+pub mod integer;
 pub mod validation;
 
 #[derive(Error, Debug)]
 pub enum FuncBackendError {
+    #[error("invalid data - expected an integer, got: {0}")]
+    InvalidIntegerData(serde_json::Value),
     #[error("invalid data - expected a string, got: {0}")]
     InvalidStringData(serde_json::Value),
     #[error("result failure: kind={kind}, message={message}")]
@@ -45,6 +48,7 @@ pub type FuncBackendResult<T> = Result<T, FuncBackendError>;
     Copy,
 )]
 pub enum FuncBackendKind {
+    Integer,
     String,
     // Commented out while we climb back up - Adam & Fletcher
     //Number,
@@ -76,6 +80,7 @@ pub enum FuncBackendKind {
     Copy,
 )]
 pub enum FuncBackendResponseType {
+    Integer,
     String,
     // Commented out while we climb back up - Adam & Fletcher
     //Number,

--- a/lib/dal/src/func/backend/integer.rs
+++ b/lib/dal/src/func/backend/integer.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+
+use crate::{func::backend::FuncBackendResult, FuncBackendError};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendIntegerArgs {
+    pub value: i64,
+}
+
+impl FuncBackendIntegerArgs {
+    pub fn new(value: i64) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendInteger {
+    args: FuncBackendIntegerArgs,
+}
+
+impl FuncBackendInteger {
+    pub fn new(args: FuncBackendIntegerArgs) -> Self {
+        Self { args }
+    }
+
+    #[instrument(
+        name = "funcbackendinteger.execute",
+        skip_all,
+        level = "debug",
+        fields(
+            otel.kind = %SpanKind::Client,
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.func.result = Empty
+        )
+    )]
+    pub async fn execute(self) -> FuncBackendResult<serde_json::Value> {
+        let span = Span::current();
+
+        let value = serde_json::to_value(&self.args.value)?;
+
+        if !value.is_i64() {
+            return Err(span.record_err(FuncBackendError::InvalidIntegerData(value)));
+        }
+
+        span.record_ok();
+        span.record("si.func.result", &tracing::field::debug(&value));
+        Ok(value)
+    }
+}

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -9,6 +9,7 @@ use serde_json::Value as JsonValue;
 use tokio::sync::mpsc;
 use veritech::{Client, QualificationCheckResultSuccess, ResourceSyncResultSuccess};
 
+use crate::func::backend::integer::{FuncBackendInteger, FuncBackendIntegerArgs};
 use crate::func::backend::{
     FuncBackendJsQualification, FuncBackendJsQualificationArgs, FuncBackendJsResourceSync,
     FuncBackendJsResourceSyncArgs,
@@ -232,6 +233,14 @@ impl FuncBinding {
                 .execute()
                 .await?;
                 execution.process_output(txn, nats, rx).await?;
+                Some(return_value)
+            }
+            FuncBackendKind::Integer => {
+                execution
+                    .set_state(txn, nats, super::execution::FuncExecutionState::Run)
+                    .await?;
+                let args: FuncBackendIntegerArgs = serde_json::from_value(self.args.clone())?;
+                let return_value = FuncBackendInteger::new(args).execute().await?;
                 Some(return_value)
             }
             FuncBackendKind::String => {

--- a/lib/dal/src/func/builtins.rs
+++ b/lib/dal/src/func/builtins.rs
@@ -13,6 +13,7 @@ pub async fn migrate(txn: &PgTxn<'_>, nats: &NatsTxn) -> FuncResult<()> {
     );
 
     si_set_string(txn, nats, &tenancy, &visibility, &history_actor).await?;
+    si_set_integer(txn, nats, &tenancy, &visibility, &history_actor).await?;
     si_unset(txn, nats, &tenancy, &visibility, &history_actor).await?;
     si_validate_string_equals(txn, nats, &tenancy, &visibility, &history_actor).await?;
     si_qualification_always_true(txn, nats, &tenancy, &visibility, &history_actor).await?;
@@ -109,6 +110,39 @@ async fn si_set_string(
         .await
         .expect("cannot create func");
     }
+    Ok(())
+}
+
+async fn si_set_integer(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+) -> FuncResult<()> {
+    let existing_func = Func::find_by_attr(
+        txn,
+        tenancy,
+        visibility,
+        "name",
+        &"si:setString".to_string(),
+    )
+    .await?;
+    if existing_func.is_empty() {
+        Func::new(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            "si:setInteger",
+            FuncBackendKind::Integer,
+            FuncBackendResponseType::Integer,
+        )
+        .await
+        .expect("cannot create func");
+    }
+
     Ok(())
 }
 

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -42,6 +42,7 @@ pk!(PropId);
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum PropKind {
+    Integer,
     String,
 }
 

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -523,28 +523,23 @@ async fn docker_image(
         .add_schema_variant(txn, nats, visibility, history_actor, variant.id())
         .await?;
 
-    let (func, func_binding) = match malandro_é_malandro_e_mané_é_mané_prop.kind() {
-        PropKind::String => {
-            let func_name = "si:totallyRandomString".to_string();
-            let mut funcs =
-                Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-            let func = funcs.pop().ok_or(SchemaError::MissingFunc(func_name))?;
-            let (func_binding, _) = FuncBinding::find_or_create(
-                txn,
-                nats,
-                tenancy,
-                visibility,
-                history_actor,
-                serde_json::to_value(Option::<()>::None)?,
-                *func.id(),
-                *func.backend_kind(),
-            )
-            .await?;
+    let func_name = "si:totallyRandomString".to_string();
+    let mut funcs = Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
+    let func = funcs.pop().ok_or(SchemaError::MissingFunc(func_name))?;
+    let (func_binding, _) = FuncBinding::find_or_create(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        serde_json::to_value(Option::<()>::None)?,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await?;
 
-            func_binding.execute(txn, nats, veritech.clone()).await?;
-            (func, func_binding)
-        }
-    };
+    func_binding.execute(txn, nats, veritech.clone()).await?;
+
     let mut attribute_resolver_context = AttributeResolverContext::new();
     attribute_resolver_context.set_prop_id(*malandro_é_malandro_e_mané_é_mané_prop.id());
     AttributeResolver::upsert(


### PR DESCRIPTION
This also modifies the signature of `Component.check_validations` to take the value as an `Option<serde_json::Value>` instead of as a `&str` so that we can validate more than just strings.

Co-authored-by: Nick Gerace <nick@systeminit.com>