### PR TITLE
feat(dal/ver/cyc): Pass secrets in ComponentView as Sensitive data

### DIFF
--- a/bin/lang-js/src/code_generation.ts
+++ b/bin/lang-js/src/code_generation.ts
@@ -33,9 +33,14 @@ export interface CodeGenerationResultFailure extends ResultFailure {
   something?: never;
 }
 
-  export function executeCodeGeneration(request: CodeGenerationRequest): void {
+export function executeCodeGeneration(request: CodeGenerationRequest): void {
   const code = base64Decode(request.codeBase64);
+
   debug({ code });
+
+  // TODO: remove this, needed for now as it's messing with the generated yaml
+  request.component.properties.maybe_sensitive_container_kind = undefined;
+
   const compiledCode = new VMScript(wrapCode(code, request.handler, request.component)).compile();
   debug({ code: compiledCode.code });
   const sandbox = createSandbox(FunctionKind.CodeGeneration, request.executionId);

--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -39,6 +39,7 @@ async function main() {
   try {
     const requestJson = fs.readFileSync(0, "utf8");
     const request = JSON.parse(requestJson);
+    // TODO: we should filter credentials, at least they won't appear here as component/parents is logged as [Array]
     debug({ request });
     if (request.executionId) {
       executionId = request.executionId;

--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -442,11 +442,12 @@ mod tests {
     use super::*;
     use crate::{
         code_generation::CodeGenerated,
+        component_view::ComponentKind,
         qualification_check::QualificationCheckComponent,
         resolver_function::ResolverFunctionComponent,
         resolver_function::ResolverFunctionRequest,
         server::{Config, ConfigBuilder, UdsIncomingStream},
-        ComponentView, FunctionResult, ProgressMessage, Server,
+        ComponentView, FunctionResult, MaybeSensitive, ProgressMessage, Server,
     };
 
     fn rand_uds() -> TempPath {
@@ -682,19 +683,22 @@ mod tests {
             component: ResolverFunctionComponent {
                 data: ComponentView {
                     name: "Child".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: MaybeSensitive::Plain(serde_json::json!({})),
                     system: None,
+                    kind: ComponentKind::Standard,
                 },
                 parents: vec![
                     ComponentView {
                         name: "Parent 1".to_owned(),
-                        properties: serde_json::json!({}),
+                        properties: MaybeSensitive::Plain(serde_json::json!({})),
                         system: None,
+                        kind: ComponentKind::Standard,
                     },
                     ComponentView {
                         name: "Parent 2".to_owned(),
-                        properties: serde_json::json!({}),
+                        properties: MaybeSensitive::Plain(serde_json::json!({})),
                         system: None,
+                        kind: ComponentKind::Standard,
                     },
                 ],
             },
@@ -772,19 +776,22 @@ mod tests {
             component: ResolverFunctionComponent {
                 data: ComponentView {
                     name: "Child".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: MaybeSensitive::Plain(serde_json::json!({})),
                     system: None,
+                    kind: ComponentKind::Standard,
                 },
                 parents: vec![
                     ComponentView {
                         name: "Parent 1".to_owned(),
-                        properties: serde_json::json!({}),
+                        properties: MaybeSensitive::Plain(serde_json::json!({})),
                         system: None,
+                        kind: ComponentKind::Standard,
                     },
                     ComponentView {
                         name: "Parent 2".to_owned(),
-                        properties: serde_json::json!({}),
+                        properties: MaybeSensitive::Plain(serde_json::json!({})),
                         system: None,
+                        kind: ComponentKind::Standard,
                     },
                 ],
             },
@@ -860,10 +867,12 @@ mod tests {
             component: QualificationCheckComponent {
                 data: ComponentView {
                     name: "pringles".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: MaybeSensitive::Plain(serde_json::json!({})),
                     system: None,
+                    kind: ComponentKind::Standard,
                 },
                 codes: Vec::new(),
+                parents: Vec::new(),
             },
             code_base64: base64::encode(
                 r#"function checkit(component) {
@@ -948,10 +957,12 @@ mod tests {
             component: QualificationCheckComponent {
                 data: ComponentView {
                     name: "pringles".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: MaybeSensitive::Plain(serde_json::json!({})),
                     system: None,
+                    kind: ComponentKind::Standard,
                 },
                 codes: Vec::new(),
+                parents: Vec::new(),
             },
             code_base64: base64::encode(
                 r#"function checkit(component) {
@@ -1031,8 +1042,9 @@ mod tests {
 
         let component = ComponentView {
             name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: MaybeSensitive::Plain(serde_json::json!({})),
             system: None,
+            kind: ComponentKind::Standard,
         };
         let req = ResourceSyncRequest {
             execution_id: "1234".to_string(),
@@ -1110,8 +1122,9 @@ mod tests {
 
         let component = ComponentView {
             name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: MaybeSensitive::Plain(serde_json::json!({})),
             system: None,
+            kind: ComponentKind::Standard,
         };
         let req = ResourceSyncRequest {
             execution_id: "1234".to_string(),
@@ -1187,8 +1200,9 @@ mod tests {
 
         let component = ComponentView {
             name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: MaybeSensitive::Plain(serde_json::json!({})),
             system: None,
+            kind: ComponentKind::Standard,
         };
         let req = CodeGenerationRequest {
             execution_id: "1234".to_string(),
@@ -1198,7 +1212,7 @@ mod tests {
                 r#"function portugueseJsonGeneration(component) {
                     console.log(JSON.stringify(component));
                     console.log('generate');
-                    return { format: "json", code: JSON.stringify({nome: component.name}) };
+                    return { format: "json", code: JSON.stringify({nome: component.name }) };
                 }"#,
             ),
         };
@@ -1216,8 +1230,9 @@ mod tests {
         match progress.next().await {
             Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(
-                    output.message,
-                    serde_json::to_string(&component).expect("Unable to serialize ComponentView")
+                    serde_json::from_str::<serde_json::Value>(&output.message)
+                        .expect("Unable to serialize output to json"),
+                    serde_json::json!({"name": component.name, "properties": {}, "system": null, "kind": "standard" })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -1273,8 +1288,9 @@ mod tests {
 
         let component = ComponentView {
             name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: MaybeSensitive::Plain(serde_json::json!({})),
             system: None,
+            kind: ComponentKind::Standard,
         };
         let req = CodeGenerationRequest {
             execution_id: "1234".to_string(),
@@ -1302,8 +1318,9 @@ mod tests {
         match progress.next().await {
             Some(Ok(ProgressMessage::OutputStream(output))) => {
                 assert_eq!(
-                    output.message,
-                    serde_json::to_string(&component).expect("Unable to serialize ComponentView")
+                    serde_json::from_str::<serde_json::Value>(&output.message)
+                        .expect("Unable to serialize output to json"),
+                    serde_json::json!({"name": component.name, "properties": {}, "system": null, "kind": "standard" })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),

--- a/lib/cyclone/src/component_view.rs
+++ b/lib/cyclone/src/component_view.rs
@@ -1,4 +1,18 @@
+use crate::MaybeSensitive;
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum ComponentKind {
+    Standard,
+    Credential,
+}
+
+impl Default for ComponentKind {
+    fn default() -> Self {
+        Self::Standard
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -6,10 +20,22 @@ pub struct SystemView {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentView {
     pub name: String,
     pub system: Option<SystemView>,
-    pub properties: serde_json::Value,
+    pub kind: ComponentKind,
+    pub properties: MaybeSensitive<serde_json::Value>,
+}
+
+impl Default for ComponentView {
+    fn default() -> Self {
+        Self {
+            name: Default::default(),
+            system: Default::default(),
+            kind: Default::default(),
+            properties: MaybeSensitive::Plain(serde_json::json!({})),
+        }
+    }
 }

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -20,9 +20,10 @@ mod qualification_check;
 mod readiness;
 mod resolver_function;
 mod resource_sync;
+mod sensitive_container;
 
 pub use code_generation::{CodeGenerated, CodeGenerationRequest, CodeGenerationResultSuccess};
-pub use component_view::{ComponentView, SystemView};
+pub use component_view::{ComponentKind, ComponentView, SystemView};
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use progress::{
     FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,
@@ -37,6 +38,7 @@ pub use resolver_function::{
     ResolverFunctionComponent, ResolverFunctionRequest, ResolverFunctionResultSuccess,
 };
 pub use resource_sync::{ResourceSyncRequest, ResourceSyncResultSuccess};
+pub use sensitive_container::{MaybeSensitive, SensitiveContainer};
 
 #[cfg(feature = "process")]
 pub mod process;

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -14,6 +14,7 @@ pub struct QualificationCheckRequest {
 #[serde(rename_all = "camelCase")]
 pub struct QualificationCheckComponent {
     pub data: ComponentView,
+    pub parents: Vec<ComponentView>,
     pub codes: Vec<CodeGenerated>,
 }
 

--- a/lib/cyclone/src/sensitive_container.rs
+++ b/lib/cyclone/src/sensitive_container.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use std::{fmt, ops::Deref, ops::DerefMut};
+
+// Note: Should this file be here or in si-data? (and make cyclone depend on si-data too)
+
+#[derive(Debug, Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Copy)]
+#[serde(tag = "maybe_sensitive_container_kind")]
+pub enum MaybeSensitive<T> {
+    Sensitive(SensitiveContainer<T>),
+    Plain(T),
+}
+
+impl<T: fmt::Display> fmt::Display for MaybeSensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sensitive(container) => container.fmt(f),
+            Self::Plain(value) => value.fmt(f),
+        }
+    }
+}
+
+/// A display/debug redacting [`T`].
+///
+/// The [`SensitiveContainer`] type is wrapper around the `T` type, except that it will
+/// not emit its value in its [`std::fmt::Display`] and [`std::fmt::Debug`] implementations. This
+/// should be suitable to use when handling passwords, credentials, tokens, etc. as any
+/// logging/tracing/debugging should redact it actual value and prevent accidental leaking of
+/// sensitive data.
+#[derive(Clone, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Copy)]
+#[repr(transparent)]
+pub struct SensitiveContainer<T>(T);
+
+impl<T> DerefMut for SensitiveContainer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Deref for SensitiveContainer<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for SensitiveContainer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple(&format!(
+            "SensitiveContainer<{}>",
+            std::any::type_name::<T>()
+        ))
+        .field(&"...")
+        .finish()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for SensitiveContainer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("...")
+    }
+}
+
+impl<T> From<T> for SensitiveContainer<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}

--- a/lib/dal/src/billing_account.rs
+++ b/lib/dal/src/billing_account.rs
@@ -7,10 +7,10 @@ use crate::schema::variant::SchemaVariantError;
 use crate::standard_model::option_object_from_row;
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_has_many,
-    Capability, CapabilityError, Group, GroupError, HistoryActor, HistoryEventError, KeyPair,
-    KeyPairError, NodeError, Organization, OrganizationError, SchemaError, StandardModel,
-    StandardModelError, System, SystemError, Tenancy, Timestamp, User, UserError, Visibility,
-    Workspace, WorkspaceError,
+    Capability, CapabilityError, EncryptedSecret, Group, GroupError, HistoryActor,
+    HistoryEventError, KeyPair, KeyPairError, NodeError, Organization, OrganizationError,
+    SchemaError, SecretKind, SecretObjectType, StandardModel, StandardModelError, System,
+    SystemError, Tenancy, Timestamp, User, UserError, Visibility, Workspace, WorkspaceError,
 };
 
 const INITIAL_SYSTEM_NAME: &str = "production";
@@ -315,6 +315,31 @@ impl BillingAccount {
         system
             .set_workspace(txn, nats, visibility, &user_history_actor, workspace.id())
             .await?;
+
+        let message = serde_json::json!({"song": "país tropical"});
+        let crypted = sodiumoxide::crypto::sealedbox::seal(
+            &serde_json::to_vec(&message)?,
+            key_pair.public_key(),
+        );
+
+        // TODO: remove this dummy secret
+        let _secret = EncryptedSecret::new(
+            txn,
+            nats,
+            &workspace_tenancy,
+            visibility,
+            &user_history_actor,
+            "abençoado por deus e bonito por natureza",
+            SecretObjectType::Credential,
+            SecretKind::DockerHub,
+            &crypted,
+            *key_pair.id(),
+            Default::default(),
+            Default::default(),
+            *billing_account.id(),
+        )
+        .await
+        .expect("Unable to create encrypted secret");
 
         Ok(BillingAccountSignup {
             billing_account,

--- a/lib/dal/src/migrations/U0031__schema.sql
+++ b/lib/dal/src/migrations/U0031__schema.sql
@@ -16,7 +16,8 @@ CREATE TABLE schemas
     ui_menu_name                text,
     ui_menu_category            ltree,
     ui_hidden                   boolean                  NOT NULL DEFAULT false,
-    default_schema_variant_id   bigint
+    default_schema_variant_id   bigint,
+    component_kind              text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('schemas');
 SELECT many_to_many_table_create_v1('schema_many_to_many_billing_account', 'schemas', 'billing_accounts');
@@ -39,6 +40,7 @@ CREATE OR REPLACE FUNCTION schema_create_v1(
     this_visibility jsonb,
     this_name text,
     this_kind text,
+    this_component_kind text,
     OUT object json) AS
 $$
 DECLARE
@@ -51,11 +53,11 @@ BEGIN
 
     INSERT INTO schemas (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                          tenancy_workspace_ids,
-                         visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name, kind)
+                         visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name, kind, component_kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
-            this_visibility_record.visibility_deleted, this_name, this_kind)
+            this_visibility_record.visibility_deleted, this_name, this_kind, this_component_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/migrations/U0035__components.sql
+++ b/lib/dal/src/migrations/U0035__components.sql
@@ -11,7 +11,8 @@ CREATE TABLE components
     visibility_deleted          bool,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
-    name                        text                     NOT NULL
+    name                        text                     NOT NULL,
+    kind                        text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('components');
 SELECT belongs_to_table_create_v1('component_belongs_to_schema', 'components', 'schemas');
@@ -27,6 +28,7 @@ CREATE OR REPLACE FUNCTION component_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
     this_name text,
+    this_kind text,
     OUT object json) AS
 $$
 DECLARE
@@ -39,11 +41,11 @@ BEGIN
 
     INSERT INTO components (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                           tenancy_workspace_ids,
-                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name)
+                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name, kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
-            this_visibility_record.visibility_deleted, this_name)
+            this_visibility_record.visibility_deleted, this_name, this_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/migrations/U0054__secrets.sql
+++ b/lib/dal/src/migrations/U0054__secrets.sql
@@ -14,6 +14,7 @@ CREATE TABLE encrypted_secrets
     name                        text                     NOT NULL,
     object_type                 text                     NOT NULL,
     kind                        text                     NOT NULL,
+    billing_account_id          bigint                   NOT NULL,
     crypted                     text                     NOT NULL,
     version                     text                     NOT NULL,
     algorithm                   text                     NOT NULL
@@ -57,6 +58,7 @@ CREATE OR REPLACE FUNCTION encrypted_secret_create_v1(
     this_crypted text,
     this_version text,
     this_algorithm text,
+    this_billing_account_id bigint,
     OUT object json) AS
 $$
 DECLARE
@@ -77,6 +79,7 @@ BEGIN
                                    name,
                                    object_type,
                                    kind,
+                                   billing_account_id,
                                    crypted,
                                    version,
                                    algorithm)
@@ -90,6 +93,7 @@ BEGIN
             this_name,
             this_object_type,
             this_kind,
+            this_billing_account_id,
             this_crypted,
             this_version,
             this_algorithm)

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -9,15 +9,16 @@ use veritech::{Instance, StandardConfig};
 
 use crate::{
     billing_account::BillingAccountSignup,
+    component::ComponentKind,
     func::{binding::FuncBinding, FuncId},
     jwt_key::JwtSecretKey,
     key_pair::KeyPairId,
     node::NodeKind,
-    schema, socket, BillingAccount, ChangeSet, Component, EditSession, EncryptedSecret, Func,
-    FuncBackendKind, FuncBackendResponseType, Group, HistoryActor, KeyPair, Node, Organization,
-    Prop, PropKind, QualificationCheck, Schema, SchemaId, SchemaKind, SchemaVariantId, Secret,
-    SecretKind, SecretObjectType, StandardModel, System, Tenancy, User, Visibility, Workspace,
-    NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
+    schema, socket, BillingAccount, BillingAccountId, ChangeSet, Component, EditSession,
+    EncryptedSecret, Func, FuncBackendKind, FuncBackendResponseType, Group, HistoryActor, KeyPair,
+    Node, Organization, Prop, PropKind, QualificationCheck, Schema, SchemaId, SchemaKind,
+    SchemaVariantId, Secret, SecretKind, SecretObjectType, StandardModel, System, Tenancy, User,
+    Visibility, Workspace, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
 };
 
 #[derive(Debug)]
@@ -392,9 +393,18 @@ pub async fn create_schema(
     kind: &SchemaKind,
 ) -> Schema {
     let name = generate_fake_name();
-    Schema::new(txn, nats, tenancy, visibility, history_actor, &name, kind)
-        .await
-        .expect("cannot create schema")
+    Schema::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        &name,
+        kind,
+        &ComponentKind::Standard,
+    )
+    .await
+    .expect("cannot create schema")
 }
 
 pub async fn create_schema_ui_menu(
@@ -722,6 +732,7 @@ pub async fn create_secret(
     visibility: &Visibility,
     history_actor: &HistoryActor,
     key_pair_id: KeyPairId,
+    billing_account_id: BillingAccountId,
 ) -> Secret {
     let name = generate_fake_name();
     EncryptedSecret::new(
@@ -744,11 +755,13 @@ pub async fn create_secret(
         key_pair_id,
         Default::default(),
         Default::default(),
+        billing_account_id,
     )
     .await
     .expect("cannot create secret")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_secret_with_message(
     txn: &PgTxn<'_>,
     nats: &NatsTxn,
@@ -757,6 +770,7 @@ pub async fn create_secret_with_message(
     history_actor: &HistoryActor,
     key_pair_id: KeyPairId,
     message: &serde_json::Value,
+    billing_account_id: BillingAccountId,
 ) -> Secret {
     let name = generate_fake_name();
     EncryptedSecret::new(
@@ -772,6 +786,7 @@ pub async fn create_secret_with_message(
         key_pair_id,
         Default::default(),
         Default::default(),
+        billing_account_id,
     )
     .await
     .expect("cannot create secret")

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -283,8 +283,12 @@ async fn qualification_view() {
             "data": {
                 "name": "mastodon",
                 "system": null,
-                "properties": {},
+                "kind": "standard",
+                "properties": {
+                    "maybe_sensitive_container_kind": "Plain"
+                }
             },
+            "parents": [],
             "codes": []
         }),
     );

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -2,7 +2,7 @@ use crate::test_setup;
 
 use dal::schema::SchemaKind;
 use dal::test_harness::{billing_account_signup, create_schema, create_schema_ui_menu};
-use dal::{HistoryActor, Schema, StandardModel, Tenancy, Visibility};
+use dal::{component::ComponentKind, HistoryActor, Schema, StandardModel, Tenancy, Visibility};
 
 pub mod ui_menu;
 pub mod variant;
@@ -30,6 +30,7 @@ async fn new() {
         &history_actor,
         "mastodon",
         &SchemaKind::Concrete,
+        &ComponentKind::Standard,
     )
     .await
     .expect("cannot create schema");
@@ -50,6 +51,7 @@ async fn billing_accounts() {
         &history_actor,
         "mastodon",
         &SchemaKind::Concrete,
+        &ComponentKind::Standard,
     )
     .await
     .expect("cannot create schema");
@@ -102,6 +104,7 @@ async fn organizations() {
         &history_actor,
         "mastodon",
         &SchemaKind::Concrete,
+        &ComponentKind::Standard,
     )
     .await
     .expect("cannot create schema");
@@ -154,6 +157,7 @@ async fn workspaces() {
         &history_actor,
         "mastodon",
         &SchemaKind::Concrete,
+        &ComponentKind::Standard,
     )
     .await
     .expect("cannot create schema");

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -29,6 +29,7 @@ async fn new_encrypted_secret() {
         *nba.key_pair.id(),
         SecretVersion::V1,
         SecretAlgorithm::Sealedbox,
+        *nba.billing_account.id(),
     )
     .await
     .expect("failed to create secret");
@@ -60,6 +61,7 @@ async fn secret_get_by_id() {
         &visibility,
         &history_actor,
         *nba.key_pair.id(),
+        *nba.billing_account.id(),
     )
     .await;
 
@@ -85,6 +87,7 @@ async fn encrypted_secret_get_by_id() {
         &visibility,
         &history_actor,
         *nba.key_pair.id(),
+        *nba.billing_account.id(),
     )
     .await;
 
@@ -114,6 +117,7 @@ async fn secret_update_name() {
         &visibility,
         &history_actor,
         *nba.key_pair.id(),
+        *nba.billing_account.id(),
     )
     .await;
 
@@ -157,6 +161,7 @@ async fn encrypt_decrypt_round_trip() {
         *nba.key_pair.id(),
         Default::default(),
         Default::default(),
+        *nba.billing_account.id(),
     )
     .await
     .expect("failed to create encrypted secret");
@@ -165,7 +170,7 @@ async fn encrypt_decrypt_round_trip() {
         .await
         .expect("failed to fetch encrypted secret")
         .expect("failed to find encrypted secret for tenancy and/or visibility")
-        .decrypt(&txn, &visibility, *nba.billing_account.id())
+        .decrypt(&txn, &visibility)
         .await
         .expect("failed to decrypt encrypted secret");
     assert_eq!(decrypted.name(), secret.name());

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -5,8 +5,9 @@ use dal::test_harness::{
     create_visibility_change_set, create_visibility_edit_session, create_visibility_head,
 };
 use dal::{
-    standard_model, BillingAccount, Group, GroupId, HistoryActor, KeyPair, Schema, SchemaKind,
-    StandardModel, Tenancy, User, UserId, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
+    component::ComponentKind, standard_model, BillingAccount, Group, GroupId, HistoryActor,
+    KeyPair, Schema, SchemaKind, StandardModel, Tenancy, User, UserId, NO_CHANGE_SET_PK,
+    NO_EDIT_SESSION_PK,
 };
 
 #[tokio::test]
@@ -1061,6 +1062,7 @@ async fn find_by_attr() {
         &history_actor,
         schema_one.name(),
         schema_one.kind(),
+        &ComponentKind::Standard,
     )
     .await
     .expect("cannot create another schema with the same name");

--- a/lib/sdf/src/server/service/schema/create_schema.rs
+++ b/lib/sdf/src/server/service/schema/create_schema.rs
@@ -1,7 +1,7 @@
 use super::SchemaResult;
 use crate::server::extract::{Authorization, NatsTxn, PgRwTxn};
 use axum::Json;
-use dal::{HistoryActor, Schema, SchemaKind, Tenancy, Visibility};
+use dal::{component::ComponentKind, HistoryActor, Schema, SchemaKind, Tenancy, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -37,6 +37,7 @@ pub async fn create_schema(
         &history_actor,
         &request.name,
         &request.kind,
+        &ComponentKind::Standard,
     )
     .await?;
     txn.commit().await?;

--- a/lib/sdf/src/server/service/secret/create_secret.rs
+++ b/lib/sdf/src/server/service/secret/create_secret.rs
@@ -54,6 +54,7 @@ pub async fn create_secret(
         request.key_pair_id,
         request.version,
         request.algorithm,
+        claim.billing_account_id,
     )
     .await?;
 

--- a/lib/sdf/src/server/service/secret/list_secrets.rs
+++ b/lib/sdf/src/server/service/secret/list_secrets.rs
@@ -1,9 +1,6 @@
 use axum::extract::Query;
 use axum::Json;
-use dal::{
-    secret::SecretKind, secret::SecretObjectType, secret::SecretView, Secret, StandardModel,
-    Tenancy, Visibility,
-};
+use dal::{secret::SecretView, Secret, StandardModel, Tenancy, Visibility};
 use serde::{Deserialize, Serialize};
 
 use super::SecretResult;
@@ -25,17 +22,10 @@ pub async fn list_secrets(
     let txn = txn.start().await?;
     let mut tenancy = Tenancy::new_billing_account(vec![claim.billing_account_id]);
     tenancy.universal = true;
-    let mut response: Vec<SecretView> = Secret::list(&txn, &tenancy, &request.visibility)
+    let response: Vec<SecretView> = Secret::list(&txn, &tenancy, &request.visibility)
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    // TODO: remove this when we can create some secret, but as we can't this helps with debugging
-    response.push(SecretView {
-        id: 1.into(),
-        name: "moro num pais tropical".to_owned(),
-        kind: SecretKind::DockerHub,
-        object_type: SecretObjectType::Credential,
-    });
     Ok(Json(response))
 }

--- a/lib/sdf/tests/service_tests/secret.rs
+++ b/lib/sdf/tests/service_tests/secret.rs
@@ -63,7 +63,7 @@ async fn create_secret() {
     .await
     .expect("failed to fetch encrypted secret")
     .expect("failed to find encrypted secret in tenancy and/or visibility")
-    .decrypt(&txn, &visibility, *nba.billing_account.id())
+    .decrypt(&txn, &visibility)
     .await
     .expect("failed to decrypt secret");
 

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -27,11 +27,12 @@ pub mod client;
 pub use client::{Client, ClientError, ClientResult};
 #[cfg(feature = "client")]
 pub use cyclone::{
-    CodeGenerated, CodeGenerationRequest, CodeGenerationResultSuccess, ComponentView,
-    FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
-    QualificationCheckRequest, QualificationCheckResultSuccess, QualificationSubCheck,
-    QualificationSubCheckStatus, ResolverFunctionComponent, ResolverFunctionRequest,
-    ResourceSyncRequest, ResourceSyncResultSuccess, SystemView,
+    CodeGenerated, CodeGenerationRequest, CodeGenerationResultSuccess, ComponentKind,
+    ComponentView, FunctionResult, FunctionResultFailure, MaybeSensitive, OutputStream,
+    QualificationCheckComponent, QualificationCheckRequest, QualificationCheckResultSuccess,
+    QualificationSubCheck, QualificationSubCheckStatus, ResolverFunctionComponent,
+    ResolverFunctionRequest, ResourceSyncRequest, ResourceSyncResultSuccess, SensitiveContainer,
+    SystemView,
 };
 
 const NATS_QUALIFICATION_CHECK_DEFAULT_SUBJECT: &str = "veritech.fn.qualificationcheck";


### PR DESCRIPTION
Qualifications now receive parent/configuration components.

The parent components are parsed in FuncBinding and the secrets get extracted and unencrypted.
The secret is then passed as a SensitiveContainer<serde_json::Value> to cyclone and then lang-js.
Nats and lang-js are the only places where secrets could be exposed. We need to implement a filter in lang-js.
To deal with Nats we should encrypt the data e2e from dal to cyclone (symetric crypto should be ok).

Schemas/Components now get a ComponentKind, as credentials components need special treatment.

The biggest loose end this PR creates is that we can't actually know which property is a secret, as we need to unencrypt the secrets the lowest in the stack possible to avoid leaking the data to the database, but by then we lose info about the prop.

So for now we are only decrypting the root props that are integers. Which sucks hard. But it's workable. This shouldn't be solved this week tho.

Example: if done in ComponentView::for_component_and_system we could check for prop.widget_kind() and only decrypt for WidgetKind::SecretSelect, but it would store the secret in the FuncBinding)

It's not clear if we want to remove the credential tag from the properties, as it's useful to the functions. For now we only remove on the code generation as it messes with the YAML. We need more thinking into this.

<img src="https://media0.giphy.com/media/fWgdQGsrCsU4NoQ6D9/giphy.gif"/>