### PR TITLE
feat(dal,cyc): Add root->(si,domain) props to variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
+ "tracing-subscriber",
  "url",
  "uuid",
  "veritech",

--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -11,7 +11,6 @@
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/legacy-modes": "^0.19.0",
         "@codemirror/stream-parser": "^0.19.6",
-        "@codemirror/theme-one-dark": "^0.19.1",
         "@pixi/layers": "^1.0.11",
         "@reactivex/rxjs": "^6.6.7",
         "@xstate/vue": "^0.8.1",
@@ -408,16 +407,6 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
-    },
-    "node_modules/@codemirror/theme-one-dark": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-0.19.1.tgz",
-      "integrity": "sha512-8gc4c2k2o/EhyHoWkghCxp5vyDT96JaFGtRy35PHwIom0LZdx7aU4AbDUnITvwiFB+0+i54VO+WQjBqgTyJvqg==",
-      "dependencies": {
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
     },
     "node_modules/@codemirror/tooltip": {
       "version": "0.19.16",
@@ -7592,16 +7581,6 @@
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
-    },
-    "@codemirror/theme-one-dark": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-0.19.1.tgz",
-      "integrity": "sha512-8gc4c2k2o/EhyHoWkghCxp5vyDT96JaFGtRy35PHwIom0LZdx7aU4AbDUnITvwiFB+0+i54VO+WQjBqgTyJvqg==",
-      "requires": {
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
     },
     "@codemirror/tooltip": {
       "version": "0.19.16",

--- a/app/web/src/organisims/EditForm/HeaderWidget.vue
+++ b/app/web/src/organisims/EditForm/HeaderWidget.vue
@@ -7,19 +7,20 @@
     >
       <div v-if="openState" class="flex" :style="propObjectStyle">
         <VueFeather type="chevron-down" />
-        {{ editField.name }}
+        {{ props.editField.name }}
       </div>
       <div v-else class="flex" :style="propObjectStyle">
         <VueFeather type="chevron-right" />
-        {{ editField.name }}
+        {{ props.editField.name }}
       </div>
     </div>
   </section>
   <Widgets
     :show="showChildren"
     :edit-fields="widgetEditFields"
-    :indent-level="indentLevel + 1"
-    :tree-open-state="treeOpenState"
+    :core-edit-fields="props.coreEditField"
+    :indent-level="props.indentLevel + 1"
+    :tree-open-state="props.treeOpenState"
     @toggle-header="bubbleToggleHeader"
   />
 </template>
@@ -56,8 +57,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "toggleHeader", fieldId: string): void;
 }>();
