### PR TITLE
feat(dal,sdf): Implement lazy Component async task

### DIFF
--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -405,7 +405,7 @@ impl RequestContext {
 }
 
 /// A request context builder which requires a [`Visibility`] to be completed.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AccessBuilder {
     /// A suitable read tenancy for the consuming DAL objects.
     read_tenancy: ReadTenancy,

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -86,7 +86,7 @@ pub use code_generation_resolver::{
     CodeGenerationResolver, CodeGenerationResolverError, CodeGenerationResolverId,
 };
 pub use code_view::{CodeLanguage, CodeView};
-pub use component::{Component, ComponentError, ComponentId, ComponentView};
+pub use component::{Component, ComponentAsyncTasks, ComponentError, ComponentId, ComponentView};
 pub use context::{
     AccessBuilder, DalContext, DalContextBuilder, RequestContext, ServicesContext, Transactions,
     TransactionsError, TransactionsStarter,

--- a/lib/dal/src/test/helpers.rs
+++ b/lib/dal/src/test/helpers.rs
@@ -174,13 +174,14 @@ pub async fn create_component_for_schema(
     schema_id: &SchemaId,
 ) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, &name, schema_id)
         .await
         .expect("cannot create component");
     component
         .set_schema(ctx, schema_id)
         .await
         .expect("cannot set the schema for our component");
+    task.run(ctx).await.expect("unable to run component tasks");
     component
 }
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -396,9 +396,11 @@ pub async fn create_component_and_schema(ctx: &DalContext<'_, '_>) -> Component 
         .await
         .expect("cannot set schema variant");
     let name = generate_fake_name();
-    let (entity, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant.id())
-        .await
-        .expect("cannot create entity");
+    let (entity, _, task) =
+        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant.id())
+            .await
+            .expect("cannot create entity");
+    task.run(ctx).await.expect("unable to run component tasks");
     entity
 }
 
@@ -408,9 +410,11 @@ pub async fn create_component_for_schema_variant(
     schema_variant_id: &SchemaVariantId,
 ) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-        .await
-        .expect("cannot create component");
+    let (component, _, task) =
+        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
+            .await
+            .expect("cannot create component");
+    task.run(ctx).await.expect("unable to run component tasks");
     component
 }
 
@@ -420,13 +424,14 @@ pub async fn create_component_for_schema(
     schema_id: &SchemaId,
 ) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, &name, schema_id)
         .await
         .expect("cannot create component");
     component
         .set_schema(ctx, schema_id)
         .await
         .expect("cannot set the schema for our component");
+    task.run(ctx).await.expect("unable to run component tasks");
     component
 }
 

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -533,7 +533,7 @@ async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
     prop.set_parent_prop(ctx, root.domain_prop_id, base_attribute_read_context)
         .await
         .expect("cannot set parent of prop");
