### PR TITLE
feat(web): Create unset component for widgets

### DIFF
--- a/app/web/src/atoms/Unset.vue
+++ b/app/web/src/atoms/Unset.vue
@@ -1,0 +1,25 @@
+<template>
+  <button
+    v-if="(props.editValue ?? undefined) !== undefined"
+    @click="props.unset && props.unset()"
+  >
+    <VueFeather type="trash-2" size="1em" class="ml-1" />
+  </button>
+</template>
+
+<script setup lang="ts">
+import type { EditFieldValue } from "@/api/sdf/dal/edit_field";
+import VueFeather from "vue-feather";
+
+const props = defineProps<{
+  editValue?: EditFieldValue;
+  unset: () => void;
+}>();
+</script>
+
+<style scoped>
+/* Is this what we want? It's how the demo works */
+button:focus {
+  outline: 1px dotted;
+}
+</style>

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -1,11 +1,11 @@
 <template>
   <EditFormField
     :show="show"
-    :validation-errors="editField.validation_errors"
+    :validation-errors="props.editField.validation_errors"
     :core-edit-field="coreEditField"
   >
     <template #name>
-      {{ editField.name }}
+      {{ props.editField.name }}
     </template>
     <template #edit>
       <div class="flex flex-col mt-1">
@@ -20,6 +20,9 @@
           <button @click="addToArray">
             <VueFeather type="plus" />
           </button>
+        </div>
+        <div class="flex flex-row items-center w-10 ml-1 bg-red">
+          <Unset :edit-value="props.editField.value" :unset="unset" />
         </div>
       </div>
     </template>
@@ -41,6 +44,7 @@
 import { computed } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
+import Unset from "@/atoms/Unset.vue";
 import { ArrayWidgetDal } from "@/api/sdf/dal/edit_field";
 import VueFeather from "vue-feather";
 import { EditFieldService } from "@/service/edit_field";
@@ -74,6 +78,20 @@ const widget = computed<ArrayWidgetDal>(() => {
 });
 
 const addToArray = () => {
+  EditFieldService.updateFromEditField({
+    objectKind: props.editField.object_kind,
+    objectId: props.editField.object_id,
+    editFieldId: props.editField.id,
+    value: null,
+    baggage: props.editField.baggage,
+  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
+};
+
+const unset = () => {
   EditFieldService.updateFromEditField({
     objectKind: props.editField.object_kind,
     objectId: props.editField.object_id,

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -1,24 +1,26 @@
 <template>
   <EditFormField
     :show="show"
-    :validation-errors="editField.validation_errors"
+    :validation-errors="props.editField.validation_errors"
     :core-edit-field="coreEditField"
   >
-    <template #name>{{ editField.name }}</template>
+    <template #name>{{ props.editField.name }}</template>
     <template #edit>
       <input
-        v-model="inputValue"
+        v-model="currentValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         type="checkbox"
-        placeholder="text"
         @change="onBlur"
         @focus="onFocus"
         @blur="onBlur"
       />
+      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+        <Unset :edit-value="props.editField.value" :unset="unset" />
+      </div>
     </template>
     <template #show>
-      <span :class="textColor">{{ editField.value }}</span>
+      <span :class="textColor">{{ props.editField.value }}</span>
     </template>
   </EditFormField>
 </template>
@@ -28,6 +30,7 @@ import { computed, ref, watch } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import { EditFieldService } from "@/service/edit_field";
 import EditFormField from "./EditFormField.vue";
+import Unset from "@/atoms/Unset.vue";
 import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
@@ -62,6 +65,20 @@ const onBlur = () => {
     });
   }
   updating.value = false;
+};
+
+const unset = () => {
+  EditFieldService.updateFromEditField({
+    objectKind: props.editField.object_kind,
+    objectId: props.editField.object_id,
+    editFieldId: props.editField.id,
+    value: null,
+    baggage: props.editField.baggage,
+  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
 };
 
 watch(

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -1,11 +1,11 @@
 <template>
   <EditFormField
     :show="show"
-    :validation-errors="editField.validation_errors"
+    :validation-errors="props.editField.validation_errors"
     :core-edit-field="coreEditField"
   >
     <template #name>
-      {{ editField.name }}
+      {{ props.editField.name }}
     </template>
     <template #edit>
       <select
@@ -24,9 +24,12 @@
           {{ option.label }}
         </option>
       </select>
+      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+        <Unset :edit-value="props.editField.value" :unset="unset" />
+      </div>
     </template>
     <template #show>
-      <span :class="textColor">{{ editField.value }}</span>
+      <span :class="textColor">{{ props.editField.value }}</span>
     </template>
   </EditFormField>
 </template>
@@ -35,6 +38,7 @@
 import { computed, ref, watch } from "vue";
 import type { EditField, SelectWidgetDal } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
+import Unset from "@/atoms/Unset.vue";
 import { EditFieldService } from "@/service/edit_field";
 import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
@@ -75,6 +79,20 @@ const onBlur = () => {
     });
   }
   updating.value = false;
+};
+
+const unset = () => {
+  EditFieldService.updateFromEditField({
+    objectKind: props.editField.object_kind,
+    objectId: props.editField.object_id,
+    editFieldId: props.editField.id,
+    value: null,
+    baggage: props.editField.baggage,
+  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
 };
 
 watch(

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -3,10 +3,10 @@
   <EditFormField
     :show="show"
     :core-edit-field="coreEditField"
-    :validation-errors="editField.validation_errors"
+    :validation-errors="props.editField.validation_errors"
   >
     <template #name>
-      {{ editField.name }}
+      {{ props.editField.name }}
     </template>
     <template #edit>
       <input
@@ -20,9 +20,12 @@
         @focus="onFocus"
         @blur="onBlur"
       />
+      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+        <Unset :edit-value="props.editField.value" :unset="unset" />
+      </div>
     </template>
     <template #show>
-      <span :class="textColor">{{ editField.value }}</span>
+      <span :class="textColor">{{ props.editField.value }}</span>
     </template>
   </EditFormField>
 </template>
@@ -31,6 +34,7 @@
 import { computed, ref, watch } from "vue";
 import type { EditField } from "@/api/sdf/dal/edit_field";
 import EditFormField from "./EditFormField.vue";
+import Unset from "@/atoms/Unset.vue";
 import { EditFieldService } from "@/service/edit_field";
 import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
@@ -70,6 +74,21 @@ const onKeyEnter = (event: KeyboardEvent) => {
     event.target.blur();
   }
 };
+
+const unset = () => {
+  EditFieldService.updateFromEditField({
+    objectKind: props.editField.object_kind,
+    objectId: props.editField.object_id,
+    editFieldId: props.editField.id,
+    value: null,
+    baggage: props.editField.baggage,
+  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
+};
+
 watch(
   () => props.editField,
   (editField, _prevEditField) => {


### PR DESCRIPTION
Creates trash icon and unsets widgets when clicked. The backend fails for
now, but the frontend part is done.

There is an open question related to outline when the trashcan is
focused, the demo's default is dotted grey, the current one is blue solid.
I copied the demo as it felt better but it may not be the right approach.

This also fix a reactivity issue when changing components (the widgets
didn't update properly).

It's not clear if Arrays are working properly as unset should work for
inner values, but we can't test it for now.

<img src="https://media1.giphy.com/media/71CMwl2MEIVck/giphy.gif"/>