### PR TITLE
feat(dal,sdf,web): add remove from edit field

### DIFF
--- a/app/web/src/atoms/Unset.vue
+++ b/app/web/src/atoms/Unset.vue
@@ -1,20 +1,37 @@
 <template>
-  <button
-    v-if="(props.editValue ?? undefined) !== undefined"
-    @click="props.unset && props.unset()"
-  >
+  <button @click="removeFromEditField">
+    <!-- NOTE(nick): we may want to consider using the backspace icon or something else -->
     <VueFeather type="trash-2" size="1em" class="ml-1" />
   </button>
 </template>
 
 <script setup lang="ts">
-import type { EditFieldValues } from "@/api/sdf/dal/edit_field";
+import type { EditField } from "@/api/sdf/dal/edit_field";
 import VueFeather from "vue-feather";
+import { AttributeContext } from "@/api/sdf/dal/attribute";
+import { EditFieldService } from "@/service/edit_field";
+import { ApiResponse } from "@/api/sdf";
+import { RemoveFromEditFieldResponse } from "@/service/edit_field/remove_from_edit_field";
+import { GlobalErrorService } from "@/service/global_error";
 
 const props = defineProps<{
-  editValue?: EditFieldValues;
-  unset: () => void;
+  attributeContext: AttributeContext;
+  editField: EditField;
 }>();
+
+const removeFromEditField = () => {
+  EditFieldService.removeFromEditField({
+    objectKind: props.editField.object_kind,
+    objectId: props.editField.object_id,
+    editFieldId: props.editField.id,
+    baggage: props.editField.baggage,
+    attributeContext: props.attributeContext,
+  }).subscribe((response: ApiResponse<RemoveFromEditFieldResponse>) => {
+    if (response.error) {
+      GlobalErrorService.set(response);
+    }
+  });
+};
 </script>
 
 <style scoped>

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -30,7 +30,10 @@
           v-if="!coreEditField"
           class="flex flex-row items-center w-10 ml-1 bg-red"
         >
-          <Unset :edit-value="props.editField.value" :unset="unset" />
+          <Unset
+            :edit-field="props.editField"
+            :attribute-context="props.attributeContext"
+          />
         </div>
       </div>
     </template>
@@ -95,21 +98,6 @@ const widget = computed<ArrayWidgetDal>(() => {
 });
 
 const addToArray = () => {
-  EditFieldService.updateFromEditField({
-    objectKind: props.editField.object_kind,
-    objectId: props.editField.object_id,
-    editFieldId: props.editField.id,
-    value: null,
-    baggage: props.editField.baggage,
-    attributeContext: props.attributeContext,
-  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
-    if (response.error) {
-      GlobalErrorService.set(response);
-    }
-  });
-};
-
-const unset = () => {
   EditFieldService.updateFromEditField({
     objectKind: props.editField.object_kind,
     objectId: props.editField.object_id,

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -19,7 +19,10 @@
         v-if="!coreEditField"
         class="flex flex-row items-center w-10 ml-1 bg-red"
       >
-        <Unset :edit-value="props.editField.value" :unset="unset" />
+        <Unset
+          :edit-field="props.editField"
+          :attribute-context="props.attributeContext"
+        />
       </div>
     </template>
     <template #show>
@@ -71,21 +74,6 @@ const onBlur = () => {
     });
   }
   updating.value = false;
-};
-
-const unset = () => {
-  EditFieldService.updateFromEditField({
-    objectKind: props.editField.object_kind,
-    objectId: props.editField.object_id,
-    editFieldId: props.editField.id,
-    value: null,
-    baggage: props.editField.baggage,
-    attributeContext: props.attributeContext,
-  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
-    if (response.error) {
-      GlobalErrorService.set(response);
-    }
-  });
 };
 
 watch(

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -28,7 +28,10 @@
         v-if="!coreEditField"
         class="flex flex-row items-center w-10 ml-1 bg-red"
       >
-        <Unset :edit-value="props.editField.value" :unset="unset" />
+        <Unset
+          :edit-field="props.editField"
+          :attribute-context="props.attributeContext"
+        />
       </div>
     </template>
     <template #show>
@@ -85,21 +88,6 @@ const onBlur = () => {
     });
   }
   updating.value = false;
