### PR TITLE
feat(dal): implement AttributePrototype::remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,28 +110,38 @@ Now, you have SI running!
 make down
 ```
 
-## Prepare Your Changes
+## Preparing Your Changes and Running Tests
 
-Navigate to the `Makefile` in the [ci](./ci) directory to see local development targets.
-These targets include code linting, formatting, running CI locally, etc.
-For instance, you can tidy up your Rust code before opening a pull request by executing the following:
-
-```bash
-make tidy
-```
+Navigate to the `Makefile` in the [ci](./ci) directory to see local development
+targets. These targets include code linting, formatting, running CI locally,
+etc.
 
 To verify that all lints will pass in CI, execute the following target:
 
 ```bash
-make lint
+( cd ci; make ci-lint )
 ```
 
-You can also run individual tests before bringing up the entire SI stack, as neeeded.
-This can be done in the root of the repository:
+> **Optional:** use the "tidy" make targets. Be careful, as the Rust-related
+> tidy actions are more aggressive than what the lint target checks for.
+>
+> ```bash
+> ( cd ci; make tidy )
+> ```
+
+You can also run individual [DAL](./lib/dal) integration tests before bringing
+up the entire SI stack, as neeeded. This can be done in the root of the
+repository with two terminal panes.
+
+In one pane, prepare the test environment:
 
 ```bash
-make prepare
-cargo build
+make prepare; sleep 10; make veritech-run
+```
+
+In the other pane, run your test:
+
+```bash
 RUST_BACKTRACE=1 cargo test <your-test-name>
 ```
 

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1,3 +1,7 @@
+//! An [`AttributeValue`] represents which [`FuncBinding`] and [`FuncBindingReturnValue`] provide
+//! attribute's value. Moreover, it tracks whether the value is proxied or not. Proxied values
+//! "point" to another [`AttributeValue`] to provide the attribute's value.
+
 use serde::{Deserialize, Serialize};
 use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 
@@ -6,6 +10,7 @@ use thiserror::Error;
 use uuid::Uuid;
 use veritech::EncryptionKey;
 
+use crate::func::backend::FuncBackendKind;
 use crate::{
     attribute::context::{AttributeContext, AttributeContextBuilderError, AttributeReadContext},
     attribute::prototype::{AttributePrototype, AttributePrototypeId},
@@ -23,9 +28,9 @@ use crate::{
     impl_standard_model, pk,
     standard_model::{self, TypeHint},
     standard_model_accessor, standard_model_belongs_to, standard_model_has_many, Func,
-    FuncBackendKind, HistoryActor, HistoryEventError, IndexMap, Prop, PropError, PropId, PropKind,
-    ReadTenancy, ReadTenancyError, StandardModel, StandardModelError, Tenancy, Timestamp,
-    Visibility, WriteTenancy,
+    HistoryActor, HistoryEventError, IndexMap, Prop, PropError, PropId, PropKind, ReadTenancy,
+    ReadTenancyError, StandardModel, StandardModelError, Tenancy, Timestamp, Visibility,
+    WriteTenancy,
 };
 
 const FIND_WITH_PARENT_AND_PROTOTYPE_FOR_CONTEXT: &str =

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -175,11 +175,15 @@ impl Prop {
         )
         .await?;
 
-        if created {
-            func_binding
-                .execute(txn, nats, veritech.clone(), encryption_key)
-                .await?;
-        }
+        let func_binding_return_value_id = match created {
+            true => Some(
+                *func_binding
+                    .execute(txn, nats, veritech.clone(), encryption_key)
+                    .await?
+                    .id(),
+            ),
+            false => None,
+        };
 
         let attribute_context = AttributeContext::builder()
             .set_prop_id(*object.id())
@@ -193,6 +197,7 @@ impl Prop {
             history_actor,
             *func.id(),
             *func_binding.id(),
+            func_binding_return_value_id,
             attribute_context,
             None,
             None,


### PR DESCRIPTION
- Implement AttributePrototype::remove (we are not creating
  AttributeValue::remove at this time)
- Add two integration tests
  - One for least-specific context removal
  - One for component-specific context removal
- Add FuncBindingReturnValue setting through Prop::new and
  AttributePrototype::new (as possible)
- Misc README changes for testing now since they predate veritech's
  re-inclusion

Fixes ENG-23
