### PR TITLE
feat(dal): Allow setting parent for a Prop

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -541,7 +541,7 @@ impl Component {
             (PropKind::Integer, None) => {
                 todo!("We haven't dealt with unsetting an integer")
             }
-            (PropKind::PropObject, Some(value_json)) => {
+            (PropKind::Object, Some(value_json)) => {
                 let value = match value_json.as_object() {
                     Some(object) => object,
                     None => {
@@ -575,7 +575,7 @@ impl Component {
                 }
                 (func, func_binding, created)
             }
-            (PropKind::PropObject, None) => {
+            (PropKind::Object, None) => {
                 todo!("We haven't dealt with unsetting an object")
             }
             (PropKind::String, Some(value_json)) => {
@@ -616,6 +616,9 @@ impl Component {
             }
             (PropKind::String, None) => {
                 todo!("we haven't dealt with unseting a string");
+            }
+            (PropKind::Map, _) => {
+                todo!("deal with maps!");
             }
         };
 

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -43,7 +43,7 @@ pub enum EditFieldDataType {
     Integer,
     Map,
     None,
-    PropObject,
+    Object,
     String,
 }
 
@@ -53,7 +53,8 @@ impl From<PropKind> for EditFieldDataType {
             PropKind::Array => EditFieldDataType::Array,
             PropKind::Boolean => EditFieldDataType::Boolean,
             PropKind::Integer => EditFieldDataType::Integer,
-            PropKind::PropObject => EditFieldDataType::PropObject,
+            PropKind::Map => EditFieldDataType::Map,
+            PropKind::Object => EditFieldDataType::Object,
             PropKind::String => EditFieldDataType::String,
         }
     }

--- a/lib/dal/src/func/backend/array.rs
+++ b/lib/dal/src/func/backend/array.rs
@@ -50,7 +50,7 @@ impl FuncBackendArray {
                 } else if entry.is_i64() {
                     PropKind::Integer
                 } else if entry.is_object() {
-                    PropKind::PropObject
+                    PropKind::Object
                 } else if entry.is_boolean() {
                     PropKind::Boolean
                 } else {

--- a/lib/dal/src/migrations/U0040__props.sql
+++ b/lib/dal/src/migrations/U0040__props.sql
@@ -17,9 +17,11 @@ CREATE TABLE props
 SELECT standard_model_table_constraints_v1('props');
 SELECT many_to_many_table_create_v1('prop_many_to_many_schema_variants', 'props',
                                     'schema_variants');
+SELECT belongs_to_table_create_v1('prop_belongs_to_prop', 'props', 'props');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
 VALUES ('props', 'model', 'prop', 'Prop'),
+       ('prop_belongs_to_prop', 'belongs_to', 'prop.child_prop', 'Parent Prop <> Child Prop'),
        ('prop_many_to_many_schema_variants', 'many_to_many', 'prop.schema_variant', 'Prop <> Schema Variant');
 
 -- Limit values of props.kind to a known set of variants. Is this required? No! But such a constraint

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -594,6 +594,28 @@ pub async fn create_prop(
     .expect("cannot create prop")
 }
 
+pub async fn create_prop_of_kind(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    prop_kind: PropKind,
+) -> Prop {
+    let name = generate_fake_name();
+    Prop::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        name,
+        prop_kind,
+    )
+    .await
+    .expect("cannot create prop")
+}
+
 pub async fn create_func(
     txn: &PgTxn<'_>,
     nats: &NatsTxn,

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -1,6 +1,6 @@
 use dal::{
-    test_harness::{create_prop, create_schema_variant},
-    HistoryActor, Prop, PropKind, StandardModel, Tenancy, Visibility,
+    test_harness::{create_prop, create_prop_of_kind, create_schema_variant},
+    HistoryActor, Prop, PropError, PropKind, StandardModel, Tenancy, Visibility,
 };
 
 use crate::test_setup;
@@ -85,4 +85,96 @@ async fn schema_variants() {
         .await
         .expect("cannot get schema variants");
     assert_eq!(relations, vec![]);
+}
+
+#[tokio::test]
+async fn parent_props() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let parent_prop = create_prop_of_kind(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::Object,
+    )
+    .await;
+    let child_prop = create_prop_of_kind(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+    )
+    .await;
+
+    child_prop
+        .set_parent_prop(&txn, &nats, &visibility, &history_actor, *parent_prop.id())
+        .await
+        .expect("cannot set parent prop");
+    let retrieved_parent_prop = child_prop
+        .parent_prop(&txn, &visibility)
+        .await
+        .expect("cannot get parent prop")
+        .expect("there was no parent prop and we expected one!");
+    assert_eq!(retrieved_parent_prop, parent_prop);
+
+    let children = parent_prop
+        .child_props(&txn, &tenancy, &visibility)
+        .await
+        .expect("should have children");
+    assert_eq!(children, vec![child_prop]);
+}
+
+#[tokio::test]
+async fn parent_props_wrong_prop_kinds() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        _veritech
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let parent_prop = create_prop_of_kind(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+    )
+    .await;
+    let child_prop = create_prop_of_kind(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::Object,
+    )
+    .await;
+
+    let result = child_prop
+        .set_parent_prop(&txn, &nats, &visibility, &history_actor, *parent_prop.id())
+        .await;
+    result.expect_err("should have errored, and it did not");
 }


### PR DESCRIPTION
Only `PropKind::Object`, `PropKind::Array`, and `PropKind::Map` are valid parents of other `Prop`s.

Co-authored-by: Jacob Helwig <jacob@systeminit.com>