### PR TITLE
feat(dal): Implement prop unsetting

### DIFF
--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -21,7 +21,10 @@
             <VueFeather type="plus" />
           </button>
         </div>
-        <div class="flex flex-row items-center w-10 ml-1 bg-red">
+        <div
+          v-if="!coreEditField"
+          class="flex flex-row items-center w-10 ml-1 bg-red"
+        >
           <Unset :edit-value="props.editField.value" :unset="unset" />
         </div>
       </div>

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -15,7 +15,10 @@
         @focus="onFocus"
         @blur="onBlur"
       />
-      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+      <div
+        v-if="!coreEditField"
+        class="flex flex-row items-center w-10 ml-1 bg-red"
+      >
         <Unset :edit-value="props.editField.value" :unset="unset" />
       </div>
     </template>

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -24,7 +24,10 @@
           {{ option.label }}
         </option>
       </select>
-      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+      <div
+        v-if="!coreEditField"
+        class="flex flex-row items-center w-10 ml-1 bg-red"
+      >
         <Unset :edit-value="props.editField.value" :unset="unset" />
       </div>
     </template>

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -20,7 +20,10 @@
         @focus="onFocus"
         @blur="onBlur"
       />
-      <div class="flex flex-row items-center w-10 ml-1 bg-red">
+      <div
+        v-if="!coreEditField"
+        class="flex flex-row items-center w-10 ml-1 bg-red"
+      >
         <Unset :edit-value="props.editField.value" :unset="unset" />
       </div>
     </template>

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -21,9 +21,9 @@ use crate::func::backend::integer::FuncBackendIntegerArgs;
 use crate::func::backend::map::FuncBackendMapArgs;
 use crate::func::backend::validation::{FuncBackendValidateStringValueArgs, ValidationError};
 use crate::func::backend::{
-    js_code_generation::FuncBackendJsCodeGenerationArgs,
+    js_attribute::FuncBackendJsAttributeArgs, js_code_generation::FuncBackendJsCodeGenerationArgs,
     js_qualification::FuncBackendJsQualificationArgs, js_resource::FuncBackendJsResourceSyncArgs,
-    js_string::FuncBackendJsStringArgs, string::FuncBackendStringArgs,
+    string::FuncBackendStringArgs,
 };
 use crate::func::binding::{FuncBinding, FuncBindingError};
 use crate::func::binding_return_value::FuncBindingReturnValue;
