### PR TITLE
chore(ci): remove make backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,9 +221,8 @@ clean-containers: clean-dev-deps
 	cd ./components/si-web-app && $(MAKE) clean-container
 .PHONY: clean-containers
 
-# TODO(nick): The below targets are to be used during the transition period between the
-# Vue 2 to Vue 3 rewrite. These targets should be merged into existing ones once the transition is
-# complete.
+# TODO(nick): The below targets are to be used during the transition period between the Vue 2 to
+# Vue 3 rewrite. These targets should be merged into existing ones once the transition is complete.
 
 down:
 	-cd $(MAKEPATH)/deploy && $(MAKE) down
@@ -235,20 +234,14 @@ prepare: down
 	cd $(MAKEPATH)/deploy && $(MAKE) partial
 .PHONY: prepare
 
-backend: down
-	cd $(MAKEPATH)/bin/lang-js; npm install
-	cd $(MAKEPATH)/bin/lang-js; npm run package
-	cd $(MAKEPATH)/deploy && $(MAKE) backend
-.PHONY: backend
-
 veritech-run:
-	cd $(MAKEPATH); cargo build
+	cd $(MAKEPATH); cargo build --all
 	cd $(MAKEPATH); cargo build --bin cyclone
 	cd $(MAKEPATH)/bin/veritech; cargo run
 .PHONY: veritech-run
 
 sdf-run:
-	cd $(MAKEPATH); cargo build
+	cd $(MAKEPATH); cargo build --all
 	cd $(MAKEPATH); cargo run --bin sdf -- --disable-opentelemetry
 .PHONY: sdf-run
 
@@ -268,3 +261,11 @@ troubleshoot: down
 deploy-prod:
 	@$(MAKEPATH)/scripts/deploy-prod.sh
 .PHONY: deploy-prod
+
+lint:
+	cd $(MAKEPATH)/ci && $(MAKE) ci-lint
+.PHONY: lint
+
+tidy:
+	cd $(MAKEPATH)/ci && $(MAKE) tidy
+.PHONY: tidy

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ These targets include code linting, formatting, running CI locally, etc.
 For instance, you can tidy up your Rust code before opening a pull request by executing the following:
 
 ```bash
-( cd ci; make tidy )
+make tidy
 ```
 
 To verify that all lints will pass in CI, execute the following target:
 
 ```bash
-( cd ci; make ci-lint )
+make lint
 ```
 
 You can also run individual tests before bringing up the entire SI stack, as neeeded.
@@ -133,28 +133,6 @@ This can be done in the root of the repository:
 make prepare
 cargo build
 RUST_BACKTRACE=1 cargo test <your-test-name>
-```
-
-## UI Development
-
-Are you only working on the UI?
-You can execute the following target to get started:
-
-```bash
-make backend
-```
-
-Now, everything but the web application should be running.
-You can run the web application manually, or with the following target:
-
-```bash
-make app-run
-```
-
-You can teardown everything with the same target that the **Quickstart** guide uses.
-
-```bash
-make down
 ```
 
 ## Writing Documentation

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -15,18 +15,6 @@ partial: init
 			-f $(MAKEPATH)/docker-compose.env.yml \
 		up -d nats pg otel
 
-# Run this target alongside local developer builds of web.
-# This target does not compose down beforehand. This is especially helpful for iterating on the UI
-# without having to build backend components.
-backend: init
-	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-	REPOPATH=$(REPOPATH) \
-		docker-compose \
-			-f $(MAKEPATH)/docker-compose.yml \
-			-f $(MAKEPATH)/docker-compose.env.yml \
-			-f $(MAKEPATH)/docker-compose.backend.yml \
-		up -d nats pg otel sdf veritech
-
 # Run interactively and compose down beforehand. This target is meant to be run iteratively for
 # local development and testing.
 dev: down init


### PR DESCRIPTION
- Remove make backend targets and documentation since SI development
  does not need them
- Put make lint and make tidy targets in the root Makefile with
  documentation for them