### PR TITLE
bug(corp): skip ci for corp, fix typo and job link

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,8 @@ A-ci:
   - .github/**/*
 A-docs:
   - docs/**/*
+A-corp:
+  - app/corp/**/*
 
 #
 # System Initiative apps (i.e. webapps/ios apps/android apps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
     branches:
       - staging
       - trying
+    paths-ignore:
+      - 'app/corp/**'
+      - 'bin/si-discord-bot/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'app/corp/**'
+      - 'bin/si-discord-bot/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/corp/components/CurrentHome.vue
+++ b/app/corp/components/CurrentHome.vue
@@ -138,7 +138,7 @@
     <div
       class="flex flex-row border-solid border-t border-zinc-800 pt-10 pb-10 place-content-end pr-10"
     >
-      <a href="/jobs">Jobs</a>
+      <a href="https://systeminit.pinpointhq.com/">Jobs</a>
     </div>
     <div class="flex flex-row text-zinc-600 place-content-center">
       &copy; 2022, System Initiative, Inc. all rights reserved.

--- a/app/corp/components/NextHeader.vue
+++ b/app/corp/components/NextHeader.vue
@@ -114,7 +114,7 @@
         <p
           class="mt-3 max-w-md mx-auto text-base text-gray-200 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl"
         >
-          A real time, collaborative power tool for Devops Teams.
+          A real time, collaborative power tool for DevOps Teams.
         </p>
       </div>
     </div>
@@ -130,6 +130,6 @@ const navigation = [
   { name: "Product", href: "/#product" },
   { name: "Features", href: "/#features" },
   { name: "Blog", href: "/blog" },
-  { name: "Jobs", href: "/jobs" },
+  { name: "Jobs", href: "https://systeminit.pinpointhq.com/" },
 ];
 </script>


### PR DESCRIPTION
We should skip ci for corp site changes, and fix a couple typos and
links.

<img src="https://media1.giphy.com/media/R6gvnAxj2ISzJdbA63/giphy-downsized-medium.gif"/>