### PR TITLE
feat(dal,web): Do not hard-code all EditFields for Props as being of type "String"

### DIFF
--- a/app/web/src/api/sdf/dal/edit_field.ts
+++ b/app/web/src/api/sdf/dal/edit_field.ts
@@ -7,13 +7,13 @@ export enum EditFieldObjectKind {
 }
 
 export enum EditFieldDataType {
-  String = "String",
-  Number = "Number",
-  Object = "Object",
-  Boolean = "Boolean",
-  Map = "Map",
   Array = "Array",
+  Boolean = "Boolean",
+  Integer = "Integer",
+  Map = "Map",
   None = "None",
+  Object = "Object",
+  String = "String",
 }
 
 export interface CheckboxWidgetDal {

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-for="editField in editFields"
+    v-for="editField in props.editFields"
     :key="editField.id"
     class="flex flex-row w-full"
   >
@@ -42,7 +42,7 @@ import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
 import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
 import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
 
-defineProps({
+const props = defineProps({
   editFields: {
     type: Array as PropType<EditFields>,
     required: true,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1367,7 +1367,7 @@ impl EditFieldAble for Component {
                 vec!["properties".to_string()],
                 object_kind,
                 *id,
-                EditFieldDataType::String,
+                (*prop.kind()).into(),
                 Widget::Text(TextWidget::new()),
                 value,
                 visibility_diff,

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     func::backend::validation::ValidationError, label_list::ToLabelList, HistoryActor, LabelList,
-    LabelListError, PropId, SystemId, Tenancy, Visibility,
+    LabelListError, PropId, PropKind, SystemId, Tenancy, Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -35,15 +35,27 @@ impl EditFieldError {
 
 pub type EditFieldResult<T> = Result<T, EditFieldError>;
 
+// NOTE: This might not need to be its own thing. We might be able to use PropKind directly?
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub enum EditFieldDataType {
-    String,
-    Number,
-    Object,
-    Boolean,
-    Map,
     Array,
+    Boolean,
+    Integer,
+    Map,
     None,
+    PropObject,
+    String,
+}
+
+impl From<PropKind> for EditFieldDataType {
+    fn from(prop_kind: PropKind) -> Self {
+        match prop_kind {
+            PropKind::Boolean => EditFieldDataType::Boolean,
+            PropKind::Integer => EditFieldDataType::Integer,
+            PropKind::PropObject => EditFieldDataType::PropObject,
+            PropKind::String => EditFieldDataType::String,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -37,7 +37,17 @@ pk!(PropPk);
 pk!(PropId);
 
 #[derive(
-    AsRefStr, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
 )]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]


### PR DESCRIPTION
This ended up being a whole lot of reading, and mapping out the landscape, only to discover that there might not really be all that much that needs to change right now (at least until we really start filling out `PropObject`/`Array`/`Map` `PropKind`s more).