### PR TITLE
feat(web): Rename/restyle some buttons

### DIFF
--- a/app/web/src/molecules/NodeAddMenu.vue
+++ b/app/web/src/molecules/NodeAddMenu.vue
@@ -4,23 +4,20 @@
     @mouseleave="onMouseLeave"
     @mouseenter="cancelClose"
   >
-    <button
-      class="w-full focus:outline-none"
+    <SiButton
+      icon="plus"
+      :label="props.addTo ? `Add to ${props.addTo}` : `Add`"
+      class="w-full focus:outline-none add-margin-top items-center self-center text-sm subpixel-antialiased font-light tracking-tight"
+      :class="{
+        'text-gray-200': !isOpen,
+        'menu-selected': isOpen,
+        'text-gray-600': props.disabled ?? false,
+      }"
+      size="xs"
       data-cy="editor-schematic-node-add-button"
-      :disabled="disabled"
+      :disabled="props.disabled ?? false"
       @click="isOpen = !isOpen"
-    >
-      <div
-        class="add-margin-top items-center self-center w-full text-sm subpixel-antialiased font-light tracking-tight"
-        :class="{
-          'text-gray-200': !isOpen,
-          'menu-selected': isOpen,
-          'text-gray-600': disabled,
-        }"
-      >
-        Add
-      </div>
-    </button>
+    />
 
     <NodeAddMenuCategory
       :is-open="isOpen"
@@ -35,20 +32,19 @@
 <script setup lang="ts">
 import { MenuFilter, MenuItem } from "@/api/sdf/dal/schematic";
 import NodeAddMenuCategory from "./NodeAddMenu/NodeAddMenuCategory.vue";
-import { onBeforeUnmount, PropType, ref } from "vue";
+import { onBeforeUnmount, ref } from "vue";
 import { refFrom, fromRef } from "vuse-rx";
 import _ from "lodash";
 import { SchematicService } from "@/service/schematic";
 import { GlobalErrorService } from "@/service/global_error";
 import { combineLatest, from, switchMap } from "rxjs";
+import SiButton from "@/atoms/SiButton.vue";
 
-const props = defineProps({
-  disabled: { type: Boolean, default: false },
-  filter: {
-    type: Object as PropType<MenuFilter>,
-    required: true,
-  },
-});
+const props = defineProps<{
+  disabled?: boolean;
+  filter: MenuFilter;
+  addTo?: string;
+}>();
 const emits = defineEmits(["selected"]);
 
 const isOpen = ref<boolean>(false);

--- a/app/web/src/molecules/Panel.vue
+++ b/app/web/src/molecules/Panel.vue
@@ -24,7 +24,7 @@
           />
         </div>
       </div>
-      <div class="flex justify-start flex-grow">
+      <div class="flex flex-row items-center flex-grow">
         <slot name="menuButtons"></slot>
       </div>
       <div class="flex flex-row items-center justify-end flex-grow">
@@ -138,7 +138,7 @@ onMounted(() => {
 const panelTypes = computed<LabelList<PanelType>>(() => {
   return [
     {
-      label: "Schematic",
+      label: "Diagram",
       value: PanelType.Schematic,
     },
     {

--- a/app/web/src/organisims/SchematicViewer/model/node.ts
+++ b/app/web/src/organisims/SchematicViewer/model/node.ts
@@ -116,7 +116,7 @@ export interface NodeUpdate {
 
 export function fakeNodeFromTemplate(
   template: NodeTemplate,
-  deploymentNodeId: number | null,
+  deploymentNodeId?: number,
 ): Node {
   let componentId;
   switch (template.kind) {
@@ -134,7 +134,7 @@ export function fakeNodeFromTemplate(
       {
         id: "-1",
         schematic_kind: schematicKindFromNodeKind(template.kind),
-        deployment_node_id: deploymentNodeId,
+        deployment_node_id: deploymentNodeId ?? null,
         x: 0,
         y: 0,
       },


### PR DESCRIPTION
Minor design changes made from user tests inputs.

- Rename Schematic panel to Diagram panel
- Restyle node add button to be similar to the "new application" one
- Rename node add button in deployment panel to "Add to application"
- Rename node add button in component panel to `Add to ${schema.name}` or `Add` if no deployment is selected

<img width="1440" alt="Screen Shot 2022-05-03 at 14 06 36" src="https://user-images.githubusercontent.com/6289779/166504357-da675449-f727-4d1a-9054-26b6ab366c13.png">

<img width="1440" alt="Screen Shot 2022-05-03 at 14 06 43" src="https://user-images.githubusercontent.com/6289779/166504348-1c46adc7-3915-409d-8300-a0ae52272db6.png">

<img width="1440" alt="Screen Shot 2022-05-03 at 14 06 55" src="https://user-images.githubusercontent.com/6289779/166504331-ac56fd3d-131b-4b23-ad8e-77b9b11f303e.png">

<img src="https://media1.giphy.com/media/LN6AfV6TxxJtu/giphy.gif"/>