### PR TITLE
feat(dal): add builtin identity func

### DIFF
--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -7,6 +7,7 @@ use crate::{edit_field::ToSelectWidget, label_list::ToLabelList, PropKind};
 
 pub mod array;
 pub mod boolean;
+pub mod identity;
 pub mod integer;
 pub mod js_attribute;
 pub mod js_code_generation;
@@ -63,6 +64,8 @@ pub type FuncBackendResult<T> = Result<T, FuncBackendError>;
 pub enum FuncBackendKind {
     Array,
     Boolean,
+    /// Mathematical identity of the [`Func`](crate::Func)'s arguments.
+    Identity,
     Integer,
     JsQualification,
     JsResourceSync,
@@ -97,6 +100,8 @@ pub enum FuncBackendKind {
 pub enum FuncBackendResponseType {
     Array,
     Boolean,
+    /// Mathematical identity of the [`Func`](crate::Func)'s arguments.
+    Identity,
     Integer,
     Map,
     PropObject,

--- a/lib/dal/src/func/backend/identity.rs
+++ b/lib/dal/src/func/backend/identity.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncBackendIdentityArgs {
+    pub identity: serde_json::Value,
+}

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -11,6 +11,7 @@ use veritech::{
 
 use crate::func::backend::array::{FuncBackendArray, FuncBackendArrayArgs};
 use crate::func::backend::boolean::{FuncBackendBoolean, FuncBackendBooleanArgs};
+use crate::func::backend::identity::FuncBackendIdentityArgs;
 use crate::func::backend::integer::{FuncBackendInteger, FuncBackendIntegerArgs};
 use crate::func::backend::map::{FuncBackendMap, FuncBackendMapArgs};
 use crate::func::backend::prop_object::{FuncBackendPropObject, FuncBackendPropObjectArgs};
@@ -219,6 +220,10 @@ impl FuncBinding {
                 let args: FuncBackendBooleanArgs = serde_json::from_value(self.args.clone())?;
                 let return_value = FuncBackendBoolean::new(args).execute().await?;
                 Some(return_value)
+            }
+            FuncBackendKind::Identity => {
+                let args: FuncBackendIdentityArgs = serde_json::from_value(self.args.clone())?;
+                Some(args.identity)
             }
             FuncBackendKind::Integer => {
                 execution

--- a/lib/dal/src/func/builtins.rs
+++ b/lib/dal/src/func/builtins.rs
@@ -9,6 +9,8 @@ pub async fn migrate(ctx: &DalContext<'_, '_>) -> FuncResult<()> {
     si_set_map(ctx).await?;
     si_set_prop_object(ctx).await?;
     si_set_string(ctx).await?;
+
+    si_identity(ctx).await?;
     si_unset(ctx).await?;
 
     si_validate_string_equals(ctx).await?;
@@ -151,6 +153,21 @@ async fn si_set_string(ctx: &DalContext<'_, '_>) -> FuncResult<()> {
             "si:setString",
             FuncBackendKind::String,
             FuncBackendResponseType::String,
+        )
+        .await
+        .expect("cannot create func");
+    }
+    Ok(())
+}
+
+async fn si_identity(ctx: &DalContext<'_, '_>) -> FuncResult<()> {
+    let existing_func = Func::find_by_attr(ctx, "name", &"si:identity".to_string()).await?;
+    if existing_func.is_empty() {
+        Func::new(
+            ctx,
+            "si:identity",
+            FuncBackendKind::Identity,
+            FuncBackendResponseType::Identity,
         )
         .await
         .expect("cannot create func");


### PR DESCRIPTION
Let's add the built-in identity function! This will be used for the "providers" work in order to return the mathematical value, which is useful for "populating" (probably a better verb exists and encapsulates the idea, but 🤷‍♂️) one field's value with the value of another field.

Research PR: #924

<img src="https://media0.giphy.com/media/6aSppwcSsn4NB553YV/giphy.gif"/>

Fixes ENG-163