### PR TITLE
chore(web): prepare AttributeViewer edit count with static value

### DIFF
--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -1,13 +1,21 @@
 <template>
-  <div v-if="componentId" class="flex flex-col w-full overflow-hidden">
+  <div class="flex flex-col w-full overflow-hidden">
     <div
       class="flex flex-row items-center h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
     >
       <div v-if="componentMetadata?.schemaName" class="text-lg">
         {{ componentMetadata.schemaName }}
       </div>
+      <div
+        class="flex flow-row items-center justify-end flex-grow h-full text-xs text-center"
+      >
+        <div class="flex flex-row items-center">
+          <VueFeather type="edit" size="0.75rem" class="gold-bars-icon" />
+          <div v-if="editCount" class="ml-1 text-center">{{ editCount }}</div>
+        </div>
+      </div>
     </div>
-    <EditFormComponent :object-id="props.componentId" />
+    <EditFormComponent v-if="editFields" :edit-fields="editFields" />
   </div>
 </template>
 
@@ -15,11 +23,14 @@
 import EditFormComponent from "@/organisims/EditFormComponent.vue";
 import { ComponentService } from "@/service/component";
 import { GetComponentMetadataResponse } from "@/service/component/get_component_metadata";
-import { toRefs } from "vue";
+import { computed, toRefs } from "vue";
 import { fromRef, refFrom } from "vuse-rx";
 import { from, combineLatest } from "rxjs";
 import { switchMap } from "rxjs/operators";
 import { GlobalErrorService } from "@/service/global_error";
+import VueFeather from "vue-feather";
+import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
+import { EditFieldService } from "@/service/edit_field";
 
 const props = defineProps<{
   componentId: number;
@@ -31,6 +42,25 @@ const { componentId } = toRefs(props);
 // that stream to emit a value immediately (the first value, as well as all
 // subsequent values)
 const componentId$ = fromRef<number>(componentId, { immediate: true });
+
+const editFields = refFrom<EditFields | undefined>(
+  combineLatest([componentId$]).pipe(
+    switchMap(([componentId]) => {
+      return EditFieldService.getEditFields({
+        id: componentId,
+        objectKind: EditFieldObjectKind.Component,
+      });
+    }),
+    switchMap((response) => {
+      if (response.error) {
+        GlobalErrorService.set(response);
+        return from([[]]);
+      } else {
+        return from([response.fields]);
+      }
+    }),
+  ),
+);
 
 const componentMetadata = refFrom<GetComponentMetadataResponse | undefined>(
   combineLatest([componentId$]).pipe(
@@ -49,6 +79,26 @@ const componentMetadata = refFrom<GetComponentMetadataResponse | undefined>(
     }),
   ),
 );
+
+const editCount = computed(() => {
+  if (editFields === undefined) {
+    return undefined;
+  } else {
+    // TODO(fnichol): Implement the logic to count edited fields.
+    //
+    // To accomplish this, we can interate through each `EditField` and filter
+    // only entries that have:
+    //
+    // `editField.visibility_diff != VisibilityDiffNone`
+    //
+    // The tricky part is that `EditField`s nest, so we need to visit and count
+    // inside of each `PropObject`, `PropArray`, and `PropMap` type. That's the
+    // same traversal/visit logic needed for other info such as computing the
+    // deepest path in a Component, so I suspect there's something
+    // generalizable once we get the first iteration of an implementation.
+    return 666;
+  }
+});
 </script>
 
 <style scoped>
