### PR TITLE
feat(web): add public key use for true encryption

### DIFF
--- a/app/web/src/api/sdf/dal/key_pair.ts
+++ b/app/web/src/api/sdf/dal/key_pair.ts
@@ -2,6 +2,7 @@ import { StandardModel } from "@/api/sdf/dal/standard_model";
 
 export interface PublicKey extends StandardModel {
   name: string;
+  // This is base64 encoded. The consumer may need to execute "Base64.toUint8Array(<public-key>)" to get the key.
   public_key: string;
   created_lampot_clock: string;
 }

--- a/app/web/src/service/secret.ts
+++ b/app/web/src/service/secret.ts
@@ -1,9 +1,11 @@
 import { listSecretKinds } from "./secret/list_secret_kinds";
 import { createSecret } from "./secret/create_secret";
 import { listSecrets } from "./secret/list_secrets";
+import { getPublicKeyRaw } from "./secret/get_public_key";
 
 export const SecretService = {
   createSecret,
   listSecrets,
+  getPublicKeyRaw,
   listSecretKinds,
 };

--- a/app/web/src/service/secret/get_public_key.ts
+++ b/app/web/src/service/secret/get_public_key.ts
@@ -1,0 +1,20 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { lastValueFrom } from "rxjs";
+import Bottle from "bottlejs";
+import { PublicKey } from "@/api/sdf/dal/key_pair";
+
+// The response _is_ the "PublicKey" from the DAL. You may need to decode the actual public key via "Base64.toUint8Array"
+// or equivalent.
+export type GetPublicKeyResponse = PublicKey;
+
+// This is a blocking call, unlike most service calls. It does not return an observable.
+export async function getPublicKeyRaw(): Promise<
+  ApiResponse<GetPublicKeyResponse>
+> {
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+  const reply$ = sdf.get<ApiResponse<GetPublicKeyResponse>>(
+    "secret/get_public_key",
+  );
+  return await lastValueFrom(reply$);
+}

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -149,11 +149,16 @@ fn encode_secret_key(key: &BoxSecretKey) -> String {
 ///
 /// This type only contains the public half of the underlying key pair and is therefore safe to
 /// expose via external API.
+///
+/// The field "public_key" is base64 encoded into a string when this struct is serialized, and
+/// decoded when deserialized. Thus, the DAL "PublicKey" (this struct) must be used for transport
+/// between SI components rather than the nested "BoxPublicKey".
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublicKey {
     pk: KeyPairPk,
     id: KeyPairId,
     name: String,
+    /// This field is base64 encoded into a string. Consumers will have to base64 decode it.
     #[serde(with = "key_pair_box_public_key_serde")]
     public_key: BoxPublicKey,
     created_lamport_clock: u64,

--- a/lib/sdf/src/server/service/secret.rs
+++ b/lib/sdf/src/server/service/secret.rs
@@ -4,10 +4,11 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Json;
 use axum::Router;
-use dal::StandardModelError;
+use dal::{KeyPairError, StandardModelError};
 use std::convert::Infallible;
 use thiserror::Error;
 
+pub mod get_public_key;
 pub mod list_secrets;
 
 #[derive(Debug, Error)]
@@ -18,6 +19,8 @@ pub enum SecretError {
     Pg(#[from] si_data::PgError),
     #[error(transparent)]
     StandardModel(#[from] StandardModelError),
+    #[error(transparent)]
+    KeyPairError(#[from] KeyPairError),
 }
 
 pub type SecretResult<T> = std::result::Result<T, SecretError>;
@@ -41,5 +44,7 @@ impl IntoResponse for SecretError {
 }
 
 pub fn routes() -> Router {
-    Router::new().route("/list_secrets", get(list_secrets::list_secrets))
+    Router::new()
+        .route("/get_public_key", get(get_public_key::get_public_key))
+        .route("/list_secrets", get(list_secrets::list_secrets))
 }

--- a/lib/sdf/src/server/service/secret/get_public_key.rs
+++ b/lib/sdf/src/server/service/secret/get_public_key.rs
@@ -1,0 +1,20 @@
+use axum::Json;
+use dal::{PublicKey, Tenancy, Visibility};
+
+use super::SecretResult;
+use crate::server::extract::{Authorization, PgRoTxn};
+
+pub type GetPublicKeyResponse = PublicKey;
+
+pub async fn get_public_key(
+    mut txn: PgRoTxn,
+    Authorization(claim): Authorization,
+) -> SecretResult<Json<GetPublicKeyResponse>> {
+    let txn = txn.start().await?;
+    let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
+    tenancy.universal = true;
+    let visibility = Visibility::new_head(false);
+    let response: GetPublicKeyResponse =
+        PublicKey::get_current(&txn, &tenancy, &visibility, &claim.billing_account_id).await?;
+    Ok(Json(response))
+}


### PR DESCRIPTION
- Add get public key SDF route using DAL PublicKey
- Add get public key blocking service in frontend
- Use get public key within secret creation function
- Add doc comments for discoveries found during development

<img src="https://media2.giphy.com/media/VAG0Ct1MbUCju/giphy.gif"/>