### PR TITLE
feat(web,dal): Improve code generation UI

### DIFF
--- a/app/web/src/organisims/CodeViewer.vue
+++ b/app/web/src/organisims/CodeViewer.vue
@@ -4,6 +4,10 @@
       class="flex flex-row items-center justify-between h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
     >
       <div class="text-lg">Component ID {{ props.componentId }} Code</div>
+
+      <button class="ml-2 text-base" @click="copyCode">
+        <VueFeather type="copy" size="1em" />
+      </button>
     </div>
     <div class="w-full h-full overflow-auto">
       <div
@@ -18,6 +22,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, toRefs } from "vue";
+import VueFeather from "vue-feather";
 import { EditorState, EditorView, basicSetup } from "@codemirror/basic-setup";
 import { yaml } from "@codemirror/legacy-modes/mode/yaml";
 import { StreamLanguage } from "@codemirror/stream-parser";
@@ -41,6 +46,11 @@ const view = ref<null | EditorView>(null);
 const view$ = fromRef(view, { immediate: true });
 const readOnly = new Compartment();
 
+// This doesn't work on IE, do we care? (is it polyfilled by our build system?)
+const copyCode = () => {
+  navigator.clipboard.writeText(view.value.state.doc.text.join("\n"));
+};
+
 onMounted(() => {
   if (editorMount.value) {
     const fixedHeightEditor = EditorView.theme({
@@ -56,7 +66,7 @@ onMounted(() => {
           fixedHeightEditor,
           keymap.of([indentWithTab]),
           StreamLanguage.define(yaml),
-          readOnly.of(EditorState.readOnly.of(false)),
+          readOnly.of(EditorState.readOnly.of(true)),
         ],
       }),
       parent: editorMount.value,
@@ -85,7 +95,7 @@ const _code = refFrom(
                 to: view.state.doc.length,
                 insert,
               },
-              effects: readOnly.reconfigure(EditorState.readOnly.of(false)),
+              effects: readOnly.reconfigure(EditorState.readOnly.of(true)),
             });
           } else {
             view.dispatch({

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -275,6 +275,11 @@ impl Component {
             .set_value_by_json_pointer(ctx, "/root/si/name", Some(name.as_ref()))
             .await?;
 
+        component.generate_code(ctx, UNSET_ID_VALUE.into()).await?;
+        component
+            .check_qualifications(ctx, UNSET_ID_VALUE.into())
+            .await?;
+
         Ok((component, node))
     }
 
@@ -333,6 +338,8 @@ impl Component {
         //       a ResourcePrototype for the Component's SchemaVariant.
         let _resource = Resource::new(ctx, &self.id, system_id).await?;
 
+        self.generate_code(ctx, *system_id).await?;
+        self.check_qualifications(ctx, *system_id).await?;
         Ok(())
     }
 

--- a/lib/dal/src/func/builtins/generateYAML.js
+++ b/lib/dal/src/func/builtins/generateYAML.js
@@ -1,6 +1,7 @@
 function generateYAML(component) {
   return {
     format: "yaml",
-    code: YAML.stringify(component.properties.domain),
+    code: Object.keys(component.properties.domain).length > 0 ?
+      YAML.stringify(component.properties.domain) : ""
   };
 }


### PR DESCRIPTION
Add copy button, to send code generated to the copy paste buffer.
This isn't the most standardized behavior ever, so there are
questions about how it works across all platforms.

Make code read-only, as the backend doesn't take user input on it
yet.

Force code generation to run when component is created (no system)
and when component gets a system, so the code isn't empty when it
shouldn't.

YAML.stringify has weird behaviors for empty object, so we fix that.

And to you, the reviewer, here's some Omar knowledge:

<img src="https://media3.giphy.com/media/OVtqvymKkkcTu/giphy.gif"/>