### PR TITLE
feat(dal): add AttributeResolverContextBuilder

### DIFF
--- a/lib/dal/src/attribute_resolver_context.rs
+++ b/lib/dal/src/attribute_resolver_context.rs
@@ -1,17 +1,28 @@
+//! This module contains the [`AttributeResolverContext`], and its corresponding builder, [`AttributeResolverContextBuilder`].
+//! The context can be scoped with varying levels of specificity, using an order of precendence.
+//! The builder ensures the correct order of precedence is maintained whilst setting and unsetting
+//! fields of specificity.
+//!
+//! The order of precendence is as follows (from least to most "specificity"):
+//! - [`PropId`]
+//! - [`SchemaId`]
+//! - [`SchemaVariantId`]
+//! - [`ComponentId`]
+//! - [`SystemId`]
+
 use serde::{Deserialize, Serialize};
 use std::default::Default;
+use thiserror::Error;
 
 use crate::attribute_resolver::UNSET_ID_VALUE;
 use crate::{ComponentId, PropId, SchemaId, SchemaVariantId, SystemId};
 
-// Prop and Component IDs might both be set, unset, or a combination of the two. In fact, by
-// default, [`AttributeResolverContext`] is created with _all_ IDs as [`UNSET_ID_VALUE`].
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct AttributeResolverContext {
     prop_id: PropId,
-    component_id: ComponentId,
     schema_id: SchemaId,
     schema_variant_id: SchemaVariantId,
+    component_id: ComponentId,
     system_id: SystemId,
 }
 
