### PR TITLE
feat(dal): add AttributePrototypeArgument

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -266,20 +266,18 @@ Our crates leverage `rustdoc` for seamless integration with `cargo doc`, [Intell
 
 ### Reading Rust Documentation
 
-Build the docs for all of our crates and open the docs in your browser at [dal](./lib/dal) by executing the following:
+Build the docs for all of our crates and open the docs in your browser at [dal](./lib/dal) by executing
+the following make target:
 
 ```bash
-cargo doc --all
-cargo doc -p dal --open
+make docs-open
 ```
 
 If you would like to live-recompile docs while making changes on your development branch, you can execute the following
 make target:
 
 ```bash
-# Choose one! Both work.
-make doc
-make docs
+make docs-watch
 ```
 
 > Please note: [cargo-watch](https://github.com/watchexec/cargo-watch) needs to be installed before using the above make target.

--- a/Makefile
+++ b/Makefile
@@ -270,9 +270,15 @@ tidy:
 	cd $(MAKEPATH)/ci && $(MAKE) tidy
 .PHONY: tidy
 
-docs:
-	cd $(MAKEPATH); cargo watch -x doc
-.PHONY: docs
+tidy-crates:
+	cd $(MAKEPATH)/ci && $(MAKE) tidy-crates
+.PHONY: tidy-crates
 
-doc: docs
-.PHONY: doc
+docs-open:
+	cd $(MAKEPATH); cargo doc --all
+	cd $(MAKEPATH); cargo doc -p dal --open
+.PHONY: docs-open
+
+docs-watch:
+	cd $(MAKEPATH); cargo watch -x doc
+.PHONY: docs-watch

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -1,0 +1,125 @@
+//! An [`AttributePrototypeArgument`] represents an argument name and its corresponding
+//! [`InternalProvider`](crate::InternalProvider). An
+//! [`AttributePrototype`](crate::AttributePrototype) can have multiple arguments.
+
+use serde::{Deserialize, Serialize};
+use si_data::PgError;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::provider::internal::InternalProviderId;
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor_ro, standard_model_belongs_to,
+    AttributePrototype, AttributePrototypeId, DalContext, HistoryEventError, StandardModel,
+    StandardModelError, Timestamp, Visibility, WriteTenancy,
+};
+
+const LIST_FOR_ATTRIBUTE_PROTOTYPE: &str =
+    include_str!("../../queries/attribute_prototype_argument_list_for_attribute_prototype.sql");
+
+#[derive(Error, Debug)]
+pub enum AttributePrototypeArgumentError {
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type AttributePrototypeArgumentResult<T> = Result<T, AttributePrototypeArgumentError>;
+
+pk!(AttributePrototypeArgumentPk);
+pk!(AttributePrototypeArgumentId);
+
+/// Contains a "key" and "value" for an argument that can be dynamically used
+/// for [`AttributePrototypes`](crate::AttributePrototype).
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct AttributePrototypeArgument {
+    pk: AttributePrototypeArgumentPk,
+    id: AttributePrototypeArgumentId,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    visibility: Visibility,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+
+    /// The "key" for a given argument.
+    name: String,
+    /// The "value" for a given argument.
+    internal_provider_id: InternalProviderId,
+}
+
+impl_standard_model! {
+    model: AttributePrototypeArgument,
+    pk: AttributePrototypeArgumentPk,
+    id: AttributePrototypeArgumentId,
+    table_name: "attribute_prototype_arguments",
+    history_event_label_base: "attribute_prototype_argument",
+    history_event_message_name: "Attribute Prototype Argument"
+}
+
+impl AttributePrototypeArgument {
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_>,
+        name: String,
+        internal_provider_id: &InternalProviderId,
+        attribute_prototype_id: &AttributePrototypeId,
+    ) -> AttributePrototypeArgumentResult<Self> {
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM attribute_prototype_argument_create_v1($1, $2, $3, $4)",
+                &[
+                    ctx.write_tenancy(),
+                    ctx.visibility(),
+                    &name,
+                    internal_provider_id,
+                ],
+            )
+            .await?;
+        let object: AttributePrototypeArgument =
+            standard_model::finish_create_from_row(ctx, row).await?;
+        object
+            .set_attribute_prototype(ctx, attribute_prototype_id)
+            .await?;
+        Ok(object)
+    }
+
+    standard_model_accessor_ro!(name, String);
+    standard_model_accessor_ro!(internal_provider_id, InternalProviderId);
+    standard_model_belongs_to!(
+        lookup_fn: attribute_prototype,
+        set_fn: set_attribute_prototype,
+        unset_fn: unset_attribute_prototype,
+        table: "attribute_prototype_argument_belongs_to_attribute_prototype",
+        model_table: "attribute_prototypes",
+        belongs_to_id: AttributePrototypeId,
+        returns: AttributePrototype,
+        result: AttributePrototypeArgumentResult,
+    );
+
+    /// Find all [`Self`] for a given [`AttributePrototype`](crate::AttributePrototype).
+    #[tracing::instrument(skip(ctx))]
+    pub async fn list_for_attribute_prototype(
+        ctx: &DalContext<'_, '_>,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeArgumentResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_FOR_ATTRIBUTE_PROTOTYPE,
+                &[
+                    ctx.read_tenancy(),
+                    ctx.visibility(),
+                    &attribute_prototype_id,
+                ],
+            )
+            .await?;
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
+}

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -492,6 +492,7 @@ impl AttributeValue {
             *func_binding.id(),
             *func_binding_return_value.id(),
             parent_attribute_value_id,
+            None,
             Some(*attribute_value.id()),
         )
         .await
