### PR TITLE
chore(dal): Remove AttributePrototype <> AttributePrototype relationship

### DIFF
--- a/lib/dal/src/migrations/U0055__attribute_prototypes.sql
+++ b/lib/dal/src/migrations/U0055__attribute_prototypes.sql
@@ -21,11 +21,9 @@ CREATE TABLE attribute_prototypes
     key                         text
 );
 SELECT standard_model_table_constraints_v1('attribute_prototypes');
-select belongs_to_table_create_v1('attribute_prototype_belongs_to_attribute_prototype', 'attribute_prototypes', 'attribute_prototypes');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
-VALUES ('attribute_prototypes', 'model', 'attribute_prototype', 'Attribute Prototype'),
-       ('attribute_prototype_belongs_to_attribute_prototype', 'belongs_to', 'attribute_prototype.child_attribute_prototype', 'Parent Attribute Prototype <> Child Attribute Prototype');
+VALUES ('attribute_prototypes', 'model', 'attribute_prototype', 'Attribute Prototype');
 
 CREATE OR REPLACE FUNCTION attribute_prototype_create_v1(
     this_tenancy jsonb,

--- a/lib/dal/tests/integration_test/attribute_prototype.rs
+++ b/lib/dal/tests/integration_test/attribute_prototype.rs
@@ -212,16 +212,6 @@ async fn list_for_context() {
     .expect("cannot retrieve attribute prototype for album")
     .pop()
     .expect("no attribute prototype found for album");
-    album_prop_prototype
-        .set_parent_attribute_prototype(
-            &txn,
-            &nats,
-            &visibility,
-            &history_actor,
-            *albums_prop_prototype.id(),
-        )
-        .await
-        .expect("cannot set parent attribute prototype for album prototype");
 
     let name_prop = create_prop_of_kind_with_name(
         &txn,
@@ -252,16 +242,6 @@ async fn list_for_context() {
     .expect("cannot retrieve attribute prototype for album name")
     .pop()
     .expect("no attribute prototype found for album name");
-    album_name_prototype
-        .set_parent_attribute_prototype(
-            &txn,
-            &nats,
-            &visibility,
-            &history_actor,
-            *album_prop_prototype.id(),
-        )
-        .await
-        .expect("cannot set parent attribute prototype for album name prototype");
 
     let artist_prop = create_prop_of_kind_with_name(
         &txn,
@@ -491,16 +471,6 @@ async fn list_for_context_with_a_hash() {
     .expect("cannot retrieve attribute prototype for album")
     .pop()
     .expect("no attribute prototype found for album");
-    album_prop_prototype
-        .set_parent_attribute_prototype(
-            &txn,
-            &nats,
-            &visibility,
-            &history_actor,
-            *albums_prop_prototype.id(),
-        )
-        .await
-        .expect("cannot set parent attribute prototype for album prototype");
 
     let hash_key_prop = create_prop_of_kind_with_name(
         &txn,
@@ -531,16 +501,6 @@ async fn list_for_context_with_a_hash() {
     .expect("cannot retrieve attribute prototype for album hash key")
     .pop()
     .expect("no attribute prototype found for album hash key");
-    prop_hash_key_prototype
-        .set_parent_attribute_prototype(
-            &txn,
-            &nats,
-            &visibility,
-            &history_actor,
-            *album_prop_prototype.id(),
-        )
-        .await
-        .expect("cannot set parent attribute prototype for album hash key prototype");
 
     let func = Func::new(
         &txn,


### PR DESCRIPTION
This relationship should not be necessary, as all relevant lineage information should be available through the associated Prop, or through the AttributeValue for the AttributePrototype in question.