### PR TITLE
feat(dal): Implement and test ReadTenancy

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -45,15 +45,15 @@ use crate::func::backend::prop_object::FuncBackendPropObjectArgs;
 use crate::{
     impl_standard_model, pk, qualification::QualificationError, standard_model,
     standard_model_accessor, standard_model_belongs_to, standard_model_has_many, AttributeResolver,
-    AttributeResolverError, BillingAccountId, CodeGenerationPrototype,
-    CodeGenerationPrototypeError, CodeGenerationResolver, CodeGenerationResolverError, Func,
-    FuncBackendKind, HistoryActor, HistoryEventError, LabelEntry, LabelList, Node, NodeError,
-    OrganizationError, Prop, PropId, PropKind, QualificationPrototype, QualificationPrototypeError,
-    QualificationResolver, QualificationResolverError, Resource, ResourceError, ResourcePrototype,
-    ResourcePrototypeError, ResourceResolver, ResourceResolverError, ResourceView, Schema,
-    SchemaError, SchemaId, StandardModel, StandardModelError, SystemId, Tenancy, Timestamp,
-    ValidationPrototype, ValidationPrototypeError, ValidationResolver, ValidationResolverError,
-    Visibility, Workspace, WorkspaceError,
+    AttributeResolverError, CodeGenerationPrototype, CodeGenerationPrototypeError,
+    CodeGenerationResolver, CodeGenerationResolverError, Func, FuncBackendKind, HistoryActor,
+    HistoryEventError, LabelEntry, LabelList, Node, NodeError, OrganizationError, Prop, PropId,
+    PropKind, QualificationPrototype, QualificationPrototypeError, QualificationResolver,
+    QualificationResolverError, ReadTenancy, ReadTenancyError, Resource, ResourceError,
+    ResourcePrototype, ResourcePrototypeError, ResourceResolver, ResourceResolverError,
+    ResourceView, Schema, SchemaError, SchemaId, StandardModel, StandardModelError, SystemId,
+    Tenancy, Timestamp, ValidationPrototype, ValidationPrototypeError, ValidationResolver,
+    ValidationResolverError, Visibility, WorkspaceError,
 };
 
 #[derive(Error, Debug)]
