### PR TITLE
fix(web): Fix schematic panel bugs

### DIFF
--- a/app/web/src/molecules/NodeAddMenu.vue
+++ b/app/web/src/molecules/NodeAddMenu.vue
@@ -11,7 +11,7 @@
       @click="isOpen = !isOpen"
     >
       <div
-        class="items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
+        class="add-margin-top items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
         :class="{
           'text-gray-200': !isOpen,
           'menu-selected': isOpen,
@@ -136,6 +136,9 @@ onBeforeUnmount(() => {
   left: 100%;
   top: auto;
   margin-top: -1.305rem;
+}
+.add-margin-top {
+  margin-top: 0.25rem;
 }
 
 /* .menu-category:hover .category-items { */

--- a/app/web/src/organisims/PanelSchematic.vue
+++ b/app/web/src/organisims/PanelSchematic.vue
@@ -94,11 +94,7 @@ import { refFrom, untilUnmounted } from "vuse-rx";
 import { switchMap } from "rxjs/operators";
 import { ChangeSetService } from "@/service/change_set";
 import { NodeAddEvent, ViewerEventObservable } from "./SchematicViewer/event";
-import {
-  deploymentSelection$,
-  componentSelection$,
-  SelectedNode,
-} from "./SchematicViewer/state";
+import { deploymentSelection$, SelectedNode } from "./SchematicViewer/state";
 import { visibility$ } from "@/observable/visibility";
 import { SchematicService } from "@/service/schematic";
 import { GlobalErrorService } from "@/service/global_error";

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -554,13 +554,18 @@ export default defineComponent({
       if (
         this.component.isActive &&
         this.interactionManager &&
-        node.position.length > 0
+        node.position.length > 0 &&
+        this.schematicKind
       ) {
         // Fake nodes will always only have one position as they don't exist in the db yet
-        const nodeObj = new OBJ.Node(node, {
-          x: parseFloat(node.position[0].x as string),
-          y: parseFloat(node.position[0].y as string),
-        });
+        const nodeObj = new OBJ.Node(
+          node,
+          {
+            x: parseFloat(node.position[0].x as string),
+            y: parseFloat(node.position[0].y as string),
+          },
+          this.schematicKind,
+        );
         this.send(ViewerEventKind.ACTIVATE_NODEADD);
         this.interactionManager.nodeAddManager.addNode(nodeObj, schemaId);
       }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
@@ -11,6 +11,7 @@ import { Connection } from "./connection";
 import { SelectionStatus } from "./node/status";
 import { QualificationStatus } from "./node/status";
 import { ResourceStatus } from "./node/status/resource";
+import { SchematicKind } from "@/api/sdf/dal/schematic";
 import { NodeKind } from "@/api/sdf/dal/node";
 
 interface Position {
@@ -38,11 +39,14 @@ export class Node extends PIXI.Container {
   isSelected = false;
   title: string;
   connections: Array<Connection>;
+  panelKind: SchematicKind;
   selection?: SelectionStatus;
 
-  constructor(n: MODEL.Node, pos: Position) {
+  constructor(n: MODEL.Node, pos: Position, panelKind: SchematicKind) {
     super();
     this.id = n.id;
+
+    this.panelKind = panelKind;
 
     this.name = n.label.name;
     this.title = n.label.title;
@@ -111,7 +115,7 @@ export class Node extends PIXI.Container {
   }
 
   setSockets(inputs: MODEL.Socket[], outputs: MODEL.Socket[]): void {
-    const sockets = new Sockets(this.id, inputs, outputs);
+    const sockets = new Sockets(this.id, inputs, outputs, this.panelKind);
     sockets.zIndex = 2;
     this.addChild(sockets);
   }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets.ts
@@ -2,27 +2,61 @@ import * as PIXI from "pixi.js";
 
 import * as MODEL from "../../../model";
 import { Socket, SocketType } from "./sockets/socket";
+import { SchematicKind } from "@/api/sdf/dal/schematic";
 
 const NODE_WIDTH = 140;
+const NODE_HEIGHT = 100;
 
 const INPUT_SOCKET_OFFSET = 45;
 const OUTPUT_SOCKET_OFFSET = 35;
 const SOCKET_SPACING = 20;
 
 export class Sockets extends PIXI.Container {
-  constructor(nodeId: number, inputs: MODEL.Socket[], outputs: MODEL.Socket[]) {
+  constructor(
+    nodeId: number,
+    inputs: MODEL.Socket[],
+    outputs: MODEL.Socket[],
+    panelKind: SchematicKind,
+  ) {
     super();
 
-    this.setInputSockets(nodeId, inputs);
-    this.setOutputSockets(nodeId, outputs);
+    this.setInputSockets(nodeId, inputs, panelKind);
+    this.setOutputSockets(nodeId, outputs, panelKind);
   }
 
-  setInputSockets(nodeId: number, inputs: MODEL.Socket[]): void {
+  setInputSockets(
+    nodeId: number,
+    inputs: MODEL.Socket[],
+    panelKind: SchematicKind,
+  ): void {
+    let pos, growth, color;
+    let displaySocketLabel = false;
+    switch (panelKind) {
+      case SchematicKind.Component:
+        pos = {
+          x: 0,
+          y: INPUT_SOCKET_OFFSET,
+        };
+        growth = { x: 0, y: SOCKET_SPACING };
+        color = 0xffdd44;
+        displaySocketLabel = true;
+        break;
+      case SchematicKind.Deployment:
+        pos = {
+          x: (NODE_WIDTH - (inputs.length * SOCKET_SPACING) / 2) / 2,
+          y: 0,
+        };
+        growth = { x: SOCKET_SPACING, y: 0 };
+        color = 0x80c037;
+        displaySocketLabel = false;
+        break;
+    }
+
     for (let i = 0; i < inputs.length; i++) {
       const s = inputs[i];
 
       let socketLabel = null;
-      if (s.name) {
+      if (s.name && displaySocketLabel) {
         socketLabel = s.name;
       }
 
@@ -31,17 +65,38 @@ export class Sockets extends PIXI.Container {
         nodeId,
         socketLabel,
         SocketType.input,
-        {
-          x: 0,
-          y: INPUT_SOCKET_OFFSET + SOCKET_SPACING * i,
-        },
-        0xffdd44,
+        pos,
+        color,
       );
       this.addChild(socket);
+
+      pos.x += growth.x;
+      pos.y += growth.y;
     }
   }
 
-  setOutputSockets(nodeId: number, outputs: MODEL.Socket[]): void {
+  setOutputSockets(
+    nodeId: number,
+    outputs: MODEL.Socket[],
+    panelKind: SchematicKind,
+  ): void {
+    let pos, color;
+    switch (panelKind) {
+      case SchematicKind.Component:
+        pos = {
+          x: NODE_WIDTH,
+          y: OUTPUT_SOCKET_OFFSET,
+        };
+        color = 0xeb44ff;
+        break;
+      case SchematicKind.Deployment:
+        pos = {
+          x: NODE_WIDTH / 2,
+          y: NODE_HEIGHT,
+        };
+        color = 0x00b0bc;
+        break;
+    }
     for (let i = 0; i < outputs.length; i++) {
       const s = outputs[i];
 
@@ -50,11 +105,8 @@ export class Sockets extends PIXI.Container {
         nodeId,
         null,
         SocketType.output,
-        {
-          x: NODE_WIDTH,
-          y: OUTPUT_SOCKET_OFFSET,
-        },
-        0xeb44ff,
+        pos,
+        color,
       );
       this.addChild(socket);
     }

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -90,8 +90,8 @@ export class SceneManager {
     this.clearSceneData();
 
     this.group = {
-      nodes: new NodeGroup("nodes", 20),
-      connections: new ConnectionGroup("connections", 30),
+      connections: new ConnectionGroup("connections", 20),
+      nodes: new NodeGroup("nodes", 30),
     };
     this.root.addChild(this.group.nodes);
     this.root.addChild(this.group.connections);
@@ -114,10 +114,14 @@ export class SceneManager {
             pos.deployment_node_id === selectedDeploymentNodeId,
         );
         if (pos) {
-          const node = new OBJ.Node(n, {
-            x: parseFloat(pos.x as string),
-            y: parseFloat(pos.y as string),
-          });
+          const node = new OBJ.Node(
+            n,
+            {
+              x: parseFloat(pos.x as string),
+              y: parseFloat(pos.y as string),
+            },
+            schematicKind,
+          );
           // If the node was previously selected we re-select again as some operations
           // were lost on the re-render (example: update node position)
           const isSelected = (

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -41,8 +41,8 @@ pub async fn migrate(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     service(ctx).await?;
     kubernetes_service(ctx).await?;
     kubernetes_deployment(ctx).await?;
-    docker_image(ctx).await?;
     docker_hub_credential(ctx).await?;
+    docker_image(ctx).await?;
 
     Ok(())
 }
@@ -275,18 +275,12 @@ async fn docker_hub_credential(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     .await?;
     variant.add_socket(ctx, includes_socket.id()).await?;
 
-    let mut ui_menu = UiMenu::new(ctx, &(*schema.kind()).into()).await?;
-    ui_menu
-        .set_name(ctx, Some(schema.name().to_string()))
-        .await?;
-
     let application_name = "application".to_string();
-    ui_menu
-        .set_category(ctx, Some(application_name.clone()))
-        .await?;
-    ui_menu
-        .set_schematic_kind(ctx, SchematicKind::from(*schema.kind()))
-        .await?;
+
+    // Note: I wasn't able to create a ui menu with two layers
+    let mut ui_menu = UiMenu::new(ctx, &(*schema.kind()).into()).await?;
+    ui_menu.set_name(ctx, Some("credential".to_owned())).await?;
+    ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     let application_schema_results = Schema::find_by_attr(ctx, "name", &application_name).await?;
@@ -330,17 +324,10 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     .ok_or(AttributeValueError::Missing)?;
 
     let mut ui_menu = UiMenu::new(ctx, &(*schema.kind()).into()).await?;
-    ui_menu
-        .set_name(ctx, Some(schema.name().to_string()))
-        .await?;
+    ui_menu.set_name(ctx, Some("image")).await?;
 
     let application_name = "application".to_string();
-    ui_menu
-        .set_category(ctx, Some(application_name.clone()))
-        .await?;
-    ui_menu
-        .set_schematic_kind(ctx, SchematicKind::from(*schema.kind()))
-        .await?;
+    ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     let application_schema_results = Schema::find_by_attr(ctx, "name", &application_name).await?;

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -146,19 +146,15 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> SchemaResult<()>
 
     // TODO: abstract this boilerplate away
     let mut ui_menu = UiMenu::new(ctx, &(*schema.kind()).into()).await?;
-    ui_menu
-        .set_name(ctx, Some(schema.name().to_string()))
-        .await?;
+    ui_menu.set_name(ctx, Some("deployment".to_owned())).await?;
 
-    let application_name = "application".to_string();
-    ui_menu
-        .set_category(ctx, Some(application_name.clone()))
-        .await?;
+    ui_menu.set_category(ctx, Some("kubernetes")).await?;
     ui_menu
         .set_schematic_kind(ctx, SchematicKind::from(*schema.kind()))
         .await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
+    let application_name = "application".to_string();
     let application_schema_results = Schema::find_by_attr(ctx, "name", &application_name).await?;
     let application_schema = application_schema_results
         .first()


### PR DESCRIPTION
- Fix node Add button alignment.
- Change UiMenu structure for component schemas.
- Render connections below nodes (and its sockets).
- Render sockets in the node's top/bottom for the deployment schematic panel.

Notes:

I wasn't able to make a UiMenu with more than 2 layers as it expects a schema to represent a layer and it doesn't make sense to create a docker schema just to put it there, I feel I need to invest more time to learn it and fix it if it's really a bug. Instead of just lack of knowhow (I think Adam is the one that mostly knows how UiMenu works). It's still way better than before (and closer to the demo).

Socket position is still weird, it was hackish I haven't changed much, just expanded the hack to support vertical sockets. They might not work well with arbitrary socket numbers.

<img src="https://media1.giphy.com/media/RFcJpLHnBNBXi4imqp/giphy.gif"/>