### PR TITLE
chore(dal): Remove unnecessary clone

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -810,7 +810,7 @@ impl Component {
             } else {
                 None
             };
-            if current_parent_value.value().cloned() != new_parent_prop_value {
+            if current_parent_value.value() != new_parent_prop_value.as_ref() {
                 let parent_attribute_resolver = AttributeResolver::get_by_id(
                     txn,
                     tenancy,


### PR DESCRIPTION
`.cloned()` will do `Option<&T> -> Option<T>` (`.value()` is returning an `Option<&T>`), while `&new_parent_prop_value` will do Option<T> -> &Option<T>`.

We can avoid all of this by using `new_parent_prop_value.as_ref()`, though, as it does `Option<T> -> Option<&T>` (which matches what `.value()` returns).