### PR TITLE
feat(dal): add encrypted secrets

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -33,9 +33,9 @@ use crate::qualification_resolver::QualificationResolverContext;
 use crate::resource_resolver::ResourceResolverContext;
 use crate::schema::variant::{SchemaVariantError, SchemaVariantId};
 use crate::schema::SchemaVariant;
-use crate::secret::Secret;
 use crate::validation_resolver::ValidationResolverContext;
 use crate::ws_event::{WsEvent, WsEventError};
+use crate::Secret;
 use crate::{AttributeResolverId, Edge, EdgeError, PropError, System};
 
 use crate::func::backend::array::FuncBackendArrayArgs;
@@ -1911,11 +1911,12 @@ async fn edit_field_for_prop(
     let widget = match prop.widget_kind() {
         WidgetKind::SecretSelect => {
             let mut entries = Vec::new();
+            let secrets = Secret::list(txn, tenancy, visibility).await?;
 
-            for secret in Secret::all() {
+            for secret in secrets.into_iter() {
                 entries.push(LabelEntry::new(
-                    secret.to_string(),
-                    serde_json::to_value(secret)?,
+                    secret.name(),
+                    serde_json::json!(i64::from(*secret.id())),
                 ));
             }
             Widget::Select(SelectWidget::new(LabelList::new(entries), None))

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -102,6 +102,22 @@ impl KeyPair {
         Ok(object)
     }
 
+    pub async fn get_current(
+        txn: &PgTxn<'_>,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        billing_account_id: &BillingAccountId,
+    ) -> KeyPairResult<Self> {
+        let row = txn
+            .query_one(
+                PUBLIC_KEY_GET_CURRENT,
+                &[&tenancy, &visibility, &billing_account_id],
+            )
+            .await?;
+        let object = standard_model::object_from_row(row)?;
+        Ok(object)
+    }
+
     standard_model_accessor!(name, String, KeyPairResult);
     standard_model_accessor_ro!(public_key, BoxPublicKey);
     standard_model_accessor_ro!(secret_key, BoxSecretKey);

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -78,7 +78,7 @@ pub use group::{Group, GroupError, GroupId, GroupResult};
 pub use history_event::{HistoryActor, HistoryEvent, HistoryEventError};
 pub use index_map::IndexMap;
 pub use jwt_key::{create_jwt_key_if_missing, JwtSecretKey};
-pub use key_pair::{KeyPair, KeyPairError, KeyPairResult};
+pub use key_pair::{KeyPair, KeyPairError, KeyPairResult, PublicKey};
 pub use label_list::{LabelEntry, LabelList, LabelListError};
 pub use node::{Node, NodeError, NodeKind, NodeTemplate, NodeView};
 pub use node_menu::{MenuFilter, NodeMenuError};
@@ -106,6 +106,10 @@ pub use schema::{
     Schema, SchemaError, SchemaId, SchemaKind, SchemaPk, SchemaVariant, SchemaVariantId,
 };
 pub use schematic::{Connection, Schematic, SchematicError, SchematicKind};
+pub use secret::{
+    DecryptedSecret, EncryptedSecret, Secret, SecretAlgorithm, SecretError, SecretId, SecretKind,
+    SecretObjectType, SecretPk, SecretResult, SecretVersion,
+};
 pub use standard_model::{StandardModel, StandardModelError, StandardModelResult};
 pub use system::{System, SystemError, SystemId, SystemPk, SystemResult};
 pub use tenancy::{Tenancy, TenancyError};

--- a/lib/dal/src/migrations/U0054__secrets.sql
+++ b/lib/dal/src/migrations/U0054__secrets.sql
@@ -1,0 +1,106 @@
+CREATE TABLE encrypted_secrets
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted          bool,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    name                        text                     NOT NULL,
+    object_type                 text                     NOT NULL,
+    kind                        text                     NOT NULL,
+    crypted                     text                     NOT NULL,
+    version                     text                     NOT NULL,
+    algorithm                   text                     NOT NULL
+);
+SELECT standard_model_table_constraints_v1('encrypted_secrets');
+SELECT belongs_to_table_create_v1('encrypted_secret_belongs_to_workspace', 'encrypted_secrets', 'workspaces');
+SELECT belongs_to_table_create_v1('encrypted_secret_belongs_to_key_pair', 'encrypted_secrets', 'key_pairs');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('encrypted_secrets', 'model', 'encrypted_secret', 'Encrypted Secret'),
+       ('encrypted_secret_belongs_to_workspace', 'belongs_to', 'encrypted_secret.workspace',
+        'Encrypted Secret <> Workspace'),
+       ('encrypted_secret_belongs_to_key_pair', 'belongs_to', 'encrypted_secret.key_pair',
+        'Encrypted Secret <> Key Pair');
+
+-- The Rust type `Secret` will use this view as its source-of-truth "table" as
+-- it is a read-only subset of encrypted_secrets data
+CREATE VIEW secrets AS
+SELECT pk,
+       id,
+       tenancy_universal,
+       tenancy_billing_account_ids,
+       tenancy_organization_ids,
+       tenancy_workspace_ids,
+       visibility_change_set_pk,
+       visibility_edit_session_pk,
+       visibility_deleted,
+       created_at,
+       updated_at,
+       name,
+       object_type,
+       kind
+FROM encrypted_secrets;
+
+CREATE OR REPLACE FUNCTION encrypted_secret_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    this_object_type text,
+    this_kind text,
+    this_crypted text,
+    this_version text,
+    this_algorithm text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           encrypted_secrets%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO encrypted_secrets (tenancy_universal,
+                                   tenancy_billing_account_ids,
+                                   tenancy_organization_ids,
+                                   tenancy_workspace_ids,
+                                   visibility_change_set_pk,
+                                   visibility_edit_session_pk,
+                                   visibility_deleted,
+                                   name,
+                                   object_type,
+                                   kind,
+                                   crypted,
+                                   version,
+                                   algorithm)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_name,
+            this_object_type,
+            this_kind,
+            this_crypted,
+            this_version,
+            this_algorithm)
+    RETURNING * INTO this_new_row;
+
+    -- Purge the returning record of sensitive data to avoid accidentally
+    -- deserializing these fields in application code
+    this_new_row.crypted = null;
+    this_new_row.version = null;
+    this_new_row.algorithm = null;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -1,8 +1,691 @@
-pub struct Secret;
+use std::fmt;
 
-// TODO: actually implement proper secret fetching
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use si_data::{NatsTxn, PgError, PgTxn};
+use sodiumoxide::crypto::{
+    box_::{PublicKey, SecretKey},
+    sealedbox,
+};
+use strum_macros::{AsRefStr, Display, EnumString};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    impl_standard_model,
+    key_pair::KeyPairId,
+    pk,
+    standard_model::{self, TypeHint},
+    standard_model_accessor, standard_model_accessor_ro, standard_model_belongs_to, HistoryActor,
+    HistoryEvent, HistoryEventError, KeyPair, KeyPairError, StandardModel, StandardModelError,
+    Tenancy, Timestamp, Visibility,
+};
+
+/// Error type for Secrets.
+#[derive(Error, Debug)]
+pub enum SecretError {
+    #[error("error when decrypting crypted secret")]
+    DecryptionFailed,
+    #[error("error deserializing message: {0}")]
+    DeserializeMessage(#[source] serde_json::Error),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("key pair error: {0}")]
+    KeyPair(#[from] KeyPairError),
+    #[error("key pair not found for secret")]
+    KeyPairNotFound,
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+/// Result type for Secrets.
+pub type SecretResult<T> = Result<T, SecretError>;
+
+pk!(SecretPk);
+pk!(SecretId);
+
+/// A reference to a database-persisted encrypted secret.
+///
+/// This type does not contain any encrypted information nor any encryption metadata and is
+/// therefore safe to expose via external API.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Secret {
+    pk: SecretPk,
+    id: SecretId,
+    name: String,
+    object_type: SecretObjectType,
+    kind: SecretKind,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: Secret,
+    pk: SecretPk,
+    id: SecretId,
+    table_name: "secrets",
+    history_event_label_base: "secret",
+    history_event_message_name: "Secret"
+}
+
 impl Secret {
-    pub fn all() -> Vec<String> {
-        vec!["My Biggest Secret".to_owned(), "Pls No Tell".to_owned()]
+    standard_model_accessor_ro!(name, str);
+
+    // Update the underlying `encrypted_secrets` table rather than attempting to update the
+    // `secrets` view
+    pub async fn set_name(
+        &mut self,
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        value: impl Into<String>,
+    ) -> SecretResult<()> {
+        let value = value.into();
+        let updated_at = standard_model::update(
+            txn,
+            "encrypted_secrets",
+            "name",
+            self.tenancy(),
+            visibility,
+            self.id(),
+            &value,
+            TypeHint::Text,
+        )
+        .await?;
+        let _history_event = HistoryEvent::new(
+            txn,
+            nats,
+            Self::history_event_label(vec!["updated"]),
+            history_actor,
+            Self::history_event_message("updated"),
+            &serde_json::json!({"pk": self.pk, "field": "name", "value": &value}),
+            self.tenancy(),
+        )
+        .await?;
+        self.timestamp.updated_at = updated_at;
+        self.name = value;
+
+        Ok(())
+    }
+
+    // Once created, these object fields are to be considered immutable
+    standard_model_accessor_ro!(object_type, SecretObjectType);
+    standard_model_accessor_ro!(kind, SecretKind);
+
+    standard_model_belongs_to!(
+        lookup_fn: key_pair,
+        set_fn: set_key_pair,
+        unset_fn: unset_key_pair,
+        table: "encrypted_secret_belongs_to_key_pair",
+        model_table: "key_pairs",
+        belongs_to_id: KeyPairId,
+        returns: KeyPair,
+        result: SecretResult,
+    );
+}
+
+/// A database-persisted encrypted secret.
+///
+/// This type contains the raw encrypted payload as well as the necessary encryption metadata and
+/// should therefore should *only* be used internally when decrypting secrets for use by Cyclone.
+///
+/// NOTE: Other than creating a new encrypted secret, any external API will likely want to use
+/// the [`Secret`] type which does not expose extra encryption information.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct EncryptedSecret {
+    pk: SecretPk,
+    id: SecretId,
+    name: String,
+    object_type: SecretObjectType,
+    kind: SecretKind,
+    #[serde(with = "crypted_serde")]
+    crypted: Vec<u8>,
+    version: SecretVersion,
+    algorithm: SecretAlgorithm,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl fmt::Debug for EncryptedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedSecret")
+            .field("pk", &self.pk)
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("object_type", &self.object_type)
+            .field("kind", &self.kind)
+            .field("version", &self.version)
+            .field("algorithm", &self.algorithm)
+            .field("tenancy", &self.tenancy)
+            .field("timestamp", &self.timestamp)
+            .field("visibility", &self.visibility)
+            .finish_non_exhaustive()
+    }
+}
+
+impl_standard_model! {
+    model: EncryptedSecret,
+    pk: SecretPk,
+    id: SecretId,
+    table_name: "encrypted_secrets",
+    history_event_label_base: "encrypted_secret",
+    history_event_message_name: "Encrypted Secret"
+}
+
+impl EncryptedSecret {
+    /// Creates a new encypted secret and returns a corresponding [`Secret`] representation.
+    #[allow(clippy::too_many_arguments, clippy::new_ret_no_self)]
+    pub async fn new(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        name: impl AsRef<str>,
+        object_type: SecretObjectType,
+        kind: SecretKind,
+        crypted: &[u8],
+        key_pair_id: KeyPairId,
+        version: SecretVersion,
+        algorithm: SecretAlgorithm,
+    ) -> SecretResult<Secret> {
+        let name = name.as_ref();
+
+        let row = txn
+            .query_one(
+                "SELECT object FROM encrypted_secret_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    tenancy,
+                    visibility,
+                    &name,
+                    &object_type.as_ref(),
+                    &kind.as_ref(),
+                    &encode_crypted(crypted),
+                    &version.as_ref(),
+                    &algorithm.as_ref(),
+                ],
+            )
+            .await?;
+        let object: Secret = standard_model::finish_create_from_row(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            row,
+        )
+        .await?;
+
+        object
+            .set_key_pair(txn, nats, visibility, history_actor, &key_pair_id)
+            .await?;
+
+        Ok(object)
+    }
+
+    standard_model_accessor!(name, String, SecretResult);
+
+    // Once created, these object fields are to be considered immutable
+    standard_model_accessor_ro!(object_type, SecretObjectType);
+    standard_model_accessor_ro!(kind, SecretKind);
+    standard_model_accessor_ro!(version, SecretVersion);
+    standard_model_accessor_ro!(algorithm, SecretAlgorithm);
+
+    standard_model_belongs_to!(
+        lookup_fn: key_pair,
+        set_fn: set_key_pair,
+        unset_fn: unset_key_pair,
+        table: "encrypted_secret_belongs_to_key_pair",
+        model_table: "key_pairs",
+        belongs_to_id: KeyPairId,
+        returns: KeyPair,
+        result: SecretResult,
+    );
+
+    /// Decrypts the encrypted secret with its associated [`KeyPair`] and returns a
+    /// [`DecryptedSecret`].
+    pub async fn decrypt(
+        self,
+        txn: &PgTxn<'_>,
+        visibility: &Visibility,
+    ) -> SecretResult<DecryptedSecret> {
+        let key_pair = self
+            .key_pair(txn, visibility)
+            .await?
+            .ok_or(SecretError::KeyPairNotFound)?;
+        self.into_decrypted(key_pair.public_key(), key_pair.secret_key())
+    }
+
+    fn into_decrypted(self, pkey: &PublicKey, skey: &SecretKey) -> SecretResult<DecryptedSecret> {
+        // Explicitly match on (version, algorithm) tuple to ensure that any new
+        // versions/algorithms will trigger a compilation failure
+        match (self.version, self.algorithm) {
+            (SecretVersion::V1, SecretAlgorithm::Sealedbox) => Ok(DecryptedSecret {
+                name: self.name,
+                object_type: self.object_type,
+                kind: self.kind,
+                message: serde_json::from_slice(
+                    &sealedbox::open(&self.crypted, pkey, skey)
+                        .map_err(|_| SecretError::DecryptionFailed)?,
+                )
+                .map_err(SecretError::DeserializeMessage)?,
+            }),
+        }
+    }
+}
+
+/// A secret that has been decrypted.
+///
+/// This type is returned by calling `EncryptedSecret.decrypt(&txn).await?` which contains the raw
+/// decrypted message, and without the encrypted payload and other metadata. It is not persistable
+/// and is only intended to be used internally when passing secrets through to Cyclone.
+//
+// NOTE: We're being a bit careful here as to which traits are derrived in an effort to minimize
+// leaking sensitive data.
+#[derive(Serialize)]
+pub struct DecryptedSecret {
+    name: String,
+    object_type: SecretObjectType,
+    kind: SecretKind,
+    message: Value,
+}
+
+impl DecryptedSecret {
+    /// Gets a reference to the decrypted secret's name.
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    /// Gets the decrypted secret's object type.
+    pub fn object_type(&self) -> SecretObjectType {
+        self.object_type
+    }
+
+    /// Gets the decrypted secret's kind.
+    pub fn kind(&self) -> SecretKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for DecryptedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DecryptedSecret")
+            .field("name", &self.name)
+            .field("object_type", &self.object_type)
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The version of encryption used to encrypt a secret.
+#[derive(
+    AsRefStr, Clone, Copy, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretVersion {
+    /// Version 1 of the encryption
+    V1,
+}
+
+impl Default for SecretVersion {
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+/// The algorithm used to encrypt a secret.
+#[derive(
+    AsRefStr, Clone, Copy, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretAlgorithm {
+    /// The "sealedbox" encryption algorithm, provided by libsodium
+    Sealedbox,
+}
+
+impl Default for SecretAlgorithm {
+    fn default() -> Self {
+        Self::Sealedbox
+    }
+}
+
+/// The object type of a secret.
+#[derive(
+    AsRefStr, Clone, Copy, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretObjectType {
+    /// Represents a secret which is a credential
+    Credential,
+}
+
+/// The kind of a secret.
+#[derive(
+    AsRefStr, Clone, Copy, Debug, Deserialize, Display, EnumString, Eq, PartialEq, Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SecretKind {
+    /// A Docker Hub credential
+    DockerHub,
+    /// An AWS access key
+    AwsAccessKey,
+    /// A Helm repository credential
+    HelmRepo,
+    /// An Azure service principal
+    AzureServicePrincipal,
+}
+
+fn encode_crypted(crypted: &[u8]) -> String {
+    base64::encode_config(crypted, base64::STANDARD_NO_PAD)
+}
+
+mod crypted_serde {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    use super::encode_crypted;
+
+    pub fn serialize<S>(crypted: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = encode_crypted(crypted);
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let buffer =
+            base64::decode_config(s, base64::STANDARD_NO_PAD).map_err(serde::de::Error::custom)?;
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod encrypted_secret {
+        use sodiumoxide::crypto::box_;
+
+        use super::*;
+
+        fn encrypted_secret(
+            name: impl Into<String>,
+            object_type: SecretObjectType,
+            kind: SecretKind,
+            crypted: impl Into<Vec<u8>>,
+        ) -> EncryptedSecret {
+            let name = name.into();
+            let crypted = crypted.into();
+
+            EncryptedSecret {
+                pk: 1.into(),
+                id: 1.into(),
+                name,
+                object_type,
+                kind,
+                crypted,
+                version: Default::default(),
+                algorithm: Default::default(),
+                tenancy: Tenancy::new_empty(),
+                timestamp: Timestamp::now(),
+                visibility: Visibility::new_head(false),
+            }
+        }
+
+        fn crypt<T>(value: &T, pkey: &PublicKey) -> Vec<u8>
+        where
+            T: ?Sized + Serialize,
+        {
+            sealedbox::seal(
+                &serde_json::to_vec(value).expect("failed to serialize value"),
+                pkey,
+            )
+        }
+
+        #[test]
+        fn into_decrypted() {
+            sodiumoxide::init().expect("crypto failed to init");
+            let (pkey, skey) = box_::gen_keypair();
+
+            let message =
+                serde_json::json!({"username": "The Cadillac Three", "password": "Slow Rollin"});
+            let crypted = crypt(&message, &pkey);
+
+            let encrypted = encrypted_secret(
+                "the-cadillac-three",
+                SecretObjectType::Credential,
+                SecretKind::DockerHub,
+                crypted,
+            );
+            let decrypted = encrypted
+                .into_decrypted(&pkey, &skey)
+                .expect("could not decrypt secret");
+
+            assert_eq!("the-cadillac-three", decrypted.name);
+            assert_eq!(SecretObjectType::Credential, decrypted.object_type);
+            assert_eq!(SecretKind::DockerHub, decrypted.kind);
+            assert_eq!(message, decrypted.message);
+        }
+    }
+
+    mod secret_object_type {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            object_type: SecretObjectType,
+        }
+
+        fn str() -> &'static str {
+            r#"{"objectType":"credential"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"objectType":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                object_type: SecretObjectType::Credential,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            if serde_json::from_str::<Object>(invalid()).is_ok() {
+                panic!("deserialize should not succeed")
+            }
+        }
+    }
+
+    mod secret_kind {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            kind: SecretKind,
+        }
+
+        fn str() -> &'static str {
+            r#"{"kind":"dockerHub"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"kind":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                kind: SecretKind::DockerHub,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            if serde_json::from_str::<Object>(invalid()).is_ok() {
+                panic!("deserialize should not succeed")
+            }
+        }
+    }
+
+    mod secret_version {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            version: SecretVersion,
+        }
+
+        fn str() -> &'static str {
+            r#"{"version":"v1"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"version":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                version: SecretVersion::V1,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            if serde_json::from_str::<Object>(invalid()).is_ok() {
+                panic!("deserialize should not succeed")
+            }
+        }
+
+        #[test]
+        fn default() {
+            // This test is intended to catch if and when we update the default variant for this
+            // type
+            assert_eq!(SecretAlgorithm::Sealedbox, SecretAlgorithm::default())
+        }
+    }
+
+    mod secret_algorithm {
+        use super::*;
+
+        #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            algorithm: SecretAlgorithm,
+        }
+
+        fn str() -> &'static str {
+            r#"{"algorithm":"sealedbox"}"#
+        }
+
+        fn invalid() -> &'static str {
+            r#"{"algorithm":"nope"}"#
+        }
+
+        fn object() -> Object {
+            Object {
+                algorithm: SecretAlgorithm::Sealedbox,
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            assert_eq!(
+                str(),
+                serde_json::to_string(&object()).expect("failed to serialize")
+            );
+        }
+
+        #[test]
+        fn deserialize() {
+            assert_eq!(
+                object(),
+                serde_json::from_str(str()).expect("failed to deserialize")
+            );
+        }
+
+        #[test]
+        fn deserialize_invalid() {
+            if serde_json::from_str::<Object>(invalid()).is_ok() {
+                panic!("deserialize should not succeed")
+            }
+        }
+
+        #[test]
+        fn default() {
+            // This test is intended to catch if and when we update the default variant for this
+            // type
+            assert_eq!(SecretAlgorithm::Sealedbox, SecretAlgorithm::default())
+        }
     }
 }

