### PR TITLE
feat(dal): Create Kubernetes Deployment Props

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1589,7 +1589,14 @@ impl EditFieldAble for Component {
             .ok_or(ComponentError::SchemaVariantNotFound)?;
 
         let props = schema_variant.props(txn, visibility).await?;
-        for prop in props.iter() {
+        for prop in &props {
+            // TODO: remove this as soon as edit fields are implemented
+            // But for now we need the boilerplate to setup the props even if not editable
+            // So it was breaking some tests
+            if *prop.kind() == PropKind::Array || *prop.kind() == PropKind::Map {
+                continue;
+            }
+
             edit_fields.push(
                 edit_field_for_prop(
                     txn,
@@ -1768,6 +1775,13 @@ async fn edit_field_for_prop(
             //       less gross.
             let mut child_edit_fields = vec![];
             for child_prop in prop.child_props(txn, tenancy, visibility).await? {
+                // TODO: remove this as soon as edit fields are implemented
+                // But for now we need the boilerplate to setup the props even if not editable
+                // So it was breaking some tests
+                if *child_prop.kind() == PropKind::Array || *child_prop.kind() == PropKind::Map {
+                    continue;
+                }
+
                 child_edit_fields.push(
                     edit_field_for_prop(
                         txn,

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -1,0 +1,279 @@
+use crate::code_generation_prototype::CodeGenerationPrototypeContext;
+use crate::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
+use crate::schema::builtins::kubernetes_metadata::create_metadata_prop;
+use crate::schema::builtins::kubernetes_selector::create_selector_prop;
+use crate::schema::builtins::kubernetes_template::create_template_prop;
+use crate::schema::builtins::{create_prop, create_schema, create_string_prop_with_default};
+use crate::schema::{SchemaResult, SchemaVariant, UiMenu};
+use crate::socket::{Socket, SocketArity, SocketEdgeKind};
+use crate::{
+    CodeGenerationPrototype, Func, HistoryActor, PropKind, Schema, SchemaError, SchemaKind,
+    SchematicKind, StandardModel, Tenancy, Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+pub async fn kubernetes_deployment(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    veritech: veritech::Client,
+) -> SchemaResult<()> {
+    let name = "kubernetes_deployment".to_string();
+    let mut schema = match create_schema(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        &name,
+        &SchemaKind::Concept, // Note: what is this?
+    )
+    .await?
+    {
+        Some(schema) => schema,
+        None => return Ok(()),
+    };
+
+    let variant = SchemaVariant::new(txn, nats, tenancy, visibility, history_actor, "v0").await?;
+    variant
+        .set_schema(txn, nats, visibility, history_actor, schema.id())
+        .await?;
+    schema
+        .set_default_schema_variant_id(txn, nats, visibility, history_actor, Some(*variant.id()))
+        .await?;
+
+    {
+        // TODO: add validation (si-registry ensures the value is unchanged)
+        let _api_version_prop = create_string_prop_with_default(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant.id(),
+            "apiVersion",
+            "apps/v1".to_owned(),
+            None,
+            veritech.clone(),
+        )
+        .await?;
+    }
+    {
+        // TODO: add validation (si-registry ensures the value is unchanged)
+        let _kind_prop = create_string_prop_with_default(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant.id(),
+            "kind",
+            "Deployment".to_owned(),
+            None,
+            veritech.clone(),
+        )
+        .await?;
+    }
+
+    {
+        let _metadata_prop = create_metadata_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant.id(),
+            Some(schema.name().to_owned()),
+            true, // is name required, note: bool is not ideal here tho
+            None,
+            veritech.clone(),
+        )
+        .await?;
+    }
+
+    {
+        let spec_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant.id(),
+            "spec",
+            PropKind::Object,
+            None,
+        )
+        .await?;
+
+        {
+            let _replicas_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant.id(),
+                "replicas",
+                PropKind::Integer,
+                Some(*spec_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let _selector_prop = create_selector_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant.id(),
+                Some(*spec_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let _template_prop = create_template_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant.id(),
+                Some(*spec_prop.id()),
+                veritech.clone(),
+            )
+            .await?;
+        }
+    }
+
+    // Code Generation Prototype
+    let code_generation_func_name = "si:generateYAML".to_owned();
+    let mut code_generation_funcs =
+        Func::find_by_attr(txn, tenancy, visibility, "name", &code_generation_func_name).await?;
+    let code_generation_func = code_generation_funcs
+        .pop()
+        .ok_or(SchemaError::FuncNotFound(code_generation_func_name))?;
+    let code_generation_args = FuncBackendJsCodeGenerationArgs {
+        component: veritech::CodeGenerationComponent::default(),
+    };
+    let code_generation_args_json = serde_json::to_value(&code_generation_args)?;
+    let mut code_generation_prototype_context = CodeGenerationPrototypeContext::new();
+    code_generation_prototype_context.set_schema_variant_id(*variant.id());
+
+    let _prototype = CodeGenerationPrototype::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        *code_generation_func.id(),
+        code_generation_args_json,
+        code_generation_prototype_context,
+    )
+    .await?;
+
+    // TODO: it's not clear if these are the desired sockets
+    // Note: This is not right; each schema needs its own socket types.
+    //       Also, they should clearly inherit from the core schema? Something
+    //       for later.
+    let input_socket = Socket::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        "input",
+        &SocketEdgeKind::Configures,
+        &SocketArity::Many,
+    )
+    .await?;
+    variant
+        .add_socket(txn, nats, visibility, history_actor, input_socket.id())
+        .await?;
+
+    let output_socket = Socket::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        "output",
+        &SocketEdgeKind::Output,
+        &SocketArity::Many,
+    )
+    .await?;
+    variant
+        .add_socket(txn, nats, visibility, history_actor, output_socket.id())
+        .await?;
+
+    let includes_socket = Socket::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        "includes",
+        &SocketEdgeKind::Includes,
+        &SocketArity::Many,
+    )
+    .await?;
+    variant
+        .add_socket(txn, nats, visibility, history_actor, includes_socket.id())
+        .await?;
+
+    // TODO: abstract this boilerplate away
+    let mut ui_menu = UiMenu::new(txn, nats, tenancy, visibility, history_actor).await?;
+    ui_menu
+        .set_name(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            Some(schema.name().to_string()),
+        )
+        .await?;
+
+    let application_name = "application".to_string();
+    ui_menu
+        .set_category(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            Some(application_name.clone()),
+        )
+        .await?;
+    ui_menu
+        .set_schematic_kind(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            SchematicKind::Deployment,
+        )
+        .await?;
+    ui_menu
+        .set_schema(txn, nats, visibility, history_actor, schema.id())
+        .await?;
+
+    let application_schema_results =
+        Schema::find_by_attr(txn, tenancy, visibility, "name", &application_name).await?;
+    let application_schema = application_schema_results
+        .first()
+        .ok_or(SchemaError::NotFoundByName(application_name))?;
+    ui_menu
+        .add_root_schematic(
+            txn,
+            nats,
+            visibility,
+            history_actor,
+            application_schema.id(),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/lib/dal/src/schema/builtins/kubernetes_metadata.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_metadata.rs
@@ -1,0 +1,142 @@
+use crate::schema::builtins::{create_prop, create_string_prop_with_default};
+use crate::schema::SchemaResult;
+use crate::{
+    HistoryActor, Prop, PropId, PropKind, SchemaVariantId, StandardModel, Tenancy, Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create_metadata_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    variant_id: &SchemaVariantId,
+    schema_name: Option<String>,
+    is_schema_name_required: bool,
+    parent_prop_id: Option<PropId>,
+    veritech: veritech::Client,
+) -> SchemaResult<Prop> {
+    let metadata_prop = create_prop(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        variant_id,
+        "metadata",
+        PropKind::Object,
+        parent_prop_id,
+    )
+    .await?;
+
+    {
+        // TODO: add validation
+        //validation: [
+        //  {
+        //    kind: ValidatorKind.Regex,
+        //    regex: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,251}[A-Za-z0-9])?$",
+        //    message: "Kubernetes names must be valid DNS subdomains",
+        //    link:
+        //      "https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names",
+        //  },
+        //],
+        if is_schema_name_required {
+            // TODO: add a required field validation here
+        }
+
+        let _name_prop = if let Some(schema_name) = schema_name {
+            // Note: do we actually want this branch to exist?
+            create_string_prop_with_default(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "name",
+                schema_name,
+                Some(*metadata_prop.id()),
+                veritech,
+            )
+            .await?;
+        } else {
+            create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "name",
+                PropKind::String,
+                Some(*metadata_prop.id()),
+            )
+            .await?;
+        };
+    }
+
+    {
+        let _generate_name_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "generateName",
+            PropKind::String,
+            Some(*metadata_prop.id()),
+        )
+        .await?;
+    }
+
+    {
+        // Note: should this come from a k8s namespace component configuring us?
+        let _namespace_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "namespace",
+            PropKind::String,
+            Some(*metadata_prop.id()),
+        )
+        .await?;
+    }
+
+    {
+        let _labels_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "labels",
+            PropKind::Map, // How to specify it as a map of string values?
+            Some(*metadata_prop.id()),
+        )
+        .await?;
+    }
+
+    {
+        let _annotations_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "annotations",
+            PropKind::Map, // How to specify it as a map of string values?
+            Some(*metadata_prop.id()),
+        )
+        .await?;
+    }
+
+    Ok(metadata_prop)
+}

--- a/lib/dal/src/schema/builtins/kubernetes_selector.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_selector.rs
@@ -1,0 +1,107 @@
+use crate::schema::builtins::create_prop;
+use crate::schema::SchemaResult;
+use crate::{
+    HistoryActor, Prop, PropId, PropKind, SchemaVariantId, StandardModel, Tenancy, Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+pub async fn create_selector_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    variant_id: &SchemaVariantId,
+    parent_prop_id: Option<PropId>,
+) -> SchemaResult<Prop> {
+    let selector_prop = create_prop(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        variant_id,
+        "selector",
+        PropKind::Object,
+        parent_prop_id,
+    )
+    .await?;
+
+    {
+        let match_expressions_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "matchExpressions",
+            PropKind::Array, // How to specify it as an array of objects?
+            Some(*selector_prop.id()),
+        )
+        .await?;
+
+        {
+            let _key_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "key",
+                PropKind::String,
+                Some(*match_expressions_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            // TODO: validate to ensure it's either "In", "NotInt", "Exists", "DoesNotExist"
+            // Is there a selector widget? If so how to enable it
+            let _operator_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "operator",
+                PropKind::String,
+                Some(*match_expressions_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let _values_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "values",
+                PropKind::Array, // How to specify it as an array of strings?
+                Some(*match_expressions_prop.id()),
+            )
+            .await?;
+        }
+    }
+
+    {
+        let _match_labels_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "matchLabels",
+            PropKind::Array, // How to specify it as an array of strings?
+            Some(*selector_prop.id()),
+        )
+        .await?;
+    }
+    Ok(selector_prop)
+}

--- a/lib/dal/src/schema/builtins/kubernetes_spec.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_spec.rs
@@ -1,0 +1,611 @@
+use crate::schema::builtins::create_prop;
+use crate::schema::SchemaResult;
+use crate::{
+    HistoryActor, Prop, PropId, PropKind, SchemaVariantId, StandardModel, Tenancy, Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+pub async fn create_spec_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    variant_id: &SchemaVariantId,
+    parent_prop_id: PropId,
+) -> SchemaResult<Prop> {
+    let spec_prop = create_prop(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        variant_id,
+        "spec",
+        PropKind::Object,
+        Some(parent_prop_id),
+    )
+    .await?;
+
+    {
+        let containers_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "containers",
+            PropKind::Array, // How to specify it as an array of objects?
+            Some(*spec_prop.id()),
+        )
+        .await?;
+
+        {
+            // Do we want default values here?
+            let _name_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "name",
+                PropKind::String,
+                Some(*containers_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let _image_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "image",
+                PropKind::String,
+                Some(*containers_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            // si-registry has some editPartials, but I'm not clear what are they
+            let env_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "env",
+                PropKind::Array, // How to specify it as an array of objects?
+                Some(*containers_prop.id()),
+            )
+            .await?;
+
+            {
+                let _name_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "name",
+                    PropKind::String,
+                    Some(*env_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                let _value_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "value",
+                    PropKind::String,
+                    Some(*env_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                let _value_from_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "valueFrom",
+                    PropKind::Object,
+                    Some(*env_prop.id()),
+                )
+                .await?;
+
+                {
+                    let _secret_key_ref_prop = create_prop(
+                        txn,
+                        nats,
+                        tenancy,
+                        visibility,
+                        history_actor,
+                        variant_id,
+                        "secretKeyRef",
+                        PropKind::Object,
+                        Some(*_value_from_prop.id()),
+                    )
+                    .await?;
+
+                    {
+                        let _name_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "name",
+                            PropKind::String,
+                            Some(*_secret_key_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _key_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "key",
+                            PropKind::String,
+                            Some(*_secret_key_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _optional_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "optional",
+                            PropKind::Boolean,
+                            Some(*_secret_key_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+                }
+
+                {
+                    let _config_map_ref_prop = create_prop(
+                        txn,
+                        nats,
+                        tenancy,
+                        visibility,
+                        history_actor,
+                        variant_id,
+                        "configMapRef",
+                        PropKind::Object,
+                        Some(*_value_from_prop.id()),
+                    )
+                    .await?;
+
+                    {
+                        let _name_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "name",
+                            PropKind::String,
+                            Some(*_config_map_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _key_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "key",
+                            PropKind::String,
+                            Some(*_config_map_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _optional_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "optional",
+                            PropKind::Boolean,
+                            Some(*_config_map_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+                }
+
+                {
+                    let _resource_field_ref_prop = create_prop(
+                        txn,
+                        nats,
+                        tenancy,
+                        visibility,
+                        history_actor,
+                        variant_id,
+                        "resourceFieldRef",
+                        PropKind::Object,
+                        Some(*_value_from_prop.id()),
+                    )
+                    .await?;
+
+                    {
+                        let _container_name_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "containerName",
+                            PropKind::String,
+                            Some(*_resource_field_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _resource_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "resource",
+                            PropKind::String,
+                            Some(*_resource_field_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _divisor_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "divisor",
+                            PropKind::String,
+                            Some(*_resource_field_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+                }
+
+                {
+                    let _field_ref_prop = create_prop(
+                        txn,
+                        nats,
+                        tenancy,
+                        visibility,
+                        history_actor,
+                        variant_id,
+                        "fieldRef",
+                        PropKind::Object,
+                        Some(*_value_from_prop.id()),
+                    )
+                    .await?;
+
+                    {
+                        // TODO: this should be autopopulated
+                        let _api_version_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "apiVersion",
+                            PropKind::String,
+                            Some(*_field_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+
+                    {
+                        let _field_path_prop = create_prop(
+                            txn,
+                            nats,
+                            tenancy,
+                            visibility,
+                            history_actor,
+                            variant_id,
+                            "fieldPath",
+                            PropKind::String,
+                            Some(*_field_ref_prop.id()),
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+
+        {
+            // TODO: validate to ensure it's either "Always", "Never", "IfNotPresent"
+            // Is there a selector widget? If so how to enable it
+            // TODO: required
+            let _image_pull_policy_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "imagePullPolicy",
+                PropKind::String,
+                Some(*containers_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let ports_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "ports",
+                PropKind::Array, // How to specify it as an array of objects?
+                Some(*containers_prop.id()),
+            )
+            .await?;
+
+            {
+                let _name_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "name",
+                    PropKind::String,
+                    Some(*ports_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                // TODO: int from 0 to 65536
+                let _container_port_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "containerPort",
+                    PropKind::Integer,
+                    Some(*ports_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                let _host_ip_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "hostIp",
+                    PropKind::String,
+                    Some(*ports_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                // TODO: int from 0 to 65536
+                let _host_port_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "hostPort",
+                    PropKind::Integer,
+                    Some(*ports_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                // TODO: validate to ensure it's either "TCP", "UDP" or "SCTP"
+                // Is there a selector widget? If so how to enable it
+                let _protocol_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "protocol",
+                    PropKind::String,
+                    Some(*ports_prop.id()),
+                )
+                .await?;
+            }
+        }
+
+        {
+            let volume_mounts_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "volumeMounts",
+                PropKind::Array, // How to specify it as an array of objects?
+                Some(*containers_prop.id()),
+            )
+            .await?;
+
+            {
+                let _name_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "name",
+                    PropKind::String,
+                    Some(*volume_mounts_prop.id()),
+                )
+                .await?;
+            }
+
+            {
+                let _mount_path_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "mountPath",
+                    PropKind::String,
+                    Some(*volume_mounts_prop.id()),
+                )
+                .await?;
+            }
+        }
+    }
+
+    {
+        let volumes_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "volumes",
+            PropKind::Array, // How to specify it as an array of objects?
+            Some(*spec_prop.id()),
+        )
+        .await?;
+
+        {
+            let _name_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "name",
+                PropKind::String,
+                Some(*volumes_prop.id()),
+            )
+            .await?;
+        }
+
+        {
+            let config_map_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "configMap",
+                PropKind::Object,
+                Some(*volumes_prop.id()),
+            )
+            .await?;
+
+            {
+                let _name_prop = create_prop(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    variant_id,
+                    "name",
+                    PropKind::String,
+                    Some(*config_map_prop.id()),
+                )
+                .await?;
+            }
+        }
+    }
+
+    {
+        let image_pull_secrets_prop = create_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            "imagePullSecrets",
+            PropKind::Array, // How to specify it as an array of objects?
+            Some(*spec_prop.id()),
+        )
+        .await?;
+
+        {
+            let _name_prop = create_prop(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                variant_id,
+                "name",
+                PropKind::String,
+                Some(*image_pull_secrets_prop.id()),
+            )
+            .await?;
+        }
+    }
+
+    Ok(spec_prop)
+}

--- a/lib/dal/src/schema/builtins/kubernetes_template.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_template.rs
@@ -1,0 +1,63 @@
+use crate::schema::builtins::create_prop;
+use crate::schema::builtins::kubernetes_metadata::create_metadata_prop;
+use crate::schema::builtins::kubernetes_spec::create_spec_prop;
+use crate::schema::SchemaResult;
+use crate::{
+    HistoryActor, Prop, PropId, PropKind, SchemaVariantId, StandardModel, Tenancy, Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create_template_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    variant_id: &SchemaVariantId,
+    parent_prop_id: Option<PropId>,
+    veritech: veritech::Client,
+) -> SchemaResult<Prop> {
+    let template_prop = create_prop(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        variant_id,
+        "template",
+        PropKind::Object,
+        parent_prop_id,
+    )
+    .await?;
+
+    {
+        let _optional_metadata_prop = create_metadata_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            None,
+            false,
+            Some(*template_prop.id()),
+            veritech.clone(),
+        )
+        .await?;
+    }
+
+    {
+        let _spec_prop = create_spec_prop(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            variant_id,
+            *template_prop.id(),
+        )
+        .await?;
+    }
+    Ok(template_prop)
+}


### PR DESCRIPTION
Translate props from `si-registry` to the rust code 1-to-1.

No validation or qualification for now.

We had to disable editing for maps and arrays since they weren't
available, but since we wanted to generate the boilerplate for them in a
schema it was breaking tests.

Since it's too much boilerplate copied by hand it might not be 100%
done, only when generating the YAML and validating it we will be sure.

Note: The Attribute UI for Kubernetes Deployment is completely broken
after this PR (too many fields in a tiny space)

![image](https://user-images.githubusercontent.com/6289779/153094211-eada63c3-fdaa-4ad8-829d-c830445f167b.png)

<img src="https://media2.giphy.com/media/kC3WKtkoR0rihSq9O2/giphy.gif"/>