### PR TITLE
feat(web): hide/show headers in attribute viewer

### DIFF
--- a/app/web/src/organisims/EditForm.vue
+++ b/app/web/src/organisims/EditForm.vue
@@ -1,5 +1,11 @@
 <template>
-  <Widgets v-if="editFields" :edit-fields="editFields" :indent-level="1" />
+  <Widgets
+    v-if="editFields"
+    :show="true"
+    :edit-fields="editFields"
+    :indent-level="1"
+    :tree-open-state="{}"
+  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -14,7 +14,12 @@
           :key="index"
           class="flex flex-col justify-between w-full p-1 border border-gray-500"
         >
-          <Widgets :edit-fields="editFields" :indent-level="indentLevel + 1" />
+          <Widgets
+            :show="show"
+            :edit-fields="editFields"
+            :indent-level="indentLevel + 1"
+            :tree-open-state="treeOpenState"
+          />
         </div>
         <div class="flex flex-row mt-1 ml-1">
           <button @click="addToArray">
@@ -36,7 +41,12 @@
           :key="index"
           class="flex flex-col justify-between w-full mx-1 border border-gray-500"
         >
-          <Widgets :edit-fields="editFields" :indent-level="indentLevel + 1" />
+          <Widgets
+            :show="show"
+            :edit-fields="editFields"
+            :indent-level="indentLevel + 1"
+            :tree-open-state="treeOpenState"
+          />
         </div>
       </div>
     </template>
@@ -56,6 +66,7 @@ import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_ed
 import { GlobalErrorService } from "@/service/global_error";
 import { defineAsyncComponent, DefineComponent } from "vue";
 import type { WidgetsProps } from "./Widgets.vue";
+import { ITreeOpenState } from "@/utils/edit_field_visitor";
 
 // Eliminate the circular dependency of HeaderWidget -> Widgets -> HeaderWidget
 // by using `defineAsyncComponent` in a careful way to preserve the ability for