-    let (component, _) = Component::new_for_schema_with_node(ctx, "toddhoward", schema.id())
+    let (component, _, _) = Component::new_for_schema_with_node(ctx, "toddhoward", schema.id())
         .await
         .expect("cannot create component");
 

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -35,9 +35,10 @@ async fn update_for_context_simple(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot set parent of name_prop");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
-        .await
-        .expect("Unable to create component");
+    let (component, _, _) =
+        Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
+            .await
+            .expect("Unable to create component");
 
     let read_context = AttributeReadContext {
         prop_id: None,

--- a/lib/dal/tests/integration_test/code_generation_prototype.rs
+++ b/lib/dal/tests/integration_test/code_generation_prototype.rs
@@ -16,7 +16,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
         .expect("cannot find kubernetes deployment")
         .pop()
         .expect("no kubernetes deployment found");
-    let (component, _node) = Component::new_for_schema_with_node(ctx, &name, schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, &name, schema.id())
         .await
         .expect("could not create component");
 
@@ -62,7 +62,7 @@ async fn find_for_component(ctx: &DalContext<'_, '_>, _nba: BillingAccountSignup
         .default_schema_variant_id()
         .expect("cannot get default schema variant id");
 
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
         .await
         .expect("cannot create new component");
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -31,7 +31,7 @@ async fn new_for_schema_variant_with_node(ctx: &DalContext<'_, '_>, wid: Workspa
         .await
         .expect("cannot set schema variant");
 
-    let (component, _node) =
+    let (component, _node, _) =
         Component::new_for_schema_variant_with_node(ctx, "mastodon", schema_variant.id())
             .await
             .expect("cannot create component");
@@ -93,7 +93,7 @@ async fn qualification_view(ctx: &DalContext<'_, '_>) {
         .set_schema(ctx, schema.id())
         .await
         .expect("cannot set schema variant to schema");
-    let (component, _) =
+    let (component, _, _) =
         Component::new_for_schema_variant_with_node(ctx, "mastodon", schema_variant.id())
             .await
             .expect("Unable to create component");
@@ -144,7 +144,7 @@ async fn list_qualifications(ctx: &DalContext<'_, '_>) {
         .expect("cannot find docker image schema")
         .pop()
         .expect("no docker image schema found");
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "ash", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "ash", schema.id())
         .await
         .expect("cannot create docker_image component");
 
@@ -167,7 +167,7 @@ async fn list_qualifications_by_component_id(ctx: &DalContext<'_, '_>) {
         .expect("cannot find docker image schema")
         .pop()
         .expect("no docker image schema found");
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "ash", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "ash", schema.id())
         .await
         .expect("cannot create docker_image component");
 
@@ -193,7 +193,7 @@ async fn get_resource_by_component_id(ctx: &DalContext<'_, '_>, wid: WorkspaceId
 
     let (system, _system_node) = create_system_with_node(ctx, &wid).await;
 
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "chvrches", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "chvrches", schema.id())
         .await
         .expect("cannot create ash component");
 

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -454,7 +454,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 async fn only_string_props(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
-    let (component, _) =
+    let (component, _, _) =
         Component::new_for_schema_variant_with_node(ctx, "capoeira", schema_variant.id())
             .await
             .expect("Unable to create component");
@@ -549,7 +549,7 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
 async fn one_object_prop(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
-    let (component, _) =
+    let (component, _, _) =
         Component::new_for_schema_variant_with_node(ctx, "santos dumont", schema_variant.id())
             .await
             .expect("Unable to create component");
@@ -672,7 +672,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         dust_prop,
         root_prop,
     ) = create_schema_with_nested_objects_and_string_prop(ctx).await;
-    let (component, _) =
+    let (component, _, _) =
         Component::new_for_schema_variant_with_node(ctx, "free ronaldinho", schema_variant.id())
             .await
             .expect("Unable to create component");
@@ -837,7 +837,7 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
-    let (component, _) =
+    let (component, _, _) =
         Component::new_for_schema_variant_with_node(ctx, "tim maia", schema_variant.id())
             .await
             .expect("Unable to create component");
@@ -943,7 +943,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         song_name_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, _) = Component::new_for_schema_variant_with_node(
         ctx,
         "An Integralist Doesn't Run, It Flies",
         schema_variant.id(),
@@ -1165,7 +1165,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
 async fn simple_map(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, _) = Component::new_for_schema_variant_with_node(
         ctx,
         "E como isso afeta o Grêmio?",
         schema_variant.id(),
@@ -1274,7 +1274,7 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         song_map_item_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects_and_a_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, _) = Component::new_for_schema_variant_with_node(
         ctx,
         "E como isso afeta o Grêmio?",
         schema_variant.id(),

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -32,12 +32,12 @@ async fn new(ctx: &DalContext<'_, '_>) {
         .find(|s| s.name() == "output")
         .expect("cannot find output socket");
 
-    let (head_component, head_node) =
+    let (head_component, head_node, _) =
         Component::new_for_schema_with_node(ctx, "head", service_schema.id())
             .await
             .expect("cannot create component and node for service");
 
-    let (tail_component, tail_node) =
+    let (tail_component, tail_node, _) =
         Component::new_for_schema_with_node(ctx, "head", service_schema.id())
             .await
             .expect("cannot create component and node for service");
@@ -74,7 +74,7 @@ async fn include_component_in_system(
 
     let service_schema = find_schema_by_name(ctx, "service").await;
 
-    let (first_component, first_component_node) =
+    let (first_component, first_component_node, _) =
         Component::new_for_schema_with_node(ctx, "first", service_schema.id())
             .await
             .expect("cannot create component and node for service");
@@ -94,7 +94,7 @@ async fn include_component_in_system(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 2);
 
-    let (second_component, second_component_node) =
+    let (second_component, second_component_node, _) =
         Component::new_for_schema_with_node(ctx, "second", service_schema.id())
             .await
             .expect("cannot create component and node for service");
@@ -145,7 +145,7 @@ async fn include_component_in_system_with_edit_sessions(
 
     let service_schema = find_schema_by_name(ctx, "service").await;
 
-    let (first_component, first_component_node) =
+    let (first_component, first_component_node, _) =
         Component::new_for_schema_with_node(ctx, "first", service_schema.id())
             .await
             .expect("cannot create component and node for service");
@@ -165,7 +165,7 @@ async fn include_component_in_system_with_edit_sessions(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 2);
 
-    let (second_component, second_component_node) =
+    let (second_component, second_component_node, _) =
         Component::new_for_schema_with_node(ctx, "second", service_schema.id())
             .await
             .expect("cannot create component and node for service");

--- a/lib/dal/tests/integration_test/edit_field.rs
+++ b/lib/dal/tests/integration_test/edit_field.rs
@@ -60,7 +60,7 @@ async fn get_edit_fields_for_component(ctx: &DalContext<'_, '_>) {
     )
     .await;
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "radahn", schema.id())
+    let (component, _, _) = Component::new_for_schema_with_node(ctx, "radahn", schema.id())
         .await
         .expect("cannot create component");
 
@@ -142,7 +142,7 @@ async fn update_edit_field_for_component(ctx: &DalContext<'_, '_>) {
     )
     .await;
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "radahn", schema.id())
+    let (component, _, _) = Component::new_for_schema_with_node(ctx, "radahn", schema.id())
         .await
         .expect("cannot create component");
 

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -16,7 +16,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
         .expect("cannot find docker image")
         .pop()
         .expect("no docker image found");
-    let (component, _node) = Component::new_for_schema_with_node(ctx, &name, schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, &name, schema.id())
         .await
         .expect("could not create component");
 
@@ -64,7 +64,7 @@ async fn find_for_component(ctx: &DalContext<'_, '_>) {
         .default_schema_variant_id()
         .expect("cannot get default schema variant id");
 
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
         .await
         .expect("cannot create new component");
 

--- a/lib/dal/tests/integration_test/resource_prototype.rs
+++ b/lib/dal/tests/integration_test/resource_prototype.rs
@@ -15,7 +15,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
         .expect("cannot find docker image")
         .pop()
         .expect("no docker image found");
-    let (component, _node) = Component::new_for_schema_with_node(ctx, &name, schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, &name, schema.id())
         .await
         .expect("could not create component");
 
@@ -62,7 +62,7 @@ async fn find_for_component(ctx: &DalContext<'_, '_>) {
         .default_schema_variant_id()
         .expect("cannot get default schema variant id");
 
-    let (component, _node) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
+    let (component, _node, _) = Component::new_for_schema_with_node(ctx, "silverado", schema.id())
         .await
         .expect("cannot create new component");
 

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -34,7 +34,7 @@ async fn get_schematic(ctx: &DalContext<'_, '_>, application_id: ApplicationId) 
         .find(|s| s.name() == "output")
         .expect("cannot find output socket");
 
-    let (_component, node) =
+    let (_component, node, _) =
         Component::new_for_schema_with_node(ctx, "sc-component-get_schematic", service_schema.id())
             .await
             .expect("unable to create component for schema");
@@ -64,7 +64,7 @@ async fn get_schematic(ctx: &DalContext<'_, '_>, application_id: ApplicationId) 
     let ctx = ctx.clone_with_new_application_node_id(Some(*application_id2.id()));
     let ctx = &ctx;
 
-    let (_component, node2) = Component::new_for_schema_with_node(
+    let (_component, node2, _) = Component::new_for_schema_with_node(
         ctx,
         "sc-component-get_schematic2",
         service_schema.id(),
@@ -150,12 +150,12 @@ async fn create_connection(ctx: &DalContext<'_, '_>) {
         .find(|s| s.name() == "output")
         .expect("cannot find output socket");
 
-    let (_head_component, head_node) =
+    let (_head_component, head_node, _) =
         Component::new_for_schema_with_node(ctx, "head", service_schema.id())
             .await
             .expect("cannot create component and node for service");
 
-    let (_tail_component, tail_node) =
+    let (_tail_component, tail_node, _) =
         Component::new_for_schema_with_node(ctx, "tail", service_schema.id())
             .await
             .expect("cannot create component and node for service");

--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -24,6 +24,8 @@ pub enum EditFieldError {
     Nats(#[from] si_data::NatsError),
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
+    #[error(transparent)]
+    PgPool(#[from] si_data::PgPoolError),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
     #[error("qualification check error: {0}")]

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -26,6 +26,8 @@ pub enum SchematicError {
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error(transparent)]
+    PgPool(#[from] si_data::PgPoolError),
+    #[error(transparent)]
     StandardModel(#[from] StandardModelError),
     #[error(transparent)]
     ContextTransaction(#[from] TransactionsError),


### PR DESCRIPTION
Functions that need to lazily execute veritech calls now return a `ComponentAsyncTask` structure that has `run` method, calling `Component::run_async_tasks`.

This is used to generate code and qualify changes asynchronously.

The SDF routes that have a ComponentAsyncTask need to spawn a tokio task after commiting their transaction, and inside of it create a new one. We do it manually in all places as the structure is not clear, but eventually we will want to abstract that away.

It's not clear if this is the way we want to move forward with async execution, specially because it can fail, but the possible failure and feedback to the user will be implemented as future tasks.

I tried with an implicit queue on the DalContext, but wasn't able to make it ergonomic, as there are way too many lifetime issues. And it's hard to know which sdf tasks need to execute, and how to do so in a transparent way.

The biggest problem with a implicit queue is informing it that it can start execution (as in, the previous transaction got commited). So for now being explicit works.

<img src="https://media1.giphy.com/media/5YuhLwDgrgtRVwI7OY/giphy.gif"/>