### PR TITLE
Add troubleshoot make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,9 +258,12 @@ app-run:
 	cd $(MAKEPATH)/app/web; npm run dev
 .PHONY: app-run
 
-cargo-clean:
+troubleshoot: down
+	cd $(MAKEPATH)/app/web; npm install
+	cd $(MAKEPATH)/app/web; npm run vite-clean
 	cd $(MAKEPATH); cargo clean
-.PHONY: clean-cargo
+	$(MAKEPATH)/scripts/bootstrap.sh
+.PHONY: troubleshoot
 
 deploy-prod:
 	@$(MAKEPATH)/scripts/deploy-prod.sh

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ You can teardown everything with the same target that the **Quickstart** guide u
 make down
 ```
 
+## Troubleshooting
+
+Having trouble running SI or its tests?
+Want to go back to the beginning and wipe the slate clean?
+We have a `make` target for that.
+
+```bash
+make troubleshoot
+```
+
 ## Architecture
 
 The diagram below illustrates a _very_ high-level overview of SI's calling stack.


### PR DESCRIPTION
Sometimes, you just want to drive your face through your monitor when
ensuring that you can run SI and its tests. Luckily, we now have a
button for reducing the pain there: make troubleshoot! [sc-2258]

<img src="https://media2.giphy.com/media/sFoZicXyLjH7FnCVp2/giphy.gif"/>