### PR TITLE
 Update edit fields with PropObj nesting 

### DIFF
--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -66,7 +66,9 @@ impl From<PropKind> for EditFieldDataType {
 
 #[derive(AsRefStr, Clone, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize)]
 pub enum EditFieldObjectKind {
+    /// Update the Component itself.
     Component,
+    /// Update a property on the Component (and not the Component itself).
     ComponentProp,
     Prop,
     QualificationCheck,
@@ -99,6 +101,7 @@ pub enum EditFieldBaggage {
 pub struct EditField {
     id: String,
     pub name: String,
+    /// A descendant edit field can be specified using "path" (e.g. "metadata.name").
     path: Vec<String>,
     object_kind: EditFieldObjectKind,
     object_id: i64,

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -64,6 +64,26 @@ pub enum PropKind {
     Map,
 }
 
+impl PropKind {
+    /// Determine the "PropKind" based on the "serde_json::Value". Returns "None" if there is not a
+    /// direct match. FIXME(nick): object returns object and _does not_ account for maps.
+    pub fn from(value: &serde_json::Value) -> Option<PropKind> {
+        if value.is_array() {
+            Some(PropKind::Array)
+        } else if value.is_i64() {
+            Some(PropKind::Integer)
+        } else if value.is_boolean() {
+            Some(PropKind::Boolean)
+        } else if value.is_string() {
+            Some(PropKind::String)
+        } else if value.is_object() {
+            Some(PropKind::Object)
+        } else {
+            None
+        }
+    }
+}
+
 impl ToLabelList for PropKind {}
 impl ToSelectWidget for PropKind {}
 


### PR DESCRIPTION
- Update edit fields with PropObject nesting [sc-2218]
- Updating PropObjects now takes nesting into effect, but Arrays and
  Maps are skipped