### PR TITLE
bug(app): roll back codemirror and fix refresh

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -8,9 +8,12 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "@codemirror/basic-setup": "^0.20.0",
-        "@codemirror/legacy-modes": "^0.20.0",
+        "@codemirror/basic-setup": "^0.19.0",
+        "@codemirror/commands": "^0.19.0",
+        "@codemirror/legacy-modes": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
         "@codemirror/stream-parser": "^0.19.9",
+        "@codemirror/view": "^0.19.0",
         "@pixi/layers": "^1.0.11",
         "@reactivex/rxjs": "^6.6.7",
         "@xstate/vue": "^2.0.0",
@@ -80,159 +83,95 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.0.tgz",
-      "integrity": "sha512-F6VOM8lImn5ApqxJcaWgdl7hhlw8B5yAfZJGlsQifcpNotkZOMND61mBFZ84OmSLWxtT8/smkSeLvJupKbjP9w==",
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
+      "integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
       "dependencies": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@codemirror/language": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@lezer/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-    },
-    "node_modules/@codemirror/autocomplete/node_modules/@lezer/lr": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/state": "^0.19.4",
+        "@codemirror/text": "^0.19.2",
+        "@codemirror/tooltip": "^0.19.12",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.0"
       }
     },
     "node_modules/@codemirror/basic-setup": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.20.0.tgz",
-      "integrity": "sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.3.tgz",
+      "integrity": "sha512-2hfO+QDk/HTpQzeYk1NyL1G9D5L7Sj78dtaQP8xBU42DKU9+OBPF5MdjLYnxP0jKzm6IfQfsLd89fnqW3rBVfQ==",
       "dependencies": {
-        "@codemirror/autocomplete": "^0.20.0",
-        "@codemirror/commands": "^0.20.0",
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/lint": "^0.20.0",
-        "@codemirror/search": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0"
+        "@codemirror/autocomplete": "^0.19.0",
+        "@codemirror/closebrackets": "^0.19.0",
+        "@codemirror/commands": "^0.19.0",
+        "@codemirror/comment": "^0.19.0",
+        "@codemirror/fold": "^0.19.0",
+        "@codemirror/gutter": "^0.19.0",
+        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/history": "^0.19.0",
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/lint": "^0.19.0",
+        "@codemirror/matchbrackets": "^0.19.0",
+        "@codemirror/rectangular-selection": "^0.19.2",
+        "@codemirror/search": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.31"
       }
     },
-    "node_modules/@codemirror/basic-setup/node_modules/@codemirror/language": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
+    "node_modules/@codemirror/closebrackets": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
+      "integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@lezer/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-    },
-    "node_modules/@codemirror/basic-setup/node_modules/@lezer/lr": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.44"
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.20.0.tgz",
-      "integrity": "sha512-v9L5NNVA+A9R6zaFvaTbxs30kc69F6BkOoiEbeFw4m4I0exmDEKBILN6mK+GksJtvTzGBxvhAPlVFTdQW8GB7Q==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
+      "integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
       "dependencies": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/matchbrackets": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/text": "^0.19.6",
+        "@codemirror/view": "^0.19.22",
+        "@lezer/common": "^0.15.0"
       }
     },
-    "node_modules/@codemirror/commands/node_modules/@codemirror/language": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
+    "node_modules/@codemirror/comment": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0"
+        "@codemirror/state": "^0.19.9",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
       }
     },
-    "node_modules/@codemirror/commands/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/commands/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
+    "node_modules/@codemirror/fold": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
+      "integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
+        "@codemirror/gutter": "^0.19.0",
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.22"
       }
     },
-    "node_modules/@codemirror/commands/node_modules/@lezer/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-    },
-    "node_modules/@codemirror/commands/node_modules/@lezer/lr": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
+    "node_modules/@codemirror/gutter": {
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
+      "integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
       "dependencies": {
-        "@lezer/common": "^0.16.0"
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.23"
       }
     },
     "node_modules/@codemirror/highlight": {
@@ -248,6 +187,15 @@
         "style-mod": "^4.0.0"
       }
     },
+    "node_modules/@codemirror/history": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
+      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
+      "dependencies": {
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
@@ -261,76 +209,45 @@
       }
     },
     "node_modules/@codemirror/legacy-modes": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.20.0.tgz",
