### PR TITLE
chore(ci): tidy up 2 outputs in the CI flow

### DIFF
--- a/app/web/script/promote-image.sh
+++ b/app/web/script/promote-image.sh
@@ -109,7 +109,7 @@ promote() {
 
   need_cmd docker
 
-  echo "  - Pulling image tagged with ${img}:${src_sha}"
+  echo "  - Pulling image tagged with ${img}:sha-${src_sha}"
   docker pull "$img:sha-$src_sha"
   echo "  - Tagging image ${img}: sha-${src_sha} -> ${tag}"
   docker tag "$img:sha-$src_sha" "$img:$tag"

--- a/ci/scripts/check-image-build-statuses.sh
+++ b/ci/scripts/check-image-build-statuses.sh
@@ -48,7 +48,7 @@ if [ "${OTELCOL_RUN}" == "true" ]; then
 fi
 
 if [ "${POSTGRES_RUN}" == "true" ]; then
-  echo "::group:Postgres build check"
+  echo "::group::Postgres build check"
   set -x
   if [ "${POSTGRES_STATUS}" != "success" ]; then
     EXIT_STATUS=1


### PR DESCRIPTION
* More accurately print the tag nname that is getting pulled (i.e.
  include `sha-` in the tag name)
* Add an extra colon to delineate a GitHub Actions output group

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>