### PR TITLE
feat(web): Make grid infinite

### DIFF
--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/grid.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/grid.ts
@@ -9,20 +9,18 @@ export class Grid extends PIXI.Container {
   zoomFactor?: number;
   quad: PIXI.Mesh<PIXI.Shader>;
 
-  constructor(size: number) {
+  constructor(rendererWidth: number, rendererHeight: number) {
     super();
 
     this.name = BACKGROUND_GRID_NAME;
     this.zoomFactor = 1;
 
-    const x = size;
-    const y = size;
+    const side = Math.max(rendererWidth, rendererHeight) * 2.0;
 
-    const v1 = { x: -x, y: -y };
-    const v2 = { x: x, y: -y };
-    const v3 = { x: x, y: y };
-    const v4 = { x: -x, y: y };
-
+    const v1 = { x: -side, y: -side };
+    const v2 = { x: side, y: -side };
+    const v3 = { x: side, y: side };
+    const v4 = { x: -side, y: side };
     const geo = new PIXI.Geometry()
       .addAttribute(
         "aVertexPosition",
@@ -35,7 +33,7 @@ export class Grid extends PIXI.Container {
     const uniforms = {
       uColor: [0.198, 0.198, 0.198],
       uBorderThickness: 0.02,
-      uGridSubdivisions: 80.0,
+      uGridSubdivisions: side / 10.0,
       uZoomFactor: this.zoomFactor,
     };
 
@@ -48,13 +46,13 @@ export class Grid extends PIXI.Container {
     this.quad = new PIXI.Mesh(geo, shader);
     this.quad.name = "quad";
     this.quad.blendMode = PIXI.BLEND_MODES.NORMAL_NPM;
-    this.quad.position.set(x, y);
     this.quad.scale.set(1);
     this.addChild(this.quad);
   }
 
   updateZoomFactor(zoomFactor: number) {
     const c = this.getChildByName("quad") as PIXI.Mesh<PIXI.Shader>;
-    c.shader.uniforms.uZoomFactor = zoomFactor;
+    // clamp(zoomFactor, 0.1, 1.);
+    c.shader.uniforms.uZoomFactor = Math.max(Math.min(zoomFactor, 1), 0.1);
   }
 }

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -50,7 +50,7 @@ export class SceneManager {
     this.scene.addChild(this.root);
 
     this.initializeSceneData();
-    this.setBackgroundGrid();
+    this.setBackgroundGrid(renderer.width, renderer.height);
 
     this.zoomFactor = 1;
   }
@@ -70,19 +70,9 @@ export class SceneManager {
     }
   }
 
-  setBackgroundGrid(): void {
-    const viewport = {
-      width: 800,
-      height: 800,
-    };
-
-    const size = Math.max(viewport.width, viewport.height);
-    const grid = new Grid(size);
+  setBackgroundGrid(rendererWidth: number, rendererHeight: number): void {
+    const grid = new Grid(rendererWidth, rendererHeight);
     grid.zIndex = 1;
-
-    grid.position.x = -(size * 0.5);
-    grid.position.y = -(size * 0.5);
-
     this.root.addChild(grid);
   }
 

--- a/app/web/src/organisims/SchematicViewer/Viewer/shader/grid.frag
+++ b/app/web/src/organisims/SchematicViewer/Viewer/shader/grid.frag
@@ -9,23 +9,22 @@ uniform float uBorderThickness;
 uniform float uGridSubdivisions;
 uniform float uZoomFactor;
 
-float rect(in vec2 _st, in float _thickness) {
-    vec2 bottomLeftCorner = step(vec2(_thickness), _st);
-    vec2 topRightCorner = step(vec2(_thickness), 1.0 - _st);
+float rect(in vec2 st, in float thickness) {
+    vec2 bottomLeftCorner = step(vec2(thickness), st);
+    vec2 topRightCorner = step(vec2(thickness), 1. - st);
     float border = bottomLeftCorner.s * bottomLeftCorner.t * topRightCorner.s * topRightCorner.t;
     return 1.0 - border;
 }
 
 void main() {
-    vec3 color = vec3(uColor);
-    vec2 st1 = vUvs;
+    float thicknessAdjustment = pow((1. / uZoomFactor), 1.2);
 
-    float thicknessAdjustment = pow((1.0 / uZoomFactor), 1.2);
-    st1 *= uGridSubdivisions;
+    vec2 st1 = vUvs;
+    st1 *= uGridSubdivisions / uZoomFactor;
     st1 = fract(st1); // x - floor(x)
     float rectInner = rect(st1, uBorderThickness * 1.75 * thicknessAdjustment);
 
-    float alpha = rectInner * clamp(uZoomFactor, 0.1, 1.0);
+    float alpha = rectInner * uZoomFactor;
 
-    gl_FragColor = vec4(color, alpha);
+    gl_FragColor = vec4(uColor, alpha);
 }

--- a/app/web/src/organisims/SchematicViewer/Viewer/shader/grid.vert
+++ b/app/web/src/organisims/SchematicViewer/Viewer/shader/grid.vert
@@ -1,14 +1,44 @@
 precision mediump float;
 
+/// Position of each corner of the grid
+/// Should represent the canvas' rectangle
 attribute vec2 aVertexPosition;
-attribute vec2 aUvs;
 
-uniform mat3 translationMatrix;
-uniform mat3 projectionMatrix;
+attribute vec2 aUvs;
 
 varying vec2 vUvs;
 
+/// Translates position to follow the camera
+uniform mat3 translationMatrix;
+
+/// Projects grid onto 2D plane
+uniform mat3 projectionMatrix;
+
+uniform float uGridSubdivisions;
+uniform float uZoomFactor;
+
+/// fmod implementation, pretty much `a % b`, but for floats
+float modulo(float f1, float f2) {
+  return f1 - (f2 * floor(f1 / f2));
+}
+
 void main() {
-    vUvs = aUvs;
-    gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
+  vUvs = aUvs;
+
+  vec3 camera = translationMatrix * vec3(1., 1., 1.);
+
+  // We multiply squareSize by 10. to avoid the feeling of glitchy teleportation
+  float squareSize = abs(aVertexPosition.x) / uGridSubdivisions * uZoomFactor * 10.;
+
+  // Caps translation difference at 1 squareSize
+  // Rendering a fixed grid, shifting it by at most 1 square
+  // As it's symmetric
+  vec3 pos = vec3(
+    modulo(camera.x, squareSize) + aVertexPosition.x,
+    modulo(camera.y, squareSize) + aVertexPosition.y,
+    camera.z
+  );
+
+  // Sets point of one grid vertex
+  gl_Position = vec4((projectionMatrix * pos).xy, 0.0, 1.0);
 }


### PR DESCRIPTION
Rethink vector shader so instead of a 800x800 grid it renders a square grid with the biggest renderer side * 2 (to deal with zoom). Instead of moving it around with the camera, it modulos the translation, so it only moves by 10 squares, and then resets the panel to the original position. So 1 sized grid just emulates a infinite grid.

Update frag shader so it takes zoom into account when setting the individual square size. The zoom worked on the previous version, but the refactor exposed the bug for some reason.

Note: I don't know much about shaders, this probably has bugs, so it should be tested by the reviewer, as we are so close to user tests, breaking something is a big problem. But from my tests it seems ok. It does behave weirdly when you change the browser's zoom, but it works nonetheless. I'm not sure how responsive it is, ideally I didn't affect responsivity, but I can't be sure.

<img src="https://media1.giphy.com/media/l0JMrPWRQkTeg3jjO/giphy.gif"/>