### PR TITLE
feat(web): Add selection box scape to component panel lock

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -236,9 +236,10 @@ componentSelection$.pipe(untilUnmounted).subscribe((selections) => {
     : undefined;
 
   // Ignores fake nodes as they don't have any attributes
-  if (componentId === -1) return;
+  // We never de-select with the panel
+  if (componentId === -1 || !componentId) return;
 
-  selectedComponentId.value = componentId ?? "";
+  selectedComponentId.value = componentId;
 });
 deploymentSelection$.pipe(untilUnmounted).subscribe((selections) => {
   if (isPinned.value) return;
@@ -251,9 +252,10 @@ deploymentSelection$.pipe(untilUnmounted).subscribe((selections) => {
     : undefined;
 
   // Ignores fake nodes as they don't have any attributes
-  if (componentId === -1) return;
+  // We never de-select with the panel
+  if (componentId === -1 || !componentId) return;
 
-  selectedComponentId.value = componentId ?? "";
+  selectedComponentId.value = componentId;
 });
 
 const props = defineProps<{

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -135,6 +135,11 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    componentPanelPin: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
   },
   setup(props) {
     const { state, send, service } = useMachine(props.viewerState.machine);
@@ -185,6 +190,12 @@ export default defineComponent({
     };
   },
   watch: {
+    async componentPanelPin(ctx) {
+      if (this.dataManager && this.schematicData) {
+        this.dataManager.selectedDeploymentNodeId = ctx;
+        await this.loadSchematicData(this.schematicData);
+      }
+    },
     isComponentPanelPinned(ctx) {
       if (this.dataManager) {
         this.dataManager.isComponentPanelPinned = ctx;


### PR DESCRIPTION
Added a select-box to PanelSchematic to choose the component.

We obtain the selected component id from the select box in
PanelSchematic and pass it to SchematicViewer, which then
uses its schematicData to convert the componentId to a nodeId.

We pass that nodeId to Viewer bypassing the lock as we hold it,
determining the selectedDeploymentNodeId.

PanelSchematic also monitors the deployment selection to sync
the select box whenever unlocked.

We don't sync de-selection with AttributePanel's select-box.

We also reset some forgotten state on visibility changes.

Cleaned up some old vue style while defining props.

<img src="https://media3.giphy.com/media/2bUpP71bbVnZ3x7lgQ/giphy.gif"/>