### PR TITLE
 feat(web,dal): Add link to validation prototypes

### DIFF
--- a/app/web/src/organisims/EditForm/ValidationErrorsWidget.vue
+++ b/app/web/src/organisims/EditForm/ValidationErrorsWidget.vue
@@ -15,9 +15,9 @@
           {{ error.message }}
         </div>
         <div v-if="error.link" class="ml-1 align-top">
-          <a target="_blank" :href="error.link">
+          <SiLink :uri="error.link" :blank-target="true">
             <VueFeather type="external-link" stroke="grey" size="1.0em" />
-          </a>
+          </SiLink>
         </div>
       </div>
     </li>
@@ -26,6 +26,7 @@
 
 <script setup lang="ts">
 import VueFeather from "vue-feather";
+import SiLink from "@/atoms/SiLink.vue";
 import type { ValidationErrors } from "@/api/sdf/dal/edit_field";
 
 const props = defineProps<{

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -75,10 +75,10 @@
               >
                 {{ q.title }}
               </div>
-              <div v-if="q.link" class="flex ml-2">
-                <a target="_blank" :href="q.link">
+              <div v-for="link in q.links" :key="link" class="flex ml-2">
+                <SiLink :blank-target="true" :uri="link">
                   <VueFeather type="info" class="info-button" size="1.1em" />
-                </a>
+                </SiLink>
               </div>
               <!-- NOTE(nick): We only render the button div if a description OR if a result exists
               in order to avoid user confusion. In essence, we want to ensure that we actually
@@ -136,6 +136,7 @@ import { computed, ref, toRefs } from "vue";
 import { ChangeSetService } from "@/service/change_set";
 import { eventCheckedQualifications$ } from "@/observable/qualification";
 import { system$ } from "@/observable/system";
+import SiLink from "@/atoms/SiLink.vue";
 //import { ListQualificationsResponse } from "@/service/component/list_qualifications";
 
 const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());

--- a/lib/dal/src/migrations/U0045__validation_prototypes.sql
+++ b/lib/dal/src/migrations/U0045__validation_prototypes.sql
@@ -13,6 +13,7 @@ CREATE TABLE validation_prototypes
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     func_id                     bigint                   NOT NULL,
     args                        jsonb                    NOT NULL,
+    link                        text,
     prop_id                     bigint                   NOT NULL,
     schema_id                   bigint                   NOT NULL,
     schema_variant_id           bigint                   NOT NULL,

--- a/lib/dal/src/queries/validation_resolver_find_values_for_component.sql
+++ b/lib/dal/src/queries/validation_resolver_find_values_for_component.sql
@@ -6,6 +6,7 @@ SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
                               validation_resolvers.schema_id,
                               validation_resolvers.schema_variant_id,
                               validation_resolvers.system_id,
+                              validation_resolvers.validation_prototype_id,
                               row_to_json(func_binding_return_values.*) AS object
 FROM validation_resolvers
 INNER JOIN func_binding_return_value_belongs_to_func_binding ON 

--- a/lib/dal/src/queries/validation_resolver_find_values_for_context.sql
+++ b/lib/dal/src/queries/validation_resolver_find_values_for_context.sql
@@ -6,6 +6,7 @@ SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
                               validation_resolvers.schema_id,
                               validation_resolvers.schema_variant_id,
                               validation_resolvers.system_id,
+                              validation_resolvers.validation_prototype_id,
                               row_to_json(func_binding_return_values.*) AS object
 FROM validation_resolvers
 INNER JOIN func_binding_return_value_belongs_to_func_binding ON 

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -37,6 +37,7 @@ pub async fn migrate(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     kubernetes_deployment(ctx).await?;
     docker_hub_credential(ctx).await?;
     docker_image(ctx).await?;
+    bobao(ctx).await?;
 
     Ok(())
 }
@@ -319,7 +320,7 @@ async fn docker_hub_credential(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     )
     .await?;
     prototype
-        .set_doc_link(ctx, "http://hub.docker.com".into())
+        .set_link(ctx, "http://hub.docker.com".into())
         .await?;
 
     // Note: This is not right; each schema needs its own socket types.
@@ -439,35 +440,6 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
     exposed_ports_prop
         .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
         .await?;
