### PR TITLE
chore(ci): Ensure build-image.sh reports Docker image builds

### DIFF
--- a/app/web/script/build-image.sh
+++ b/app/web/script/build-image.sh
@@ -222,7 +222,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \

--- a/bin/sdf/script/build-image.sh
+++ b/bin/sdf/script/build-image.sh
@@ -216,7 +216,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \

--- a/bin/veritech/script/build-image.sh
+++ b/bin/veritech/script/build-image.sh
@@ -216,7 +216,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \

--- a/component/nats/script/build-image.sh
+++ b/component/nats/script/build-image.sh
@@ -220,7 +220,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \

--- a/component/otelcol/script/build-image.sh
+++ b/component/otelcol/script/build-image.sh
@@ -220,7 +220,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \

--- a/component/postgres/script/build-image.sh
+++ b/component/postgres/script/build-image.sh
@@ -220,7 +220,7 @@ build() {
 
   echo "--- Building image '$img'"
   set -x
-  docker "${args[@]}"
+  docker "${args[@]}" || die "Docker build failed"
   set +x
 
   build_manifest "$img" "$build_version" "$revision" "$created" \


### PR DESCRIPTION
There appears to be something about `docker "${args[@]}"` that is causing `set -e` to be ineffective. Even when explicitly doing `set -e` immediately before the `docker` line, the scrip is continuing on, and not exiting when the `docker` line returns non-zero (at least in my testing). Adding a `|| die "message"` does get the script to exit and report the failure as we want, though.