@@ -74,6 +85,7 @@ const props = defineProps<{
   coreEditField: boolean;
   indentLevel: number;
   editField: EditField;
+  treeOpenState: ITreeOpenState;
 }>();
 
 const widget = computed<ArrayWidgetDal>(() => {

--- a/app/web/src/organisims/EditForm/EditFormField.vue
+++ b/app/web/src/organisims/EditForm/EditFormField.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="props.coreEditField">
-    <div class="flex flex-row items-center mx-6 mt-2">
+    <div v-show="show" class="flex flex-row items-center mx-6 mt-2">
       <div class="text-sm leading-tight text-right text-white w-28">
         <slot name="name"></slot>
       </div>
@@ -21,7 +21,7 @@
     </div>
   </template>
   <template v-else>
-    <div v-if="props.show" class="flex flex-row items-center w-full">
+    <div v-show="show" class="flex flex-row items-center w-full">
       <div class="flex flex-col w-full">
         <div class="flex flex-row items-center">
           <div

--- a/app/web/src/organisims/EditForm/Widget.vue
+++ b/app/web/src/organisims/EditForm/Widget.vue
@@ -1,36 +1,39 @@
 <template>
   <HeaderWidget
     v-if="editField.widget.kind === 'Header'"
-    :show="true"
-    :edit-field="editField"
+    :show="props.show"
+    :edit-field="props.editField"
     :background-colors="backgroundColors"
-    :core-edit-field="coreEditField"
-    :indent-level="indentLevel"
+    :core-edit-field="props.coreEditField"
+    :indent-level="props.indentLevel"
+    :tree-open-state="props.treeOpenState"
+    @toggle-header="toggleHeader"
   />
   <ArrayWidget
     v-else-if="editField.widget.kind === 'Array'"
-    :show="true"
-    :edit-field="editField"
-    :core-edit-field="coreEditField"
-    :indent-level="indentLevel"
+    :show="props.show"
+    :edit-field="props.editField"
+    :core-edit-field="props.coreEditField"
+    :indent-level="props.indentLevel"
+    :tree-open-state="treeOpenState"
   />
   <TextWidget
     v-else-if="editField.widget.kind === 'Text'"
-    :show="true"
-    :edit-field="editField"
-    :core-edit-field="coreEditField"
+    :show="props.show"
+    :edit-field="props.editField"
+    :core-edit-field="props.coreEditField"
   />
   <CheckboxWidget
     v-else-if="editField.widget.kind === 'Checkbox'"
-    :show="true"
-    :edit-field="editField"
-    :core-edit-field="coreEditField"
+    :show="props.show"
+    :edit-field="props.editField"
+    :core-edit-field="props.coreEditField"
   />
   <SelectWidget
     v-else-if="editField.widget.kind === 'Select'"
-    :show="true"
-    :edit-field="editField"
-    :core-edit-field="coreEditField"
+    :show="props.show"
+    :edit-field="props.editField"
+    :core-edit-field="props.coreEditField"
   />
 </template>
 
@@ -41,11 +44,22 @@ import TextWidget from "@/organisims/EditForm/TextWidget.vue";
 import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
 import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
 import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
+import { ITreeOpenState } from "@/utils/edit_field_visitor";
 
-defineProps<{
+const props = defineProps<{
+  show: boolean;
   coreEditField: boolean;
   indentLevel: number;
   editField: EditField;
+  treeOpenState: ITreeOpenState;
   backgroundColors: number[][];
 }>();
+
+const emit = defineEmits<{
+  (e: "toggleHeader", fieldId: string): void;
+}>();
+
+const toggleHeader = (fieldId: string) => {
+  emit("toggleHeader", fieldId);
+};
 </script>

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -1,20 +1,24 @@
 <template>
-  <template v-for="editField in editFields" :key="editField.id">
+  <template v-for="editField in props.editFields" :key="editField.id">
     <Widget
       v-if="isCoreEditField"
-      :show="true"
+      :show="props.show"
       :edit-field="editField"
       :background-colors="backgroundColors"
       :core-edit-field="isCoreEditField"
-      :indent-level="indentLevel"
+      :indent-level="props.indentLevel"
+      :tree-open-state="props.treeOpenState"
+      @toggle-header="toggleHeader"
     />
     <div v-else class="my-2">
       <Widget
-        :show="true"
+        :show="props.show"
         :edit-field="editField"
         :background-colors="backgroundColors"
         :core-edit-field="isCoreEditField"
-        :indent-level="indentLevel"
+        :indent-level="props.indentLevel"
+        :tree-open-state="props.treeOpenState"
+        @toggle-header="toggleHeader"
       />
     </div>
   </template>
@@ -25,13 +29,25 @@ import { computed } from "vue";
 import { EditFields } from "@/api/sdf/dal/edit_field";
 import Widget from "@/organisims/EditForm/Widget.vue";
 import { interpolateColors } from "@/utils/interpolateColors";
+import { ITreeOpenState } from "@/utils/edit_field_visitor";
 
 export interface WidgetsProps {
+  show: boolean;
   editFields: EditFields;
   coreEditFields?: boolean;
   indentLevel: number;
+  treeOpenState: ITreeOpenState;
 }
+
 const props = defineProps<WidgetsProps>();
+
+const emit = defineEmits<{
+  (e: "toggleHeader", fieldId: string): void;
+}>();
+
+const toggleHeader = (fieldId: string) => {
+  emit("toggleHeader", fieldId);
+};
 
 const isCoreEditField = computed(() =>
   props.coreEditFields === undefined ? false : props.coreEditFields,

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="flex flex-col w-full overflow-auto scrollbar">
     <Widgets
+      :show="true"
       :edit-fields="coreEditFields"
       :core-edit-fields="true"
       :indent-level="1"
+      :tree-open-state="{}"
     />
     <div
       class="pt1 pb-1 pl-6 mt-2 text-base text-white align-middle property-section-bg-color"
@@ -11,16 +13,26 @@
       Properties
     </div>
     <div class="w-full">
-      <Widgets :edit-fields="propertyEditFields" :indent-level="1" />
+      <Widgets
+        :show="true"
+        :edit-fields="propertyEditFields"
+        :indent-level="1"
+        :tree-open-state="treeOpenState"
+        @toggle-header="toggleHeader"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
 import _ from "lodash";
+import {
+  InitialTreeOpenStateVisitor,
+  ITreeOpenState,
+} from "@/utils/edit_field_visitor";
 
 const props = defineProps<{
   editFields: EditFields;
@@ -45,6 +57,44 @@ const propertyEditFields = computed(() => {
     (field) => field.object_kind == EditFieldObjectKind.ComponentProp,
   );
 });
+
+const initialTreeOpenState = computed(
+  (): ITreeOpenState => {
+    const visitor = new InitialTreeOpenStateVisitor();
+    visitor.visitEditFields(propertyEditFields.value);
+    return visitor.initialTreeState();
+  },
+);
+
+const setTreeOpenState = ref<ITreeOpenState>({});
+
+const treeOpenState = computed(
+  (): ITreeOpenState => {
+    const state: ITreeOpenState = {};
+    for (const [fieldId, initialOpenState] of Object.entries(
+      initialTreeOpenState.value,
+    )) {
+      const setOpenState = setTreeOpenState.value[fieldId];
+      if (setOpenState === undefined) {
+        state[fieldId] = initialOpenState;
+      } else {
+        state[fieldId] = setOpenState;
+      }
+    }
+    return state;
+  },
+);
+
+const toggleHeader = (fieldId: string) => {
+  console.log(`toggling: ${fieldId}`, {
+    setTreeOpenState: setTreeOpenState.value,
+  });
+  if (setTreeOpenState.value[fieldId] === undefined) {
+    setTreeOpenState.value[fieldId] = true;
+  } else {
+    setTreeOpenState.value[fieldId] = !setTreeOpenState.value[fieldId];
+  }
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
I had a great breakdown and explanation of the implementation only to
lose the commit message contents, so now I'm dejected and simply want to
ship this change. Long story short, there's a computed `treeOpenState`
datastructure that is passed down the tree as a prop to provide state,
and a `toggleHeader` event that is emitted up from a `HeaderWidget`
which ultimately updates the `treeOpenState` so everything is reactive
accoringly.

Consult fnichol for more exciting details :)

References: hide show the headers in the attribute editor [sc-2297]

<img src="https://media2.giphy.com/media/AZa4KP7o6J7Us/giphy.gif"/>