### PR TITLE
fix(web): fix eslint warnings

### DIFF
--- a/app/web/src/api/sdf/dal/edit_field.ts
+++ b/app/web/src/api/sdf/dal/edit_field.ts
@@ -26,7 +26,10 @@ export interface TextWidgetDal {
 
 export interface SelectWidgetDal {
   kind: "Select";
-  options: LabelList<unknown>;
+  options: {
+    options: LabelList<unknown>;
+    default?: unknown;
+  };
   default?: unknown;
 }
 

--- a/app/web/src/atoms/SiTextBox.vue
+++ b/app/web/src/atoms/SiTextBox.vue
@@ -45,11 +45,6 @@ import { computed } from "vue";
 import VueFeather from "vue-feather";
 
 const props = defineProps({
-  name: {
-    type: String,
-    // NOTE(nick): name is currently unused, so it is not required, unlike in old-web.
-    required: false,
-  },
   size: {
     type: String as () => "xs" | "sm" | "base" | "lg",
     default: "base",

--- a/app/web/src/atoms/Unset.vue
+++ b/app/web/src/atoms/Unset.vue
@@ -8,11 +8,11 @@
 </template>
 
 <script setup lang="ts">
-import type { EditFieldValue } from "@/api/sdf/dal/edit_field";
+import type { EditFieldValues } from "@/api/sdf/dal/edit_field";
 import VueFeather from "vue-feather";
 
 const props = defineProps<{
-  editValue?: EditFieldValue;
+  editValue?: EditFieldValues;
   unset: () => void;
 }>();
 </script>

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -7,7 +7,7 @@
     <template #name>{{ props.editField.name }}</template>
     <template #edit>
       <input
-        v-model="currentValue"
+        v-model="inputValue"
         class="pl-2 text-sm leading-tight text-gray-400 border border-solid focus:outline-none input-bg-color-grey si-property disabled:opacity-50"
         :class="borderColor"
         type="checkbox"

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -26,7 +26,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { EditFields } from "@/api/sdf/dal/edit_field";
+import type {
+  EditFields,
+  EditField,
+  HeaderWidgetDal,
+} from "@/api/sdf/dal/edit_field";
+import { EditFieldDataType } from "@/api/sdf/dal/edit_field";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
 import {
   InitialTreeOpenStateVisitor,
@@ -41,12 +46,20 @@ const props = defineProps<{
  * Returns core edit fields that are *not* component properties
  */
 const coreEditFields = computed(() => {
-  let fields = [];
-  props.editFields.forEach((root) =>
-    root.widget.options.edit_fields
-      .filter((p) => p.name === "si")
-      .forEach((p) => (fields = fields.concat(p.widget.options.edit_fields))),
-  );
+  let fields: Array<EditField> = [];
+  props.editFields.forEach((root) => {
+    if (root.data_type === EditFieldDataType.Object) {
+      const widget = root.widget as HeaderWidgetDal;
+      widget.options.edit_fields
+        .filter((p) => p.name === "si")
+        .forEach((p) => {
+          if (p.data_type === EditFieldDataType.Object) {
+            const w = p.widget as HeaderWidgetDal;
+            fields = fields.concat(w.options.edit_fields);
+          }
+        });
+    }
+  });
   return fields;
 });
 
@@ -54,12 +67,20 @@ const coreEditFields = computed(() => {
  * Returns edit fields are component properties
  */
 const propertyEditFields = computed(() => {
-  let fields = [];
-  props.editFields.forEach((root) =>
-    root.widget.options.edit_fields
-      .filter((p) => p.name === "domain")
-      .forEach((p) => (fields = fields.concat(p.widget.options.edit_fields))),
-  );
+  let fields: Array<EditField> = [];
+  props.editFields.forEach((root) => {
+    if (root.data_type === EditFieldDataType.Object) {
+      const widget = root.widget as HeaderWidgetDal;
+      widget.options.edit_fields
+        .filter((p) => p.name === "domain")
+        .forEach((p) => {
+          if (p.data_type === EditFieldDataType.Object) {
+            const w = p.widget as HeaderWidgetDal;
+            fields = fields.concat(w.options.edit_fields);
+          }
+        });
+    }
+  });
   return fields;
 });
 

--- a/app/web/src/service/ws_event.ts
+++ b/app/web/src/service/ws_event.ts
@@ -7,6 +7,7 @@ import {
 } from "@/observable/change_set";
 import { eventEditSessionSaved$ } from "@/observable/edit_session";
 import { eventResourceSynced$ } from "@/observable/resource";
+import { eventSecretCreated$ } from "@/observable/secret";
 
 const eventMap: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,6 +18,7 @@ const eventMap: {
   ChangeSetCanceled: eventChangeSetCanceled$,
   EditSessionSaved: eventEditSessionSaved$,
   ResourceSynced: eventResourceSynced$,
+  SecretCreated: eventSecretCreated$,
 };
 
 export function dispatch(wsEvent: WsEvent<WsPayloadKinds>) {


### PR DESCRIPTION
This is an attempt to fix the warnings #793 targeted and a few others created after without breaking the runtime (it mostly was a mismatch between what came from the wire and what typescript expected).

<img src="https://media2.giphy.com/media/13aSSyJaI5NkTm/giphy.gif"/>