### PR TITLE
feat(app): add secret panel

### DIFF
--- a/app/web/src/organisims/PanelSecret.vue
+++ b/app/web/src/organisims/PanelSecret.vue
@@ -1,0 +1,75 @@
+<template>
+  <Panel
+    :panel-index="props.panelIndex"
+    :panel-ref="props.panelRef"
+    :panel-container-ref="props.panelContainerRef"
+    :initial-maximized-container="props.initialMaximizedContainer"
+    :initial-maximized-full="props.initialMaximizedFull"
+    :is-visible="props.isVisible"
+    :is-maximized-container-enabled="props.isMaximizedContainerEnabled"
+  >
+    <template #menuButtons>
+      <!-- FIXME(nick): took some liberties here with the classes since old-web does not display
+      this button cleanly. At the same time, this should get re-evaluated as we clean things up.
+      -->
+      <div class="justify-start flew flex-grow">
+        <div class="min-w-max pl-2 align-middle">
+          <SiButton
+            icon="plus"
+            label="new"
+            size="xs"
+            class="pl-2 align-middle"
+            :disabled="activeView.value === View.Create"
+            @click="setActiveView(View.Create)"
+          />
+        </div>
+      </div>
+    </template>
+    <template #content>
+      <div class="w-full">
+        <SecretList v-if="activeView === View.List" />
+        <div
+          v-else-if="activeView === View.Create"
+          class="flex items-center justify-center"
+        >
+          <div
+            class="flex flex-grow px-4 py-4 mx-8 mt-8 border border-gray-700"
+          >
+            <SecretCreate
+              @cancel="activeView === View.List"
+              @submit="activeView === View.List"
+            />
+          </div>
+        </div>
+      </div>
+    </template>
+  </Panel>
+</template>
+
+<script setup lang="ts">
+import SecretCreate from "@/organisims/Secret/SecretCreate.vue";
+import SecretList from "@/organisims/Secret/SecretList.vue";
+import Panel from "@/molecules/Panel.vue";
+import SiButton from "@/atoms/SiButton.vue";
+import { ref } from "vue";
+
+const props = defineProps({
+  panelIndex: { type: Number, required: true },
+  panelRef: { type: String, required: true },
+  panelContainerRef: { type: String, required: true },
+  initialMaximizedFull: Boolean,
+  initialMaximizedContainer: Boolean,
+  isVisible: Boolean,
+  isMaximizedContainerEnabled: Boolean,
+});
+
+enum View {
+  Create,
+  List,
+}
+
+const activeView = ref<View>(View.List);
+const setActiveView = (view: View) => {
+  activeView.value = view;
+};
+</script>

--- a/app/web/src/organisims/PanelTree/PanelSelector.vue
+++ b/app/web/src/organisims/PanelTree/PanelSelector.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="flex flex-row w-full h-full">
+    <!-- FIXME(nick): noticed that "whichComponent" has the following warning (but does not seem to matter right now) -->
+    <!-- "Type {} is not assignable to type string | ComponentDefinition" -->
     <component
       :is="whichComponent"
       :is-visible="isVisible"
@@ -26,6 +28,7 @@ import PanelEmpty from "@/organisims/PanelEmpty.vue";
 
 import PanelAttribute from "@/organisims/PanelAttribute.vue";
 import PanelSchematic from "@/organisims/PanelSchematic.vue";
