### PR TITLE
feat(web,dal,sdf): Create nodes in SchematicKind

### DIFF
--- a/app/web/src/api/sdf/dal/schematic.ts
+++ b/app/web/src/api/sdf/dal/schematic.ts
@@ -9,6 +9,16 @@ export enum SchematicKind {
   Component = "component",
 }
 
+export function schematicKindFromNodeKind(kind: NodeKind): SchematicKind {
+  switch (kind) {
+    case NodeKind.Deployment:
+      return SchematicKind.Deployment;
+    case NodeKind.Component:
+      return SchematicKind.Component;
+  }
+  throw Error(`Unknown NodeKind member: ${kind}`);
+}
+
 export function nodeKindFromSchematicKind(
   kind: SchematicKind | null,
 ): NodeKind | null {
@@ -27,9 +37,8 @@ export function schematicKindFromString(s: string): SchematicKind {
       return SchematicKind.Deployment;
     case "component":
       return SchematicKind.Component;
-    default:
-      throw Error(`Unknown SchematicKind member: ${s}`);
   }
+  throw Error(`Unknown SchematicKind member: ${s}`);
 }
 
 export interface MenuFilter {

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/selection.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/selection.ts
@@ -1,16 +1,21 @@
 import * as Rx from "rxjs";
 
-import { Node } from "../obj";
+import { SchematicKind } from "@/api/sdf/dal/schematic";
+import * as OBJ from "../obj";
+import { deploymentSelection$, componentSelection$ } from "../../state";
 
 export class SelectionManager {
-  selection: Array<Node>;
+  selection: Array<OBJ.Node>;
 
   constructor() {
     this.selection = [];
   }
 
   // Selection should not be cleared when the schematic updates.
-  select(node: Node, selection$?: Rx.ReplaySubject<Array<Node> | null>): void {
+  select(
+    node: OBJ.Node,
+    selection$?: Rx.ReplaySubject<Array<OBJ.Node> | null>,
+  ): void {
     if (this.selection.length > 0) {
       this.clearSelection();
     }
@@ -21,7 +26,7 @@ export class SelectionManager {
     if (selection$) selection$.next(this.selection);
   }
 
-  clearSelection(selection$?: Rx.ReplaySubject<Array<Node> | null>): void {
+  clearSelection(selection$?: Rx.ReplaySubject<Array<OBJ.Node> | null>): void {
     for (const selection of this.selection) {
       selection.deselect();
       selection.zIndex -= 1;
@@ -29,5 +34,17 @@ export class SelectionManager {
     this.selection = [];
 
     if (selection$) selection$.next(null);
+  }
+
+  selectionObserver(
+    schematicKind: SchematicKind,
+  ): Rx.ReplaySubject<Array<OBJ.Node> | null> {
+    switch (schematicKind) {
+      case SchematicKind.Deployment:
+        return deploymentSelection$;
+      case SchematicKind.Component:
+        return componentSelection$;
+    }
+    throw Error(`invalid schematic kind: ${schematicKind}`);
   }
 }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
@@ -11,6 +11,7 @@ import { Connection } from "./connection";
 import { SelectionStatus } from "./node/status";
 import { QualificationStatus } from "./node/status";
 import { ResourceStatus } from "./node/status/resource";
+import { NodeKind } from "@/api/sdf/dal/node";
 
 interface Position {
   x: number;
@@ -32,6 +33,7 @@ const SOCKET_HEIGHT = 3;
 
 export class Node extends PIXI.Container {
   kind: string;
+  nodeKind?: NodeKind;
   isSelected = false;
   id: number;
   title: string;
@@ -45,6 +47,7 @@ export class Node extends PIXI.Container {
     this.name = n.label.name;
     this.title = n.label.title;
     this.kind = "node";
+    this.nodeKind = n.kind;
     this.connections = [];
 
     if (typeof n.position[0].x == typeof "") {

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -1,5 +1,6 @@
 import * as PIXI from "pixi.js";
 import * as OBJ from "../obj";
+import * as Rx from "rxjs";
 
 import { SchematicGroup, NodeGroup, ConnectionGroup } from "../group";
 import { Renderer } from "../renderer";
@@ -55,7 +56,7 @@ export class SceneManager {
 
   subscribeToInteractionEvents(
     interactionManager: InteractionManager,
-  ): Subscription {
+  ): Rx.Subscription {
     return interactionManager.zoomFactor$.subscribe({
       next: (v) => this.updateZoomFactor(v),
     });
@@ -126,6 +127,10 @@ export class SceneManager {
               sourceSocketId,
               true,
             );
+            // Note: this happens when we switch panels with a connection rendered
+            // The nodes and the connections don't disappear
+            // We need to understand this better, but continuing here works by now, it may leak something tho
+            if (!sourceSocket) continue;
 
             const destinationSocketId = `${connection.destination.nodeId}.${connection.destination.socketId}`;
             const destinationSocket = this.scene.getChildByName(

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -102,6 +102,7 @@ export class SchematicDataManager {
         systemId: e.systemId,
         x: e.x,
         y: e.y,
+        parentNodeId: e.parentNodeId,
       }).subscribe((response) => {
         if (response.error) {
           GlobalErrorService.set(response);

--- a/app/web/src/organisims/SchematicViewer/data/event.ts
+++ b/app/web/src/organisims/SchematicViewer/data/event.ts
@@ -4,4 +4,5 @@ export interface NodeCreate {
   systemId?: number;
   x: string;
   y: string;
+  parentNodeId?: number;
 }

--- a/app/web/src/service/schematic/create_node.ts
+++ b/app/web/src/service/schematic/create_node.ts
@@ -16,6 +16,7 @@ export interface CreateNodeArgs {
   x: string;
   y: string;
   systemId?: number;
+  parentNodeId?: number;
 }
 
 export interface CreateNodeRequest extends CreateNodeArgs, Visibility {

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -5,8 +5,9 @@ use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
 use dal::{
-    ComponentError, NodeError, NodeMenuError, NodePositionError, ReadTenancyError,
-    SchemaError as DalSchemaError, SchematicError as DalSchematicError, StandardModelError,
+    node::NodeId, ComponentError, NodeError, NodeKind, NodeMenuError, NodePositionError,
+    ReadTenancyError, SchemaError as DalSchemaError, SchematicError as DalSchematicError,
+    SchematicKind, StandardModelError,
 };
 use std::convert::Infallible;
 use thiserror::Error;
@@ -31,6 +32,8 @@ pub enum SchematicError {
     Schema(#[from] DalSchemaError),
     #[error("schema not found")]
     SchemaNotFound,
+    #[error("schema variant not found")]
+    SchemaVariantNotFound,
     #[error("node menu error: {0}")]
     NodeMenu(#[from] NodeMenuError),
     #[error("node error: {0}")]
@@ -47,6 +50,14 @@ pub enum SchematicError {
     ReadTenancy(#[from] ReadTenancyError),
     #[error("not authorized")]
     NotAuthorized,
+    #[error("invalid system")]
+    InvalidSystem,
+    #[error("invalid schema kind ({0}) and parent node id pair ({1:?})")]
+    InvalidSchematicKindParentNodeIdPair(SchematicKind, Option<NodeId>),
+    #[error("parent node not found {0}")]
+    ParentNodeNotFound(NodeId),
+    #[error("invalid parent node kind {0}")]
+    InvalidParentNode(NodeKind),
 }
 
 pub type SchematicResult<T> = std::result::Result<T, SchematicError>;


### PR DESCRIPTION
Fix reactivity bug on vue's hot-reload.

Fix reactivity bug with connections being hidden when schematic sub-panel changes.

Properly hide component nodes when no deployment node is selected.

Expect parent node id when creating a schematic component node (and system). Parent must be a schematic deployment node. Schematic deployment nodes only belong to the system. All nodes belong to a system.

Provide component creation functions for schematic deployment and for schematic component.

Provide function to include schematic component in schematic deployment.

<img src="https://media1.giphy.com/media/l0Ex0hbO8ZaTRnSyQ/giphy.gif"/>