### PR TITLE
feat(web): add message encryption to secrets UI

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -16,6 +16,7 @@
         "pixi-filters": "^4.1.5",
         "pixi.js": "^6.2.0",
         "rxjs": "^7.4.0",
+        "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
         "vue": "^3.2.22",
         "vuse-rx": "systeminit/vuse-rx#bug/fix-options",
         "xstate": "^4.26.0"
@@ -50,7 +51,6 @@
         "rxjs": "^7.4.0",
         "sass": "^1.43.2",
         "tailwindcss": "^2.2.17",
-        "tweetnacl-sealedbox-js": "^1.2.0",
         "typescript": "^4.4.3",
         "vite": "^2.6.4",
         "vite-plugin-eslint": "^1.3.0",
@@ -1964,8 +1964,7 @@
     "node_modules/blakejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
-      "dev": true
+      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "node_modules/blob-util": {
       "version": "2.0.2",
@@ -6116,19 +6115,17 @@
     },
     "node_modules/tweetnacl-sealedbox-js": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl-sealedbox-js/-/tweetnacl-sealedbox-js-1.2.0.tgz",
-      "integrity": "sha512-QoCr8K2hwri+ky7SUa22oSre8g88XaWi0hwwWd16pJMuDyn5gL/UyE0PyR2EOFEMJ70T2trJ9+Sv+Qa18olEmQ==",
-      "dev": true,
+      "resolved": "git+ssh://git@github.com/systeminit/tweetnacl-sealed-box.git#82176635615f8d55c4fc8f602bc8e0390e004d49",
+      "license": "MIT",
       "dependencies": {
         "blakejs": "^1.1.0",
-        "tweetnacl": "^1.0.1"
+        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/tweetnacl-sealedbox-js/node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8359,8 +8356,7 @@
     "blakejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
-      "dev": true
+      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "blob-util": {
       "version": "2.0.2",
@@ -11505,20 +11501,17 @@
       "dev": true
     },
     "tweetnacl-sealedbox-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl-sealedbox-js/-/tweetnacl-sealedbox-js-1.2.0.tgz",
-      "integrity": "sha512-QoCr8K2hwri+ky7SUa22oSre8g88XaWi0hwwWd16pJMuDyn5gL/UyE0PyR2EOFEMJ70T2trJ9+Sv+Qa18olEmQ==",
-      "dev": true,
+      "version": "git+ssh://git@github.com/systeminit/tweetnacl-sealed-box.git#82176635615f8d55c4fc8f602bc8e0390e004d49",
+      "from": "tweetnacl-sealedbox-js@github:systeminit/tweetnacl-sealed-box#master",
       "requires": {
         "blakejs": "^1.1.0",
-        "tweetnacl": "^1.0.1"
+        "tweetnacl": "^1.0.3"
       },
       "dependencies": {
         "tweetnacl": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-          "dev": true
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         }
       }
     },

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -26,6 +26,7 @@
     "pixi-filters": "^4.1.5",
     "pixi.js": "^6.2.0",
     "rxjs": "^7.4.0",
+    "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
     "vue": "^3.2.22",
     "vuse-rx": "systeminit/vuse-rx#bug/fix-options",
     "xstate": "^4.26.0"
@@ -60,7 +61,6 @@
     "rxjs": "^7.4.0",
     "sass": "^1.43.2",
     "tailwindcss": "^2.2.17",
-    "tweetnacl-sealedbox-js": "^1.2.0",
     "typescript": "^4.4.3",
     "vite": "^2.6.4",
     "vite-plugin-eslint": "^1.3.0",

--- a/app/web/src/api/sdf/dal/secret.ts
+++ b/app/web/src/api/sdf/dal/secret.ts
@@ -7,15 +7,17 @@ export interface Secret {
   name: string;
   kind: string;
   objectType: string;
+  contents: number[];
 }
 
 export interface SecretKind {
   name: string;
-  type: string;
-  fields?: SecretField[];
+  objectType: string;
+  fields: SecretField[];
 }
 
 export interface SecretField {
   name: string;
+  displayName: string;
   password: boolean;
 }

--- a/app/web/src/organisims/Secret/SecretCreateFields.vue
+++ b/app/web/src/organisims/Secret/SecretCreateFields.vue
@@ -5,37 +5,37 @@
         class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle border-blue-100"
       >
         <label :for="idFor(field.name, field.password)"
-          >{{ field.name }}:</label
+          >{{ field.displayName }}:</label
         >
       </div>
       <div class="w-1/2 align-middle">
         <SiTextBox
           :id="idFor(field.name, field.password)"