@@ -525,278 +525,222 @@ impl Component {
         let mut schema_tenancy = tenancy.clone();
         schema_tenancy.universal = true;
 
+        // Allows for finding the default Attribute Resolver for a Prop
         let mut attribute_resolver_context = AttributeResolverContext::new();
         attribute_resolver_context.set_prop_id(*prop.id());
+
+        fn as_type<T: serde::de::DeserializeOwned>(json: serde_json::Value) -> ComponentResult<T> {
+            T::deserialize(&json).map_err(|_| {
+                ComponentError::InvalidPropValue(std::any::type_name::<T>().to_owned(), json)
+            })
+        }
+
+        async fn set_value<T: Serialize>(
+            txn: &PgTxn<'_>,
+            nats: &NatsTxn,
+            veritech: veritech::Client,
+            tenancy: &Tenancy,
+            visibility: &Visibility,
+            history_actor: &HistoryActor,
+            func_name: &str,
+            args: T,
+        ) -> ComponentResult<(Func, FuncBinding, bool)> {
+            let mut schema_tenancy = tenancy.clone();
+            schema_tenancy.universal = true;
+
+            let func_name = func_name.to_owned();
+            let mut funcs =
+                Func::find_by_attr(txn, &schema_tenancy, visibility, "name", &func_name).await?;
+            let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
+            let (func_binding, created) = FuncBinding::find_or_create(
+                txn,
+                nats,
+                tenancy,
+                visibility,
+                history_actor,
+                serde_json::to_value(args)?,
+                *func.id(),
+                *func.backend_kind(),
+            )
+            .await?;
+
+            // Note for future humans - if this isn't a built in, then we need to
+            // think about execution time. Probably higher up than this? But just
+            // an FYI.
+            if created {
+                func_binding.execute(txn, nats, veritech).await?;
+            }
+            Ok((func, func_binding, created))
+        }
+
+        async fn unset_value(
+            txn: &PgTxn<'_>,
+            nats: &NatsTxn,
+            veritech: veritech::Client,
+            tenancy: &Tenancy,
+            visibility: &Visibility,
+            history_actor: &HistoryActor,
+            args_default: FuncBackendJsAttributeArgs,
+            attribute_resolver_context: AttributeResolverContext,
+        ) -> ComponentResult<(Func, FuncBinding, bool)> {
+            let mut schema_tenancy = tenancy.clone();
+            schema_tenancy.universal = true;
+
+            if let Some(resolver) = AttributeResolver::find_for_context(
+                txn,
+                &schema_tenancy,
+                visibility,
+                attribute_resolver_context,
+            )
+            .await?
+            {
+                let func = Func::get_by_id(txn, &schema_tenancy, visibility, &resolver.func_id())
+                    .await?
+                    .ok_or_else(|| ComponentError::MissingFunc(resolver.func_id().to_string()))?;
+                let (func_binding, created) = FuncBinding::find_or_create(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    serde_json::to_value(&args_default)?,
+                    *func.id(),
+                    *func.backend_kind(),
+                )
+                .await?;
+
+                if created {
+                    func_binding.execute(txn, nats, veritech).await?;
+                }
+
+                Ok((func, func_binding, created))
+            } else {
+                set_value(
+                    txn,
+                    nats,
+                    veritech,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    "si:unset",
+                    (),
+                )
+                .await
+            }
+        }
 
         // We shouldn't be leaking this value, because it may or may not be actually set. But
         // when you YOLO, YOLO hard. -- Adam
         let (func, func_binding, created) = match (prop.kind(), value.clone()) {
             (PropKind::Array, Some(value_json)) => {
-                // FIXME(nick): handle nesting for Map.
-                let value = match value_json.as_array() {
-                    Some(boolean) => boolean,
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "Array".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
+                // FIXME(nick): handle nesting for Array.
 
-                let func_name = "si:setArray".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendArrayArgs::new(value.clone()))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
+                let value: Vec<serde_json::Value> = as_type(value_json)?;
+                set_value(
                     txn,
                     nats,
+                    veritech,
                     tenancy,
                     visibility,
                     history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
+                    "si:setArray",
+                    FuncBackendArrayArgs::new(value),
                 )
-                .await?;
-
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::Array, None) => {
-                todo!("We haven't dealt with unsetting an array")
+                .await?
             }
             (PropKind::Boolean, Some(value_json)) => {
-                let value = match value_json.as_bool() {
-                    Some(boolean) => boolean,
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "Boolean".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
-
-                let func_name = "si:setBoolean".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, &schema_tenancy, visibility, "name", &func_name)
-                        .await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendBooleanArgs::new(value))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
+                let value: bool = as_type(value_json)?;
+                set_value(
                     txn,
                     nats,
+                    veritech,
                     tenancy,
                     visibility,
                     history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
+                    "si:setBoolean",
+                    FuncBackendBooleanArgs::new(value),
                 )
-                .await?;
-
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::Boolean, None) => {
-                todo!("We haven't dealt with unsetting a boolean")
+                .await?
             }
             (PropKind::Integer, Some(value_json)) => {
-                let value = match value_json.as_i64() {
-                    Some(integer) => integer,
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "Integer".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
-
-                let func_name = "si:setInteger".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendIntegerArgs::new(value))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
+                let value: i64 = as_type(value_json)?;
+                set_value(
                     txn,
                     nats,
+                    veritech,
                     tenancy,
                     visibility,
                     history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
+                    "si:setInteger",
+                    FuncBackendIntegerArgs::new(value),
                 )
-                .await?;
-
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::Integer, None) => {
-                todo!("Unsetting a Integer PropKind isn't supported yet");
+                .await?
             }
             (PropKind::Map, Some(value_json)) => {
                 // FIXME(nick): handle nesting for Map.
-                let value = match value_json.as_object() {
-                    Some(map) => map,
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "Map".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
 
-                let func_name = "si:setMap".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendMapArgs::new(value.clone()))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
+                let value: serde_json::Map<String, serde_json::Value> = as_type(value_json)?;
+                set_value(
                     txn,
                     nats,
+                    veritech,
                     tenancy,
                     visibility,
                     history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
-                )
-                .await?;
-
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::Map, None) => {
-                todo!("Unsetting a Map PropKind isn't supported yet");
-            }
-            (PropKind::Object, Some(value_json)) => {
-                // FIXME(nick): deny objects that aren't empty here. The value must be empty
-                // for a PropObject.
-                let value = match value_json.as_object() {
-                    Some(object) => object,
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "Object".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
-
-                let func_name = "si:setPropObject".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, &schema_tenancy, visibility, "name", &func_name)
-                        .await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendPropObjectArgs::new(value.clone()))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
-                    txn,
-                    nats,
-                    tenancy,
-                    visibility,
-                    history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
-                )
-                .await?;
-
-                // FIXME(nick,jacob): add object nesting. This is incomplete!
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::Object, None) => {
-                todo!("We haven't dealt with unsetting an object")
-            }
-            (PropKind::String, Some(value_json)) => {
-                let value = match value_json.as_str() {
-                    Some(string) => string.to_string(),
-                    None => {
-                        return Err(ComponentError::InvalidPropValue(
-                            "String".to_string(),
-                            value_json,
-                        ))
-                    }
-                };
-
-                let func_name = "si:setString".to_string();
-                let mut funcs =
-                    Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-                let func = funcs.pop().ok_or(ComponentError::MissingFunc(func_name))?;
-                let args = serde_json::to_value(FuncBackendStringArgs::new(value.clone()))?;
-                let (func_binding, created) = FuncBinding::find_or_create(
-                    txn,
-                    nats,
-                    tenancy,
-                    visibility,
-                    history_actor,
-                    args,
-                    *func.id(),
-                    *func.backend_kind(),
-                )
-                .await?;
-
-                // Note for future humans - if this isn't a built in, then we need to
-                // think about execution time. Probably higher up than this? But just
-                // an FYI.
-                if created {
-                    func_binding.execute(txn, nats, veritech.clone()).await?;
-                }
-                (func, func_binding, created)
-            }
-            (PropKind::String, None) => {
-                if let Some(resolver) = AttributeResolver::find_for_context(
-                    txn,
-                    &schema_tenancy,
-                    visibility,
-                    attribute_resolver_context.clone(),
+                    "si:setMap",
+                    FuncBackendMapArgs::new(value),
                 )
                 .await?
-                {
-                    let func =
-                        Func::get_by_id(txn, &schema_tenancy, visibility, &resolver.func_id())
-                            .await?
-                            .ok_or_else(|| {
-                                ComponentError::MissingFunc(resolver.func_id().to_string())
-                            })?;
-                    let (func_binding, created) = FuncBinding::find_or_create(
-                        txn,
-                        nats,
-                        tenancy,
-                        visibility,
-                        history_actor,
-                        serde_json::to_value(FuncBackendJsStringArgs {
-                            component: self
-                                .veritech_attribute_resolver_component(
-                                    txn,
-                                    &schema_tenancy,
-                                    visibility,
-                                )
-                                .await?,
-                        })?,
-                        *func.id(),
-                        *func.backend_kind(),
-                    )
-                    .await?;
+            }
+            (PropKind::Object, Some(value_json)) => {
+                // FIXME(nick): deny objects that aren't empty here. The value must be empty for a PropObject.
+                // FIXME(nick,jacob): add object nesting. This is incomplete!
 
-                    if created {
-                        func_binding.execute(txn, nats, veritech.clone()).await?;
-                    }
+                let value: serde_json::Map<String, serde_json::Value> = as_type(value_json)?;
+                set_value(
+                    txn,
+                    nats,
+                    veritech,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    "si:setPropObject",
+                    FuncBackendPropObjectArgs::new(value),
+                )
+                .await?
+            }
+            (PropKind::String, Some(value_json)) => {
+                let value: String = as_type(value_json)?;
 
-                    (func, func_binding, true)
-                } else {
-                    todo!("Unsetting a String PropKind without a fallback AttributeResolver isn't supported yet");
-                }
+                set_value(
+                    txn,
+                    nats,
+                    veritech,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    "si:setString",
+                    FuncBackendStringArgs::new(value),
+                )
+                .await?
+            }
+            (_, None) => {
+                let args_default = FuncBackendJsAttributeArgs {
+                    component: self
+                        .veritech_attribute_resolver_component(txn, &schema_tenancy, visibility)
+                        .await?,
+                };
+                unset_value(
+                    txn,
+                    nats,
+                    veritech,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    args_default,
+                    attribute_resolver_context,
+                )
+                .await?
             }
         };
 

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -8,10 +8,10 @@ use crate::{edit_field::ToSelectWidget, label_list::ToLabelList, PropKind};
 pub mod array;
 pub mod boolean;
 pub mod integer;
