### PR TITLE
Performance fix: remove recursive pattern for component edit fields assembly

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -354,11 +354,15 @@ impl AttributeValue {
             let parent_attribute_value_id: Option<AttributeValueId> =
                 row.try_get("parent_attribute_value_id")?;
 
+            let child_attribute_value_ids: Option<Vec<AttributeValueId>> =
+                row.try_get("child_attribute_value_ids")?;
+
             result.push(AttributeValuePayload::new(
                 prop,
                 fbrv,
                 attribute_value,
                 parent_attribute_value_id,
+                child_attribute_value_ids,
             ));
         }
         Ok(result)
@@ -710,6 +714,7 @@ pub struct AttributeValuePayload {
     pub fbrv: Option<FuncBindingReturnValue>,
     pub attribute_value: AttributeValue,
     pub parent_attribute_value_id: Option<AttributeValueId>,
+    pub child_attribute_value_ids: Option<Vec<AttributeValueId>>,
 }
 
 impl AttributeValuePayload {
@@ -718,12 +723,14 @@ impl AttributeValuePayload {
         fbrv: Option<FuncBindingReturnValue>,
         attribute_value: AttributeValue,
         parent_attribute_value_id: Option<AttributeValueId>,
+        child_attribute_value_ids: Option<Vec<AttributeValueId>>,
     ) -> Self {
         Self {
             prop,
             fbrv,
             attribute_value,
             parent_attribute_value_id,
+            child_attribute_value_ids,
         }
     }
 }

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -102,6 +102,7 @@ impl ComponentView {
                 fbrv,
                 attribute_value,
                 parent_attribute_value_id,
+                child_attribute_value_ids,
             }) = work_queue.pop()
             {
                 if let Some(fbrv) = fbrv {
@@ -163,6 +164,7 @@ impl ComponentView {
                                 Some(fbrv),
                                 attribute_value,
                                 parent_attribute_value_id,
+                                child_attribute_value_ids,
                             ));
                         }
                     }

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -99,8 +99,6 @@ pub struct EditFieldBaggage {
 pub struct EditField {
     id: String,
     pub name: String,
-    /// A descendant [`EditField`] can be specified using "path" (e.g. "metadata.name").
-    path: Vec<String>,
     object_kind: EditFieldObjectKind,
     // NOTE(nick): what is this for?
     object_id: i64,
@@ -117,7 +115,6 @@ impl EditField {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: impl Into<String>,
-        path: Vec<String>,
         object_kind: EditFieldObjectKind,
         object_id: impl Into<i64>,
         data_type: EditFieldDataType,
@@ -128,9 +125,7 @@ impl EditField {
     ) -> Self {
         let name = name.into();
         let object_id = object_id.into();
-        let mut id_parts = path.clone();
-        id_parts.push(name.clone());
-        let id = id_parts.join(".");
+        let id = format!("{object_id}");
         EditField {
             id,
             object_kind,
@@ -138,7 +133,6 @@ impl EditField {
             data_type,
             widget,
             name,
-            path,
             value,
             visibility_diff,
             validation_errors,

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -308,7 +308,6 @@ impl Prop {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,
@@ -338,7 +337,6 @@ impl Prop {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,

--- a/lib/dal/src/qualification_check.rs
+++ b/lib/dal/src/qualification_check.rs
@@ -114,7 +114,6 @@ impl QualificationCheck {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,

--- a/lib/dal/src/queries/attribute_value_list_payload_for_read_context.sql
+++ b/lib/dal/src/queries/attribute_value_list_payload_for_read_context.sql
@@ -12,6 +12,7 @@ SELECT DISTINCT ON (
     attribute_values.attribute_context_component_id,
     attribute_values.attribute_context_system_id,
     parent_attribute_values.id AS parent_attribute_value_id,
+    child_attribute_values.child_attribute_value_ids,
     row_to_json(attribute_values.*) AS attribute_value_object,
     row_to_json(props.*) AS prop_object,
     row_to_json(func_binding_return_values) AS object
@@ -30,6 +31,60 @@ LEFT JOIN attribute_values AS parent_attribute_values ON
     attribute_value_belongs_to_attribute_value.belongs_to_id = parent_attribute_values.id
     AND is_visible_v1($2, parent_attribute_values.visibility_change_set_pk, parent_attribute_values.visibility_edit_session_pk,
                       parent_attribute_values.visibility_deleted)
+
+LEFT JOIN (SELECT attribute_value_belongs_to_attribute_value.belongs_to_id AS attribute_value_id,
+                  array_agg(attribute_value_belongs_to_attribute_value.object_id) AS child_attribute_value_ids
+           FROM attribute_value_belongs_to_attribute_value
+           WHERE is_visible_v1($2,
+                        attribute_value_belongs_to_attribute_value.visibility_change_set_pk,
+                        attribute_value_belongs_to_attribute_value.visibility_edit_session_pk,
+                        attribute_value_belongs_to_attribute_value.visibility_deleted)
+                 AND attribute_value_belongs_to_attribute_value.object_id IN (SELECT id FROM (
+                     SELECT DISTINCT ON (
+                            attribute_values.attribute_context_prop_id,
+                            attribute_value_belongs_to_attribute_value.belongs_to_id,
+                            attribute_values.key
+                     )
+                       attribute_values.id,
+                       attribute_values.visibility_change_set_pk,
+                       attribute_values.visibility_edit_session_pk,
+                       attribute_values.attribute_context_prop_id,
+                       attribute_values.attribute_context_schema_id,
+                       attribute_values.attribute_context_schema_variant_id,
+                       attribute_values.attribute_context_component_id,
+                       attribute_values.attribute_context_system_id
+                     FROM attribute_values
+                     LEFT JOIN attribute_value_belongs_to_attribute_value ON
+                          attribute_values.id = attribute_value_belongs_to_attribute_value.object_id
+                          AND is_visible_v1($2, attribute_value_belongs_to_attribute_value.visibility_change_set_pk,
+                                                attribute_value_belongs_to_attribute_value.visibility_edit_session_pk,
+                                                attribute_value_belongs_to_attribute_value.visibility_deleted)
+                     WHERE in_tenancy_v1($1, attribute_values.tenancy_universal,
+                                             attribute_values.tenancy_billing_account_ids,
+                                             attribute_values.tenancy_organization_ids,
+                                             attribute_values.tenancy_workspace_ids)
+                           AND is_visible_v1($2, attribute_values.visibility_change_set_pk,
+                                                 attribute_values.visibility_edit_session_pk,
+                                                 attribute_values.visibility_deleted)
+                           AND in_attribute_context_v1($3, attribute_values.attribute_context_prop_id,
+                                                           attribute_values.attribute_context_schema_id,
+                                                           attribute_values.attribute_context_schema_variant_id,
+                                                           attribute_values.attribute_context_component_id,
+                                                           attribute_values.attribute_context_system_id)
+                           ORDER BY
+                               attribute_values.attribute_context_prop_id,
+                               attribute_value_belongs_to_attribute_value.belongs_to_id,
+                               attribute_values.key,
+                               visibility_change_set_pk DESC,
+                               visibility_edit_session_pk DESC,
+                               attribute_context_schema_id DESC,
+                               attribute_context_schema_variant_id DESC,
+                               attribute_context_component_id DESC,
+                               attribute_context_system_id DESC
+                 ) AS child_ids)
+    GROUP BY attribute_value_belongs_to_attribute_value.belongs_to_id) AS child_attribute_values
+    ON attribute_values.id = child_attribute_values.attribute_value_id
+
 WHERE in_tenancy_v1($1, attribute_values.tenancy_universal, attribute_values.tenancy_billing_account_ids, attribute_values.tenancy_organization_ids,
                     attribute_values.tenancy_workspace_ids)
     AND is_visible_v1($2, attribute_values.visibility_change_set_pk, attribute_values.visibility_edit_session_pk, attribute_values.visibility_deleted)

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -326,7 +326,6 @@ impl Schema {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             object_kind,
             object.id,
             EditFieldDataType::String,
@@ -357,7 +356,6 @@ impl Schema {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             object_kind,
             object.id,
             EditFieldDataType::String,
@@ -399,13 +397,11 @@ impl Schema {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             object_kind,
             object.id,
             EditFieldDataType::None,
             Widget::Header(HeaderWidget::new(vec![EditField::new(
                 "schemaVariants",
-                vec![field_name.to_string()],
                 EditFieldObjectKind::Schema,
                 object.id,
                 EditFieldDataType::Array,
@@ -432,13 +428,11 @@ impl Schema {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             object_kind,
             object.id,
             EditFieldDataType::None,
             Widget::Header(HeaderWidget::new(vec![EditField::new(
                 "menuItems",
-                vec![field_name.to_string()],
                 EditFieldObjectKind::Schema,
                 object.id,
                 EditFieldDataType::Array,

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -165,7 +165,6 @@ impl EditFieldAble for UiMenu {
         Ok(vec![
             EditField::new(
                 String::from("name"),
-                vec![],
                 EditFieldObjectKind::SchemaUiMenu,
                 object.id,
                 EditFieldDataType::String,
@@ -176,7 +175,6 @@ impl EditFieldAble for UiMenu {
             ),
             EditField::new(
                 String::from("category"),
-                vec![],
                 EditFieldObjectKind::SchemaUiMenu,
                 object.id,
                 EditFieldDataType::String,
@@ -187,7 +185,6 @@ impl EditFieldAble for UiMenu {
             ),
             EditField::new(
                 String::from("schematic_kind"),
-                vec![],
                 EditFieldObjectKind::SchemaUiMenu,
                 object.id,
                 EditFieldDataType::String,

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -179,7 +179,6 @@ impl SchemaVariant {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,
@@ -203,7 +202,6 @@ impl SchemaVariant {
         }
         Ok(EditField::new(
             field_name,
-            vec![],
             EditFieldObjectKind::Prop,
             object.id,
             EditFieldDataType::Array,
@@ -228,13 +226,11 @@ impl SchemaVariant {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::None,
             Widget::Header(HeaderWidget::new(vec![EditField::new(
                 "sockets",
-                vec![field_name.to_string()],
                 EditFieldObjectKind::SchemaVariant,
                 object.id,
                 EditFieldDataType::Array,

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -165,7 +165,6 @@ impl Socket {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,
@@ -195,7 +194,6 @@ impl Socket {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,
@@ -225,7 +223,6 @@ impl Socket {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::String,
@@ -255,7 +252,6 @@ impl Socket {
 
         Ok(EditField::new(
             field_name,
-            vec![],
             Self::edit_field_object_kind(),
             object.id,
             EditFieldDataType::Boolean,

--- a/lib/dal/tests/database.rs
+++ b/lib/dal/tests/database.rs
@@ -13,7 +13,7 @@ const UNSET_ID_VALUE: i64 = -1;
 /// Smoke test to ensure the database is running and setup worked (migrations, etc.).
 #[test]
 async fn database_smoke(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
-    assert!(System::get_by_id(&ctx, &UNSET_ID_VALUE.into())
+    assert!(System::get_by_id(ctx, &UNSET_ID_VALUE.into())
         .await
         .is_ok())
 }


### PR DESCRIPTION
- Remove query recursion for get edit fields for component by using a
  deferential work queue
  - This should boost performance marginally by decreasing the total
    number of queries for the get edit fields SDF route
- Augment the existing "list payload for read context" attribute value
  query to include the child attribute values for a given attribute
  value
  - We use this query for our new get edit fields logic
- Remove edit fields "path" field since it is unused
  - While the field had been unused for awhile, this refactor unveiled
    its assembly would be difficult for little-to-no benefit
- Directly create the prop widget rather than performing an additional
  prop kind check for maps, arrays, and headers

<img src="https://media4.giphy.com/media/aA7WDclCy08hy/giphy.gif"/>