### PR TITLE
feat(web): Lock component panel

### DIFF
--- a/app/web/src/organisims/SchematicViewer.vue
+++ b/app/web/src/organisims/SchematicViewer.vue
@@ -8,6 +8,7 @@
       :viewer-event$="props.viewerEvent$"
       :editor-context="editorContext"
       :schematic-kind="schematicKind"
+      :is-pinned="isPinned"
     />
   </div>
 </template>
@@ -63,6 +64,10 @@ const props = defineProps({
   },
   schematicKind: {
     type: String as PropType<SchematicKind | null>,
+    required: true,
+  },
+  isPinned: {
+    type: Boolean,
     required: true,
   },
 });

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -127,6 +127,10 @@ export default defineComponent({
       type: String as PropType<SchematicKind | null>,
       required: true,
     },
+    isPinned: {
+      type: Boolean,
+      required: true,
+    },
   },
   setup(props) {
     const { state, send, service } = useMachine(props.viewerState.machine);
@@ -208,9 +212,14 @@ export default defineComponent({
         selectionObserver(ctx).next(nodes);
       }
     },
-    schematicData(schematic) {
-      if (this.dataManager && this.schematicData) {
-        this.dataManager.schematicData$.next(schematic);
+    async schematicData(schematic) {
+      if (this.dataManager && this.schematicData && this.schematicKind) {
+        const nodes = await Rx.firstValueFrom(
+          selectionObserver(this.schematicKind),
+        );
+        if (!_.isEqual(nodes, schematic)) {
+          this.dataManager.schematicData$.next(schematic);
+        }
       }
     },
   },
@@ -326,7 +335,7 @@ export default defineComponent({
             break;
           case SchematicKind.Component:
             // The deployment node selected defines which nodes appear in the Component panel
-            if (this.schematicData) {
+            if (this.schematicData && !this.isPinned) {
               await this.loadSchematicData(this.schematicData);
             }
             break;

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -149,7 +149,7 @@ export class SceneManager {
       }
     }
 
-    if (selected) {
+    if (selected?.nodeKind) {
       const selectionObserver = selectionManager.selectionObserver(
         schematicKindFromNodeKind(selected.nodeKind.kind),
       );


### PR DESCRIPTION
Locks component panel based on specific deployment node.

There is an edge case tho, locking isn't synced between two
component schematic panels, it's not clear if it's ideal, or
if we want that parity between the two panels.

<img src="https://media3.giphy.com/media/VSU7EyWJxnJxm/giphy.gif"/>