-      "integrity": "sha512-SYllodnzD8OI6Y6NoFzCv+77cU9aTdfqDO0Zn8j5PbjUIAD+pIofwHAvecd9/ePLAICr+EYCEuqUxldHAR+pLQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz",
+      "integrity": "sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==",
       "dependencies": {
-        "@codemirror/language": "^0.20.0"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes/node_modules/@codemirror/language": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/legacy-modes/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes/node_modules/@lezer/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-    },
-    "node_modules/@codemirror/legacy-modes/node_modules/@lezer/lr": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
+        "@codemirror/stream-parser": "^0.19.0"
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.1.tgz",
-      "integrity": "sha512-aWbeicDiNe5tb2aZuXs7sKk3hQ89Z1YcUuUX8ngQu23tT6EY4kcY2cayDjizvkLn8iHkObNf97uSudjNmUon2Q==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
+      "integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.2",
+        "@codemirror/gutter": "^0.19.4",
+        "@codemirror/panel": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.1",
+        "@codemirror/state": "^0.19.4",
+        "@codemirror/tooltip": "^0.19.16",
+        "@codemirror/view": "^0.19.22",
         "crelt": "^1.0.5"
       }
     },
-    "node_modules/@codemirror/lint/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/lint/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
+    "node_modules/@codemirror/matchbrackets": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
+      "integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "node_modules/@codemirror/panel": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
+      "integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
+      "dependencies": {
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
       }
     },
     "node_modules/@codemirror/rangeset": {
@@ -341,29 +258,27 @@
         "@codemirror/state": "^0.19.0"
       }
     },
-    "node_modules/@codemirror/search": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.20.1.tgz",
-      "integrity": "sha512-ROe6gRboQU5E4z6GAkNa2kxhXqsGNbeLEisbvzbOeB7nuDYXUZ70vGIgmqPu0tB+1M3F9yWk6W8k2vrFpJaD4Q==",
+    "node_modules/@codemirror/rectangular-selection": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
+      "integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "crelt": "^1.0.5"
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/text": "^0.19.4",
+        "@codemirror/view": "^0.19.48"
       }
     },
-    "node_modules/@codemirror/search/node_modules/@codemirror/state": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-    },
-    "node_modules/@codemirror/search/node_modules/@codemirror/view": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-      "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
+    "node_modules/@codemirror/search": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
+      "integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
       "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
+        "@codemirror/panel": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.3",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.34",
+        "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
@@ -392,10 +307,19 @@
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
+    "node_modules/@codemirror/tooltip": {
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
+      "dependencies": {
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
     "node_modules/@codemirror/view": {
-      "version": "0.19.45",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.45.tgz",
-      "integrity": "sha512-wR19UBYvJMeV9axa5Xo6ATbAP1jl30BPFZ5buu3cJjYXwlRhJDjzw2wUbxk1zsR1LtAe5jrRNeWEtGA+IPacxw==",
+      "version": "0.19.48",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
       "dependencies": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -506,19 +430,6 @@
       "version": "0.15.11",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.11.tgz",
       "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
-    },
-    "node_modules/@lezer/highlight": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
-      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@lezer/highlight/node_modules/@lezer/common": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
     },
     "node_modules/@lezer/lr": {
       "version": "0.15.8",
@@ -6132,165 +6043,95 @@
       "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg=="
     },
     "@codemirror/autocomplete": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.0.tgz",
-      "integrity": "sha512-F6VOM8lImn5ApqxJcaWgdl7hhlw8B5yAfZJGlsQifcpNotkZOMND61mBFZ84OmSLWxtT8/smkSeLvJupKbjP9w==",
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
+      "integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
       "requires": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
-      },
-      "dependencies": {
-        "@codemirror/language": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-          "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "@codemirror/view": "^0.20.0",
-            "@lezer/common": "^0.16.0",
-            "@lezer/highlight": "^0.16.0",
-            "@lezer/lr": "^0.16.0"
-          }
-        },
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        },
-        "@lezer/common": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-          "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-        },
-        "@lezer/lr": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-          "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/state": "^0.19.4",
+        "@codemirror/text": "^0.19.2",
+        "@codemirror/tooltip": "^0.19.12",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.0"
       }
     },
     "@codemirror/basic-setup": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.20.0.tgz",
