### PR TITLE
fix(ci): run veritech/cyclone/lang-js from source in cypress tests

### DIFF
--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -9,6 +9,15 @@ services:
     entrypoint:
       - "/usr/local/bin/sdf"
 
+  veritech:
+    image: "fedora:latest"
+    volumes:
+      - "${REPOPATH:-..}/target/debug/veritech:/usr/local/bin/veritech"
+      - "${REPOPATH:-..}/target/debug/cyclone:/usr/local/bin/cyclone"
+      - "${REPOPATH:-..}/bin/lang-js/target/lang-js:/usr/local/bin/lang-js"
+    entrypoint:
+      - "/usr/local/bin/veritech"
+
   web:
     image: "nginx:1.21.4-alpine"
     # NOTE(nick): "dist" is a directory and the other mounts are files. This might help when debugging permissions errors


### PR DESCRIPTION
This change ensures that we're running the same source-built versions
of:

* veritech
* cyclone
* lang-js

in the cypress (acceptance) test suite, which gets triggered by the
`ci-web` Make target (in the `ci/` directory).

Future work will likely change the `docker-compose.ci.yml` to use some
Dockerfiles with `COPY` to side-step our Linux bind-mount tricks which
lead to setup/teardown permissions issues.

SMALL STEPS FORWARD!!

<img src="https://media0.giphy.com/media/mlvseq9yvZhba/giphy.gif"/>

Co-authored-by: Jacob Helwig <jacob@systeminit.com>
Co-authored-by: Paulo Cabral Sanz <paulo@systeminit.com>
Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>