+import PanelSecret from "@/organisims/PanelSecret.vue";
 
 const props = defineProps({
   panelIndex: { type: Number, required: true },
@@ -46,12 +49,17 @@ const emit = defineEmits([
 const panelType = ref<PanelType>(props.initialPanelType);
 
 const whichComponent = computed<
-  typeof PanelAttribute | typeof PanelSchematic | typeof PanelEmpty
+  | typeof PanelAttribute
+  | typeof PanelSchematic
+  | typeof PanelSecret
+  | typeof PanelEmpty
 >(() => {
   if (panelType.value == "attribute") {
     return PanelAttribute;
   } else if (panelType.value == "schematic") {
     return PanelSchematic;
+  } else if (panelType.value == "secret") {
+    return PanelSecret;
   } else {
     return PanelEmpty;
   }

--- a/app/web/src/organisims/Secret/Create/DockerHubCredential.vue
+++ b/app/web/src/organisims/Secret/Create/DockerHubCredential.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle">
+        <label for="username">Docker Hub Username:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          id="username"
+          v-model="username"
+          size="xs"
+          name="username"
+          placeholder=""
+          :is-show-type="false"
+          required
+          @input="updateUsername(username)"
+        />
+      </div>
+    </div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div
+        class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle border-blue-100"
+      >
+        <label for="password">Docker Hub Password:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          id="password"
+          v-model="password"
+          size="xs"
+          name="password"
+          placeholder=""
+          :is-show-type="false"
+          required
+          type="password"
+          @input="updatePassword(password)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import SiTextBox from "@/atoms/SiTextBox.vue";
+
+const username = ref<string>("ilikemybutt");
+const password = ref<string>("");
+
+const updateUsername = (input: string) => {
+  username.value = input;
+};
+const updatePassword = (input: string) => {
+  username.value = input;
+};
+</script>

--- a/app/web/src/organisims/Secret/SecretCreate.vue
+++ b/app/web/src/organisims/Secret/SecretCreate.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="flex flex-col w-full">
+    <SiError
+      v-if="placeholderShowError"
+      :test="placeholderString"
+      :message="placeholderString"
+      :success="true"
+      @clear="placeholderFunc"
+    />
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle">
+        <label for="placeholderString">Secret Name:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiTextBox
+          id="placeholderString"
+          v-model="placeholderForm.secretName"
+          size="xs"
+          name="secretName"
+          placeholder="secret name"
+          :is-show-type="false"
+          required
+        />
+      </div>
+    </div>
+    <div class="flex flex-row items-center w-full pb-2">
+      <div class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle">
+        <label for="placeholderString">Secret Kind:</label>
+      </div>
+      <div class="w-1/2 align-middle">
+        <SiSelect
+          id="placeholderString"
+          v-model="selectedSecretKind"
+          size="xs"
+          name="secretKind"
+          :options="secretKinds"
+          required
+        />
+      </div>
+    </div>
+
+    <DockerHubCredential
+      v-if="selectedSecretKind === SecretKind.DockerHubCredential"
+      @input="placeholderFunc"
+    />
+
+    <div class="flex justify-end w-full">
+      <div class="pr-2">
+        <SiButton
+          size="xs"
+          label="Cancel"
+          kind="cancel"
+          icon="null"
+          @click="placeholderFunc"
+        />
+      </div>
+      <div>
+        <SiButton
+          size="xs"
+          label="Create"
+          kind="save"
+          icon="null"
+          @click="placeholderFunc"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SiButton from "@/atoms/SiButton.vue";
+import SiError from "@/atoms/SiError.vue";
+import SiSelect, { SelectPropsOption } from "@/atoms/SiSelect.vue";
+import SiTextBox from "@/atoms/SiTextBox.vue";
+import DockerHubCredential from "@/organisims/Secret/Create/DockerHubCredential.vue";
+import { ref } from "vue";
+
+enum SecretKind {
+  DockerHubCredential = "DockerHub Credential",
+  Empty = "",
+}
+
+// FIXME(nick): change this to only be calculated once and dynamically loaded.
+const secretKinds: SelectPropsOption[] = [
+  {
+    value: SecretKind.DockerHubCredential,
+    label: SecretKind.DockerHubCredential,
+  },
+  { value: SecretKind.Empty, label: SecretKind.Empty },
+];
+
+const selectedSecretKind = ref<SecretKind>(SecretKind.Empty);
+
+const placeholderShowError = false;
+const placeholderString = "ilikemybutt";
+const placeholderSecretKind = SecretKind.DockerHubCredential;
+const placeholderFunc = () => {
+  console.log(placeholderString);
+};
+const placeholderForm = {
+  secretName: placeholderString,
+  secretKind: SecretKind.DockerHubCredential,
+  message: placeholderString,
+};
+</script>
+
+<style scoped>
+.background {
+  background-color: #1e1e1e;
+}
+
+.header {
+  background-color: #3a3d40;
+}
+
+.row-item {
+  background-color: #262626;
+}
+
+.row-item:nth-child(odd) {
+  background-color: #2c2c2c;
+}
+
+.table-border {
+  border-bottom: 1px solid #46494d;
+}
+</style>

--- a/app/web/src/organisims/Secret/SecretList.vue
+++ b/app/web/src/organisims/Secret/SecretList.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="flex w-full h-full">
+    <SiError
+      v-if="placeholderShowError"
+      :test="placeholderString"
+      :message="placeholderString"
+      @clear="placeholderFunc"
+    />
+    <div class="flex w-full h-full">
+      <div class="flex flex-col w-full shadow-sm table-fixed">
+        <div class="flex w-full text-sm font-medium text-gray-200 header">
+          <div class="w-6/12 px-2 py-1 text-center align-middle table-border">
+            Name
+          </div>
+          <div class="w-3/12 px-2 py-1 text-center table-border">Kind</div>
+          <div class="w-3/12 px-2 py-1 text-center table-border">Type</div>
+        </div>
+
+        <div class="flex flex-col overflow-y-scroll text-xs text-gray-300">
+          <div
+            v-for="secret in placeholderSecretList"
+            :key="secret.id"
+            class="flex items-center row-item"
+          >
+            <div class="w-6/12 px-2 py-1 text-center">
+              {{ secret.name }}
+            </div>
+            <div class="w-3/12 px-2 py-1 text-center">
+              {{ placeholderLabelForKind(secret.kind) }}
+            </div>
+            <div class="w-3/12 px-2 py-1 text-center">
+              {{ placeholderLabelForObjectType(secret.objectType) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SiError from "@/atoms/SiError.vue";
+
+const placeholderString = "ilikemybutt";
+const placeholderFunc = () => {
+  console.log(placeholderString);
+};
+
+const placeholderShowError = false;
+const placeholderSecretList = [
+  {
+    id: placeholderString,
+    name: placeholderString,
+    kind: "DockerHub",
+    objectType: "Credential",
+  },
+];
+const placeholderLabelForKind = (kind: string) => {
+  return kind;
+};
+const placeholderLabelForObjectType = (objectType: string) => {
+  return objectType;
+};
+</script>
+
+<style scoped>
+.background {
+  background-color: #1e1e1e;
+}
+
+.header {
+  background-color: #3a3d40;
+}
+
+.row-item {
+  background-color: #262626;
+}
+
+.row-item:nth-child(odd) {
+  background-color: #2c2c2c;
+}
+
+.table-border {
+  border-bottom: 1px solid #46494d;
+}
+</style>


### PR DESCRIPTION
- Add secret panel [sc-2253]
- Add minimal implementations of SecretCreate and SecretList without
  their functionality
- Known bug: you cannot "exit" SecretCreate currently (using the
  picker to switch to another panel is the recommended workaround)
- Add PanelSecret to PanelSelector
- Add DockerHubCredential minimal implementation with "Empty" unsetting
  the option chosen (and "Empty" is set by default)

<img src="https://media2.giphy.com/media/hj8eOHrXqoLntsCyWz/giphy.gif"/>