-      "integrity": "sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.3.tgz",
+      "integrity": "sha512-2hfO+QDk/HTpQzeYk1NyL1G9D5L7Sj78dtaQP8xBU42DKU9+OBPF5MdjLYnxP0jKzm6IfQfsLd89fnqW3rBVfQ==",
       "requires": {
-        "@codemirror/autocomplete": "^0.20.0",
-        "@codemirror/commands": "^0.20.0",
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/lint": "^0.20.0",
-        "@codemirror/search": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0"
-      },
-      "dependencies": {
-        "@codemirror/language": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-          "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "@codemirror/view": "^0.20.0",
-            "@lezer/common": "^0.16.0",
-            "@lezer/highlight": "^0.16.0",
-            "@lezer/lr": "^0.16.0"
-          }
-        },
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        },
-        "@lezer/common": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-          "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-        },
-        "@lezer/lr": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-          "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
+        "@codemirror/autocomplete": "^0.19.0",
+        "@codemirror/closebrackets": "^0.19.0",
+        "@codemirror/commands": "^0.19.0",
+        "@codemirror/comment": "^0.19.0",
+        "@codemirror/fold": "^0.19.0",
+        "@codemirror/gutter": "^0.19.0",
+        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/history": "^0.19.0",
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/lint": "^0.19.0",
+        "@codemirror/matchbrackets": "^0.19.0",
+        "@codemirror/rectangular-selection": "^0.19.2",
+        "@codemirror/search": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.31"
+      }
+    },
+    "@codemirror/closebrackets": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
+      "integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
+      "requires": {
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.44"
       }
     },
     "@codemirror/commands": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.20.0.tgz",
-      "integrity": "sha512-v9L5NNVA+A9R6zaFvaTbxs30kc69F6BkOoiEbeFw4m4I0exmDEKBILN6mK+GksJtvTzGBxvhAPlVFTdQW8GB7Q==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
+      "integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
       "requires": {
-        "@codemirror/language": "^0.20.0",
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0"
-      },
-      "dependencies": {
-        "@codemirror/language": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-          "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "@codemirror/view": "^0.20.0",
-            "@lezer/common": "^0.16.0",
-            "@lezer/highlight": "^0.16.0",
-            "@lezer/lr": "^0.16.0"
-          }
-        },
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        },
-        "@lezer/common": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-          "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-        },
-        "@lezer/lr": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-          "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/matchbrackets": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/text": "^0.19.6",
+        "@codemirror/view": "^0.19.22",
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "@codemirror/comment": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
+      "requires": {
+        "@codemirror/state": "^0.19.9",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
+    "@codemirror/fold": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
+      "integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
+      "requires": {
+        "@codemirror/gutter": "^0.19.0",
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.22"
+      }
+    },
+    "@codemirror/gutter": {
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
+      "integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
+      "requires": {
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.23"
       }
     },
     "@codemirror/highlight": {
@@ -6306,6 +6147,15 @@
         "style-mod": "^4.0.0"
       }
     },
+    "@codemirror/history": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
+      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
+      "requires": {
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
     "@codemirror/language": {
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
@@ -6319,80 +6169,45 @@
       }
     },
     "@codemirror/legacy-modes": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.20.0.tgz",
-      "integrity": "sha512-SYllodnzD8OI6Y6NoFzCv+77cU9aTdfqDO0Zn8j5PbjUIAD+pIofwHAvecd9/ePLAICr+EYCEuqUxldHAR+pLQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz",
+      "integrity": "sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==",
       "requires": {
-        "@codemirror/language": "^0.20.0"
-      },
-      "dependencies": {
-        "@codemirror/language": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
-          "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "@codemirror/view": "^0.20.0",
-            "@lezer/common": "^0.16.0",
-            "@lezer/highlight": "^0.16.0",
-            "@lezer/lr": "^0.16.0"
-          }
-        },
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        },
-        "@lezer/common": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-          "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-        },
-        "@lezer/lr": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
-          "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
+        "@codemirror/stream-parser": "^0.19.0"
       }
     },
     "@codemirror/lint": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.1.tgz",
