### PR TITLE
feat(dal/sdf/web): Attribute panel node selection and locking

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -20,6 +20,7 @@
               class="pl-1"
               :value-as-number="true"
               :options="componentNamesOnlyList"
+              :disabled="!isPinned"
             />
           </div>
           <LockButton v-model="isPinned" />
@@ -209,9 +210,26 @@ import CodeViewer from "@/organisims/CodeViewer.vue";
 import VueFeather from "vue-feather";
 import _ from "lodash";
 import cheechSvg from "@/assets/images/cheech-and-chong.svg";
+import {
+  deploymentSelection$,
+  componentSelection$,
+} from "./SchematicViewer/state";
 
 const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | "">("");
+
+componentSelection$.subscribe((node) => {
+  if (isPinned.value) return;
+
+  const maybe = node?.length ? node[0]?.nodeKind?.componentId : undefined;
+  selectedComponentId.value = maybe ?? "";
+});
+deploymentSelection$.subscribe((node) => {
+  if (isPinned.value) return;
+
+  const maybe = node?.length ? node[0]?.nodeKind?.componentId : undefined;
+  selectedComponentId.value = maybe ?? "";
+});
 
 const props = defineProps<{
   panelIndex: number;

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
@@ -15,6 +15,7 @@ import { PanningManager } from "./panning";
 import { ConnectingManager } from "./connecting";
 import { ZoomingManager } from "./zooming";
 import { NodeAddManager } from "./nodeAdd";
+import { schematicKindFromNodeKind } from "@/api/sdf/dal/schematic";
 
 // import { PanningInteractionData } from "./interaction/panning";
 
@@ -154,6 +155,7 @@ export class InteractionManager {
           this.dataManager.schematicKind$,
         );
         if (schematicKind) {
+          console.debug("Deselecting node");
           const selectionObserver = this.selectionManager.selectionObserver(
             schematicKind,
           );
@@ -177,9 +179,10 @@ export class InteractionManager {
         ST.readySelecting(this.stateService);
         ST.selecting(this.stateService);
 
-        if (!isFakeNode) {
+        if (!isFakeNode && target.nodeKind?.kind) {
+          console.debug("Selecting real node");
           const selectionObserver = this.selectionManager.selectionObserver(
-            target.nodeKind,
+            schematicKindFromNodeKind(target.nodeKind.kind),
           );
           this.selectionManager.select(target, selectionObserver);
         }

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/nodeAdd.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/nodeAdd.ts
@@ -54,9 +54,10 @@ export class NodeAddManager {
     this.node = this.sceneManager.getGeo(nodeObj.name) as OBJ.Node;
 
     // Since node doesn't exist yet let's not sync the node add
-    if (nodeObj.nodeKind) {
+    if (nodeObj.nodeKind?.kind) {
+      console.debug("Initiating node add");
       const selectionObserver = this.selectionManager.selectionObserver(
-        schematicKindFromNodeKind(nodeObj.nodeKind),
+        schematicKindFromNodeKind(nodeObj.nodeKind.kind),
       );
       this.selectionManager.clearSelection(selectionObserver);
       this.selectionManager.select(this.node);

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
@@ -32,10 +32,10 @@ const SOCKET_SPACING = 20;
 const SOCKET_HEIGHT = 3;
 
 export class Node extends PIXI.Container {
-  kind: string;
-  nodeKind?: NodeKind;
-  isSelected = false;
   id: number;
+  kind: string;
+  nodeKind?: { kind: NodeKind; componentId?: number };
+  isSelected = false;
   title: string;
   connections: Array<Connection>;
   selection?: SelectionStatus;

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -9,6 +9,7 @@ import { Schematic } from "../../model";
 import { Position } from "../cg";
 import { InteractionManager } from "../interaction";
 import { SelectionManager } from "../interaction/selection";
+import { schematicKindFromNodeKind } from "@/api/sdf/dal/schematic";
 
 export type SceneGraphData = Schematic;
 
@@ -104,6 +105,7 @@ export class SceneManager {
   ): void {
     this.initializeSceneData();
 
+    let selected;
     if (data) {
       for (const n of data.nodes) {
         if (n.position.length > 0) {
@@ -111,7 +113,7 @@ export class SceneManager {
           // If the node was previously selected we re-select again as some operations
           // were lost on the re-render (example: update node position)
           if (node.id === (selectionManager.selection[0] ?? {}).id) {
-            selectionManager.select(node);
+            selected = node;
           }
           this.addNode(node);
         } else {
@@ -147,6 +149,17 @@ export class SceneManager {
           }
         }
       }
+    }
+
+    if (selected) {
+      const selectionObserver = selectionManager.selectionObserver(
+        schematicKindFromNodeKind(selected.nodeKind.kind),
+      );
+      console.debug(
+        "Re-selecting node: " +
+          schematicKindFromNodeKind(selected.nodeKind.kind),
+      );
+      selectionManager.select(selected, selectionObserver);
     }
 
     this.renderer.renderStage();

--- a/app/web/src/organisims/SchematicViewer/model/common.ts
+++ b/app/web/src/organisims/SchematicViewer/model/common.ts
@@ -10,12 +10,3 @@ export interface SchematicData {
   lastUpdated: Date;
   checksum: string;
 }
-
-interface SchematicParticipation {
-  deployment: boolean;
-  component: boolean;
-}
-
-export interface SchematicObject extends SchematicData {
-  schematic: SchematicParticipation;
-}

--- a/app/web/src/organisims/SchematicViewer/model/connection.ts
+++ b/app/web/src/organisims/SchematicViewer/model/connection.ts
@@ -1,4 +1,4 @@
-import { Color, SchematicObject } from "./common";
+import { Color, SchematicData } from "./common";
 
 /**  Replace string for correct connecion type */
 export enum ConnectionKind {
@@ -31,7 +31,7 @@ interface Destination {
 }
 
 /**  A connection (from an output to an input) */
-export interface Connection extends SchematicObject {
+export interface Connection extends SchematicData {
   id: number;
   classification: ConnectionClassification;
   source: Source;

--- a/app/web/src/organisims/SchematicViewer/model/node.ts
+++ b/app/web/src/organisims/SchematicViewer/model/node.ts
@@ -1,4 +1,4 @@
-import { Color, SchematicObject } from "./common";
+import { Color, SchematicData } from "./common";
 import { Socket } from "./socket";
 import { NodeTemplate } from "@/api/sdf/dal/node";
 import { NodeKind } from "@/api/sdf/dal/node";
@@ -91,9 +91,9 @@ interface NodeConnection {
 }
 
 /**  A node */
-export interface Node extends SchematicObject {
+export interface Node extends SchematicData {
   id: number;
-  kind: NodeKind;
+  kind: { kind: NodeKind; componentId?: number };
   label: NodeLabel;
   classification: NodeClassification;
   status?: NodeStatus;
@@ -116,9 +116,16 @@ export interface NodeUpdate {
 }
 
 export function fakeNodeFromTemplate(template: NodeTemplate): Node {
+  let componentId;
+  switch (template.kind) {
+    case NodeKind.Component:
+    case NodeKind.Deployment:
+      componentId = -1;
+      break;
+  }
   const node: Node = {
     id: -1,
-    kind: template.kind,
+    kind: { kind: template.kind, componentId },
     label: template.label,
     classification: template.classification,
     position: [
@@ -133,10 +140,6 @@ export function fakeNodeFromTemplate(template: NodeTemplate): Node {
     display: template.display,
     lastUpdated: new Date(Date.now()),
     checksum: "j4j4j4j4j4j4j4j4j4j4j4",
-    schematic: {
-      deployment: template.kind === NodeKind.Deployment,
-      component: template.kind === NodeKind.Component,
-    },
   };
   return node;
 }

--- a/lib/dal/src/migrations/U0036__nodes.sql
+++ b/lib/dal/src/migrations/U0036__nodes.sql
@@ -11,7 +11,7 @@ CREATE TABLE nodes
     visibility_deleted          bool,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
-    kind                        text NOT NULL
+    kind                        text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('nodes');
 SELECT belongs_to_table_create_v1('node_belongs_to_component', 'nodes', 'components');

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -816,5 +816,4 @@ macro_rules! standard_model_accessor {
             $result_type,
         );
     };
-
 }

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -11,7 +11,7 @@ use dal::{
     },
     AttributePrototypeError, AttributeReadContext, AttributeValue, Component, ComponentView, Func,
     FuncBackendKind, FuncBackendResponseType, HistoryActor, PropKind, ReadTenancy, Schema,
-    SchemaKind, StandardModel, Tenancy, Visibility, WriteTenancy,
+    SchemaKind, StandardModel, Tenancy, Visibility,
 };
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -540,11 +540,6 @@ async fn get_resource_by_component_id() {
     .pop()
     .expect("no docker image schema found");
 
-    let variant = schema
-        .default_variant(&txn, &read_tenancy, &visibility)
-        .await
-        .expect("could not retrieve default variant");
-
     let system =
         find_or_create_production_system(&txn, &nats, &tenancy, &visibility, &history_actor).await;
 

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -57,7 +57,7 @@ pub enum SchematicError {
     InvalidSchematicKindParentNodeIdPair(SchematicKind, Option<NodeId>),
     #[error("parent node not found {0}")]
     ParentNodeNotFound(NodeId),
-    #[error("invalid parent node kind {0}")]
+    #[error("invalid parent node kind {0:?}")]
     InvalidParentNode(NodeKind),
 }
 


### PR DESCRIPTION
Sync attribute panel's selected component with the node's selection in the UI.

Allow locking the attribute panel  component selection through the UI, provide dropdown to
change component while locked in a controlled way.

Add a new NodeKindWithBaggage that allows NodeView to inform the frontend of
whichever component it's tied to (if any).

<img src="https://media0.giphy.com/media/Skx32VOazLRMk/giphy.gif"/>