@@ -581,6 +582,7 @@ impl AttributeValue {
                 context,
                 key.clone(),
                 Some(parent_attribute_value_id),
+                None,
                 *attribute_value.id(),
             )
             .await

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -65,6 +65,10 @@ pub use attribute::{
     context::{
         AttributeContext, AttributeContextBuilderError, AttributeContextError, AttributeReadContext,
     },
+    prototype::argument::{
+        AttributePrototypeArgument, AttributePrototypeArgumentError, AttributePrototypeArgumentId,
+        AttributePrototypeArgumentResult,
+    },
     prototype::{
         AttributePrototype, AttributePrototypeError, AttributePrototypeId, AttributePrototypeResult,
     },

--- a/lib/dal/src/migrations/U0056__attribute_prototypes.sql
+++ b/lib/dal/src/migrations/U0056__attribute_prototypes.sql
@@ -19,7 +19,8 @@ CREATE TABLE attribute_prototypes
     created_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
     func_id                                bigint                   NOT NULL,
-    key                                    text
+    key                                    text,
+    attribute_prototype_argument_ids       bigint[]                 NOT NULL
 );
 SELECT standard_model_table_constraints_v1('attribute_prototypes');
 
@@ -32,6 +33,7 @@ CREATE OR REPLACE FUNCTION attribute_prototype_create_v1(
     this_attribute_context jsonb,
     this_func_id bigint,
     this_key text,
+    this_attribute_prototype_argument_ids bigint[],
     OUT object json) AS
 $$
 DECLARE
@@ -59,7 +61,8 @@ BEGIN
                                      attribute_context_component_id,
                                      attribute_context_system_id,
                                      func_id,