-
-// const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
 
 const widgetEditFields = computed<EditFields>(() => {
   if (props.editField.widget.kind == "Header") {

--- a/app/web/src/organisims/EditForm/Widget.vue
+++ b/app/web/src/organisims/EditForm/Widget.vue
@@ -1,36 +1,36 @@
 <template>
   <HeaderWidget
-    v-if="editField.widget.kind === 'Header'"
+    v-if="props.editField.widget.kind === 'Header'"
     :show="props.show"
     :edit-field="props.editField"
-    :background-colors="backgroundColors"
+    :background-colors="props.backgroundColors"
     :core-edit-field="props.coreEditField"
     :indent-level="props.indentLevel"
     :tree-open-state="props.treeOpenState"
     @toggle-header="toggleHeader"
   />
   <ArrayWidget
-    v-else-if="editField.widget.kind === 'Array'"
+    v-else-if="props.editField.widget.kind === 'Array'"
     :show="props.show"
     :edit-field="props.editField"
     :core-edit-field="props.coreEditField"
     :indent-level="props.indentLevel"
-    :tree-open-state="treeOpenState"
+    :tree-open-state="props.treeOpenState"
   />
   <TextWidget
-    v-else-if="editField.widget.kind === 'Text'"
+    v-else-if="props.editField.widget.kind === 'Text'"
     :show="props.show"
     :edit-field="props.editField"
     :core-edit-field="props.coreEditField"
   />
   <CheckboxWidget
-    v-else-if="editField.widget.kind === 'Checkbox'"
+    v-else-if="props.editField.widget.kind === 'Checkbox'"
     :show="props.show"
     :edit-field="props.editField"
     :core-edit-field="props.coreEditField"
   />
   <SelectWidget
-    v-else-if="editField.widget.kind === 'Select'"
+    v-else-if="props.editField.widget.kind === 'Select'"
     :show="props.show"
     :edit-field="props.editField"
     :core-edit-field="props.coreEditField"

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -49,9 +49,7 @@ const toggleHeader = (fieldId: string) => {
   emit("toggleHeader", fieldId);
 };
 
-const isCoreEditField = computed(() =>
-  props.coreEditFields === undefined ? false : props.coreEditFields,
-);
+const isCoreEditField = computed(() => props.coreEditFields ?? false);
 
 const backgroundColors = computed(() => {
   const longestProp = 50;

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -26,9 +26,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
+import { EditFields } from "@/api/sdf/dal/edit_field";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
-import _ from "lodash";
 import {
   InitialTreeOpenStateVisitor,
   ITreeOpenState,
@@ -42,20 +41,26 @@ const props = defineProps<{
  * Returns core edit fields that are *not* component properties
  */
 const coreEditFields = computed(() => {
-  return _.filter(
-    props.editFields,
-    (field) => field.object_kind == EditFieldObjectKind.Component,
+  let fields = [];
+  props.editFields.forEach((root) =>
+    root.widget.options.edit_fields
+      .filter((p) => p.id === "root.si")
+      .forEach((p) => (fields = fields.concat(p.widget.options.edit_fields))),
   );
+  return fields;
 });
 
 /**
  * Returns edit fields are component properties
  */
 const propertyEditFields = computed(() => {
-  return _.filter(
-    props.editFields,
-    (field) => field.object_kind == EditFieldObjectKind.ComponentProp,
+  let fields = [];
+  props.editFields.forEach((root) =>
+    root.widget.options.edit_fields
+      .filter((p) => p.id === "root.domain")
+      .forEach((p) => (fields = fields.concat(p.widget.options.edit_fields))),
   );
+  return fields;
 });
 
 const initialTreeOpenState = computed(

--- a/lib/cyclone/src/client.rs
+++ b/lib/cyclone/src/client.rs
@@ -714,20 +714,17 @@ mod tests {
             handler: "doit".to_string(),
             component: ResolverFunctionComponent {
                 data: ComponentView {
-                    name: "Child".to_owned(),
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
                 },
                 parents: vec![
                     ComponentView {
-                        name: "Parent 1".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
                     },
                     ComponentView {
-                        name: "Parent 2".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
@@ -808,20 +805,17 @@ mod tests {
             handler: "doit".to_string(),
             component: ResolverFunctionComponent {
                 data: ComponentView {
-                    name: "Child".to_owned(),
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
                 },
                 parents: vec![
                     ComponentView {
-                        name: "Parent 1".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
                     },
                     ComponentView {
-                        name: "Parent 2".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
@@ -901,8 +895,7 @@ mod tests {
             handler: "checkit".to_string(),
             component: QualificationCheckComponent {
                 data: ComponentView {
-                    name: "pringles".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: serde_json::json!({ "si": { "name": "Aipim Frito" } }),
                     system: None,
                     kind: ComponentKind::Standard,
                 },
@@ -913,7 +906,7 @@ mod tests {
                 r#"function checkit(component) {
                     console.log('i like');
                     console.log('my butt');
-                    if (component.data.name == "pringles") {
+                    if (component.data.properties.si.name == "Aipim Frito") {
                         return { qualified: true };
                     } else {
                         return {
@@ -993,8 +986,7 @@ mod tests {
             handler: "checkit".to_string(),
             component: QualificationCheckComponent {
                 data: ComponentView {
-                    name: "pringles".to_owned(),
-                    properties: serde_json::json!({}),
+                    properties: serde_json::json!({ "si": { "name": "Aipim Frito" } }),
                     system: None,
                     kind: ComponentKind::Standard,
                 },
@@ -1005,7 +997,7 @@ mod tests {
                 r#"function checkit(component) {
                     console.log('i like');
                     console.log('my butt');
-                    if (component.data.name == "pringles") {
+                    if (component.data.properties.si.name == "Aipim Frito") {
                         return { qualified: true };
                     } else {
                         return {
@@ -1080,7 +1072,6 @@ mod tests {
             http_client_for_running_server(builder.enable_qualification(true), key).await;
 
         let component = ComponentView {
-            name: "pringles".to_string(),
             properties: serde_json::json!({}),
             system: None,
             kind: ComponentKind::Standard,
@@ -1162,7 +1153,6 @@ mod tests {
                 .await;
 
         let component = ComponentView {
-            name: "pringles".to_string(),
             properties: serde_json::json!({}),
             system: None,
             kind: ComponentKind::Standard,
@@ -1242,8 +1232,7 @@ mod tests {
             http_client_for_running_server(builder.enable_qualification(true), key).await;
 
         let component = ComponentView {
-            name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: serde_json::json!({ "si": { "name": "Ablublubé"}}),
             system: None,
             kind: ComponentKind::Standard,
         };
@@ -1255,7 +1244,7 @@ mod tests {
                 r#"function portugueseJsonGeneration(component) {
                     console.log(JSON.stringify(component));
                     console.log('generate');
-                    return { format: "json", code: JSON.stringify({nome: component.name }) };
+                    return { format: "json", code: JSON.stringify({nome: component.properties.si.name }) };
                 }"#,
             ),
         };
@@ -1275,7 +1264,7 @@ mod tests {
                 assert_eq!(
                     serde_json::from_str::<serde_json::Value>(&output.message)
                         .expect("Unable to serialize output to json"),
-                    serde_json::json!({"name": component.name, "properties": {}, "system": null, "kind": "standard" })
+                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard" })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -1311,7 +1300,7 @@ mod tests {
                     success.data,
                     CodeGenerated {
                         format: "json".to_owned(),
-                        code: serde_json::to_string(&serde_json::json!({ "nome": "pringles" }))
+                        code: serde_json::to_string(&serde_json::json!({ "nome": "Ablublubé" }))
                             .expect("unable to deserialize"),
                     }
                 );
@@ -1332,8 +1321,7 @@ mod tests {
                 .await;
 
         let component = ComponentView {
-            name: "pringles".to_string(),
-            properties: serde_json::json!({}),
+            properties: serde_json::json!({ "si": { "name": "Ablublubé"}}),
             system: None,
             kind: ComponentKind::Standard,
         };
@@ -1345,7 +1333,7 @@ mod tests {
                 r#"function portugueseJsonGeneration(component) {
                     console.log(JSON.stringify(component));
                     console.log('generate');
-                    return { format: "json", code: JSON.stringify({nome: component.name}) };
+                    return { format: "json", code: JSON.stringify({nome: component.properties.si.name }) };
                 }"#,
             ),
         };
@@ -1365,7 +1353,7 @@ mod tests {
                 assert_eq!(
                     serde_json::from_str::<serde_json::Value>(&output.message)
                         .expect("Unable to serialize output to json"),
-                    serde_json::json!({"name": component.name, "properties": {}, "system": null, "kind": "standard" })
+                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard" })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -1401,7 +1389,7 @@ mod tests {
                     success.data,
                     CodeGenerated {
                         format: "json".to_owned(),
-                        code: serde_json::to_string(&serde_json::json!({ "nome": "pringles" }))
+                        code: serde_json::to_string(&serde_json::json!({ "nome": "Ablublubé" }))
                             .expect("unable to deserialize"),
                     }
                 );

--- a/lib/cyclone/src/component_view.rs
+++ b/lib/cyclone/src/component_view.rs
@@ -23,7 +23,6 @@ pub struct SystemView {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentView {
-    pub name: String,
     pub system: Option<SystemView>,
     pub kind: ComponentKind,
     pub properties: Value,
@@ -32,7 +31,6 @@ pub struct ComponentView {
 impl Default for ComponentView {
     fn default() -> Self {
         Self {
-            name: Default::default(),
             system: Default::default(),
             kind: Default::default(),
             properties: serde_json::json!({}),

--- a/lib/cyclone/src/server/request.rs
+++ b/lib/cyclone/src/server/request.rs
@@ -310,7 +310,6 @@ mod tests {
         );
 
         let secrets = ComponentView {
-            name: "Redacting".to_owned(),
             system: None,
             kind: ComponentKind::Credential,
             properties: serde_json::json!({
@@ -346,7 +345,6 @@ mod tests {
         );
 
         let json = ComponentView {
-            name: "Decrypting".to_owned(),
             system: None,
             kind: ComponentKind::Credential,
             properties: serde_json::json!({
@@ -362,7 +360,6 @@ mod tests {
         .expect("Unable to decrypt component view");
 
         let decrypted_json = serde_json::json!({
-            "name": "Decrypting",
             "system": null,
             "kind": "credential",
             "properties": {

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -40,6 +40,8 @@ paste = "1.0"
 async-trait = "0.1.51"
 veritech = { path = "../../lib/veritech", features = ["client"] }
 
+tracing-subscriber = { version = "0.2.19", default-features = false, features = ["env-filter", "fmt"] }
+
 [dev-dependencies]
 insta = "1.8.0"
 veritech = { path = "../../lib/veritech", features = ["client", "server"] }

--- a/lib/dal/src/attribute_resolver.rs
+++ b/lib/dal/src/attribute_resolver.rs
@@ -215,9 +215,12 @@ impl AttributeResolver {
             parent_attribute_resolver_id,
             *visibility,
         ))?;
+
+        let mut schema_tenancy = self.tenancy.clone();
+        schema_tenancy.universal = true;
         let parent_prop = Prop::get_by_id(
             txn,
-            self.tenancy(),
+            &schema_tenancy,
             visibility,
             &parent_attribute_resolver.context.prop_id(),
         )
@@ -270,7 +273,9 @@ impl AttributeResolver {
         tenancy: &Tenancy,
         visibility: &Visibility,
     ) -> AttributeResolverResult<()> {
-        let prop = Prop::get_by_id(txn, tenancy, visibility, &self.context.prop_id())
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
+        let prop = Prop::get_by_id(txn, &schema_tenancy, visibility, &self.context.prop_id())
             .await?
             .ok_or(AttributeResolverError::MissingProp)?;
         if let Some(parent) = prop.parent_prop(txn, visibility).await? {
@@ -549,9 +554,11 @@ impl AttributeResolver {
                 .await?
             };
 
+        let mut schema_tenancy = tenancy.clone();
+        schema_tenancy.universal = true;
         let prop = Prop::get_by_id(
             txn,
-            tenancy,
+            &schema_tenancy,
             visibility,
             &attribute_resolver.context.prop_id(),
         )

--- a/lib/dal/src/func/builtins/generateYAML.js
+++ b/lib/dal/src/func/builtins/generateYAML.js
@@ -1,6 +1,6 @@
 function generateYAML(component) {
   return {
     format: "yaml",
-    code: YAML.stringify(component.properties),
+    code: YAML.stringify(component.properties.domain),
   };
 }

--- a/lib/dal/src/func/builtins/qualificationDockerHubLogin.js
+++ b/lib/dal/src/func/builtins/qualificationDockerHubLogin.js
@@ -1,6 +1,6 @@
 async function qualificationDockerHubLogin(component) {
   // This feels a little verbose
-  const { username, password } = component.data.properties.secret.message;
+  const { username, password } = component.data.properties.domain.secret.message;
 
   const request = await fetch("https://hub.docker.com/v2/users/login", {
     method: "POST",

--- a/lib/dal/src/func/builtins/qualificationDockerImageNameInspect.js
+++ b/lib/dal/src/func/builtins/qualificationDockerImageNameInspect.js
@@ -1,6 +1,6 @@
 async function qualificationDockerImageNameInspect(component) {
   console.log(JSON.stringify(component))
-  const child = await siExec.waitUntilEnd("skopeo", ["inspect", `docker://docker.io/${component.data.properties.image}`]);
+  const child = await siExec.waitUntilEnd("skopeo", ["inspect", `docker://docker.io/${component.data.properties.domain.image}`]);
   return {
     qualified: child.exitCode === 0,
     // Note: Do we want stdout on success? Do we want both, always? Do we want to filter the output?

--- a/lib/dal/src/func/builtins/resourceSyncHammer.js
+++ b/lib/dal/src/func/builtins/resourceSyncHammer.js
@@ -1,4 +1,4 @@
 function resourceSyncHammer(component) {
-    component.name = `Cant touch this: ${component.name}`;
+    component.name = `Cant touch this: ${component.properties.si.name}`;
     return { data: component };
 }

--- a/lib/dal/src/jwt_key.rs
+++ b/lib/dal/src/jwt_key.rs
@@ -129,7 +129,6 @@ impl JwtSecretKey {
     }
 }
 
-#[tracing::instrument(skip(txn, jwt_id))]
 pub async fn get_jwt_validation_key(
     txn: &PgTxn<'_>,
     jwt_id: impl AsRef<str>,
@@ -143,14 +142,9 @@ pub async fn get_jwt_validation_key(
     tokio::task::spawn_blocking(move || {
         RS256PublicKey::from_pem(&key).map_err(|err| JwtKeyError::KeyFromPem(format!("{}", err)))
     })
-    .instrument(info_span!(
-        "from_pem",
-        code.namespace = "jwt_simple::algorithms::RS256PublicKey"
-    ))
     .await?
 }
 
-#[tracing::instrument(skip(txn, bearer_token))]
 pub async fn validate_bearer_token(
     txn: &PgTxn<'_>,
     bearer_token: impl AsRef<str>,
@@ -173,10 +167,6 @@ pub async fn validate_bearer_token(
             .verify_token::<UserClaim>(&token, None)
             .map_err(|err| JwtKeyError::Verify(format!("{}", err)))
     })
-    .instrument(info_span!(
-        "verify_token",
-        code.namespace = "jwt_simple::algorithms::RSAPublicKeyLike"
-    ))
     .await??;
     Ok(claims)
 }

--- a/lib/dal/src/migrations/U0035__components.sql
+++ b/lib/dal/src/migrations/U0035__components.sql
@@ -11,7 +11,6 @@ CREATE TABLE components
     visibility_deleted          bool,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
-    name                        text                     NOT NULL,
     kind                        text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('components');
@@ -27,7 +26,6 @@ VALUES ('components', 'model', 'component', 'Component'),
 CREATE OR REPLACE FUNCTION component_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
-    this_name text,
     this_kind text,
     OUT object json) AS
 $$
@@ -41,11 +39,11 @@ BEGIN
 
     INSERT INTO components (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                           tenancy_workspace_ids,
-                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, name, kind)
+                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted, kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
-            this_visibility_record.visibility_deleted, this_name, this_kind)
+            this_visibility_record.visibility_deleted, this_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -490,8 +490,8 @@ impl EditFieldAble for Schema {
     async fn update_from_edit_field(
         txn: &PgTxn<'_>,
         nats: &NatsTxn,
-        _veritech: veritech::Client,
-        _encryption_key: &EncryptionKey,
+        veritech: veritech::Client,
+        encryption_key: &EncryptionKey,
         tenancy: &Tenancy,
         visibility: &Visibility,
         history_actor: &HistoryActor,
@@ -528,13 +528,15 @@ impl EditFieldAble for Schema {
                 None => return Err(EditFieldError::MissingValue.into()),
             },
             "variants.schemaVariants" => {
-                let variant = SchemaVariant::new(
+                let (variant, _) = SchemaVariant::new(
                     txn,
                     nats,
                     tenancy,
                     visibility,
                     history_actor,
                     "TODO: name me!",
+                    veritech,
+                    encryption_key,
                 )
                 .await?;
                 variant

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -40,7 +40,17 @@ pub async fn kubernetes_deployment(
         None => return Ok(()),
     };
 
-    let variant = SchemaVariant::new(txn, nats, tenancy, visibility, history_actor, "v0").await?;
+    let (variant, root_prop) = SchemaVariant::new(
+        txn,
+        nats,
+        tenancy,
+        visibility,
+        history_actor,
+        "v0",
+        veritech.clone(),
+        encryption_key,
+    )
+    .await?;
     variant
         .set_schema(txn, nats, visibility, history_actor, schema.id())
         .await?;
@@ -59,7 +69,7 @@ pub async fn kubernetes_deployment(
             variant.id(),
             "apiVersion",
             "apps/v1".to_owned(),
-            None,
+            Some(root_prop.domain_prop_id),
             veritech.clone(),
             encryption_key,
         )
@@ -76,7 +86,7 @@ pub async fn kubernetes_deployment(
             variant.id(),
             "kind",
             "Deployment".to_owned(),
-            None,
+            Some(root_prop.domain_prop_id),
             veritech.clone(),
             encryption_key,
         )
@@ -92,7 +102,7 @@ pub async fn kubernetes_deployment(
             history_actor,
             variant.id(),
             true, // is name required, note: bool is not ideal here tho
-            None,
+            Some(root_prop.domain_prop_id),
             veritech.clone(),
             encryption_key,
         )
@@ -111,7 +121,7 @@ pub async fn kubernetes_deployment(
             variant.id(),
             "spec",
             PropKind::Object,
-            None,
+            Some(root_prop.domain_prop_id),
         )
         .await?;
 

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -29,6 +29,8 @@ pub enum SchematicError {
     PositionNotFound,
     #[error("component not found")]
     ComponentNotFound,
+    #[error("component name not found")]
+    ComponentNameNotFound,
     #[error("schema not found")]
     SchemaNotFound,
     #[error("system error: {0}")]
@@ -195,7 +197,15 @@ impl Schematic {
                         .ok_or(SchematicError::SchemaNotFound)?;
                     (
                         schema,
-                        component.name().to_owned(),
+                        component
+                            .find_prop_value_by_json_pointer::<String>(
+                                txn,
+                                &tenancy,
+                                visibility,
+                                "/root/si/name",
+                            )
+                            .await?
+                            .ok_or(SchematicError::ComponentNameNotFound)?,
                         SchematicKind::Component,
                     )
                 }

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -363,7 +363,7 @@ macro_rules! standard_model_belongs_to {
 
 #[macro_export]
 macro_rules! standard_model_accessor_ro {
-    ($column:ident, $value_type:ident) => {
+    ($column:ident, $value_type:ty) => {
         pub fn $column(&self) -> &$value_type {
             &self.$column
         }

--- a/lib/dal/tests/integration_test/code_generation_prototype.rs
+++ b/lib/dal/tests/integration_test/code_generation_prototype.rs
@@ -20,7 +20,7 @@ async fn new() {
         nats_conn,
         nats,
         veritech,
-        _encr_key
+        encr_key
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -38,6 +38,7 @@ async fn new() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -84,7 +85,7 @@ async fn find_for_component() {
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)
 
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, _encr_key);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, encr_key);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
@@ -105,6 +106,7 @@ async fn find_for_component() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/code_generation_resolver.rs
+++ b/lib/dal/tests/integration_test/code_generation_resolver.rs
@@ -39,6 +39,8 @@ async fn new() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -118,6 +120,8 @@ async fn find_for_prototype() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1,11 +1,11 @@
 use dal::{
     system::UNSET_SYSTEM_ID,
     test_harness::{
-        create_component_for_schema_variant, create_prop_of_kind_with_name, create_schema,
-        create_schema_variant, find_or_create_production_system,
+        create_prop_of_kind_with_name, create_schema, create_schema_variant_with_root,
+        find_or_create_production_system,
     },
-    ComponentView, HistoryActor, Prop, PropKind, SchemaKind, SchemaVariant, StandardModel, Tenancy,
-    Visibility,
+    Component, ComponentView, HistoryActor, Prop, PropKind, SchemaKind, SchemaVariant,
+    StandardModel, Tenancy, Visibility,
 };
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 use si_data::{NatsTxn, PgTxn};
@@ -36,8 +36,16 @@ pub async fn create_schema_with_object_and_string_prop(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -95,6 +103,10 @@ pub async fn create_schema_with_object_and_string_prop(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    queen_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent prop");
     killer_prop
         .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
         .await
@@ -129,8 +141,16 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -218,6 +238,10 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    queen_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent prop");
     killer_prop
         .set_parent_prop(txn, nats, &visibility, &history_actor, *queen_prop.id())
         .await
@@ -263,8 +287,16 @@ pub async fn create_schema_with_string_props(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -296,6 +328,10 @@ pub async fn create_schema_with_string_props(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    bohemian_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent prop");
 
     let killer_prop = create_prop_of_kind_with_name(
         txn,
@@ -313,6 +349,10 @@ pub async fn create_schema_with_string_props(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    killer_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent prop");
     schema_variant
 }
 
@@ -338,8 +378,16 @@ pub async fn create_schema_with_array_of_string_props(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -371,6 +419,10 @@ pub async fn create_schema_with_array_of_string_props(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    sammy_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent");
 
     let album_string_prop = create_prop_of_kind_with_name(
         txn,
@@ -417,8 +469,16 @@ pub async fn create_schema_with_nested_array_objects(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -450,6 +510,10 @@ pub async fn create_schema_with_nested_array_objects(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    sammy_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent");
 
     let album_object_prop = create_prop_of_kind_with_name(
         txn,
@@ -572,8 +636,16 @@ pub async fn create_simple_map(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -605,6 +677,10 @@ pub async fn create_simple_map(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    album_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent");
 
     let album_item_prop = create_prop_of_kind_with_name(
         txn,
@@ -651,8 +727,16 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
         &SchemaKind::Concrete,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(txn, nats, &tenancy, &visibility, &history_actor).await;
+    let (schema_variant, root) = create_schema_variant_with_root(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encryption_key,
+    )
+    .await;
     schema_variant
         .set_schema(txn, nats, &visibility, &history_actor, schema.id())
         .await
@@ -684,6 +768,10 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
         .add_schema_variant(txn, nats, &visibility, &history_actor, schema_variant.id())
         .await
         .expect("cannot associate prop with schema variant");
+    sammy_prop
+        .set_parent_prop(txn, nats, &visibility, &history_actor, root.domain_prop_id)
+        .await
+        .expect("cannot set parent");
 
     let album_object_prop = create_prop_of_kind_with_name(
         txn,
@@ -815,22 +903,31 @@ async fn only_string_props() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
+    let _ =
+        find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let schema_variant =
         create_schema_with_string_props(&txn, &nats, veritech.clone(), encr_key).await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "capoeira",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let props = schema_variant
         .props(&txn, &visibility)
         .await
         .expect("cannot get props for schema_variant");
-    for prop in props.iter() {
+    for prop in props
+        .iter()
+        .filter(|p| !["root", "si", "domain", "name"].contains(&p.name()))
+    {
         component
             .resolve_attribute(
                 &txn,
@@ -858,10 +955,9 @@ async fn only_string_props() {
     )
     .await
     .expect("cannot get component view");
-    assert_eq!(component_view.name, component.name());
     assert_eq!(
         component_view.properties,
-        serde_json::json![{"bohemian_rhapsody": "woohoo", "killer_queen": "woohoo"}]
+        serde_json::json![{ "si": { "name": "capoeira" }, "domain": { "bohemian_rhapsody": "woohoo", "killer_queen": "woohoo" } }]
     );
 }
 
@@ -885,15 +981,19 @@ async fn one_object_prop() {
         find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let schema_variant =
         create_schema_with_object_and_string_prop(&txn, &nats, veritech.clone(), encr_key).await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "santos dumont",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let props = schema_variant
         .all_props(&txn, &visibility)
         .await
@@ -920,7 +1020,10 @@ async fn one_object_prop() {
         )
         .await
         .expect("cannot resolve object attribute to empty object");
-    for prop in props.iter().filter(|p| p.name() != "queen") {
+    for prop in props
+        .iter()
+        .filter(|p| !["queen", "root", "si", "domain", "name"].contains(&p.name()))
+    {
         component
             .resolve_attribute(
                 &txn,
@@ -948,10 +1051,12 @@ async fn one_object_prop() {
     )
     .await
     .expect("cannot get component view");
-    assert_eq!(component_view.name, component.name());
-    assert_eq!(
+    assert_eq_sorted!(
         component_view.properties,
-        serde_json::json![{"queen": {"bohemian_rhapsody": "woohoo", "killer_queen": "woohoo"}}]
+        serde_json::json![{
+            "si": { "name": "santos dumont" },
+            "domain": { "queen": { "bohemian_rhapsody": "woohoo", "killer_queen": "woohoo" } }
+        }]
     );
 }
 
@@ -976,15 +1081,19 @@ async fn nested_object_prop() {
     let (schema_variant, queen_prop, bohemian_prop, killer_prop, pressure_prop, dust_prop) =
         create_schema_with_nested_objects_and_string_prop(&txn, &nats, veritech.clone(), encr_key)
             .await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "free ronaldinho",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let (_, queen_object_resolver_id, _) = component
         .resolve_attribute(
             &txn,
@@ -1080,10 +1189,9 @@ async fn nested_object_prop() {
     )
     .await
     .expect("cannot get component view");
-    assert_eq!(component_view.name, component.name());
     assert_eq!(
         component_view.properties,
-        serde_json::json![{"queen": {"bohemian_rhapsody": "scaramouche", "killer_queen": "cake", "under_pressure": { "another_one_bites_the_dust": "another one gone"}}}]
+        serde_json::json![{ "si": { "name": "free ronaldinho" }, "domain": {"queen": {"bohemian_rhapsody": "scaramouche", "killer_queen": "cake", "under_pressure": { "another_one_bites_the_dust": "another one gone"}}}}]
     );
 }
 
@@ -1107,15 +1215,19 @@ async fn simple_array_of_strings() {
         find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let schema_variant =
         create_schema_with_array_of_string_props(&txn, &nats, veritech.clone(), encr_key).await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "tim maia",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let props = schema_variant
         .all_props(&txn, &visibility)
         .await
@@ -1142,7 +1254,10 @@ async fn simple_array_of_strings() {
         )
         .await
         .expect("cannot resolve the attributes for the component");
-    for prop in props.iter().filter(|p| p.name() != "sammy_hagar") {
+    for prop in props
+        .iter()
+        .filter(|p| !["sammy_hagar", "root", "si", "domain", "name"].contains(&p.name()))
+    {
         component
             .resolve_attribute(
                 &txn,
@@ -1188,10 +1303,9 @@ async fn simple_array_of_strings() {
     .await
     .expect("cannot get component view");
     // txn.commit().await.expect("cannot commit txn");
-    assert_eq!(component_view.name, component.name());
     assert_eq!(
         component_view.properties,
-        serde_json::json![{"sammy_hagar": ["standing_hampton", "voa"]}]
+        serde_json::json![{"si": {"name": "tim maia" }, "domain": {"sammy_hagar": ["standing_hampton", "voa"]}}]
     );
 }
 
@@ -1221,15 +1335,19 @@ async fn complex_nested_array_of_objects() {
         songs_array_prop,
         song_name_prop,
     ) = create_schema_with_nested_array_objects(&txn, &nats, veritech.clone(), encr_key).await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "An Integralist Doesn't Run, It Flies",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let (_, sammy_resolver_id, _) = component
         .resolve_attribute(
             &txn,
@@ -1427,10 +1545,10 @@ async fn complex_nested_array_of_objects() {
     .await
     .expect("cannot get component view");
     // txn.commit().await.expect("cannot commit txn");
-    assert_eq!(component_view.name, component.name());
     assert_eq_sorted!(
-        serde_json::json![
-            {
+        serde_json::json![{
+            "si": {"name": "An Integralist Doesn't Run, It Flies"},
+            "domain": {
                 "sammy_hagar": [
                     {
                         "album": "standing_hampton",
@@ -1448,7 +1566,7 @@ async fn complex_nested_array_of_objects() {
                     }
                 ]
             }
-        ], // expected
+        }], // expected
         component_view.properties, // actual
     );
 }
@@ -1473,15 +1591,19 @@ async fn simple_map() {
         find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
     let (schema_variant, album_prop, album_item_prop) =
         create_simple_map(&txn, &nats, veritech.clone(), encr_key).await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "E como isso afeta o Grêmio?",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let (_, album_resolver_id, _) = component
         .resolve_attribute(
             &txn,
@@ -1544,16 +1666,16 @@ async fn simple_map() {
     .await
     .expect("cannot get component view");
     // txn.commit().await.expect("cannot commit txn");
-    assert_eq!(component_view.name, component.name());
     assert_eq_sorted!(
-        serde_json::json![
-            {
+        serde_json::json![{
+            "si": {"name": "E como isso afeta o Grêmio?"},
+            "domain": {
                 "albums": {
                     "black_dahlia": "nocturnal",
                     "meshuggah": "destroy erase improve",
                 }
             }
-        ], // expected
+        }], // expected
         component_view.properties, // actual
     );
 }
@@ -1586,15 +1708,19 @@ async fn complex_nested_array_of_objects_with_a_map() {
         song_map_item_prop,
     ) = create_schema_with_nested_array_objects_and_a_map(&txn, &nats, veritech.clone(), encr_key)
         .await;
-    let component = create_component_for_schema_variant(
+    let (component, _) = Component::new_for_schema_variant_with_node(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
+        "E como isso afeta o Grêmio?",
         schema_variant.id(),
     )
-    .await;
+    .await
+    .expect("Unable to create component");
     let (_, sammy_resolver_id, _) = component
         .resolve_attribute(
             &txn,
@@ -1726,10 +1852,10 @@ async fn complex_nested_array_of_objects_with_a_map() {
     .expect("cannot get component view");
 
     // txn.commit().await.expect("cannot commit txn");
-    assert_eq!(component_view.name, component.name());
     assert_eq_sorted!(
-        serde_json::json![
-            {
+        serde_json::json![{
+            "si": { "name": "E como isso afeta o Grêmio?" },
+            "domain": {
                 "sammy_hagar": [
                     {
                         "album": "standing_hampton",
@@ -1739,7 +1865,7 @@ async fn complex_nested_array_of_objects_with_a_map() {
                     },
                 ]
             }
-        ], // expected
+        }], // expected
         component_view.properties, // actual
     );
 }
@@ -1770,7 +1896,6 @@ async fn cyclone_crypto_e2e() {
         handler: "testE2ECrypto".to_owned(),
         component: veritech::ResolverFunctionComponent {
             data: veritech::ComponentView {
-                name: "testE2ECrypto".to_owned(),
                 kind: veritech::ComponentKind::Credential,
                 system: None,
                 properties: serde_json::json!({

--- a/lib/dal/tests/integration_test/deculture/attribute_prototype.rs
+++ b/lib/dal/tests/integration_test/deculture/attribute_prototype.rs
@@ -59,6 +59,8 @@ async fn new() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -147,8 +149,16 @@ async fn list_for_context() {
     )
     .await;
 
-    let schema_variant =
-        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let schema_variant = create_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encr_key,
+    )
+    .await;
     schema_variant
         .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
         .await
@@ -312,6 +322,8 @@ async fn list_for_context() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -428,8 +440,16 @@ async fn list_for_context_with_a_hash() {
     )
     .await;
 
-    let schema_variant =
-        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let schema_variant = create_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encr_key,
+    )
+    .await;
     schema_variant
         .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
         .await
@@ -637,6 +657,8 @@ async fn list_for_context_with_a_hash() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -18,7 +18,7 @@ async fn new() {
         _nats_conn,
         nats,
         veritech,
-        _encr_key,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -58,6 +58,7 @@ async fn new() {
         &txn,
         &nats,
         veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -71,6 +72,7 @@ async fn new() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -122,7 +124,7 @@ async fn include_component_in_system() {
         _nats_conn,
         nats,
         veritech,
-        _ency_key,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -149,6 +151,7 @@ async fn include_component_in_system() {
         &txn,
         &nats,
         veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -162,6 +165,7 @@ async fn include_component_in_system() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -199,7 +203,7 @@ async fn include_component_in_system_with_edit_sessions() {
         _nats_conn,
         nats,
         veritech,
-        _encr_key,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -229,6 +233,7 @@ async fn include_component_in_system_with_edit_sessions() {
         &txn,
         &nats,
         veritech.clone(),
+        &encr_key,
         &tenancy,
         &edit_session_visibility,
         &history_actor,
@@ -242,6 +247,7 @@ async fn include_component_in_system_with_edit_sessions() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &edit_session_visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -44,14 +44,22 @@ async fn component_relationships() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let component =
-        create_component_and_schema(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let component = create_component_and_schema(
+        &txn,
+        &nats,
+        veritech,
+        &encr_key,
+        &tenancy,
+        &visibility,
+        &history_actor,
+    )
+    .await;
     let node = create_node(
         &txn,
         &nats,
@@ -82,8 +90,8 @@ async fn new_node_template() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -98,8 +106,16 @@ async fn new_node_template() {
         &SchemaKind::Concept,
     )
     .await;
-    let schema_variant =
-        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let schema_variant = create_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech,
+        encr_key,
+    )
+    .await;
     schema_variant
         .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
         .await

--- a/lib/dal/tests/integration_test/node_menu.rs
+++ b/lib/dal/tests/integration_test/node_menu.rs
@@ -7,7 +7,7 @@ use crate::test_setup;
 
 #[tokio::test]
 async fn get_node_menu() {
-    test_setup!(ctx, secret_key, _pg, _conn, txn, _nats_conn, nats, _veritech, _encr_key);
+    test_setup!(ctx, secret_key, _pg, _conn, txn, _nats_conn, nats, veritech, encr_key);
     let (nba, _key) = billing_account_signup(&txn, &nats, secret_key).await;
     let visibility = Visibility::new_head(false);
     let tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
@@ -31,6 +31,8 @@ async fn get_node_menu() {
     let application = create_component_for_schema(
         &txn,
         &nats,
+        veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -55,8 +55,16 @@ async fn schema_variants() {
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let schema_variant =
-        create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let schema_variant = create_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech.clone(),
+        encr_key,
+    )
+    .await;
     let prop = create_prop(
         &txn,
         &nats,

--- a/lib/dal/tests/integration_test/qualification_check.rs
+++ b/lib/dal/tests/integration_test/qualification_check.rs
@@ -44,8 +44,8 @@ async fn schema_variants() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -61,7 +61,16 @@ async fn schema_variants() {
         &SchemaKind::Concrete,
     )
     .await;
-    let variant = create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let variant = create_schema_variant(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        veritech,
+        encr_key,
+    )
+    .await;
     variant
         .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())
         .await

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -19,7 +19,7 @@ async fn new() {
         nats_conn,
         nats,
         veritech,
-        _encr_key
+        encr_key
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -37,6 +37,7 @@ async fn new() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -89,7 +90,7 @@ async fn find_for_component() {
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)
 
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, _encr_key);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, encr_key);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
@@ -110,6 +111,7 @@ async fn find_for_component() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/qualification_resolver.rs
+++ b/lib/dal/tests/integration_test/qualification_resolver.rs
@@ -39,6 +39,8 @@ async fn new() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -123,6 +125,8 @@ async fn find_for_prototype() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/resource.rs
+++ b/lib/dal/tests/integration_test/resource.rs
@@ -1,6 +1,7 @@
 use crate::test_setup;
 
-use dal::{Component, HistoryActor, Resource, StandardModel, System, Tenancy, Visibility};
+use dal::test_harness::create_component_and_schema;
+use dal::{HistoryActor, Resource, StandardModel, System, Tenancy, Visibility};
 
 #[tokio::test]
 async fn new() {
@@ -12,22 +13,22 @@ async fn new() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let component = Component::new(
+    let component = create_component_and_schema(
         &txn,
         &nats,
+        veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
-        "mastodon",
     )
-    .await
-    .expect("cannot create component");
+    .await;
     let system = System::new(
         &txn,
         &nats,
@@ -62,32 +63,32 @@ async fn get_by_component_and_system_id() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let mastodon_component = Component::new(
+    let mastodon_component = create_component_and_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
-        "mastodon",
     )
-    .await
-    .expect("cannot create component");
-    let blue_oyster_component = Component::new(
+    .await;
+    let blue_oyster_component = create_component_and_schema(
         &txn,
         &nats,
+        veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
-        "Blue Öyster Cult",
     )
-    .await
-    .expect("cannot create component");
+    .await;
     let production_system = System::new(
         &txn,
         &nats,

--- a/lib/dal/tests/integration_test/resource_prototype.rs
+++ b/lib/dal/tests/integration_test/resource_prototype.rs
@@ -19,7 +19,7 @@ async fn new() {
         nats_conn,
         nats,
         veritech,
-        _encr_key
+        encr_key
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -37,6 +37,7 @@ async fn new() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -83,7 +84,7 @@ async fn find_for_component() {
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)
 
-    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, _encr_key);
+    test_setup!(ctx, secret_key, pg, _conn, txn, nats_conn, nats, veritech, encr_key);
     let (nba, _token) = billing_account_signup(&txn, &nats, secret_key).await;
     let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
     tenancy.universal = true;
@@ -104,6 +105,7 @@ async fn find_for_component() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/resource_resolver.rs
+++ b/lib/dal/tests/integration_test/resource_resolver.rs
@@ -39,6 +39,8 @@ async fn new() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -118,6 +120,8 @@ async fn find_for_prototype() {
     let component = create_component_for_schema_variant(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -1,7 +1,6 @@
 use dal::{
-    schema::SchemaVariant,
-    test_harness::{create_schema, create_schema_variant},
-    HistoryActor, SchemaKind, StandardModel, Tenancy, Visibility,
+    schema::SchemaVariant, test_harness::create_schema, HistoryActor, SchemaKind, StandardModel,
+    Tenancy, Visibility,
 };
 
 use crate::test_setup;
@@ -16,15 +15,24 @@ async fn new() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let variant = SchemaVariant::new(&txn, &nats, &tenancy, &visibility, &history_actor, "ringo")
-        .await
-        .expect("cannot create schema ui menu");
+    let (variant, _) = SchemaVariant::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "ringo",
+        veritech,
+        encr_key,
+    )
+    .await
+    .expect("cannot create schema ui menu");
     assert_eq!(variant.name(), "ringo");
 }
 
@@ -38,8 +46,8 @@ async fn set_schema() {
         txn,
         _nats_conn,
         nats,
-        _veritech,
-        _encr_key,
+        veritech,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -53,7 +61,18 @@ async fn set_schema() {
         &SchemaKind::Concrete,
     )
     .await;
-    let variant = create_schema_variant(&txn, &nats, &tenancy, &visibility, &history_actor).await;
+    let (variant, _) = SchemaVariant::new(
+        &txn,
+        &nats,
+        &tenancy,
+        &visibility,
+        &history_actor,
+        "v0",
+        veritech,
+        encr_key,
+    )
+    .await
+    .expect("cannot create schema ui menu");
 
     variant
         .set_schema(&txn, &nats, &visibility, &history_actor, schema.id())

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -15,7 +15,7 @@ async fn get_schematic() {
         _nats_conn,
         nats,
         veritech,
-        _encr_key
+        encr_key
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -38,6 +38,7 @@ async fn get_schematic() {
         &txn,
         &nats,
         veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -57,6 +58,7 @@ async fn get_schematic() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -108,7 +110,7 @@ async fn create_connection() {
         _nats_conn,
         nats,
         veritech,
-        _encr_key,
+        encr_key,
     );
     let tenancy = Tenancy::new_universal();
     let visibility = Visibility::new_head(false);
@@ -147,6 +149,7 @@ async fn create_connection() {
         &txn,
         &nats,
         veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -160,6 +163,7 @@ async fn create_connection() {
         &txn,
         &nats,
         veritech,
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -52,6 +52,8 @@ async fn new() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -145,6 +147,8 @@ async fn find_for_prototype() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -281,6 +285,8 @@ async fn find_values_for_prop_and_component() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,
@@ -423,6 +429,8 @@ async fn find_values_for_prop_and_component_override() {
     let component = create_component_for_schema(
         &txn,
         &nats,
+        veritech.clone(),
+        &encr_key,
         &tenancy,
         &visibility,
         &history_actor,

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -40,6 +40,8 @@ pub enum ComponentError {
     WsEvent(#[from] WsEventError),
     #[error("component not found")]
     ComponentNotFound,
+    #[error("component name not found")]
+    ComponentNameNotFound,
     #[error("resource not found")]
     ResourceNotFound(ComponentId, SystemId),
 }

--- a/lib/veritech/src/client.rs
+++ b/lib/veritech/src/client.rs
@@ -354,7 +354,7 @@ mod subscription {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, env};
+    use std::env;
 
     use cyclone::{
         CodeGenerated, ComponentView, QualificationCheckComponent, ResolverFunctionComponent,
@@ -440,20 +440,17 @@ mod tests {
             handler: "numberOfParents".to_string(),
             component: ResolverFunctionComponent {
                 data: ComponentView {
-                    name: "Child".to_owned(),
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
                 },
                 parents: vec![
                     ComponentView {
-                        name: "Parent 1".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
                     },
                     ComponentView {
-                        name: "Parent 2".to_owned(),
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
@@ -501,7 +498,6 @@ mod tests {
             handler: "check".to_string(),
             component: QualificationCheckComponent {
                 data: ComponentView {
-                    name: "cider".to_string(),
                     properties: serde_json::json!({"image": "systeminit/whiskers"}),
                     system: None,
                     kind: ComponentKind::Standard,
@@ -610,9 +606,7 @@ mod tests {
         }
 
         request.execution_id = "9012".to_string();
-        request.component.data.name = "emacs".to_string();
         request.component.data = ComponentView {
-            name: "cider".to_string(),
             properties: serde_json::json!({"image": "abc"}),
             system: None,
             kind: ComponentKind::Standard,
@@ -654,7 +648,6 @@ mod tests {
             execution_id: "7867".to_string(),
             handler: "syncItOut".to_string(),
             component: ComponentView {
-                name: "cider".to_string(),
                 properties: serde_json::json!({"pkg": "cider"}),
                 system: None,
                 kind: ComponentKind::Standard,
@@ -692,13 +685,10 @@ mod tests {
             }
         });
 
-        let mut properties = HashMap::new();
-        properties.insert("pkg".to_string(), serde_json::json!("cider"));
         let request = CodeGenerationRequest {
             execution_id: "7868".to_string(),
             handler: "generateItOut".to_string(),
             component: ComponentView {
-                name: "cider".to_string(),
                 properties: serde_json::json!({"pkg": "cider"}),
                 system: None,
                 kind: ComponentKind::Standard,


### PR DESCRIPTION
Create three props for all schema variant: root->(si/domain). Name
field was removed from component and added to root->si->name. All props
that existed before this became children of root->domain.

Creates `find_prop_by_json_pointer`, `set_prop_by_json_pointer` and
`find_prop_value_by_json_pointer` in Component as helpers to manipulate
specific props (used for getting/setting the name). Doesn't work for
arrays and maps, although these methods should be gone when
AttributeResolvers are complete.

Update tests to pass encryption key on schema_variant and component
creation.

On component creation set root->si->name to the name received. Assumes
all schema_variants have these, as SchemaVariant::new creates them.

Add instrumentation in hard to debug functions. Remove instrumentation
from some battle tested functions that only created bloat in the logs.

Fixed universal tenancy issues in a bunch of places.

Fixed dal tests that sometimes had stack-overflows on builtin schema
setup by making the migrations in a new `tokio::task::spawn`ed stack.

Fixed edit_field path passed to the front-end, except for arrays and
maps.

Fixed duplicated fields and some reactivity issues in AttributeViewer.

Initialized tracing in dal tests.

<img src="https://media0.giphy.com/media/dRfuJCevVsadVVEXU0/giphy.gif"/>