### PR TITLE
feat(dal,sdf,web): add ProviderViewer

### DIFF
--- a/app/web/src/api/sdf/dal/provider.ts
+++ b/app/web/src/api/sdf/dal/provider.ts
@@ -1,0 +1,20 @@
+import { StandardModel } from "@/api/sdf/dal/standard_model";
+
+export interface InternalProvider extends StandardModel {
+  propId: number;
+  schemaId: number;
+  schemaVariantId: number;
+  name?: string;
+  internal_consumer: boolean;
+  inbound_type_definition?: string;
+  outbound_type_definition?: string;
+}
+
+export interface ExternalProvider extends StandardModel {
+  propId: number;
+  schemaId: number;
+  schemaVariantId: number;
+  name?: string;
+  type_definition?: string;
+  attribute_prototype_id: number;
+}

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -65,6 +65,13 @@
           >
             <AtSymbolIcon />
           </SiButtonIcon>
+          <SiButtonIcon
+            tooltip-text="Provider Viewer"
+            :color="activeView === 'provider' ? 'cyan' : 'white'"
+            @click="setActiveView('provider')"
+          >
+            <BeakerIcon />
+          </SiButtonIcon>
         </div>
 
         <div class="flex items-center">
@@ -120,6 +127,10 @@
           v-else-if="activeView === 'code'"
           :component-id="selectedComponentIdentification.componentId"
         />
+        <ProviderViewer
+          v-else-if="activeView === 'provider'"
+          :schema-variant-id="selectedComponentIdentification.schemaVariantId"
+        />
         <div v-else-if="activeView === 'connection'">
           ActiveView "{{ activeView }}" not implemented
         </div>
@@ -152,6 +163,7 @@ import * as Rx from "rxjs";
 import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import AttributeViewer from "@/organisims/AttributeViewer.vue";
+import ProviderViewer from "@/organisims/ProviderViewer.vue";
 import QualificationViewer from "@/organisims/QualificationViewer.vue";
 import ResourceViewer from "@/organisims/ResourceViewer.vue";
 import CodeViewer from "@/organisims/CodeViewer.vue";
@@ -170,6 +182,7 @@ import {
   PlayIcon,
   CubeIcon,
   CodeIcon,
+  BeakerIcon,
 } from "@heroicons/vue/solid";
 
 const randomString = () => `${Math.floor(Math.random() * 50000)}`;

--- a/app/web/src/organisims/ProviderViewer.vue
+++ b/app/web/src/organisims/ProviderViewer.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="flex flex-col w-full overflow-hidden">
+    <div
+      class="flex flex-row items-center h-10 px-6 py-2 text-base text-white align-middle property-section-bg-color"
+    >
+      <div class="text-lg">Providers</div>
+    </div>
+
+    <div class="flex text-sm p-6 flex-col">
+      <div class="font-semibold">InternalProviders</div>
+      <div v-if="allProviders && allProviders.internalProviders.length > 0">
+        <div
+          v-for="internalProvider in allProviders.internalProviders"
+          :key="internalProvider.id"
+        >
+          <div class="flex flex-row row-item">
+            {{ internalProvider }}
+          </div>
+        </div>
+      </div>
+      <div v-else class="flex">None</div>
+    </div>
+
+    <div class="flex text-sm p-6 flex-col">
+      <div class="font-semibold">ExternalProviders</div>
+      <div v-if="allProviders && allProviders.externalProviders.length > 0">
+        <div
+          v-for="externalProvider in allProviders.externalProviders"
+          :key="externalProvider.id"
+        >
+          <div class="flex flex-row row-item">
+            {{ externalProvider }}
+          </div>
+        </div>
+      </div>
+      <div v-else class="flex">None</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as Rx from "rxjs";
+import { toRefs } from "vue";
+import { fromRef, refFrom } from "vuse-rx";
+import { GlobalErrorService } from "@/service/global_error";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import { editSessionWritten$ } from "@/observable/edit_session";
+import { ProviderService } from "@/service/provider";
+import { ListAllProviderResponse } from "@/service/provider/list_all_providers";
+
+const props = defineProps<{
+  schemaVariantId: number;
+}>();
+
+const { schemaVariantId } = toRefs(props);
+const schemaVariantId$ = fromRef<number>(schemaVariantId, { immediate: true });
+
+const allProviders = refFrom<ListAllProviderResponse | undefined>(
+  Rx.combineLatest([
+    schemaVariantId$,
+    standardVisibilityTriggers$,
+    editSessionWritten$,
+  ]).pipe(
+    Rx.switchMap(([schemaVariantId, [visibility]]) => {
+      return ProviderService.listAllProviders({
+        schemaVariantId: schemaVariantId,
+        ...visibility,
+      });
+    }),
+    Rx.switchMap((response) => {
+      if (response === null) {
+        return Rx.from([undefined]);
+      } else if (response.error) {
+        GlobalErrorService.set(response);
+        return Rx.from([undefined]);
+      } else {
+        return Rx.from([response]);
+      }
+    }),
+  ),
+);
+</script>
+
+<style scoped>
+.scrollbar {
+  -ms-overflow-style: none; /* edge, and ie */
+  scrollbar-width: none; /* firefox */
+}
+.scrollbar::-webkit-scrollbar {
+  display: none; /*chrome, opera, and safari */
+}
+.gold-bars-icon {
+  color: #ce7f3e;
+}
+.property-section-bg-color {
+  background-color: #292c2d;
+}
+.ok {
+  color: #86f0ad;
+}
+.warning {
+  color: #f0d286;
+}
+.error {
+  color: #f08686;
+}
+.unknown {
+  color: #5b6163;
+}
+</style>

