### PR TITLE
feat(web,sdf,dal): Add Component Metadata Route

### DIFF
--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -3,7 +3,9 @@
     <div
       class="flex flex-row items-center h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
     >
-      <div class="text-lg">TODO: componmentType</div>
+      <div v-if="componentMetadata?.schemaName" class="text-lg">
+        {{ componentMetadata.schemaName }}
+      </div>
     </div>
     <EditFormComponent :object-id="props.componentId" />
   </div>
@@ -11,10 +13,41 @@
 
 <script setup lang="ts">
 import EditFormComponent from "@/organisims/EditFormComponent.vue";
+import { ComponentService } from "@/service/component";
+import { GetComponentMetadataResponse } from "@/service/component/get_component_metadata";
+import { toRefs } from "vue";
+import { fromRef, refFrom } from "vuse-rx";
+import { from, switchMap, combineLatest } from "rxjs";
+import { GlobalErrorService } from "@/service/global_error";
 
 const props = defineProps<{
   componentId: number;
 }>();
+
+const { componentId } = toRefs(props);
+
+// We need an observable stream of props.componentId. We also want
+// that stream to emit a value immediately (the first value, as well as all
+// subsequent values)
+const componentId$ = fromRef<number>(componentId, { immediate: true });
+
+const componentMetadata = refFrom<GetComponentMetadataResponse | undefined>(
+  combineLatest([componentId$]).pipe(
+    switchMap(([componentId]) => {
+      return ComponentService.getComponentMetadata({
+        componentId,
+      });
+    }),
+    switchMap((response) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+        return from([null]);
+      } else {
+        return from([response]);
+      }
+    }),
+  ),
+);
 </script>
 
 <style scoped>

--- a/app/web/src/service/component.ts
+++ b/app/web/src/service/component.ts
@@ -2,9 +2,11 @@ import { listComponentsNamesOnly } from "./component/list_components_names_only"
 import { listQualifications } from "./component/list_qualifications";
 import { getResource } from "./component/get_resource";
 import { syncResource } from "./component/sync_resource";
