### PR TITLE
feat(sdf,dal): Add UiMenu test with 3 layers

### DIFF
--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -12,8 +12,7 @@ use crate::{
     component::ComponentKind, edit_field::widget::*, func::binding::FuncBinding,
     validation_prototype::ValidationPrototypeContext, Func, FuncBackendKind,
     FuncBackendResponseType, Prop, PropId, PropKind, QualificationPrototype, ResourcePrototype,
-    Schema, SchemaError, SchemaKind, SchemaVariantId, SchematicKind, StandardModel,
-    ValidationPrototype,
+    Schema, SchemaError, SchemaKind, SchemaVariantId, StandardModel, ValidationPrototype,
 };
 use crate::{
     AttributeContext, AttributePrototype, AttributePrototypeError, AttributeReadContext,
@@ -122,9 +121,6 @@ async fn service(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     let application_name = "application".to_string();
     ui_menu
         .set_category(ctx, Some(application_name.clone()))
-        .await?;
-    ui_menu
-        .set_schematic_kind(ctx, SchematicKind::from(*schema.kind()))
         .await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -1,15 +1,14 @@
 use dal::DalContext;
 
 use crate::dal::test;
+use dal::node_menu::{get_node_menu_items, GenerateMenuItem};
 use dal::schema::SchemaKind;
 use dal::test_harness::{create_schema, create_schema_ui_menu};
-use dal::{schema::UiMenu, HistoryActor, SchematicKind, StandardModel, Visibility, WriteTenancy};
+use dal::{schema::UiMenu, Component, MenuFilter, Schema, SchematicKind, StandardModel};
+use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
 #[test]
 async fn new(ctx: &DalContext<'_, '_>) {
-    let _write_tenancy = WriteTenancy::new_universal();
-    let _visibility = Visibility::new_head(false);
-    let _history_actor = HistoryActor::SystemInit;
     let schema_ui_menu = UiMenu::new(ctx, &SchematicKind::Component)
         .await
         .expect("cannot create schema ui menu");
@@ -68,4 +67,107 @@ async fn root_schematics(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot list root schematics");
     assert_eq!(no_root_schematics, vec![]);
+}
+
+#[test]
+async fn three_layers(ctx: &DalContext<'_, '_>) {
+    let schema = create_schema(ctx, &SchemaKind::Concrete).await;
+
+    let application_name = "application";
+    let application_schema_results = Schema::find_by_attr(ctx, "name", &application_name)
+        .await
+        .expect("unable to find application");
+    let application_schema = application_schema_results
+        .first()
+        .expect("unable to find application schema");
+
+    let (application_component, _node) =
+        Component::new_application_with_node(ctx, "application".to_owned())
+            .await
+            .expect("unable to create application");
+
+    let mut root_ui_menu = create_schema_ui_menu(ctx).await;
+    root_ui_menu
+        .set_name(ctx, Some("root-test".to_owned()))
+        .await
+        .expect("unable to set name");
+    root_ui_menu
+        .add_root_schematic(ctx, application_schema.id())
+        .await
+        .expect("unable to set root schematic");
+
+    let mut parent_ui_menu = create_schema_ui_menu(ctx).await;
+    parent_ui_menu
+        .set_name(ctx, Some("parent-test".to_owned()))
+        .await
+        .expect("unable to set name");
+    parent_ui_menu
+        .add_root_schematic(ctx, application_schema.id())
+        .await
+        .expect("unable to set root schematic");
+    parent_ui_menu
+        .set_category(ctx, Some("root-test".to_owned()))
+        .await
+        .expect("unable to set category");
+
+    // root-test->parent-test->schema.name()
+    let mut schema_ui_menu = create_schema_ui_menu(ctx).await;
+    schema_ui_menu
+        .set_name(ctx, Some(schema.name().to_string()))
+        .await
+        .expect("unable to set name");
+    schema_ui_menu
+        .set_category(ctx, Some("root-test.parent-test".to_owned()))
+        .await
+        .expect("unable to set category");
+    schema_ui_menu
+        .add_root_schematic(ctx, application_schema.id())
+        .await
+        .expect("unable to set root schematic");
+    schema_ui_menu
+        .set_schema(ctx, schema.id())
+        .await
+        .expect("unable to set schema");
+
+    let items = get_node_menu_items(
+        &ctx,
+        &MenuFilter {
+            schematic_kind: SchematicKind::Component,
+            root_component_id: *application_component.id(),
+        },
+    )
+    .await
+    .expect("unable to get_node_menu_items");
+    let response = {
+        let gmi = GenerateMenuItem::new();
+        gmi.create_menu_json(items)
+            .expect("unable to generate menu json")
+    };
+
+    assert_eq_sorted!(
+        response
+            .as_array()
+            .expect("response was not an array")
+            .iter()
+            .find(|obj| obj
+                .get("name")
+                .expect("unable to get name")
+                .as_str()
+                .expect("name wasnt a string")
+                == "root".to_owned())
+            .expect("root not found"),
+        &serde_json::json!({
+            "kind": "category",
+            "name": "root-test",
+            "items": [{
+                "kind": "category",
+                "name": "parent-test",
+                "items": [{
+                    "kind": "item",
+                    "name": schema.name(),
+                    "items": []
+                }]
+            }],
+        })
+    );
 }

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -110,7 +110,7 @@ async fn get_components_metadata() {
         .await
         .expect("cannot set schema variant");
 
-    let component = create_component_for_schema_variant(&dal_ctx, schema_variant.id()).await;
+    let _component = create_component_for_schema_variant(&dal_ctx, schema_variant.id()).await;
     dal_txns.commit().await.expect("cannot commit transaction");
 
     let request = GetComponentsMetadataRequest {


### PR DESCRIPTION
While debugging the UiMenu I found the need for a test with 3 layers, but I am blocked now trying to make it succeed. I feel I need more understanding of the UiMenu machinery, as I might be setting things up wrong.

I will focus on fixing schematic panel bugs for now.

@adamhjk could you review this, and zoom whenever you have some time? So we can talk more about how to make this test work and make the schema builtins do something similar. It's not urgent as I can focus on other things.