-          v-model="password"
+          v-model="createFields[field.name]"
           size="xs"
           placeholder=""
           :is-show-type="false"
           required
           type="password"
-          @input="updatePassword(password)"
+          @input="updateInput"
         />
       </div>
     </div>
     <div v-else class="flex flex-row items-center w-full pb-2">
       <div class="w-1/2 pr-2 text-sm text-right text-gray-400 align-middle">
         <label :for="idFor(field.name, field.password)"
-          >{{ field.name }}:</label
+          >{{ field.displayName }}:</label
         >
       </div>
       <div class="w-1/2 align-middle">
         <SiTextBox
           :id="idFor(field.name, field.password)"
-          v-model="username"
+          v-model="createFields[field.name]"
           size="xs"
           placeholder=""
           :is-show-type="false"
           required
-          @input="updateUsername(username)"
+          @input="updateInput"
         />
       </div>
     </div>
@@ -49,6 +49,7 @@ import { SecretKind } from "@/api/sdf/dal/secret";
 
 const props = defineProps<{
   secretKind: SecretKind;
+  modelValue: Record<string, string>;
 }>();
 
 const idFor = (name: string, password: boolean): string => {
@@ -58,13 +59,10 @@ const idFor = (name: string, password: boolean): string => {
   return "secret-text-" + name;
 };
 
-// FIXME(nick): these fields need to actually work and become dynamic for what fields are passed in.
-const username = ref<string>("username");
-const password = ref<string>("");
-const updateUsername = (input: string) => {
-  username.value = input;
-};
-const updatePassword = (input: string) => {
-  password.value = input;
+const createFields = ref<Record<string, string>>({});
+
+const emits = defineEmits(["update:modelValue"]);
+const updateInput = () => {
+  emits("update:modelValue", createFields);
 };
 </script>

--- a/app/web/src/organisims/Secret/SecretList.vue
+++ b/app/web/src/organisims/Secret/SecretList.vue
@@ -16,7 +16,8 @@
           <div class="w-3/12 px-2 py-1 text-center table-border">Type</div>
         </div>
 
-        <div class="flex flex-col overflow-y-scroll text-xs text-gray-300">
+        <!-- NOTE(nick): removed scrollbar that was found in old-web. -->
+        <div class="flex flex-col text-xs text-gray-300">
           <div
             v-for="secret in secrets"
             :key="secret.id"

--- a/app/web/src/service/secret/list_secret_kinds.ts
+++ b/app/web/src/service/secret/list_secret_kinds.ts
@@ -4,14 +4,16 @@ export function listSecretKinds(): SecretKind[] {
   return [
     {
       name: "Docker Hub",
-      type: "Credential",
+      objectType: "Credential",
       fields: [
         {
-          name: "Docker Hub Username",
+          name: "username",
+          displayName: "Docker Hub Username",
           password: false,
         },
         {
-          name: "Docker Hub Password",
+          name: "password",
+          displayName: "Docker Hub Password",
           password: true,
         },
       ],

--- a/app/web/src/service/secret/list_secrets.ts
+++ b/app/web/src/service/secret/list_secrets.ts
@@ -7,6 +7,7 @@ export function listSecrets(): Secret[] {
       name: "ilikemybutt",
       kind: "DockerHub",
       objectType: "Credential",
+      contents: [0],
     },
   ];
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -137,7 +137,7 @@ function install-kubeval-linux-amd64 {
     wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz -P /tmp/kubeval-download
     tar -xf /tmp/kubeval-download/kubeval-linux-amd64.tar.gz --directory /tmp/kubeval-download
     if [ -f /usr/local/bin/kubeval ]; then
-        rm -f /usr/local/bin/kubeval
+        sudo rm -f /usr/local/bin/kubeval
     fi
     sudo cp /tmp/kubeval-download/kubeval /usr/local/bin
     rm -rf /tmp/kubeval-download


### PR DESCRIPTION
- Add message encryption to secrets UI using our internally re-published
  npm module [sc-2279]
- Standardize on "objectType" for Secret DAL shapes
- Add contents to Secret DAL shape (encrypted message)
- Ensure we can update values in create fields and emit them back to the
  create component
- Add create functionality using mock SDF route with encryption included
- Ensure selected secret kind is not null when creating secrets
- Use "createFields" Record to as a v-model to have reactive user input
  be emitted back to the create component
- Remove secret list scrollbar
- Add "sudo" to removing kubeval if it exists
- Add "displayName" for SecretKind DAL shape so that we use the _real_
  field names for encryption

<img src="https://media4.giphy.com/media/3ofT5zaiGaoJN7BLR6/giphy.gif"/>
