### PR TITLE
chore(web): port back attribute viewer's layout & rendering (v1)

### DIFF
--- a/app/web/src/molecules/Panel.vue
+++ b/app/web/src/molecules/Panel.vue
@@ -72,7 +72,7 @@
         </div>
       </div>
     </div>
-    <div class="flex flex-grow w-full h-full overflow-hidden">
+    <div class="flex flex-grow w-full h-full overflow-auto">
       <slot name="content"></slot>
     </div>
   </div>

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -1,17 +1,16 @@
 <template>
   <div v-if="componentId" class="flex flex-col w-full overflow-hidden">
-    <div class="flex flex-col w-full overflow-hidden scrollbar">
-      <EditForm
-        :object-kind="EditFieldObjectKind.Component"
-        :object-id="props.componentId"
-      />
+    <div
+      class="flex flex-row items-center h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
+    >
+      <div class="text-lg">TODO: componmentType</div>
     </div>
+    <EditFormComponent :object-id="props.componentId" />
   </div>
 </template>
 
 <script setup lang="ts">
-import EditForm from "@/organisims/EditForm.vue";
-import { EditFieldObjectKind } from "@/api/sdf/dal/edit_field";
+import EditFormComponent from "@/organisims/EditFormComponent.vue";
 
 const props = defineProps<{
   componentId: number;
@@ -26,5 +25,9 @@ const props = defineProps<{
 
 .scrollbar::-webkit-scrollbar {
   display: none; /*chrome, opera, and safari */
+}
+
+.property-section-bg-color {
+  background-color: #292c2d;
 }
 </style>

--- a/app/web/src/organisims/EditForm.vue
+++ b/app/web/src/organisims/EditForm.vue
@@ -1,9 +1,8 @@
 <template>
-  <Widgets v-if="editFields" :edit-fields="editFields" />
+  <Widgets v-if="editFields" :edit-fields="editFields" :indent-level="1" />
 </template>
 
 <script setup lang="ts">
-import { PropType } from "vue";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
 import { fromRef, refFrom } from "vuse-rx";
 import { EditFieldService } from "@/service/edit_field";
@@ -12,16 +11,10 @@ import Widgets from "@/organisims/EditForm/Widgets.vue";
 import { combineLatest, from } from "rxjs";
 import { switchMap } from "rxjs/operators";
 
-const props = defineProps({
-  objectKind: {
-    type: String as PropType<EditFieldObjectKind>,
-    required: true,
-  },
-  objectId: {
-    type: Number,
-    required: true,
-  },
-});
+const props = defineProps<{
+  objectKind: EditFieldObjectKind;
+  objectId: number;
+}>();
 
 const props$ = fromRef(props, { immediate: true, deep: true });
 

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -1,5 +1,9 @@
 <template>
-  <EditFormField :show="show" :validation-errors="editField.validation_errors">
+  <EditFormField
+    :show="show"
+    :validation-errors="editField.validation_errors"
+    :core-edit-field="coreEditField"
+  >
     <template #name>
       {{ editField.name }}
     </template>
@@ -10,7 +14,7 @@
           :key="index"
           class="flex flex-col justify-between w-full p-1 border border-gray-500"
         >
-          <Widgets :edit-fields="editFields" />
+          <Widgets :edit-fields="editFields" :indent-level="indentLevel + 1" />
         </div>
         <div class="flex flex-row mt-1 ml-1">
           <button @click="addToArray">
@@ -26,7 +30,7 @@
           :key="index"
           class="flex flex-col justify-between w-full mx-1 border border-gray-500"
         >
-          <Widgets :edit-fields="editFields" />
+          <Widgets :edit-fields="editFields" :indent-level="indentLevel + 1" />
         </div>
       </div>
     </template>
@@ -34,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType } from "vue";
+import { computed } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
 import { ArrayWidgetDal } from "@/api/sdf/dal/edit_field";
@@ -58,16 +62,12 @@ const Widgets = defineAsyncComponent<DefineComponent<WidgetsProps>>(
   () => import("./Widgets.vue") as any,
 );
 
-const props = defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-  editField: {
-    type: Object as PropType<EditField>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  coreEditField: boolean;
+  indentLevel: number;
+  editField: EditField;
+}>();
 
 const widget = computed<ArrayWidgetDal>(() => {
   return props.editField.widget as ArrayWidgetDal;

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -1,5 +1,9 @@
 <template>
-  <EditFormField :show="show" :validation-errors="editField.validation_errors">
+  <EditFormField
+    :show="show"
+    :validation-errors="editField.validation_errors"
+    :core-edit-field="coreEditField"
+  >
     <template #name>{{ editField.name }}</template>
     <template #edit>
       <input
@@ -20,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import { EditFieldService } from "@/service/edit_field";
 import EditFormField from "./EditFormField.vue";
@@ -28,16 +32,11 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 
-const props = defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-  editField: {
-    type: Object as PropType<EditField>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  coreEditField: boolean;
+  editField: EditField;
+}>();
 
 const updating = ref(false);
 const startValue = ref(props.editField.value);

--- a/app/web/src/organisims/EditForm/EditFormField.vue
+++ b/app/web/src/organisims/EditForm/EditFormField.vue
@@ -1,32 +1,61 @@
 <template>
-  <div v-if="props.show" class="flex flex-row items-center w-full">
-    <div class="flex flex-col w-full">
-      <div class="flex flex-row items-center">
-        <div class="flex-wrap self-start text-sm leading-tight text-right w-36">
-          <slot name="name"></slot>
-        </div>
-        <div class="flex w-full">
-          <div
-            v-if="editMode"
-            class="flex mx-2 text-sm leading-tight text-gray-400"
-            @keyup.stop
-            @keydown.stop
-          >
-            <!-- could flex-grow if needed -->
-            <slot name="edit" />
-          </div>
-
-          <div v-else class="flex mx-2 text-sm leading-tight text-gray-400">
-            <!-- could flex-grow if needed -->
-            <slot name="show" />
-          </div>
-        </div>
+  <template v-if="props.coreEditField">
+    <div class="flex flex-row items-center mx-6 mt-2">
+      <div class="text-sm leading-tight text-right text-white w-28">
+        <slot name="name"></slot>
       </div>
-      <div class="flex flex-wrap">
-        <ValidationErrorsWidget :errors="props.validationErrors" class="p-2" />
+      <div
+        v-if="editMode"
+        class="flex flex-grow pl-2 text-sm leading-tight text-gray-400"
+        @keyup.stop
+        @keydown.stop
+      >
+        <slot name="edit" />
+      </div>
+      <div
+        v-else
+        class="flex flex-grow pl-2 mr-2 text-sm leading-tight text-gray-400"
+      >
+        <slot name="show"></slot>
       </div>
     </div>
-  </div>
+  </template>
+  <template v-else>
+    <div v-if="props.show" class="flex flex-row items-center w-full">
+      <div class="flex flex-col w-full">
+        <div class="flex flex-row items-center">
+          <div
+            class="flex-wrap self-start text-sm leading-tight text-right w-36"
+          >
+            <slot name="name"></slot>
+          </div>
+          <div class="flex w-full">
+            <div
+              v-if="editMode"
+              class="flex mx-2 text-sm leading-tight text-gray-400"
+              @keyup.stop
+              @keydown.stop
+            >
+              <div class="flex flex-row">
+                <slot name="edit" />
+              </div>
+            </div>
+
+            <div v-else class="flex mx-2 text-sm leading-tight text-gray-400">
+              <!-- could flex-grow if needed -->
+              <slot name="show" />
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-wrap">
+          <ValidationErrorsWidget
+            :errors="props.validationErrors"
+            class="p-2"
+          />
+        </div>
+      </div>
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
@@ -37,6 +66,7 @@ import type { ValidationErrors } from "@/api/sdf/dal/edit_field";
 
 const props = defineProps<{
   show: boolean;
+  coreEditField: boolean;
   validationErrors: ValidationErrors;
 }>();
 

--- a/app/web/src/organisims/EditForm/HeaderWidget.vue
+++ b/app/web/src/organisims/EditForm/HeaderWidget.vue
@@ -13,14 +13,12 @@
         {{ editField.name }}
       </div>
     </div>
-    <div v-show="isOpen" class="flex w-full pt-1 pb-1 mt-2 text-sm text-white">
-      <Widgets :edit-fields="widgetEditFields" />
-    </div>
   </section>
+  <Widgets :edit-fields="widgetEditFields" :indent-level="indentLevel + 1" />
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref } from "vue";
+import { computed, ref } from "vue";
 import { EditField, EditFields } from "@/api/sdf/dal/edit_field";
 import VueFeather from "vue-feather";
 import { defineAsyncComponent, DefineComponent } from "vue";
@@ -38,20 +36,13 @@ const Widgets = defineAsyncComponent<DefineComponent<WidgetsProps>>(
   () => import("./Widgets.vue") as any,
 );
 
-const props = defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-  editField: {
-    type: Object as PropType<EditField>,
-    required: true,
-  },
-  backgroundColors: {
-    type: Array as PropType<number[][]>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  coreEditField: boolean;
+  indentLevel: number;
+  editField: EditField;
+  backgroundColors: number[][];
+}>();
 
 // const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
 
@@ -65,17 +56,14 @@ const widgetEditFields = computed<EditFields>(() => {
 
 const isOpen = ref<boolean>(true);
 
-const paddingLeft = computed<number>(() => {
-  const indentFactorPx = 10;
-  const indentCount = 1;
-  return indentCount * indentFactorPx;
-});
-
 const propObjectStyle = computed<string>(() => {
-  const rgb = props.backgroundColors[1].join(",");
-  let style = `background-color: rgb(${rgb})`;
-  style = `${style} padding-left: ${paddingLeft.value}px;`;
-  return style;
+  // const rgb = props.backgroundColors[1].join(",");
+  // let style = `background-color: rgb(${rgb})`;
+  // style = `${style} padding-left: ${paddingLeft.value}px;`;
+  // return style;
+  const backgroundColor = "background-color: rgb(50, 50, 50)";
+  const paddingLeft = `padding-left: ${props.indentLevel * 10}px`;
+  return `${backgroundColor}; ${paddingLeft};`;
 });
 </script>
 

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -1,5 +1,9 @@
 <template>
-  <EditFormField :show="show" :validation-errors="editField.validation_errors">
+  <EditFormField
+    :show="show"
+    :validation-errors="editField.validation_errors"
+    :core-edit-field="coreEditField"
+  >
     <template #name>
       {{ editField.name }}
     </template>
@@ -29,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import type { EditField, SelectWidgetDal } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
 import { EditFieldService } from "@/service/edit_field";
@@ -37,16 +41,11 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 
-const props = defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-  editField: {
-    type: Object as PropType<EditField>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  coreEditField: boolean;
+  editField: EditField;
+}>();
 
 const widget = computed<SelectWidgetDal>(() => {
   // Lies, damn lies, and statistics!

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -1,5 +1,9 @@
 <template>
-  <EditFormField :show="show" :validation-errors="editField.validation_errors">
+  <EditFormField
+    :show="show"
+    :core-edit-field="coreEditField"
+    :validation-errors="editField.validation_errors"
+  >
     <template #name>
       {{ editField.name }}
     </template>
@@ -7,7 +11,7 @@
       <input
         v-model="currentValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
-        :class="borderColor"
+        :class="inputStyles"
         type="text"
         aria-label="name"
         placeholder="text"
@@ -23,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
 import { EditFieldService } from "@/service/edit_field";
@@ -31,16 +35,11 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 
-const props = defineProps({
-  show: {
-    type: Boolean,
-    required: true,
-  },
-  editField: {
-    type: Object as PropType<EditField>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  show: boolean;
+  coreEditField: boolean;
+  editField: EditField;
+}>();
 
 const updating = ref(false);
 const startValue = ref(props.editField.value);
@@ -79,13 +78,24 @@ watch(
   },
 );
 
-const borderColor = computed(
+const inputStyles = computed(
   (): Record<string, boolean> => {
+    let styles: Record<string, boolean> = {};
+
     if (props.editField.visibility_diff.kind != "None") {
-      return { "input-border-gold": true };
+      styles["input-border-gold"] = true;
+      styles["input-border-grey"] = false;
     } else {
-      return { "input-border-grey": true };
+      styles["input-border-gold"] = false;
+      styles["input-border-grey"] = true;
     }
+    if (props.coreEditField) {
+      styles["flex-grow"] = true;
+    } else {
+      styles["flex-grow"] = false;
+    }
+
+    return styles;
   },
 );
 const textColor = computed(

--- a/app/web/src/organisims/EditForm/Widget.vue
+++ b/app/web/src/organisims/EditForm/Widget.vue
@@ -1,0 +1,51 @@
+<template>
+  <HeaderWidget
+    v-if="editField.widget.kind === 'Header'"
+    :show="true"
+    :edit-field="editField"
+    :background-colors="backgroundColors"
+    :core-edit-field="coreEditField"
+    :indent-level="indentLevel"
+  />
+  <ArrayWidget
+    v-else-if="editField.widget.kind === 'Array'"
+    :show="true"
+    :edit-field="editField"
+    :core-edit-field="coreEditField"
+    :indent-level="indentLevel"
+  />
+  <TextWidget
+    v-else-if="editField.widget.kind === 'Text'"
+    :show="true"
+    :edit-field="editField"
+    :core-edit-field="coreEditField"
+  />
+  <CheckboxWidget
+    v-else-if="editField.widget.kind === 'Checkbox'"
+    :show="true"
+    :edit-field="editField"
+    :core-edit-field="coreEditField"
+  />
+  <SelectWidget
+    v-else-if="editField.widget.kind === 'Select'"
+    :show="true"
+    :edit-field="editField"
+    :core-edit-field="coreEditField"
+  />
+</template>
+
+<script setup lang="ts">
+import { EditField } from "@/api/sdf/dal/edit_field";
+import CheckboxWidget from "@/organisims/EditForm/CheckboxWidget.vue";
+import TextWidget from "@/organisims/EditForm/TextWidget.vue";
+import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
+import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
+import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
+
+defineProps<{
+  coreEditField: boolean;
+  indentLevel: number;
+  editField: EditField;
+  backgroundColors: number[][];
+}>();
+</script>

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -1,61 +1,47 @@
 <template>
-  <div v-for="editField in editFields" :key="editField.id" class="my-2">
-    <!-- eventually this will do the show/hide logic -->
-    <HeaderWidget
-      v-if="editField.widget.kind === 'Header'"
+  <template v-for="editField in editFields" :key="editField.id">
+    <Widget
+      v-if="isCoreEditField"
       :show="true"
       :edit-field="editField"
       :background-colors="backgroundColors"
+      :core-edit-field="isCoreEditField"
+      :indent-level="indentLevel"
     />
-    <ArrayWidget
-      v-else-if="editField.widget.kind === 'Array'"
-      :show="true"
-      :edit-field="editField"
-    />
-    <TextWidget
-      v-else-if="editField.widget.kind === 'Text'"
-      :show="true"
-      :edit-field="editField"
-    />
-    <CheckboxWidget
-      v-else-if="editField.widget.kind === 'Checkbox'"
-      :show="true"
-      :edit-field="editField"
-    />
-    <SelectWidget
-      v-else-if="editField.widget.kind === 'Select'"
-      :show="true"
-      :edit-field="editField"
-    />
-  </div>
+    <div v-else class="my-2">
+      <Widget
+        :show="true"
+        :edit-field="editField"
+        :background-colors="backgroundColors"
+        :core-edit-field="isCoreEditField"
+        :indent-level="indentLevel"
+      />
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
-import { computed, PropType } from "vue";
+import { computed } from "vue";
 import { EditFields } from "@/api/sdf/dal/edit_field";
-import CheckboxWidget from "@/organisims/EditForm/CheckboxWidget.vue";
-import TextWidget from "@/organisims/EditForm/TextWidget.vue";
-import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
-import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
-import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
+import Widget from "@/organisims/EditForm/Widget.vue";
 import { interpolateColors } from "@/utils/interpolateColors";
 
 export interface WidgetsProps {
   editFields: EditFields;
+  coreEditFields?: boolean;
+  indentLevel: number;
 }
+const props = defineProps<WidgetsProps>();
 
-const props = defineProps({
-  editFields: {
-    type: Array as PropType<EditFields>,
-    required: true,
-  },
-});
+const isCoreEditField = computed(() =>
+  props.coreEditFields === undefined ? false : props.coreEditFields,
+);
 
 const backgroundColors = computed(() => {
   const longestProp = 50;
-  for (const field of props.editFields) {
-    console.log("field", { field });
-  }
+  // for (const field of props.editFields) {
+  //   console.log("field", { field });
+  // }
 
   const colors = interpolateColors(
     "rgb(50, 50, 50)",
@@ -65,7 +51,4 @@ const backgroundColors = computed(() => {
 
   return colors;
 });
-
-// type TreeOpenState = Record<string, boolean>;
-// const treeOpenState = ref<TreeOpenState>({});
 </script>

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="flex flex-col w-full overflow-auto scrollbar">
+    <Widgets
+      v-if="coreEditFields"
+      :edit-fields="coreEditFields"
+      :core-edit-fields="true"
+      :indent-level="1"
+    />
+    <div
+      v-if="propertyEditFields"
+      class="pt1 pb-1 pl-6 mt-2 text-base text-white align-middle property-section-bg-color"
+    >
+      Properties
+    </div>
+    <div class="w-full">
+      <Widgets
+        v-if="propertyEditFields"
+        :edit-fields="propertyEditFields"
+        :indent-level="1"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
+import { fromRef, refFrom } from "vuse-rx";
+import { EditFieldService } from "@/service/edit_field";
+import { GlobalErrorService } from "@/service/global_error";
+import Widgets from "@/organisims/EditForm/Widgets.vue";
+import { combineLatest, from } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import _ from "lodash";
+
+const props = defineProps<{
+  objectId: number;
+}>();
+
+const props$ = fromRef(props, { immediate: true, deep: true });
+
+/**
+ * Returns core edit fields that are *not* component properties
+ */
+const coreEditFields = computed(() => {
+  if (editFields.value === undefined) {
+    return undefined;
+  } else {
+    return _.filter(
+      editFields.value,
+      (field) => field.object_kind == EditFieldObjectKind.Component,
+    );
+  }
+});
+
+/**
+ * Returns edit fields are component properties
+ */
+const propertyEditFields = computed(() => {
+  if (editFields.value === undefined) {
+    return undefined;
+  } else {
+    return _.filter(
+      editFields.value,
+      (field) => field.object_kind == EditFieldObjectKind.ComponentProp,
+    );
+  }
+});
+
+const editFields = refFrom<EditFields | undefined>(
+  combineLatest([props$]).pipe(
+    switchMap(([props]) => {
+      return EditFieldService.getEditFields({
+        id: props.objectId,
+        objectKind: EditFieldObjectKind.Component,
+      });
+    }),
+    switchMap((response) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+        return from([[]]);
+      } else {
+        return from([response.fields]);
+      }
+    }),
+  ),
+);
+</script>
+
+<style scoped>
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+</style>


### PR DESCRIPTION
This change brings back most of the styling and layout of the attribute
viewer (i.e the top right panel in the editor). It's not all the way
down, but now should be in a state where we can resume working on in
with more parallelism. More emphasis was put into the `editMode = true`
scenario (i.e. input fields, etc), but there is some reasonable
read-only rendering at the moment.

Most of this work was done in the attribue viewer by creating a new
`kubernetes_deployment` node and then selecting the node in the
component picker.

What's working:

* Splitting apart the property-related EditFields from the
  non-property-related fields (which I called "coreEditFields" in the
  Vue components), allowing us to display "core" attributes with full
  width inputs on top of a `Properties` section as before. This is done
  by 2 computed functions that filter on `EditFieldObjectKind` and
  maintain the ordering shipped from the API.
* Header indentation is working by providing an `indentLevel` to the
  root Vue components, and the child components that nest know to
  increment the `indentLevel` when passing the value down to their
  children. It was pretty great how much easier it was.
* "Gold bars" work and are colored appropriately.

Remaining work:

* When rendering the AttributeViewer we don't have access to the name of
  the component type to display at the top of the viewer, so for the
  moment there is `TODO: componentType` text as a reminder.
* Open/closed state on header sections. This will likely be a lot easier
  with some techniques stolen from the indentation logic.
* Header background color interpolation computing. Before we could
  determine the maximum object depth by iterating over each edit field
  and getting a max length on a `path` field. Now that EditFields nest,
  we'll likely need to do a similar walk but one that accumulates over
  its children.
* Array and Map rendering. I wasn't convinced we have any yet to render
  and after realizing that there are slightly specialized EditForms
  per-object type (i.e. Schemas vs Components, etc.), this meant that I
  didn't upgrade the schema editor to a similar fidelity.
* "Driven fields" likely require some more metadata to flow in the
  EditField object which would turn the field names blue as before.

<img src="https://media2.giphy.com/media/wRvEvjCcuKBPy/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>