-      "integrity": "sha512-aWbeicDiNe5tb2aZuXs7sKk3hQ89Z1YcUuUX8ngQu23tT6EY4kcY2cayDjizvkLn8iHkObNf97uSudjNmUon2Q==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
+      "integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
       "requires": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.2",
+        "@codemirror/gutter": "^0.19.4",
+        "@codemirror/panel": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.1",
+        "@codemirror/state": "^0.19.4",
+        "@codemirror/tooltip": "^0.19.16",
+        "@codemirror/view": "^0.19.22",
         "crelt": "^1.0.5"
-      },
-      "dependencies": {
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        }
+      }
+    },
+    "@codemirror/matchbrackets": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
+      "integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
+      "requires": {
+        "@codemirror/language": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0",
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "@codemirror/panel": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
+      "integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
+      "requires": {
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/rangeset": {
@@ -6403,31 +6218,27 @@
         "@codemirror/state": "^0.19.0"
       }
     },
-    "@codemirror/search": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.20.1.tgz",
-      "integrity": "sha512-ROe6gRboQU5E4z6GAkNa2kxhXqsGNbeLEisbvzbOeB7nuDYXUZ70vGIgmqPu0tB+1M3F9yWk6W8k2vrFpJaD4Q==",
+    "@codemirror/rectangular-selection": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
+      "integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
       "requires": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/text": "^0.19.4",
