### PR TITLE
 feat(web,dal): Add documentation links to props 

### DIFF
--- a/app/web/src/api/sdf/dal/edit_field.ts
+++ b/app/web/src/api/sdf/dal/edit_field.ts
@@ -94,6 +94,7 @@ export interface EditFieldBaggage {
   parent_attribute_value_id?: number;
   key?: string;
   prop_id: number;
+  prop_doc_link?: string;
 }
 
 export interface EditField {

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -23,7 +23,7 @@
         class="flex flow-row items-center justify-end flex-grow h-full text-xs text-center"
       >
         <SiLink
-          v-if="componentMetadata.schemaLink"
+          v-if="componentMetadata?.schemaLink"
           :uri="componentMetadata.schemaLink"
           :blank-target="true"
           class="m-2 text-base"

--- a/app/web/src/organisims/EditForm/ArrayWidget.vue
+++ b/app/web/src/organisims/EditForm/ArrayWidget.vue
@@ -5,8 +5,22 @@
     :core-edit-field="coreEditField"
   >
     <template #name>
-      {{ props.editField.name }}
+      <SiLink
+        v-if="props.editField.baggage?.prop_doc_link"
+        :uri="props.editField.baggage.prop_doc_link"
+        :blank-target="true"
+        class="flex flex-row justify-end"
+      >
+        <span class="flex flex-col content-center justify-center">
+          {{ props.editField.name }}
+        </span>
+        <VueFeather type="help-circle" size="1em" class="m-2" />
+      </SiLink>
+      <template v-else>
+        {{ props.editField.name }}
+      </template>
     </template>
+
     <template #edit>
       <div class="flex flex-col mt-1">
         <div
@@ -69,6 +83,7 @@ import { defineAsyncComponent, DefineComponent } from "vue";
 import type { WidgetsProps } from "./Widgets.vue";
 import { ITreeOpenState } from "@/utils/edit_field_visitor";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
+import SiLink from "@/atoms/SiLink.vue";
 
 // Eliminate the circular dependency of HeaderWidget -> Widgets -> HeaderWidget
 // by using `defineAsyncComponent` in a careful way to preserve the ability for

--- a/app/web/src/organisims/EditForm/CheckboxWidget.vue
+++ b/app/web/src/organisims/EditForm/CheckboxWidget.vue
@@ -4,7 +4,23 @@
     :validation-errors="props.editField.validation_errors"
     :core-edit-field="coreEditField"
   >
-    <template #name>{{ props.editField.name }}</template>
+    <template #name>
+      <SiLink
+        v-if="props.editField.baggage?.prop_doc_link"
+        :uri="props.editField.baggage.prop_doc_link"
+        :blank-target="true"
+        class="flex flex-row justify-end"
+      >
+        <span class="flex flex-col content-center justify-center">
+          {{ props.editField.name }}
+        </span>
+        <VueFeather type="help-circle" size="1em" class="m-2" />
+      </SiLink>
+      <template v-else>
+        {{ props.editField.name }}
+      </template>
+    </template>
+
     <template #edit>
       <input
         v-model="inputValue"
@@ -41,6 +57,8 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
+import VueFeather from "vue-feather";
+import SiLink from "@/atoms/SiLink.vue";
 
 const props = defineProps<{
   show: boolean;

--- a/app/web/src/organisims/EditForm/HeaderWidget.vue
+++ b/app/web/src/organisims/EditForm/HeaderWidget.vue
@@ -5,13 +5,24 @@
       :style="propObjectStyle"
       @click="toggleHeader"
     >
-      <div v-if="openState" class="flex" :style="propObjectStyle">
-        <VueFeather type="chevron-down" />
-        {{ props.editField.name }}
-      </div>
-      <div v-else class="flex" :style="propObjectStyle">
-        <VueFeather type="chevron-right" />
-        {{ props.editField.name }}
+      <div class="flex" :style="propObjectStyle">
+        <VueFeather v-if="openState" type="chevron-down" />
+        <VueFeather v-else type="chevron-right" />
+
+        <SiLink
+          v-if="props.editField.baggage?.prop_doc_link"
+          :uri="props.editField.baggage.prop_doc_link"
+          :blank-target="true"
+          class="flex flex-row justify-end"
+        >
+          <span class="flex flex-col content-center justify-center">
+            {{ props.editField.name }}
+          </span>
+          <VueFeather type="help-circle" size="1em" class="m-2" />
+        </SiLink>
+        <template v-else>
+          {{ props.editField.name }}
+        </template>
       </div>
     </div>
   </section>
@@ -32,6 +43,7 @@ import VueFeather from "vue-feather";
 import { defineAsyncComponent, DefineComponent } from "vue";
 import type { WidgetsProps } from "./Widgets.vue";
 import { ITreeOpenState } from "@/utils/edit_field_visitor";
+import SiLink from "@/atoms/SiLink.vue";
 
 // Eliminate the circular dependency of HeaderWidget -> Widgets -> HeaderWidget
 // by using `defineAsyncComponent` in a careful way to preserve the ability for

--- a/app/web/src/organisims/EditForm/MapWidget.vue
+++ b/app/web/src/organisims/EditForm/MapWidget.vue
@@ -5,8 +5,22 @@
     :core-edit-field="coreEditField"
   >
     <template #name>
-      {{ props.editField.name }}
+      <SiLink
+        v-if="props.editField.baggage?.prop_doc_link"
+        :uri="props.editField.baggage.prop_doc_link"
+        :blank-target="true"
+        class="flex flex-row justify-end"
+      >
+        <span class="flex flex-col content-center justify-center">
+          {{ props.editField.name }}
+        </span>
+        <VueFeather type="help-circle" size="1em" class="m-2" />
+      </SiLink>
+      <template v-else>
+        {{ props.editField.name }}
+      </template>
     </template>
+
     <template #edit>
       <div class="flex flex-col mt-1">
         <div
@@ -68,6 +82,7 @@ import { defineAsyncComponent, DefineComponent } from "vue";
 import type { WidgetsProps } from "./Widgets.vue";
 import { ITreeOpenState } from "@/utils/edit_field_visitor";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
+import SiLink from "@/atoms/SiLink.vue";
 
 // Eliminate the circular dependency of HeaderWidget -> Widgets -> HeaderWidget
 // by using `defineAsyncComponent` in a careful way to preserve the ability for

--- a/app/web/src/organisims/EditForm/SelectWidget.vue
+++ b/app/web/src/organisims/EditForm/SelectWidget.vue
@@ -5,8 +5,22 @@
     :core-edit-field="coreEditField"
   >
     <template #name>
-      {{ props.editField.name }}
+      <SiLink
+        v-if="props.editField.baggage?.prop_doc_link"
+        :uri="props.editField.baggage.prop_doc_link"
+        :blank-target="true"
+        class="flex flex-row justify-end"
+      >
+        <span class="flex flex-col content-center justify-center">
+          {{ props.editField.name }}
+        </span>
+        <VueFeather type="help-circle" size="1em" class="m-2" />
+      </SiLink>
+      <template v-else>
+        {{ props.editField.name }}
+      </template>
     </template>
+
     <template #edit>
       <select
         v-model="currentValue"
@@ -50,6 +64,8 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
+import SiLink from "@/atoms/SiLink.vue";
+import VueFeather from "vue-feather";
 
 const props = defineProps<{
   show: boolean;

--- a/app/web/src/organisims/EditForm/TextWidget.vue
+++ b/app/web/src/organisims/EditForm/TextWidget.vue
@@ -6,8 +6,22 @@
     :validation-errors="props.editField.validation_errors"
   >
     <template #name>
-      {{ props.editField.name }}
+      <SiLink
+        v-if="props.editField.baggage?.prop_doc_link"
+        :uri="props.editField.baggage.prop_doc_link"
+        :blank-target="true"
+        class="flex flex-row justify-end"
+      >
+        <span class="flex flex-col content-center justify-center">
+          {{ props.editField.name }}
+        </span>
+        <VueFeather type="help-circle" size="1em" class="m-2" />
+      </SiLink>
+      <template v-else>
+        {{ props.editField.name }}
+      </template>
     </template>
+
     <template #edit>
       <input
         v-model="currentValue"
@@ -46,6 +60,8 @@ import { GlobalErrorService } from "@/service/global_error";
 import { UpdateFromEditFieldResponse } from "@/service/edit_field/update_from_edit_field";
 import { ApiResponse } from "@/api/sdf";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
+import SiLink from "@/atoms/SiLink.vue";
+import VueFeather from "vue-feather";
 
 const props = defineProps<{
   show: boolean;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1786,6 +1786,7 @@ async fn edit_field_for_attribute_value(
         parent_attribute_value_id,
         attribute_value.key,
         *prop.id(),
+        prop.doc_link().map(ToOwned::to_owned),
     );
 
     Ok(edit_field)

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -93,6 +93,7 @@ pub struct EditFieldBaggage {
     /// [`EditFieldDataType::Map`].
     pub key: Option<String>,
     pub prop_id: PropId,
+    pub prop_doc_link: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
@@ -173,12 +174,14 @@ impl EditField {
         parent_attribute_value_id: Option<AttributeValueId>,
         key: Option<String>,
         prop_id: PropId,
+        prop_doc_link: Option<String>,
     ) {
         self.baggage = Some(EditFieldBaggage {
             attribute_value_id,
             parent_attribute_value_id,
             key,
             prop_id,
+            prop_doc_link,
         });
     }
 

--- a/lib/dal/src/migrations/U0040__props.sql
+++ b/lib/dal/src/migrations/U0040__props.sql
@@ -13,7 +13,8 @@ CREATE TABLE props
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     name                        text                     NOT NULL,
     kind                        text                     NOT NULL,
-    widget_kind                 text                     NOT NULL
+    widget_kind                 text                     NOT NULL,
+    doc_link                    text
 );
 SELECT standard_model_table_constraints_v1('props');
 SELECT many_to_many_table_create_v1('prop_many_to_many_schema_variants', 'props',

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -104,6 +104,7 @@ pub struct Prop {
     name: String,
     kind: PropKind,
     widget_kind: WidgetKind,
+    doc_link: Option<String>,
     #[serde(flatten)]
     tenancy: WriteTenancy,
     #[serde(flatten)]
@@ -190,6 +191,7 @@ impl Prop {
     standard_model_accessor!(name, String, PropResult);
     standard_model_accessor!(kind, Enum(PropKind), PropResult);
     standard_model_accessor!(widget_kind, Enum(WidgetKind), PropResult);
+    standard_model_accessor!(doc_link, Option<String>, PropResult);
 
     standard_model_many_to_many!(
         lookup_fn: schema_variants,

--- a/lib/dal/src/schema/builtins/kubernetes_deployment.rs
+++ b/lib/dal/src/schema/builtins/kubernetes_deployment.rs
@@ -39,7 +39,7 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> SchemaResult<()>
 
     {
         // TODO: add validation (si-registry ensures the value is unchanged)
-        let _api_version_prop = create_string_prop_with_default(
+        let mut api_version_prop = create_string_prop_with_default(
             ctx,
             "apiVersion",
             "apps/v1".to_owned(),
@@ -47,6 +47,9 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> SchemaResult<()>
             base_attribute_read_context,
         )
         .await?;
+
+        // TODO: this probably is not the appropriate doc link for the prop (we probably don't need one), it just serves as reference for prop doc links
+        api_version_prop.set_doc_link(ctx, Some("https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#deployment-v1-apps".to_owned())).await?;
     }
 
     // FIXME(nick,jacob): temporary performance gain for user testing.


### PR DESCRIPTION
#927 should be merged first, then this should be rebased on main, instead of #927's branch

- Add documentation field to prop
- Generate edit_field with prop_link in Baggage
- Display prop_link with SiLink and VueFeather
- The front-end html is horrible, super hacky css, and is far from ideal, but it
was what I managed to make it work properly, we should improve it.
- Create dummy doc link in k8s apiVersion prop

<img src="https://media4.giphy.com/media/U6dFGNioYzYq17KLqP/giphy.gif"/>