### PR TITLE
feat(dal): add database smoke test

### DIFF
--- a/lib/dal/tests/database.rs
+++ b/lib/dal/tests/database.rs
@@ -1,0 +1,17 @@
+use dal::{test::DalContextUniversalHeadRef, StandardModel, System};
+use si_test_macros::dal_test as test;
+
+const UNSET_ID_VALUE: i64 = -1;
+
+/// Smoke test to ensure database setup worked.
+#[test]
+async fn smoke(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+    assert!(System::get_by_id(
+        ctx.pg_txn(),
+        &ctx.read_tenancy().into(),
+        ctx.visibility(),
+        &UNSET_ID_VALUE.into(),
+    )
+    .await
+    .is_ok())
+}


### PR DESCRIPTION
Add database smoke test that performs a simple accessor call to ensure
that database setup worked (migrations, etc.).