### PR TITLE
 feat(web,sdf): Fix schematic panel bugs 

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -1,11 +1,13 @@
 import { StandardModel } from "@/api/sdf/dal/standard_model";
+import { SchematicKind } from "@/api/sdf/dal/schematic";
 
 export interface Component extends StandardModel {
   name: string;
 }
 
-export interface ComponentWithSchemaAndVariant {
+export interface ComponentIdentification {
   componentId: number;
   schemaVariantId: number;
   schemaId: number;
+  schematicKind: SchematicKind;
 }

--- a/app/web/src/organisims/EditForm.vue
+++ b/app/web/src/organisims/EditForm.vue
@@ -16,6 +16,7 @@ import { GlobalErrorService } from "@/service/global_error";
 import Widgets from "@/organisims/EditForm/Widgets.vue";
 import { combineLatest, from } from "rxjs";
 import { switchMap } from "rxjs/operators";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
 
 const props = defineProps<{
   objectKind: EditFieldObjectKind;
@@ -25,11 +26,12 @@ const props = defineProps<{
 const props$ = fromRef(props, { immediate: true, deep: true });
 
 const editFields = refFrom<EditFields>(
-  combineLatest([props$]).pipe(
-    switchMap(([props]) => {
+  combineLatest([props$, standardVisibilityTriggers$]).pipe(
+    switchMap(([props, [visibility]]) => {
       return EditFieldService.getEditFields({
         id: props.objectId,
         objectKind: props.objectKind,
+        ...visibility,
       });
     }),
     switchMap((response) => {

--- a/app/web/src/organisims/EditForm/Widget.vue
+++ b/app/web/src/organisims/EditForm/Widget.vue
@@ -53,7 +53,7 @@ import SelectWidget from "@/organisims/EditForm/SelectWidget.vue";
 import HeaderWidget from "@/organisims/EditForm/HeaderWidget.vue";
 import ArrayWidget from "@/organisims/EditForm/ArrayWidget.vue";
 import { ITreeOpenState } from "@/utils/edit_field_visitor";
-import { ComponentWithSchemaAndVariant } from "@/api/sdf/dal/component";
+import { ComponentIdentification } from "@/api/sdf/dal/component";
 import { computed } from "vue";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
 
@@ -64,19 +64,19 @@ const props = defineProps<{
   editField: EditField;
   treeOpenState: ITreeOpenState;
   backgroundColors: number[][];
-  componentWithSchemaAndVariant?: ComponentWithSchemaAndVariant;
+  componentIdentification?: ComponentIdentification;
 }>();
 
 // FIXME(nick): handle SystemId.
 const attributeContext = computed((): AttributeContext | "" => {
-  if (!props.editField.baggage || !props.componentWithSchemaAndVariant) {
+  if (!props.editField.baggage || !props.componentIdentification) {
     return "";
   }
   return {
     propId: props.editField.baggage.prop_id,
-    schemaId: props.componentWithSchemaAndVariant.schemaId,
-    schemaVariantId: props.componentWithSchemaAndVariant.schemaVariantId,
-    componentId: props.componentWithSchemaAndVariant.componentId,
+    schemaId: props.componentIdentification.schemaId,
+    schemaVariantId: props.componentIdentification.schemaVariantId,
+    componentId: props.componentIdentification.componentId,
     systemId: -1,
   };
 });

--- a/app/web/src/organisims/EditForm/Widgets.vue
+++ b/app/web/src/organisims/EditForm/Widgets.vue
@@ -8,7 +8,7 @@
       :core-edit-field="isCoreEditField"
       :indent-level="props.indentLevel"
       :tree-open-state="props.treeOpenState"
-      :component-with-schema-and-variant="props.componentWithSchemaAndVariant"
+      :component-identification="props.componentIdentification"
       @toggle-header="toggleHeader"
     />
     <div v-else class="my-2">
@@ -19,7 +19,7 @@
         :core-edit-field="isCoreEditField"
         :indent-level="props.indentLevel"
         :tree-open-state="props.treeOpenState"
-        :component-with-schema-and-variant="props.componentWithSchemaAndVariant"
+        :component-identification="props.componentIdentification"
         @toggle-header="toggleHeader"
       />
     </div>
@@ -32,7 +32,7 @@ import { EditFields } from "@/api/sdf/dal/edit_field";
 import Widget from "@/organisims/EditForm/Widget.vue";
 import { interpolateColors } from "@/utils/interpolateColors";
 import { ITreeOpenState } from "@/utils/edit_field_visitor";
-import { ComponentWithSchemaAndVariant } from "@/api/sdf/dal/component";
+import { ComponentIdentification } from "@/api/sdf/dal/component";
 
 export interface WidgetsProps {
   show: boolean;
@@ -40,7 +40,7 @@ export interface WidgetsProps {
   coreEditFields?: boolean;
   indentLevel: number;
   treeOpenState: ITreeOpenState;
-  componentWithSchemaAndVariant?: ComponentWithSchemaAndVariant;
+  componentIdentification?: ComponentIdentification;
 }
 
 const props = defineProps<WidgetsProps>();

--- a/app/web/src/organisims/EditFormComponent.vue
+++ b/app/web/src/organisims/EditFormComponent.vue
@@ -6,7 +6,7 @@
       :core-edit-fields="true"
       :indent-level="1"
       :tree-open-state="{}"
-      :component-with-schema-and-variant="componentWithSchemaAndVariant"
+      :component-identification="componentIdentification"
     />
     <div
       class="pt1 pb-1 pl-6 mt-2 text-base text-white align-middle property-section-bg-color"
@@ -19,7 +19,7 @@
         :edit-fields="propertyEditFields"
         :indent-level="1"
         :tree-open-state="treeOpenState"
-        :component-with-schema-and-variant="componentWithSchemaAndVariant"
+        :component-identification="componentIdentification"
         @toggle-header="toggleHeader"
       />
     </div>
@@ -39,11 +39,11 @@ import {
   InitialTreeOpenStateVisitor,
   ITreeOpenState,
 } from "@/utils/edit_field_visitor";
-import { ComponentWithSchemaAndVariant } from "@/api/sdf/dal/component";
+import { ComponentIdentification } from "@/api/sdf/dal/component";
 
 const props = defineProps<{
   editFields: EditFields;
-  componentWithSchemaAndVariant: ComponentWithSchemaAndVariant;
+  componentIdentification: ComponentIdentification;
 }>();
 
 /**

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -145,35 +145,39 @@
       </div>
     </template>
 
-    <template #content>
+    <template v-if="selectedComponentIdentification" #content>
       <!-- NOTE(nick): CLion's Vue.js plugin version 213.6461.23 shows an incorrect warning message here.
-      Essentially, the IDE will say that "selectComponentId" can still be an empty string despite the "v-if" directive
+      Essentially, the IDE will say that "selectComponentIdentification.componentId" can still be null despite the "v-if" directive
       checking the "truthiness" of it (either in the div or the viewer declarations). Due to the usage of the directive,
       we know it will be a number and the warning is incorrect.
       For more information: https://v3.vuejs.org/guide/conditional.html#v-if
       -->
+
+      <!-- NOTE(paulo): `npm run type-check` complains about selectedComponetnIdentification.componentId being null
+      if we only check in the template, but checking in the template ensures we can't endup rendering two #content slots
+      so we check on both places
+      -->
       <div
-        v-if="selectedComponentWithSchemaAndVariant"
+        v-if="selectedComponentIdentification"
         class="flex flex-row w-full h-full overflow-auto"
       >
         <AttributeViewer
           v-if="activeView === 'attribute'"
-          :component-id="selectedComponentWithSchemaAndVariant.componentId"
-          :component-with-schema-and-variant="
-            selectedComponentWithSchemaAndVariant
-          "
+          :key="attributeViewerKey"
+          :component-id="selectedComponentIdentification.componentId"
+          :component-identification="selectedComponentIdentification"
         />
         <QualificationViewer
           v-else-if="activeView === 'qualification'"
-          :component-id="selectedComponentWithSchemaAndVariant.componentId"
+          :component-id="selectedComponentIdentification.componentId"
         />
         <ResourceViewer
           v-else-if="activeView === 'resource'"
-          :component-id="selectedComponentWithSchemaAndVariant.componentId"
+          :component-id="selectedComponentIdentification.componentId"
         />
         <CodeViewer
           v-else-if="activeView === 'code'"
-          :component-id="selectedComponentWithSchemaAndVariant.componentId"
+          :component-id="selectedComponentIdentification.componentId"
         />
         <div v-else-if="activeView === 'connection'">
           ActiveView "{{ activeView }}" not implemented
@@ -202,8 +206,7 @@ import SiSelect from "@/atoms/SiSelect.vue";
 import { computed, ref } from "vue";
 import { LabelList } from "@/api/sdf/dal/label_list";
 import { refFrom, untilUnmounted } from "vuse-rx";
-import { switchMap } from "rxjs/operators";
-import { from } from "rxjs";
+import * as Rx from "rxjs";
 import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import AttributeViewer from "@/organisims/AttributeViewer.vue";
@@ -213,54 +216,56 @@ import CodeViewer from "@/organisims/CodeViewer.vue";
 import VueFeather from "vue-feather";
 import _ from "lodash";
 import cheechSvg from "@/assets/images/cheech-and-chong.svg";
-import {
-  deploymentSelection$,
-  componentSelection$,
-} from "./SchematicViewer/state";
+import { lastSelectedNode$ } from "./SchematicViewer/state";
+import { ComponentIdentification } from "@/api/sdf/dal/component";
+import { schematicData$ } from "./SchematicViewer/Viewer/scene/observable";
 import { visibility$ } from "@/observable/visibility";
-import { ComponentWithSchemaAndVariant } from "@/api/sdf/dal/component";
 
+const randomString = () => `${Math.floor(Math.random() * 50000)}`;
+const attributeViewerKey = ref(randomString());
 const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | "">("");
 
-visibility$.pipe(untilUnmounted).subscribe(() => {
+let visibilityChanged = false;
+visibility$.pipe(untilUnmounted).subscribe(() => (visibilityChanged = true));
+
+schematicData$.pipe(untilUnmounted).subscribe((schematic) => {
+  if (!schematic || selectedComponentId.value === "") {
+    visibilityChanged = false;
+    return;
+  }
+
+  for (const node of schematic.nodes) {
+    if (selectedComponentId.value === node.kind.componentId) {
+      // Horrible hack to ensure we refetch the edit fields when visibility changes
+      // It will flash the screen, but I don't see a better way right now (I'm fixing other schematic panel bugs)
+      if (visibilityChanged) {
+        attributeViewerKey.value = randomString();
+        visibilityChanged = false;
+      }
+      return;
+    }
+  }
+  visibilityChanged = false;
+
   isPinned.value = false;
   selectedComponentId.value = "";
 });
 
-// We garantee that the latest update will always be the last element in the list
-componentSelection$.pipe(untilUnmounted).subscribe((selections) => {
+lastSelectedNode$.pipe(untilUnmounted).subscribe((node) => {
   if (isPinned.value) return;
 
-  const last = selections?.length
-    ? selections[selections.length - 1]
-    : undefined;
-  const componentId = last?.nodes?.length
-    ? last.nodes[0]?.nodeKind?.componentId
-    : undefined;
+  const componentId = node?.nodeKind?.componentId;
 
-  // Ignores fake nodes as they don't have any attributes
-  // We never de-select with the panel
+  // Ignores deselection and fake nodes, as they don't have any attributes
   if (!componentId || componentId === -1) return;
 
   selectedComponentId.value = componentId;
 });
-deploymentSelection$.pipe(untilUnmounted).subscribe((selections) => {
-  if (isPinned.value) return;
-
-  const last = selections?.length
-    ? selections[selections.length - 1]
-    : undefined;
-  const componentId = last?.nodes?.length
-    ? last.nodes[0]?.nodeKind?.componentId
-    : undefined;
-
-  // Ignores fake nodes as they don't have any attributes
-  // We never de-select with the panel
-  if (!componentId || componentId === -1) return;
-
-  selectedComponentId.value = componentId;
-});
+// Re-selects so our observable gets it
+Rx.firstValueFrom(lastSelectedNode$).then((last) =>
+  lastSelectedNode$.next(last),
+);
 
 const props = defineProps<{
   panelIndex: number;
@@ -277,20 +282,20 @@ const setActiveView = (view: string) => {
   activeView.value = view;
 };
 
-const componentWithSchemaAndVariantList = refFrom<
-  LabelList<ComponentWithSchemaAndVariant | "">
+const componentIdentificationList = refFrom<
+  LabelList<ComponentIdentification | "">
 >(
-  ComponentService.listComponentsWithSchemaAndVariant().pipe(
-    switchMap((response) => {
+  ComponentService.listComponentsIdentification().pipe(
+    Rx.switchMap((response) => {
       if (response.error) {
         GlobalErrorService.set(response);
-        return from([[]]);
+        return Rx.from([[]]);
       } else {
-        const list: LabelList<ComponentWithSchemaAndVariant | ""> = _.cloneDeep(
+        const list: LabelList<ComponentIdentification | ""> = _.cloneDeep(
           response.list,
         );
         list.push({ label: "", value: "" });
-        return from([list]);
+        return Rx.from([list]);
       }
     }),
   ),
@@ -299,8 +304,8 @@ const componentWithSchemaAndVariantList = refFrom<
 const componentList = computed(
   (): LabelList<number | ""> => {
     let list: LabelList<number | ""> = [];
-    if (componentWithSchemaAndVariantList.value) {
-      for (const item of componentWithSchemaAndVariantList.value) {
+    if (componentIdentificationList.value) {
+      for (const item of componentIdentificationList.value) {
         let value: number | "" = "";
         if (item.value !== "") {
           value = item.value.componentId;
@@ -313,10 +318,10 @@ const componentList = computed(
 );
 
 const componentRecord = computed(
-  (): Record<number, ComponentWithSchemaAndVariant> => {
-    let record: Record<number, ComponentWithSchemaAndVariant> = {};
-    if (componentWithSchemaAndVariantList.value) {
-      for (const item of componentWithSchemaAndVariantList.value) {
+  (): Record<number, ComponentIdentification> => {
+    let record: Record<number, ComponentIdentification> = {};
+    if (componentIdentificationList.value) {
+      for (const item of componentIdentificationList.value) {
         if (item.value !== "") {
           record[item.value.componentId] = item.value;
         }
@@ -326,18 +331,18 @@ const componentRecord = computed(
   },
 );
 
-const selectedComponentWithSchemaAndVariant = computed(():
-  | ComponentWithSchemaAndVariant
-  | "" => {
-  if (selectedComponentId.value) {
-    let record = componentRecord.value[selectedComponentId.value];
-    if (record === null || record === undefined) {
-      return "";
+const selectedComponentIdentification = computed(
+  (): ComponentIdentification | null => {
+    if (selectedComponentId.value) {
+      let record = componentRecord.value[selectedComponentId.value];
+      if (record === null || record === undefined) {
+        return null;
+      }
+      return componentRecord.value[selectedComponentId.value];
     }
-    return componentRecord.value[selectedComponentId.value];
-  }
-  return "";
-});
+    return null;
+  },
+);
 </script>
 
 <style scoped>

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/InteractionManager.ts
@@ -17,6 +17,11 @@ import { PanningManager } from "./panning";
 import { ConnectingManager } from "./connecting";
 import { ZoomingManager } from "./zooming";
 import { NodeAddManager } from "./nodeAdd";
+import {
+  lastSelectedNode$,
+  lastSelectedDeploymentNode$,
+  nodeSelection$,
+} from "../../state";
 
 // import { PanningInteractionData } from "./interaction/panning";
 
@@ -159,17 +164,16 @@ export class InteractionManager {
         ST.readySelecting(this.stateService);
         ST.deSelecting(this.stateService);
 
-        if (schematicKind) {
-          const selectionObserver = this.selectionManager.selectionObserver(
-            schematicKind,
-          );
-
-          this.selectionManager.clearSelection(
-            parentDeploymentNodeId,
-            selectionObserver,
-          );
-          this.renderer.renderStage();
+        lastSelectedNode$.next(null);
+        if (schematicKind === SchematicKind.Deployment) {
+          lastSelectedDeploymentNode$.next(null);
         }
+
+        this.selectionManager.clearSelection(
+          parentDeploymentNodeId,
+          nodeSelection$,
+        );
+        this.renderer.renderStage();
       }
     }
 
@@ -187,14 +191,13 @@ export class InteractionManager {
         ST.readySelecting(this.stateService);
         ST.selecting(this.stateService);
 
-        if (!isFakeNode && schematicKind) {
-          const selectionObserver = this.selectionManager.selectionObserver(
-            schematicKind,
-          );
-          this.selectionManager.select(
-            { parentDeploymentNodeId, nodes: [target] },
-            selectionObserver,
-          );
+        this.selectionManager.select(
+          { parentDeploymentNodeId, nodes: [target] },
+          nodeSelection$,
+        );
+        lastSelectedNode$.next(target);
+        if (schematicKind === SchematicKind.Deployment) {
+          lastSelectedDeploymentNode$.next(target);
         }
 
         if (canEdit) {

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/nodeAdd.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/nodeAdd.ts
@@ -8,6 +8,7 @@ import { SelectionManager } from "./selection";
 import { Renderer } from "../renderer";
 import { NodeCreate } from "../../data/event";
 import { SchematicKind } from "@/api/sdf/dal/schematic";
+import { nodeSelection$ } from "../../state";
 
 export interface NodeAddInteractionData {
   position: {
@@ -56,9 +57,6 @@ export class NodeAddManager {
 
     if (schematicKind) {
       console.debug("Initiating node add");
-      const selectionObserver = this.selectionManager.selectionObserver(
-        schematicKind,
-      );
 
       let parentDeploymentNodeId = null;
       switch (schematicKind) {
@@ -69,18 +67,13 @@ export class NodeAddManager {
           break;
       }
 
-      this.selectionManager.clearSelection(
-        parentDeploymentNodeId,
-        selectionObserver,
+      this.selectionManager.select(
+        {
+          parentDeploymentNodeId,
+          nodes: [this.node],
+        },
+        nodeSelection$,
       );
-
-      // Since node doesn't exist yet let's not sync the node add
-      // This might be synced by the selection manager if other actions happen
-      // So the node with -1 id will need to be ignored elsewhere
-      this.selectionManager.select({
-        parentDeploymentNodeId,
-        nodes: [this.node],
-      });
     }
   }
 

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/observable.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/observable.ts
@@ -1,21 +1,5 @@
 import * as Rx from "rxjs";
-import { SceneGraphData } from "./sceneManager";
+import { Schematic } from "../../model";
 
-export const sceneGraphData$ = new Rx.ReplaySubject<SceneGraphData | null>(1);
-sceneGraphData$.next(null);
-
-export const nodeUpdate$ = new Rx.ReplaySubject<string | null>(1);
-nodeUpdate$.next(null);
-
-export const createConnection$ = new Rx.ReplaySubject<string | null>(1);
-createConnection$.next(null);
-
-export const deleteConnection$ = new Rx.ReplaySubject<string | null>(1);
-deleteConnection$.next(null);
-
-export function schematicData(): Rx.ReplaySubject<SceneGraphData | null> {
-  console.log("creating a new schematicData observable");
-  const o = new Rx.ReplaySubject<SceneGraphData | null>(1);
-  nodeUpdate$.next(null);
-  return o;
-}
+export const schematicData$ = new Rx.ReplaySubject<Schematic | null>(1);
+schematicData$.next(null);

--- a/app/web/src/organisims/SchematicViewer/state/observable.ts
+++ b/app/web/src/organisims/SchematicViewer/state/observable.ts
@@ -10,11 +10,14 @@ export interface SelectedNode {
   nodes: Array<Node>;
 }
 
-export const deploymentSelection$ = new Rx.ReplaySubject<SelectedNode[]>(1);
-deploymentSelection$.next([]);
+export const nodeSelection$ = new Rx.ReplaySubject<SelectedNode[]>(1);
+nodeSelection$.next([]);
 
-export const componentSelection$ = new Rx.ReplaySubject<SelectedNode[]>(1);
-componentSelection$.next([]);
+export const lastSelectedNode$ = new Rx.ReplaySubject<Node | null>(1);
+lastSelectedNode$.next(null);
+
+export const lastSelectedDeploymentNode$ = new Rx.ReplaySubject<Node | null>(1);
+lastSelectedNode$.next(null);
 
 // export const zoomMagnitude$ = new Rx.ReplaySubject<number | null>(1);
 // zoomMagnitude$.next(null);

--- a/app/web/src/service/component.ts
+++ b/app/web/src/service/component.ts
@@ -1,4 +1,4 @@
-import { listComponentsWithSchemaAndVariant } from "./component/list_components_with_schema_and_variant";
+import { listComponentsIdentification } from "./component/list_components_identification";
 import { listQualifications } from "./component/list_qualifications";
 import { getResource } from "./component/get_resource";
 import { syncResource } from "./component/sync_resource";
@@ -6,7 +6,7 @@ import { getComponentMetadata } from "./component/get_component_metadata";
 import { getCode } from "./component/get_code";
 
 export const ComponentService = {
-  listComponentsWithSchemaAndVariant,
+  listComponentsIdentification,
   getComponentMetadata,
   listQualifications,
   getResource,

--- a/app/web/src/service/component/get_component_metadata.ts
+++ b/app/web/src/service/component/get_component_metadata.ts
@@ -1,20 +1,17 @@
 import { ApiResponse, SDF } from "@/api/sdf";
-import { combineLatest, combineLatestWith, from, Observable } from "rxjs";
-import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import { combineLatest, from, Observable } from "rxjs";
 import Bottle from "bottlejs";
 import { switchMap } from "rxjs/operators";
 import { workspace$ } from "@/observable/workspace";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import _ from "lodash";
 
-export interface GetComponentMetadataArgs {
+export interface GetComponentMetadataArgs extends Visibility {
   componentId: number;
   systemId: number;
 }
 
-export interface GetComponentMetadataRequest
-  extends GetComponentMetadataArgs,
-    Visibility {
+export interface GetComponentMetadataRequest extends GetComponentMetadataArgs {
   workspaceId: number;
 }
 
@@ -27,9 +24,8 @@ export interface GetComponentMetadataResponse {
 export function getComponentMetadata(
   args: GetComponentMetadataArgs,
 ): Observable<ApiResponse<GetComponentMetadataResponse>> {
-  return combineLatest([standardVisibilityTriggers$]).pipe(
-    combineLatestWith(workspace$),
-    switchMap(([[[visibility]], workspace]) => {
+  return combineLatest([workspace$]).pipe(
+    switchMap(([workspace]) => {
       const bottle = Bottle.pop("default");
       const sdf: SDF = bottle.container.SDF;
       if (_.isNull(workspace)) {
@@ -44,7 +40,6 @@ export function getComponentMetadata(
         ]);
       }
       const request: GetComponentMetadataRequest = {
-        ...visibility,
         ...args,
         workspaceId: workspace.id,
       };

--- a/app/web/src/service/component/list_components_identification.ts
+++ b/app/web/src/service/component/list_components_identification.ts
@@ -7,17 +7,17 @@ import { workspace$ } from "@/observable/workspace";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import _ from "lodash";
 import { LabelList } from "@/api/sdf/dal/label_list";
-import { ComponentWithSchemaAndVariant } from "@/api/sdf/dal/component";
+import { ComponentIdentification } from "@/api/sdf/dal/component";
 
-export interface ListComponentsWithSchemaAndVariantRequest extends Visibility {
+export interface ListComponentsIdentificationRequest extends Visibility {
   workspaceId: number;
 }
 
-export interface ListComponentsWithSchemaAndVariantResponse {
-  list: LabelList<ComponentWithSchemaAndVariant>;
+export interface ListComponentsIdentificationResponse {
+  list: LabelList<ComponentIdentification>;
 }
 
-const componentWithSchemaAndVariantList$ = combineLatest([
+const componentIdentificationList$ = combineLatest([
   standardVisibilityTriggers$,
 ]).pipe(
   combineLatestWith(workspace$),
@@ -35,20 +35,20 @@ const componentWithSchemaAndVariantList$ = combineLatest([
         },
       ]);
     }
-    const request: ListComponentsWithSchemaAndVariantRequest = {
+    const request: ListComponentsIdentificationRequest = {
       ...visibility,
       workspaceId: workspace.id,
     };
-    return sdf.get<ApiResponse<ListComponentsWithSchemaAndVariantResponse>>(
-      "component/list_components_with_schema_and_variant",
+    return sdf.get<ApiResponse<ListComponentsIdentificationResponse>>(
+      "component/list_components_identification",
       request,
     );
   }),
   shareReplay({ bufferSize: 1, refCount: true }),
 );
 
-export function listComponentsWithSchemaAndVariant(): Observable<
-  ApiResponse<ListComponentsWithSchemaAndVariantResponse>
+export function listComponentsIdentification(): Observable<
+  ApiResponse<ListComponentsIdentificationResponse>
 > {
-  return componentWithSchemaAndVariantList$;
+  return componentIdentificationList$;
 }

--- a/app/web/src/utils/edit_field_visitor.ts
+++ b/app/web/src/utils/edit_field_visitor.ts
@@ -97,7 +97,7 @@ export class ChangedEditFieldCounterVisitor implements EditFieldVisitor {
 
     // TODO(fnichol): implement support of maps once we have a reasonable
     // widget type
-    throw new Error("Map kinds are not yet supported, sorry!");
+    //throw new Error("Map kinds are not yet supported, sorry!");
   }
 
   visitNone(field: NoneEditField) {
@@ -176,7 +176,7 @@ export class InitialTreeOpenStateVisitor implements EditFieldVisitor {
   visitMap(_field: MapEditField) {
     // TODO(fnichol): implement support of maps once we have a reasonable
     // widget type
-    throw new Error("Map kinds are not yet supported, sorry!");
+    //throw new Error("Map kinds are not yet supported, sorry!");
   }
 
   visitNone(field: NoneEditField) {

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 pub mod get_code;
 pub mod get_component_metadata;
 pub mod get_resource;
-pub mod list_components_with_schema_and_variant;
+pub mod list_components_identification;
 pub mod list_qualifications;
 pub mod sync_resource;
 
@@ -79,8 +79,8 @@ impl IntoResponse for ComponentError {
 pub fn routes() -> Router {
     Router::new()
         .route(
-            "/list_components_with_schema_and_variant",
-            get(list_components_with_schema_and_variant::list_components_with_schema_and_variant),
+            "/list_components_identification",
+            get(list_components_identification::list_components_identification),
         )
         .route(
             "/get_component_metadata",

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -10,12 +10,12 @@ use dal::{Component, SchemaKind, StandardModel, Visibility};
 use sdf::service::component::get_component_metadata::{
     GetComponentMetadataRequest, GetComponentMetadataResponse,
 };
-use sdf::service::component::list_components_with_schema_and_variant::{
-    ListComponentsWithSchemaAndVariantRequest, ListComponentsWithSchemaAndVariantResponse,
+use sdf::service::component::list_components_identification::{
+    ListComponentsIdentificationRequest, ListComponentsIdentificationResponse,
 };
 
 #[test]
-async fn list_components_with_schema_and_variant() {
+async fn list_components_identification() {
     test_setup!(
         _ctx,
         _secret_key,
@@ -50,13 +50,13 @@ async fn list_components_with_schema_and_variant() {
     }
     dal_txns.commit().await.expect("cannot commit transaction");
 
-    let request = ListComponentsWithSchemaAndVariantRequest {
+    let request = ListComponentsIdentificationRequest {
         visibility,
         workspace_id: *nba.workspace.id(),
     };
-    let response: ListComponentsWithSchemaAndVariantResponse = api_request_auth_query(
+    let response: ListComponentsIdentificationResponse = api_request_auth_query(
         app,
-        "/api/component/list_components_with_schema_and_variant",
+        "/api/component/list_components_identification",
         &auth_token,
         &request,
     )


### PR DESCRIPTION
- Only show deployment nodes in component panel deployment select box
- Rename ComponentWithSchemaAndVariant to ComponentIdentification
  - Add SchematicKind to it
- Comment-out throws on Maps/Arrays props as they were breaking the UI
- Change AttributeViewer template key to force it to re-fetch edit fields when visibility changes
  - We need to check if the selection is valid first, and if not, remove it
- Make EditFieldService.getEditFields non reactive to visibility, as the componentId might not exist anymore
  - The reactivity is responsibility of the caller
- Make ComponentService.getComponentMetadata non reactive to visibility, as the componentId might not exist anymore
  - The reactivity is responsibility of the caller
- Try to fix AttributeViewer duplication by filtering the template, instead of the content of the template
- Fix node selection in AttributeViewer and PanelSchematic
- Unify selection observables componentSelection$ and deploymentSelection$ in nodeSelection$, filtering by parentDeploymentNodeId
- Clean PanelSchematic up

<img src="https://media3.giphy.com/media/Zu6AATBpCeUzm/giphy.gif"/>