-                                     key)
+                                     key,
+                                     attribute_prototype_argument_ids)
     VALUES (this_tenancy_record.tenancy_universal,
             this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids,
@@ -75,7 +78,8 @@ BEGIN
             this_attribute_context_record.attribute_context_component_id,
             this_attribute_context_record.attribute_context_system_id,
             this_func_id,
-            this_key)
+            this_key,
+            this_attribute_prototype_argument_ids)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
+++ b/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
@@ -1,0 +1,61 @@
+CREATE TABLE attribute_prototype_arguments
+(
+    pk bigserial PRIMARY KEY,
+    id bigserial NOT NULL,
+    tenancy_universal bool NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids bigint[],
+    tenancy_workspace_ids bigint[],
+    visibility_change_set_pk bigint,
+    visibility_edit_session_pk bigint,
+    visibility_deleted bool,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    name text NOT NULL,
+    internal_provider_id bigint NOT NULL
+);
+SELECT standard_model_table_constraints_v1('attribute_prototype_arguments');
+SELECT belongs_to_table_create_v1('attribute_prototype_argument_belongs_to_attribute_prototype', 'attribute_prototype_arguments', 'attribute_prototypes');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+    VALUES ('attribute_prototype_arguments', 'model', 'attribute_prototype_argument', 'Attribute Prototype Argument'),
+           ('attribute_prototype_argument_belongs_to_attribute_prototype', 'belongs_to', 'attribute_prototype_argument.attribute_prototype', 'Attribute Prototype Argument <> Attribute Prototype');
+
+CREATE OR REPLACE FUNCTION attribute_prototype_argument_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    this_internal_provider_id bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record           tenancy_record_v1;
+    this_visibility_record        visibility_record_v1;
+    this_new_row                  attribute_prototype_arguments%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO attribute_prototype_arguments (tenancy_universal,
+                               tenancy_billing_account_ids,
+                               tenancy_organization_ids,
+                               tenancy_workspace_ids,
+                               visibility_change_set_pk,
+                               visibility_edit_session_pk,
+                               visibility_deleted,
+                               name,
+                               internal_provider_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted,
+            this_name,
+            this_internal_provider_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -181,6 +181,7 @@ impl Prop {
             attribute_context,
             None,
             None,
+            None,
         )
         .await
         .map_err(|e| PropError::AttributePrototype(format!("{e}")))?;

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -38,8 +38,8 @@ impl_standard_model! {
     history_event_message_name: "External Provider"
 }
 
-/// This provider can only provide data to external [`SchemaVariant`]s. It can only consume data
-/// within its own [`SchemaVariant`].
+/// This provider can only provide data to external [`SchemaVariants`](crate::SchemaVariant). It can
+/// only consume data within its own [`SchemaVariant`](crate::SchemaVariant).
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ExternalProvider {
     pk: ExternalProviderPk,
@@ -51,19 +51,19 @@ pub struct ExternalProvider {
     #[serde(flatten)]
     timestamp: Timestamp,
 
-    /// Indicates which [`Prop`] this provider belongs to.
+    /// Indicates which [`Prop`](crate::Prop) this provider belongs to.
     prop_id: PropId,
-    /// Indicates which [`Schema`] this provider belongs to.
+    /// Indicates which [`Schema`](crate::Schema) this provider belongs to.
     schema_id: SchemaId,
-    /// Indicates which [`SchemaVariant`] this provider belongs to.
+    /// Indicates which [`SchemaVariant`](crate::SchemaVariant) this provider belongs to.
     schema_variant_id: SchemaVariantId,
     /// Name for [`Self`] that can be used for identification.
     name: Option<String>,
     /// Definition of the data type (e.g. "JSONSchema" or "Number").
     type_definition: Option<String>,
-    /// The [`AttributePrototype`] of the transformation to perform for the socket.
-    /// It includes the transformation function itself and where to get the arguments for the
-    /// transformation function.
+    /// The [`AttributePrototype`](crate::AttributePrototype) of the transformation to perform for
+    /// the provider. It includes the transformation function itself and where to get the arguments
+    /// for the transformation function.
     attribute_prototype_id: AttributePrototypeId,
 }
 
@@ -107,7 +107,7 @@ impl ExternalProvider {
     standard_model_accessor!(type_definition, Option<String>, ExternalProviderResult);
     standard_model_accessor_ro!(attribute_prototype_id, AttributePrototypeId);
 
-    /// Find all external providers for a given [`SchemaVariant`].
+    /// Find all external providers for a given [`SchemaVariant`](crate::SchemaVariant).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
         ctx: &DalContext<'_, '_>,

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -38,10 +38,11 @@ impl_standard_model! {
     history_event_message_name: "Internal Provider"
 }
 
-/// This provider can only provide data within its own [`SchemaVariant`]. If the "internal_consumer"
-/// field is set to "true", this provider can only consume data from within its own
-/// [`SchemaVariant`]. If the "internal_consumer" field is set to "false", this provider can only
-/// consume data from other [`SchemaVariant`]s.
+/// This provider can only provide data within its own [`SchemaVariant`](crate::SchemaVariant). If
+/// the "internal_consumer" field is set to "true", this provider can only consume data from within
+/// its own [`SchemaVariant`](crate::SchemaVariant). If the "internal_consumer" field is set to
+/// "false", this provider can only consume data from other
+/// [`SchemaVariants`](crate::SchemaVariant).
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct InternalProvider {
     pk: InternalProviderPk,
@@ -53,17 +54,17 @@ pub struct InternalProvider {
     #[serde(flatten)]
     timestamp: Timestamp,
 
-    /// Indicates which [`Prop`] this provider belongs to.
+    /// Indicates which [`Prop`](crate::Prop) this provider belongs to.
     prop_id: PropId,
-    /// Indicates which [`Schema`] this provider belongs to.
+    /// Indicates which [`Schema`](crate::Schema) this provider belongs to.
     schema_id: SchemaId,
-    /// Indicates which [`SchemaVariant`] this provider belongs to.
+    /// Indicates which [`SchemaVariant`](crate::SchemaVariant) this provider belongs to.
     schema_variant_id: SchemaVariantId,
     /// Name for [`Self`] that can be used for identification.
     name: Option<String>,
     /// If this field is set to "true", the provider can only consume data from within its own
-    /// [`SchemaVariant`]. If this field field is set to "false", the provider can only consume data
-    /// from other [`SchemaVariant`]s.
+    /// [`SchemaVariant`](crate::SchemaVariant). If this field field is set to "false", the provider
+    /// can only consume data from other [`SchemaVariants`](crate::SchemaVariant).
     internal_consumer: bool,
     /// Definition of the inbound type (e.g. "JSONSchema" or "Number").
     inbound_type_definition: Option<String>,
@@ -122,7 +123,7 @@ impl InternalProvider {
         InternalProviderResult
     );
 
-    /// Find all internal providers for a given [`SchemaVariant`].
+    /// Find all internal providers for a given [`SchemaVariant`](crate::SchemaVariant).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
         ctx: &DalContext<'_, '_>,

--- a/lib/dal/src/queries/attribute_prototype_argument_list_for_attribute_prototype.sql
+++ b/lib/dal/src/queries/attribute_prototype_argument_list_for_attribute_prototype.sql
@@ -1,0 +1,36 @@
+SELECT DISTINCT ON (attribute_prototype_arguments.id) attribute_prototype_arguments.id,
+                                           attribute_prototype_arguments.visibility_change_set_pk,
+                                           attribute_prototype_arguments.visibility_edit_session_pk,
+                                           attribute_prototype_arguments.name,
+                                           attribute_prototype_arguments.internal_provider_id,
+                                           row_to_json(attribute_prototype_arguments.*) AS object
+FROM attribute_prototype_arguments
+
+    INNER JOIN attribute_prototype_argument_belongs_to_attribute_prototype ON
+               attribute_prototype_argument_belongs_to_attribute_prototype.object_id = attribute_prototype_arguments.id
+        AND in_tenancy_v1($1, attribute_prototype_argument_belongs_to_attribute_prototype.tenancy_universal,
+                          attribute_prototype_argument_belongs_to_attribute_prototype.tenancy_billing_account_ids,
+                          attribute_prototype_argument_belongs_to_attribute_prototype.tenancy_organization_ids,
+                          attribute_prototype_argument_belongs_to_attribute_prototype.tenancy_workspace_ids)
+        AND is_visible_v1($2, attribute_prototype_argument_belongs_to_attribute_prototype.visibility_change_set_pk,
+                          attribute_prototype_argument_belongs_to_attribute_prototype.visibility_edit_session_pk,
+                          attribute_prototype_argument_belongs_to_attribute_prototype.visibility_deleted)
+    INNER JOIN attribute_prototypes ON
+               attribute_prototypes.id = attribute_prototype_argument_belongs_to_attribute_prototype.belongs_to_id
+        AND in_tenancy_v1($1, attribute_prototypes.tenancy_universal,
+                          attribute_prototypes.tenancy_billing_account_ids,
+                          attribute_prototypes.tenancy_organization_ids,
+                          attribute_prototypes.tenancy_workspace_ids)
+        AND is_visible_v1($2, attribute_prototypes.visibility_change_set_pk,
+                          attribute_prototypes.visibility_edit_session_pk,
+                          attribute_prototypes.visibility_deleted)
+        AND attribute_prototypes.id = $3
+
+WHERE in_tenancy_v1($1, attribute_prototype_arguments.tenancy_universal, attribute_prototype_arguments.tenancy_billing_account_ids,
+                    attribute_prototype_arguments.tenancy_organization_ids, attribute_prototype_arguments.tenancy_workspace_ids)
+  AND is_visible_v1($2, attribute_prototype_arguments.visibility_change_set_pk, attribute_prototype_arguments.visibility_edit_session_pk,
+                    attribute_prototype_arguments.visibility_deleted)
+
+ORDER BY attribute_prototype_arguments.id,
+         visibility_change_set_pk DESC,
+         visibility_edit_session_pk DESC

--- a/lib/dal/src/schema/builtins.rs
+++ b/lib/dal/src/schema/builtins.rs
@@ -496,6 +496,7 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> SchemaResult<()> {
         *func_binding.id(),
         *func_binding_return_value.id(),
         Some(*root_prop_attribute_value.id()),
+        None,
         Some(
             *AttributeValue::find_for_context(ctx, number_of_parents_prop_context.into())
                 .await?

--- a/lib/dal/tests/integration_test/attribute.rs
+++ b/lib/dal/tests/integration_test/attribute.rs
@@ -1,2 +1,3 @@
 pub mod prototype;
+pub mod prototype_argument;
 pub mod value;

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -74,6 +74,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
         context,
         None,
         None,
+        None,
     )
     .await
     .expect("cannot create new attribute prototype");
@@ -224,6 +225,7 @@ async fn list_for_context(ctx: &DalContext<'_, '_>) {
         component_name_prototype_context,
         None,
         None,
+        None,
     )
     .await
     .expect("cannot create attribute prototype for component album name");
@@ -368,6 +370,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
         prop_hash_key_prototype_context,
         Some("Undertow".to_string()),
         None,
+        None,
     )
     .await
     .expect("cannot create attribute prototype for component album name");
@@ -393,6 +396,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
         *func_binding_return_value.id(),
         prop_hash_key_prototype_context,
         Some("Lateralus".to_string()),
+        None,
         None,
     )
     .await
@@ -428,6 +432,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
         component_hash_key_prototype_context,
         Some("Lateralus".to_string()),
         None,
+        None,
     )
     .await
     .expect("cannot create attribute prototype for component album name");
@@ -453,6 +458,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
         *func_binding_return_value.id(),
         component_hash_key_prototype_context,
         Some("Fear Inoculum".to_string()),
+        None,
         None,
     )
     .await

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -1,0 +1,139 @@
+use crate::dal::test;
+use dal::{
+    attribute::context::AttributeContext,
+    attribute::prototype::AttributePrototype,
+    func::{backend::string::FuncBackendStringArgs, binding::FuncBinding},
+    test_harness::{create_schema, create_schema_variant_with_root},
+    AttributeReadContext, Func, FuncBackendKind, FuncBackendResponseType, PropKind, SchemaKind,
+    StandardModel,
+};
+use dal::{AttributePrototypeArgument, DalContext, InternalProvider};
+
+use dal::test_harness::create_prop_of_kind_and_set_parent_with_name;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn create_and_list_for_attribute_prototype(ctx: &DalContext<'_, '_>) {
+    let mut schema = create_schema(ctx, &SchemaKind::Concrete).await;
+    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    schema_variant
+        .set_schema(ctx, schema.id())
+        .await
+        .expect("cannot associate variant with schema");
+    schema
+        .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+
+    let base_attribute_read_context = AttributeReadContext {
+        schema_id: Some(*schema.id()),
+        schema_variant_id: Some(*schema_variant.id()),
+        ..AttributeReadContext::default()
+    };
+
+    // domain: Object
+    // └─ object: Object
+    //    └─ name: String
+    let object_prop = create_prop_of_kind_and_set_parent_with_name(
+        ctx,
+        PropKind::Object,
+        "object",
+        root_prop.domain_prop_id,
+        base_attribute_read_context,
+    )
+    .await;
+    let name_prop = create_prop_of_kind_and_set_parent_with_name(
+        ctx,
+        PropKind::String,
+        "name",
+        *object_prop.id(),
+        base_attribute_read_context,
+    )
+    .await;
+
+    let func = Func::new(
+        ctx,
+        "test:setString",
+        FuncBackendKind::String,
+        FuncBackendResponseType::String,
+    )
+    .await
+    .expect("cannot create func");
+    let args = FuncBackendStringArgs::new("starfield".to_string());
+    let func_binding = FuncBinding::new(
+        ctx,
+        serde_json::to_value(args).expect("cannot turn args into json"),
+        *func.id(),
+        *func.backend_kind(),
+    )
+    .await
+    .expect("cannot create function binding");
+    let func_binding_return_value = func_binding
+        .execute(ctx)
+        .await
+        .expect("failed to execute func binding");
+    let context = AttributeContext::builder()
+        .set_prop_id(*name_prop.id())
+        .set_schema_id(*schema.id())
+        .set_schema_variant_id(*schema_variant.id())
+        .to_context()
+        .expect("cannot create context");
+
+    let attribute_prototype = AttributePrototype::new(
+        ctx,
+        *func.id(),
+        *func_binding.id(),
+        *func_binding_return_value.id(),
+        context,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("cannot create new attribute prototype");
+
+    let internal_provider = InternalProvider::new(
+        ctx,
+        *name_prop.id(),
+        *schema.id(),
+        *schema_variant.id(),
+        Some("name".to_string()),
+        true,
+        None,
+        None,
+    )
+    .await
+    .expect("could not create internal provider");
+
+    let argument = AttributePrototypeArgument::new(
+        ctx,
+        "title".to_string(),
+        internal_provider.id(),
+        attribute_prototype.id(),
+    )
+    .await
+    .expect("could not create attribute prototype argument");
+
+    let mut found_arguments =
+        AttributePrototypeArgument::list_for_attribute_prototype(ctx, *attribute_prototype.id())
+            .await
+            .expect("could not list attribute prototype argument for attribute prototype");
+    let found_argument = found_arguments
+        .pop()
+        .expect("found attribute prototype arguments are empty");
+    if !found_arguments.is_empty() {
+        panic!("expected empty: found attribute prototype arguments returned more results than expected");
+    }
+
+    assert_eq!(found_argument.name(), argument.name());
+    assert_eq!(
+        found_argument.internal_provider_id(),
+        argument.internal_provider_id()
+    );
+    let found_prototype = found_argument
+        .attribute_prototype(ctx)
+        .await
+        .expect("could not get attribute prototype for attribute prototype argument")
+        .expect("attribute prototype for attribute prototype argument not found");
+    assert_eq!(found_prototype.id(), attribute_prototype.id());
+}

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -128,6 +128,7 @@ async fn create_and_list_for_schema_variant(ctx: &DalContext<'_, '_>) {
         attribute_context,
         None,
         None,
+        None,
     )
     .await
     .expect("cannot create new attribute prototype");


### PR DESCRIPTION
Primary changes:
- Add AttributePrototypeArgument, a key-value type that may contain more
  metadata in the future
- Consume AttributePrototypeArgument within AttributePrototype
- Add "belongs_to" relationship for AttributePrototypeArgument and
  AttributePrototype
- Add AttributePrototypeArgument::list_for_attribute_prototype and its
  corresponding query

Misc changes:
- Fix misc cargo doc links
- Update make targets and DEVELOPING for cargo doc in hopes of catching
  errors in cargo doc links in the future
- Add tidy-crates target to root Makefile

Research PR: #924

<img src="https://media3.giphy.com/media/sRMPFaVQLGSw8/giphy-downsized-medium.gif"/>

Fixes ENG-114