+pub mod js_attribute;
 pub mod js_code_generation;
 pub mod js_qualification;
 pub mod js_resource;
-pub mod js_string;
 pub mod map;
 pub mod prop_object;
 pub mod string;
@@ -67,7 +67,7 @@ pub enum FuncBackendKind {
     JsQualification,
     JsResourceSync,
     JsCodeGeneration,
-    JsString,
+    JsAttribute,
     Map,
     PropObject,
     String,

--- a/lib/dal/src/func/backend/js_attribute.rs
+++ b/lib/dal/src/func/backend/js_attribute.rs
@@ -6,23 +6,23 @@ use veritech::{Client, FunctionResult, OutputStream, ResolverFunctionRequest};
 use crate::func::backend::{FuncBackendError, FuncBackendResult};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct FuncBackendJsStringArgs {
+pub struct FuncBackendJsAttributeArgs {
     pub component: veritech::ResolverFunctionComponent,
 }
 
 #[derive(Debug)]
-pub struct FuncBackendJsString {
+pub struct FuncBackendJsAttribute {
     veritech: Client,
     output_tx: mpsc::Sender<OutputStream>,
     request: ResolverFunctionRequest,
 }
 
-impl FuncBackendJsString {
+impl FuncBackendJsAttribute {
     pub fn new(
         veritech: Client,
         output_tx: mpsc::Sender<OutputStream>,
         handler: impl Into<String>,
-        args: FuncBackendJsStringArgs,
+        args: FuncBackendJsAttributeArgs,
         code_base64: impl Into<String>,
     ) -> Self {
         let request = ResolverFunctionRequest {

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -14,13 +14,13 @@ use crate::func::backend::integer::{FuncBackendInteger, FuncBackendIntegerArgs};
 use crate::func::backend::map::{FuncBackendMap, FuncBackendMapArgs};
 use crate::func::backend::prop_object::{FuncBackendPropObject, FuncBackendPropObjectArgs};
 use crate::func::backend::{
+    js_attribute::{FuncBackendJsAttribute, FuncBackendJsAttributeArgs},
     js_code_generation::FuncBackendJsCodeGeneration,
     js_code_generation::FuncBackendJsCodeGenerationArgs,
     js_qualification::FuncBackendJsQualification,
     js_qualification::FuncBackendJsQualificationArgs,
     js_resource::FuncBackendJsResourceSync,
     js_resource::FuncBackendJsResourceSyncArgs,
-    js_string::{FuncBackendJsString, FuncBackendJsStringArgs},
     string::FuncBackendString,
     string::FuncBackendStringArgs,
     validation::{FuncBackendValidateStringValue, FuncBackendValidateStringValueArgs},
@@ -345,7 +345,7 @@ impl FuncBinding {
                 execution.process_output(txn, nats, rx).await?;
                 Some(serde_json::to_value(&veritech_result)?)
             }
-            FuncBackendKind::JsString => {
+            FuncBackendKind::JsAttribute => {
                 execution
                     .set_state(txn, nats, super::execution::FuncExecutionState::Dispatch)
                     .await?;
@@ -358,13 +358,13 @@ impl FuncBinding {
                     .code_base64()
                     .ok_or(FuncBindingError::JsFuncNotFound(self.pk))?;
 
-                let args: FuncBackendJsStringArgs = serde_json::from_value(self.args.clone())?;
+                let args: FuncBackendJsAttributeArgs = serde_json::from_value(self.args.clone())?;
 
                 execution
                     .set_state(txn, nats, super::execution::FuncExecutionState::Run)
                     .await?;
 
-                let return_value = FuncBackendJsString::new(
+                let return_value = FuncBackendJsAttribute::new(
                     veritech,
                     tx,
                     handler.to_owned(),

--- a/lib/dal/src/func/builtins.rs
+++ b/lib/dal/src/func/builtins.rs
@@ -93,7 +93,7 @@ async fn si_number_of_parents(
             visibility,
             history_actor,
             "si:numberOfParents",
-            FuncBackendKind::JsString, // Should be integer, but the js integer backend isn't 100% there yet and is being worked on in parallel
+            FuncBackendKind::JsAttribute, // Should be integer, but the js integer backend isn't 100% there yet and is being worked on in parallel
             FuncBackendResponseType::String,
         )
         .await

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -16,7 +16,7 @@ use crate::{
     schema::ui_menu::UiMenuId,
     standard_model, standard_model_accessor, standard_model_has_many, standard_model_many_to_many,
     AttributeResolverError, BillingAccount, BillingAccountId, CodeGenerationPrototypeError,
-    Component, HistoryActor, HistoryEventError, LabelEntry, LabelList, Organization,
+    Component, FuncError, HistoryActor, HistoryEventError, LabelEntry, LabelList, Organization,
     OrganizationId, PropError, QualificationPrototypeError, ResourcePrototypeError, StandardModel,
     StandardModelError, Tenancy, Timestamp, ValidationPrototypeError, Visibility, Workspace,
     WorkspaceId, WsEventError,
@@ -76,6 +76,8 @@ pub enum SchemaError {
     ResourcePrototype(#[from] ResourcePrototypeError),
     #[error("code generation prototype error: {0}")]
     CodeGenerationPrototype(#[from] CodeGenerationPrototypeError),
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
 }
 
 pub type SchemaResult<T> = Result<T, SchemaError>;

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
+use crate::func::backend::js_attribute::FuncBackendJsAttributeArgs;
 use crate::func::backend::js_qualification::FuncBackendJsQualificationArgs;
 use crate::func::backend::js_resource::FuncBackendJsResourceSyncArgs;
-use crate::func::backend::js_string::FuncBackendJsStringArgs;
-use crate::func::backend::string::FuncBackendStringArgs;
 use crate::func::backend::validation::FuncBackendValidateStringValueArgs;
 use crate::qualification_prototype::QualificationPrototypeContext;
 use crate::resource_prototype::ResourcePrototypeContext;
@@ -11,9 +10,10 @@ use crate::schema::{SchemaResult, SchemaVariant, UiMenu};
 use crate::socket::{Socket, SocketArity, SocketEdgeKind};
 use crate::{
     attribute_resolver::AttributeResolverContext, func::binding::FuncBinding,
-    validation_prototype::ValidationPrototypeContext, AttributeResolver, Func, HistoryActor, Prop,
-    PropId, PropKind, QualificationPrototype, ResourcePrototype, Schema, SchemaError, SchemaKind,
-    SchemaVariantId, SchematicKind, StandardModel, Tenancy, ValidationPrototype, Visibility,
+    validation_prototype::ValidationPrototypeContext, AttributeResolver, Func, FuncBackendKind,
+    FuncBackendResponseType, HistoryActor, Prop, PropId, PropKind, QualificationPrototype,
+    ResourcePrototype, Schema, SchemaError, SchemaKind, SchemaVariantId, SchematicKind,
+    StandardModel, Tenancy, ValidationPrototype, Visibility,
 };
 use si_data::{NatsTxn, PgTxn};
 
@@ -574,7 +574,7 @@ async fn docker_image(
         tenancy,
         visibility,
         history_actor,
-        serde_json::to_value(FuncBackendJsStringArgs {
+        serde_json::to_value(FuncBackendJsAttributeArgs {
             component: veritech::ResolverFunctionComponent {
                 name: number_of_parents_prop.name().to_owned(),
                 properties,
@@ -812,17 +812,44 @@ pub async fn create_string_prop_with_default(
     )
     .await?;
 
-    let func_name = "si:setString".to_string();
-    let mut funcs = Func::find_by_attr(txn, tenancy, visibility, "name", &func_name).await?;
-    let func = funcs.pop().ok_or(SchemaError::MissingFunc(func_name))?;
+    let mut func = Func::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        &format!("si:setDefaultToProp{}", prop.id()),
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::String,
+    )
+    .await
+    .expect("cannot create func");
+    func.set_handler(txn, nats, visibility, history_actor, Some("defaultValue"))
+        .await?;
+    func.set_code_base64(
+        txn,
+        nats,
+        visibility,
+        history_actor,
+        Some(base64::encode(&format!(
+            "function defaultValue(component) {{ return \"{default_string}\"; }}"
+        ))),
+    )
+    .await?;
+
     let (func_binding, created) = FuncBinding::find_or_create(
         txn,
         nats,
         tenancy,
         visibility,
         history_actor,
-        serde_json::to_value(FuncBackendStringArgs {
-            value: default_string,
+        // The default run doesn't have useful information, but it's just a reference for future reruns
+        serde_json::to_value(FuncBackendJsAttributeArgs {
+            component: veritech::ResolverFunctionComponent {
+                name: prop.name().to_owned(),
+                properties: HashMap::new(),
+                parents: vec![],
+            },
         })?,
         *func.id(),
         *func.backend_kind(),


### PR DESCRIPTION
Rename JsString backends to JsAttribute, to make intent more clear and
as Attributes might have different types (first instance of func backend
kind being different than func backend response type).

Change default string setters from si:setString to JsAttribute,
otherwise unsetting gets complex.

Implement field unsetting (reruning default AttributeResolver if
available, or calling si:unset if not).

Make prop resolver code into simple functions that are reused, avoiding
boilerplate.

Remove unset button from core edit fields.

<img src="https://media4.giphy.com/media/DZu3mnCcmsJKE/giphy.gif"/>