### PR TITLE
feat(dal/cyc/ver/lang): CodeGeneration e2e support

### DIFF
--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -80,6 +80,14 @@ pub(crate) struct Args {
     #[clap(long, group = "sync")]
     pub(crate) disable_sync: bool,
 
+    /// Enables code generation endpoint.
+    #[clap(long, group = "code_generation")]
+    pub(crate) enable_code_generation: bool,
+
+    /// Disables code generation endpoint.
+    #[clap(long, group = "code_generation")]
+    pub(crate) disable_code_generation: bool,
+
     /// Path to the lang server program.
     #[clap(long, env = "SI_LANG_SERVER", setting = ArgSettings::HideEnvValues)]
     pub(crate) lang_server: PathBuf,
@@ -134,6 +142,12 @@ impl TryFrom<Args> for Config {
             builder.enable_sync(true);
         } else if args.disable_sync {
             builder.enable_sync(false);
+        }
+
+        if args.enable_code_generation {
+            builder.enable_code_generation(true);
+        } else if args.disable_code_generation {
+            builder.enable_code_generation(false);
         }
 
         if args.lang_server.is_file() {

--- a/bin/lang-js/examples/codeGenerationTest.json
+++ b/bin/lang-js/examples/codeGenerationTest.json
@@ -1,0 +1,9 @@
+{
+  "executionId": "9012",
+  "handler": "generate",
+  "component": {
+    "name": "jane",
+    "properties": {}
+  },
+  "codeBase64": "Ly8gRW5jb2RlIHRoaXMgaW50byBCYXNlNjQgd2l0aDoKLy8KLy8gYGBgc2gKLy8gY2F0IGV4YW1wbGVzL2NvZGVHZW5lcmF0aW9uVGVzdENvZGUuanMgfCBiYXNlNjQgfCB0ciAtZCAnXG4nCi8vIGBgYAoKZnVuY3Rpb24gZ2VuZXJhdGUoY29tcG9uZW50KSB7CiAgY29uc29sZS5sb2coSlNPTi5zdHJpbmdpZnkoY29tcG9uZW50KSk7CiAgY29uc29sZS5sb2coImdlbmVyYXRpbmcgc29tZXRoaW5nLCByaWdodD8iKTsKICByZXR1cm4geyBmb3JtYXQ6ICJqc29uIiwgY29kZTogSlNPTi5zdHJpbmdpZnkoY29tcG9uZW50KSB9Owp9Cg=="
+}

--- a/bin/lang-js/examples/codeGenerationTestCode.js
+++ b/bin/lang-js/examples/codeGenerationTestCode.js
@@ -1,0 +1,11 @@
+// Encode this into Base64 with:
+//
+// ```sh
+// cat examples/codeGenerationTestCode.js | base64 | tr -d '\n'
+// ```
+
+function generate(component) {
+  console.log(JSON.stringify(component));
+  console.log("generating something, right?");
+  return { format: "json", code: JSON.stringify(component) };
+}

--- a/bin/lang-js/package-lock.json
+++ b/bin/lang-js/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lang-js",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {
         "commander": "^8.2.0",
         "debug": "^4.3.3",
         "execa": "^4.1.0",
+        "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "vm2": "^3.9.3"
       },
@@ -20,6 +22,7 @@
       "devDependencies": {
         "@types/debug": "^4.1.5",
         "@types/jest": "^26.0.20",
+        "@types/js-yaml": "^4.0.5",
         "@types/lodash": "^4.14.168",
         "@typescript-eslint/eslint-plugin": "^4.17.0",
         "@typescript-eslint/parser": "^4.17.0",
@@ -701,6 +704,15 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -708,6 +720,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -744,6 +769,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
@@ -1161,6 +1208,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -1539,13 +1592,9 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -2779,6 +2828,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -2810,6 +2868,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/espree": {
@@ -4718,13 +4789,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -8598,11 +8667,30 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
@@ -8636,6 +8724,25 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -9002,6 +9109,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -9263,13 +9376,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -10137,6 +10246,15 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "eslint-utils": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -10159,6 +10277,16 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
@@ -11697,13 +11825,11 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsdom": {

--- a/bin/lang-js/package.json
+++ b/bin/lang-js/package.json
@@ -38,6 +38,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.168",
+    "@types/js-yaml": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",
@@ -55,7 +56,8 @@
     "debug": "^4.3.3",
     "lodash": "^4.17.21",
     "vm2": "^3.9.3",
-    "execa": "^4.1.0"
+    "execa": "^4.1.0",
+    "js-yaml": "^4.1.0"
   },
   "volta": {
     "node": "16.5.0",

--- a/bin/lang-js/src/code_generation.ts
+++ b/bin/lang-js/src/code_generation.ts
@@ -1,0 +1,116 @@
+import Debug from "debug";
+import _ from "lodash";
+import { VM, VMScript } from "vm2";
+import { base64Decode } from "./base64";
+import {
+  failureExecution,
+  FunctionKind,
+  Request,
+  ResultFailure,
+  ResultSuccess,
+} from "./function";
+import { createSandbox } from "./sandbox";
+import { createVm } from "./vm";
+
+const debug = Debug("langJs:codeGeneration");
+
+export interface CodeGenerationRequest extends Request {
+  handler: string;
+  component: Component;
+  codeBase64: string;
+}
+
+export interface Component {
+  name: string;
+  // TODO(fnichol): Highly, highly, highly TBD!
+  properties: Record<string, unknown>;
+}
+
+export type CodeGenerationResult =
+  | CodeGenerationResultSuccess
+  | CodeGenerationResultFailure;
+
+export interface CodeGenerationResultSuccess extends ResultSuccess {
+  data?: string;
+}
+
+export interface CodeGenerationResultFailure extends ResultFailure {
+  something?: never;
+}
+
+  export function executeCodeGeneration(request: CodeGenerationRequest): void {
+  const code = base64Decode(request.codeBase64);
+  debug({ code });
+  const compiledCode = new VMScript(wrapCode(code, request.handler, request.component)).compile();
+  debug({ code: compiledCode.code });
+  const sandbox = createSandbox(FunctionKind.CodeGeneration, request.executionId);
+  const vm = createVm(sandbox);
+
+  const result = execute(vm, compiledCode, request.executionId);
+  debug({ result });
+
+  console.log(JSON.stringify(result));
+}
+
+function execute(
+  vm: VM,
+  code: VMScript,
+  executionId: string
+): CodeGenerationResult {
+  let codeGenerationResult;
+  try {
+    codeGenerationResult = vm.run(code);
+  } catch (err) {
+    return failureExecution(err, executionId);
+  }
+
+  if (_.isUndefined(codeGenerationResult) || _.isNull(codeGenerationResult)) {
+    return {
+      protocol: "result",
+      status: "failure",
+      executionId,
+      error: {
+        kind: "InvalidReturnType",
+        message: "Return type must not be null or undefined",
+      },
+    };
+  }
+
+  if (!_.isString(codeGenerationResult["format"])) {
+    return {
+      protocol: "result",
+      status: "failure",
+      executionId,
+      error: {
+        kind: "FormatFieldWrongType",
+        message: "The format field type must be string",
+      },
+    };
+  }
+
+  if (!_.isString(codeGenerationResult["code"])) {
+    return {
+      protocol: "result",
+      status: "failure",
+      executionId,
+      error: {
+        kind: "CodeFieldWrongType",
+        message: "The code field type must be string",
+      },
+    };
+  }
+
+  // TODO(fnichol): minimum checking of other result fields here...
+
+  const result: CodeGenerationResultSuccess = {
+    protocol: "result",
+    status: "success",
+    data: codeGenerationResult,
+    executionId,
+  };
+  return result;
+}
+
+function wrapCode(code: string, handle: string, component: Component): string {
+  return code + `\n${handle}(${JSON.stringify(component)});\n`;
+}

--- a/bin/lang-js/src/function.ts
+++ b/bin/lang-js/src/function.ts
@@ -2,13 +2,14 @@ export enum FunctionKind {
   QualificationCheck = "qualificationcheck",
   ResolverFunction = "resolverfunction",
   ResourceSync = "resourceSync",
+  CodeGeneration = "codeGeneration",
 }
 
 export function function_kinds(): Array<string> {
   return [
     FunctionKind.QualificationCheck,
     FunctionKind.ResolverFunction,
-    FunctionKind.ResourceSync,
+    FunctionKind.CodeGeneration,
   ];
 }
 

--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -8,6 +8,7 @@ import { makeConsole } from "./sandbox/console";
 import { executeQualificationCheck } from "./qualification_check";
 import { executeResolverFunction } from "./resolver_function";
 import { executeResourceSync } from "./resource_sync";
+import { executeCodeGeneration } from "./code_generation";
 
 const debug = Debug("langJs");
 
@@ -56,6 +57,9 @@ async function main() {
         break;
       case FunctionKind.ResourceSync:
         executeResourceSync(request);
+        break;
+      case FunctionKind.CodeGeneration:
+        executeCodeGeneration(request);
         break;
       default:
         throw Error(`Unknown Kind variant: ${kind}`);

--- a/bin/lang-js/src/sandbox.ts
+++ b/bin/lang-js/src/sandbox.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import yaml from "js-yaml";
 
 import { FunctionKind } from "./function";
 import { makeConsole } from "./sandbox/console";
@@ -25,6 +26,11 @@ const resolverFunctionSandbox = {};
 
 const resourceSyncSandbox = {};
 
+const codeGenerationSandbox = {
+  // Is there any risk leaking this function plainly here? It smells like a risk for RCE outside of the sandbox
+  YAML: { stringify: yaml.dump }
+};
+
 function qualificationCheckSandbox(executionId: string): Sandbox {
   return {
     siExec: makeExec(executionId),
@@ -50,6 +56,11 @@ export function createSandbox(
       return {
         ...commonSandbox(executionId),
         ...resourceSyncSandbox,
+      };
+    case FunctionKind.CodeGeneration:
+      return {
+        ...commonSandbox(executionId),
+        ...codeGenerationSandbox,
       };
     default:
       throw new UnknownSandboxKind(kind);

--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -33,6 +33,10 @@ pub use tokio_tungstenite::tungstenite::{
     protocol::frame::CloseFrame as WebSocketCloseFrame, Message as WebSocketMessage,
 };
 
+pub use self::code_generation::{
+    CodeGenerationExecution, CodeGenerationExecutionClosing, CodeGenerationExecutionError,
+    CodeGenerationExecutionStarted,
+};
 pub use self::ping::{PingExecution, PingExecutionError};
 pub use self::qualification_check::{
     QualificationCheckExecution, QualificationCheckExecutionClosing,
@@ -48,11 +52,12 @@ pub use self::resource_sync::{
 };
 pub use self::watch::{Watch, WatchError, WatchStarted};
 pub use crate::{
-    qualification_check::QualificationCheckRequest, resolver_function::ResolverFunctionRequest,
-    resource_sync::ResourceSyncRequest, LivenessStatus, LivenessStatusParseError, ReadinessStatus,
-    ReadinessStatusParseError,
+    code_generation::CodeGenerationRequest, qualification_check::QualificationCheckRequest,
+    resolver_function::ResolverFunctionRequest, resource_sync::ResourceSyncRequest, LivenessStatus,
+    LivenessStatusParseError, ReadinessStatus, ReadinessStatusParseError,
 };
 
+mod code_generation;
 mod ping;
 mod qualification_check;
 mod resolver_function;
@@ -164,6 +169,11 @@ where
         &mut self,
         request: ResourceSyncRequest,
     ) -> result::Result<ResourceSyncExecution<Strm>, ClientError>;
+
+    async fn execute_code_generation(
+        &mut self,
+        request: CodeGenerationRequest,
+    ) -> result::Result<CodeGenerationExecution<Strm>, ClientError>;
 }
 
 impl Client<(), (), ()> {
@@ -294,6 +304,14 @@ where
     ) -> Result<ResourceSyncExecution<Strm>> {
         let stream = self.websocket_stream("/execute/sync").await?;
         Ok(resource_sync::execute(stream, request))
+    }
+
+    async fn execute_code_generation(
+        &mut self,
+        request: CodeGenerationRequest,
+    ) -> result::Result<CodeGenerationExecution<Strm>, ClientError> {
+        let stream = self.websocket_stream("/execute/code_generation").await?;
+        Ok(code_generation::execute(stream, request))
     }
 }
 
@@ -428,6 +446,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        code_generation::CodeGenerationComponent,
         qualification_check::QualificationCheckComponent,
         resolver_function::ResolverFunctionRequest,
         resolver_function::{ResolverFunctionComponent, ResolverFunctionParentComponent},
@@ -1142,6 +1161,168 @@ mod tests {
             FunctionResult::Success(success) => {
                 assert_eq!(success.execution_id, "1234");
                 // TODO(fnichol): check the future return value fields, pls
+            }
+            FunctionResult::Failure(failure) => {
+                panic!("result should be success; failure={:?}", failure)
+            }
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn http_execute_code_generation() {
+        let mut builder = Config::builder();
+        let mut client = http_client_for_running_server(builder.enable_qualification(true)).await;
+
+        let component = CodeGenerationComponent {
+            name: "pringles".to_string(),
+            properties: HashMap::new(),
+        };
+        let req = CodeGenerationRequest {
+            execution_id: "1234".to_string(),
+            handler: "portugueseJsonGeneration".to_string(),
+            component: component.clone(),
+            code_base64: base64::encode(
+                r#"function portugueseJsonGeneration(component) {
+                    console.log(JSON.stringify(component));
+                    console.log('generate');
+                    return { format: "json", code: JSON.stringify({nome: component.name}) };
+                }"#,
+            ),
+        };
+
+        // Start the protocol
+        let mut progress = client
+            .execute_code_generation(req)
+            .await
+            .expect("failed to establish websocket stream")
+            .start()
+            .await
+            .expect("failed to start protocol");
+
+        // Consume the output messages
+        match progress.next().await {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
+                assert_eq!(
+                    output.message,
+                    serde_json::to_string(&component)
+                        .expect("Unable to serialize CodeGenerationComponent")
+                )
+            }
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive 'i like' output: err={:?}", err),
+            None => panic!("output stream ended early"),
+        };
+        match progress.next().await {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
+                assert_eq!(output.message, "generate")
+            }
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive 'i like' output: err={:?}", err),
+            None => panic!("output stream ended early"),
+        };
+        // TODO(fnichol): until we've determined how to handle processing the result server side,
+        // we're going to see a heartbeat come back when a request is processed
+        match progress.next().await {
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
+            None => panic!("output stream ended early"),
+        }
+        match progress.next().await {
+            None => assert!(true),
+            Some(unexpected) => panic!("output stream should be done: {:?}", unexpected),
+        };
+        // Get the result
+        let result = progress.finish().await.expect("failed to return result");
+        match result {
+            FunctionResult::Success(success) => {
+                assert_eq!(success.execution_id, "1234");
+                assert_eq!(
+                    success.data,
+                    serde_json::json!({ "format": "json", "code": serde_json::to_string(&serde_json::json!({ "nome": "pringles" })).expect("unable to deserialize") })
+                );
+            }
+            FunctionResult::Failure(failure) => {
+                panic!("result should be success; failure={:?}", failure)
+            }
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn uds_execute_code_generation() {
+        let tmp_socket = rand_uds();
+        let mut builder = Config::builder();
+        let mut client =
+            uds_client_for_running_server(builder.enable_qualification(true), &tmp_socket).await;
+
+        let component = CodeGenerationComponent {
+            name: "pringles".to_string(),
+            properties: HashMap::new(),
+        };
+        let req = CodeGenerationRequest {
+            execution_id: "1234".to_string(),
+            handler: "portugueseJsonGeneration".to_string(),
+            component: component.clone(),
+            code_base64: base64::encode(
+                r#"function portugueseJsonGeneration(component) {
+                    console.log(JSON.stringify(component));
+                    console.log('generate');
+                    return { format: "json", code: JSON.stringify({nome: component.name}) };
+                }"#,
+            ),
+        };
+
+        // Start the protocol
+        let mut progress = client
+            .execute_code_generation(req)
+            .await
+            .expect("failed to establish websocket stream")
+            .start()
+            .await
+            .expect("failed to start protocol");
+
+        // Consume the output messages
+        match progress.next().await {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
+                assert_eq!(
+                    output.message,
+                    serde_json::to_string(&component)
+                        .expect("Unable to serialize CodeGenerationComponent")
+                )
+            }
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive 'i like' output: err={:?}", err),
+            None => panic!("output stream ended early"),
+        };
+        match progress.next().await {
+            Some(Ok(ProgressMessage::OutputStream(output))) => {
+                assert_eq!(output.message, "generate")
+            }
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive 'i like' output: err={:?}", err),
+            None => panic!("output stream ended early"),
+        };
+        // TODO(fnichol): until we've determined how to handle processing the result server side,
+        // we're going to see a heartbeat come back when a request is processed
+        match progress.next().await {
+            Some(Ok(ProgressMessage::Heartbeat)) => assert!(true),
+            Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
+            Some(Err(err)) => panic!("failed to receive heartbeat: err={:?}", err),
+            None => panic!("output stream ended early"),
+        }
+        match progress.next().await {
+            None => assert!(true),
+            Some(unexpected) => panic!("output stream should be done: {:?}", unexpected),
+        };
+        // Get the result
+        let result = progress.finish().await.expect("failed to return result");
+        match result {
+            FunctionResult::Success(success) => {
+                assert_eq!(success.execution_id, "1234");
+                assert_eq!(
+                    success.data,
+                    serde_json::json!({ "format": "json", "code": serde_json::to_string(&serde_json::json!({ "nome": "pringles" })).expect("unable to deserialize") })
+                );
             }
             FunctionResult::Failure(failure) => {
                 panic!("result should be success; failure={:?}", failure)

--- a/lib/cyclone/src/client/code_generation.rs
+++ b/lib/cyclone/src/client/code_generation.rs
@@ -1,0 +1,224 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Future, SinkExt, Stream, StreamExt};
+use hyper::client::connect::Connection;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_tungstenite::WebSocketStream;
+
+use crate::{
+    CodeGenerationRequest, CodeGenerationResultSuccess, FunctionResult, Message, ProgressMessage,
+};
+
+pub use tokio_tungstenite::tungstenite::{
+    protocol::frame::CloseFrame as WebSocketCloseFrame, Message as WebSocketMessage,
+};
+
+pub fn execute<T>(
+    stream: WebSocketStream<T>,
+    request: CodeGenerationRequest,
+) -> CodeGenerationExecution<T> {
+    CodeGenerationExecution { stream, request }
+}
+
+#[derive(Debug, Error)]
+pub enum CodeGenerationExecutionError {
+    #[error("closing execution stream without a result")]
+    ClosingWithoutResult,
+    #[error("finish message received before result message was received")]
+    FinishBeforeResult,
+    #[error("failed to deserialize json message")]
+    JSONDeserialize(#[source] serde_json::Error),
+    #[error("failed to serialize json message")]
+    JSONSerialize(#[source] serde_json::Error),
+    #[error("unexpected websocket message after finish was sent: {0}")]
+    MessageAfterFinish(WebSocketMessage),
+    #[error("unexpected qualification check message before start was sent: {0:?}")]
+    MessageBeforeStart(Message<CodeGenerationResultSuccess>),
+    #[error("unexpected websocket message type: {0}")]
+    UnexpectedMessageType(WebSocketMessage),
+    #[error("websocket stream is closed, but finish was not sent")]
+    WSClosedBeforeFinish,
+    #[error("websocket stream is closed, but start was not sent")]
+    WSClosedBeforeStart,
+    #[error("failed to read websocket message")]
+    WSReadIO(#[source] tokio_tungstenite::tungstenite::Error),
+    #[error("failed to send websocket message")]
+    WSSendIO(#[source] tokio_tungstenite::tungstenite::Error),
+}
+
+type Result<T> = std::result::Result<T, CodeGenerationExecutionError>;
+
+#[derive(Debug)]
+pub struct CodeGenerationExecution<T> {
+    stream: WebSocketStream<T>,
+    request: CodeGenerationRequest,
+}
+
+impl<T> CodeGenerationExecution<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    pub async fn start(mut self) -> Result<CodeGenerationExecutionStarted<T>> {
+        match self.stream.next().await {
+            Some(Ok(WebSocketMessage::Text(json_str))) => {
+                let msg = Message::deserialize_from_str(&json_str)
+                    .map_err(CodeGenerationExecutionError::JSONDeserialize)?;
+                match msg {
+                    Message::Start => {
+                        // received correct message, so proceed
+                    }
+                    unexpected => {
+                        return Err(CodeGenerationExecutionError::MessageBeforeStart(unexpected))
+                    }
+                }
+            }
+            Some(Ok(unexpected)) => {
+                return Err(CodeGenerationExecutionError::UnexpectedMessageType(
+                    unexpected,
+                ))
+            }
+            Some(Err(err)) => return Err(CodeGenerationExecutionError::WSReadIO(err)),
+            None => return Err(CodeGenerationExecutionError::WSClosedBeforeStart),
+        }
+
+        let msg = self
+            .request
+            .serialize_to_string()
+            .map_err(CodeGenerationExecutionError::JSONSerialize)?;
+        self.stream
+            .send(WebSocketMessage::Text(msg))
+            .await
+            .map_err(CodeGenerationExecutionError::WSSendIO)?;
+
+        Ok(self.into())
+    }
+}
+
+impl<T> From<CodeGenerationExecution<T>> for CodeGenerationExecutionStarted<T> {
+    fn from(value: CodeGenerationExecution<T>) -> Self {
+        Self {
+            stream: value.stream,
+            result: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CodeGenerationExecutionStarted<T> {
+    stream: WebSocketStream<T>,
+    result: Option<FunctionResult<CodeGenerationResultSuccess>>,
+}
+
+impl<T> CodeGenerationExecutionStarted<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    pub async fn finish(self) -> Result<FunctionResult<CodeGenerationResultSuccess>> {
+        CodeGenerationExecutionClosing::try_from(self)?
+            .finish()
+            .await
+    }
+}
+
+impl<T> Stream for CodeGenerationExecutionStarted<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    type Item = Result<ProgressMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream.next()).poll(cx) {
+            // We successfully got a websocket text message
+            Poll::Ready(Some(Ok(WebSocketMessage::Text(json_str)))) => {
+                let msg = Message::deserialize_from_str(&json_str)
+                    .map_err(CodeGenerationExecutionError::JSONDeserialize)?;
+                match msg {
+                    // We got a heartbeat message, pass it on
+                    Message::Heartbeat => Poll::Ready(Some(Ok(ProgressMessage::Heartbeat))),
+                    // We got an output message, pass it on
+                    Message::OutputStream(output_stream) => {
+                        Poll::Ready(Some(Ok(ProgressMessage::OutputStream(output_stream))))
+                    }
+                    // We got a funtion result message, save it and continue
+                    Message::Result(function_result) => {
+                        self.result = Some(function_result);
+                        // TODO(fnichol): what is the right return here??
+                        // (future fnichol): hey buddy! pretty sure you can:
+                        // `cx.waker().wake_by_ref()` before returning Poll::Ready which immediatly
+                        // re-wakes this stream to maybe pop another item off. cool huh? I think
+                        // you're learning and that's great.
+                        Poll::Ready(Some(Ok(ProgressMessage::Heartbeat)))
+                        //Poll::Pending
+                    }
+                    // We got a finish message
+                    Message::Finish => {
+                        if self.result.is_some() {
+                            // If we have saved the result, then close this stream out
+                            Poll::Ready(None)
+                        } else {
+                            // Otherwise we got a finish before seeing the result
+                            Poll::Ready(Some(Err(CodeGenerationExecutionError::FinishBeforeResult)))
+                        }
+                    }
+                    // We got an unexpected message
+                    unexpected => Poll::Ready(Some(Err(
+                        CodeGenerationExecutionError::MessageBeforeStart(unexpected),
+                    ))),
+                }
+            }
+            // We successfully got an unexpected websocket message type that was not text
+            Poll::Ready(Some(Ok(unexpected))) => Poll::Ready(Some(Err(
+                CodeGenerationExecutionError::UnexpectedMessageType(unexpected),
+            ))),
+            // We failed to get the next websocket message
+            Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(CodeGenerationExecutionError::WSReadIO(err))))
+            }
+            // We see the end of the websocket stream, but finish was never sent
+            Poll::Ready(None) => Poll::Ready(Some(Err(
+                CodeGenerationExecutionError::WSClosedBeforeFinish,
+            ))),
+            // Not ready, so...not ready!
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CodeGenerationExecutionClosing<T> {
+    stream: WebSocketStream<T>,
+    result: FunctionResult<CodeGenerationResultSuccess>,
+}
+
+impl<T> TryFrom<CodeGenerationExecutionStarted<T>> for CodeGenerationExecutionClosing<T> {
+    type Error = CodeGenerationExecutionError;
+
+    fn try_from(value: CodeGenerationExecutionStarted<T>) -> Result<Self> {
+        match value.result {
+            Some(result) => Ok(Self {
+                stream: value.stream,
+                result,
+            }),
+            None => Err(Self::Error::ClosingWithoutResult),
+        }
+    }
+}
+
+impl<T> CodeGenerationExecutionClosing<T>
+where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+{
+    async fn finish(mut self) -> Result<FunctionResult<CodeGenerationResultSuccess>> {
+        match self.stream.next().await {
+            Some(Ok(WebSocketMessage::Close(_))) | None => Ok(self.result),
+            Some(Ok(unexpected)) => {
+                Err(CodeGenerationExecutionError::MessageAfterFinish(unexpected))
+            }
+            Some(Err(err)) => Err(CodeGenerationExecutionError::WSReadIO(err)),
+        }
+    }
+}

--- a/lib/cyclone/src/code_generation.rs
+++ b/lib/cyclone/src/code_generation.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodeGenerationRequest {
+    pub execution_id: String,
+    pub handler: String,
+    pub component: CodeGenerationComponent,
+    pub code_base64: String,
+}
+
+impl CodeGenerationRequest {
+    pub fn deserialize_from_str(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+
+    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CodeGenerationComponent {
+    pub name: String,
+    pub properties: HashMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CodeGenerationResultSuccess {
+    pub execution_id: String,
+    pub timestamp: u64,
+    pub data: serde_json::Value,
+}

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -12,6 +12,7 @@
 )]
 
 pub mod canonical_command;
+mod code_generation;
 mod liveness;
 mod progress;
 mod qualification_check;
@@ -19,6 +20,9 @@ mod readiness;
 mod resolver_function;
 mod resource_sync;
 
+pub use code_generation::{
+    CodeGenerationComponent, CodeGenerationRequest, CodeGenerationResultSuccess,
+};
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use progress::{
     FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,

--- a/lib/cyclone/src/server.rs
+++ b/lib/cyclone/src/server.rs
@@ -5,6 +5,7 @@ pub use routes::routes;
 pub use server::Server;
 pub use uds::{UdsIncomingStream, UdsIncomingStreamError};
 
+pub mod code_generation;
 mod config;
 pub(crate) mod extract;
 mod handlers;

--- a/lib/cyclone/src/server/code_generation.rs
+++ b/lib/cyclone/src/server/code_generation.rs
@@ -1,0 +1,356 @@
+use std::{io, path::PathBuf, process::Stdio, time::Duration};
+
+use axum::extract::ws::WebSocket;
+use bytes_lines_codec::BytesLinesCodec;
+use chrono::Utc;
+use futures::{SinkExt, StreamExt, TryStreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{
+    process::{Child, ChildStdin, ChildStdout, Command},
+    time,
+};
+use tokio_serde::{
+    formats::{Json, SymmetricalJson},
+    Framed, SymmetricallyFramed,
+};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use crate::{
+    process::{self, ShutdownError},
+    server::WebSocketMessage,
+    CodeGenerationRequest, CodeGenerationResultSuccess, FunctionResult, FunctionResultFailure,
+    FunctionResultFailureError, Message, OutputStream,
+};
+
+const TX_TIMEOUT_SECS: Duration = Duration::from_secs(2);
+
+pub fn execute(
+    lang_server_path: impl Into<PathBuf>,
+    lang_server_debugging: bool,
+) -> CodeGenerationExecution {
+    CodeGenerationExecution {
+        lang_server_path: lang_server_path.into(),
+        lang_server_debugging,
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CodeGenerationError {
+    #[error("failed to consume the {0} stream for the child process")]
+    ChildIO(&'static str),
+    #[error("failed to receive child process message")]
+    ChildRecvIO(#[source] io::Error),
+    #[error("failed to send child process message")]
+    ChildSendIO(#[source] io::Error),
+    #[error("failed to spawn child process; program={0}")]
+    ChildSpawn(#[source] io::Error, PathBuf),
+    #[error(transparent)]
+    ChildShutdown(#[from] ShutdownError),
+    #[error("failed to deserialize json message")]
+    JSONDeserialize(#[source] serde_json::Error),
+    #[error("failed to serialize json message")]
+    JSONSerialize(#[source] serde_json::Error),
+    #[error("send timeout")]
+    SendTimeout(#[source] tokio::time::error::Elapsed),
+    #[error("failed to close websocket")]
+    WSClose(#[source] axum::Error),
+    #[error("failed to receive websocket message--stream is closed")]
+    WSRecvClosed,
+    #[error("failed to receive websocket message")]
+    WSRecvIO(#[source] axum::Error),
+    #[error("failed to send websocket message")]
+    WSSendIO(#[source] axum::Error),
+    #[error("unexpected websocket message type: {0:?}")]
+    UnexpectedMessageType(WebSocketMessage),
+}
+
+type Result<T> = std::result::Result<T, CodeGenerationError>;
+
+#[derive(Debug)]
+pub struct CodeGenerationExecution {
+    lang_server_path: PathBuf,
+    lang_server_debugging: bool,
+}
+
+impl CodeGenerationExecution {
+    pub async fn start(self, ws: &mut WebSocket) -> Result<CodeGenerationServerExecutionStarted> {
+        Self::ws_send_start(ws).await?;
+        let request = Self::read_request(ws).await?;
+
+        let mut command = Command::new(&self.lang_server_path);
+        command
+            .arg("codeGeneration")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped());
+        if self.lang_server_debugging {
+            command.env("DEBUG", "*").env("DEBUG_DEPTH", "5");
+        }
+        debug!(cmd = ?command, "spawning child process");
+        let mut child = command
+            .spawn()
+            .map_err(|err| CodeGenerationError::ChildSpawn(err, self.lang_server_path.clone()))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(CodeGenerationError::ChildIO("stdin"))?;
+        Self::child_send_function_request(stdin, request).await?;
+
+        let stdout = {
+            let stdout = child
+                .stdout
+                .take()
+                .ok_or(CodeGenerationError::ChildIO("stdout"))?;
+            let codec = FramedRead::new(stdout, BytesLinesCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+
+        Ok(CodeGenerationServerExecutionStarted { child, stdout })
+    }
+
+    async fn read_request(ws: &mut WebSocket) -> Result<CodeGenerationRequest> {
+        let request = match ws.next().await {
+            Some(Ok(WebSocketMessage::Text(json_str))) => {
+                CodeGenerationRequest::deserialize_from_str(&json_str)
+                    .map_err(CodeGenerationError::JSONDeserialize)?
+            }
+            Some(Ok(unexpected)) => {
+                return Err(CodeGenerationError::UnexpectedMessageType(unexpected))
+            }
+            Some(Err(err)) => return Err(CodeGenerationError::WSRecvIO(err)),
+            None => return Err(CodeGenerationError::WSRecvClosed),
+        };
+        Ok(request)
+    }
+
+    async fn ws_send_start(ws: &mut WebSocket) -> Result<()> {
+        let msg = Message::<CodeGenerationResultSuccess>::Start
+            .serialize_to_string()
+            .map_err(CodeGenerationError::JSONSerialize)?;
+
+        time::timeout(TX_TIMEOUT_SECS, ws.send(WebSocketMessage::Text(msg)))
+            .await
+            .map_err(CodeGenerationError::SendTimeout)?
+            .map_err(CodeGenerationError::WSSendIO)?;
+        Ok(())
+    }
+
+    async fn child_send_function_request(
+        stdin: ChildStdin,
+        request: CodeGenerationRequest,
+    ) -> Result<()> {
+        let codec = FramedWrite::new(stdin, BytesLinesCodec::new());
+        let mut stdin = SymmetricallyFramed::new(codec, SymmetricalJson::default());
+
+        time::timeout(TX_TIMEOUT_SECS, stdin.send(request))
+            .await
+            .map_err(CodeGenerationError::SendTimeout)?
+            .map_err(CodeGenerationError::ChildSendIO)?;
+        time::timeout(TX_TIMEOUT_SECS, stdin.close())
+            .await
+            .map_err(CodeGenerationError::SendTimeout)?
+            .map_err(CodeGenerationError::ChildSendIO)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct CodeGenerationServerExecutionStarted {
+    child: Child,
+    stdout: Framed<
+        FramedRead<ChildStdout, BytesLinesCodec>,
+        LangServerCodeGenerationMessage,
+        LangServerCodeGenerationMessage,
+        Json<LangServerCodeGenerationMessage, LangServerCodeGenerationMessage>,
+    >,
+}
+
+impl CodeGenerationServerExecutionStarted {
+    pub async fn process(self, ws: &mut WebSocket) -> Result<CodeGenerationServerExecutionClosing> {
+        let mut stream = self
+            .stdout
+            .map(|ls_result| match ls_result {
+                Ok(ls_msg) => match ls_msg {
+                    LangServerCodeGenerationMessage::Output(output) => {
+                        Ok(Message::OutputStream(output.into()))
+                    }
+                    LangServerCodeGenerationMessage::Result(result) => {
+                        Ok(Message::Result(result.into()))
+                    }
+                },
+                Err(err) => Err(CodeGenerationError::ChildRecvIO(err)),
+            })
+            .map(|msg_result: Result<_>| match msg_result {
+                Ok(msg) => match msg
+                    .serialize_to_string()
+                    .map_err(CodeGenerationError::JSONSerialize)
+                {
+                    Ok(json_str) => Ok(WebSocketMessage::Text(json_str)),
+                    Err(err) => Err(err),
+                },
+                Err(err) => Err(err),
+            });
+
+        while let Some(msg) = stream.try_next().await? {
+            ws.send(msg).await.map_err(CodeGenerationError::WSSendIO)?;
+        }
+
+        Ok(CodeGenerationServerExecutionClosing { child: self.child })
+    }
+}
+
+#[derive(Debug)]
+pub struct CodeGenerationServerExecutionClosing {
+    child: Child,
+}
+
+impl CodeGenerationServerExecutionClosing {
+    pub async fn finish(mut self, mut ws: WebSocket) -> Result<()> {
+        let finished = Self::ws_send_finish(&mut ws).await;
+        let closed = Self::ws_close(ws).await;
+        let shutdown =
+            process::child_shutdown(&mut self.child, Some(process::Signal::SIGTERM), None)
+                .await
+                .map_err(Into::into);
+        drop(self.child);
+
+        match (finished, closed, shutdown) {
+            // Everything succeeds, great!
+            (Ok(_), Ok(_), Ok(_)) => Ok(()),
+
+            // One of the steps failed, return its error
+            (Ok(_), Ok(_), Err(err)) | (Ok(_), Err(err), Ok(_)) | (Err(err), Ok(_), Ok(_)) => {
+                Err(err)
+            }
+
+            // 2/3 steps errored so warn about the lower priority error and return the highest
+            // priority
+            (Ok(_), Err(err), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                Err(err)
+            }
+            (Err(err), Ok(_), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                Err(err)
+            }
+            (Err(err), Err(closed), Ok(_)) => {
+                warn!(error = ?closed, "failed to cleanly close websocket");
+                Err(err)
+            }
+
+            // All steps failed so warn about the lower priorities and return the highest priority
+            (Err(err), Err(closed), Err(shutdown)) => {
+                warn!(error = ?shutdown, "failed to shutdown child cleanly");
+                warn!(error = ?closed, "failed to cleanly close websocket");
+                Err(err)
+            }
+        }
+    }
+
+    async fn ws_send_finish(ws: &mut WebSocket) -> Result<()> {
+        let msg = Message::<CodeGenerationResultSuccess>::Finish
+            .serialize_to_string()
+            .map_err(CodeGenerationError::JSONSerialize)?;
+        time::timeout(TX_TIMEOUT_SECS, ws.send(WebSocketMessage::Text(msg)))
+            .await
+            .map_err(CodeGenerationError::SendTimeout)?
+            .map_err(CodeGenerationError::WSSendIO)?;
+
+        Ok(())
+    }
+
+    async fn ws_close(ws: WebSocket) -> Result<()> {
+        ws.close().await.map_err(CodeGenerationError::WSClose)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "protocol", rename_all = "camelCase")]
+enum LangServerCodeGenerationMessage {
+    Output(LangServerOutput),
+    Result(LangServerResult),
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerOutput {
+    execution_id: String,
+    stream: String,
+    level: String,
+    group: Option<String>,
+    message: String,
+    data: Option<Value>,
+}
+
+impl From<LangServerOutput> for OutputStream {
+    fn from(value: LangServerOutput) -> Self {
+        Self {
+            execution_id: value.execution_id,
+            stream: value.stream,
+            level: value.level,
+            group: value.group,
+            data: value.data,
+            message: value.message,
+            timestamp: timestamp(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+enum LangServerResult {
+    Success(LangServerSuccess),
+    Failure(LangServerFailure),
+}
+
+impl From<LangServerResult> for FunctionResult<CodeGenerationResultSuccess> {
+    fn from(value: LangServerResult) -> Self {
+        match value {
+            LangServerResult::Success(success) => Self::Success(CodeGenerationResultSuccess {
+                execution_id: success.execution_id,
+                timestamp: timestamp(),
+                data: success.data,
+            }),
+            LangServerResult::Failure(failure) => Self::Failure(FunctionResultFailure {
+                execution_id: failure.execution_id,
+                error: FunctionResultFailureError {
+                    kind: failure.error.kind,
+                    message: failure.error.message,
+                },
+                timestamp: timestamp(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerSuccess {
+    execution_id: String,
+    message: Option<String>,
+    data: Value,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerFailure {
+    #[serde(default)]
+    execution_id: String,
+    error: LangServerFailureError,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LangServerFailureError {
+    kind: String,
+    message: String,
+}
+
+fn timestamp() -> u64 {
+    // We're going eat any timestamp values that are negative (it is an `i64`) and replace them
+    // with 0, which will then safely fit in a `u64` without overflow/underflow
+    u64::try_from(std::cmp::max(Utc::now().timestamp(), 0)).expect("timestamp not be negative")
+}

--- a/lib/cyclone/src/server/config.rs
+++ b/lib/cyclone/src/server/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     #[builder(default = "true")]
     enable_sync: bool,
 
+    #[builder(default = "true")]
+    enable_code_generation: bool,
+
     #[builder(default = "IncomingStream::default()")]
     incoming_stream: IncomingStream,
 
@@ -83,6 +86,12 @@ impl Config {
     #[must_use]
     pub fn enable_sync(&self) -> bool {
         self.enable_sync
+    }
+
+    /// Gets a reference to the config's enable sync.
+    #[must_use]
+    pub fn enable_code_generation(&self) -> bool {
+        self.enable_code_generation
     }
 
     /// Gets a reference to the config's incoming stream.

--- a/lib/cyclone/src/server/routes.rs
+++ b/lib/cyclone/src/server/routes.rs
@@ -122,6 +122,15 @@ fn execute_routes(config: &Config, shutdown_tx: mpsc::Sender<ShutdownSource>) ->
             .or(Router::new().route("/sync", get(handlers::ws_execute_sync)))
             .boxed();
     }
+    if config.enable_code_generation() {
+        debug!("enabling code generation endpoint");
+        router = router
+            .or(Router::new().route(
+                "/code_generation",
+                get(handlers::ws_execute_code_generation),
+            ))
+            .boxed();
+    }
 
     let limit_requests = Arc::new(config.limit_requests().map(|i| i.into()));
 

--- a/lib/dal/src/code_generation_prototype.rs
+++ b/lib/dal/src/code_generation_prototype.rs
@@ -1,0 +1,211 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::FuncId, impl_standard_model, pk, standard_model, standard_model_accessor, ComponentId,
+    HistoryActor, HistoryEventError, SchemaId, SchemaVariantId, StandardModel, StandardModelError,
+    SystemId, Tenancy, Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum CodeGenerationPrototypeError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+    #[error("component not found: {0}")]
+    ComponentNotFound(ComponentId),
+    #[error("component error: {0}")]
+    Component(String),
+    #[error("schema not found")]
+    SchemaNotFound,
+    #[error("schema variant not found")]
+    SchemaVariantNotFound,
+}
+
+pub type CodeGenerationPrototypeResult<T> = Result<T, CodeGenerationPrototypeError>;
+
+pub const UNSET_ID_VALUE: i64 = -1;
+const FIND_FOR_CONTEXT: &str =
+    include_str!("./queries/code_generation_prototype_find_for_context.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CodeGenerationPrototypeContext {
+    component_id: ComponentId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+}
+
+// Hrm - is this a universal resolver context? -- Adam
+impl Default for CodeGenerationPrototypeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeGenerationPrototypeContext {
+    pub fn new() -> Self {
+        Self {
+            component_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(CodeGenerationPrototypePk);
+pk!(CodeGenerationPrototypeId);
+
+// An CodeGenerationPrototype joins a `Func` to the context in which
+// the component that is created with it can use to generate a CodeGenerationResolver.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CodeGenerationPrototype {
+    pk: CodeGenerationPrototypePk,
+    id: CodeGenerationPrototypeId,
+    func_id: FuncId,
+    args: serde_json::Value,
+    #[serde(flatten)]
+    context: CodeGenerationPrototypeContext,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: CodeGenerationPrototype,
+    pk: CodeGenerationPrototypePk,
+    id: CodeGenerationPrototypeId,
+    table_name: "code_generation_prototypes",
+    history_event_label_base: "code_generation_prototype",
+    history_event_message_name: "CodeGeneration Prototype"
+}
+
+impl CodeGenerationPrototype {
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        func_id: FuncId,
+        args: serde_json::Value,
+        context: CodeGenerationPrototypeContext,
+    ) -> CodeGenerationPrototypeResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM code_generation_prototype_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    &tenancy,
+                    &visibility,
+                    &func_id,
+                    &args,
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(func_id, Pk(FuncId), CodeGenerationPrototypeResult);
+    standard_model_accessor!(args, Json<JsonValue>, CodeGenerationPrototypeResult);
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_for_component(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        component_id: ComponentId,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+        system_id: SystemId,
+    ) -> CodeGenerationPrototypeResult<Vec<Self>> {
+        let rows = txn
+            .query(
+                FIND_FOR_CONTEXT,
+                &[
+                    &tenancy,
+                    &visibility,
+                    &component_id,
+                    &system_id,
+                    &schema_variant_id,
+                    &schema_id,
+                ],
+            )
+            .await?;
+        let object = standard_model::objects_from_rows(rows)?;
+        Ok(object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CodeGenerationPrototypeContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = CodeGenerationPrototypeContext::new();
+        c.set_component_id(22.into());
+        assert_eq!(c.component_id(), 22.into());
+    }
+}

--- a/lib/dal/src/code_generation_resolver.rs
+++ b/lib/dal/src/code_generation_resolver.rs
@@ -1,0 +1,210 @@
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, NatsTxn, PgError, PgTxn};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::{binding::FuncBindingId, FuncId},
+    impl_standard_model, pk, standard_model, standard_model_accessor, CodeGenerationPrototypeId,
+    ComponentId, HistoryActor, HistoryEventError, SchemaId, SchemaVariantId, StandardModel,
+    StandardModelError, SystemId, Tenancy, Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum CodeGenerationResolverError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type CodeGenerationResolverResult<T> = Result<T, CodeGenerationResolverError>;
+
+pub const UNSET_ID_VALUE: i64 = -1;
+const FIND_FOR_PROTOTYPE: &str =
+    include_str!("./queries/code_generation_resolver_find_for_context.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CodeGenerationResolverContext {
+    component_id: ComponentId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+}
+
+// Hrm - is this a universal resolver context? -- Adam
+impl Default for CodeGenerationResolverContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeGenerationResolverContext {
+    pub fn new() -> Self {
+        CodeGenerationResolverContext {
+            component_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(CodeGenerationResolverPk);
+pk!(CodeGenerationResolverId);
+
+// An CodeGenerationResolver joins a `FuncBinding` to the context in which
+// its corresponding `FuncBindingResultValue` is consumed.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CodeGenerationResolver {
+    pk: CodeGenerationResolverPk,
+    id: CodeGenerationResolverId,
+    code_generation_prototype_id: CodeGenerationPrototypeId,
+    func_id: FuncId,
+    func_binding_id: FuncBindingId,
+    #[serde(flatten)]
+    context: CodeGenerationResolverContext,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: CodeGenerationResolver,
+    pk: CodeGenerationResolverPk,
+    id: CodeGenerationResolverId,
+    table_name: "code_generation_resolvers",
+    history_event_label_base: "code_generation_resolver",
+    history_event_message_name: "CodeGeneration Resolver"
+}
+
+impl CodeGenerationResolver {
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(txn, nats))]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        code_generation_prototype_id: CodeGenerationPrototypeId,
+        func_id: FuncId,
+        func_binding_id: FuncBindingId,
+        context: CodeGenerationResolverContext,
+    ) -> CodeGenerationResolverResult<Self> {
+        let row = txn
+            .query_one(
+                "SELECT object FROM code_generation_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[
+                    &tenancy,
+                    &visibility,
+                    &code_generation_prototype_id,
+                    &func_id,
+                    &func_binding_id,
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(
+        code_generation_prototype_id,
+        Pk(CodeGenerationPrototypeId),
+        CodeGenerationResolverResult
+    );
+    standard_model_accessor!(func_id, Pk(FuncId), CodeGenerationResolverResult);
+    standard_model_accessor!(
+        func_binding_id,
+        Pk(FuncBindingId),
+        CodeGenerationResolverResult
+    );
+
+    pub async fn find_for_prototype_and_component(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        code_generation_prototype_id: &CodeGenerationPrototypeId,
+        component_id: &ComponentId,
+    ) -> CodeGenerationResolverResult<Vec<Self>> {
+        let rows = txn
+            .query(
+                FIND_FOR_PROTOTYPE,
+                &[
+                    &tenancy,
+                    &visibility,
+                    code_generation_prototype_id,
+                    component_id,
+                ],
+            )
+            .await?;
+        let object = standard_model::objects_from_rows(rows)?;
+        Ok(object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CodeGenerationResolverContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = CodeGenerationResolverContext::new();
+        c.set_component_id(15.into());
+        assert_eq!(c.component_id(), 15.into());
+    }
+}

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -8,6 +8,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::attribute_resolver::{AttributeResolverContext, UNSET_ID_VALUE};
+use crate::code_generation_resolver::CodeGenerationResolverContext;
 use crate::edit_field::{
     value_and_visibility_diff, value_and_visibility_diff_json_option, widget::prelude::*,
     EditField, EditFieldAble, EditFieldBaggage, EditFieldBaggageComponentProp, EditFieldDataType,
@@ -16,6 +17,7 @@ use crate::edit_field::{
 use crate::func::backend::integer::FuncBackendIntegerArgs;
 use crate::func::backend::validation::{FuncBackendValidateStringValueArgs, ValidationError};
 use crate::func::backend::{
+    js_code_generation::FuncBackendJsCodeGenerationArgs,
     js_qualification::FuncBackendJsQualificationArgs, js_resource::FuncBackendJsResourceSyncArgs,
     js_string::FuncBackendJsStringArgs, string::FuncBackendStringArgs,
 };
@@ -37,9 +39,10 @@ use crate::func::backend::prop_object::FuncBackendPropObjectArgs;
 use crate::{
     impl_standard_model, pk, qualification::QualificationError, standard_model,
     standard_model_accessor, standard_model_belongs_to, standard_model_has_many, AttributeResolver,
-    AttributeResolverError, BillingAccountId, Func, FuncBackendKind, HistoryActor,
-    HistoryEventError, Node, NodeError, OrganizationError, Prop, PropId, PropKind,
-    QualificationPrototype, QualificationPrototypeError, QualificationResolver,
+    AttributeResolverError, BillingAccountId, CodeGenerationPrototype,
+    CodeGenerationPrototypeError, CodeGenerationResolver, CodeGenerationResolverError, Func,
+    FuncBackendKind, HistoryActor, HistoryEventError, Node, NodeError, OrganizationError, Prop,
+    PropId, PropKind, QualificationPrototype, QualificationPrototypeError, QualificationResolver,
     QualificationResolverError, Resource, ResourceError, ResourcePrototype, ResourcePrototypeError,
     ResourceResolver, ResourceResolverError, ResourceView, Schema, SchemaError, SchemaId,
     StandardModel, StandardModelError, SystemId, Tenancy, Timestamp, ValidationPrototype,
@@ -61,6 +64,10 @@ pub enum ComponentError {
     ResourcePrototype(#[from] ResourcePrototypeError),
     #[error("resource resolver error: {0}")]
     ResourceResolver(#[from] ResourceResolverError),
+    #[error("code generation prototype error: {0}")]
+    CodeGenerationPrototype(#[from] CodeGenerationPrototypeError),
+    #[error("code generation resolver error: {0}")]
+    CodeGenerationResolver(#[from] CodeGenerationResolverError),
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("pg error: {0}")]
@@ -465,6 +472,18 @@ impl Component {
 
         component
             .check_qualifications(
+                txn,
+                nats,
+                veritech.clone(),
+                tenancy,
+                visibility,
+                history_actor,
+                UNSET_ID_VALUE.into(), // TODO: properly obtain a system_id
+            )
+            .await?;
+
+        component
+            .generate_code(
                 txn,
                 nats,
                 veritech,
@@ -966,6 +985,114 @@ impl Component {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub async fn generate_code(
+        &self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        veritech: veritech::Client,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        system_id: SystemId,
+    ) -> ComponentResult<()> {
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
+
+        let schema = self
+            .schema_with_tenancy(txn, &schema_tenancy, visibility)
+            .await?
+            .ok_or(ComponentError::SchemaNotFound)?;
+        let schema_variant = self
+            .schema_variant_with_tenancy(txn, &schema_tenancy, visibility)
+            .await?
+            .ok_or(ComponentError::SchemaVariantNotFound)?;
+
+        let code_generation_prototypes = CodeGenerationPrototype::find_for_component(
+            txn,
+            &schema_tenancy,
+            visibility,
+            *self.id(),
+            *schema.id(),
+            *schema_variant.id(),
+            system_id,
+        )
+        .await?;
+
+        for prototype in code_generation_prototypes {
+            let func = Func::get_by_id(txn, &schema_tenancy, visibility, &prototype.func_id())
+                .await?
+                .ok_or_else(|| ComponentError::MissingFunc(prototype.func_id().to_string()))?;
+
+            let args = FuncBackendJsCodeGenerationArgs {
+                component: self
+                    .veritech_code_generation_component(txn, &schema_tenancy, visibility)
+                    .await?,
+            };
+            let json_args = serde_json::to_value(args)?;
+
+            let (func_binding, created) = FuncBinding::find_or_create(
+                txn,
+                nats,
+                &schema_tenancy,
+                visibility,
+                history_actor,
+                json_args,
+                prototype.func_id(),
+                *func.backend_kind(),
+            )
+            .await?;
+
+            if created {
+                // Note for future humans - if this isn't a built in, then we need to
+                // think about execution time. Probably higher up than this? But just
+                // an FYI.
+                func_binding.execute(txn, nats, veritech.clone()).await?;
+
+                let mut existing_resolvers =
+                    CodeGenerationResolver::find_for_prototype_and_component(
+                        txn,
+                        &schema_tenancy,
+                        visibility,
+                        prototype.id(),
+                        self.id(),
+                    )
+                    .await?;
+
+                // If we do not have one, create the code generation resolver. If we do, update the
+                // func binding id to point to the new value.
+                if let Some(mut resolver) = existing_resolvers.pop() {
+                    resolver
+                        .set_func_binding_id(
+                            txn,
+                            nats,
+                            visibility,
+                            history_actor,
+                            *func_binding.id(),
+                        )
+                        .await?;
+                } else {
+                    let mut resolver_context = CodeGenerationResolverContext::new();
+                    resolver_context.set_component_id(*self.id());
+                    CodeGenerationResolver::new(
+                        txn,
+                        nats,
+                        tenancy,
+                        visibility,
+                        history_actor,
+                        *prototype.id(),
+                        *func.id(),
+                        *func_binding.id(),
+                        resolver_context,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     #[tracing::instrument(skip(txn))]
     pub async fn list_validations_as_qualification_for_component_id(
         txn: &PgTxn<'_>,
@@ -1157,6 +1284,31 @@ impl Component {
             name: self.name().into(),
             properties: HashMap::new(),
             parents,
+        };
+
+        for edit_field in Self::get_edit_fields(txn, &tenancy, visibility, self.id()).await? {
+            // This whole segment needs to be replaced with something that can handle the
+            // full complexity here.
+            if let Some(v) = edit_field.value {
+                component.properties.insert(edit_field.name, v);
+            }
+        }
+
+        Ok(component)
+    }
+
+    pub async fn veritech_code_generation_component(
+        &self,
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+    ) -> ComponentResult<veritech::CodeGenerationComponent> {
+        let mut tenancy = tenancy.clone();
+        tenancy.universal = true;
+
+        let mut component = veritech::CodeGenerationComponent {
+            name: self.name().into(),
+            properties: HashMap::new(),
         };
 
         for edit_field in Self::get_edit_fields(txn, &tenancy, visibility, self.id()).await? {

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -8,6 +8,7 @@ use crate::{edit_field::ToSelectWidget, label_list::ToLabelList, PropKind};
 pub mod array;
 pub mod boolean;
 pub mod integer;
+pub mod js_code_generation;
 pub mod js_qualification;
 pub mod js_resource;
 pub mod js_string;
@@ -62,6 +63,7 @@ pub enum FuncBackendKind {
     Integer,
     JsQualification,
     JsResourceSync,
+    JsCodeGeneration,
     JsString,
     PropObject,
     String,
@@ -95,6 +97,7 @@ pub enum FuncBackendResponseType {
     PropObject,
     Qualification,
     ResourceSync,
+    CodeGeneration,
     String,
     Unset,
     // Commented out while we climb back up - Adam & Fletcher

--- a/lib/dal/src/func/backend/js_code_generation.rs
+++ b/lib/dal/src/func/backend/js_code_generation.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+use tokio::sync::mpsc;
+use veritech::{
+    Client, CodeGenerationComponent, CodeGenerationRequest, FunctionResult, OutputStream,
+};
+
+use crate::func::backend::{FuncBackendError, FuncBackendResult};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendJsCodeGenerationResult {
+    format: String,
+    code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendJsCodeGenerationArgs {
+    pub component: CodeGenerationComponent,
+}
+
+#[derive(Debug)]
+pub struct FuncBackendJsCodeGeneration {
+    veritech: Client,
+    output_tx: mpsc::Sender<OutputStream>,
+    request: CodeGenerationRequest,
+}
+
+impl FuncBackendJsCodeGeneration {
+    pub fn new(
+        veritech: Client,
+        output_tx: mpsc::Sender<OutputStream>,
+        handler: impl Into<String>,
+        component: CodeGenerationComponent,
+        code_base64: impl Into<String>,
+    ) -> Self {
+        let request = CodeGenerationRequest {
+            // Once we start tracking the state of these executions, then this id will be useful,
+            // but for now it's passed along and back, and is opaue
+            execution_id: "wagnermoura".to_string(),
+            handler: handler.into(),
+            component,
+            code_base64: code_base64.into(),
+        };
+
+        Self {
+            veritech,
+            output_tx,
+            request,
+        }
+    }
+
+    #[instrument(
+    name = "funcbackendjscodegeneration.execute",
+    skip_all,
+    level = "debug",
+    fields(
+    otel.kind = %SpanKind::Client,
+    otel.status_code = Empty,
+    otel.status_message = Empty,
+    si.func.result = Empty
+    )
+    )]
+    pub async fn execute(self) -> FuncBackendResult<serde_json::Value> {
+        let span = Span::current();
+
+        let result = self
+            .veritech
+            .execute_code_generation(self.output_tx, &self.request)
+            .await
+            .map_err(|err| span.record_err(err))?;
+        let value = match result {
+            FunctionResult::Success(check_result) => serde_json::to_value(&check_result)?,
+            FunctionResult::Failure(failure) => {
+                return Err(span.record_err(FuncBackendError::ResultFailure {
+                    kind: failure.error.kind,
+                    message: failure.error.message,
+                }));
+            }
+        };
+
+        span.record_ok();
+        span.record("si.func.result", &tracing::field::debug(&value));
+        Ok(value)
+    }
+}

--- a/lib/dal/src/func/builtins/generateYAML.js
+++ b/lib/dal/src/func/builtins/generateYAML.js
@@ -1,0 +1,7 @@
+function generateYAML(component) {
+  return {
+    format: "yaml",
+    // TODO: do we want the whole component, just the properties, is there a need for value mapping or is this correct?
+    code: YAML.stringify(component),
+  };
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -7,6 +7,8 @@ pub mod attribute_resolver;
 pub mod billing_account;
 pub mod capability;
 pub mod change_set;
+pub mod code_generation_prototype;
+pub mod code_generation_resolver;
 pub mod component;
 pub mod edge;
 pub mod edit_field;
@@ -53,6 +55,12 @@ pub use billing_account::{
 };
 pub use capability::{Capability, CapabilityError, CapabilityId, CapabilityPk, CapabilityResult};
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetPk, ChangeSetStatus, NO_CHANGE_SET_PK};
+pub use code_generation_prototype::{
+    CodeGenerationPrototype, CodeGenerationPrototypeError, CodeGenerationPrototypeId,
+};
+pub use code_generation_resolver::{
+    CodeGenerationResolver, CodeGenerationResolverError, CodeGenerationResolverId,
+};
 pub use component::{Component, ComponentError, ComponentId};
 pub use edge::{Edge, EdgeError, EdgeResult};
 pub use edit_session::{

--- a/lib/dal/src/migrations/U0052__code_generation_prototype.sql
+++ b/lib/dal/src/migrations/U0052__code_generation_prototype.sql
@@ -1,0 +1,75 @@
+CREATE TABLE code_generation_prototypes
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    func_id                     bigint                   NOT NULL,
+    args                        jsonb                    NOT NULL,
+    component_id                bigint                   NOT NULL,
+    schema_id                   bigint                   NOT NULL,
+    schema_variant_id           bigint                   NOT NULL,
+    system_id                   bigint                   NOT NULL
+);
+SELECT standard_model_table_constraints_v1('code_generation_prototypes');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('code_generation_prototypes', 'model', 'code_generation_prototype', 'code generation Prototype');
+
+CREATE OR REPLACE FUNCTION code_generation_prototype_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id bigint,
+    this_args jsonb,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           code_generation_prototypes%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO code_generation_prototypes (tenancy_universal,
+                                       tenancy_billing_account_ids,
+                                       tenancy_organization_ids,
+                                       tenancy_workspace_ids,
+                                       visibility_change_set_pk,
+                                       visibility_edit_session_pk,
+                                       visibility_deleted,
+                                       func_id,
+                                       args,
+                                       component_id,
+                                       schema_id,
+                                       schema_variant_id,
+                                       system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_func_id,
+            this_args,
+            this_component_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/migrations/U0053__code_generation_resolver.sql
+++ b/lib/dal/src/migrations/U0053__code_generation_resolver.sql
@@ -1,0 +1,79 @@
+CREATE TABLE code_generation_resolvers
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    code_generation_prototype_id  bigint                   NOT NULL,
+    func_id                     bigint                   NOT NULL,
+    func_binding_id             bigint                   NOT NULL,
+    component_id                bigint                   NOT NULL,
+    schema_id                   bigint                   NOT NULL,
+    schema_variant_id           bigint                   NOT NULL,
+    system_id                   bigint                   NOT NULL
+);
+SELECT standard_model_table_constraints_v1('code_generation_resolvers');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('code_generation_resolvers', 'model', 'code_generation_resolver', 'code generation Resolver');
+
+CREATE OR REPLACE FUNCTION code_generation_resolver_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_code_generation_prototype_id bigint,
+    this_func_id bigint,
+    this_func_binding_id bigint,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           code_generation_resolvers%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO code_generation_resolvers (tenancy_universal,
+                                     tenancy_billing_account_ids,
+                                     tenancy_organization_ids,
+                                     tenancy_workspace_ids,
+                                     visibility_change_set_pk,
+                                     visibility_edit_session_pk,
+                                     visibility_deleted,
+                                     code_generation_prototype_id,
+                                     func_id,
+                                     func_binding_id,
+                                     component_id,
+                                     schema_id,
+                                     schema_variant_id,
+                                     system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_code_generation_prototype_id,
+            this_func_id,
+            this_func_binding_id,
+            this_component_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/code_generation_find_for_prototype.sql
+++ b/lib/dal/src/queries/code_generation_find_for_prototype.sql
@@ -1,0 +1,21 @@
+SELECT DISTINCT ON (code_generation_resolvers.id) code_generation_resolvers.id,
+                                             code_generation_resolvers.visibility_change_set_pk,
+                                             code_generation_resolvers.visibility_edit_session_pk,
+                                             code_generation_resolvers.component_id,
+                                             code_generation_resolvers.schema_id,
+                                             code_generation_resolvers.schema_variant_id,
+                                             code_generation_resolvers.system_id,
+                                             row_to_json(code_generation_resolvers.*) as object
+FROM code_generation_resolvers
+WHERE in_tenancy_v1($1, code_generation_resolvers.tenancy_universal, code_generation_resolvers.tenancy_billing_account_ids, code_generation_resolvers.tenancy_organization_ids,
+                    code_generation_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, code_generation_resolvers.visibility_change_set_pk, code_generation_resolvers.visibility_edit_session_pk, code_generation_resolvers.visibility_deleted)
+  AND code_generation_resolvers.code_generation_prototype_id = $3
+  AND code_generation_resolvers.component_id = $4
+ORDER BY code_generation_resolvers.id,
+         visibility_change_set_pk DESC,
+         visibility_edit_session_pk DESC,
+         component_id DESC,
+         system_id DESC,
+         schema_variant_id DESC,
+         schema_id DESC;

--- a/lib/dal/src/queries/code_generation_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/code_generation_prototype_find_for_context.sql
@@ -1,0 +1,24 @@
+SELECT DISTINCT ON (code_generation_prototypes.id) code_generation_prototypes.id,
+    code_generation_prototypes.component_id,
+    code_generation_prototypes.schema_id,
+    code_generation_prototypes.schema_variant_id,
+    code_generation_prototypes.system_id,
+    code_generation_prototypes.visibility_change_set_pk,
+    code_generation_prototypes.visibility_edit_session_pk,
+    row_to_json(code_generation_prototypes.*) AS object
+  FROM code_generation_prototypes
+  WHERE in_tenancy_v1($1, code_generation_prototypes.tenancy_universal, code_generation_prototypes.tenancy_billing_account_ids, code_generation_prototypes.tenancy_organization_ids,
+      code_generation_prototypes.tenancy_workspace_ids)
+    AND is_visible_v1($2, code_generation_prototypes.visibility_change_set_pk, code_generation_prototypes.visibility_edit_session_pk, code_generation_prototypes.visibility_deleted)
+    AND (code_generation_prototypes.schema_id = $6
+            OR code_generation_prototypes.schema_variant_id = $5
+            OR code_generation_prototypes.component_id = $3)
+    AND (code_generation_prototypes.system_id = $4 OR code_generation_prototypes.system_id = -1)
+ORDER BY code_generation_prototypes.id,
+    visibility_change_set_pk DESC,
+    visibility_edit_session_pk DESC,
+    component_id DESC,
+    func_id DESC,
+    system_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;

--- a/lib/dal/src/queries/code_generation_resolver_find_for_context.sql
+++ b/lib/dal/src/queries/code_generation_resolver_find_for_context.sql
@@ -1,0 +1,21 @@
+SELECT DISTINCT ON (code_generation_resolvers.id) code_generation_resolvers.id,
+                                             code_generation_resolvers.visibility_change_set_pk,
+                                             code_generation_resolvers.visibility_edit_session_pk,
+                                             code_generation_resolvers.component_id,
+                                             code_generation_resolvers.schema_id,
+                                             code_generation_resolvers.schema_variant_id,
+                                             code_generation_resolvers.system_id,
+                                             row_to_json(code_generation_resolvers.*) as object
+FROM code_generation_resolvers
+WHERE in_tenancy_v1($1, code_generation_resolvers.tenancy_universal, code_generation_resolvers.tenancy_billing_account_ids, code_generation_resolvers.tenancy_organization_ids,
+                    code_generation_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, code_generation_resolvers.visibility_change_set_pk, code_generation_resolvers.visibility_edit_session_pk, code_generation_resolvers.visibility_deleted)
+  AND code_generation_resolvers.code_generation_prototype_id = $3
+  AND code_generation_resolvers.component_id = $4
+ORDER BY code_generation_resolvers.id,
+         visibility_change_set_pk DESC,
+         visibility_edit_session_pk DESC,
+         component_id DESC,
+         system_id DESC,
+         schema_variant_id DESC,
+         schema_id DESC;

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -15,10 +15,11 @@ use crate::{
     impl_standard_model, pk,
     schema::ui_menu::UiMenuId,
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
-    AttributeResolverError, BillingAccount, BillingAccountId, Component, HistoryActor,
-    HistoryEventError, LabelEntry, LabelList, Organization, OrganizationId, PropError,
-    QualificationPrototypeError, ResourcePrototypeError, StandardModel, StandardModelError,
-    Tenancy, Timestamp, ValidationPrototypeError, Visibility, Workspace, WorkspaceId, WsEventError,
+    AttributeResolverError, BillingAccount, BillingAccountId, CodeGenerationPrototypeError,
+    Component, HistoryActor, HistoryEventError, LabelEntry, LabelList, Organization,
+    OrganizationId, PropError, QualificationPrototypeError, ResourcePrototypeError, StandardModel,
+    StandardModelError, Tenancy, Timestamp, ValidationPrototypeError, Visibility, Workspace,
+    WorkspaceId, WsEventError,
 };
 
 use crate::socket::SocketError;
@@ -73,6 +74,8 @@ pub enum SchemaError {
     QualificationPrototype(#[from] QualificationPrototypeError),
     #[error("resource prototype error: {0}")]
     ResourcePrototype(#[from] ResourcePrototypeError),
+    #[error("code generation prototype error: {0}")]
+    CodeGenerationPrototype(#[from] CodeGenerationPrototypeError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -126,6 +126,7 @@ async fn veritech_server_for_uds_cyclone(
             .qualification()
             .resolver()
             .sync()
+            .code_generation()
             .build()
             .expect("failed to build cyclone spec"),
     );

--- a/lib/dal/tests/integration_test/code_generation_prototype.rs
+++ b/lib/dal/tests/integration_test/code_generation_prototype.rs
@@ -1,0 +1,121 @@
+use crate::test_setup;
+
+use dal::code_generation_prototype::CodeGenerationPrototypeContext;
+use dal::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
+use dal::test_harness::find_or_create_production_system;
+use dal::{
+    code_generation_prototype::UNSET_ID_VALUE, test_harness::billing_account_signup,
+    CodeGenerationPrototype, Component, Func, HistoryActor, Schema, StandardModel, Tenancy,
+    Visibility,
+};
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech,);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+
+    let name = "docker_image".to_string();
+    let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)
+        .await
+        .expect("cannot find docker image")
+        .pop()
+        .expect("no docker image found");
+    let (component, _node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &name,
+        schema.id(),
+    )
+    .await
+    .expect("could not create component");
+
+    let func_name = "si:generateYAML".to_string();
+    let mut funcs = Func::find_by_attr(&txn, &tenancy, &visibility, "name", &func_name)
+        .await
+        .expect("Error fetching builtin function");
+    let func = funcs
+        .pop()
+        .expect("Missing builtin function si:generateYAML");
+
+    let args = FuncBackendJsCodeGenerationArgs {
+        component: component
+            .veritech_code_generation_component(&txn, &tenancy, &visibility)
+            .await
+            .expect("could not create component code_generation view"),
+    };
+
+    let mut prototype_context = CodeGenerationPrototypeContext::new();
+    prototype_context.set_component_id(*component.id());
+    let _prototype = CodeGenerationPrototype::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *func.id(),
+        serde_json::to_value(&args).expect("serialization failed"),
+        prototype_context,
+    )
+    .await
+    .expect("cannot create new prototype");
+}
+
+#[tokio::test]
+async fn find_for_component() {
+    // TODO: This test is brittle, because it relies on the behavior of docker_image. I'm okay
+    // with that for now, but not for long. If it breaks before we fix it - future person, I'm
+    // sorry. ;)
+
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    tenancy.universal = true;
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let name = "docker_image".to_string();
+    let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)
+        .await
+        .expect("cannot find docker image")
+        .pop()
+        .expect("no docker image found");
+    let default_schema_variant_id = schema
+        .default_schema_variant_id()
+        .expect("cannot get default schema variant id");
+
+    let (component, _node) = Component::new_for_schema_with_node(
+        &txn,
+        &nats,
+        veritech,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "silverado",
+        schema.id(),
+    )
+    .await
+    .expect("cannot create new component");
+
+    let mut found_prototype = CodeGenerationPrototype::find_for_component(
+        &txn,
+        &tenancy,
+        &visibility,
+        *component.id(),
+        *schema.id(),
+        *default_schema_variant_id,
+        UNSET_ID_VALUE.into(),
+    )
+    .await
+    .expect("could not create component code_generation view");
+    let _found = found_prototype
+        .pop()
+        .expect("found no code_generation prototypes");
+}

--- a/lib/dal/tests/integration_test/code_generation_resolver.rs
+++ b/lib/dal/tests/integration_test/code_generation_resolver.rs
@@ -1,0 +1,178 @@
+use crate::test_setup;
+
+use dal::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
+use dal::{
+    code_generation_resolver::{CodeGenerationResolverContext, UNSET_ID_VALUE},
+    func::binding::FuncBinding,
+    test_harness::{billing_account_signup, create_component_for_schema_variant},
+    CodeGenerationResolver, Func, HistoryActor, Schema, StandardModel, Tenancy, Visibility,
+};
+
+#[tokio::test]
+async fn new() {
+    test_setup!(ctx, _secret_key, _pg, _conn, txn, nats_conn, nats, veritech);
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let name = "docker_image".to_string();
+    let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)
+        .await
+        .expect("cannot find docker image")
+        .pop()
+        .expect("no docker image found");
+    let schema_variant = schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("No default schema variant found for schema docker_image");
+
+    let component = create_component_for_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await;
+
+    let func_name = "si:generateYAML".to_owned();
+    let mut funcs = Func::find_by_attr(&txn, &tenancy, &visibility, "name", &func_name)
+        .await
+        .expect("Error fetching builtin function");
+    let func = funcs
+        .pop()
+        .expect("Missing builtin function si:generateYAML");
+
+    let args = FuncBackendJsCodeGenerationArgs {
+        component: component
+            .veritech_code_generation_component(&txn, &tenancy, &visibility)
+            .await
+            .expect("could not create component code_generation view"),
+    };
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats, veritech)
+        .await
+        .expect("failed to execute func binding");
+
+    let mut code_generation_resolver_context = CodeGenerationResolverContext::new();
+    code_generation_resolver_context.set_component_id(*component.id());
+    let _code_generation_esolver = CodeGenerationResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        UNSET_ID_VALUE.into(),
+        *func.id(),
+        *func_binding.id(),
+        code_generation_resolver_context,
+    )
+    .await
+    .expect("cannot create new attribute resolver");
+}
+
+#[tokio::test]
+async fn find_for_prototype() {
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    tenancy.universal = true;
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let name = "docker_image".to_string();
+    let schema = Schema::find_by_attr(&txn, &tenancy, &visibility, "name", &name)
+        .await
+        .expect("cannot find docker image")
+        .pop()
+        .expect("no docker image found");
+
+    let schema_variant = schema
+        .default_variant(&txn, &tenancy, &visibility)
+        .await
+        .expect("No default schema variant found for schema docker_image");
+
+    let component = create_component_for_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await;
+
+    let func_name = "si:generateYAML".to_owned();
+    let mut funcs = Func::find_by_attr(&txn, &tenancy, &visibility, "name", &func_name)
+        .await
+        .expect("Error fetching builtin function");
+    let func = funcs
+        .pop()
+        .expect("Missing builtin function si:generateYAML");
+
+    let args = FuncBackendJsCodeGenerationArgs {
+        component: component
+            .veritech_code_generation_component(&txn, &tenancy, &visibility)
+            .await
+            .expect("could not create component code_generation view"),
+    };
+    let func_binding = FuncBinding::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        serde_json::to_value(args.clone()).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    func_binding
+        .execute(&txn, &nats, veritech)
+        .await
+        .expect("failed to execute func binding");
+
+    let mut resolver_context = CodeGenerationResolverContext::new();
+    resolver_context.set_component_id(*component.id());
+    let created = CodeGenerationResolver::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        UNSET_ID_VALUE.into(),
+        *func.id(),
+        *func_binding.id(),
+        resolver_context,
+    )
+    .await
+    .expect("cannot create new attribute resolver");
+
+    let mut found_resolver = CodeGenerationResolver::find_for_prototype_and_component(
+        &txn,
+        &tenancy,
+        &visibility,
+        &UNSET_ID_VALUE.into(),
+        component.id(),
+    )
+    .await
+    .expect("cannot find resolvers");
+    let found = found_resolver
+        .pop()
+        .expect("found no code_generation resolvers");
+    assert_eq!(created, found);
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -2,6 +2,8 @@ mod attribute_resolver;
 mod billing_account;
 mod capability;
 mod change_set;
+mod code_generation_prototype;
+mod code_generation_resolver;
 mod component;
 mod edge;
 mod edit_session;

--- a/lib/deadpool-cyclone/examples/deadpool-cyclone-code-generation-pool.rs
+++ b/lib/deadpool-cyclone/examples/deadpool-cyclone-code-generation-pool.rs
@@ -1,0 +1,147 @@
+use std::{
+    env, io,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use cyclone::{FunctionResult, ProgressMessage};
+use deadpool_cyclone::{
+    client::{CodeGenerationRequest, CycloneClient},
+    instance::{
+        cyclone::{LocalUdsInstance, LocalUdsInstanceSpec},
+        Instance,
+    },
+    Manager, Pool,
+};
+use futures::{stream, StreamExt, TryStreamExt};
+use tokio::signal;
+use tracing::{error, info};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env("SI_LOG")
+                .unwrap_or_else(|_| EnvFilter::new("info,deadpool_cyclone=trace,cyclone=trace")),
+        )
+        .with(fmt::layer())
+        .try_init()?;
+
+    let concurrency = match env::args().nth(1) {
+        Some(arg) => usize::from_str(&arg)?,
+        None => 4,
+    };
+
+    let spec = LocalUdsInstance::spec()
+        .try_cyclone_cmd_path("../../target/debug/cyclone")?
+        .try_lang_server_cmd_path("../../bin/lang-js/target/lang-js")?
+        .code_generation()
+        .build()?;
+    let manager = Manager::new(spec);
+    let pool = Pool::builder(manager).max_size(64).build()?;
+
+    let ctrl_c = signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    info!("waiting for request on stdin...");
+    let request: CodeGenerationRequest = serde_json::from_reader(io::stdin())?;
+    info!(request = ?request);
+    info!("running executions");
+
+    let count = AtomicU64::new(0);
+
+    let concurrent_executions = stream::repeat_with(|| execute(&pool, &request))
+        .map(Ok)
+        .try_for_each_concurrent(concurrency, |execution_task| async {
+            let result = execution_task.await;
+            count.fetch_add(1, Ordering::SeqCst);
+            result
+        });
+
+    loop {
+        tokio::select! {
+            _ = &mut ctrl_c => {
+                info!("received ctrl-c signal, shutting down");
+                break
+            }
+            result = concurrent_executions => {
+                match result {
+                    Ok(_) => {
+                        info!("finished executions");
+                        break
+                    }
+                    Err(err) => {
+                        error!(error = ?err, "found error in execution stream");
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    info!("closing the pool");
+    pool.close();
+
+    info!(
+        "program complete; executions={}",
+        count.load(Ordering::Relaxed)
+    );
+    Ok(())
+}
+
+async fn execute(
+    pool: &Pool<LocalUdsInstanceSpec>,
+    request: &CodeGenerationRequest,
+) -> Result<(), Box<(dyn std::error::Error + 'static)>> {
+    // Generate a random execution_id
+    let mut request = (*request).clone();
+    request.execution_id = Uuid::new_v4().to_string();
+
+    info!(status = ?pool.status(), "Getting an instance from the pool");
+    let mut instance = pool.get().await?;
+    info!("Checking if instance is healthy");
+    instance.ensure_healthy().await?;
+
+    info!(
+        execution_id = &request.execution_id.as_str(),
+        "Executing code generation"
+    );
+    let mut progress = instance
+        .execute_code_generation(request)
+        .await?
+        .start()
+        .await?;
+    while let Some(message) = progress.try_next().await? {
+        match message {
+            ProgressMessage::Heartbeat => info!("heartbeat"),
+            ProgressMessage::OutputStream(output) => {
+                info!(
+                    execution_id = &output.execution_id.as_str(),
+                    stream = &output.stream.as_str(),
+                    level = &output.level.as_str(),
+                    message = &output.message.as_str(),
+                    data = ?output.data,
+                    timestamp = output.timestamp,
+                );
+            }
+        }
+    }
+    let result = progress.finish().await?;
+    match result {
+        FunctionResult::Success(success) => info!(
+            execution_id = &success.execution_id.as_str(),
+            // TODO(fnichol): show more fields when we have them
+            timestamp = success.timestamp,
+        ),
+        FunctionResult::Failure(failure) => error!(
+            execution_id = &failure.execution_id.as_str(),
+            error_kind = &failure.error.kind.as_str(),
+            error_message = &failure.error.message.as_str(),
+            timestamp = failure.timestamp,
+        ),
+    }
+
+    Ok(())
+}

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
@@ -8,13 +8,13 @@ use async_trait::async_trait;
 use cyclone::{
     canonical_command::CanonicalCommand,
     client::{
-        Connection, PingExecution, QualificationCheckExecution, QualificationCheckRequest,
-        ResolverFunctionExecution, ResolverFunctionRequest, ResourceSyncExecution, Watch,
-        WatchError, WatchStarted,
+        CodeGenerationExecution, Connection, PingExecution, QualificationCheckExecution,
+        QualificationCheckRequest, ResolverFunctionExecution, ResolverFunctionRequest,
+        ResourceSyncExecution, Watch, WatchError, WatchStarted,
     },
     process::{self, ShutdownError},
-    Client, ClientError, CycloneClient, HttpClient, LivenessStatus, ReadinessStatus,
-    ResourceSyncRequest,
+    Client, ClientError, CodeGenerationRequest, CycloneClient, HttpClient, LivenessStatus,
+    ReadinessStatus, ResourceSyncRequest,
 };
 use derive_builder::Builder;
 use futures::StreamExt;
@@ -174,6 +174,20 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .map_err(ClientError::unhealthy)?;
 
         let result = self.client.execute_sync(request).await;
+        self.count_request();
+
+        result
+    }
+
+    async fn execute_code_generation(
+        &mut self,
+        request: CodeGenerationRequest,
+    ) -> result::Result<CodeGenerationExecution<TcpStream>, ClientError> {
+        self.ensure_healthy_client()
+            .await
+            .map_err(ClientError::unhealthy)?;
+
+        let result = self.client.execute_code_generation(request).await;
         self.count_request();
 
         result

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -9,12 +9,14 @@ use async_trait::async_trait;
 use cyclone::{
     canonical_command::CanonicalCommand,
     client::{
-        Connection, PingExecution, QualificationCheckExecution, ResolverFunctionExecution,
-        ResourceSyncExecution, UnixStream, Watch, WatchError, WatchStarted,
+        CodeGenerationExecution, Connection, PingExecution, QualificationCheckExecution,
+        ResolverFunctionExecution, ResourceSyncExecution, UnixStream, Watch, WatchError,
+        WatchStarted,
     },
     process::{self, ShutdownError},
-    Client, ClientError, CycloneClient, LivenessStatus, QualificationCheckRequest, ReadinessStatus,
-    ResolverFunctionRequest, ResourceSyncRequest, UdsClient,
+    Client, ClientError, CodeGenerationRequest, CycloneClient, LivenessStatus,
+    QualificationCheckRequest, ReadinessStatus, ResolverFunctionRequest, ResourceSyncRequest,
+    UdsClient,
 };
 use derive_builder::Builder;
 use futures::StreamExt;
@@ -183,6 +185,20 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
 
         result
     }
+
+    async fn execute_code_generation(
+        &mut self,
+        request: CodeGenerationRequest,
+    ) -> result::Result<CodeGenerationExecution<UnixStream>, ClientError> {
+        self.ensure_healthy_client()
+            .await
+            .map_err(ClientError::unhealthy)?;
+
+        let result = self.client.execute_code_generation(request).await;
+        self.count_request();
+
+        result
+    }
 }
 
 impl LocalUdsInstance {
@@ -253,6 +269,10 @@ pub struct LocalUdsInstanceSpec {
     /// Enables the `sync` execution endpoint for a spawned Cyclone server.
     #[builder(private, setter(name = "_sync"), default = "false")]
     sync: bool,
+
+    /// Enables the `code_generation` execution endpoint for a spawned Cyclone server.
+    #[builder(private, setter(name = "_code_generation"), default = "false")]
+    code_generation: bool,
 }
 
 #[async_trait]
@@ -374,6 +394,11 @@ impl LocalUdsInstanceSpecBuilder {
     /// Enables the `sync` execution endpoint for a spawned Cyclone server.
     pub fn sync(&mut self) -> &mut Self {
         self._sync(true)
+    }
+
+    /// Enables the `code_generation` execution endpoint for a spawned Cyclone server.
+    pub fn code_generation(&mut self) -> &mut Self {
+        self._code_generation(true)
     }
 }
 

--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::instance::{Instance, Spec};
 
 pub use cyclone::{
     client::{self, ResolverFunctionExecutionError},
-    CycloneClient, FunctionResult, OutputStream, ProgressMessage, QualificationCheckRequest,
-    ResolverFunctionRequest, ResourceSyncRequest,
+    CodeGenerationRequest, CycloneClient, FunctionResult, OutputStream, ProgressMessage,
+    QualificationCheckRequest, ResolverFunctionRequest, ResourceSyncRequest,
 };
 
 /// [`Instance`] implementations.

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -27,15 +27,17 @@ pub mod client;
 pub use client::{Client, ClientError, ClientResult};
 #[cfg(feature = "client")]
 pub use cyclone::{
-    FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
-    QualificationCheckRequest, QualificationCheckResultSuccess, QualificationSubCheck,
-    QualificationSubCheckStatus, ResolverFunctionComponent, ResolverFunctionParentComponent,
-    ResolverFunctionRequest, ResourceSyncComponent, ResourceSyncRequest, ResourceSyncResultSuccess,
+    CodeGenerationComponent, CodeGenerationRequest, CodeGenerationResultSuccess, FunctionResult,
+    FunctionResultFailure, OutputStream, QualificationCheckComponent, QualificationCheckRequest,
+    QualificationCheckResultSuccess, QualificationSubCheck, QualificationSubCheckStatus,
+    ResolverFunctionComponent, ResolverFunctionParentComponent, ResolverFunctionRequest,
+    ResourceSyncComponent, ResourceSyncRequest, ResourceSyncResultSuccess,
 };
 
 const NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT: &str = "veritech.fn.qualificationcheck";
 const NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT: &str = "veritech.fn.resolverfunction";
 const NATS_RESOURCE_SYNC_DEFAULT_SUBJECT: &str = "veritech.fn.resourcesync";
+const NATS_CODE_GENERATION_DEFAULT_SUBJECT: &str = "veritech.fn.codegeneration";
 
 pub(crate) const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";
 
@@ -57,6 +59,10 @@ pub(crate) fn nats_resolver_function_subject(prefix: Option<&str>) -> String {
 
 pub(crate) fn nats_resource_sync_subject(prefix: Option<&str>) -> String {
     nats_subject(prefix, NATS_RESOURCE_SYNC_DEFAULT_SUBJECT)
+}
+
+pub(crate) fn nats_code_generation_subject(prefix: Option<&str>) -> String {
+    nats_subject(prefix, NATS_CODE_GENERATION_DEFAULT_SUBJECT)
 }
 
 pub(crate) fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {

--- a/lib/veritech/src/server/server.rs
+++ b/lib/veritech/src/server/server.rs
@@ -1,6 +1,6 @@
 use deadpool_cyclone::{
-    instance::cyclone::LocalUdsInstanceSpec, CycloneClient, Manager, Pool, ProgressMessage,
-    QualificationCheckRequest, ResolverFunctionRequest, ResourceSyncRequest,
+    instance::cyclone::LocalUdsInstanceSpec, CodeGenerationRequest, CycloneClient, Manager, Pool,
+    ProgressMessage, QualificationCheckRequest, ResolverFunctionRequest, ResourceSyncRequest,
 };
 use futures::{channel::oneshot, join, StreamExt};
 use si_data::NatsClient;
@@ -36,6 +36,8 @@ pub enum ServerError {
     ResolverFunction(#[from] deadpool_cyclone::client::ResolverFunctionExecutionError),
     #[error(transparent)]
     ResourceSync(#[from] deadpool_cyclone::client::ResourceSyncExecutionError),
+    #[error(transparent)]
+    CodeGeneration(#[from] deadpool_cyclone::client::CodeGenerationExecutionError),
     #[error("failed to setup signal handler")]
     Signal(#[source] io::Error),
     #[error(transparent)]
@@ -146,6 +148,12 @@ impl Server {
                 self.cyclone_pool.clone(),
                 self.shutdown_broadcast_tx.subscribe(),
             ),
+            process_code_generation_requests_task(
+                self.nats.clone(),
+                self.subject_prefix.clone(),
+                self.cyclone_pool.clone(),
+                self.shutdown_broadcast_tx.subscribe(),
+            ),
         );
 
         let _ = self.shutdown_rx.await;
@@ -167,7 +175,7 @@ impl ShutdownHandle {
     }
 }
 
-// NOTE(fnichol): the resolver_function and qualification_check paths are parallel and extremely
+// NOTE(fnichol): the resolver_function, qualification_check, code_generation and resource_sync paths are parallel and extremely
 // similar, so there is a lurking "unifying" refactor here. It felt like waiting until the third
 // time adding one of these would do the trick, and as a result the first 2 impls are here and not
 // split apart into their own modules.
@@ -490,6 +498,118 @@ async fn resource_sync_request(
         .await
         .map_err(|err| ServerError::CyclonePool(Box::new(err)))?;
     let mut progress = client.execute_sync(cyclone_request).await?.start().await?;
+
+    while let Some(msg) = progress.next().await {
+        match msg {
+            Ok(ProgressMessage::OutputStream(output)) => {
+                publisher.publish_output(&output).await?;
+            }
+            Ok(ProgressMessage::Heartbeat) => {
+                trace!("received heartbeat message");
+            }
+            Err(err) => {
+                warn!(error = ?err, "next progress message was an error, skipping to next message");
+            }
+        }
+    }
+    publisher.finalize_output().await?;
+
+    let function_result = progress.finish().await?;
+    publisher.publish_result(&function_result).await?;
+
+    Ok(())
+}
+
+async fn process_code_generation_requests_task(
+    nats: NatsClient,
+    subject_prefix: Option<String>,
+    cyclone_pool: Pool<LocalUdsInstanceSpec>,
+    shutdown_broadcast_rx: broadcast::Receiver<()>,
+) {
+    if let Err(err) =
+        process_code_generation_requests(nats, subject_prefix, cyclone_pool, shutdown_broadcast_rx)
+            .await
+    {
+        warn!(error = ?err, "processing resource sync requests failed");
+    }
+}
+
+async fn process_code_generation_requests(
+    nats: NatsClient,
+    subject_prefix: Option<String>,
+    cyclone_pool: Pool<LocalUdsInstanceSpec>,
+    mut shutdown_broadcast_rx: broadcast::Receiver<()>,
+) -> Result<()> {
+    let mut requests = Subscriber::code_generation(&nats, subject_prefix.as_deref()).await?;
+
+    loop {
+        tokio::select! {
+            // Got a broadcasted shutdown message
+            _ = shutdown_broadcast_rx.recv() => {
+                trace!("process resource sync requests task received shutdown");
+                break;
+            }
+            // Got the next message on from the subscriber
+            request = requests.next() => {
+                match request {
+                    Some(Ok(request)) => {
+                        // Spawn a task an process the request
+                        tokio::spawn(code_generation_request_task(
+                            nats.clone(),
+                            cyclone_pool.clone(),
+                            request,
+                        ));
+                    }
+                    Some(Err(err)) => {
+                        warn!(error = ?err, "next resource sync request had error");
+                    }
+                    None => {
+                        trace!("resource sync requests subscriber stream has closed");
+                        break;
+                    }
+                }
+            }
+            // All other arms are closed, nothing left to do but return
+            else => {
+                trace!("returning with all select arms closed");
+                break
+            }
+        }
+    }
+
+    // Unsubscribe from subscription
+    requests.unsubscribe().await?;
+
+    Ok(())
+}
+
+async fn code_generation_request_task(
+    nats: NatsClient,
+    cyclone_pool: Pool<LocalUdsInstanceSpec>,
+    request: Request<CodeGenerationRequest>,
+) {
+    if let Err(err) = code_generation_request(nats, cyclone_pool, request).await {
+        warn!(error = ?err, "resource sync execution failed");
+    }
+}
+
+async fn code_generation_request(
+    nats: NatsClient,
+    cyclone_pool: Pool<LocalUdsInstanceSpec>,
+    request: Request<CodeGenerationRequest>,
+) -> Result<()> {
+    let (reply_mailbox, cyclone_request) = request.into_parts();
+
+    let publisher = Publisher::new(&nats, &reply_mailbox);
+    let mut client = cyclone_pool
+        .get()
+        .await
+        .map_err(|err| ServerError::CyclonePool(Box::new(err)))?;
+    let mut progress = client
+        .execute_code_generation(cyclone_request)
+        .await?
+        .start()
+        .await?;
 
     while let Some(msg) = progress.next().await {
         match msg {

--- a/lib/veritech/src/server/subscriber.rs
+++ b/lib/veritech/src/server/subscriber.rs
@@ -4,7 +4,9 @@ use std::{
     task::{Context, Poll},
 };
 
-use deadpool_cyclone::{QualificationCheckRequest, ResolverFunctionRequest, ResourceSyncRequest};
+use deadpool_cyclone::{
+    CodeGenerationRequest, QualificationCheckRequest, ResolverFunctionRequest, ResourceSyncRequest,
+};
 use futures::{Stream, StreamExt};
 use futures_lite::FutureExt;
 use pin_project_lite::pin_project;
@@ -14,7 +16,8 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::{
-    nats_qualification_check_subject, nats_resolver_function_subject, nats_resource_sync_subject,
+    nats_code_generation_subject, nats_qualification_check_subject, nats_resolver_function_subject,
+    nats_resource_sync_subject,
 };
 
 #[derive(Error, Debug)]
@@ -86,6 +89,26 @@ impl Subscriber {
         debug!(
             messaging.destination = &subject.as_str(),
             "subscribing for resource sync requests"
+        );
+        let inner = nats
+            .subscribe(subject)
+            .await
+            .map_err(SubscriberError::NatsSubscribe)?;
+
+        Ok(Subscription {
+            inner,
+            _phantom: PhantomData,
+        })
+    }
+
+    pub async fn code_generation(
+        nats: &NatsClient,
+        subject_prefix: Option<&str>,
+    ) -> Result<Subscription<CodeGenerationRequest>> {
+        let subject = nats_code_generation_subject(subject_prefix);
+        debug!(
+            messaging.destination = &subject.as_str(),
+            "subscribing for code generation requests"
         );
         let inner = nats
             .subscribe(subject)


### PR DESCRIPTION
Creates a Code Generation backend for lang-js/cyclone/deadpool-cyclone/veritech.

Code Generation lang-js sandbox contains access to js-yaml's dump function.

Creates CodeGeneration(Prototype/Resolver) in the DAL.

For now CodeGenerationResolver cannot be displayed as there is no sdf
route, but there are dal functions (which is tested).

<img src="https://media1.giphy.com/media/3glthFyTpvN2d9Qo6p/giphy.gif"/>
[sc-2220]