--- a/lib/dal/src/timestamp.rs
+++ b/lib/dal/src/timestamp.rs
@@ -12,3 +12,13 @@ pub struct Timestamp {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
+
+impl Timestamp {
+    pub fn now() -> Self {
+        let now = Utc::now();
+        Self {
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -26,6 +26,7 @@ mod resource_prototype;
 mod resource_resolver;
 mod schema;
 mod schematic;
+mod secret;
 mod socket;
 mod standard_model;
 mod system;

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -1,0 +1,181 @@
+use dal::{
+    test_harness::{billing_account_signup, create_secret, generate_fake_name},
+    EncryptedSecret, HistoryActor, Secret, SecretAlgorithm, SecretKind, SecretObjectType,
+    SecretVersion, StandardModel, Tenancy, Visibility,
+};
+
+use crate::test_setup;
+
+#[tokio::test]
+async fn new_encrypted_secret() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let name = generate_fake_name();
+
+    let secret = EncryptedSecret::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &name,
+        SecretObjectType::Credential,
+        SecretKind::DockerHub,
+        "im-crypted-bytes-maybe".as_bytes(),
+        *nba.key_pair.id(),
+        SecretVersion::V1,
+        SecretAlgorithm::Sealedbox,
+    )
+    .await
+    .expect("failed to create secret");
+
+    assert_eq!(secret.name(), name);
+    assert_eq!(secret.object_type(), &SecretObjectType::Credential);
+    assert_eq!(secret.kind(), &SecretKind::DockerHub);
+
+    let key_pair = secret
+        .key_pair(&txn, &visibility)
+        .await
+        .expect("failed to fetch key pair")
+        .expect("failed to find key pair");
+    assert_eq!(key_pair.pk(), nba.key_pair.pk());
+}
+
+#[tokio::test]
+async fn secret_get_by_id() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let og_secret = create_secret(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *nba.key_pair.id(),
+    )
+    .await;
+
+    let secret = Secret::get_by_id(&txn, &tenancy, &visibility, og_secret.id())
+        .await
+        .expect("failed to get secret")
+        .expect("failed to find secret in current tenancy and visibility");
+    assert_eq!(secret, og_secret);
+}
+
+#[tokio::test]
+async fn encrypted_secret_get_by_id() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let secret = create_secret(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *nba.key_pair.id(),
+    )
+    .await;
+
+    let encrypted_secret = EncryptedSecret::get_by_id(&txn, &tenancy, &visibility, secret.id())
+        .await
+        .expect("failed to get encrypted secret")
+        .expect("failed to find encrypted secret in current tenancy and visibility");
+    assert_eq!(secret.id(), encrypted_secret.id());
+    assert_eq!(secret.pk(), encrypted_secret.pk());
+    assert_eq!(secret.name(), encrypted_secret.name());
+    assert_eq!(secret.object_type(), encrypted_secret.object_type());
+    assert_eq!(secret.kind(), encrypted_secret.kind());
+}
+
+#[tokio::test]
+async fn secret_update_name() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let mut secret = create_secret(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        *nba.key_pair.id(),
+    )
+    .await;
+
+    let original_name = secret.name().to_string();
+    secret
+        .set_name(&txn, &nats, &visibility, &history_actor, "even-more-secret")
+        .await
+        .expect("failed to set name");
+
+    assert_ne!(secret.name(), original_name);
+    assert_eq!(secret.name(), "even-more-secret");
+}
+
+#[tokio::test]
+async fn encrypt_decrypt_round_trip() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech);
+    let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
+    let tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let visibility = Visibility::new_head(false);
+    let history_actor = HistoryActor::SystemInit;
+
+    let pkey = nba.key_pair.public_key();
+    let name = generate_fake_name();
+
+    let message = serde_json::json!({"song": "Bar Round Here"});
+    let crypted = sodiumoxide::crypto::sealedbox::seal(
+        &serde_json::to_vec(&message).expect("failed to serilaze message"),
+        pkey,
+    );
+
+    let secret = EncryptedSecret::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        &name,
+        SecretObjectType::Credential,
+        SecretKind::DockerHub,
+        &crypted,
+        *nba.key_pair.id(),
+        Default::default(),
+        Default::default(),
+    )
+    .await
+    .expect("failed to create encrypted secret");
+
+    let decrypted = EncryptedSecret::get_by_id(&txn, &tenancy, &visibility, secret.id())
+        .await
+        .expect("failed to fetch encrypted secret")
+        .expect("failed to find encrypted secret for tenancy and/or visibility")
+        .decrypt(&txn, &visibility)
+        .await
+        .expect("failed to decrypt encrypted secret");
+    assert_eq!(decrypted.name(), secret.name());
+    assert_eq!(decrypted.object_type(), *secret.object_type());
+    assert_eq!(decrypted.kind(), *secret.kind());
+
+    // We don't provide a direct getter for the raw decrypted message (higher effort should mean
+    // less chance of developer error when handling `DecryptedSecret` types), so we'll serialize to
+    // a `Value` to compare messages
+    let decrypted_value =
+        serde_json::to_value(&decrypted).expect("failed to serial decrypted into Value");
+    assert_eq!(decrypted_value["message"], message);
+}


