### PR TITLE
chore(dal,sdf): add `HandlerContext` & request ctx builder extractors

### DIFF
--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -1,14 +1,16 @@
-use axum::body::{Bytes, Full};
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::routing::{get, post};
-use axum::Json;
-use axum::Router;
-use dal::{
-    ComponentError as DalComponentError, ComponentId, SchemaError, StandardModelError, SystemId,
-    WsEventError,
-};
 use std::convert::Infallible;
+
+use axum::{
+    body::{Bytes, Full},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use dal::{
+    context::TransactionsError, ComponentError as DalComponentError, ComponentId, SchemaError,
+    StandardModelError, SystemId, WsEventError,
+};
 use thiserror::Error;
 
 pub mod get_code;
@@ -25,7 +27,7 @@ pub enum ComponentError {
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error(transparent)]
-    PgPool(#[from] si_data::PgPoolError),
+    Transactions(#[from] TransactionsError),
     #[error(transparent)]
     StandardModel(#[from] StandardModelError),
     #[error("entity error: {0}")]


### PR DESCRIPTION
This change hadds 2 new SDF axum extractors for route handler functions:

* `HandlerContext(builder, mut txns): HandlerContext` - extracts a
  `DalContextBuilder` and a new `Transactions` type that can start
  PostgreSQL and NATS transactions (and commit/rollback together)
* `AccessBuilder(request_ctx): AccessBuilder` - extracts a new
  `AccessBuilder` builder that has tenancies and a history_actor read to
  use and builds a `RequestContext` with a `Visibility`

Additionally this ships a few smaller related refactorings:

* Alter the `DalContextBuilder` to own a `ServicesContext` rather than
  borrowing one.
* Update the `DalContextBuilder` to not consume itself when a
  `DalContext` is created, allowing for multiple `DalContext`'s to be
  created.
* Add a `Transactions` type to move the atomically-related transactions
  around together while still exposing accessors to each member field.
* Update the `Rejection` types for our SDF axum extractors. All
  extractors now reject with a `(StatusCode, Json<serde_json::Value>)`
  consistently, which helped to reuse them and work better with the
  question mark operator when dealing with error cases.
* Add several error converting helper functions in the `extract` module,
  which all help to return a more unified JSON error message and
  correct/appropriate HTTP response code.

<img src="https://media0.giphy.com/media/xZsLh7B3KMMyUptD9D/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>