### PR TITLE
fix(dal): trim k8s deployment for user testing

### DIFF
--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -2,15 +2,13 @@ use crate::code_generation_prototype::CodeGenerationPrototypeContext;
 use crate::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
 use crate::func::backend::js_qualification::FuncBackendJsQualificationArgs;
 use crate::qualification_prototype::QualificationPrototypeContext;
-use crate::schema::builtins::kubernetes_metadata::create_metadata_prop;
-use crate::schema::builtins::kubernetes_selector::create_selector_prop;
-use crate::schema::builtins::kubernetes_template::create_template_prop;
-use crate::schema::builtins::{create_prop, create_schema, create_string_prop_with_default};
+
+use crate::schema::builtins::{create_schema, create_string_prop_with_default};
 use crate::schema::{SchemaResult, SchemaVariant, UiMenu};
 use crate::socket::{Socket, SocketArity, SocketEdgeKind};
 use crate::{
-    AttributeReadContext, CodeGenerationPrototype, DalContext, Func, PropKind,
-    QualificationPrototype, Schema, SchemaError, SchemaKind, SchematicKind, StandardModel,
+    AttributeReadContext, CodeGenerationPrototype, DalContext, Func, QualificationPrototype,
+    Schema, SchemaError, SchemaKind, SchematicKind, StandardModel,
 };
 
 pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
@@ -41,61 +39,63 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> SchemaResult<()>
         )
         .await?;
     }
-    {
-        // TODO: add validation (si-registry ensures the value is unchanged)
-        let _kind_prop = create_string_prop_with_default(
-            ctx,
-            "kind",
-            "Deployment".to_owned(),
-            Some(root_prop.domain_prop_id),
-            base_attribute_read_context,
-        )
-        .await?;
-    }
 
-    {
-        let _metadata_prop = create_metadata_prop(
-            ctx,
-            true, // is name required, note: bool is not ideal here tho
-            Some(root_prop.domain_prop_id),
-            base_attribute_read_context,
-        )
-        .await?;
-    }
-
-    {
-        let spec_prop = create_prop(
-            ctx,
-            "spec",
-            PropKind::Object,
-            Some(root_prop.domain_prop_id),
-            base_attribute_read_context,
-        )
-        .await?;
-
-        {
-            let _replicas_prop = create_prop(
-                ctx,
-                "replicas",
-                PropKind::Integer,
-                Some(*spec_prop.id()),
-                base_attribute_read_context,
-            )
-            .await?;
-        }
-
-        {
-            let _selector_prop =
-                create_selector_prop(ctx, Some(*spec_prop.id()), base_attribute_read_context)
-                    .await?;
-        }
-
-        {
-            let _template_prop =
-                create_template_prop(ctx, Some(*spec_prop.id()), base_attribute_read_context)
-                    .await?;
-        }
-    }
+    // FIXME(nick,jacob): temporary performance gain for user testing.
+    // {
+    //     // TODO: add validation (si-registry ensures the value is unchanged)
+    //     let _kind_prop = create_string_prop_with_default(
+    //         ctx,
+    //         "kind",
+    //         "Deployment".to_owned(),
+    //         Some(root_prop.domain_prop_id),
+    //         base_attribute_read_context,
+    //     )
+    //     .await?;
+    // }
+    //
+    // {
+    //     let _metadata_prop = create_metadata_prop(
+    //         ctx,
+    //         true, // is name required, note: bool is not ideal here tho
+    //         Some(root_prop.domain_prop_id),
+    //         base_attribute_read_context,
+    //     )
+    //     .await?;
+    // }
+    //
+    // {
+    //     let spec_prop = create_prop(
+    //         ctx,
+    //         "spec",
+    //         PropKind::Object,
+    //         Some(root_prop.domain_prop_id),
+    //         base_attribute_read_context,
+    //     )
+    //     .await?;
+    //
+    //     {
+    //         let _replicas_prop = create_prop(
+    //             ctx,
+    //             "replicas",
+    //             PropKind::Integer,
+    //             Some(*spec_prop.id()),
+    //             base_attribute_read_context,
+    //         )
+    //         .await?;
+    //     }
+    //
+    //     {
+    //         let _selector_prop =
+    //             create_selector_prop(ctx, Some(*spec_prop.id()), base_attribute_read_context)
+    //                 .await?;
+    //     }
+    //
+    //     {
+    //         let _template_prop =
+    //             create_template_prop(ctx, Some(*spec_prop.id()), base_attribute_read_context)
+    //                 .await?;
+    //     }
+    // }
 
     // Qualification Prototype
     let qualification_func_name = "si:qualificationYamlKubeval".to_owned();

--- a/lib/dal/src/schema/builtins/kubernetes_metadata.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_metadata.rs
@@ -4,6 +4,7 @@ use crate::{AttributeReadContext, DalContext};
 use crate::{Prop, PropId, PropKind, StandardModel};
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn create_metadata_prop(
     ctx: &DalContext<'_, '_>,
     is_name_required: bool,

--- a/lib/dal/src/schema/builtins/kubernetes_selector.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_selector.rs
@@ -4,6 +4,7 @@ use crate::{AttributeReadContext, DalContext};
 use crate::{Prop, PropId, PropKind, StandardModel};
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn create_selector_prop(
     ctx: &DalContext<'_, '_>,
     parent_prop_id: Option<PropId>,

--- a/lib/dal/src/schema/builtins/kubernetes_spec.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_spec.rs
@@ -4,6 +4,7 @@ use crate::{AttributeReadContext, DalContext};
 use crate::{Prop, PropId, PropKind, StandardModel};
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn create_spec_prop(
     ctx: &DalContext<'_, '_>,
     parent_prop_id: PropId,

--- a/lib/dal/src/schema/builtins/kubernetes_template.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_template.rs
@@ -6,6 +6,7 @@ use crate::{AttributeReadContext, DalContext};
 use crate::{Prop, PropId, PropKind, StandardModel};
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn create_template_prop(
     ctx: &DalContext<'_, '_>,
     parent_prop_id: Option<PropId>,


### PR DESCRIPTION
Heavily trim Kubernetes Deployment builtin schema for user testing. Now,
"get edit fields" takes ~500-700ms and clicking the trash can icon for
"removeFromEditFields" works too.

<img src="https://media2.giphy.com/media/u5bbqJE63sBGM/giphy.gif"/>