### PR TITLE
feat(cyclone): Filter secrets in lang-js outputs

### DIFF
--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -39,7 +39,6 @@ async function main() {
   try {
     const requestJson = fs.readFileSync(0, "utf8");
     const request = JSON.parse(requestJson);
-    // TODO: we should filter credentials, at least they won't appear here as component/parents is logged as [Array]
     debug({ request });
     if (request.executionId) {
       executionId = request.executionId;

--- a/lib/cyclone/src/code_generation.rs
+++ b/lib/cyclone/src/code_generation.rs
@@ -1,4 +1,4 @@
-use crate::ComponentView;
+use crate::{sensitive_container::ListSecrets, ComponentView, SensitiveString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -8,6 +8,12 @@ pub struct CodeGenerationRequest {
     pub handler: String,
     pub component: ComponentView,
     pub code_base64: String,
+}
+
+impl ListSecrets for CodeGenerationRequest {
+    fn list_secrets(&self) -> Vec<SensitiveString> {
+        self.component.list_secrets()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/cyclone/src/component_view.rs
+++ b/lib/cyclone/src/component_view.rs
@@ -1,5 +1,6 @@
-use crate::MaybeSensitive;
+use crate::{sensitive_container::ListSecrets, MaybeSensitive, SensitiveString};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Copy)]
 #[serde(rename_all = "camelCase")]
@@ -26,7 +27,70 @@ pub struct ComponentView {
     pub name: String,
     pub system: Option<SystemView>,
     pub kind: ComponentKind,
-    pub properties: MaybeSensitive<serde_json::Value>,
+    pub properties: MaybeSensitive<Value>,
+}
+
+impl ListSecrets for ComponentView {
+    // TODO: in the future we will want to only filter the props with WidgetKind::SecretSelect
+    // For now we don't have the metadata, so we try to find a DecryptedSecret from a ComponentKind::Credential
+    // We only censor some critical DecryptedSecret metadata and the secret's JSON values
+    fn list_secrets(&self) -> Vec<SensitiveString> {
+        if let MaybeSensitive::Sensitive(properties) = &self.properties {
+            let mut credentials: Vec<SensitiveString> = vec![];
+
+            // We need to first parse the tree for the secrets and then list them
+            let mut secret_objects = vec![];
+            let mut is_inside_secret_object = false;
+
+            let mut work_queue = vec![&**properties];
+
+            while let Some(work) = work_queue.pop() {
+                match work {
+                    Value::Array(values) => work_queue.extend(values),
+                    Value::Object(object) => {
+                        // We try to find DecryptedSecret from its keys as we lack the proper metadata
+                        // Note: if we ever edit dal::DecryptedSecret we will have to edit this function too
+                        let is_decrypted_secret =
+                            object.get("secret_kind").map_or(false, |v| v.is_string())
+                                && object.get("object_type").map_or(false, |v| v.is_string())
+                                && object.get("message").map_or(false, |v| v.is_object())
+                                && object.get("name").map_or(false, |v| v.is_string());
+
+                        if !is_inside_secret_object && is_decrypted_secret {
+                            // We only want to censor message of a DecryptedSecret
+                            // But message will be a Value::Object, so we need to encrypt it's values too
+                            // Note: do we want to encrypt the message's keys?
+                            secret_objects.push(&object["message"]);
+                        } else {
+                            object.values().for_each(|v| work_queue.push(v));
+                        }
+                    }
+
+                    // Scalar values don't make sense outside of a secret's message JSON object
+                    Value::String(value) if is_inside_secret_object => {
+                        credentials.push(value.clone().into())
+                    }
+                    Value::String(_) => {}
+
+                    // For now credentials can only be strings, although we should reconsider it
+                    Value::Null => {}
+                    Value::Bool(_) => {}
+                    Value::Number(_) => {}
+                }
+
+                // We should only process secrets at the end, as they behave differently
+                if work_queue.is_empty() {
+                    if let Some(obj) = secret_objects.pop() {
+                        is_inside_secret_object = true;
+                        work_queue.push(obj);
+                    }
+                }
+            }
+            credentials
+        } else {
+            vec![]
+        }
+    }
 }
 
 impl Default for ComponentView {
@@ -37,5 +101,34 @@ impl Default for ComponentView {
             kind: Default::default(),
             properties: MaybeSensitive::Plain(serde_json::json!({})),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{sensitive_container::ListSecrets, ComponentKind, ComponentView, MaybeSensitive};
+
+    #[tokio::test]
+    async fn redact() {
+        let secrets = ComponentView {
+            name: "Redacting".to_owned(),
+            system: None,
+            kind: ComponentKind::Credential,
+            properties: MaybeSensitive::Sensitive(
+                serde_json::json!({
+                    "secret": {
+                        "name": "ufo",
+                        "secret_kind": "dockerHub",
+                        "object_type": "credential",
+                        "message": {
+                            "my-super-secret": "Varginha's UFO",
+                        },
+                    },
+                })
+                .into(),
+            ),
+        }
+        .list_secrets();
+        assert_eq!(secrets[0].as_str(), "Varginha's UFO");
     }
 }

--- a/lib/cyclone/src/lib.rs
+++ b/lib/cyclone/src/lib.rs
@@ -38,7 +38,7 @@ pub use resolver_function::{
     ResolverFunctionComponent, ResolverFunctionRequest, ResolverFunctionResultSuccess,
 };
 pub use resource_sync::{ResourceSyncRequest, ResourceSyncResultSuccess};
-pub use sensitive_container::{MaybeSensitive, SensitiveContainer};
+pub use sensitive_container::{MaybeSensitive, SensitiveContainer, SensitiveString};
 
 #[cfg(feature = "process")]
 pub mod process;

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -1,4 +1,4 @@
-use crate::{CodeGenerated, ComponentView};
+use crate::{sensitive_container::ListSecrets, CodeGenerated, ComponentView, SensitiveString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -16,6 +16,19 @@ pub struct QualificationCheckComponent {
     pub data: ComponentView,
     pub parents: Vec<ComponentView>,
     pub codes: Vec<CodeGenerated>,
+}
+
+impl ListSecrets for QualificationCheckRequest {
+    fn list_secrets(&self) -> Vec<SensitiveString> {
+        let mut secrets = self.component.data.list_secrets();
+        secrets.extend(
+            self.component
+                .parents
+                .iter()
+                .flat_map(ListSecrets::list_secrets),
+        );
+        secrets
+    }
 }
 
 // Note: these map 1:1 to the DAL qualificationsubcheck data in the qualification view.

--- a/lib/cyclone/src/resolver_function.rs
+++ b/lib/cyclone/src/resolver_function.rs
@@ -1,4 +1,4 @@
-use crate::ComponentView;
+use crate::{sensitive_container::ListSecrets, ComponentView, SensitiveString};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -17,6 +17,19 @@ pub struct ResolverFunctionComponent {
     pub data: ComponentView,
     pub parents: Vec<ComponentView>,
     // TODO: add widget data here (for example select's options)
+}
+
+impl ListSecrets for ResolverFunctionRequest {
+    fn list_secrets(&self) -> Vec<SensitiveString> {
+        let mut secrets = self.component.data.list_secrets();
+        secrets.extend(
+            self.component
+                .parents
+                .iter()
+                .flat_map(ListSecrets::list_secrets),
+        );
+        secrets
+    }
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/cyclone/src/resource_sync.rs
+++ b/lib/cyclone/src/resource_sync.rs
@@ -1,4 +1,4 @@
-use crate::ComponentView;
+use crate::{sensitive_container::ListSecrets, ComponentView, SensitiveString};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -8,6 +8,12 @@ pub struct ResourceSyncRequest {
     pub handler: String,
     pub component: ComponentView,
     pub code_base64: String,
+}
+
+impl ListSecrets for ResourceSyncRequest {
+    fn list_secrets(&self) -> Vec<SensitiveString> {
+        self.component.list_secrets()
+    }
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/cyclone/src/sensitive_container.rs
+++ b/lib/cyclone/src/sensitive_container.rs
@@ -3,6 +3,13 @@ use std::{fmt, ops::Deref, ops::DerefMut};
 
 // Note: Should this file be here or in si-data? (and make cyclone depend on si-data too)
 
+pub trait ListSecrets {
+    fn list_secrets(&self) -> Vec<SensitiveString>;
+}
+
+// FIXME: for now ser/de for MaybeSensitive<SensitiveString> is broken
+pub type SensitiveString = SensitiveContainer<String>;
+
 #[derive(Debug, Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Copy)]
 #[serde(tag = "maybe_sensitive_container_kind")]
 pub enum MaybeSensitive<T> {

--- a/lib/cyclone/src/server/handlers.rs
+++ b/lib/cyclone/src/server/handlers.rs
@@ -17,6 +17,7 @@ use super::{
     routes::{State, WatchKeepalive},
 };
 use crate::{
+    sensitive_container::ListSecrets,
     server::{execution, execution::Execution, watch},
     CodeGenerationRequest, CodeGenerationResultSuccess, LivenessStatus, Message,
     QualificationCheckRequest, QualificationCheckResultSuccess, ReadinessStatus,
@@ -159,7 +160,7 @@ pub async fn ws_execute_code_generation(
 }
 
 async fn handle_socket<
-    Request: Serialize + DeserializeOwned + Unpin,
+    Request: ListSecrets + Serialize + DeserializeOwned + Unpin,
     Success: Serialize + DeserializeOwned + Unpin,
 >(
     mut socket: WebSocket,

--- a/lib/dal/src/func/builtins/qualificationDockerImageNameInspect.js
+++ b/lib/dal/src/func/builtins/qualificationDockerImageNameInspect.js
@@ -1,6 +1,5 @@
 async function qualificationDockerImageNameInspect(component) {
-  // TODO: this only works for public images, we need to handle secrets to expand on this
-  // TODO: how to ensure skopeo is always installed and in the path? (we added it to the bootstrap script, but is it enough?)
+  console.log(JSON.stringify(component))
   const child = await siExec.waitUntilEnd("skopeo", ["inspect", `docker://docker.io/${component.data.properties.image}`]);
   return {
     qualified: child.exitCode === 0,

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -302,7 +302,7 @@ impl EncryptedSecret {
             (SecretVersion::V1, SecretAlgorithm::Sealedbox) => Ok(DecryptedSecret {
                 name: self.name,
                 object_type: self.object_type,
-                kind: self.kind,
+                secret_kind: self.kind,
                 message: serde_json::from_slice(
                     &sealedbox::open(&self.crypted, pkey, skey)
                         .map_err(|_| SecretError::DecryptionFailed)?,
@@ -325,7 +325,7 @@ impl EncryptedSecret {
 pub struct DecryptedSecret {
     name: String,
     object_type: SecretObjectType,
-    kind: SecretKind,
+    secret_kind: SecretKind,
     message: Value,
 }
 
@@ -342,7 +342,7 @@ impl DecryptedSecret {
 
     /// Gets the decrypted secret's kind.
     pub fn kind(&self) -> SecretKind {
-        self.kind
+        self.secret_kind
     }
 }
 
@@ -351,7 +351,7 @@ impl fmt::Debug for DecryptedSecret {
         f.debug_struct("DecryptedSecret")
             .field("name", &self.name)
             .field("object_type", &self.object_type)
-            .field("kind", &self.kind)
+            .field("secret_kind", &self.secret_kind)
             .finish_non_exhaustive()
     }
 }
@@ -513,7 +513,7 @@ mod tests {
 
             assert_eq!("the-cadillac-three", decrypted.name);
             assert_eq!(SecretObjectType::Credential, decrypted.object_type);
-            assert_eq!(SecretKind::DockerHub, decrypted.kind);
+            assert_eq!(SecretKind::DockerHub, decrypted.secret_kind);
             assert_eq!(message, decrypted.message);
         }
     }

--- a/lib/veritech/src/server/server.rs
+++ b/lib/veritech/src/server/server.rs
@@ -290,7 +290,8 @@ async fn resolver_function_request(
                 trace!("received heartbeat message");
             }
             Err(err) => {
-                warn!(error = ?err, "next progress message was an error, skipping to next message");
+                warn!(error = ?err, "next progress message was an error, bailing out");
+                break;
             }
         }
     }
@@ -406,7 +407,8 @@ async fn qualification_check_request(
                 trace!("received heartbeat message");
             }
             Err(err) => {
-                warn!(error = ?err, "next progress message was an error, skipping to next message");
+                warn!(error = ?err, "next progress message was an error, bailing out");
+                break;
             }
         }
     }
@@ -514,7 +516,8 @@ async fn resource_sync_request(
                 trace!("received heartbeat message");
             }
             Err(err) => {
-                warn!(error = ?err, "next progress message was an error, skipping to next message");
+                warn!(error = ?err, "next progress message was an error, bailing out");
+                break;
             }
         }
     }
@@ -626,7 +629,8 @@ async fn code_generation_request(
                 trace!("received heartbeat message");
             }
             Err(err) => {
-                warn!(error = ?err, "next progress message was an error, skipping to next message");
+                warn!(error = ?err, "next progress message was an error, bailing out");
+                break;
             }
         }
     }


### PR DESCRIPTION
Collects secrets from a ComponentView by iterating over properties
of a ComponentKind::Credential and trying to identify DecryptedSecret
from it's fields. We only censor DecryptedSecret::secret_kind and
DecryptedSecret::message from ComponentViews.

Censored data is replaced for '[redacted]' and is matched by substring
so it could match with data out of context therefore exposing that we
have a secret just because some random substring happened to match it.

Filters lang-js stderr, function logs and iterates over the
success result and replaces the values. This last part might
not be wanted, but a qualification message might accidentally leak
a credential. So it seemed net positive to do so.

For now we are ignoring credential keys, but this might not be ideal.

Example of a redacted output:
```
2022-02-23T16:53:03.186Z langJs:qualificationCheck {
  result: {
    protocol: 'result',
    status: 'success',
    executionId: 'danielcraig',
    title: undefined,
    link: undefined,
    subChecks: undefined,
    qualified: false,
    message: '{"data":{"name":"si-1480","system":null,"kind":"standard","properties":{"maybe_sensitive_container_kind":"Plain","image":"sss","Number of Parents":"0"}},"parents":[{"name":"si-9454","system":null,"kind":"credential","properties":{"maybe_sensitive_container_kind":"Sensitive","secret":{"name":"abençoado por deus e bonito por natureza","object_type":"credential","secret_kind":"dockerHub","message":{"song":"[redacted]"}}}}],"codes":[]}'
  }
}
```

<img src="https://media3.giphy.com/media/MXpVk1PmdSvAmNjvUg/giphy.gif"/>