### PR TITLE
feat(dal/web): Split schematic panels + better reactivity

### DIFF
--- a/app/web/src/organisims/Application/ApplicationView.vue
+++ b/app/web/src/organisims/Application/ApplicationView.vue
@@ -69,6 +69,7 @@ import {
 } from "vue-router";
 import { ChangeSetService } from "@/service/change_set";
 import { refFrom, untilUnmounted } from "vuse-rx";
+import { switchToHead } from "@/service/change_set/switch_to_head";
 import _ from "lodash";
 import { ApplicationService } from "@/service/application";
 import { setIfError } from "@/service/global_error";
@@ -111,6 +112,7 @@ const leave = () => {
   if (navDestination.value) {
     unsavedChangesModalShow.value = false;
     reallyLeave.value = true;
+    switchToHead();
     router
       .push(navDestination.value)
       .catch((err) => console.log("route error", { err }));

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/selection.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/selection.ts
@@ -1,4 +1,5 @@
-import { selection$ } from "../../state";
+import * as Rx from "rxjs";
+
 import { Node } from "../obj";
 
 export class SelectionManager {
@@ -9,23 +10,24 @@ export class SelectionManager {
   }
 
   // Selection should not be cleared when the schematic updates.
-  select(node: Node): void {
+  select(node: Node, selection$?: Rx.ReplaySubject<Array<Node> | null>): void {
     if (this.selection.length > 0) {
       this.clearSelection();
     }
+
     node.select();
     node.zIndex += 1;
     this.selection.push(node);
-    selection$.next(this.selection);
+    if (selection$) selection$.next(this.selection);
   }
 
-  clearSelection(): void {
-    for (let i = 0; i < this.selection.length; i++) {
-      this.selection[i].deselect();
-      this.selection[i].zIndex -= 1;
-      delete this.selection[i];
+  clearSelection(selection$?: Rx.ReplaySubject<Array<Node> | null>): void {
+    for (const selection of this.selection) {
+      selection.deselect();
+      selection.zIndex -= 1;
     }
     this.selection = [];
-    selection$.next(null);
+
+    if (selection$) selection$.next(null);
   }
 }

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -21,6 +21,7 @@ export class SchematicDataManager {
   connectionCreate$: Rx.ReplaySubject<ConnectionCreate | null>;
   nodeCreate$: Rx.ReplaySubject<NodeCreate | null>;
   editorContext$: Rx.ReplaySubject<EditorContext | null>;
+  schematicKind$: Rx.ReplaySubject<SchematicKind | null>;
 
   constructor() {
     this.id = _.uniqueId();
@@ -42,6 +43,9 @@ export class SchematicDataManager {
     this.editorContext$ = new Rx.ReplaySubject<EditorContext | null>(1);
     this.editorContext$.next(null);
 
+    this.schematicKind$ = new Rx.ReplaySubject<SchematicKind | null>(1);
+    this.schematicKind$.next(null);
+
     this.initialize();
   }
 
@@ -53,9 +57,10 @@ export class SchematicDataManager {
 
   async updateNodePosition(nodeUpdate: NodeUpdate | null): Promise<void> {
     const editorContext = await Rx.firstValueFrom(this.editorContext$);
+    const schematicKind = await Rx.firstValueFrom(this.schematicKind$);
     if (nodeUpdate && editorContext) {
       SchematicService.setNodePosition({
-        schematicKind: SchematicKind.Component,
+        schematicKind,
         x: `${nodeUpdate.position.x}`,
         y: `${nodeUpdate.position.y}`,
         nodeId: nodeUpdate.nodeId,

--- a/app/web/src/organisims/SchematicViewer/model/node.ts
+++ b/app/web/src/organisims/SchematicViewer/model/node.ts
@@ -1,6 +1,7 @@
 import { Color, SchematicObject } from "./common";
 import { Socket } from "./socket";
 import { NodeTemplate } from "@/api/sdf/dal/node";
+import { SchematicKind } from "@/api/sdf/dal/schematic";
 
 export interface NodeLabel {
   title: string;
@@ -115,12 +116,12 @@ export interface NodeUpdate {
 
 export function fakeNodeFromTemplate(template: NodeTemplate): Node {
   const node: Node = {
-    id: "A:1",
+    id: -1,
     label: template.label,
     classification: template.classification,
     position: [
       {
-        id: "A:1",
+        id: -1,
         x: 0,
         y: 0,
       },
@@ -131,8 +132,8 @@ export function fakeNodeFromTemplate(template: NodeTemplate): Node {
     lastUpdated: new Date(Date.now()),
     checksum: "j4j4j4j4j4j4j4j4j4j4j4",
     schematic: {
-      deployment: false,
-      component: true,
+      deployment: template.kind === SchematicKind.Deployment,
+      component: template.kind === SchematicKind.Component,
     },
   };
   return node;
@@ -148,9 +149,10 @@ export function generateNode(
   title: string,
   name: string,
   position: { x: number; y: number },
+  schematicKind: SchematicKind,
 ): Node {
   const node: Node = {
-    id: "A:1",
+    id: -1,
     label: {
       title: title,
       name: name,
@@ -169,29 +171,29 @@ export function generateNode(
     ],
     input: [
       {
-        id: "A:1.S:1",
+        id: -2,
         type: "kubernetes.namespace",
         name: "namespace",
       },
       {
-        id: "A:1.S:2",
+        id: -3,
         type: "kubernetes.deployment",
         name: "deployment",
       },
       {
-        id: "A:1.S:3",
+        id: -4,
         type: "kubernetes.service",
         name: "service",
       },
       {
-        id: "A:1.S:4",
+        id: -5,
         type: "kubernetes.env",
         name: "env",
       },
     ],
     output: [
       {
-        id: "A:1.S:5",
+        id: -6,
         type: "kubernetes.service",
       },
     ],
@@ -201,8 +203,8 @@ export function generateNode(
     lastUpdated: new Date(Date.now()),
     checksum: "j4j4j4j4j4j4j4j4j4j4j4",
     schematic: {
-      deployment: false,
-      component: true,
+      deployment: schematicKind === SchematicKind.Deployment,
+      component: schematicKind === SchematicKind.Component,
     },
   };
 

--- a/app/web/src/organisims/SchematicViewer/state/observable.ts
+++ b/app/web/src/organisims/SchematicViewer/state/observable.ts
@@ -2,8 +2,13 @@ import * as Rx from "rxjs";
 
 import { Node } from "../Viewer/obj";
 
-export const selection$ = new Rx.ReplaySubject<Array<Node> | null>(1);
-selection$.next(null);
+// These shouldn't be global, interaction manager should own them
+
+export const deploymentSelection$ = new Rx.ReplaySubject<Array<Node> | null>(1);
+deploymentSelection$.next(null);
+
+export const componentSelection$ = new Rx.ReplaySubject<Array<Node> | null>(1);
+componentSelection$.next(null);
 
 // export const zoomMagnitude$ = new Rx.ReplaySubject<number | null>(1);
 // zoomMagnitude$.next(null);

--- a/app/web/src/service/change_set/apply_change_set.ts
+++ b/app/web/src/service/change_set/apply_change_set.ts
@@ -1,10 +1,9 @@
 import Bottle from "bottlejs";
 import { ApiResponse, SDF } from "@/api/sdf";
-import { editMode$ } from "@/observable/edit_mode";
 import { from, mergeMap, Observable, take, tap } from "rxjs";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
+import { switchToHead } from "@/service/change_set/switch_to_head";
 import { changeSet$ } from "@/observable/change_set";
-import { editSession$ } from "@/observable/edit_session";
 
 /**
  * Returns the change set that has been applied, or null if no
@@ -38,9 +37,7 @@ export function applyChangeSet(): Observable<
     }),
     tap((response) => {
       if (!response.error) {
-        changeSet$.next(null);
-        editSession$.next(null);
-        editMode$.next(false);
+        switchToHead();
       }
     }),
     take(1),

--- a/app/web/src/service/schematic/set_node_position.ts
+++ b/app/web/src/service/schematic/set_node_position.ts
@@ -11,7 +11,7 @@ import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
 
 export interface SetNodePositionArgs {
-  nodeId: string;
+  nodeId: number;
   schematicKind: SchematicKind;
   rootNodeId: number;
   systemId?: number;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -25,7 +25,6 @@ use crate::func::backend::{
 };
 use crate::func::binding::{FuncBinding, FuncBindingError};
 use crate::func::binding_return_value::FuncBindingReturnValue;
-use crate::node::NodeKind;
 use crate::qualification::QualificationView;
 use crate::qualification_resolver::QualificationResolverContext;
 use crate::resource_resolver::ResourceResolverContext;
@@ -302,7 +301,7 @@ impl Component {
             &tenancy.into(),
             visibility,
             history_actor,
-            &NodeKind::Component,
+            &(*schema.kind()).into(),
         )
         .await?;
         node.set_component(txn, nats, visibility, history_actor, component.id())

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -298,7 +298,15 @@ async fn service(
         None => return Ok(()),
     };
 
-    let mut ui_menu = UiMenu::new(txn, nats, write_tenancy, visibility, history_actor).await?;
+    let mut ui_menu = UiMenu::new(
+        txn,
+        nats,
+        write_tenancy,
+        visibility,
+        history_actor,
+        &(*schema.kind()).into(),
+    )
+    .await?;
     ui_menu
         .set_name(
             txn,
@@ -325,7 +333,7 @@ async fn service(
             nats,
             visibility,
             history_actor,
-            SchematicKind::Deployment,
+            SchematicKind::from(*schema.kind()),
         )
         .await?;
     ui_menu
@@ -677,7 +685,15 @@ async fn docker_hub_credential(
         .add_socket(txn, nats, visibility, history_actor, includes_socket.id())
         .await?;
 
-    let mut ui_menu = UiMenu::new(txn, nats, write_tenancy, visibility, history_actor).await?;
+    let mut ui_menu = UiMenu::new(
+        txn,
+        nats,
+        write_tenancy,
+        visibility,
+        history_actor,
+        &(*schema.kind()).into(),
+    )
+    .await?;
     ui_menu
         .set_name(
             txn,
@@ -704,7 +720,7 @@ async fn docker_hub_credential(
             nats,
             visibility,
             history_actor,
-            SchematicKind::Deployment, // Note: This isn't right, but we are not fixing the SchematicKind::Component UI in this PR
+            SchematicKind::from(*schema.kind()),
         )
         .await?;
     ui_menu
@@ -754,7 +770,7 @@ async fn docker_image(
         visibility,
         history_actor,
         &name,
-        &SchemaKind::Concept,
+        &SchemaKind::Concrete,
     )
     .await?
     {
@@ -797,7 +813,15 @@ async fn docker_image(
     .ok_or(AttributeValueError::Missing)?;
 
     let read_tenancy = write_tenancy.clone_into_read_tenancy(txn).await?;
-    let mut ui_menu = UiMenu::new(txn, nats, write_tenancy, visibility, history_actor).await?;
+    let mut ui_menu = UiMenu::new(
+        txn,
+        nats,
+        write_tenancy,
+        visibility,
+        history_actor,
+        &(*schema.kind()).into(),
+    )
+    .await?;
     ui_menu
         .set_name(
             txn,
@@ -824,7 +848,7 @@ async fn docker_image(
             nats,
             visibility,
             history_actor,
-            SchematicKind::Deployment,
+            SchematicKind::from(*schema.kind()),
         )
         .await?;
     ui_menu

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -276,7 +276,15 @@ pub async fn kubernetes_deployment(
         .await?;
 
     // TODO: abstract this boilerplate away
-    let mut ui_menu = UiMenu::new(txn, nats, write_tenancy, visibility, history_actor).await?;
+    let mut ui_menu = UiMenu::new(
+        txn,
+        nats,
+        write_tenancy,
+        visibility,
+        history_actor,
+        &(*schema.kind()).into(),
+    )
+    .await?;
     ui_menu
         .set_name(
             txn,
@@ -303,7 +311,7 @@ pub async fn kubernetes_deployment(
             nats,
             visibility,
             history_actor,
-            SchematicKind::Deployment,
+            SchematicKind::from(*schema.kind()),
         )
         .await?;
     ui_menu

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -53,15 +53,12 @@ impl UiMenu {
         write_tenancy: &WriteTenancy,
         visibility: &Visibility,
         history_actor: &HistoryActor,
+        schematic_kind: &SchematicKind,
     ) -> SchemaResult<Self> {
         let row = txn
             .query_one(
                 "SELECT object FROM schema_ui_menu_create_v1($1, $2, $3)",
-                &[
-                    write_tenancy,
-                    &visibility,
-                    &SchematicKind::Component.as_ref(),
-                ],
+                &[write_tenancy, &visibility, &schematic_kind.as_ref()],
             )
             .await?;
         let object = standard_model::finish_create_from_row(
@@ -210,7 +207,7 @@ impl EditFieldAble for UiMenu {
                 EditFieldDataType::String,
                 Widget::Select(SelectWidget::new(
                     LabelList::new(vec![]),
-                    Some(serde_json::to_value(SchematicKind::Component)?),
+                    Some(serde_json::to_value(object.schematic_kind)?),
                 )),
                 schematic_kind_value,
                 schematic_kind_visibility_diff,

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -49,7 +49,10 @@ pub type SchematicResult<T> = Result<T, SchematicError>;
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum SchematicKind {
+    /// Only shows SchemaKind::Concrete and SchemaKind::Implementation
+    /// They all have implementation input socket tied to a service output socket (?)
     Component,
+    /// Only shows SchemaKind::Concept
     Deployment,
     System,
 }
@@ -185,8 +188,9 @@ impl Schematic {
 
         let mut node_views = Vec::with_capacity(nodes.len());
         for node in nodes {
-            let (schema, name, schematic_kind) = match node.kind() {
-                NodeKind::Component => {
+            let schematic_kind = (*node.kind()).into();
+            let (schema, name) = match node.kind() {
+                NodeKind::Deployment | NodeKind::Component => {
                     let component = node
                         .component(txn, visibility)
                         .await?
@@ -207,7 +211,6 @@ impl Schematic {
                             )
                             .await?
                             .ok_or(SchematicError::ComponentNameNotFound)?,
-                        SchematicKind::Component,
                     )
                 }
                 NodeKind::System => {
@@ -230,7 +233,7 @@ impl Schematic {
                     //     .await?
                     //     .ok_or(SchematicError::SchemaNotFound)?;
 
-                    // (schema, system.name().to_owned(), SchematicKind::System)
+                    // (schema, system.name().to_owned())
                 }
             };
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -20,8 +20,8 @@ use crate::{
     BillingAccount, BillingAccountId, ChangeSet, Component, EditSession, EncryptedSecret, Func,
     FuncBackendKind, FuncBackendResponseType, Group, HistoryActor, KeyPair, Node, Organization,
     Prop, PropId, PropKind, QualificationCheck, Schema, SchemaId, SchemaKind, SchemaVariantId,
-    Secret, SecretKind, SecretObjectType, StandardModel, System, Tenancy, User, Visibility,
-    Workspace, WriteTenancy, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
+    SchematicKind, Secret, SecretKind, SecretObjectType, StandardModel, System, Tenancy, User,
+    Visibility, Workspace, WriteTenancy, NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK,
 };
 
 #[derive(Debug)]
@@ -492,9 +492,16 @@ pub async fn create_schema_ui_menu(
     visibility: &Visibility,
     history_actor: &HistoryActor,
 ) -> schema::UiMenu {
-    schema::UiMenu::new(txn, nats, &tenancy.into(), visibility, history_actor)
-        .await
-        .expect("cannot create schema ui menu")
+    schema::UiMenu::new(
+        txn,
+        nats,
+        &tenancy.into(),
+        visibility,
+        history_actor,
+        &SchematicKind::Component,
+    )
+    .await
+    .expect("cannot create schema ui menu")
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -23,9 +23,16 @@ async fn new() {
     let write_tenancy = WriteTenancy::new_universal();
     let visibility = Visibility::new_head(false);
     let history_actor = HistoryActor::SystemInit;
-    let schema_ui_menu = UiMenu::new(&txn, &nats, &write_tenancy, &visibility, &history_actor)
-        .await
-        .expect("cannot create schema ui menu");
+    let schema_ui_menu = UiMenu::new(
+        &txn,
+        &nats,
+        &write_tenancy,
+        &visibility,
+        &history_actor,
+        &SchematicKind::Component,
+    )
+    .await
+    .expect("cannot create schema ui menu");
     assert_eq!(schema_ui_menu.name(), None);
     assert_eq!(schema_ui_menu.category(), None);
     assert_eq!(schema_ui_menu.schematic_kind(), &SchematicKind::Component);

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -2,7 +2,7 @@ use crate::dal::test;
 use crate::test_setup;
 use dal::{
     test_harness::find_or_create_production_system, Component, Connection, HistoryActor,
-    NodePosition, Schema, Schematic, SchematicKind, StandardModel, SystemId, Tenancy, Visibility,
+    NodePosition, Schema, Schematic, StandardModel, SystemId, Tenancy, Visibility,
 };
 
 #[test]
@@ -75,7 +75,7 @@ async fn get_schematic() {
         &(&tenancy).into(),
         &visibility,
         &history_actor,
-        SchematicKind::Component,
+        (*service_schema.kind()).into(),
         &Some(SystemId::from(1)),
         *root_node.id(),
         *node.id(),
@@ -97,6 +97,7 @@ async fn get_schematic() {
     )
     .await
     .expect("cannot find schematic");
+    dbg!(&schematic);
     assert_eq!(schematic.nodes()[0].id(), root_node.id());
     assert_eq!(schematic.nodes()[1].id(), node.id());
     assert_eq!(schematic.nodes()[1].positions()[0].x(), node_position.x());

--- a/lib/sdf/src/server/service/schematic/create_node.rs
+++ b/lib/sdf/src/server/service/schematic/create_node.rs
@@ -3,7 +3,7 @@ use crate::service::schematic::{SchematicError, SchematicResult};
 use axum::Json;
 use dal::{
     generate_name, node::NodeId, Component, HistoryActor, NodePosition, NodeTemplate, NodeView,
-    SchemaId, SchematicKind, StandardModel, SystemId, Tenancy, Visibility, Workspace, WorkspaceId,
+    SchemaId, StandardModel, SystemId, Tenancy, Visibility, Workspace, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -78,7 +78,7 @@ pub async fn create_node(
         &(&tenancy).into(),
         &request.visibility,
         &history_actor,
-        SchematicKind::Component,
+        (*node.kind()).into(),
         request.root_node_id,
         request.x,
         request.y,


### PR DESCRIPTION
Properly update schematic panel when visibility changes, edit session is written to. Clears visibility when application is left.

Fix schematic panel select dropdown.

Disable add menu if in component schematic panel and no deployment node is selected. Filter component nodes to only show those that implement the selected deployment node (contain an edge with its implementation input socket), no deployment node selected means the panel should empty and adding nodes is disabled (for now node creation will not connect the component to the selected deployment, so we aren't enforcing this as we should, but the next PR will handle component creation).

After clicking the node it will be kept selected, and it will sync the other panel (if using the same schematic subpanel). Deselecting also is synced. A `deploymentSelection$` and a `componentSelection$` observers were created to keep them in sync. And also to help the other panels to give relevant information about the nodes in question.

Fix fake node id (mock node used during creation dragging), it's now -1, so we filter with it.

Inherit SchematicKind/NodeKind from SchemaKind.

<img src="https://media2.giphy.com/media/cdNSp4L5vCU7aQrYnV/giphy.gif"/>