+        "@codemirror/view": "^0.19.48"
+      }
+    },
+    "@codemirror/search": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
+      "integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
+      "requires": {
+        "@codemirror/panel": "^0.19.0",
+        "@codemirror/rangeset": "^0.19.0",
+        "@codemirror/state": "^0.19.3",
+        "@codemirror/text": "^0.19.0",
+        "@codemirror/view": "^0.19.34",
         "crelt": "^1.0.5"
-      },
-      "dependencies": {
-        "@codemirror/state": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
-          "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
-        },
-        "@codemirror/view": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.2.tgz",
-          "integrity": "sha512-vbvOlRTgN6DX3DnZM2yCqBfUfIlDM48Mp7E9NFIDZEnrsUAgoIgGH8dUJYqyplE3H5YBXa4eBhVTOmd9p5j0Hg==",
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        }
       }
     },
     "@codemirror/state": {
@@ -6456,10 +6267,19 @@
       "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
+    "@codemirror/tooltip": {
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
+      "requires": {
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
     "@codemirror/view": {
-      "version": "0.19.45",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.45.tgz",
-      "integrity": "sha512-wR19UBYvJMeV9axa5Xo6ATbAP1jl30BPFZ5buu3cJjYXwlRhJDjzw2wUbxk1zsR1LtAe5jrRNeWEtGA+IPacxw==",
+      "version": "0.19.48",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -6560,21 +6380,6 @@
       "version": "0.15.11",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.11.tgz",
       "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
-    },
-    "@lezer/highlight": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
-      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
-      "requires": {
-        "@lezer/common": "^0.16.0"
-      },
-      "dependencies": {
-        "@lezer/common": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
-          "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
-        }
-      }
     },
     "@lezer/lr": {
       "version": "0.15.8",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -18,8 +18,11 @@
     "checks": "npm run eslint; npm run type-check; npm run prettier-check"
   },
   "dependencies": {
-    "@codemirror/basic-setup": "^0.20.0",
-    "@codemirror/legacy-modes": "^0.20.0",
+    "@codemirror/state": "^0.19.0",
+    "@codemirror/view": "^0.19.0",
+    "@codemirror/commands": "^0.19.0",
+    "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/legacy-modes": "^0.19.0",
     "@codemirror/stream-parser": "^0.19.9",
     "@pixi/layers": "^1.0.11",
     "@reactivex/rxjs": "^6.6.7",

--- a/app/web/src/organisims/CodeViewer.vue
+++ b/app/web/src/organisims/CodeViewer.vue
@@ -12,11 +12,15 @@
 
         <button
           v-if="editMode"
-          ref="sync"
           class="pl-1 focus:outline-none sync-button ml-2"
           @click="generateCode"
         >
-          <VueFeather type="refresh-cw" class="text-sm" size="1.1em" />
+          <VueFeather
+            type="refresh-cw"
+            class="text-sm"
+            size="1.1em"
+            :class="refreshClasses"
+          />
         </button>
       </div>
     </div>
@@ -34,7 +38,7 @@
 <script setup lang="ts">
 import _ from "lodash";
 import * as Rx from "rxjs";
-import { ref, onMounted, toRefs } from "vue";
+import { ref, onMounted, toRefs, computed } from "vue";
 import VueFeather from "vue-feather";
 import { EditorState, EditorView, basicSetup } from "@codemirror/basic-setup";
 import { yaml } from "@codemirror/legacy-modes/mode/yaml";
@@ -148,26 +152,23 @@ const _code = refFrom(
   ),
 );
 
-const sync = ref<HTMLElement | null>(null);
-
-const animateSyncButton = () => {
-  const button = sync.value;
-  if (button) {
-    button.animate(
-      [{ transform: "rotate(0deg)" }, { transform: "rotate(720deg)" }],
-      {
-        duration: 2500,
-        easing: "linear",
-      },
-    );
+const currentSyncAnimate = ref<boolean>(false);
+const refreshClasses = computed(() => {
+  const classes: { [key: string]: boolean } = {};
+  if (currentSyncAnimate.value) {
+    classes["animate-spin"] = true;
+  } else {
+    classes["animate-spin"] = false;
   }
-};
+  return classes;
+});
 
 const generateCode = () => {
-  animateSyncButton();
+  currentSyncAnimate.value = true;
   ComponentService.generateCode({
     componentId: props.componentId,
   }).subscribe((reply) => {
+    currentSyncAnimate.value = false;
     if (reply.error) {
       GlobalErrorService.set(reply);
     } else if (!reply.success) {

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -10,7 +10,6 @@
       <div class="flex">
         <button
           v-if="editMode"
-          ref="sync"
           class="pl-1 focus:outline-none run-button"
           @click="runQualification"
         >
@@ -153,6 +152,8 @@ enum QualifiedState {
 }
 
 const currentQualifiedState = ref<QualifiedState>(QualifiedState.Unknown);
+const currentQualifiedAnimate = ref<boolean>(false);
+
 const getQualifiedState = (
   qualifications: Array<Qualification>,
 ): QualifiedState => {
@@ -171,26 +172,12 @@ const getQualifiedState = (
   return QualifiedState.Success;
 };
 
-const sync = ref<HTMLElement | null>(null);
-
-const animateSyncButton = () => {
-  const button = sync.value;
-  if (button) {
-    button.animate(
-      [{ transform: "rotate(0deg)" }, { transform: "rotate(720deg)" }],
-      {
-        duration: 2500,
-        easing: "linear",
-      },
-    );
-  }
-};
-
 const runQualification = () => {
-  animateSyncButton();
+  currentQualifiedAnimate.value = true;
   ComponentService.checkQualifications({
     componentId: props.componentId,
   }).subscribe((reply) => {
+    currentQualifiedAnimate.value = false;
     if (reply.error) {
       GlobalErrorService.set(reply);
     } else if (!reply.success) {
@@ -218,6 +205,12 @@ const refreshButtonClasses = computed(() => {
   } else {
     classes["error"] = false;
     classes["success"] = false;
+    classes["unknown"] = true;
+  }
+  if (currentQualifiedAnimate.value) {
+    classes["animate-spin"] = true;
+    classes["success"] = false;
+    classes["error"] = false;
     classes["unknown"] = true;
   }
   return classes;


### PR DESCRIPTION
Rolls back codemirror to 0.19, until there is a release of the streaming
language backend to match the codemirror 0.20 releases from last week.

This also fixes the way the refresh icons work - they were animating the
rotation of the button, rather than the icon, which caused the icon to
appear as if it was spinning off its axis a little. It also now tracks
the animation state to the length of the refresh - so it stops spinning
when the call completes. It also now uses the tailwind animation
classes, rather than hand-rolled javascript applied to the html element
through a reference.

<img src="https://media1.giphy.com/media/B6t7VO5xPVca8zLl2c/giphy.gif"/>