### PR TITLE
feat: use a signup secret when creating billing account

### DIFF
--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -34,4 +34,3 @@ RUN rm -rf /etc/nginx/conf.d/default.conf /usr/share/nginx/html/*
 COPY --from=builder /usr/src/app/web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/web/nginx/* /etc/ssl/certs/
 COPY --from=builder /usr/src/app/web/dist /usr/share/nginx/html
-COPY --from=builder /usr/src/app/web/htpasswd /htpasswd

--- a/app/web/cypress/integration/1-signup/signup.spec.ts
+++ b/app/web/cypress/integration/1-signup/signup.spec.ts
@@ -10,6 +10,7 @@ describe("Signup", () => {
     cy.getBySel("userName").type("a");
     cy.getBySel("userEmail").type("a");
     cy.getBySel("userPassword").type("a");
+    cy.getBySel("signupSecret").type("cool-steam");
     cy.getBySel("signUp").click();
     cy.url().should("be.match", /\/authenticate\/login$/);
   });

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -66,11 +66,13 @@ Cypress.Commands.add("signup", () => {
       const userName = faker.name.findName();
       const userEmail = faker.internet.email();
       const userPassword = "snakes";
+      const signupSecret = "cool-steam";
       const request = {
         billingAccountName,
         userName,
         userEmail,
         userPassword,
+        signupSecret,
       };
       cy.wrap(request).as("nba");
       return firstValueFrom(signup.createAccount(request));

--- a/app/web/htpasswd
+++ b/app/web/htpasswd
@@ -1,1 +1,0 @@
-max:$2y$05$IjSLp2MNV4Xbq2H3r4sc.eSmMyCS.SVKAC./QghlA.KvLwRp2Avw.

--- a/app/web/nginx.conf
+++ b/app/web/nginx.conf
@@ -22,9 +22,6 @@ server {
     add_header X-Content-Type-Options nosniff;
     ssl_dhparam /etc/ssl/certs/dhparam.pem;
 
-    auth_basic           "S00perS3kret Authentication";
-    auth_basic_user_file /htpasswd;
-
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
@@ -38,7 +35,6 @@ server {
     }
 
     location /api/ws {
-      auth_basic off;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
@@ -47,7 +43,6 @@ server {
     }
 
     location /api {
-      auth_basic off;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;

--- a/app/web/src/organisims/SignupForm.vue
+++ b/app/web/src/organisims/SignupForm.vue
@@ -69,6 +69,23 @@
           />
         </div>
       </div>
+      <div class="flex flex-row items-center object-center mx-2 my-2">
+        <div class="w-2/3 pr-2 text-right text-gray-400 align-middle">
+          <label class="signup-form-text" for="signupSecret">
+            Agent Passphrase
+          </label>
+        </div>
+        <div class="w-2/3 align-middle">
+          <input
+            id="signupSecret"
+            v-model="form.signupSecret"
+            data-test="signupSecret"
+            class="block w-full px-2 py-1 pr-8 leading-tight shadow signup-form-input focus:outline-none"
+            :class="inputStyling('signupSecret')"
+            type="password"
+          />
+        </div>
+      </div>
       <!-- <div class="flex flex-row items-center object-center mx-2 my-2">
         <div class="w-2/3 pr-2 text-right text-gray-400 align-middle">
           <label for="userPasswordSecond">Password Again</label>
@@ -118,6 +135,7 @@ enum InputKind {
   Name = "name",
   Email = "email",
   Password = "password",
+  SignupSecret = "signupSecret",
 }
 
 interface IData {
@@ -135,6 +153,7 @@ export default defineComponent({
         userName: "",
         userEmail: "",
         userPassword: "",
+        signupSecret: "",
       },
       errorMessage: undefined,
     };
@@ -160,7 +179,8 @@ export default defineComponent({
           this.form.billingAccountName) ||
         (inputKind == InputKind.Name && this.form.userName) ||
         (inputKind == InputKind.Email && this.form.userEmail) ||
-        (inputKind == InputKind.Password && this.form.userPassword)
+        (inputKind == InputKind.Password && this.form.userPassword) ||
+        (inputKind == InputKind.SignupSecret && this.form.signupSecret)
       ) {
         classes["signup-form-input-validated"] = true;
       }

--- a/app/web/src/service/signup/create_account.ts
+++ b/app/web/src/service/signup/create_account.ts
@@ -7,6 +7,7 @@ export interface CreateAccountRequest {
   userName: string;
   userEmail: string;
   userPassword: string;
+  signupSecret: string;
 }
 
 export interface CreateAccountResponse {

--- a/lib/sdf/src/server/extract.rs
+++ b/lib/sdf/src/server/extract.rs
@@ -233,6 +233,23 @@ impl JwtSecretKey {
     }
 }
 
+pub struct SignupSecret(pub super::routes::SignupSecret);
+
+#[async_trait]
+impl<P> FromRequest<P> for SignupSecret
+where
+    P: Send,
+{
+    type Rejection = (StatusCode, Json<serde_json::Value>);
+
+    async fn from_request(req: &mut RequestParts<P>) -> Result<Self, Self::Rejection> {
+        let Extension(signup_secret) = Extension::<super::routes::SignupSecret>::from_request(req)
+            .await
+            .map_err(internal_error)?;
+        Ok(Self(signup_secret))
+    }
+}
+
 pub struct Authorization(pub UserClaim);
 
 #[async_trait]

--- a/lib/sdf/src/server/server.rs
+++ b/lib/sdf/src/server/server.rs
@@ -14,7 +14,9 @@ use dal::{
     migrate, migrate_builtin_schemas, ResourceScheduler, ServicesContext,
 };
 use hyper::server::{accept::Accept, conn::AddrIncoming};
-use si_data::{NatsClient, NatsConfig, NatsError, PgError, PgPool, PgPoolConfig, PgPoolError};
+use si_data::{
+    NatsClient, NatsConfig, NatsError, PgError, PgPool, PgPoolConfig, PgPoolError, SensitiveString,
+};
 use telemetry::{prelude::*, TelemetryClient};
 use thiserror::Error;
 use tokio::{
@@ -84,6 +86,7 @@ impl Server<(), ()> {
                     veritech,
                     encryption_key,
                     jwt_secret_key,
+                    config.signup_secret().clone(),
                 )?;
 
                 info!("binding to HTTP socket; socket_addr={}", &socket_addr);
@@ -121,6 +124,7 @@ impl Server<(), ()> {
                     veritech,
                     encryption_key,
                     jwt_secret_key,
+                    config.signup_secret().clone(),
                 )?;
 
                 info!("binding to Unix domain socket; path={}", path.display());
@@ -258,6 +262,7 @@ pub fn build_service(
     veritech: veritech::Client,
     encryption_key: veritech::EncryptionKey,
     jwt_secret_key: JwtSecretKey,
+    signup_secret: SensitiveString,
 ) -> Result<(Router, oneshot::Receiver<()>)> {
     let (shutdown_tx, shutdown_rx) = mpsc::channel(4);
     // Note the channel parameter corresponds to the number of channels that may be maintained when
@@ -272,6 +277,7 @@ pub fn build_service(
         veritech,
         encryption_key,
         jwt_secret_key,
+        signup_secret,
         shutdown_tx,
         shutdown_broadcast_tx.clone(),
     )

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -261,6 +261,7 @@ macro_rules! test_setup {
             $veritech.clone(),
             $encr_key.clone(),
             $jwt_secret_key.clone(),
+            "myunusedsignupsecret".into(),
         )
         .expect("cannot build new server");
         let $app: axum::Router = $app.into();


### PR DESCRIPTION
This change migrates the web app away from an HTTP basic authentication
password to a shared secret provided in the form during signup.

In SDF, there is a new configuration parameter `signup_secret` which is
the string which must be provided when signing up for a new billing
account. By default (i.e. for development and testing convenience) the
shared secret is `cool-steam`. This value can be overidden in SDF's
config file or with the `SI_SDF__SIGNUP_SECRET` environment variable.

References: ENG-99

<img src="https://media1.giphy.com/media/l0MYsxZiDtc1wPHmU/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>