### PR TITLE
chore(dal): add component edit field update test

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -15,7 +15,7 @@ use crate::attribute::{context::UNSET_ID_VALUE, value::AttributeValueError};
 use crate::code_generation_resolver::CodeGenerationResolverContext;
 use crate::edit_field::{
     widget::prelude::*, EditField, EditFieldAble, EditFieldBaggage, EditFieldError,
-    EditFieldObjectKind, EditFields,
+    EditFieldObjectKind,
 };
 use crate::func::backend::validation::{FuncBackendValidateStringValueArgs, ValidationError};
 use crate::func::backend::{
@@ -1207,7 +1207,7 @@ impl EditFieldAble for Component {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &ComponentId,
-    ) -> ComponentResult<EditFields> {
+    ) -> ComponentResult<Vec<EditField>> {
         let head_visibility = Visibility::new_head(ctx.visibility().deleted);
         let change_set_visibility =
             Visibility::new_change_set(ctx.visibility().change_set_pk, ctx.visibility().deleted);

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -106,7 +106,7 @@ pub struct EditField {
     object_id: i64,
     data_type: EditFieldDataType,
     widget: Widget,
-    pub value: Option<serde_json::Value>,
+    value: Option<serde_json::Value>,
     visibility_diff: VisibilityDiff,
     validation_errors: Vec<ValidationError>,
     /// Additional context for an [`EditField`] that's not directly consumed by the frontend.
@@ -146,6 +146,26 @@ impl EditField {
         }
     }
 
+    pub fn baggage(&self) -> &Option<EditFieldBaggage> {
+        &self.baggage
+    }
+
+    pub fn data_type(&self) -> &EditFieldDataType {
+        &self.data_type
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn value(&self) -> &Option<serde_json::Value> {
+        &self.value
+    }
+
+    pub fn widget(&self) -> &Widget {
+        &self.widget
+    }
+
     /// Creates a new [`EditFieldBaggage`] and sets it on the corresponding field on [`Self`].
     pub fn set_new_baggage(
         &mut self,
@@ -166,26 +186,7 @@ impl EditField {
     pub fn unset_baggage(&mut self) {
         self.baggage = None;
     }
-
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    pub fn data_type(&self) -> &EditFieldDataType {
-        &self.data_type
-    }
-
-    // FIXME(nick): this only works for Object! It does not work for Arrays and Maps.
-    pub fn get_child_edit_fields(&self) -> Option<EditFields> {
-        if let Widget::Header(header) = &self.widget {
-            Some(header.edit_fields().to_vec())
-        } else {
-            None
-        }
-    }
 }
-
-pub type EditFields = Vec<EditField>;
 
 pub type UpdateFunction = Box<dyn Fn(String) -> Pin<Box<dyn Future<Output = EditFieldResult<()>>>>>;
 
@@ -197,7 +198,7 @@ pub trait EditFieldAble {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &Self::Id,
-    ) -> Result<EditFields, Self::Error>;
+    ) -> Result<Vec<EditField>, Self::Error>;
 
     #[allow(clippy::too_many_arguments)]
     async fn update_from_edit_field(

--- a/lib/dal/src/edit_field/widget/array_widget.rs
+++ b/lib/dal/src/edit_field/widget/array_widget.rs
@@ -1,20 +1,20 @@
 use serde::{Deserialize, Serialize};
 
-use crate::edit_field::EditFields;
+use crate::edit_field::EditField;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct ArrayWidget {
-    entries: Vec<EditFields>,
+    entries: Vec<Vec<EditField>>,
 }
 
 impl ArrayWidget {
-    pub fn new(entries: Vec<EditFields>) -> Self {
+    pub fn new(entries: Vec<Vec<EditField>>) -> Self {
         ArrayWidget { entries }
     }
 }
 
-impl From<Vec<EditFields>> for ArrayWidget {
-    fn from(entries: Vec<EditFields>) -> Self {
+impl From<Vec<Vec<EditField>>> for ArrayWidget {
+    fn from(entries: Vec<Vec<EditField>>) -> Self {
         Self::new(entries)
     }
 }

--- a/lib/dal/src/edit_field/widget/header_widget.rs
+++ b/lib/dal/src/edit_field/widget/header_widget.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-use crate::edit_field::EditFields;
+use crate::edit_field::EditField;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct HeaderWidget {
-    edit_fields: EditFields,
+    edit_fields: Vec<EditField>,
 }
 
 impl HeaderWidget {
-    pub fn new(edit_fields: EditFields) -> Self {
+    pub fn new(edit_fields: Vec<EditField>) -> Self {
         HeaderWidget { edit_fields }
     }
 
-    pub fn edit_fields(&self) -> &EditFields {
+    pub fn edit_fields(&self) -> &Vec<EditField> {
         &self.edit_fields
     }
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -12,7 +12,7 @@ use crate::{
     attribute::{prototype::AttributePrototype, value::AttributeValue},
     edit_field::{
         value_and_visibility_diff, widget::prelude::*, EditField, EditFieldAble, EditFieldDataType,
-        EditFieldError, EditFieldObjectKind, EditFields,
+        EditFieldError, EditFieldObjectKind,
     },
     func::binding::{FuncBinding, FuncBindingError},
     impl_standard_model,
@@ -326,7 +326,7 @@ impl EditFieldAble for Prop {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &Self::Id,
-    ) -> Result<EditFields, Self::Error> {
+    ) -> Result<Vec<EditField>, Self::Error> {
         let object = Self::get_by_id(ctx, id)
             .await?
             .ok_or_else(|| Self::Error::NotFound(*id, *ctx.visibility()))?;

--- a/lib/dal/src/qualification_check.rs
+++ b/lib/dal/src/qualification_check.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use crate::{
     edit_field::{
         value_and_visibility_diff, widget::prelude::*, EditField, EditFieldAble, EditFieldDataType,
-        EditFieldError, EditFieldObjectKind, EditFields,
+        EditFieldError, EditFieldObjectKind,
     },
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_many_to_many,
     HistoryEventError, SchemaVariant, SchemaVariantId, StandardModel, StandardModelError,
@@ -134,7 +134,7 @@ impl EditFieldAble for QualificationCheck {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &QualificationCheckId,
-    ) -> Result<EditFields, Self::Error> {
+    ) -> Result<Vec<EditField>, Self::Error> {
         let object = Self::get_by_id(ctx, id)
             .await?
             .ok_or(QualificationCheckError::NotFound(*id))?;

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -11,7 +11,7 @@ use crate::{
     component::ComponentKind,
     edit_field::{
         value_and_visibility_diff, widget::prelude::*, EditField, EditFieldAble, EditFieldDataType,
-        EditFieldError, EditFieldObjectKind, EditFields, VisibilityDiff,
+        EditFieldError, EditFieldObjectKind, VisibilityDiff,
     },
     func::binding::FuncBindingError,
     impl_standard_model,
@@ -382,7 +382,7 @@ impl Schema {
         let field_name = "variants";
         let object_kind = EditFieldObjectKind::Schema;
 
-        let mut items: Vec<EditFields> = vec![];
+        let mut items: Vec<Vec<EditField>> = vec![];
         for variant in object.variants(ctx).await?.into_iter() {
             let edit_fields = SchemaVariant::get_edit_fields(ctx, variant.id()).await?;
             items.push(edit_fields);
@@ -415,7 +415,7 @@ impl Schema {
         let field_name = "ui";
         let object_kind = EditFieldObjectKind::Schema;
 
-        let mut items: Vec<EditFields> = vec![];
+        let mut items: Vec<Vec<EditField>> = vec![];
         for ui_menu in object.ui_menus(ctx).await?.into_iter() {
             let edit_fields = UiMenu::get_edit_fields(ctx, ui_menu.id()).await?;
             items.push(edit_fields);
@@ -450,7 +450,10 @@ impl EditFieldAble for Schema {
     type Id = SchemaId;
     type Error = SchemaError;
 
-    async fn get_edit_fields(ctx: &DalContext<'_, '_>, id: &SchemaId) -> SchemaResult<EditFields> {
+    async fn get_edit_fields(
+        ctx: &DalContext<'_, '_>,
+        id: &SchemaId,
+    ) -> SchemaResult<Vec<EditField>> {
         let object = Schema::get_by_id(ctx, id)
             .await?
             .ok_or(SchemaError::NotFound(*id))?;

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -8,7 +8,7 @@ use telemetry::prelude::*;
 use crate::{
     edit_field::{
         value_and_visibility_diff, value_and_visibility_diff_option, widget::prelude::*, EditField,
-        EditFieldAble, EditFieldDataType, EditFieldError, EditFieldObjectKind, EditFields,
+        EditFieldAble, EditFieldDataType, EditFieldError, EditFieldObjectKind,
     },
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
     standard_model_many_to_many, LabelList, SchemaError, SchematicKind, StandardModel, Timestamp,
@@ -121,7 +121,7 @@ impl EditFieldAble for UiMenu {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &Self::Id,
-    ) -> Result<EditFields, Self::Error> {
+    ) -> Result<Vec<EditField>, Self::Error> {
         let object = UiMenu::get_by_id(ctx, id)
             .await?
             .ok_or(SchemaError::UiMenuNotFound(*id))?;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::{
     edit_field::{
         value_and_visibility_diff, widget::prelude::*, EditField, EditFieldAble, EditFieldDataType,
-        EditFieldError, EditFieldObjectKind, EditFields, VisibilityDiff,
+        EditFieldError, EditFieldObjectKind, VisibilityDiff,
     },
     impl_standard_model, pk,
     schema::builtins::{create_root_prop, RootProp},
@@ -196,7 +196,7 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<EditField> {
         let field_name = "properties";
 
-        let mut items: Vec<EditFields> = vec![];
+        let mut items: Vec<Vec<EditField>> = vec![];
         for prop in object.props(ctx).await?.into_iter() {
             let edit_fields = Prop::get_edit_fields(ctx, prop.id()).await?;
             items.push(edit_fields);
@@ -220,7 +220,7 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<EditField> {
         let field_name = "connections";
 
-        let mut items: Vec<EditFields> = vec![];
+        let mut items: Vec<Vec<EditField>> = vec![];
         for socket in object.sockets(ctx).await?.into_iter() {
             let edit_fields = Socket::get_edit_fields(ctx, socket.id()).await?;
             items.push(edit_fields);
@@ -259,7 +259,7 @@ impl EditFieldAble for SchemaVariant {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &Self::Id,
-    ) -> Result<EditFields, Self::Error> {
+    ) -> Result<Vec<EditField>, Self::Error> {
         let object = Self::get_by_id(ctx, id)
             .await?
             .ok_or(SchemaVariantError::NotFound(*id))?;

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::{
     edit_field::{
         value_and_visibility_diff, value_and_visibility_diff_copy, widget::prelude::*, EditField,
-        EditFieldAble, EditFieldDataType, EditFieldError, EditFieldObjectKind, EditFields,
+        EditFieldAble, EditFieldDataType, EditFieldError, EditFieldObjectKind,
     },
     impl_standard_model,
     label_list::ToLabelList,
@@ -271,7 +271,7 @@ impl EditFieldAble for Socket {
     async fn get_edit_fields(
         ctx: &DalContext<'_, '_>,
         id: &SocketId,
-    ) -> Result<EditFields, Self::Error> {
+    ) -> Result<Vec<EditField>, Self::Error> {
         let object = Self::get_by_id(ctx, id)
             .await?
             .ok_or(SocketError::NotFound(*id))?;

--- a/lib/dal/tests/integration_test/edit_field.rs
+++ b/lib/dal/tests/integration_test/edit_field.rs
@@ -1,4 +1,6 @@
 use crate::dal::test;
+use dal::attribute::context::AttributeContextBuilder;
+use dal::edit_field::{EditFieldBaggage, Widget};
 use dal::DalContext;
 use dal::{
     component::Component,
@@ -25,9 +27,9 @@ async fn get_edit_fields_for_component(ctx: &DalContext<'_, '_>) {
         .expect("cannot set default schema variant");
 
     // domain: Object
-    // |- object: Object
-    //    |- name: String
-    //    |- value: String
+    // └─ object: Object
+    //    ├─ name: String
+    //    └─ value: String
     let object_prop = create_prop_of_kind_and_set_parent_with_name(
         ctx,
         PropKind::Object,
@@ -54,28 +56,15 @@ async fn get_edit_fields_for_component(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot create component");
 
-    let edit_fields = Component::get_edit_fields(ctx, component.id())
+    let base_edit_fields = Component::get_edit_fields(ctx, component.id())
         .await
         .expect("could not get edit fields");
+    let edit_fields = recursive_edit_fields(base_edit_fields);
 
-    fn recursive_edit_fields(edit_fields: Vec<EditField>) -> Vec<EditField> {
-        let mut temp: Vec<EditField> = Vec::new();
-        for edit_field in &edit_fields {
-            if let Some(children) = edit_field.get_child_edit_fields() {
-                temp.append(&mut recursive_edit_fields(children));
-            }
-        }
-        let mut combined = edit_fields;
-        combined.append(&mut temp);
-        combined
-    }
-
-    // FIXME(nick): use HashSet for automatic ordering.
-    let edit_fields = recursive_edit_fields(edit_fields);
-    let mut found: Vec<(&str, &EditFieldDataType)> = Vec::new();
-    for edit_field in &edit_fields {
-        found.push((edit_field.id(), edit_field.data_type()));
-    }
+    let mut found: Vec<(&str, &EditFieldDataType)> = edit_fields
+        .iter()
+        .map(|v| (v.id(), v.data_type()))
+        .collect();
 
     let mut expected = vec![
         ("properties.root", &EditFieldDataType::Object),
@@ -93,8 +82,135 @@ async fn get_edit_fields_for_component(ctx: &DalContext<'_, '_>) {
         ),
     ];
 
-    // FIXME(nick): use HashSet to avoid sorting.
     found.sort_by_key(|v| v.0);
     expected.sort_by_key(|v| v.0);
     assert_eq!(found, expected);
+}
+
+#[test]
+async fn update_edit_field_for_component(ctx: &DalContext<'_, '_>) {
+    let mut schema = create_schema(ctx, &SchemaKind::Concrete).await;
+    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    schema_variant
+        .set_schema(ctx, schema.id())
+        .await
+        .expect("cannot associate variant with schema");
+    schema
+        .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+
+    // domain: Object
+    // └─ object: Object
+    //    ├─ name: String
+    //    └─ value: String
+    let object_prop = create_prop_of_kind_and_set_parent_with_name(
+        ctx,
+        PropKind::Object,
+        "object",
+        root.domain_prop_id,
+    )
+    .await;
+    let _name_prop = create_prop_of_kind_and_set_parent_with_name(
+        ctx,
+        PropKind::String,
+        "name",
+        *object_prop.id(),
+    )
+    .await;
+    let _value_prop = create_prop_of_kind_and_set_parent_with_name(
+        ctx,
+        PropKind::String,
+        "value",
+        *object_prop.id(),
+    )
+    .await;
+
+    let (component, _) = Component::new_for_schema_with_node(ctx, "radahn", schema.id())
+        .await
+        .expect("cannot create component");
+
+    let old_base_edit_fields = Component::get_edit_fields(ctx, component.id())
+        .await
+        .expect("could not get edit fields");
+    let old_edit_fields = recursive_edit_fields(old_base_edit_fields);
+
+    let target_edit_field_id = "properties.root.domain.object.value";
+    let old_edit_field = select_edit_field_by_id(&old_edit_fields, target_edit_field_id)
+        .expect("could not find edit field by id");
+    assert_eq!(*old_edit_field.value(), None);
+
+    let old_baggage = old_edit_field
+        .baggage()
+        .clone()
+        .expect("baggage not found on edit field");
+
+    let attribute_context = AttributeContextBuilder::new()
+        .set_prop_id(old_baggage.prop_id)
+        .set_schema_id(*schema.id())
+        .set_schema_variant_id(*schema_variant.id())
+        .set_component_id(*component.id())
+        .to_context()
+        .expect("could not create attribute context from builder");
+
+    let new_value = Some(serde_json::json!("Aubrey Drake Graham"));
+    Component::update_from_edit_field_with_baggage(
+        &ctx,
+        new_value.clone(),
+        attribute_context,
+        old_baggage,
+    )
+    .await
+    .expect("could not update from edit field");
+
+    // Check if the value was updated properly.
+    let updated_base_edit_fields = Component::get_edit_fields(ctx, component.id())
+        .await
+        .expect("could not get edit fields");
+    let updated_edit_fields = recursive_edit_fields(updated_base_edit_fields);
+    let updated_edit_field = select_edit_field_by_id(&updated_edit_fields, target_edit_field_id)
+        .expect("could not find edit field by id");
+    assert_eq!(*updated_edit_field.value(), new_value);
+
+    // Ensure that no other values were changed in the process of updating a sole edit field.
+    let mut old_values: Vec<(&str, &Option<serde_json::Value>, &Option<EditFieldBaggage>)> =
+        old_edit_fields
+            .iter()
+            .map(|v| (v.id(), v.value(), v.baggage()))
+            .collect();
+    old_values.retain(|v| v.0 != target_edit_field_id);
+    old_values.sort_by_key(|v| v.0);
+
+    let mut updated_values: Vec<(&str, &Option<serde_json::Value>, &Option<EditFieldBaggage>)> =
+        updated_edit_fields
+            .iter()
+            .map(|v| (v.id(), v.value(), v.baggage()))
+            .collect();
+    updated_values.retain(|v| v.0 != target_edit_field_id);
+    updated_values.sort_by_key(|v| v.0);
+
+    assert_eq!(old_values, updated_values);
+}
+
+fn select_edit_field_by_id(edit_fields: &Vec<EditField>, id: &str) -> Option<EditField> {
+    for edit_field in edit_fields {
+        if edit_field.id() == id {
+            return Some(edit_field.to_owned());
+        }
+    }
+    return None;
+}
+
+fn recursive_edit_fields(edit_fields: Vec<EditField>) -> Vec<EditField> {
+    let mut temp: Vec<EditField> = Vec::new();
+    for edit_field in &edit_fields {
+        // FIXME(nick): this way of getting children only works for Object! It does not work for
+        // Arrays and Maps... unless they end up using Widget::Header.
+        if let Widget::Header(header) = edit_field.widget() {
+            temp.append(&mut recursive_edit_fields(header.edit_fields().to_vec()));
+        }
+    }
+    let mut combined = edit_fields;
+    combined.append(&mut temp);
+    combined
 }

--- a/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
+++ b/lib/sdf/src/server/service/edit_field/get_edit_fields.rs
@@ -1,7 +1,8 @@
 use axum::extract::Query;
 use axum::Json;
+use dal::edit_field::EditField;
 use dal::{
-    edit_field::{EditFieldAble, EditFieldObjectKind, EditFields},
+    edit_field::{EditFieldAble, EditFieldObjectKind},
     schema,
     socket::Socket,
     Component, Prop, QualificationCheck, Schema, Visibility, WorkspaceId,
@@ -24,7 +25,7 @@ pub struct GetEditFieldsRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetEditFieldsResponse {
-    pub fields: EditFields,
+    pub fields: Vec<EditField>,
 }
 
 pub async fn get_edit_fields(


### PR DESCRIPTION
- Add update from edit field for component integration test
- Remove "EditFields" type in favor of "Vec<EditField>" for readability
- Re-order accessor methods on EditField struct to be directly after the
  constructor method (alphebetically)
- Make value field private on EditField struct in favor of accessor
  method
- Remove get child edit fields method from EditField since it was only
  used by tests and is unfinished
  - Move core logic to EditField integration tests


<img src="https://media0.giphy.com/media/eCwAEs05phtK/giphy.gif"/>

Fixes ENG-83