@@ -59,6 +109,10 @@ const componentMetadata = refFrom<GetComponentMetadataResponse | undefined>(
 
 .scrollbar::-webkit-scrollbar {
   display: none; /*chrome, opera, and safari */
+}
+
+.gold-bars-icon {
+  color: #ce7f3e;
 }
 
 .property-section-bg-color {

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -7,7 +7,7 @@
     <template #name>{{ editField.name }}</template>
     <template #edit>
       <input
-        v-model="value"
+        v-model="inputValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         type="checkbox"
@@ -73,13 +73,22 @@ watch(
   },
 );
 
-const value = computed((): boolean | undefined => {
+const inputValue = computed((): boolean | undefined => {
   if (
     currentValue.value === undefined ||
     typeof currentValue.value === "boolean"
   ) {
+    // We'd expect the optional value to be undefined if not provided or a
+    // boolean
     return currentValue.value;
+  } else if (currentValue.value === null) {
+    // Or, getting a `null` implies this value has not yet been set on a
+    // Component, as in "unset"
+    return false;
   } else {
+    // Otherwise, this is a deeply unexpected value type and we're not going to
+    // let JavaScript coerce something invalid into a `bool` so, throw an error
+    // instead
     throw new Error(
       `Current editField prop must be a boolean | undefined: '${JSON.stringify(
         currentValue.value,

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -1,23 +1,17 @@
 <template>
   <div class="flex flex-col w-full overflow-auto scrollbar">
     <Widgets
-      v-if="coreEditFields"
       :edit-fields="coreEditFields"
       :core-edit-fields="true"
       :indent-level="1"
     />
     <div
-      v-if="propertyEditFields"
       class="pt1 pb-1 pl-6 mt-2 text-base text-white align-middle property-section-bg-color"
     >
       Properties
     </div>
     <div class="w-full">
-      <Widgets
-        v-if="propertyEditFields"
-        :edit-fields="propertyEditFields"
-        :indent-level="1"
-      />
+      <Widgets :edit-fields="propertyEditFields" :indent-level="1" />
     </div>
   </div>
 </template>
@@ -25,66 +19,32 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
-import { fromRef, refFrom } from "vuse-rx";
-import { EditFieldService } from "@/service/edit_field";
-import { GlobalErrorService } from "@/service/global_error";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
-import { combineLatest, from } from "rxjs";
-import { switchMap } from "rxjs/operators";
 import _ from "lodash";
 
 const props = defineProps<{
-  objectId: number;
+  editFields: EditFields;
 }>();
-
-const props$ = fromRef(props, { immediate: true, deep: true });
 
 /**
  * Returns core edit fields that are *not* component properties
  */
 const coreEditFields = computed(() => {
-  if (editFields.value === undefined) {
-    return undefined;
-  } else {
-    return _.filter(
-      editFields.value,
-      (field) => field.object_kind == EditFieldObjectKind.Component,
-    );
-  }
+  return _.filter(
+    props.editFields,
+    (field) => field.object_kind == EditFieldObjectKind.Component,
+  );
 });
 
 /**
  * Returns edit fields are component properties
  */
 const propertyEditFields = computed(() => {
-  if (editFields.value === undefined) {
-    return undefined;
-  } else {
-    return _.filter(
-      editFields.value,
-      (field) => field.object_kind == EditFieldObjectKind.ComponentProp,
-    );
-  }
+  return _.filter(
+    props.editFields,
+    (field) => field.object_kind == EditFieldObjectKind.ComponentProp,
+  );
 });
-
-const editFields = refFrom<EditFields | undefined>(
-  combineLatest([props$]).pipe(
-    switchMap(([props]) => {
-      return EditFieldService.getEditFields({
-        id: props.objectId,
-        objectKind: EditFieldObjectKind.Component,
-      });
-    }),
-    switchMap((response) => {
-      if (response.error) {
-        GlobalErrorService.set(response);
-        return from([[]]);
-      } else {
-        return from([response.fields]);
-      }
-    }),
-  ),
-);
 </script>
 
 <style scoped>


### PR DESCRIPTION
This change lands all the work for adding back edit counts except for
the logic to calulate the number.

In the course of landing this work, I discovered a solution to the
`EditFieldComponent`'s repopulating issues. In short, it appears easier
to load/reload/update `EditField`s from the `AttributeViewer` and pass
down the array of `EditField`s as a prop to the `EditFormComponent`
component. You can see the cleanup in that child component and how easy
the logic got which felt like a second symbol that we're possibly on the
right track.

<img src="https://media4.giphy.com/media/U2GUItmwNBzjTcRW1a/giphy-downsized-medium.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>