-};
-
-const unset = () => {
-  EditFieldService.updateFromEditField({
-    objectKind: props.editField.object_kind,
-    objectId: props.editField.object_id,
-    editFieldId: props.editField.id,
-    value: null,
-    baggage: props.editField.baggage,
-    attributeContext: props.attributeContext,
-  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
-    if (response.error) {
-      GlobalErrorService.set(response);
-    }
-  });
 };
 
 watch(

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -24,7 +24,10 @@
         v-if="!coreEditField"
         class="flex flex-row items-center w-10 ml-1 bg-red"
       >
-        <Unset :edit-value="props.editField.value" :unset="unset" />
+        <Unset
+          :edit-field="props.editField"
+          :attribute-context="props.attributeContext"
+        />
       </div>
     </template>
     <template #show>
@@ -79,21 +82,6 @@ const onKeyEnter = (event: KeyboardEvent) => {
   if (event?.target instanceof HTMLElement) {
     event.target.blur();
   }
-};
-
-const unset = () => {
-  EditFieldService.updateFromEditField({
-    objectKind: props.editField.object_kind,
-    objectId: props.editField.object_id,
-    editFieldId: props.editField.id,
-    value: null,
-    baggage: props.editField.baggage,
-    attributeContext: props.attributeContext,
-  }).subscribe((response: ApiResponse<UpdateFromEditFieldResponse>) => {
-    if (response.error) {
-      GlobalErrorService.set(response);
-    }
-  });
 };
 
 watch(

--- a/app/web/src/service/edit_field.ts
+++ b/app/web/src/service/edit_field.ts
@@ -1,7 +1,9 @@
 import { getEditFields } from "./edit_field/get_edit_fields";
+import { removeFromEditField } from "./edit_field/remove_from_edit_field";
 import { updateFromEditField } from "./edit_field/update_from_edit_field";
 
 export const EditFieldService = {
   getEditFields,
+  removeFromEditField,
   updateFromEditField,
 };

--- a/app/web/src/service/edit_field/remove_from_edit_field.ts
+++ b/app/web/src/service/edit_field/remove_from_edit_field.ts
@@ -1,0 +1,79 @@
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, from, Observable, take, tap } from "rxjs";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { visibility$ } from "@/observable/visibility";
+import { switchMap } from "rxjs/operators";
+import { EditFieldObjectKind } from "@/api/sdf/dal/edit_field";
+import { editSessionWritten$ } from "@/observable/edit_session";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
+import { AttributeContext } from "@/api/sdf/dal/attribute";
+
+export interface RemoveFromEditFieldArgs {
+  objectKind: EditFieldObjectKind;
+  objectId: number;
+  editFieldId: string;
+  attributeContext: AttributeContext;
+  baggage?: unknown;
+}
+
+export interface RemoveFromEditFieldRequest
+  extends RemoveFromEditFieldArgs,
+    Visibility {
+  workspaceId?: number;
+}
+
+export interface RemoveFromEditFieldResponse {
+  success: boolean;
+}
+
+export function removeFromEditField(
+  args: RemoveFromEditFieldArgs,
+): Observable<ApiResponse<RemoveFromEditFieldResponse>> {
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+  return combineLatest([visibility$, workspace$]).pipe(
+    take(1),
+    switchMap(([visibility, workspace]) => {
+      let request: RemoveFromEditFieldRequest;
+      if (
+        args.objectKind === EditFieldObjectKind.Component ||
+        args.objectKind === EditFieldObjectKind.ComponentProp
+      ) {
+        if (_.isNull(workspace)) {
+          return from([
+            {
+              error: {
+                statusCode: 10,
+                message: "cannot make call without a workspace; bug!",
+                code: 10,
+              },
+            },
+          ]);
+        }
+        request = {
+          ...args,
+          ...visibility,
+          workspaceId: workspace.id,
+        };
+      } else {
+        request = {
+          ...args,
+          ...visibility,
+        };
+      }
+      return sdf
+        .post<ApiResponse<RemoveFromEditFieldResponse>>(
+          "edit_field/remove_from_edit_field",
+          request,
+        )
+        .pipe(
+          tap((response) => {
+            editSessionWritten$.next(true);
+            console.log({ response });
+          }),
+        );
+    }),
+  );
+}

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -89,8 +89,8 @@ pub enum VisibilityDiff {
 pub struct EditFieldBaggage {
     pub attribute_value_id: AttributeValueId,
     pub parent_attribute_value_id: Option<AttributeValueId>,
-    /// Optional key used to indicate which value to use for [`EditFieldObjectKind::Array`] and
-    /// [`EditFieldObjectKind::Map`].
+    /// Optional key used to indicate which value to use for [`EditFieldDataType::Array`] and
+    /// [`EditFieldDataType::Map`].
     pub key: Option<String>,
     pub prop_id: PropId,
 }

--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -13,6 +13,7 @@ use std::convert::Infallible;
 use thiserror::Error;
 
 pub mod get_edit_fields;
+pub mod remove_from_edit_field;
 pub mod update_from_edit_field;
 
 #[derive(Debug, Error)]
@@ -69,6 +70,10 @@ impl IntoResponse for EditFieldError {
 pub fn routes() -> Router {
     Router::new()
         .route("/get_edit_fields", get(get_edit_fields::get_edit_fields))
+        .route(
+            "/remove_from_edit_field",
+            post(remove_from_edit_field::remove_from_edit_field),
+        )
         .route(
             "/update_from_edit_field",
             post(update_from_edit_field::update_from_edit_field),

--- a/lib/sdf/src/server/service/edit_field/remove_from_edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field/remove_from_edit_field.rs
@@ -1,0 +1,120 @@
+use axum::Json;
+use dal::{
+    edit_field::{EditFieldAble, EditFieldBaggage, EditFieldObjectKind},
+    schema::{self, SchemaVariant},
+    socket::Socket,
+    AttributeContext, Component, Prop, QualificationCheck, Schema, Visibility, WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{EditFieldError, EditFieldResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveFromEditFieldRequest {
+    pub object_kind: EditFieldObjectKind,
+    pub object_id: i64,
+    pub edit_field_id: String,
+    pub baggage: Option<EditFieldBaggage>,
+    pub workspace_id: Option<WorkspaceId>,
+    pub attribute_context: Option<AttributeContext>,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveFromEditFieldResponse {
+    pub success: bool,
+}
+
+/// This function is very similar to [`crate::server::service::edit_field::update_from_edit_field::update_from_edit_field()`],
+/// but instead of using a value in the request payload, [`None`] is used for the value in the
+/// underlying update functions.
+pub async fn remove_from_edit_field(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<RemoveFromEditFieldRequest>,
+) -> EditFieldResult<Json<RemoveFromEditFieldResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    match request.object_kind {
+        EditFieldObjectKind::Component => {
+            Component::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::ComponentProp => {
+            let baggage = request.baggage.ok_or(EditFieldError::MissingBaggage)?;
+            let attribute_context = request
+                .attribute_context
+                .ok_or(EditFieldError::MissingAttributeContext)?;
+            Component::update_from_edit_field_with_baggage(&ctx, None, attribute_context, baggage)
+                .await?
+        }
+        EditFieldObjectKind::Prop => {
+            Prop::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::QualificationCheck => {
+            QualificationCheck::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::Schema => {
+            Schema::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::SchemaUiMenu => {
+            schema::UiMenu::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::SchemaVariant => {
+            SchemaVariant::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+        EditFieldObjectKind::Socket => {
+            Socket::update_from_edit_field(
+                &ctx,
+                request.object_id.into(),
+                request.edit_field_id,
+                None,
+            )
+            .await?
+        }
+    };
+
+    txns.commit().await?;
+
+    Ok(Json(RemoveFromEditFieldResponse { success: true }))
+}

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -110,7 +110,7 @@ async fn get_components_metadata() {
         .await
         .expect("cannot set schema variant");
 
-    let component = create_component_for_schema_variant(&dal_ctx, schema_variant.id()).await;
+    let _component = create_component_for_schema_variant(&dal_ctx, schema_variant.id()).await;
     dal_txns.commit().await.expect("cannot commit transaction");
 
     let request = GetComponentsMetadataRequest {


### PR DESCRIPTION
- Add remove from edit field functionality by passing in "None" to
  update from edit field function(s)
- Remove value requirement from copied update from edit field frontend
  service
- Refactor existing unset atom to leverage new removal code
- Fix misc edit field cargo doc mistakes

Side note: we are skipping integration tests for now, since we will
revisit them once insert for edit field has been implemented. Future
integration tests should use all three (update, insert, and remove) to
ensure edit field mutations work as intended, which include nested
arrays and maps.

<img src="https://media0.giphy.com/media/1knAxGqTI1GW9Keaon/giphy-downsized-medium.gif"/>

Fixes ENG-39
Fixes ENG-91
Fixes ENG-92