### PR TITLE
feat(sdf): use a configurable Tokio runtime with larger stack size

### DIFF
--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -8,8 +8,17 @@ use telemetry::{
 
 mod args;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
+
+fn main() -> Result<()> {
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> Result<()> {
     color_eyre::install()?;
     let config = telemetry::Config::builder()
         .service_name("sdf")


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/xTiTndRhkTeDSUEgak/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>