@@ -25,9 +36,9 @@ impl AttributeResolverContext {
     pub fn new() -> Self {
         AttributeResolverContext {
             prop_id: UNSET_ID_VALUE.into(),
-            component_id: UNSET_ID_VALUE.into(),
             schema_id: UNSET_ID_VALUE.into(),
             schema_variant_id: UNSET_ID_VALUE.into(),
+            component_id: UNSET_ID_VALUE.into(),
             system_id: UNSET_ID_VALUE.into(),
         }
     }
@@ -38,14 +49,6 @@ impl AttributeResolverContext {
 
     pub fn set_prop_id(&mut self, prop_id: PropId) {
         self.prop_id = prop_id;
-    }
-
-    pub fn component_id(&self) -> ComponentId {
-        self.component_id
-    }
-
-    pub fn set_component_id(&mut self, component_id: ComponentId) {
-        self.component_id = component_id;
     }
 
     pub fn schema_id(&self) -> SchemaId {
@@ -64,11 +67,199 @@ impl AttributeResolverContext {
         self.schema_variant_id = schema_variant_id;
     }
 
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
     pub fn system_id(&self) -> SystemId {
         self.system_id
     }
 
     pub fn set_system_id(&mut self, system_id: SystemId) {
         self.system_id = system_id;
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum AttributeResolverContextBuilderError {
+    #[error("for builder {0:?}, the following fields must be set: {1:?}")]
+    PrerequisteFieldsUnset(AttributeResolverContextBuilder, Vec<&'static str>),
+}
+
+pub type AttributeResolverContextBuilderResult<T> = Result<T, AttributeResolverContextBuilderError>;
+
+/// A builder with non-consuming "setter" and "unsetter" methods that verify the order of
+/// precedence for [`AttributeResolverContext`].
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Copy)]
+pub struct AttributeResolverContextBuilder {
+    prop_id: PropId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    component_id: ComponentId,
+    system_id: SystemId,
+}
+
+/// Returns [`Self::new()`].
+impl Default for AttributeResolverContextBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttributeResolverContextBuilder {
+    /// Creates [`Self`] with all fields set to [`UNSET_ID_VALUE`].
+    pub fn new() -> Self {
+        Self {
+            prop_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            component_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    /// Converts [`AttributeResolverContext`] to [`Self`].
+    pub fn from_context(context: &AttributeResolverContext) -> Self {
+        Self {
+            prop_id: context.prop_id(),
+            schema_id: context.schema_id(),
+            schema_variant_id: context.schema_variant_id(),
+            component_id: context.component_id(),
+            system_id: context.system_id(),
+        }
+    }
+
+    /// Converts [`Self`] to [`AttributeResolverContext`]. This method will fail if the order of
+    /// precedence is broken (i.e. more-specific fields are set, but one-to-all less-specific
+    /// fields are unset).
+    pub fn to_context(&self) -> AttributeResolverContextBuilderResult<AttributeResolverContext> {
+        let mut unset_prerequisite_fields = Vec::new();
+
+        // Start with the second highest specificty and work our way down.
+        if self.component_id == UNSET_ID_VALUE.into() && self.system_id != UNSET_ID_VALUE.into() {
+            unset_prerequisite_fields.push("ComponentId");
+        }
+        if self.schema_variant_id == UNSET_ID_VALUE.into()
+            && (self.component_id != UNSET_ID_VALUE.into()
+                || self.system_id != UNSET_ID_VALUE.into())
+        {
+            unset_prerequisite_fields.push("SchemaVariantId");
+        }
+        if self.schema_id == UNSET_ID_VALUE.into()
+            && (self.schema_variant_id != UNSET_ID_VALUE.into()
+                || self.component_id != UNSET_ID_VALUE.into()
+                || self.system_id != UNSET_ID_VALUE.into())
+        {
+            unset_prerequisite_fields.push("SchemaId");
+        }
+        if self.prop_id == UNSET_ID_VALUE.into()
+            && (self.schema_id != UNSET_ID_VALUE.into()
+                || self.schema_variant_id != UNSET_ID_VALUE.into()
+                || self.component_id != UNSET_ID_VALUE.into()
+                || self.system_id != UNSET_ID_VALUE.into())
+        {
+            unset_prerequisite_fields.push("PropId");
+        }
+
+        if !unset_prerequisite_fields.is_empty() {
+            return Err(
+                AttributeResolverContextBuilderError::PrerequisteFieldsUnset(
+                    *self,
+                    unset_prerequisite_fields,
+                ),
+            );
+        }
+
+        Ok(AttributeResolverContext {
+            prop_id: self.prop_id,
+            schema_id: self.schema_id,
+            schema_variant_id: self.schema_variant_id,
+            component_id: self.component_id,
+            system_id: self.system_id,
+        })
+    }
+
+    /// Sets the [`PropId`] field. If [`UNSET_ID_VALUE`] is the ID passed in, then
+    /// [`Self::unset_prop_id()`] is returned.
+    pub fn set_prop_id(&mut self, prop_id: PropId) -> &mut Self {
+        if prop_id == UNSET_ID_VALUE.into() {
+            return self.unset_prop_id();
+        }
+        self.prop_id = prop_id;
+        self
+    }
+
+    /// Sets the [`SchemaId`] field. If [`UNSET_ID_VALUE`] is the ID passed in, then
+    /// [`Self::unset_schema_id()`] is returned.
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) -> &mut Self {
+        if schema_id == UNSET_ID_VALUE.into() {
+            return self.unset_schema_id();
+        }
+        self.schema_id = schema_id;
+        self
+    }
+
+    /// Sets the [`SchemaVariantId`] field. If [`UNSET_ID_VALUE`] is the ID passed in, then
+    /// [`Self::unset_schema_variant_id()`] is returned.
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) -> &mut Self {
+        if schema_variant_id == UNSET_ID_VALUE.into() {
+            return self.unset_schema_variant_id();
+        }
+        self.schema_variant_id = schema_variant_id;
+        self
+    }
+
+    /// Sets the [`ComponentId`] field. If [`UNSET_ID_VALUE`] is the ID passed in, then
+    /// [`Self::unset_component_id()`] is returned.
+    pub fn set_component_id(&mut self, component_id: ComponentId) -> &mut Self {
+        if component_id == UNSET_ID_VALUE.into() {
+            return self.unset_component_id();
+        }
+        self.component_id = component_id;
+        self
+    }
+
+    /// Sets the [`SystemId`] field. If [`UNSET_ID_VALUE`] is the ID passed in, then
+    /// [`Self::unset_system_id()`] is returned.
+    pub fn set_system_id(&mut self, system_id: SystemId) -> &mut Self {
+        if system_id == UNSET_ID_VALUE.into() {
+            return self.unset_system_id();
+        }
+        self.system_id = system_id;
+        self
+    }
+
+    /// Unsets the [`PropId`].
+    pub fn unset_prop_id(&mut self) -> &mut Self {
+        self.prop_id = UNSET_ID_VALUE.into();
+        self
+    }
+
+    /// Unsets the [`SchemaId`].
+    pub fn unset_schema_id(&mut self) -> &mut Self {
+        self.schema_id = UNSET_ID_VALUE.into();
+        self
+    }
+
+    /// Unsets the [`SchemaVariantId`].
+    pub fn unset_schema_variant_id(&mut self) -> &mut Self {
+        self.schema_variant_id = UNSET_ID_VALUE.into();
+        self
+    }
+
+    /// Unsets the [`ComponentId`].
+    pub fn unset_component_id(&mut self) -> &mut Self {
+        self.component_id = UNSET_ID_VALUE.into();
+        self
+    }
+
+    /// Unsets the [`SystemId`].
+    pub fn unset_system_id(&mut self) -> &mut Self {
+        self.system_id = UNSET_ID_VALUE.into();
+        self
     }
 }

--- a/lib/dal/tests/integration_test/attribute_resolver_context.rs
+++ b/lib/dal/tests/integration_test/attribute_resolver_context.rs
@@ -1,0 +1,383 @@
+use dal::{
+    attribute_resolver_context::{AttributeResolverContext, AttributeResolverContextBuilder},
+    ComponentId, PropId, SchemaId, SchemaVariantId, SystemId,
+};
+
+// NOTE(nick): there are only error permutations tests for fields that have at least two prerequisite
+// fields. Thus, SystemId, ComponentId, and SchemaVariantId have error permutations tests and SchemaId
+// and PropId do not.
+
+const SET_ID_VALUE: i64 = 1;
+const UNSET_ID_VALUE: i64 = -1;
+
+#[tokio::test]
+async fn builder_new() {
+    let prop_id: PropId = SET_ID_VALUE.into();
+    let schema_id: SchemaId = SET_ID_VALUE.into();
+    let schema_variant_id: SchemaVariantId = SET_ID_VALUE.into();
+    let component_id: ComponentId = SET_ID_VALUE.into();
+    let system_id: SystemId = SET_ID_VALUE.into();
+
+    let mut builder = AttributeResolverContextBuilder::new();
+    let mut context = AttributeResolverContext::new();
+
+    // Empty (PASS)
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SchemaId (FAIL) --> PropId (PASS)
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+    builder.unset_schema_id();
+    context.set_prop_id(prop_id);
+    builder.set_prop_id(prop_id);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SchemaVariantId (FAIL) --> SchemaId (PASS)
+    builder.set_schema_variant_id(schema_variant_id);
+    assert!(builder.to_context().is_err());
+    builder.unset_schema_variant_id();
+    context.set_schema_id(schema_id);
+    builder.set_schema_id(schema_id);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // ComponentId (FAIL) --> SchemaVariantId (PASS)
+    builder.set_component_id(component_id);
+    assert!(builder.to_context().is_err());
+    builder.unset_component_id();
+    context.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SystemId (FAIL) --> ComponentId (PASS)
+    builder.set_system_id(system_id);
+    assert!(builder.to_context().is_err());
+    builder.unset_system_id();
+    context.set_component_id(component_id);
+    builder.set_component_id(component_id);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SystemId (PASS)
+    context.set_system_id(system_id);
+    builder.set_system_id(system_id);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+}
+
+#[tokio::test]
+async fn builder_from_context() {
+    let prop_id: PropId = SET_ID_VALUE.into();
+    let schema_id: SchemaId = SET_ID_VALUE.into();
+    let schema_variant_id: SchemaVariantId = SET_ID_VALUE.into();
+    let component_id: ComponentId = SET_ID_VALUE.into();
+    let system_id: SystemId = SET_ID_VALUE.into();
+
+    // Empty (PASS)
+    let mut context = AttributeResolverContext::new();
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SchemaId (FAIL) --> PropId (PASS) [using previous builder]
+    context = builder.to_context().expect("could not convert to context");
+    context.set_schema_id(schema_id);
+    let failure_builder = AttributeResolverContextBuilder::from_context(&context);
+    assert!(failure_builder.to_context().is_err());
+    context.set_schema_id(UNSET_ID_VALUE.into());
+    context.set_prop_id(prop_id);
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SchemaVariantId (FAIL) --> SchemaId (PASS) [using previous builder]
+    context = builder.to_context().expect("could not convert to context");
+    context.set_schema_variant_id(schema_variant_id);
+    let failure_builder = AttributeResolverContextBuilder::from_context(&context);
+    assert!(failure_builder.to_context().is_err());
+    context.set_schema_variant_id(UNSET_ID_VALUE.into());
+    context.set_schema_id(schema_id);
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // ComponentId (FAIL) --> SchemaVariantId (PASS) [using previous builder]
+    context = builder.to_context().expect("could not convert to context");
+    context.set_component_id(component_id);
+    let failure_builder = AttributeResolverContextBuilder::from_context(&context);
+    assert!(failure_builder.to_context().is_err());
+    context.set_component_id(UNSET_ID_VALUE.into());
+    context.set_schema_variant_id(schema_variant_id);
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SystemId (FAIL) --> ComponentId (PASS) [using previous builder]
+    context = builder.to_context().expect("could not convert to context");
+    context.set_system_id(system_id);
+    let failure_builder = AttributeResolverContextBuilder::from_context(&context);
+    assert!(failure_builder.to_context().is_err());
+    context.set_system_id(UNSET_ID_VALUE.into());
+    context.set_component_id(component_id);
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+
+    // SystemId (PASS) [using previous builder]
+    context = builder.to_context().expect("could not convert to context");
+    context.set_system_id(system_id);
+    let builder = AttributeResolverContextBuilder::from_context(&context);
+    assert_eq!(
+        builder.to_context().expect("could not convert to context"),
+        context
+    );
+}
+
+#[tokio::test]
+async fn builder_system_id_error_permutations() {
+    let prop_id: PropId = SET_ID_VALUE.into();
+    let schema_id: SchemaId = SET_ID_VALUE.into();
+    let schema_variant_id: SchemaVariantId = SET_ID_VALUE.into();
+    let component_id: ComponentId = SET_ID_VALUE.into();
+    let system_id: SystemId = SET_ID_VALUE.into();
+
+    // ----------------
+    // Prerequisites: 0
+    // ----------------
+
+    // ComponentId [ ] --> SchemaVariantId [ ] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 1
+    // ----------------
+
+    // ComponentId [x] --> SchemaVariantId [ ] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [x] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [ ] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [ ] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 2
+    // ----------------
+
+    // ComponentId [x] --> SchemaVariantId [x] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [x] --> SchemaVariantId [ ] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [x] --> SchemaVariantId [ ] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [x] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [x] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [ ] --> SchemaId [x] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_id(schema_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 3
+    // ----------------
+
+    // ComponentId [x] --> SchemaVariantId [x] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [x] --> SchemaVariantId [ ] --> SchemaId [x] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_schema_id(schema_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [x] --> SchemaVariantId [x] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ComponentId [ ] --> SchemaVariantId [x] --> SchemaId [x] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_system_id(system_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_id(schema_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+}
+
+#[tokio::test]
+async fn builder_component_id_error_permutations() {
+    let prop_id: PropId = SET_ID_VALUE.into();
+    let schema_id: SchemaId = SET_ID_VALUE.into();
+    let schema_variant_id: SchemaVariantId = SET_ID_VALUE.into();
+    let component_id: ComponentId = SET_ID_VALUE.into();
+
+    // ----------------
+    // Prerequisites: 0
+    // ----------------
+
+    // SchemaVariantId [ ] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 1
+    // ----------------
+
+    // SchemaVariantId [x] --> SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    assert!(builder.to_context().is_err());
+
+    // SchemaVariantId [ ] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // SchemaVariantId [ ] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 2
+    // ----------------
+
+    // SchemaVariantId [x] --> SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // SchemaVariantId [x] --> SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+
+    // SchemaVariantId [ ] --> SchemaId [x] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_component_id(component_id);
+    builder.set_schema_id(schema_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+}
+
+#[tokio::test]
+async fn builder_schema_variant_id_error_permutations() {
+    let prop_id: PropId = SET_ID_VALUE.into();
+    let schema_id: SchemaId = SET_ID_VALUE.into();
+    let schema_variant_id: SchemaVariantId = SET_ID_VALUE.into();
+
+    // ----------------
+    // Prerequisites: 0
+    // ----------------
+
+    // SchemaId [ ] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_schema_variant_id(schema_variant_id);
+    assert!(builder.to_context().is_err());
+
+    // ----------------
+    // Prerequisites: 1
+    // ----------------
+
+    // SchemaId [x] --> PropId [ ]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_schema_id(schema_id);
+    assert!(builder.to_context().is_err());
+
+    // SchemaId [ ] --> PropId [x]
+    let mut builder = AttributeResolverContextBuilder::new();
+    builder.set_schema_variant_id(schema_variant_id);
+    builder.set_prop_id(prop_id);
+    assert!(builder.to_context().is_err());
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,5 +1,6 @@
 mod attribute_prototype;
 mod attribute_resolver;
+mod attribute_resolver_context;
 mod billing_account;
 mod capability;
 mod change_set;


### PR DESCRIPTION
Add AttributeResolverContextBuilder with a standardized and enforced
order of precedence [sc-2312]. This builder can convert to and from an
AttributeResolverContext.

This can likely be "DRY'd" up, but it works!
<img src="https://media0.giphy.com/media/5PRxVlZt7HeUSJ8okN/giphy.gif"/>