### PR TITLE
feat(dal,cyc,ver): Secret selection as a prop

### DIFF
--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -17,7 +17,7 @@
         @blur="onBlur"
       >
         <option
-          v-for="option in widget.options"
+          v-for="option in widget.options.options"
           :key="String(option.value)"
           :value="option.value"
         >

--- a/lib/cyclone/src/resolver_function.rs
+++ b/lib/cyclone/src/resolver_function.rs
@@ -35,6 +35,7 @@ pub struct ResolverFunctionComponent {
     pub name: String,
     pub properties: HashMap<String, Value>,
     pub parents: Vec<ResolverFunctionParentComponent>,
+    // TODO: add widget data here (for example select's options)
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/dal/src/edit_field/widget.rs
+++ b/lib/dal/src/edit_field/widget.rs
@@ -5,6 +5,7 @@ pub mod select_widget;
 pub mod text_widget;
 
 use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, Display, EnumString};
 
 pub use self::{
     array_widget::ArrayWidget,
@@ -21,7 +22,7 @@ pub mod prelude {
         header_widget::HeaderWidget,
         select_widget::{SelectWidget, ToSelectWidget},
         text_widget::TextWidget,
-        Widget,
+        Widget, WidgetKind,
     };
 }
 
@@ -33,4 +34,17 @@ pub enum Widget {
     Header(HeaderWidget),
     Select(SelectWidget),
     Text(TextWidget),
+}
+
+#[derive(AsRefStr, Clone, Deserialize, Serialize, Debug, PartialEq, Eq, Display, EnumString)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum WidgetKind {
+    Array,
+    Checkbox,
+    Header,
+    Text,
+
+    // A custom WidgetKind is needed for every way of populating a select's options
+    SecretSelect,
 }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -35,6 +35,7 @@ pub mod resource_resolver;
 pub mod resource_scheduler;
 pub mod schema;
 pub mod schematic;
+pub mod secret;
 pub mod socket;
 pub mod standard_accessors;
 pub mod standard_model;

--- a/lib/dal/src/migrations/U0040__props.sql
+++ b/lib/dal/src/migrations/U0040__props.sql
@@ -12,7 +12,8 @@ CREATE TABLE props
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     name                        text                     NOT NULL,
-    kind                        text                     NOT NULL
+    kind                        text                     NOT NULL,
+    widget_kind                 text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('props');
 SELECT many_to_many_table_create_v1('prop_many_to_many_schema_variants', 'props',
@@ -34,6 +35,7 @@ CREATE OR REPLACE FUNCTION prop_create_v1(
     this_visibility jsonb,
     this_name text,
     this_kind text,
+    this_widget_kind text,
     OUT object json) AS
 $$
 DECLARE
@@ -47,11 +49,11 @@ BEGIN
     INSERT INTO props (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                                 tenancy_workspace_ids,
                                 visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted,
-                                name, kind)
+                                name, kind, widget_kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
-            this_visibility_record.visibility_deleted, this_name, this_kind)
+            this_visibility_record.visibility_deleted, this_name, this_kind, this_widget_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -1,0 +1,8 @@
+pub struct Secret;
+
+// TODO: actually implement proper secret fetching
+impl Secret {
+    pub fn all() -> Vec<String> {
+        vec!["My Biggest Secret".to_owned(), "Pls No Tell".to_owned()]
+    }
+}


### PR DESCRIPTION
Creates a WidgetKind to allow lazy construction of the Widgets.
Selects need a special kind so we can fill their options.

This PR is a quick-win to implement Widget setup, it's not ideal,
but way less complex than a WidgetPrototype one, which was the
initial intent.

The biggest problem with this PR is that we can't properly set a
default value for a select, as we can't get the select options in the
AttributeResolver.

Fixes a tiny bug in the SelectWidget.

Standard Accessor for Option<Enum(...)> was implemented. Albeit it's not used.

<img src="https://media2.giphy.com/media/NdKVEei95yvIY/giphy.gif"/>