--- a/app/web/src/service/provider.ts
+++ b/app/web/src/service/provider.ts
@@ -1,0 +1,5 @@
+import { listAllProviders } from "./provider/list_all_providers";
+
+export const ProviderService = {
+  listAllProviders,
+};

--- a/app/web/src/service/provider/list_all_providers.ts
+++ b/app/web/src/service/provider/list_all_providers.ts
@@ -1,0 +1,55 @@
+import { ApiResponse, SDF } from "@/api/sdf";
+import { combineLatest, Observable, from } from "rxjs";
+import Bottle from "bottlejs";
+import { switchMap } from "rxjs/operators";
+import { Visibility } from "@/api/sdf/dal/visibility";
+import { workspace$ } from "@/observable/workspace";
+import _ from "lodash";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+import { InternalProvider } from "@/api/sdf/dal/provider";
+import { ExternalProvider } from "@/api/sdf/dal/provider";
+import { system$ } from "@/observable/system";
+
+export interface ListAllProviderArgs extends Visibility {
+  schemaVariantId: number;
+}
+
+export interface ListAllProviderRequest extends ListAllProviderArgs {
+  workspaceId?: number;
+}
+
+export interface ListAllProviderResponse {
+  internalProviders: InternalProvider[];
+  externalProviders: ExternalProvider[];
+}
+
+export function listAllProviders(
+  args: ListAllProviderRequest,
+): Observable<ApiResponse<ListAllProviderResponse>> {
+  return combineLatest([standardVisibilityTriggers$, system$, workspace$]).pipe(
+    switchMap(([[visibility], system, workspace]) => {
+      const bottle = Bottle.pop("default");
+      const sdf: SDF = bottle.container.SDF;
+      if (_.isNull(workspace)) {
+        return from([
+          {
+            error: {
+              statusCode: 10,
+              message: "cannot make call without a workspace; bug!",
+              code: 10,
+            },
+          },
+        ]);
+      }
+      return sdf.get<ApiResponse<ListAllProviderResponse>>(
+        "provider/list_all_providers",
+        {
+          ...args,
+          ...visibility,
+          systemId: system?.id,
+          workspaceId: workspace.id,
+        },
+      );
+    }),
+  );
+}

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -1,4 +1,3 @@
-use crate::WriteTenancy;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use si_data::{NatsError, PgError};
@@ -7,6 +6,11 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use self::variant::{SchemaVariantError, SchemaVariantResult};
+use crate::func::binding_return_value::FuncBindingReturnValueError;
+use crate::provider::external::ExternalProviderError;
+use crate::provider::internal::InternalProviderError;
+use crate::socket::SocketError;
+use crate::WriteTenancy;
 use crate::{
     component::ComponentKind,
     edit_field::{
@@ -27,7 +31,6 @@ use crate::{
     WorkspaceId, WsEventError,
 };
 
-use crate::socket::SocketError;
 pub use ui_menu::UiMenu;
 pub use variant::{SchemaVariant, SchemaVariantId};
 
@@ -47,14 +50,20 @@ pub enum SchemaError {
     CodeGenerationPrototype(#[from] CodeGenerationPrototypeError),
     #[error("edit field error: {0}")]
     EditField(#[from] EditFieldError),
+    #[error("external provider error: {0}")]
+    ExternalProvider(#[from] ExternalProviderError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("func binding error: {0}")]
     FuncBinding(#[from] FuncBindingError),
+    #[error("func binding return value error: {0}")]
+    FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
     #[error("func not found: {0}")]
     FuncNotFound(String),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
+    #[error("internal provider error: {0}")]
+    InternalProvider(#[from] InternalProviderError),
     #[error("missing a func in attribute update: {0} not found")]
     MissingFunc(String),
     #[error("nats txn error: {0}")]

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -80,26 +80,27 @@ pub fn routes(
             crate::server::service::application::routes(),
         )
         .nest(
-            "/api/component",
-            crate::server::service::component::routes(),
-        )
-        .nest("/api/signup", crate::server::service::signup::routes())
-        .nest("/api/session", crate::server::service::session::routes())
-        .nest(
             "/api/change_set",
             crate::server::service::change_set::routes(),
         )
-        .nest("/api/schema", crate::server::service::schema::routes())
-        .nest("/api/secret", crate::server::service::secret::routes())
         .nest(
-            "/api/schematic",
-            crate::server::service::schematic::routes(),
+            "/api/component",
+            crate::server::service::component::routes(),
         )
-        .nest("/api/system", crate::server::service::system::routes())
         .nest(
             "/api/edit_field",
             crate::server::service::edit_field::routes(),
         )
+        .nest("/api/provider", crate::server::service::provider::routes())
+        .nest("/api/schema", crate::server::service::schema::routes())
+        .nest(
+            "/api/schematic",
+            crate::server::service::schematic::routes(),
+        )
+        .nest("/api/secret", crate::server::service::secret::routes())
+        .nest("/api/session", crate::server::service::session::routes())
+        .nest("/api/signup", crate::server::service::signup::routes())
+        .nest("/api/system", crate::server::service::system::routes())
         .nest("/api/ws", crate::server::service::ws::routes());
     router = test_routes(router);
     router = router

--- a/lib/sdf/src/server/service.rs
+++ b/lib/sdf/src/server/service.rs
@@ -2,6 +2,7 @@ pub mod application;
 pub mod change_set;
 pub mod component;
 pub mod edit_field;
+pub mod provider;
 pub mod schema;
 pub mod schematic;
 pub mod secret;

--- a/lib/sdf/src/server/service/provider.rs
+++ b/lib/sdf/src/server/service/provider.rs
@@ -1,0 +1,53 @@
+use axum::response::Response;
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use dal::provider::external::ExternalProviderError;
+use dal::provider::internal::InternalProviderError;
+use dal::{StandardModelError, TransactionsError};
+
+use thiserror::Error;
+
+pub mod list_all_providers;
+
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    #[error(transparent)]
+    ContextError(#[from] TransactionsError),
+    #[error(transparent)]
+    Nats(#[from] si_data::NatsError),
+    #[error(transparent)]
+    Pg(#[from] si_data::PgError),
+    #[error(transparent)]
+    PgPool(#[from] si_data::PgPoolError),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+
+    #[error("external provider error: {0}")]
+    ExternalProvider(#[from] ExternalProviderError),
+    #[error("internal provider error: {0}")]
+    InternalProvider(#[from] InternalProviderError),
+}
+
+pub type ProviderResult<T> = std::result::Result<T, ProviderError>;
+
+impl IntoResponse for ProviderError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        let body = Json(serde_json::json!({
+            "error": {
+                "message": error_message,
+                "code": 42,
+                "statusCode": status.as_u16(),
+            },
+        }));
+
+        (status, body).into_response()
+    }
+}
+
+pub fn routes() -> Router {
+    Router::new().route(
+        "/list_all_providers",
+        get(list_all_providers::list_all_providers),
+    )
+}

--- a/lib/sdf/src/server/service/provider/list_all_providers.rs
+++ b/lib/sdf/src/server/service/provider/list_all_providers.rs
@@ -1,0 +1,43 @@
+use axum::extract::Query;
+use axum::Json;
+use dal::{ExternalProvider, InternalProvider, SchemaVariantId, Visibility, WorkspaceId};
+use serde::{Deserialize, Serialize};
+
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use crate::service::provider::ProviderResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAllProviderRequest {
+    pub schema_variant_id: SchemaVariantId,
+    pub workspace_id: Option<WorkspaceId>,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAllProviderResponse {
+    pub internal_providers: Vec<InternalProvider>,
+    pub external_providers: Vec<ExternalProvider>,
+}
+
+pub async fn list_all_providers(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<ListAllProviderRequest>,
+) -> ProviderResult<Json<ListAllProviderResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    let internal_providers =
+        InternalProvider::list_for_schema_variant(&ctx, request.schema_variant_id).await?;
+    let external_providers =
+        ExternalProvider::list_for_schema_variant(&ctx, request.schema_variant_id).await?;
+
+    let response = ListAllProviderResponse {
+        internal_providers,
+        external_providers,
+    };
+    Ok(Json(response))
+}


### PR DESCRIPTION
ProviderViewer changes:
- Add ProviderViewer for viewing the InternalProviders and
  ExternalProviders on a selected Component (via its corresponding
  SchemaVariantId)
- Add provider service to SDF
- Add "list_all_providers" route to SDF on the new SDF service
- Add frontend service and dal shapes for providers

Misc changes:
- Re-order SDF service routes alphabetically

Research PR: #924

<img src="https://media4.giphy.com/media/QaRi7pzAUwnJhTcmRN/giphy.gif"/>

Fixes ENG-145