### PR TITLE
feat(dal): Auto-vivify, and -devivify parent AttributeResolvers as necessary when setting deeply nested Props

### DIFF
--- a/lib/dal/src/attribute_resolver.rs
+++ b/lib/dal/src/attribute_resolver.rs
@@ -5,26 +5,36 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::{
-    func::{binding::FuncBindingId, binding_return_value::FuncBindingReturnValue, FuncId},
+    func::{
+        backend::{
+            array::FuncBackendArrayArgs, boolean::FuncBackendBooleanArgs,
+            integer::FuncBackendIntegerArgs, map::FuncBackendMapArgs,
+            prop_object::FuncBackendPropObjectArgs, string::FuncBackendStringArgs,
+        },
+        binding::{FuncBinding, FuncBindingError, FuncBindingId},
+        binding_return_value::FuncBindingReturnValue,
+        FuncId,
+    },
     impl_standard_model, pk,
     standard_model::{self, TypeHint},
-    standard_model_accessor, standard_model_belongs_to, ComponentId, HistoryActor,
-    HistoryEventError, IndexMap, Prop, PropError, PropId, PropKind, SchemaId, SchemaVariantId,
-    StandardModel, StandardModelError, SystemId, Tenancy, Timestamp, Visibility,
+    standard_model_accessor, standard_model_belongs_to, ComponentId, Func, FuncBackendKind,
+    HistoryActor, HistoryEventError, IndexMap, Prop, PropError, PropId, PropKind, SchemaId,
+    SchemaVariantId, StandardModel, StandardModelError, SystemId, Tenancy, Timestamp, Visibility,
 };
