### PR TITLE
chore(ci): introduce bors & split image build/publish from promotion

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,0 +1,12 @@
+status = [
+  "Pull Request Checks",
+  "Release %",
+]
+block_labels = [
+  "wip"
+]
+required_approvals = 0
+delete_merged_branches = true
+update_base_for_deletes = true
+up_to_date_approvals = true
+commit_title = "merge: ${PR_REFS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 name: ci
 on:
   push:
-    branches-ignore:
-      - "main"
+    branches:
+      - staging
+      - trying
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
+    name: Pull Request Checks
     runs-on: self-hosted
     steps:
       - name: Git Checkout

--- a/.github/workflows/release-nats.yml
+++ b/.github/workflows/release-nats.yml
@@ -3,13 +3,15 @@ name: release-nats
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-nats.yml
       - component/nats/**
 
 jobs:
   release:
+    name: Release NATS
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4

--- a/.github/workflows/release-otelcol.yml
+++ b/.github/workflows/release-otelcol.yml
@@ -3,13 +3,15 @@ name: release-otelcol
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-otelcol.yml
       - component/otelcol/**
 
 jobs:
   release:
+    name: Release OTELCOL
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
@@ -65,4 +67,3 @@ jobs:
           channel: engineering
           status: failed
           color: "#f44336"
-

--- a/.github/workflows/release-postgres.yml
+++ b/.github/workflows/release-postgres.yml
@@ -3,13 +3,15 @@ name: release-postgres
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-postgres.yml
       - component/postgres/**
 
 jobs:
   release:
+    name: Release Postgres
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
@@ -65,4 +67,3 @@ jobs:
           channel: engineering
           status: failed
           color: "#f44336"
-

--- a/.github/workflows/release-sdf.yml
+++ b/.github/workflows/release-sdf.yml
@@ -3,7 +3,8 @@ name: release-sdf
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-sdf.yml
       - .cargo/**
@@ -20,6 +21,7 @@ on:
 
 jobs:
   release:
+    name: Release SDF
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4

--- a/.github/workflows/release-veritech.yml
+++ b/.github/workflows/release-veritech.yml
@@ -3,7 +3,8 @@ name: release-veritech
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-veritech.yml
       - .cargo/**
@@ -20,6 +21,7 @@ on:
 
 jobs:
   release:
+    name: Release Veritech
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -3,7 +3,8 @@ name: release-web
 on:
   push:
     branches:
-      - main
+      - staging
+      - trying
     paths:
       - .github/workflows/release-web.yml
       - .prettierrc.js
@@ -12,6 +13,7 @@ on:
 
 jobs:
   release:
+    name: Release Web
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4

--- a/app/web/script/build-image.sh
+++ b/app/web/script/build-image.sh
@@ -203,7 +203,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then

--- a/bin/sdf/script/build-image.sh
+++ b/bin/sdf/script/build-image.sh
@@ -197,7 +197,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then

--- a/bin/veritech/script/build-image.sh
+++ b/bin/veritech/script/build-image.sh
@@ -197,7 +197,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then

--- a/component/nats/script/build-image.sh
+++ b/component/nats/script/build-image.sh
@@ -201,7 +201,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then

--- a/component/otelcol/script/build-image.sh
+++ b/component/otelcol/script/build-image.sh
@@ -201,7 +201,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then

--- a/component/postgres/script/build-image.sh
+++ b/component/postgres/script/build-image.sh
@@ -201,7 +201,7 @@ build() {
     args+=(--tag "$img:latest")
   fi
   if [[ "$ci_mode" == "true" ]]; then
-    args+=(--tag "$img:stable")
+    args+=(--tag "$img:sha-$revision")
   fi
   args+=(--cache-from "type=registry,ref=$img:buildcache")
   if [[ "$ci_mode" == "true" ]]; then


### PR DESCRIPTION
This change introduces bors into our pull request/code review workflow.
The following should roughly happen for each pull request:

* When a PR is opened, the `ci` workflow will execute (any failure needs
  to be fixed)
* Ideally, a peer would code review as usual and signal if it's ready
  for merge (this doesn't depend on the approve/reject functionality in
  GitHub PRs, but it's still useful)
* Rather than hitting the "green merge" button, we want to tell bors to
  start its test-and-merge process by leaving a comment with either
  `bors r+` or `bors merge`
* bors will merge the PR branch into a `staging` branch which is based on
  the main branch, re-execute the `ci` workflow (currently the same
  tests as the initial PR but we can iterate on this later for faster
  initial feedback), and run any `release-*` workflows that apply (each
  of these would build a new image and push it with a `:sha-XXXX` tag).
* If all the above bors-related workflows succeed, bors will merge the
  `staging` branch into main (which should be a fast-forward)
* Any failure along the way, would result in bors leaving a failure
  comment with links to the failed jobs. At this point a developer needs
  to fix the work, re-push to the same branch, open a new PR, etc.

For much more documentation about bors, see
https://bors.tech/documentation/

<img src="https://media2.giphy.com/media/XHppLGyp0Mx2w/giphy.gif"/>

Co-authored-by: Jacob Helwig <jacob@systeminit.com>
Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>