### PR TITLE
feat(web): Move from local to global selection storage

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -214,21 +214,46 @@ import {
   deploymentSelection$,
   componentSelection$,
 } from "./SchematicViewer/state";
+import { visibility$ } from "@/observable/visibility";
 
 const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | "">("");
 
-componentSelection$.pipe(untilUnmounted).subscribe((node) => {
-  if (isPinned.value) return;
-
-  const maybe = node?.length ? node[0]?.nodeKind?.componentId : undefined;
-  selectedComponentId.value = maybe ?? "";
+visibility$.pipe(untilUnmounted).subscribe(() => {
+  isPinned.value = false;
+  selectedComponentId.value = "";
 });
-deploymentSelection$.pipe(untilUnmounted).subscribe((node) => {
+
+// We garantee that the latest update will always be the last element in the list
+componentSelection$.pipe(untilUnmounted).subscribe((selections) => {
   if (isPinned.value) return;
 
-  const maybe = node?.length ? node[0]?.nodeKind?.componentId : undefined;
-  selectedComponentId.value = maybe ?? "";
+  const last = selections?.length
+    ? selections[selections.length - 1]
+    : undefined;
+  const componentId = last?.nodes?.length
+    ? last.nodes[0]?.nodeKind?.componentId
+    : undefined;
+
+  // Ignores fake nodes as they don't have any attributes
+  if (componentId === -1) return;
+
+  selectedComponentId.value = componentId ?? "";
+});
+deploymentSelection$.pipe(untilUnmounted).subscribe((selections) => {
+  if (isPinned.value) return;
+
+  const last = selections?.length
+    ? selections[selections.length - 1]
+    : undefined;
+  const componentId = last?.nodes?.length
+    ? last.nodes[0]?.nodeKind?.componentId
+    : undefined;
+
+  // Ignores fake nodes as they don't have any attributes
+  if (componentId === -1) return;
+
+  selectedComponentId.value = componentId ?? "";
 });
 
 const props = defineProps<{

--- a/app/web/src/organisims/SchematicViewer.vue
+++ b/app/web/src/organisims/SchematicViewer.vue
@@ -8,7 +8,7 @@
       :viewer-event$="props.viewerEvent$"
       :editor-context="editorContext"
       :schematic-kind="schematicKind"
-      :is-pinned="isPinned"
+      :is-component-panel-pinned="isComponentPanelPinned"
     />
   </div>
 </template>
@@ -66,7 +66,7 @@ const props = defineProps({
     type: String as PropType<SchematicKind | null>,
     required: true,
   },
-  isPinned: {
+  isComponentPanelPinned: {
     type: Boolean,
     required: true,
   },

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -12,7 +12,6 @@ import { NodeCreate } from "./event";
 import { EditorContext } from "@/api/sdf/dal/schematic";
 import { CreateConnectionResponse } from "@/service/schematic/create_connection";
 import { SetNodePositionResponse } from "@/service/schematic/set_node_position";
-import { deploymentSelection$ } from "@/organisims/SchematicViewer/state";
 
 export class SchematicDataManager {
   id: string;
@@ -22,11 +21,15 @@ export class SchematicDataManager {
   nodeCreate$: Rx.ReplaySubject<NodeCreate | null>;
   editorContext$: Rx.ReplaySubject<EditorContext | null>;
   schematicKind$: Rx.ReplaySubject<SchematicKind | null>;
+  selectedDeploymentNodeId: number | null;
+  isComponentPanelPinned: boolean;
 
   constructor() {
     this.id = _.uniqueId();
 
     // TODO: define dataManagerEvent types... and refactor the following observables.
+    this.selectedDeploymentNodeId = null;
+    this.isComponentPanelPinned = false;
 
     this.schematicData$ = new Rx.ReplaySubject<Schematic | null>(1);
     this.schematicData$.next(null);
@@ -65,14 +68,11 @@ export class SchematicDataManager {
     const editorContext = await Rx.firstValueFrom(this.editorContext$);
     const schematicKind = await Rx.firstValueFrom(this.schematicKind$);
     if (nodeUpdate && editorContext && schematicKind) {
-      const selectedDeployments = await Rx.firstValueFrom(deploymentSelection$);
-      const selectedDeploymentNodeId = (selectedDeployments ?? [])[0]?.id;
-
       SchematicService.setNodePosition({
         deploymentNodeId:
           schematicKind !== SchematicKind.Deployment
-            ? selectedDeploymentNodeId
-            : undefined,
+            ? this.selectedDeploymentNodeId
+            : null,
         schematicKind,
         x: `${nodeUpdate.position.x}`,
         y: `${nodeUpdate.position.y}`,

--- a/app/web/src/organisims/SchematicViewer/data/event.ts
+++ b/app/web/src/organisims/SchematicViewer/data/event.ts
@@ -4,5 +4,5 @@ export interface NodeCreate {
   systemId?: number;
   x: string;
   y: string;
-  parentNodeId?: number;
+  parentNodeId: number | null;
 }

--- a/app/web/src/organisims/SchematicViewer/state/observable.ts
+++ b/app/web/src/organisims/SchematicViewer/state/observable.ts
@@ -4,11 +4,17 @@ import { Node } from "../Viewer/obj";
 
 // These shouldn't be global, interaction manager should own them
 
-export const deploymentSelection$ = new Rx.ReplaySubject<Array<Node> | null>(1);
-deploymentSelection$.next(null);
+export interface SelectedNode {
+  // Deployments never have a parentDeploymentNodeId, Components always have
+  parentDeploymentNodeId: number | null;
+  nodes: Array<Node>;
+}
 
-export const componentSelection$ = new Rx.ReplaySubject<Array<Node> | null>(1);
-componentSelection$.next(null);
+export const deploymentSelection$ = new Rx.ReplaySubject<SelectedNode[]>(1);
+deploymentSelection$.next([]);
+
+export const componentSelection$ = new Rx.ReplaySubject<SelectedNode[]>(1);
+componentSelection$.next([]);
 
 // export const zoomMagnitude$ = new Rx.ReplaySubject<number | null>(1);
 // zoomMagnitude$.next(null);

--- a/app/web/src/service/change_set/list_open_change_sets.ts
+++ b/app/web/src/service/change_set/list_open_change_sets.ts
@@ -35,7 +35,7 @@ export const changeSetsOpenList$ = combineLatest([
       );
     },
   ),
-  shareReplay(1),
+  shareReplay({ bufferSize: 1, refCount: true }),
 );
 
 export function listOpenChangeSets(): Observable<

--- a/app/web/src/service/change_set/switch_to_head.ts
+++ b/app/web/src/service/change_set/switch_to_head.ts
@@ -1,16 +1,10 @@
 import { changeSet$, revision$ } from "@/observable/change_set";
 import { editSession$ } from "@/observable/edit_session";
 import { editMode$ } from "@/observable/edit_mode";
-import {
-  deploymentSelection$,
-  componentSelection$,
-} from "@/organisims/SchematicViewer/state";
 
 export function switchToHead(): void {
   changeSet$.next(null);
   editSession$.next(null);
   revision$.next(null);
   editMode$.next(false);
-  deploymentSelection$.next(null);
-  componentSelection$.next(null);
 }

--- a/app/web/src/service/edit_field/get_edit_fields.ts
+++ b/app/web/src/service/edit_field/get_edit_fields.ts
@@ -75,7 +75,7 @@ export function getEditFields(
         request,
       );
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
   return getEditFieldsCollection[args.objectKind][args.id];
 }

--- a/app/web/src/service/schema/get_schema.ts
+++ b/app/web/src/service/schema/get_schema.ts
@@ -35,7 +35,7 @@ export function getSchema(
         ...visibility,
       });
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
   return getSchemaCollection[args.schemaId];
 }

--- a/app/web/src/service/schematic/create_node.ts
+++ b/app/web/src/service/schematic/create_node.ts
@@ -16,7 +16,7 @@ export interface CreateNodeArgs {
   x: string;
   y: string;
   systemId?: number;
-  parentNodeId?: number;
+  parentNodeId: number | null;
 }
 
 export interface CreateNodeRequest extends CreateNodeArgs, Visibility {

--- a/app/web/src/service/schematic/get_node_add_menu.ts
+++ b/app/web/src/service/schematic/get_node_add_menu.ts
@@ -57,7 +57,7 @@ export function getNodeAddMenu(
         request,
       );
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
   return getNodeAddMenuCollection[key];
 }

--- a/app/web/src/service/schematic/get_node_template.ts
+++ b/app/web/src/service/schematic/get_node_template.ts
@@ -59,7 +59,7 @@ export function getNodeTemplate(
         request,
       );
     }),
-    shareReplay(1),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
   return getNodeTemplateCollection[key];
 }

--- a/app/web/src/service/schematic/set_node_position.ts
+++ b/app/web/src/service/schematic/set_node_position.ts
@@ -11,7 +11,7 @@ import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
 
 export interface SetNodePositionArgs {
-  deploymentNodeId?: number;
+  deploymentNodeId: number | null;
   schematicKind: SchematicKind;
   nodeId: number;
   rootNodeId: number;


### PR DESCRIPTION
We had problems syncing multiple component panels that were locked
to different nodes. And had a lot of edge-cases while syncing both
panels when they were in weird states, as the previous architecture
was limited, because it would only store selection data of the local
panel. But when we change the panel kind, or the panel deployment parent
we had to find to appropriate state for that selection, or reset it,
losing some state that was useful because we couldn't store it.

Now SelectionManager holds a SelectedNode[] instead of a Node[],
the selected node has meta-data defining which kind of panel it is.
If the parentDeploymentNodeId is null, it's a deployment panel,
otherwise the parentDeploymentNodeId will represent to which component
schematic panel the selection data belongs to.

We still assume only one selection per panel, although the code to support
more is there, we are finding the first selection of the panel and using it.

This refactor fixed a lot of edge cases, although it's still fragile, as
its fresh and needs some battle testing to find other edge cases, but the
idea is that the edge cases will be much easier to solve with this new
structure, as we always have the data we need, we just need to refresh the screen.

The code quality is still lacking, it's better now but it's not 100%. But it's
not clear if now is the time to "fix" it. I will think about it while doing the
next task (locking scape-hatch with the select box in the component schematic panel).

Sextou is a meme in Brazil, it's a corruption of the word Sexta(-Feira), which means Friday, making it into a verb, so yeah fridayed!

https://www.urbandictionary.com/define.php?term=Sextou

Sextou no passinho!

<img src="https://media0.giphy.com/media/fOOybLFrOlaNTx1moF/giphy-downsized-medium.gif"/>

For those curious about what passinho means (it's the name of the dance in the gif).

https://daily.redbullmusicacademy.com/2013/03/passinho-feature