-
-    let func_name = "si:validateStringEquals".to_string();
-    let mut funcs = Func::find_by_attr(ctx, "name", &func_name).await?;
-    let func = funcs.pop().ok_or(SchemaError::MissingFunc(func_name))?;
-    let mut validation_prototype_ctx = ValidationPrototypeContext::default();
-    validation_prototype_ctx.set_prop_id(*image_prop.id());
-    validation_prototype_ctx.set_schema_id(*schema.id());
-    validation_prototype_ctx.set_schema_variant_id(*variant.id());
-    ValidationPrototype::new(
-        ctx,
-        *func.id(),
-        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
-            None,
-            "gambiarra".to_owned(),
-        ))?,
-        validation_prototype_ctx.clone(),
-    )
-    .await?;
-
-    ValidationPrototype::new(
-        ctx,
-        *func.id(),
-        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
-            None,
-            "Tupi or not Tupi, that is the question".to_owned(), // https://en.wikipedia.org/wiki/Manifesto_Antrop%C3%B3fago
-        ))?,
-        validation_prototype_ctx,
-    )
-    .await?;
 
     let number_of_parents_prop = Prop::new(
         ctx,
@@ -606,6 +578,198 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
         resource_sync_prototype_context,
     )
     .await?;
+
+    Ok(())
+}
+
+async fn bobao(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
+    let name = "bobão".to_string();
+    let mut schema = match create_schema(ctx, &name, &SchemaKind::Concrete).await? {
+        Some(schema) => schema,
+        None => return Ok(()),
+    };
+
+    let (variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
+    schema
+        .set_default_schema_variant_id(ctx, Some(*variant.id()))
+        .await?;
+    let mut attribute_context_builder = AttributeContext::builder();
+    attribute_context_builder
+        .set_schema_id(*schema.id())
+        .set_schema_variant_id(*variant.id());
+
+    let mut ui_menu = UiMenu::new(ctx, &(*schema.kind()).into()).await?;
+    ui_menu.set_name(ctx, Some("bobão")).await?;
+
+    let application_name = "application".to_string();
+    ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
+    ui_menu.set_schema(ctx, schema.id()).await?;
+
+    let application_schema_results = Schema::find_by_attr(ctx, "name", &application_name).await?;
+    let application_schema = application_schema_results
+        .first()
+        .ok_or(SchemaError::NotFoundByName(application_name))?;
+    ui_menu
+        .add_root_schematic(ctx, application_schema.id())
+        .await?;
+
+    let base_attribute_read_context = AttributeReadContext {
+        schema_id: Some(*schema.id()),
+        schema_variant_id: Some(*variant.id()),
+        ..AttributeReadContext::default()
+    };
+
+    let func_name = "si:validateStringEquals".to_string();
+    let mut funcs = Func::find_by_attr(ctx, "name", &func_name).await?;
+    let func = funcs.pop().ok_or(SchemaError::MissingFunc(func_name))?;
+    let mut validation_prototype_ctx = ValidationPrototypeContext::default();
+    validation_prototype_ctx.set_schema_id(*schema.id());
+    validation_prototype_ctx.set_schema_variant_id(*variant.id());
+
+    let text_prop = Prop::new(ctx, "text", PropKind::String).await?;
+    text_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+    validation_prototype_ctx.set_prop_id(*text_prop.id());
+    let mut prototype = ValidationPrototype::new(
+        ctx,
+        *func.id(),
+        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
+            None,
+            "Tupi or not Tupi, that is the question".to_owned(), // https://en.wikipedia.org/wiki/Manifesto_Antrop%C3%B3fago
+        ))?,
+        validation_prototype_ctx.clone(),
+    )
+    .await?;
+    prototype
+        .set_link(
+            ctx,
+            Some("https://en.wikipedia.org/wiki/Manifesto_Antrop%C3%B3fago".to_owned()),
+        )
+        .await?;
+
+    let integer_prop = Prop::new(ctx, "integer", PropKind::Integer).await?;
+    integer_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+
+    let boolean_prop = Prop::new(ctx, "boolean", PropKind::Boolean).await?;
+    boolean_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+
+    let object_prop = Prop::new(ctx, "object", PropKind::Object).await?;
+    object_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+    validation_prototype_ctx.set_prop_id(*integer_prop.id());
+    let mut prototype = ValidationPrototype::new(
+        ctx,
+        *func.id(),
+        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
+            None,
+            "My office is at the beach".to_owned(),
+        ))?,
+        validation_prototype_ctx.clone(),
+    )
+    .await?;
+    prototype
+        .set_link(
+            ctx,
+            Some("https://www.youtube.com/watch?v=JiVsAnIgBIs".to_owned()),
+        )
+        .await?;
+
+    let child_prop = Prop::new(ctx, "child", PropKind::String).await?;
+    child_prop
+        .set_parent_prop(ctx, *object_prop.id(), base_attribute_read_context)
+        .await?;
+
+    let map_prop = Prop::new(ctx, "map", PropKind::Object).await?;
+    map_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+    validation_prototype_ctx.set_prop_id(*map_prop.id());
+    let mut prototype = ValidationPrototype::new(
+        ctx,
+        *func.id(),
+        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
+            None,
+            "I'm just a latin american guy\nWith no money in the bank, no important relatives\nComing from the country".to_owned(),
+        ))?,
+        validation_prototype_ctx.clone(),
+    )
+    .await?;
+    prototype
+        .set_link(
+            ctx,
+            Some("https://www.youtube.com/watch?v=8VcZURSMetg".to_owned()),
+        )
+        .await?;
+
+    let array_prop = Prop::new(ctx, "array", PropKind::Object).await?;
+    array_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+    validation_prototype_ctx.set_prop_id(*array_prop.id());
+    let mut prototype = ValidationPrototype::new(
+        ctx,
+        *func.id(),
+        serde_json::to_value(&FuncBackendValidateStringValueArgs::new(
+            None,
+            "I'm brazilian, of median stature\nI like so-and-so but the other one is who wants me"
+                .to_owned(),
+        ))?,
+        validation_prototype_ctx,
+    )
+    .await?;
+    prototype
+        .set_link(
+            ctx,
+            Some("https://www.youtube.com/watch?v=Vz73zZriafQ".to_owned()),
+        )
+        .await?;
+
+    let mut secret_prop = Prop::new(ctx, "secret", PropKind::Integer).await?;
+    secret_prop
+        .set_parent_prop(ctx, root_prop.domain_prop_id, base_attribute_read_context)
+        .await?;
+    secret_prop
+        .set_widget_kind(ctx, WidgetKind::SecretSelect)
+        .await?;
+
+    // Note: This is not right; each schema needs its own socket types.
+    //       Also, they should clearly inherit from the core schema? Something
+    //       for later.
+    let input_socket = Socket::new(
+        ctx,
+        "input",
+        &SocketEdgeKind::Configures,
+        &SocketArity::Many,
+        &SchematicKind::Component,
+    )
+    .await?;
+    variant.add_socket(ctx, input_socket.id()).await?;
+
+    let output_socket = Socket::new(
+        ctx,
+        "output",
+        &SocketEdgeKind::Output,
+        &SocketArity::Many,
+        &SchematicKind::Component,
+    )
+    .await?;
+    variant.add_socket(ctx, output_socket.id()).await?;
+
+    let includes_socket = Socket::new(
+        ctx,
+        "includes",
+        &SocketEdgeKind::Includes,
+        &SocketArity::Many,
+        &SchematicKind::Component,
+    )
+    .await?;
+    variant.add_socket(ctx, includes_socket.id()).await?;
 
     Ok(())
 }

