### PR TITLE
bug(web): fixes attribute setting and edit field rendering

### DIFF
--- a/app/web/src/organisims/PanelTree.vue
+++ b/app/web/src/organisims/PanelTree.vue
@@ -151,7 +151,9 @@ Rx.combineLatest([system$, resourceSynced$])
           systemId: system.id,
         });
       } else {
-        return Rx.from([null]);
+        return ComponentService.getComponentsMetadata({
+          systemId: -1,
+        });
       }
     }),
   )

--- a/app/web/src/service/edit_field/get_edit_fields.ts
+++ b/app/web/src/service/edit_field/get_edit_fields.ts
@@ -7,6 +7,7 @@ import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
 import { workspace$ } from "@/observable/workspace";
 import { editSessionWritten$ } from "@/observable/edit_session";
 import _ from "lodash";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
 
 export interface GetEditFieldsArgs extends Visibility {
   objectKind: EditFieldObjectKind;
@@ -41,12 +42,12 @@ export function getEditFields(
   }
   getEditFieldsCollection[args.objectKind][args.id] = combineLatest([
     workspace$,
-    editSessionWritten$,
+    standardVisibilityTriggers$,
   ]).pipe(
-    switchMap(([workspace]) => {
+    switchMap(([workspace, [visibility]]) => {
       const bottle = Bottle.pop("default");
       const sdf: SDF = bottle.container.SDF;
-      const request: GetEditFieldsRequest = { ...args };
+      const request: GetEditFieldsRequest = { ...args, ...visibility };
       if (args.objectKind === EditFieldObjectKind.Component) {
         if (_.isNull(workspace)) {
           return from([


### PR DESCRIPTION
* We regressed by no longer listening to the standard visibility
  triggers for getting new edit fields, which caused all sorts of
  shenanigans.
* We also were not fetching the component metadata if the system was
  undefined, and now we are.
* We should now be able to create components outside of a system,
  enter and exit change sets, and have everything work.