@@ -128,6 +128,8 @@ pub enum ComponentError {
     QualificationView(#[from] QualificationError),
     #[error("resource error: {0}")]
     Resource(#[from] ResourceError),
+    #[error("read tenancy error: {0}")]
+    ReadTenancy(#[from] ReadTenancyError),
     #[error("workspace not found")]
     WorkspaceNotFound,
     #[error("organization not found")]
@@ -146,7 +148,6 @@ pub enum ComponentError {
 
 pub type ComponentResult<T> = Result<T, ComponentError>;
 
-const GET_WORKSPACE: &str = include_str!("./queries/component_get_workspace.sql");
 const GET_RESOURCE: &str = include_str!("./queries/component_get_resource.sql");
 const LIST_QUALIFICATIONS: &str = include_str!("./queries/component_list_qualifications.sql");
 const LIST_CODE_GENERATED: &str = include_str!("./queries/component_list_code_generated.sql");
@@ -1666,7 +1667,14 @@ impl Component {
                 .await?;
         }
 
-        let billing_account_ids = self.billing_account_ids(txn).await?;
+        let workspace_ids = self.tenancy.workspace_ids.clone();
+        if workspace_ids.is_empty() {
+            return Err(ComponentError::WorkspaceNotFound);
+        }
+        let billing_account_ids = ReadTenancy::new_workspace(txn, workspace_ids)
+            .await?
+            .billing_accounts()
+            .to_owned();
         if billing_account_ids.is_empty() {
             warn!("No billing accounts found for organization");
             return Err(ComponentError::BillingAccountNotFound);
@@ -1677,50 +1685,6 @@ impl Component {
         }
 
         Ok(())
-    }
-
-    pub async fn workspaces(&self, txn: &PgTxn<'_>) -> ComponentResult<Vec<Workspace>> {
-        if self.tenancy.workspace_ids.is_empty() {
-            return Err(ComponentError::WorkspaceNotFound);
-        }
-
-        // TODO(paulo): this is super dangerous, but for now we can't actually get a workspace from a component (as we don't know its tenancy)
-        // Note(paulo): should we filter with visibility here too, or is the current way okayish?
-        let mut workspaces = Vec::with_capacity(self.tenancy.workspace_ids.len());
-        for workspace_id in &self.tenancy.workspace_ids {
-            let row = txn
-                .query_one(GET_WORKSPACE, &[workspace_id, &self.visibility])
-                .await?;
-            let object = standard_model::object_from_row(row)?;
-            workspaces.push(object);
-        }
-        Ok(workspaces)
-    }
-
-    pub async fn billing_account_ids(
-        &self,
-        txn: &PgTxn<'_>,
-    ) -> ComponentResult<Vec<BillingAccountId>> {
-        let workspaces = self.workspaces(txn).await?;
-        if workspaces.is_empty() {
-            warn!("No workspaces for {:?}", self.id());
-            return Err(ComponentError::WorkspaceNotFound);
-        }
-
-        let mut billing_accounts = vec![];
-        for workspace in workspaces {
-            if let Some(organization) = workspace.organization(txn, workspace.visibility()).await? {
-                billing_accounts.extend(WsEvent::billing_account_id_from_tenancy(
-                    organization.tenancy(),
-                ));
-            } else {
-                warn!("No organization for {:?}", workspace.id());
-                return Err(ComponentError::OrganizationNotFound);
-            }
-        }
-        // Note(paulo): We could use a hashset to avoid this
-        billing_accounts.dedup();
-        Ok(billing_accounts)
     }
 
     // Note: Won't work for arrays and maps

--- a/lib/dal/src/cyclone_key_pair.rs
+++ b/lib/dal/src/cyclone_key_pair.rs
@@ -41,8 +41,6 @@ mod tests {
 
     use super::*;
 
-    // TODO(fnichol): fix--decryption not working??
-    #[ignore]
     #[tokio::test]
     async fn create() {
         sodiumoxide::init().expect("failed to init sodiumoxide");
@@ -65,18 +63,18 @@ mod tests {
             .read_to_end(&mut buf)
             .await
             .expect("failed to read from secret key file");
-        let public_key =
-            box_::PublicKey::from_slice(&buf).expect("unable to parse secret key from bytes");
+        let secret_key =
+            box_::SecretKey::from_slice(&buf).expect("unable to parse secret key from bytes");
 
-        let mut buf = Vec::new();
+        buf.clear();
         File::open(&public_key_path)
             .await
             .expect("unable to open public key file")
             .read_to_end(&mut buf)
             .await
             .expect("failed to read from public key file");
-        let secret_key =
-            box_::SecretKey::from_slice(&buf).expect("unable to parse public key from bytes");
+        let public_key =
+            box_::PublicKey::from_slice(&buf).expect("unable to parse public key from bytes");
 
         // Attempt an encryption/decryption round trip to ensure that both keys are related
         let message = "our-lady-peace".to_string();

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -35,6 +35,7 @@ pub mod qualification;
 pub mod qualification_check;
 pub mod qualification_prototype;
 pub mod qualification_resolver;
+pub mod read_tenancy;
 pub mod resource;
 pub mod resource_prototype;
 pub mod resource_resolver;
@@ -106,6 +107,7 @@ pub use qualification_prototype::{
 pub use qualification_resolver::{
     QualificationResolver, QualificationResolverError, QualificationResolverId,
 };
+pub use read_tenancy::{ReadTenancy, ReadTenancyError};
 pub use resource::{Resource, ResourceError, ResourceView};
 pub use resource_prototype::{ResourcePrototype, ResourcePrototypeError, ResourcePrototypeId};
 pub use resource_resolver::{ResourceResolver, ResourceResolverError, ResourceResolverId};

--- a/lib/dal/src/migrations/U0002__tenancy.sql
+++ b/lib/dal/src/migrations/U0002__tenancy.sql
@@ -23,65 +23,38 @@ BEGIN
 END ;
 $$ LANGUAGE PLPGSQL IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION in_tenancy_v1(check_tenancy jsonb,
-                                         this_tenancy_universal bool,
-                                         this_tenancy_billing_account_ids bigint[],
-                                         this_tenancy_organization_ids bigint[],
-                                         this_tenancy_workspace_ids bigint[],
+CREATE OR REPLACE FUNCTION in_tenancy_v1(read_tenancy jsonb,
+                                         row_tenancy_universal bool,
+                                         row_tenancy_billing_account_ids bigint[],
+                                         row_tenancy_organization_ids bigint[],
+                                         row_tenancy_workspace_ids bigint[],
                                          OUT result bool
 )
 AS
 $$
 DECLARE
-    check_tenancy_record  tenancy_record_v1;
-    empty_check           bool;
+    read_tenancy_record   tenancy_record_v1;
     universal_check       bool;
     billing_account_check bool;
     organization_check bool;
     workspace_check bool;
-    empty_billing_account_list bool;
-    empty_organization_list bool;
-    empty_workspace_list bool;
 BEGIN
-    check_tenancy_record := tenancy_json_to_columns_v1(check_tenancy);
-    RAISE DEBUG 'in_tenancy: % vs: u:% b:% o:% w:%', check_tenancy, this_tenancy_universal, this_tenancy_billing_account_ids, this_tenancy_organization_ids, this_tenancy_workspace_ids;
+    read_tenancy_record := tenancy_json_to_columns_v1(read_tenancy);
+    RAISE DEBUG 'in_tenancy: % vs: u:% b:% o:% w:%', read_tenancy, row_tenancy_universal, row_tenancy_billing_account_ids, row_tenancy_organization_ids, row_tenancy_workspace_ids;
 
-    empty_billing_account_list := cardinality(check_tenancy_record.tenancy_billing_account_ids) = 0;
-    RAISE DEBUG 'empty_billing_account_list: %', empty_billing_account_list;
-    empty_organization_list := cardinality(check_tenancy_record.tenancy_organization_ids) = 0;
-    RAISE DEBUG 'empty_organization_list: %', empty_organization_list;
-    empty_workspace_list := cardinality(check_tenancy_record.tenancy_workspace_ids) = 0;
-    RAISE DEBUG 'empty_workspace_list: %', empty_workspace_list;
-
-    empty_check := NOT (check_tenancy_record.tenancy_universal = false
-        AND empty_billing_account_list
-        AND empty_organization_list
-        AND empty_workspace_list);
-    RAISE DEBUG 'empty_check: %', empty_check;
-
-    universal_check := (check_tenancy_record.tenancy_universal AND check_tenancy_record.tenancy_universal = this_tenancy_universal);
+    universal_check := row_tenancy_universal AND row_tenancy_universal = read_tenancy_record.tenancy_universal;
     RAISE DEBUG 'universal_check: %', universal_check;
 
-    billing_account_check := (NOT empty_billing_account_list AND check_tenancy_record.tenancy_billing_account_ids <@ this_tenancy_billing_account_ids);
+    billing_account_check := read_tenancy_record.tenancy_billing_account_ids && row_tenancy_billing_account_ids;
     RAISE DEBUG 'billing_account_check: %', billing_account_check;
 
-    organization_check := (NOT empty_organization_list AND check_tenancy_record.tenancy_organization_ids <@ this_tenancy_organization_ids);
+    organization_check := read_tenancy_record.tenancy_organization_ids && row_tenancy_organization_ids;
     RAISE DEBUG 'organization_check: %', organization_check;
 
-    workspace_check := (NOT empty_workspace_list AND check_tenancy_record.tenancy_workspace_ids <@ this_tenancy_workspace_ids);
+    workspace_check := read_tenancy_record.tenancy_workspace_ids && row_tenancy_workspace_ids;
     RAISE DEBUG 'workspace_check: %', workspace_check;
 
-    result := (empty_check
-        AND (
-                       universal_check
-                       OR
-                       billing_account_check
-                       OR
-                       organization_check
-                       OR
-                       workspace_check
-                   )
-        );
+    result := (universal_check OR billing_account_check OR organization_check OR workspace_check);
     RAISE DEBUG 'tenancy check result: %', result;
 END ;
 $$ LANGUAGE PLPGSQL IMMUTABLE;

--- a/lib/dal/src/queries/component_get_workspace.sql
+++ b/lib/dal/src/queries/component_get_workspace.sql
@@ -1,9 +1,0 @@
-SELECT DISTINCT ON (workspaces.id) workspaces.id,
-                              workspaces.visibility_change_set_pk,
-                              workspaces.visibility_edit_session_pk,
-                              row_to_json(workspaces.*) AS object
-FROM workspaces
-WHERE workspaces.id = $1
-  AND is_visible_v1($2, workspaces.visibility_change_set_pk, workspaces.visibility_edit_session_pk, workspaces.visibility_deleted)
-ORDER BY id DESC, visibility_change_set_pk DESC, visibility_edit_session_pk DESC
-LIMIT 1;

--- a/lib/dal/src/queries/read_tenancy_get_billing_account.sql
+++ b/lib/dal/src/queries/read_tenancy_get_billing_account.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT ON (billing_accounts.id) billing_accounts.id,
+                              row_to_json(billing_accounts.*) AS object
+FROM billing_accounts
+INNER JOIN organization_belongs_to_billing_account
+  ON organization_belongs_to_billing_account.belongs_to_id = billing_accounts.id
+WHERE organization_belongs_to_billing_account.object_id = $1
+ORDER BY billing_accounts.id DESC;

--- a/lib/dal/src/queries/read_tenancy_get_workspace.sql
+++ b/lib/dal/src/queries/read_tenancy_get_workspace.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT ON (workspaces.id) workspaces.id,
+                              row_to_json(workspaces.*) AS object
+FROM workspaces
+WHERE workspaces.id = $1
+ORDER BY id DESC
+LIMIT 1;

--- a/lib/dal/src/read_tenancy.rs
+++ b/lib/dal/src/read_tenancy.rs
@@ -1,0 +1,168 @@
+use serde::{Deserialize, Serialize};
+use si_data::{PgError, PgTxn};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    standard_model, BillingAccount, BillingAccountId, OrganizationId, StandardModel,
+    StandardModelError, Tenancy, Workspace, WorkspaceError, WorkspaceId,
+};
+
+const GET_WORKSPACE: &str = include_str!("./queries/read_tenancy_get_workspace.sql");
+const GET_BILLING_ACCOUNT: &str = include_str!("./queries/read_tenancy_get_billing_account.sql");
+
+#[derive(Error, Debug)]
+pub enum ReadTenancyError {
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModel(#[from] StandardModelError),
+    #[error("workspace error: {0}")]
+    Workspace(#[from] WorkspaceError),
+    #[error("workspace not found error: {0}")]
+    WorkspaceNotFound(WorkspaceId),
+    #[error("organization not found for workspace error: {0}")]
+    OrganizationNotFoundForWorkspace(WorkspaceId),
+    #[error("billing account not found for organization error: {0}")]
+    BillingAccountNotFoundForOrganization(OrganizationId),
+}
+
+pub type ReadTenancyResult<T> = Result<T, ReadTenancyError>;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+pub struct ReadTenancy {
+    #[serde(rename = "tenancy_universal")]
+    universal: bool,
+    #[serde(rename = "tenancy_billing_account_ids")]
+    billing_account_ids: Vec<BillingAccountId>,
+    #[serde(rename = "tenancy_organization_ids")]
+    organization_ids: Vec<OrganizationId>,
+    #[serde(rename = "tenancy_workspace_ids")]
+    workspace_ids: Vec<WorkspaceId>,
+}
+
+impl ReadTenancy {
+    pub fn billing_accounts(&self) -> &[BillingAccountId] {
+        &self.billing_account_ids
+    }
+
+    pub fn new_universal() -> Self {
+        Self {
+            universal: true,
+            billing_account_ids: Vec::new(),
+            organization_ids: Vec::new(),
+            workspace_ids: Vec::new(),
+        }
+    }
+
+    pub fn new_billing_account(billing_account_ids: Vec<BillingAccountId>) -> Self {
+        Self {
+            universal: true,
+            billing_account_ids,
+            organization_ids: Vec::new(),
+            workspace_ids: Vec::new(),
+        }
+    }
+
+    pub async fn new_organization(
+        txn: &PgTxn<'_>,
+        organization_ids: Vec<OrganizationId>,
+    ) -> ReadTenancyResult<Self> {
+        let mut billing_account_ids = Vec::with_capacity(organization_ids.len());
+        for organization_id in &organization_ids {
+            let rows = txn.query(GET_BILLING_ACCOUNT, &[organization_id]).await?;
+            let billing_accounts: Vec<BillingAccount> = standard_model::objects_from_rows(rows)?;
+
+            if billing_accounts.is_empty() {
+                return Err(ReadTenancyError::BillingAccountNotFoundForOrganization(
+                    *organization_id,
+                ));
+            }
+            for billing_account in billing_accounts {
+                billing_account_ids.push(*billing_account.id());
+            }
+        }
+        Ok(Self {
+            universal: true,
+            billing_account_ids,
+            organization_ids,
+            workspace_ids: Vec::new(),
+        })
+    }
+
+    pub async fn new_workspace(
+        txn: &PgTxn<'_>,
+        workspace_ids: Vec<WorkspaceId>,
+    ) -> ReadTenancyResult<Self> {
+        let mut organization_ids = Vec::with_capacity(workspace_ids.len());
+
+        for workspace_id in &workspace_ids {
+            let row = txn.query_opt(GET_WORKSPACE, &[workspace_id]).await?;
+            match standard_model::option_object_from_row::<Workspace>(row)? {
+                None => return Err(ReadTenancyError::WorkspaceNotFound(*workspace_id)),
+                Some(workspace) => {
+                    let visibility = workspace.visibility();
+                    if let Some(organization) = workspace.organization(txn, visibility).await? {
+                        organization_ids.push(*organization.id());
+                    } else {
+                        return Err(ReadTenancyError::OrganizationNotFoundForWorkspace(
+                            *workspace_id,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut tenancy = Self::new_organization(txn, organization_ids).await?;
+        tenancy.workspace_ids = workspace_ids;
+        Ok(tenancy)
+    }
+
+    #[instrument(skip_all)]
+    pub async fn check(&self, txn: &PgTxn<'_>, check_tenancy: &Tenancy) -> ReadTenancyResult<bool> {
+        let row = txn
+            .query_one(
+                "SELECT result FROM in_tenancy_v1($1, $2, $3, $4, $5)",
+                &[
+                    self,
+                    &check_tenancy.universal,
+                    &check_tenancy.billing_account_ids,
+                    &check_tenancy.organization_ids,
+                    &check_tenancy.workspace_ids,
+                ],
+            )
+            .await?;
+        let result = row.try_get("result")?;
+        Ok(result)
+    }
+}
+
+impl postgres_types::ToSql for ReadTenancy {
+    fn to_sql(
+        &self,
+        ty: &postgres_types::Type,
+        out: &mut postgres_types::private::BytesMut,
+    ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let json = serde_json::to_value(self)?;
+        postgres_types::ToSql::to_sql(&json, ty, out)
+    }
+
+    fn accepts(ty: &postgres_types::Type) -> bool
+    where
+        Self: Sized,
+    {
+        ty == &postgres_types::Type::JSONB
+    }
+
+    fn to_sql_checked(
+        &self,
+        ty: &postgres_types::Type,
+        out: &mut postgres_types::private::BytesMut,
+    ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        let json = serde_json::to_value(self)?;
+        postgres_types::ToSql::to_sql(&json, ty, out)
+    }
+}

--- a/lib/dal/src/tenancy.rs
+++ b/lib/dal/src/tenancy.rs
@@ -86,12 +86,12 @@ impl Tenancy {
     }
 
     #[instrument(skip_all)]
-    pub async fn check(&self, txn: &PgTxn<'_>, check_tenancy: &Tenancy) -> TenancyResult<bool> {
+    pub async fn check(&self, txn: &PgTxn<'_>, read_tenancy: &Tenancy) -> TenancyResult<bool> {
         let row = txn
             .query_one(
                 "SELECT result FROM in_tenancy_v1($1, $2, $3, $4, $5)",
                 &[
-                    &check_tenancy,
+                    read_tenancy,
                     &self.universal,
                     &self.billing_account_ids,
                     &self.organization_ids,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -470,6 +470,16 @@ async fn get_resource_by_component_id() {
     )
     .await
     .expect("cannot create organization");
+    organization
+        .set_billing_account(
+            &txn,
+            &nats,
+            &visibility,
+            &history_actor,
+            billing_account.id(),
+        )
+        .await
+        .expect("unable to set organization billing account");
 
     let mut workspace_tenancy = Tenancy::new_organization(vec![*organization.id()]);
     workspace_tenancy

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -22,6 +22,7 @@ mod prop;
 mod qualification_check;
 mod qualification_prototype;
 mod qualification_resolver;
+mod read_tenancy;
 mod resource;
 mod resource_prototype;
 mod resource_resolver;

--- a/lib/dal/tests/integration_test/read_tenancy.rs
+++ b/lib/dal/tests/integration_test/read_tenancy.rs
@@ -1,0 +1,483 @@
+use crate::test_setup;
+use dal::{
+    test_harness::billing_account_signup, BillingAccountId, OrganizationId, ReadTenancy,
+    StandardModel, Tenancy, WorkspaceId,
+};
+use test_env_log::test;
+
+#[test(tokio::test)]
+async fn check_organization_specific_billing_account() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let write_tenancy = Tenancy::new_organization(vec![*nba.organization.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_in_billing_account() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+        .await
+        .expect("unable to set organization read tenancy");
+    let write_tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_specific_billing_account() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let write_tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_in_billing_account() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+        .await
+        .expect("unable to set workspace read tenancy");
+    assert_eq!(tenancy.billing_accounts(), vec![*nba.billing_account.id()]);
+    let write_tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_specific_organization() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+        .await
+        .expect("unable to set organization read tenancy");
+    assert_eq!(tenancy.billing_accounts(), vec![*nba.billing_account.id()]);
+    let write_tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_in_organization() {
+    test_setup!(ctx, secret_key, _pg, _conn, txn, nats_conn, nats, _veritech, _encr_key);
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+
+    let tenancy = ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+        .await
+        .expect("unable to set workspace read tenancy");
+    let write_tenancy = Tenancy::new_organization(vec![*nba.organization.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_universal() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![BillingAccountId::from(-1)]);
+
+    let write_tenancy = Tenancy::new_empty();
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+
+    let write_tenancy = Tenancy::new_billing_account(vec![1.into()]);
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+
+    let write_tenancy = Tenancy::new_organization(vec![1.into()]);
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+
+    let write_tenancy = Tenancy::new_workspace(vec![1.into()]);
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+
+    let mut write_tenancy = Tenancy::new_empty();
+    write_tenancy.universal = true;
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+
+    let mut write_tenancy = Tenancy::new_billing_account(vec![1.into()]);
+    write_tenancy.universal = true;
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+
+    let mut write_tenancy = Tenancy::new_organization(vec![1.into()]);
+    write_tenancy.universal = true;
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+
+    let mut write_tenancy = Tenancy::new_workspace(vec![1.into()]);
+    write_tenancy.universal = true;
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_identical() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
+    let write_tenancy = Tenancy::new_billing_account(vec![1.into()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_overlapping() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![
+        1.into(),
+        2.into(),
+        3.into(),
+        4.into(),
+        5.into(),
+        6.into(),
+    ]);
+    let write_tenancy = Tenancy::new_billing_account(vec![2.into()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_reverse_overlapping() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![2.into()]);
+    let write_tenancy = Tenancy::new_billing_account(vec![
+        1.into(),
+        2.into(),
+        3.into(),
+        4.into(),
+        5.into(),
+        6.into(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_mismatched() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
+    let write_tenancy = Tenancy::new_billing_account(vec![2.into()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_mismatched_level() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
+    let write_tenancy = Tenancy::new_organization(vec![1.into()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_pk_identical() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+        .await
+        .expect("unable to set organization read tenancy");
+    let write_tenancy = Tenancy::new_organization(vec![*nba.organization.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_pk_overlapping() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba2, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba3, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_organization(
+        &txn,
+        vec![
+            *nba.organization.id(),
+            *nba2.organization.id(),
+            *nba3.organization.id(),
+        ],
+    )
+    .await
+    .expect("unable to set organization read tenancy");
+    let write_tenancy = Tenancy::new_organization(vec![*nba2.organization.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_pk_reverse_overlapping() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba2, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba3, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_organization(&txn, vec![*nba2.organization.id()])
+        .await
+        .expect("unable to set organization read tenancy");
+    let write_tenancy = Tenancy::new_organization(vec![
+        *nba.organization.id(),
+        *nba2.organization.id(),
+        *nba3.organization.id(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_pk_mismatched() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+        .await
+        .expect("unable to set organization read tenancy");
+    let write_tenancy = Tenancy::new_organization(vec![OrganizationId::from(-1)]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_pk_identical() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+        .await
+        .expect("unable to set workspace read tenancy");
+    let write_tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_pk_overlapping() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba2, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba3, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_workspace(
+        &txn,
+        vec![
+            *nba.workspace.id(),
+            *nba2.workspace.id(),
+            *nba3.workspace.id(),
+        ],
+    )
+    .await
+    .expect("unable to set workspace read tenancy");
+    let write_tenancy = Tenancy::new_workspace(vec![*nba2.workspace.id()]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_pk_reverse_overlapping() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba2, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let (nba3, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_workspace(&txn, vec![*nba2.workspace.id()])
+        .await
+        .expect("unable to set workspace read tenancy");
+    let write_tenancy = Tenancy::new_workspace(vec![
+        *nba.workspace.id(),
+        *nba2.workspace.id(),
+        *nba3.workspace.id(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_pk_mismatched() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let tenancy = ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+        .await
+        .expect("unable to set workspace read tenancy");
+    let write_tenancy = Tenancy::new_workspace(vec![WorkspaceId::from(-1)]);
+
+    let check = tenancy
+        .check(&txn, &write_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(!check);
+}

--- a/lib/dal/tests/integration_test/tenancy.rs
+++ b/lib/dal/tests/integration_test/tenancy.rs
@@ -17,10 +17,10 @@ async fn check_universal() {
     );
 
     let tenancy = Tenancy::new_universal();
-    let check_tenancy = tenancy.clone();
+    let read_tenancy = tenancy.clone();
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -41,10 +41,10 @@ async fn check_empty_always_fails() {
     );
 
     let tenancy = Tenancy::new_empty();
-    let check_tenancy = tenancy.clone();
+    let read_tenancy = tenancy.clone();
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(!check);
@@ -65,10 +65,10 @@ async fn check_billing_account_pk_identical() {
     );
 
     let tenancy = Tenancy::new_billing_account(vec![1.into()]);
-    let check_tenancy = tenancy.clone();
+    let read_tenancy = tenancy.clone();
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -96,10 +96,41 @@ async fn check_billing_account_pk_overlapping() {
         5.into(),
         6.into(),
     ]);
-    let check_tenancy = Tenancy::new_billing_account(vec![2.into()]);
+    let read_tenancy = Tenancy::new_billing_account(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_billing_account_pk_reverse_overlapping() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = Tenancy::new_billing_account(vec![2.into()]);
+    let read_tenancy = Tenancy::new_billing_account(vec![
+        1.into(),
+        2.into(),
+        3.into(),
+        4.into(),
+        5.into(),
+        6.into(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -120,10 +151,10 @@ async fn check_billing_account_pk_mismatched() {
     );
 
     let tenancy = Tenancy::new_billing_account(vec![1.into()]);
-    let check_tenancy = Tenancy::new_billing_account(vec![2.into()]);
+    let read_tenancy = Tenancy::new_billing_account(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(!check);
@@ -143,11 +174,11 @@ async fn check_billing_account_pk_mismatched_level() {
         _encr_key
     );
 
-    let tenancy = Tenancy::new_billing_account(vec![1.into()]);
-    let check_tenancy = Tenancy::new_organization(vec![1.into()]);
+    let tenancy = Tenancy::new_organization(vec![1.into()]);
+    let read_tenancy = Tenancy::new_billing_account(vec![1.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(!check);
@@ -168,10 +199,10 @@ async fn check_organization_pk_identical() {
     );
 
     let tenancy = Tenancy::new_organization(vec![1.into()]);
-    let check_tenancy = tenancy.clone();
+    let read_tenancy = tenancy.clone();
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -199,10 +230,41 @@ async fn check_organization_pk_overlapping() {
         5.into(),
         6.into(),
     ]);
-    let check_tenancy = Tenancy::new_organization(vec![2.into()]);
+    let read_tenancy = Tenancy::new_organization(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_organization_pk_reverse_overlapping() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = Tenancy::new_organization(vec![2.into()]);
+    let read_tenancy = Tenancy::new_organization(vec![
+        1.into(),
+        2.into(),
+        3.into(),
+        4.into(),
+        5.into(),
+        6.into(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -223,10 +285,10 @@ async fn check_organization_pk_mismatched() {
     );
 
     let tenancy = Tenancy::new_organization(vec![1.into()]);
-    let check_tenancy = Tenancy::new_organization(vec![2.into()]);
+    let read_tenancy = Tenancy::new_organization(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(!check);
@@ -247,10 +309,10 @@ async fn check_workspace_pk_identical() {
     );
 
     let tenancy = Tenancy::new_workspace(vec![1.into()]);
-    let check_tenancy = tenancy.clone();
+    let read_tenancy = tenancy.clone();
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -278,10 +340,41 @@ async fn check_workspace_pk_overlapping() {
         5.into(),
         6.into(),
     ]);
-    let check_tenancy = Tenancy::new_workspace(vec![2.into()]);
+    let read_tenancy = Tenancy::new_workspace(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
+        .await
+        .expect("cannot check tenancy");
+    assert!(check);
+}
+
+#[test(tokio::test)]
+async fn check_workspace_pk_reverse_overlapping() {
+    test_setup!(
+        ctx,
+        _secret_key,
+        pg,
+        conn,
+        txn,
+        nats_conn,
+        _nats,
+        _veritech,
+        _encr_key
+    );
+
+    let tenancy = Tenancy::new_workspace(vec![2.into()]);
+    let read_tenancy = Tenancy::new_workspace(vec![
+        1.into(),
+        2.into(),
+        3.into(),
+        4.into(),
+        5.into(),
+        6.into(),
+    ]);
+
+    let check = tenancy
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
@@ -302,10 +395,10 @@ async fn check_workspace_pk_mismatched() {
     );
 
     let tenancy = Tenancy::new_workspace(vec![1.into()]);
-    let check_tenancy = Tenancy::new_workspace(vec![2.into()]);
+    let read_tenancy = Tenancy::new_workspace(vec![2.into()]);
 
     let check = tenancy
-        .check(&txn, &check_tenancy)
+        .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(!check);


### PR DESCRIPTION
It's always universal, and it always obtains the less specific parent if
available (providing workspace_id means organizations and billing_accounts
for that workspaces will be attached too).

Also strips the same logic from component as we need to climb the tree
from workspace to billing account and ReadTenancy does that by default.

Made tenancies match on intersection instead of only accepting subsets,
renamed variables and removed redundant checks in `in_teancy_v1`.

While enabling some tests I had ignored I ended up fixing a cyclone
encryption test that had a typo.

<img src="https://media4.giphy.com/media/8dYmJ6Buo3lYY/giphy.gif"/>