--- a/lib/dal/src/validation_prototype.rs
+++ b/lib/dal/src/validation_prototype.rs
@@ -102,6 +102,7 @@ pub struct ValidationPrototype {
     id: ValidationPrototypeId,
     func_id: FuncId,
     args: serde_json::Value,
+    link: Option<String>,
     #[serde(flatten)]
     context: ValidationPrototypeContext,
     #[serde(flatten)]
@@ -153,6 +154,7 @@ impl ValidationPrototype {
 
     standard_model_accessor!(func_id, Pk(FuncId), ValidationPrototypeResult);
     standard_model_accessor!(args, Json<JsonValue>, ValidationPrototypeResult);
+    standard_model_accessor!(link, Option<String>, ValidationPrototypeResult);
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_prop(

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -162,7 +162,7 @@ async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_values_for_prop_and_component(ctx: &DalContext<'_, '_>) {
+async fn find_errors_for_prop_and_component(ctx: &DalContext<'_, '_>) {
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
@@ -248,7 +248,7 @@ async fn find_values_for_prop_and_component(ctx: &DalContext<'_, '_>) {
     .await
     .expect("cannot create new attribute resolver");
 
-    let validation_results = ValidationResolver::find_values_for_prop_and_component(
+    let validation_results = ValidationResolver::find_errors_for_prop_and_component(
         ctx,
         *first_prop.id(),
         *component.id(),
@@ -347,7 +347,7 @@ async fn find_values_for_prop_and_component_override(ctx: &DalContext<'_, '_>) {
     .await
     .expect("cannot create new attribute resolver");
 
-    let validation_results = ValidationResolver::find_values_for_prop_and_component(
+    let validation_results = ValidationResolver::find_errors_for_prop_and_component(
         ctx,
         *first_prop.id(),
         *component.id(),


### PR DESCRIPTION
#928 should be merged first, then this should be rebased on main, instead of #928's branch

- Create dummy schema to allow ease of testing for attributes
- Actually run validations, as they were never being running
- Add link field to validation prototypes
- Properly extract validation results, with the prototype's link
- Change raw anchor usage to SiLink (it's safer)

<img src="https://media4.giphy.com/media/3og0IM4RMFO8siuUXC/giphy-downsized-medium.gif"/>