### PR DESCRIPTION
This change introduces the concept of secrets to the system. Currently,
secrets are not too dissimilar from Components in that a `Secret` has an
object type and kind which are currently opaque to the backend. That is,
the message component of the secret is arbitrary data which the front
end will interpret and use as structured data.

![](https://user-images.githubusercontent.com/261548/97929893-73e13080-1d27-11eb-846c-a9e2c943e2d3.gif)

A `Secret` currently has one object type of `Credential` with room to
create other types in the future (perhaps single value secret strings,
for example). Additionally, a `Secret` has a kind which helps the API
consumer to understand the message format. An example of one kind is
`DockerHub`, which consists of a `username` and `password` hash.

![](https://user-images.githubusercontent.com/261548/97929914-80658900-1d27-11eb-9378-43568c59121a.gif)

Secrets are encrypted client side (in our case, the front end in the
browser) and send to the API on creation using the active billing
account's current public key. The API
only ever exposes a `Secret` type which boils down to its name and basic
type metadata, such as `object_type` and `kind`. Notably, neither the
encypted payload nor the unencrypted message will be exposed by the API,
but rather used internally when preparing to invoke functions
in `Cylone`. For this, an `EncryptedSecret` can be fetched from the
database and then decrypted in Rust into a `DecryptedSecret`.

![](https://user-images.githubusercontent.com/261548/97929923-88252d80-1d27-11eb-94d7-9367d11b087a.gif)

The secrets API allows a encrypted secret to be created, fetched
individually, and as a list. Notably, the API currently does not support
updating a `Secret` (aside from its `name` field) are therefore assumed
to be immutable (until we decide otherwise).

![](https://user-images.githubusercontent.com/261548/97929937-94a98600-1d27-11eb-8a65-991d30ab4317.gif)

Of special note in the database creation, we have a `VIEW` of `secrets`
which represents a subset of the underlying `encrypted_secrets` table
which should prevent accidental fetching of encrypted payloads into
application memory when making routine "fetch a list of secrets for the
frontend" type calls. The result is that it almost looks like we have an
`EncryptedSecret` DAL object and an additional independant `Secret` DAL
object, which isn't strictly true. Anyway, the resulting Rust module
makes for some interesting reading as the standard model macros and
calls need to be set up very precisely, hence the additional integration
tests.

References: restore the backend part of secrets [sc-2259]

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>