### PR TITLE
feat(dal): create a ComponentView that handles nested props

### DIFF
--- a/bin/lang-js/package-lock.json
+++ b/bin/lang-js/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "lang-js",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1,4 +1,7 @@
+mod view;
+
 use std::collections::HashMap;
+pub use view::ComponentView;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -126,6 +129,8 @@ pub enum ComponentError {
     Workspace(#[from] WorkspaceError),
     #[error("organization error: {0}")]
     Organization(#[from] OrganizationError),
+    #[error("invalid json pointer: {0} for {1}")]
+    BadJsonPointer(String, String),
 }
 
 pub type ComponentResult<T> = Result<T, ComponentError>;

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -1,0 +1,99 @@
+use si_data::PgTxn;
+
+use crate::{
+    func::binding_return_value::FuncBindingReturnValue, system::UNSET_SYSTEM_ID, AttributeResolver,
+    Component, ComponentError, ComponentId, Prop, PropId, PropKind, StandardModel, System,
+    SystemId, Tenancy, Visibility,
+};
+
+use super::ComponentResult;
+
+pub struct ComponentView {
+    pub name: String,
+    pub system: Option<System>,
+    pub properties: serde_json::Value,
+}
+
+impl ComponentView {
+    pub async fn for_component_and_system(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        component_id: ComponentId,
+        system_id: SystemId,
+    ) -> ComponentResult<ComponentView> {
+        let component = Component::get_by_id(txn, tenancy, visibility, &component_id)
+            .await?
+            .ok_or(ComponentError::NotFound(component_id))?;
+
+        // Perhaps get_by_id should just do this? -- Adam
+        let system = if system_id == UNSET_SYSTEM_ID {
+            None
+        } else {
+            System::get_by_id(txn, tenancy, visibility, &system_id).await?
+        };
+        let mut work_queue = AttributeResolver::list_values_for_component(
+            txn,
+            tenancy,
+            visibility,
+            component_id,
+            system_id,
+        )
+        .await?;
+        let mut properties = serde_json::json![{}];
+        let mut root_stack: Vec<(Option<PropId>, String)> = vec![(None, "".to_string())];
+
+        while !work_queue.is_empty() {
+            let mut unprocessed: Vec<(Prop, Option<PropId>, FuncBindingReturnValue)> = vec![];
+            let (root_id, json_pointer) = root_stack
+                .pop()
+                .expect("the root prop id queue cannot be empty while work_queue is not empty");
+
+            while let Some((prop, parent_prop_id, fbrv)) = work_queue.pop() {
+                if let Some(value) = fbrv.value() {
+                    if root_id == parent_prop_id {
+                        let write_location = match properties.pointer_mut(&json_pointer) {
+                            Some(write_location) => write_location,
+                            None => {
+                                return Err(ComponentError::BadJsonPointer(
+                                    json_pointer.clone(),
+                                    properties.to_string(),
+                                ))
+                            }
+                        };
+                        let next_json_pointer = if write_location.is_object() {
+                            write_location
+                                .as_object_mut()
+                                .unwrap()
+                                .insert(prop.name().to_string(), value.clone());
+                            format!("{}/{}", json_pointer, prop.name())
+                        } else if write_location.is_array() {
+                            // This is wrong - we need to check the fbrv for what the
+                            // actual index should be. Tomorrows problem. -- Adam
+                            let array = write_location.as_array_mut().unwrap();
+                            array.push(value.clone());
+                            format!("{}/{}", json_pointer, array.len())
+                        } else {
+                            // Note: this shouldn't ever actually get used.
+                            json_pointer.to_string()
+                        };
+                        match prop.kind() {
+                            &PropKind::Object | &PropKind::Array | &PropKind::Map => {
+                                root_stack.push((Some(*prop.id()), next_json_pointer));
+                            }
+                            _ => {}
+                        }
+                    } else {
+                        unprocessed.push((prop, parent_prop_id, fbrv));
+                    }
+                }
+            }
+            work_queue = unprocessed;
+        }
+        Ok(ComponentView {
+            name: component.name().to_string(),
+            system,
+            properties,
+        })
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -61,7 +61,7 @@ pub use code_generation_prototype::{
 pub use code_generation_resolver::{
     CodeGenerationResolver, CodeGenerationResolverError, CodeGenerationResolverId,
 };
-pub use component::{Component, ComponentError, ComponentId};
+pub use component::{Component, ComponentError, ComponentId, ComponentView};
 pub use edge::{Edge, EdgeError, EdgeResult};
 pub use edit_session::{
     EditSession, EditSessionError, EditSessionPk, EditSessionStatus, NO_EDIT_SESSION_PK,

--- a/lib/dal/src/queries/attribute_resolver_list_values_for_component.sql
+++ b/lib/dal/src/queries/attribute_resolver_list_values_for_component.sql
@@ -1,0 +1,58 @@
+SELECT DISTINCT ON (attribute_resolvers.prop_id) attribute_resolvers.id,
+                              attribute_resolvers.prop_id,
+                              attribute_resolvers.visibility_change_set_pk,
+                              attribute_resolvers.visibility_edit_session_pk,
+                              attribute_resolvers.component_id,
+                              attribute_resolvers.schema_id,
+                              attribute_resolvers.schema_variant_id,
+                              attribute_resolvers.system_id,
+                              prop_belongs_to_prop.belongs_to_id AS parent_prop_id,
+                              row_to_json(props.*) AS prop_object,
+                              row_to_json(func_binding_return_values.*) AS object
+FROM attribute_resolvers
+-- First, we need to extract the schema_variant_id for this component
+INNER JOIN component_belongs_to_schema_variant ON
+    component_belongs_to_schema_variant.object_id = $3
+-- Second, we need to join on all the props that are relevant for that schema variant
+INNER JOIN props ON props.id IN (
+    WITH RECURSIVE recursive_props AS (
+        SELECT left_object_id AS prop_id
+        FROM prop_many_to_many_schema_variants
+        WHERE right_object_id = component_belongs_to_schema_variant.belongs_to_id
+        UNION ALL
+        SELECT pbp.object_id AS prop_id
+        FROM prop_belongs_to_prop AS pbp
+                 JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+    )
+    SELECT prop_id
+    FROM recursive_props
+) AND props.id = attribute_resolvers.prop_id
+-- Third, we need to find all the return values
+INNER JOIN func_binding_return_value_belongs_to_func_binding ON
+        func_binding_return_value_belongs_to_func_binding.belongs_to_id = attribute_resolvers.func_binding_id
+INNER JOIN func_binding_return_values ON
+  func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+LEFT JOIN prop_belongs_to_prop ON props.id = prop_belongs_to_prop.object_id
+WHERE in_tenancy_v1($1, attribute_resolvers.tenancy_universal, attribute_resolvers.tenancy_billing_account_ids, attribute_resolvers.tenancy_organization_ids,
+                    attribute_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, attribute_resolvers.visibility_change_set_pk, attribute_resolvers.visibility_edit_session_pk, attribute_resolvers.visibility_deleted)
+  AND is_visible_v1($2, props.visibility_change_set_pk, props.visibility_edit_session_pk, props.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_edit_session_pk, 
+    func_binding_return_value_belongs_to_func_binding.visibility_deleted)
+  AND is_visible_v1($2, 
+    func_binding_return_values.visibility_change_set_pk, 
+    func_binding_return_values.visibility_edit_session_pk, 
+    func_binding_return_values.visibility_deleted)
+   AND (attribute_resolvers.component_id = $3 OR attribute_resolvers.component_id = -1)
+   AND (attribute_resolvers.system_id = $4 OR attribute_resolvers.system_id = -1)
+	ORDER BY prop_id, 
+      visibility_change_set_pk DESC, 
+      visibility_edit_session_pk DESC, 
+      parent_prop_id DESC,
+      component_id DESC, 
+      system_id DESC, 
+      schema_variant_id DESC, 
+      schema_id DESC
+      ;

--- a/lib/dal/src/queries/schema_variant_all_props.sql
+++ b/lib/dal/src/queries/schema_variant_all_props.sql
@@ -1,0 +1,34 @@
+SELECT DISTINCT ON (props.id) props.id, 
+                              props.visibility_change_set_pk,
+                              props.visibility_edit_session_pk,
+                              row_to_json(props.*) AS object
+  FROM props
+  WHERE in_tenancy_v1(
+      $1, 
+      props.tenancy_universal, 
+      props.tenancy_billing_account_ids, 
+      props.tenancy_organization_ids,
+      props.tenancy_workspace_ids
+    )
+    AND is_visible_v1(
+      $2, 
+      props.visibility_change_set_pk, 
+      props.visibility_edit_session_pk, 
+      props.visibility_deleted
+    )
+    AND props.id IN (
+      WITH RECURSIVE recursive_props AS (
+          SELECT left_object_id AS prop_id
+            FROM prop_many_to_many_schema_variants
+            WHERE right_object_id = $3
+          UNION ALL
+            SELECT pbp.object_id AS prop_id
+            FROM prop_belongs_to_prop AS pbp
+            JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+        )
+        SELECT prop_id
+          FROM recursive_props
+    )
+ORDER BY id, visibility_change_set_pk, visibility_edit_session_pk;
+
+

--- a/lib/dal/src/system.rs
+++ b/lib/dal/src/system.rs
@@ -32,6 +32,7 @@ pk!(SystemPk);
 pk!(SystemId);
 
 pub const UNSET_ID_VALUE: i64 = -1;
+pub const UNSET_SYSTEM_ID: SystemId = SystemId(-1_i64);
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct System {

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -617,6 +617,29 @@ pub async fn create_prop_of_kind(
     .expect("cannot create prop")
 }
 
+pub async fn create_prop_of_kind_with_name(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    prop_kind: PropKind,
+    name: impl AsRef<str>,
+) -> Prop {
+    let name = name.as_ref();
+    Prop::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        name,
+        prop_kind,
+    )
+    .await
+    .expect("cannot create prop")
+}
+
 pub async fn create_func(
     txn: &PgTxn<'_>,
     nats: &NatsTxn,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -9,6 +9,8 @@ use dal::{
 };
 use serde_json::json;
 
+mod view;
+
 #[tokio::test]
 async fn new() {
     test_setup!(

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1,0 +1,495 @@
+use dal::{
+    system::{UNSET_ID_VALUE, UNSET_SYSTEM_ID},
+    test_harness::{
+        create_component_for_schema_variant, create_prop_of_kind_with_name, create_schema,
+        create_schema_variant,
+    },
+    ComponentView, HistoryActor, PropKind, SchemaKind, SchemaVariant, StandardModel, Tenancy,
+    Visibility,
+};
+use si_data::{NatsTxn, PgTxn};
+
+use crate::test_setup;
+
+/// Create a schema that looks like this:
+/// ```json
+/// { "queen": { "bohemian_rhapsody": "", "killer_queen": ""} }
+/// ```
+pub async fn create_schema_with_object_and_string_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+) -> SchemaVariant {
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let mut schema = create_schema(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Concrete,
+    )
+    .await;
+    let schema_variant =
+        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(txn, nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot associate variant with schema");
+    schema
+        .set_default_schema_variant_id(
+            txn,
+            nats,
+            &visibility,
+            &history_actor,
+            Some(*schema_variant.id()),
+        )
+        .await
+        .expect("cannot set default schema variant");
+
+    let bohemian_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "bohemian_rhapsody",
+    )
+    .await;
+
+    let killer_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "killer_queen",
+    )
+    .await;
+
+    let queen_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::Object,
+        "queen",
+    )
+    .await;
+    queen_prop
+        .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
+        .await
+        .expect("cannot associate prop with schema variant");
+    killer_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
+        .await
+        .expect("cannot set parent prop");
+    bohemian_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
+        .await
+        .expect("cannot set parent prop");
+
+    schema_variant
+}
+
+/// Create a schema that looks like this:
+/// ```json
+/// { "queen": { "bohemian_rhapsody": "", "killer_queen": "", "under_pressure": { "another_one_bites_the_dust": "" }} }
+/// ```
+pub async fn create_schema_with_nested_objects_and_string_prop(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+) -> SchemaVariant {
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let mut schema = create_schema(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Concrete,
+    )
+    .await;
+    let schema_variant =
+        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(txn, nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot associate variant with schema");
+    schema
+        .set_default_schema_variant_id(
+            txn,
+            nats,
+            &visibility,
+            &history_actor,
+            Some(*schema_variant.id()),
+        )
+        .await
+        .expect("cannot set default schema variant");
+
+    let bohemian_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "bohemian_rhapsody",
+    )
+    .await;
+
+    let killer_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "killer_queen",
+    )
+    .await;
+
+    let pressure_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::Object,
+        "under_pressure",
+    )
+    .await;
+
+    let dust_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "another_one_bites_the_dust",
+    )
+    .await;
+    dust_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *pressure_prop.id())
+        .await
+        .expect("cannot set parent prop");
+
+    let queen_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::Object,
+        "queen",
+    )
+    .await;
+    queen_prop
+        .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
+        .await
+        .expect("cannot associate prop with schema variant");
+    killer_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
+        .await
+        .expect("cannot set parent prop");
+    bohemian_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
+        .await
+        .expect("cannot set parent prop");
+    pressure_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
+        .await
+        .expect("cannot set parent prop");
+
+    schema_variant
+}
+
+/// Create a schema that looks like this:
+/// ```json
+/// { "bohemian_rhapsody": "", "killer_queen": "" }
+/// ```
+pub async fn create_schema_with_string_props(txn: &PgTxn<'_>, nats: &NatsTxn) -> SchemaVariant {
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let mut schema = create_schema(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Concrete,
+    )
+    .await;
+    let schema_variant =
+        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(txn, nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot associate variant with schema");
+    schema
+        .set_default_schema_variant_id(
+            txn,
+            nats,
+            &visibility,
+            &history_actor,
+            Some(*schema_variant.id()),
+        )
+        .await
+        .expect("cannot set default schema variant");
+
+    let bohemian_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "bohemian_rhapsody",
+    )
+    .await;
+    bohemian_prop
+        .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
+        .await
+        .expect("cannot associate prop with schema variant");
+
+    let killer_prop = create_prop_of_kind_with_name(
+        txn,
+        nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        PropKind::String,
+        "killer_queen",
+    )
+    .await;
+    killer_prop
+        .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
+        .await
+        .expect("cannot associate prop with schema variant");
+    schema_variant
+}
+
+#[tokio::test]
+async fn only_string_props() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema_variant = create_schema_with_string_props(&txn, &nats).await;
+    let component = create_component_for_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await;
+    let props = schema_variant
+        .props(&txn, &visibility)
+        .await
+        .expect("cannot get props for schema_variant");
+    for prop in props.iter() {
+        component
+            .resolve_attribute(
+                &txn,
+                &nats,
+                veritech.clone(),
+                &tenancy,
+                &visibility,
+                &history_actor,
+                prop,
+                Some(serde_json::json!["woohoo"]),
+            )
+            .await
+            .expect("cannot resolve the attributes for the component");
+    }
+    let component_view = ComponentView::for_component_and_system(
+        &txn,
+        &tenancy,
+        &visibility,
+        *component.id(),
+        UNSET_SYSTEM_ID,
+    )
+    .await
+    .expect("cannot get component view");
+    txn.commit().await.expect("cannot commit txn");
+    assert_eq!(component_view.name, component.name());
+    assert_eq!(
+        component_view.properties,
+        serde_json::json![{"bohemian_rhapsody": "woohoo", "killer_queen": "woohoo"}]
+    );
+}
+
+#[tokio::test]
+async fn one_object_prop() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema_variant = create_schema_with_object_and_string_prop(&txn, &nats).await;
+    let component = create_component_for_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await;
+    let props = schema_variant
+        .all_props(&txn, &visibility)
+        .await
+        .expect("cannot get all props");
+    for prop in props.iter() {
+        // TODO: This should happen automatically when required
+        if prop.name() == "queen" {
+            component
+                .resolve_attribute(
+                    &txn,
+                    &nats,
+                    veritech.clone(),
+                    &tenancy,
+                    &visibility,
+                    &history_actor,
+                    prop,
+                    Some(serde_json::json![{}]),
+                )
+                .await
+                .expect("cannot resolve object attribute to empty object");
+        } else {
+            component
+                .resolve_attribute(
+                    &txn,
+                    &nats,
+                    veritech.clone(),
+                    &tenancy,
+                    &visibility,
+                    &history_actor,
+                    prop,
+                    Some(serde_json::json!["woohoo"]),
+                )
+                .await
+                .expect("cannot resolve the attributes for the component");
+        }
+    }
+    let component_view = ComponentView::for_component_and_system(
+        &txn,
+        &tenancy,
+        &visibility,
+        *component.id(),
+        UNSET_SYSTEM_ID,
+    )
+    .await
+    .expect("cannot get component view");
+    txn.commit().await.expect("cannot commit txn");
+    assert_eq!(component_view.name, component.name());
+    assert_eq!(
+        component_view.properties,
+        serde_json::json![{"queen": {"bohemian_rhapsody": "woohoo", "killer_queen": "woohoo"}}]
+    );
+}
+
+#[tokio::test]
+async fn nested_object_prop() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+    );
+    let tenancy = Tenancy::new_universal();
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+    let schema_variant = create_schema_with_nested_objects_and_string_prop(&txn, &nats).await;
+    let component = create_component_for_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        schema_variant.id(),
+    )
+    .await;
+    let props = schema_variant
+        .all_props(&txn, &visibility)
+        .await
+        .expect("cannot get all props");
+    for prop in props.iter() {
+        // TODO: This should happen automatically when required
+        if prop.name() == "queen" || prop.name() == "under_pressure" {
+            component
+                .resolve_attribute(
+                    &txn,
+                    &nats,
+                    veritech.clone(),
+                    &tenancy,
+                    &visibility,
+                    &history_actor,
+                    prop,
+                    Some(serde_json::json![{}]),
+                )
+                .await
+                .expect("cannot resolve object attribute to empty object");
+        } else {
+            component
+                .resolve_attribute(
+                    &txn,
+                    &nats,
+                    veritech.clone(),
+                    &tenancy,
+                    &visibility,
+                    &history_actor,
+                    prop,
+                    Some(serde_json::json!["woohoo"]),
+                )
+                .await
+                .expect("cannot resolve the attributes for the component");
+        }
+    }
+    let component_view = ComponentView::for_component_and_system(
+        &txn,
+        &tenancy,
+        &visibility,
+        *component.id(),
+        UNSET_SYSTEM_ID,
+    )
+    .await
+    .expect("cannot get component view");
+    txn.commit().await.expect("cannot commit txn");
+    assert_eq!(component_view.name, component.name());
+    assert_eq!(
+        component_view.properties,
+        serde_json::json![{"queen": {"bohemian_rhapsody": "woohoo", "killer_queen": "woohoo", "under_pressure": { "another_one_bites_the_dust": "woohoo"}}}]
+    );
+}


### PR DESCRIPTION
This creates a `ComponentView` that can be created from a `Component`
and optional `System`. It will find all the properties for the schema
variant of the component, along with every value for those properties,
and construct the correct serde_json::Value for the components
properties.

Subsequent PRs will deal with using this construct everywhere, and fix
up a few things related to when values are created for objects and
arrays.

Signed-off-by: Adam Jacob <adam@systeminit.com>