### PR TITLE
feat(dal,sdf): Convert tenancies, refactor some DAL leafs

### DIFF
--- a/lib/dal/src/billing_account.rs
+++ b/lib/dal/src/billing_account.rs
@@ -254,7 +254,7 @@ impl BillingAccount {
         let organization = Organization::new(
             txn,
             nats,
-            &billing_account_tenancy,
+            &(&billing_account_tenancy).into(),
             visibility,
             &user_history_actor,
             "default",

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -301,7 +301,7 @@ impl Component {
         let node = Node::new(
             txn,
             nats,
-            tenancy,
+            &tenancy.into(),
             visibility,
             history_actor,
             &NodeKind::Component,
@@ -317,7 +317,7 @@ impl Component {
         let _edge = Edge::include_component_in_system(
             txn,
             nats,
-            tenancy,
+            &tenancy.into(),
             visibility,
             history_actor,
             component.id(),
@@ -1439,9 +1439,13 @@ impl Component {
         let mut tenancy = tenancy.clone();
         tenancy.universal = true;
 
-        let parent_ids =
-            Edge::find_component_configuration_parents(txn, &tenancy, visibility, self.id())
-                .await?;
+        let parent_ids = Edge::find_component_configuration_parents(
+            txn,
+            &tenancy.clone_into_read_tenancy(txn).await?,
+            visibility,
+            self.id(),
+        )
+        .await?;
         let mut parents = Vec::with_capacity(parent_ids.len());
         for id in parent_ids {
             let view =
@@ -1517,9 +1521,13 @@ impl Component {
         let mut tenancy = tenancy.clone();
         tenancy.universal = true;
 
-        let parent_ids =
-            Edge::find_component_configuration_parents(txn, &tenancy, visibility, self.id())
-                .await?;
+        let parent_ids = Edge::find_component_configuration_parents(
+            txn,
+            &tenancy.clone_into_read_tenancy(txn).await?,
+            visibility,
+            self.id(),
+        )
+        .await?;
 
         let mut parents = Vec::new();
         for id in parent_ids {

--- a/lib/dal/src/system.rs
+++ b/lib/dal/src/system.rs
@@ -166,7 +166,7 @@ impl System {
         let node = Node::new(
             txn,
             nats,
-            tenancy,
+            &tenancy.into(),
             visibility,
             history_actor,
             &NodeKind::System,

--- a/lib/dal/src/tenancy.rs
+++ b/lib/dal/src/tenancy.rs
@@ -3,7 +3,7 @@ use si_data::{PgError, PgTxn};
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::{BillingAccountId, OrganizationId, WorkspaceId};
+use crate::{BillingAccountId, OrganizationId, ReadTenancy, ReadTenancyError, WorkspaceId};
 
 #[derive(Error, Debug)]
 pub enum TenancyError {
@@ -101,6 +101,18 @@ impl Tenancy {
             .await?;
         let result = row.try_get("result")?;
         Ok(result)
+    }
+
+    pub fn into_universal(mut self) -> Self {
+        self.universal = true;
+        self
+    }
+
+    pub async fn clone_into_read_tenancy(
+        &self,
+        txn: &PgTxn<'_>,
+    ) -> Result<ReadTenancy, ReadTenancyError> {
+        ReadTenancy::try_from_tenancy(txn, self.clone()).await
     }
 }
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -356,7 +356,7 @@ pub async fn create_organization(
     history_actor: &HistoryActor,
 ) -> Organization {
     let name = generate_fake_name();
-    Organization::new(txn, nats, tenancy, visibility, history_actor, &name)
+    Organization::new(txn, nats, &tenancy.into(), visibility, history_actor, &name)
         .await
         .expect("cannot create organization")
 }
@@ -708,9 +708,16 @@ pub async fn create_node(
     history_actor: &HistoryActor,
     node_kind: &NodeKind,
 ) -> Node {
-    let node = Node::new(txn, nats, tenancy, visibility, history_actor, node_kind)
-        .await
-        .expect("cannot create node");
+    let node = Node::new(
+        txn,
+        nats,
+        &tenancy.into(),
+        visibility,
+        history_actor,
+        node_kind,
+    )
+    .await
+    .expect("cannot create node");
     node
 }
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -7,7 +7,7 @@ use dal::test_harness::{
 };
 use dal::{
     BillingAccount, Component, HistoryActor, Organization, Prop, PropKind, Resource, Schema,
-    SchemaKind, StandardModel, Tenancy, Visibility, Workspace,
+    SchemaKind, StandardModel, Tenancy, Visibility, Workspace, WriteTenancy,
 };
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 use serde_json::json;
@@ -459,7 +459,7 @@ async fn get_resource_by_component_id() {
     .await
     .expect("cannot create new billing account");
 
-    let organization_tenancy = Tenancy::new_billing_account(vec![*billing_account.id()]);
+    let organization_tenancy = WriteTenancy::new_billing_account(*billing_account.id());
     let organization = Organization::new(
         &txn,
         &nats,

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -86,7 +86,7 @@ async fn new() {
     let _edge = Edge::new(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         EdgeKind::Configures,
@@ -104,7 +104,10 @@ async fn new() {
 
     let parents = Edge::find_component_configuration_parents(
         &txn,
-        &tenancy,
+        &tenancy
+            .clone_into_read_tenancy(&txn)
+            .await
+            .expect("unable to generate read tenancy"),
         &visibility,
         head_component.id(),
     )

--- a/lib/dal/tests/integration_test/node_position.rs
+++ b/lib/dal/tests/integration_test/node_position.rs
@@ -34,7 +34,7 @@ async fn new() {
     let node_position = NodePosition::new(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         SchematicKind::Component,
@@ -85,7 +85,7 @@ async fn set_node() {
     let node_position = NodePosition::new(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         SchematicKind::Component,
@@ -151,7 +151,7 @@ async fn set_node_position() {
     let node_position = NodePosition::upsert_by_node_id(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         SchematicKind::Component,
@@ -182,7 +182,7 @@ async fn set_node_position() {
     let node_position = NodePosition::upsert_by_node_id(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         SchematicKind::Component,

--- a/lib/dal/tests/integration_test/organization.rs
+++ b/lib/dal/tests/integration_test/organization.rs
@@ -1,7 +1,7 @@
 use crate::test_setup;
 
 use dal::test_harness::{create_change_set, create_edit_session, create_visibility_edit_session};
-use dal::{HistoryActor, Organization, Tenancy};
+use dal::{HistoryActor, Organization, WriteTenancy};
 use test_env_log::test;
 
 #[test(tokio::test)]
@@ -17,15 +17,15 @@ async fn new() {
         _veritech,
         _encr_key
     );
-    let tenancy = Tenancy::new_universal();
+    let write_tenancy = WriteTenancy::new_universal();
     let history_actor = HistoryActor::SystemInit;
-    let change_set = create_change_set(&txn, &nats, &tenancy, &history_actor).await;
+    let change_set = create_change_set(&txn, &nats, &(&write_tenancy).into(), &history_actor).await;
     let edit_session = create_edit_session(&txn, &nats, &history_actor, &change_set).await;
     let visibility = create_visibility_edit_session(&change_set, &edit_session);
     let _organization = Organization::new(
         &txn,
         &nats,
-        &tenancy,
+        &write_tenancy,
         &visibility,
         &history_actor,
         "iron maiden",

--- a/lib/dal/tests/integration_test/read_tenancy.rs
+++ b/lib/dal/tests/integration_test/read_tenancy.rs
@@ -1,7 +1,7 @@
 use crate::test_setup;
 use dal::{
     test_harness::billing_account_signup, BillingAccountId, OrganizationId, ReadTenancy,
-    StandardModel, WorkspaceId, WriteTenancy,
+    StandardModel, Tenancy, WorkspaceId, WriteTenancy,
 };
 use test_env_log::test;
 
@@ -148,21 +148,21 @@ async fn check_universal() {
         .expect("cannot check tenancy");
     assert!(!check);
 
-    let mut write_tenancy = WriteTenancy::new_billing_account(1.into()).into_universal();
+    let write_tenancy = WriteTenancy::new_billing_account(1.into()).into_universal();
     let check = write_tenancy
         .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
 
-    let mut write_tenancy = WriteTenancy::new_organization(1.into()).into_universal();
+    let write_tenancy = WriteTenancy::new_organization(1.into()).into_universal();
     let check = write_tenancy
         .check(&txn, &read_tenancy)
         .await
         .expect("cannot check tenancy");
     assert!(check);
 
-    let mut write_tenancy = WriteTenancy::new_workspace(1.into()).into_universal();
+    let write_tenancy = WriteTenancy::new_workspace(1.into()).into_universal();
     let check = write_tenancy
         .check(&txn, &read_tenancy)
         .await
@@ -391,4 +391,64 @@ async fn check_workspace_pk_mismatched() {
         .await
         .expect("cannot check tenancy");
     assert!(!check);
+}
+
+#[test(tokio::test)]
+async fn into_tenancy() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    let read_tenancy = ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+        .await
+        .expect("unable to set workspace read read_tenancy");
+    let mut tenancy = Tenancy::new_workspace(vec![*nba.workspace.id()]);
+    tenancy.universal = true;
+    tenancy.organization_ids = vec![*nba.organization.id()];
+    tenancy.billing_account_ids = vec![*nba.billing_account.id()];
+    assert_eq!(Tenancy::from(&read_tenancy), tenancy);
+
+    let read_tenancy = ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+        .await
+        .expect("unable to set workspace read read_tenancy");
+    let mut tenancy = Tenancy::new_organization(vec![*nba.organization.id()]);
+    tenancy.universal = true;
+    tenancy.billing_account_ids = vec![*nba.billing_account.id()];
+    assert_eq!(Tenancy::from(&read_tenancy), tenancy);
+
+    let read_tenancy = ReadTenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    let mut tenancy = Tenancy::new_billing_account(vec![*nba.billing_account.id()]);
+    tenancy.universal = true;
+    assert_eq!(Tenancy::from(&read_tenancy), tenancy);
+}
+
+#[test(tokio::test)]
+async fn from_tenancy() {
+    test_setup!(ctx, secret_key, pg, conn, txn, nats_conn, nats, _veritech, _encr_key);
+
+    let (nba, _) = billing_account_signup(&txn, &nats, &secret_key).await;
+    assert_eq!(
+        ReadTenancy::new_workspace(&txn, vec![*nba.workspace.id()])
+            .await
+            .expect("unable to generate read tenancy"),
+        Tenancy::new_workspace(vec![*nba.workspace.id()])
+            .clone_into_read_tenancy(&txn)
+            .await
+            .expect("unable to convert to read tenancy")
+    );
+    assert_eq!(
+        ReadTenancy::new_organization(&txn, vec![*nba.organization.id()])
+            .await
+            .expect("unable to generate read tenancy"),
+        Tenancy::new_organization(vec![*nba.organization.id()])
+            .clone_into_read_tenancy(&txn)
+            .await
+            .expect("unable to convert to read tenancy")
+    );
+    assert_eq!(
+        ReadTenancy::new_billing_account(vec![*nba.billing_account.id()]),
+        Tenancy::new_billing_account(vec![*nba.billing_account.id()])
+            .clone_into_read_tenancy(&txn)
+            .await
+            .expect("unable to convert to read tenancy")
+    );
 }

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -72,7 +72,7 @@ async fn get_schematic() {
     let node_position = NodePosition::upsert_by_node_id(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         SchematicKind::Component,
@@ -87,7 +87,10 @@ async fn get_schematic() {
 
     let schematic = Schematic::find(
         &txn,
-        &tenancy,
+        &tenancy
+            .clone_into_read_tenancy(&txn)
+            .await
+            .expect("unable to generate read tenancy"),
         &visibility,
         Some(SystemId::from(1)),
         *root_node.id(),
@@ -177,7 +180,7 @@ async fn create_connection() {
     let connection = Connection::new(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &visibility,
         &history_actor,
         head_node.id(),

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -5,8 +5,8 @@ use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
 use dal::{
-    ComponentError, NodeError, NodeMenuError, NodePositionError, SchemaError as DalSchemaError,
-    SchematicError as DalSchematicError, StandardModelError,
+    ComponentError, NodeError, NodeMenuError, NodePositionError, ReadTenancyError,
+    SchemaError as DalSchemaError, SchematicError as DalSchematicError, StandardModelError,
 };
 use std::convert::Infallible;
 use thiserror::Error;
@@ -43,6 +43,10 @@ pub enum SchematicError {
     NodePosition(#[from] NodePositionError),
     #[error("dal schematic error: {0}")]
     SchematicError(#[from] DalSchematicError),
+    #[error("read tenancy error: {0}")]
+    ReadTenancy(#[from] ReadTenancyError),
+    #[error("not authorized")]
+    NotAuthorized,
 }
 
 pub type SchematicResult<T> = std::result::Result<T, SchematicError>;

--- a/lib/sdf/src/server/service/schematic/create_connection.rs
+++ b/lib/sdf/src/server/service/schematic/create_connection.rs
@@ -3,7 +3,10 @@ use crate::service::schematic::{SchematicError, SchematicResult};
 use axum::Json;
 use dal::node::NodeId;
 use dal::socket::SocketId;
-use dal::{Connection, HistoryActor, StandardModel, Tenancy, Visibility, Workspace, WorkspaceId};
+use dal::{
+    Connection, HistoryActor, StandardModel, Tenancy, Visibility, Workspace, WorkspaceId,
+    WriteTenancy,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -43,12 +46,12 @@ pub async fn create_connection(
     )
     .await?
     .ok_or(SchematicError::InvalidRequest)?;
-    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
+    let write_tenancy = WriteTenancy::new_workspace(*workspace.id());
 
     let connection = Connection::new(
         &txn,
         &nats,
-        &tenancy,
+        &write_tenancy,
         &request.visibility,
         &history_actor,
         &request.head_node_id,

--- a/lib/sdf/src/server/service/schematic/create_node.rs
+++ b/lib/sdf/src/server/service/schematic/create_node.rs
@@ -64,12 +64,9 @@ pub async fn create_node(
     )
     .await?;
 
-    let mut schema_tenancy = tenancy.clone();
-    schema_tenancy.universal = true;
-
     let node_template = NodeTemplate::new_from_schema_id(
         &txn,
-        &schema_tenancy,
+        &tenancy.clone_into_read_tenancy(&txn).await?,
         &request.visibility,
         request.schema_id,
     )
@@ -78,7 +75,7 @@ pub async fn create_node(
     let mut position = NodePosition::new(
         &txn,
         &nats,
-        &tenancy,
+        &(&tenancy).into(),
         &request.visibility,
         &history_actor,
         SchematicKind::Component,

--- a/lib/sdf/src/server/service/schematic/set_node_position.rs
+++ b/lib/sdf/src/server/service/schematic/set_node_position.rs
@@ -4,7 +4,7 @@ use axum::Json;
 use dal::node::NodeId;
 use dal::{
     HistoryActor, NodePosition, SchematicKind, StandardModel, SystemId, Tenancy, Visibility,
-    Workspace, WorkspaceId,
+    Workspace, WorkspaceId, WriteTenancy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -47,12 +47,12 @@ pub async fn set_node_position(
     )
     .await?
     .ok_or(SchematicError::InvalidRequest)?;
-    let tenancy = Tenancy::new_workspace(vec![*workspace.id()]);
 
+    let write_tenancy = WriteTenancy::new_workspace(*workspace.id());
     let position = NodePosition::upsert_by_node_id(
         &txn,
         &nats,
-        &tenancy,
+        &write_tenancy,
         &request.visibility,
         &history_actor,
         request.schematic_kind,


### PR DESCRIPTION
The conversion between ReadTenancy, WriteTenancy and Tenancy will help
us move from a era where only Tenancy existed to one where only
(Read/Write)Tenancy exist.

We refactored a few DAL leaf functions, the conversion was used to
preserve the boundary. Originally we thought about receiving
`impl Into<(Read/Write)Tenancy>`, but Read needs txn and is await,
and Write gets a little awkward with cloning ergonomy, so we decided to
be explicit on the conversions.

<img src="https://media1.giphy.com/media/PfU0R7E4hhWBhZAhJ9/giphy.gif"/>