### PR TITLE
Require FuncBindingReturnValue on AttributeValue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,3 +269,10 @@ lint:
 tidy:
 	cd $(MAKEPATH)/ci && $(MAKE) tidy
 .PHONY: tidy
+
+docs:
+	cd $(MAKEPATH); cargo watch -x doc
+.PHONY: docs
+
+doc: docs
+.PHONY: doc

--- a/README.md
+++ b/README.md
@@ -145,9 +145,36 @@ In the other pane, run your test:
 RUST_BACKTRACE=1 cargo test <your-test-name>
 ```
 
-## Writing Documentation
+## Reading and Writing Documentation
 
-### Rust Documentation (`rustdoc`)
+Our crates leverage `rustdoc` for seamless integration with `cargo doc`, [IntelliJ Rust](https://www.jetbrains.com/rust/),
+[rust-analyzer](https://rust-analyzer.github.io/), and more.
+
+### Reading Rust Documentation
+
+Build the docs for all of our crates and open the docs in your browser at `dal` by executing the following:
+
+```bash
+cargo doc --all
+cargo doc -p dal --open
+```
+
+If you would like to live-recompile docs while making changes on your development branch, you can execute the following
+make target:
+
+```bash
+# Choose one! Both work.
+make doc
+make docs
+```
+
+> Please note: [cargo-watch](https://github.com/watchexec/cargo-watch) needs to be installed before using the above make target.
+>
+> ```bash
+> cargo install --locked cargo-watch
+> ```
+
+### Writing Rust Documentation
 
 We try to follow the official ["How to write documentation"](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) guide from `rustdoc` as closely as possible.
 Older areas of the codebase may not follow the guide and conventions derived from it.

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -30,6 +30,7 @@ ci-si: setup-base ci-crates ci-web
 
 ci-crates: down
 	cd $(REPOPATH)/deploy && $(MAKE) partial
+	cd $(REPOPATH); cargo doc
 	cd $(REPOPATH); cargo test --all-features
 .PHONY: ci-crates
 

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -16,6 +16,7 @@ use si_data::{NatsError, NatsTxn, PgError, PgTxn};
 use telemetry::prelude::*;
 use thiserror::Error;
 
+use crate::func::binding_return_value::FuncBindingReturnValueError;
 use crate::{
     attribute::{
         context::{AttributeContext, AttributeContextError},
@@ -43,6 +44,8 @@ pub enum AttributePrototypeError {
     AttributeValue(#[from] AttributeValueError),
     #[error("func binding error: {0}")]
     FuncBinding(#[from] FuncBindingError),
+    #[error("func binding return value error: {0}")]
+    FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
     #[error("invalid prop value; expected {0} but got {1}")]
@@ -125,7 +128,7 @@ impl AttributePrototype {
         history_actor: &HistoryActor,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
-        func_binding_return_value_id: Option<FuncBindingReturnValueId>,
+        func_binding_return_value_id: FuncBindingReturnValueId,
         context: AttributeContext,
         key: Option<String>,
         parent_attribute_value_id: Option<AttributeValueId>,
@@ -455,7 +458,7 @@ impl AttributePrototype {
                     visibility,
                     history_actor,
                     proxy_target.func_binding_id(),
-                    proxy_target.func_binding_return_value_id().copied(),
+                    proxy_target.func_binding_return_value_id(),
                     context,
                     proxy_target.key().map(|k| k.to_string()),
                 )
@@ -496,6 +499,7 @@ impl AttributePrototype {
         context: AttributeContext,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
+        func_binding_return_value_id: FuncBindingReturnValueId,
         parent_attribute_value_id: Option<AttributeValueId>,
         existing_attribute_value_id: Option<AttributeValueId>,
     ) -> AttributePrototypeResult<AttributePrototypeId> {
@@ -561,7 +565,7 @@ impl AttributePrototype {
                 history_actor,
                 func_id,
                 func_binding_id,
-                None,
+                func_binding_return_value_id,
                 context,
                 given_attribute_prototype.key().map(|k| k.to_string()),
                 parent_attribute_value_id,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1563,21 +1563,19 @@ impl Component {
             .find_attribute_value_by_json_pointer(txn, read_tenancy, visibility, json_pointer)
             .await?
         {
-            if let Some(fbrv_id) = attribute_value.func_binding_return_value_id() {
-                if let Some(fbrv) = FuncBindingReturnValue::get_by_id(
-                    txn,
-                    &read_tenancy.into(),
-                    visibility,
-                    fbrv_id,
-                )
-                .await?
-                {
-                    return Ok(fbrv
-                        .value()
-                        .cloned()
-                        .map(serde_json::from_value)
-                        .transpose()?);
-                };
+            if let Some(fbrv) = FuncBindingReturnValue::get_by_id(
+                txn,
+                &read_tenancy.into(),
+                visibility,
+                &attribute_value.func_binding_return_value_id(),
+            )
+            .await?
+            {
+                return Ok(fbrv
+                    .value()
+                    .cloned()
+                    .map(serde_json::from_value)
+                    .transpose()?);
             };
         };
 

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -393,6 +393,7 @@ impl AccessBuilder {
             history_actor: self.history_actor,
         }
     }
+
     /// Builds and returns a new [`RequestContext`] using the given [`Visibility`].
     pub fn build(self, visibility: Visibility) -> RequestContext {
         RequestContext {

--- a/lib/dal/src/migrations/U0057__attribute_values.sql
+++ b/lib/dal/src/migrations/U0057__attribute_values.sql
@@ -19,7 +19,7 @@ CREATE TABLE attribute_values
     proxy_for_attribute_value_id        bigint,
     sealed_proxy                        bool                     NOT NULL DEFAULT False,
     func_binding_id                     bigint                   NOT NULL,
-    func_binding_return_value_id        bigint,
+    func_binding_return_value_id        bigint                   NOT NULL,
     index_map                           jsonb,
     key                                 text
 );

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -1012,7 +1012,7 @@ async fn docker_image(
     )
     .await?;
 
-    func_binding
+    let func_binding_return_value = func_binding
         .execute(txn, nats, veritech.clone(), encryption_key)
         .await?;
 
@@ -1039,6 +1039,7 @@ async fn docker_image(
         number_of_parents_prop_context,
         *func.id(),
         *func_binding.id(),
+        *func_binding_return_value.id(),
         Some(*root_prop_attribute_value.id()),
         Some(
             *AttributeValue::find_for_context(

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -101,7 +101,7 @@ async fn new() {
     )
     .await
     .expect("cannot create function binding");
-    let fbrv = func_binding
+    let func_binding_return_value = func_binding
         .execute(&txn, &nats, veritech, encr_key)
         .await
         .expect("failed to execute func binding");
@@ -121,7 +121,7 @@ async fn new() {
         &history_actor,
         *func.id(),
         *func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         context,
         None,
         None,
@@ -386,7 +386,7 @@ async fn list_for_context() {
     )
     .await
     .expect("cannot create func binding");
-    let fbrv = func_binding
+    let func_binding_return_value = func_binding
         .execute(&txn, &nats, veritech, encr_key)
         .await
         .expect("failed to execute func binding");
@@ -405,7 +405,7 @@ async fn list_for_context() {
         &history_actor,
         *func.id(),
         *func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         component_name_prototype_context,
         None,
         None,
@@ -655,7 +655,7 @@ async fn list_for_context_with_a_hash() {
     )
     .await
     .expect("cannot create func binding");
-    let fbrv = undertow_prop_func_binding
+    let func_binding_return_value = undertow_prop_func_binding
         .execute(&txn, &nats, veritech.clone(), encr_key)
         .await
         .expect("failed to execute func binding");
@@ -668,7 +668,7 @@ async fn list_for_context_with_a_hash() {
         &history_actor,
         *func.id(),
         *undertow_prop_func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         prop_hash_key_prototype_context,
         Some("Undertow".to_string()),
         None,
@@ -689,7 +689,7 @@ async fn list_for_context_with_a_hash() {
     )
     .await
     .expect("cannot create func binding");
-    let fbrv = lateralus_prop_func_binding
+    let func_binding_return_value = lateralus_prop_func_binding
         .execute(&txn, &nats, veritech.clone(), encr_key)
         .await
         .expect("failed to execute func binding");
@@ -702,7 +702,7 @@ async fn list_for_context_with_a_hash() {
         &history_actor,
         *func.id(),
         *lateralus_prop_func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         prop_hash_key_prototype_context,
         Some("Lateralus".to_string()),
         None,
@@ -741,7 +741,7 @@ async fn list_for_context_with_a_hash() {
     )
     .await
     .expect("cannot create func binding");
-    let fbrv = lateralus_component_func_binding
+    let func_binding_return_value = lateralus_component_func_binding
         .execute(&txn, &nats, veritech.clone(), encr_key)
         .await
         .expect("failed to execute func binding");
@@ -754,7 +754,7 @@ async fn list_for_context_with_a_hash() {
         &history_actor,
         *func.id(),
         *lateralus_component_func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         component_hash_key_prototype_context,
         Some("Lateralus".to_string()),
         None,
@@ -775,7 +775,7 @@ async fn list_for_context_with_a_hash() {
     )
     .await
     .expect("cannot create func binding");
-    let fbrv = fear_inoculum_component_func_binding
+    let func_binding_return_value = fear_inoculum_component_func_binding
         .execute(&txn, &nats, veritech.clone(), encr_key)
         .await
         .expect("failed to execute func binding");
@@ -788,7 +788,7 @@ async fn list_for_context_with_a_hash() {
         &history_actor,
         *func.id(),
         *fear_inoculum_component_func_binding.id(),
-        Some(*fbrv.id()),
+        *func_binding_return_value.id(),
         component_hash_key_prototype_context,
         Some("Fear Inoculum".to_string()),
         None,


### PR DESCRIPTION
Require FBRV on AttributeValue through the following, step-by-step
process:

1. execute on a func binding if was created
2. find an FBRV by func binding id if it was not created
3. execute func binding if the previous two cases are false

Find or generate FBRV as needed for AttributeValue creation:

- Ensure AttributePrototype creation and update methods require the FBRV
  as needed
- Ensure Prop creation requires the FBRV

Misc changes:

- Add cargo doc Make targets and documentation in README
- Run cargo doc in CI

<img src="https://media0.giphy.com/media/3ornjMfYXNDHHfowqA/giphy.gif"/>

Fixes ENG-65