### PR TITLE
feat(web,sdf): Create List Secrets service

### DIFF
--- a/app/web/src/organisims/Secret/SecretList.vue
+++ b/app/web/src/organisims/Secret/SecretList.vue
@@ -47,13 +47,11 @@
 
 <script setup lang="ts">
 // import SiError from "@/atoms/SiError.vue";
-import { computed } from "vue";
+import { refFrom } from "vuse-rx";
 import { Secret } from "@/api/sdf/dal/secret";
 import { SecretService } from "@/service/secret";
 
-const secrets = computed((): Secret[] => {
-  return SecretService.listSecrets();
-});
+const secrets = refFrom<Secret[]>(SecretService.listSecrets());
 </script>
 
 <style scoped>

--- a/app/web/src/service/secret/list_secrets.ts
+++ b/app/web/src/service/secret/list_secrets.ts
@@ -1,13 +1,34 @@
 import { Secret } from "@/api/sdf/dal/secret";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, combineLatestWith, from, Observable } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
 
-export function listSecrets(): Secret[] {
-  return [
-    {
-      id: 1,
-      name: "ilikemybutt",
-      kind: "DockerHub",
-      objectType: "Credential",
-      contents: [0],
-    },
-  ];
+export type ListSecretsResponse = Secret[];
+
+export function listSecrets(): Observable<ApiResponse<ListSecretsResponse>> {
+  return combineLatest([standardVisibilityTriggers$]).pipe(
+    combineLatestWith(workspace$),
+    switchMap(([[[visibility]], workspace]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      return sdf.get<ApiResponse<ListSecretsResponse>>("secret/list_secrets", {
+        ...visibility,
+      });
+    }),
+  );
 }

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -131,6 +131,26 @@ impl Secret {
     );
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretView {
+    pub id: SecretId,
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+}
+
+impl From<Secret> for SecretView {
+    fn from(secret: Secret) -> Self {
+        Self {
+            id: *secret.id(),
+            name: secret.name().to_owned(),
+            object_type: *secret.object_type(),
+            kind: *secret.kind(),
+        }
+    }
+}
+
 /// A database-persisted encrypted secret.
 ///
 /// This type contains the raw encrypted payload as well as the necessary encryption metadata and

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -70,6 +70,7 @@ pub fn routes(
             crate::server::service::change_set::routes(),
         )
         .nest("/api/schema", crate::server::service::schema::routes())
+        .nest("/api/secret", crate::server::service::secret::routes())
         .nest(
             "/api/schematic",
             crate::server::service::schematic::routes(),

--- a/lib/sdf/src/server/service.rs
+++ b/lib/sdf/src/server/service.rs
@@ -4,6 +4,7 @@ pub mod component;
 pub mod edit_field;
 pub mod schema;
 pub mod schematic;
+pub mod secret;
 pub mod session;
 pub mod signup;
 pub mod test;

--- a/lib/sdf/src/server/service/secret.rs
+++ b/lib/sdf/src/server/service/secret.rs
@@ -1,0 +1,45 @@
+use axum::body::{Bytes, Full};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Json;
+use axum::Router;
+use dal::StandardModelError;
+use std::convert::Infallible;
+use thiserror::Error;
+
+pub mod list_secrets;
+
+#[derive(Debug, Error)]
+pub enum SecretError {
+    #[error(transparent)]
+    Nats(#[from] si_data::NatsError),
+    #[error(transparent)]
+    Pg(#[from] si_data::PgError),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+}
+
+pub type SecretResult<T> = std::result::Result<T, SecretError>;
+
+impl IntoResponse for SecretError {
+    type Body = Full<Bytes>;
+    type BodyError = Infallible;
+
+    fn into_response(self) -> hyper::Response<Self::Body> {
+        let (status, error_message) = match self {
+            //SecretError::SecretNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
+
+        let body = Json(
+            serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),
+        );
+
+        (status, body).into_response()
+    }
+}
+
+pub fn routes() -> Router {
+    Router::new().route("/list_secrets", get(list_secrets::list_secrets))
+}

--- a/lib/sdf/src/server/service/secret/list_secrets.rs
+++ b/lib/sdf/src/server/service/secret/list_secrets.rs
@@ -1,0 +1,41 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{
+    secret::SecretKind, secret::SecretObjectType, secret::SecretView, Secret, StandardModel,
+    Tenancy, Visibility,
+};
+use serde::{Deserialize, Serialize};
+
+use super::SecretResult;
+use crate::server::extract::{Authorization, PgRoTxn};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ListSecretRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub type ListSecretResponse = Vec<SecretView>;
+
+pub async fn list_secrets(
+    mut txn: PgRoTxn,
+    Query(request): Query<ListSecretRequest>,
+    Authorization(claim): Authorization,
+) -> SecretResult<Json<ListSecretResponse>> {
+    let txn = txn.start().await?;
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.universal = true;
+    let mut response: Vec<SecretView> = Secret::list(&txn, &tenancy, &request.visibility)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    // TODO: remove this when we can create some secret, but as we can't this helps with debugging
+    response.push(SecretView {
+        id: 1.into(),
+        name: "moro num pais tropical".to_owned(),
+        kind: SecretKind::DockerHub,
+        object_type: SecretObjectType::Credential,
+    });
+    Ok(Json(response))
+}


### PR DESCRIPTION
Fetches the secrets list when the Secret Panel is setup. This means it won't get updated, but to update we will need a rewrite, or a websocket message telling us a secret was created, and we can't have it without having the create secrets route.

Besides fetching the database for secrets (which we can't exactly test in the sdf layer yet), it also returns a mock secret to help testing things in the frontend, but it should be removed this week still.

We need tests for this service, but as we don't actually have a secret creation route it would be a really dumb test.

[sc-2280]

<img src="https://media3.giphy.com/media/nzZAwMWi5Muac/giphy.gif"/>