+import { getComponentMetadata } from "./component/get_component_metadata";
 
 export const ComponentService = {
   listComponentsNamesOnly,
+  getComponentMetadata,
   listQualifications,
   getResource,
   syncResource,

--- a/app/web/src/service/component/get_component_metadata.ts
+++ b/app/web/src/service/component/get_component_metadata.ts
@@ -1,0 +1,54 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, combineLatestWith, from, Observable } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { shareReplay, switchMap } from "rxjs/operators";
+import { workspace$ } from "@/observable/workspace";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import _ from "lodash";
+
+export interface GetComponentMetadataArgs {
+  componentId: number;
+}
+
+export interface GetComponentMetadataRequest
+  extends GetComponentMetadataArgs,
+    Visibility {
+  workspaceId: number;
+}
+
+export interface GetComponentMetadataResponse {
+  schemaName: string;
+}
+
+export function getComponentMetadata(
+  args: GetComponentMetadataArgs,
+): Observable<ApiResponse<GetComponentMetadataResponse>> {
+  return combineLatest([standardVisibilityTriggers$]).pipe(
+    combineLatestWith(workspace$),
+    switchMap(([[[visibility]], workspace]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      const request: GetComponentMetadataRequest = {
+        ...visibility,
+        workspaceId: workspace.id,
+        componentId: args.componentId,
+      };
+      return sdf.get<ApiResponse<GetComponentMetadataResponse>>(
+        "component/get_component_metadata",
+        request,
+      );
+    }),
+  );
+}

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -30,7 +30,7 @@ pub async fn kubernetes_deployment(
         visibility,
         history_actor,
         &name,
-        &SchemaKind::Concept, // Note: what is this?
+        &SchemaKind::Concrete,
     )
     .await?
     {

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -8,6 +8,7 @@ use dal::{ComponentError as DalComponentError, SchemaError, StandardModelError, 
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod get_component_metadata;
 pub mod get_resource;
 pub mod list_components_names_only;
 pub mod list_qualifications;
@@ -63,6 +64,10 @@ pub fn routes() -> Router {
         .route(
             "/list_components_names_only",
             get(list_components_names_only::list_components_names_only),
+        )
+        .route(
+            "/get_component_metadata",
+            get(get_component_metadata::get_component_metadata),
         )
         .route(
             "/list_qualifications",

--- a/lib/sdf/src/server/service/component/get_component_metadata.rs
+++ b/lib/sdf/src/server/service/component/get_component_metadata.rs
@@ -1,0 +1,58 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{Component, ComponentId, StandardModel, Tenancy, Visibility, Workspace, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use super::{ComponentError, ComponentResult};
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetComponentMetadataRequest {
+    pub component_id: ComponentId,
+    //pub system_id: SystemId,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetComponentMetadataResponse {
+    pub schema_name: String,
+    //pub resource_state: Option<()>
+}
+
+pub async fn get_component_metadata(
+    mut txn: PgRoTxn,
+    Query(request): Query<GetComponentMetadataRequest>,
+    Authorization(claim): Authorization,
+) -> ComponentResult<Json<GetComponentMetadataResponse>> {
+    let txn = txn.start().await?;
+    let billing_account_tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    let workspace = Workspace::get_by_id(
+        &txn,
+        &billing_account_tenancy,
+        &request.visibility,
+        &request.workspace_id,
+    )
+    .await?
+    .ok_or(ComponentError::InvalidRequest)?;
+    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+
+    let component =
+        Component::get_by_id(&txn, &tenancy, &request.visibility, &request.component_id)
+            .await?
+            .ok_or(ComponentError::NotFound)?;
+    let mut schema_tenancy = tenancy.clone();
+    schema_tenancy.universal = true;
+
+    let schema = component
+        .schema_with_tenancy(&txn, &schema_tenancy, &request.visibility)
+        .await?
+        .ok_or(ComponentError::SchemaNotFound)?;
+    let response = GetComponentMetadataResponse {
+        schema_name: schema.name().to_owned(),
+    };
+    Ok(Json(response))
+}

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -2,7 +2,11 @@ use std::collections::HashSet;
 
 use crate::service_tests::api_request_auth_query;
 use crate::test_setup;
-use dal::{Component, HistoryActor, StandardModel, Tenancy, Visibility};
+use dal::test_harness::{create_schema, create_schema_variant};
+use dal::{Component, HistoryActor, SchemaKind, StandardModel, Tenancy, Visibility};
+use sdf::service::component::get_component_metadata::{
+    GetComponentMetadataRequest, GetComponentMetadataResponse,
+};
 use sdf::service::component::list_components_names_only::{
     ListComponentNamesOnlyRequest, ListComponentNamesOnlyResponse,
 };
@@ -65,4 +69,84 @@ async fn list_components_names_only() {
             .into_iter()
             .collect()
     );
+}
+
+#[tokio::test]
+async fn get_component_metadata() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        nats,
+        veritech,
+        app,
+        nba,
+        auth_token
+    );
+    let visibility = Visibility::new_head(false);
+    let tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    let history_actor = HistoryActor::SystemInit;
+
+    let mut schema_tenancy = tenancy.clone();
+    schema_tenancy.universal = true;
+    let schema = create_schema(
+        &txn,
+        &nats,
+        &schema_tenancy,
+        &visibility,
+        &history_actor,
+        &SchemaKind::Concept,
+    )
+    .await;
+
+    let schema_variant =
+        create_schema_variant(&txn, &nats, &schema_tenancy, &visibility, &history_actor).await;
+    schema_variant
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("cannot set schema variant");
+
+    let component = Component::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "hello friend",
+    )
+    .await
+    .expect("cannot create new component");
+    component
+        .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
+        .await
+        .expect("Cannot attach component to schema");
+    component
+        .set_schema_variant(
+            &txn,
+            &nats,
+            &visibility,
+            &history_actor,
+            schema_variant.id(),
+        )
+        .await
+        .expect("Cannot attach component to schema variant");
+    txn.commit().await.expect("cannot commit transaction");
+
+    let request = GetComponentMetadataRequest {
+        visibility,
+        component_id: *component.id(),
+        workspace_id: *nba.workspace.id(),
+    };
+    let response: GetComponentMetadataResponse = api_request_auth_query(
+        app,
+        "/api/component/get_component_metadata",
+        &auth_token,
+        &request,
+    )
+    .await;
+
+    assert_eq!(response.schema_name, schema.name());
 }


### PR DESCRIPTION
Initial route to group all metadata from the component.

For now we only get the schema name, but it should be expanded.

<img src="https://media0.giphy.com/media/W0cp0XrvIe6PxFEYAM/giphy.gif"/>