### PR TITLE
feat(dal, sdf): implement API for creating a secret

### DIFF
--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -165,7 +165,7 @@ async fn encrypt_decrypt_round_trip() {
         .await
         .expect("failed to fetch encrypted secret")
         .expect("failed to find encrypted secret for tenancy and/or visibility")
-        .decrypt(&txn, &visibility)
+        .decrypt(&txn, &visibility, *nba.billing_account.id())
         .await
         .expect("failed to decrypt encrypted secret");
     assert_eq!(decrypted.name(), secret.name());

--- a/lib/sdf/src/server/service/secret/create_secret.rs
+++ b/lib/sdf/src/server/service/secret/create_secret.rs
@@ -1,0 +1,64 @@
+use axum::Json;
+use dal::{
+    key_pair::KeyPairId, EncryptedSecret, HistoryActor, Secret, SecretAlgorithm, SecretKind,
+    SecretObjectType, SecretVersion, Tenancy, Visibility, WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
+
+use super::SecretResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct CreateSecretRequest {
+    pub name: String,
+    pub object_type: SecretObjectType,
+    pub kind: SecretKind,
+    pub crypted: Vec<u8>,
+    pub key_pair_id: KeyPairId,
+    pub version: SecretVersion,
+    pub algorithm: SecretAlgorithm,
+    pub workspace_id: WorkspaceId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSecretResponse {
+    pub secret: Secret,
+}
+
+pub async fn create_secret(
+    mut txn: PgRwTxn,
+    mut nats: NatsTxn,
+    Authorization(claim): Authorization,
+    Json(request): Json<CreateSecretRequest>,
+) -> SecretResult<Json<CreateSecretResponse>> {
+    let txn = txn.start().await?;
+    let nats = nats.start().await?;
+
+    let history_actor = HistoryActor::from(claim.user_id);
+    let tenancy = Tenancy::new_workspace(vec![request.workspace_id]);
+
+    let secret = EncryptedSecret::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &request.visibility,
+        &history_actor,
+        request.name,
+        request.object_type,
+        request.kind,
+        &request.crypted,
+        request.key_pair_id,
+        request.version,
+        request.algorithm,
+    )
+    .await?;
+
+    txn.commit().await?;
+    nats.commit().await?;
+
+    Ok(Json(CreateSecretResponse { secret }))
+}

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -9,6 +9,7 @@ mod application;
 mod change_set;
 mod component;
 mod schema;
+mod secret;
 mod session;
 mod signup;
 

--- a/lib/sdf/tests/service_tests/secret.rs
+++ b/lib/sdf/tests/service_tests/secret.rs
@@ -1,0 +1,79 @@
+use dal::{
+    test_harness::encrypt_message, EncryptedSecret, SecretAlgorithm, SecretKind, SecretObjectType,
+    SecretVersion, StandardModel, Tenancy, Visibility,
+};
+use hyper::Method;
+use sdf::service::secret::create_secret::{CreateSecretRequest, CreateSecretResponse};
+
+use crate::{service_tests::api_request_auth_json_body, test_setup};
+
+#[tokio::test]
+async fn create_secret() {
+    test_setup!(
+        _ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        txn,
+        _nats_conn,
+        _nats,
+        _veritech,
+        app,
+        nba,
+        auth_token
+    );
+
+    let visibility = Visibility::new_head(false);
+    let ba_tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+
+    let message = serde_json::json!({"artist":"Billy Talent"});
+    let crypted =
+        encrypt_message(&txn, &ba_tenancy, &visibility, *nba.key_pair.id(), &message).await;
+
+    let request = CreateSecretRequest {
+        name: "reckless-paradise".to_string(),
+        object_type: SecretObjectType::Credential,
+        kind: SecretKind::DockerHub,
+        crypted,
+        key_pair_id: *nba.key_pair.id(),
+        version: SecretVersion::V1,
+        algorithm: SecretAlgorithm::Sealedbox,
+        workspace_id: *nba.workspace.id(),
+        visibility,
+    };
+
+    let response: CreateSecretResponse = api_request_auth_json_body(
+        app,
+        Method::POST,
+        "/api/secret/create_secret",
+        &auth_token,
+        &request,
+    )
+    .await;
+    assert_eq!(response.secret.name(), "reckless-paradise");
+    assert_eq!(response.secret.object_type(), &SecretObjectType::Credential);
+    assert_eq!(response.secret.kind(), &SecretKind::DockerHub);
+
+    let decrypted_secret = EncryptedSecret::get_by_id(
+        &txn,
+        &Tenancy::new_workspace(vec![*nba.workspace.id()]),
+        &visibility,
+        response.secret.id(),
+    )
+    .await
+    .expect("failed to fetch encrypted secret")
+    .expect("failed to find encrypted secret in tenancy and/or visibility")
+    .decrypt(&txn, &visibility, *nba.billing_account.id())
+    .await
+    .expect("failed to decrypt secret");
+
+    assert_eq!(decrypted_secret.name(), "reckless-paradise");
+    assert_eq!(decrypted_secret.object_type(), SecretObjectType::Credential);
+    assert_eq!(decrypted_secret.kind(), SecretKind::DockerHub);
+    // We don't provide a direct getter for the raw decrypted message (higher effort should mean
+    // less chance of developer error when handling `DecryptedSecret` types), so we'll serialize to
+    // a `Value` to compare messages
+    let decrypted_value =
+        serde_json::to_value(&decrypted_secret).expect("failed to serial decrypted into Value");
+    assert_eq!(decrypted_value["message"], message);
+}


### PR DESCRIPTION
This change adds the API endpoint to create a new encrypted secret, with
a service test to ensure correct behavior.

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>