+use async_recursion::async_recursion;
 
 #[derive(Error, Debug)]
 pub enum AttributeResolverError {
-    #[error("error serializing/deserializing json: {0}")]
-    SerdeJson(#[from] serde_json::Error),
-    #[error("pg error: {0}")]
-    Pg(#[from] PgError),
-    #[error("nats txn error: {0}")]
-    Nats(#[from] NatsError),
+    #[error("func binding error: {0}")]
+    FuncBinding(#[from] FuncBindingError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
-    #[error("standard model error: {0}")]
-    StandardModelError(#[from] StandardModelError),
+    #[error("invalid prop value; expected {0} but got {1}")]
+    InvalidPropValue(String, serde_json::Value),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("func not found: {0}")]
+    MissingFunc(String),
     #[error("attribute resolvers must have an associated prop, and this one does not. bug!")]
     MissingProp,
     #[error("attribute resolver not found: {0} ({1:?})")]
@@ -33,8 +43,14 @@ pub enum AttributeResolverError {
         "parent must be for an array, map, or object prop: attribute resolver id {0} is for a {1}"
     )]
     ParentNotAllowed(AttributeResolverId, PropKind),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
 }
 
 pub type AttributeResolverResult<T> = Result<T, AttributeResolverError>;
@@ -472,8 +488,9 @@ impl AttributeResolver {
         Ok(result)
     }
 
-    /// Check if there are any [`AttributeResolver`]s that are also children of the provided `AttributeResolverId`'s
-    /// parent (siblings of the provided `AttributeResolverId`) that have a value other than `FuncBackendKind::Unset`.
+    /// Check if there are any [`AttributeResolver`]s that are also children of the provided
+    /// `AttributeResolverId`'s parent (siblings of the provided `AttributeResolverId`) that have a value
+    /// other than `FuncBackendKind::Unset`.
     pub async fn any_siblings_are_set(
         txn: &PgTxn<'_>,
         tenancy: &Tenancy,
@@ -490,6 +507,341 @@ impl AttributeResolver {
 
         Ok(siblings_have_values)
     }
+
+    /// Update the [`Func`] & [`FuncBinding`] of an [`AttributeResolver`] for a given
+    /// [`AttributeResolverContext`]. If the [`AttributeResolver`] exists, but is not specific to the given
+    /// [`AttributeResolverContext`], then a new [`AttributeResolver`] is created, specific to that
+    /// [`AttributeResolverContext`].
+    #[allow(clippy::too_many_arguments)]
+    #[async_recursion]
+    pub async fn update_for_context(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        veritech: veritech::Client,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        attribute_resolver_id: AttributeResolverId,
+        attribute_resolver_context: AttributeResolverContext,
+        value: Option<serde_json::Value>,
+        key: Option<String>,
+    ) -> AttributeResolverResult<(Option<serde_json::Value>, AttributeResolverId)> {
+        // Find the attribute resolver to update.
+        let given_attribute_resolver =
+            Self::get_by_id(txn, tenancy, visibility, &attribute_resolver_id)
+                .await?
+                .ok_or_else(|| {
+                    AttributeResolverError::NotFound(attribute_resolver_id, *visibility)
+                })?;
+
+        // If the context isn't the _specific_ context that we're trying to update, make a new one.
+        // This is necessary, since the one that we were given might be the "default" one that is directly
+        // attached to a Prop in a SchemaVariant, and the AttributeResolverContext might be specifying that
+        // we want to have a value for a specific Component/System.
+        let mut attribute_resolver =
+            if given_attribute_resolver.context == attribute_resolver_context {
+                given_attribute_resolver
+            } else {
+                Self::new(
+                    txn,
+                    nats,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    given_attribute_resolver.func_id(),
+                    given_attribute_resolver.func_binding_id(),
+                    attribute_resolver_context.clone(),
+                    given_attribute_resolver.key,
+                )
+                .await?
+            };
+
+        let prop = Prop::get_by_id(
+            txn,
+            tenancy,
+            visibility,
+            &attribute_resolver.context.prop_id(),
+        )
+        .await?
+        .ok_or(AttributeResolverError::MissingProp)?;
+
+        let (func_name, func_args) = match (prop.kind(), value.clone()) {
+            (_, None) => ("si:unset", serde_json::to_value(())?),
+            (PropKind::Array, Some(_)) => {
+                let value: Vec<serde_json::Value> = as_type(serde_json::json![[]])?;
+                (
+                    "si:setArray",
+                    serde_json::to_value(FuncBackendArrayArgs::new(value))?,
+                )
+            }
+            (PropKind::Boolean, Some(value_json)) => {
+                let value: bool = as_type(value_json)?;
+                (
+                    "si:setBoolean",
+                    serde_json::to_value(FuncBackendBooleanArgs::new(value))?,
+                )
+            }
+            (PropKind::Integer, Some(value_json)) => {
+                let value: i64 = as_type(value_json)?;
+                (
+                    "si:setInteger",
+                    serde_json::to_value(FuncBackendIntegerArgs::new(value))?,
+                )
+            }
+            (PropKind::Map, Some(_)) => {
+                let value: serde_json::Map<String, serde_json::Value> =
+                    as_type(serde_json::json![{}])?;
+                (
+                    "si:setMap",
+                    serde_json::to_value(FuncBackendMapArgs::new(value))?,
+                )
+            }
+            (PropKind::Object, Some(_)) => {
+                let value: serde_json::Map<String, serde_json::Value> =
+                    as_type(serde_json::json![{}])?;
+                (
+                    "si:setPropObject",
+                    serde_json::to_value(FuncBackendPropObjectArgs::new(value))?,
+                )
+            }
+            (PropKind::String, Some(value_json)) => {
+                let value: String = as_type(value_json)?;
+                (
+                    "si:setString",
+                    serde_json::to_value(FuncBackendStringArgs::new(value))?,
+                )
+            }
+        };
+
+        let (func, func_binding, _) = set_value(
+            txn,
+            nats,
+            veritech.clone(),
+            tenancy,
+            visibility,
+            history_actor,
+            func_name,
+            func_args,
+        )
+        .await?;
+
+        attribute_resolver
+            .set_func_id(txn, nats, visibility, history_actor, *func.id())
+            .await?;
+        attribute_resolver
+            .set_func_binding_id(txn, nats, visibility, history_actor, *func_binding.id())
+            .await?;
+        attribute_resolver
+            .set_key(txn, nats, visibility, history_actor, key)
+            .await?;
+
+        if let (Some(parent_prop), Some(parent_attribute_resolver)) = (
+            prop.parent_prop(txn, visibility).await?,
+            attribute_resolver
+                .parent_attribute_resolver(txn, visibility)
+                .await?,
+        ) {
+            let current_parent_value = Self::find_value_for_prop_and_component(
+                txn,
+                tenancy,
+                visibility,
+                *parent_prop.id(),
+                attribute_resolver_context.component_id(),
+                attribute_resolver_context.system_id(),
+            )
+            .await?;
+
+            let mut parent_attribute_resolver_context = attribute_resolver_context.clone();
+            parent_attribute_resolver_context.set_prop_id(*parent_prop.id());
+
+            let (should_update_parent, new_parent_value) = if value.is_some() {
+                (true, Some(serde_json::to_value(())?))
+            } else if Self::any_siblings_are_set(txn, tenancy, visibility, *attribute_resolver.id())
+                .await?
+            {
+                (false, None)
+            } else {
+                (true, None)
+            };
+
+            if should_update_parent
+                && current_parent_value.value().is_some() != new_parent_value.is_some()
+            {
+                let (_, parent_attribute_resolver_id) = Self::update_for_context(
+                    txn,
+                    nats,
+                    veritech,
+                    tenancy,
+                    visibility,
+                    history_actor,
+                    *parent_attribute_resolver.id(),
+                    parent_attribute_resolver_context,
+                    new_parent_value,
+                    parent_attribute_resolver.key().map(|s| s.to_string()),
+                )
+                .await?;
+
+                // We need to set our parent AttributeResolverId *after* potentially auto-vivifying our parent,
+                // because we need to use whatever the AttributeResolverId is for our parent after it's been set to
+                // whatever its "final" value is going to be in our context.
+                attribute_resolver
+                    .set_parent_attribute_resolver(
+                        txn,
+                        nats,
+                        visibility,
+                        history_actor,
+                        parent_attribute_resolver_id,
+                    )
+                    .await?
+            }
+        };
+
+        Ok((value, *attribute_resolver.id()))
+    }
+
+    /// Insert a new value for [`Prop`] in the given [`AttributeResolverContext`]. This is mostly only useful for
+    /// adding elements to a [`PropKind::Array`], or [`PropKind::Map`]. All other [`PropKind`] should be able to
+    /// directly use [`update_for_context()`](AttributeResolver::update_for_context()), as there will already be an
+    /// appropriate [`AttributeResolver`] to use.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn insert_for_context(
+        txn: &PgTxn<'_>,
+        nats: &NatsTxn,
+        veritech: veritech::Client,
+        tenancy: &Tenancy,
+        visibility: &Visibility,
+        history_actor: &HistoryActor,
+        attribute_resolver_context: AttributeResolverContext,
+        parent_attribute_resolver_id: AttributeResolverId,
+        value: Option<serde_json::Value>,
+        key: Option<String>,
+    ) -> AttributeResolverResult<(Option<serde_json::Value>, AttributeResolverId)> {
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
+
+        let parent_attribute_resolver =
+            Self::get_by_id(txn, tenancy, visibility, &parent_attribute_resolver_id)
+                .await?
+                .ok_or(AttributeResolverError::NotFound(
+                    parent_attribute_resolver_id,
+                    *visibility,
+                ))?;
+
+        let mut parent_attribute_resolver_context = attribute_resolver_context.clone();
+        parent_attribute_resolver_context.set_prop_id(parent_attribute_resolver.context.prop_id());
+        let (_, populated_parent_attribute_resolver_id) = Self::update_for_context(
+            txn,
+            nats,
+            veritech.clone(),
+            tenancy,
+            visibility,
+            history_actor,
+            parent_attribute_resolver_id,
+            parent_attribute_resolver_context,
+            Some(serde_json::json![()]),
+            parent_attribute_resolver.key,
+        )
+        .await?;
+
+        let unset_func_name = "si:unset".to_string();
+        let unset_func =
+            Func::find_by_attr(txn, &schema_tenancy, visibility, "name", &unset_func_name)
+                .await?
+                .pop()
+                .ok_or(AttributeResolverError::MissingFunc(unset_func_name))?;
+        let (unset_func_binding, _) = FuncBinding::find_or_create(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            serde_json::json![null],
+            *unset_func.id(),
+            FuncBackendKind::Unset,
+        )
+        .await?;
+
+        let attribute_resolver = Self::new(
+            txn,
+            nats,
+            tenancy,
+            visibility,
+            history_actor,
+            *unset_func.id(),
+            *unset_func_binding.id(),
+            attribute_resolver_context.clone(),
+            key.clone(),
+        )
+        .await?;
+        attribute_resolver
+            .set_parent_attribute_resolver(
+                txn,
+                nats,
+                visibility,
+                history_actor,
+                populated_parent_attribute_resolver_id,
+            )
+            .await?;
+
+        Ok(Self::update_for_context(
+            txn,
+            nats,
+            veritech,
+            tenancy,
+            visibility,
+            history_actor,
+            *attribute_resolver.id(),
+            attribute_resolver_context,
+            value,
+            key,
+        )
+        .await?)
+    }
+}
+
+fn as_type<T: serde::de::DeserializeOwned>(json: serde_json::Value) -> AttributeResolverResult<T> {
+    T::deserialize(&json).map_err(|_| {
+        AttributeResolverError::InvalidPropValue(std::any::type_name::<T>().to_owned(), json)
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn set_value(
+    txn: &PgTxn<'_>,
+    nats: &NatsTxn,
+    veritech: veritech::Client,
+    tenancy: &Tenancy,
+    visibility: &Visibility,
+    history_actor: &HistoryActor,
+    func_name: &str,
+    args: serde_json::Value,
+) -> AttributeResolverResult<(Func, FuncBinding, bool)> {
+    let mut schema_tenancy = tenancy.clone();
+    schema_tenancy.universal = true;
+
+    let func_name = func_name.to_owned();
+    let func = Func::find_by_attr(txn, &schema_tenancy, visibility, "name", &func_name)
+        .await?
+        .pop()
+        .ok_or(AttributeResolverError::MissingFunc(func_name))?;
+
+    let (func_binding, created) = FuncBinding::find_or_create(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        args,
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await?;
+
+    if created {
+        func_binding.execute(txn, nats, veritech).await?;
+    }
+
+    Ok((func, func_binding, created))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If we have a Schema like the following:

```
[
    { "name": String, "release_year": String },
]
```

When we attempt to add a new object to the array, we would like the array to automatically exist if it doesn't already. Similarly, when we unset `name` or `release_year` on an object in the array, that specific object should become unset if and only if both `name` and `release_year` are unset. This un-setting behavior should also continue up the tree to the root if all objects in the array are unset, causing the array itself to become unset.

This is preparing to migrate the behavior of `Component.resolve_attribute` into two methods within `AttributeResolver`.

`AttributeResolver::update_for_context` is intended for setting/updating the appropriate `AttributeResolver` for a given context, and should be the generally used method for setting/un-setting Props for a Component, or Schema.

`AttributeResolver::insert_for_context` is intended for adding a new element to a parent Array/Map, and uses `AttributeResolver::update_for_context` under the hood to set the value after it has created a new unset `AttributeResolver` at the appropriate place.