### PR TITLE
feat(web): Create SiButtonIcon and swap to it in PanelAttribute

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -14,6 +14,7 @@
         "@codemirror/state": "^0.19.0",
         "@codemirror/stream-parser": "^0.19.9",
         "@codemirror/view": "^0.19.0",
+        "@heroicons/vue": "^1.0.6",
         "@pixi/layers": "^1.0.11",
         "@reactivex/rxjs": "^6.6.7",
         "@xstate/vue": "^2.0.0",
@@ -25,6 +26,7 @@
         "rxjs": "^7.5.5",
         "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
         "vue": "^3.2.33",
+        "vue3-popper": "^1.4.2",
         "vuse-rx": "systeminit/vuse-rx#bug/fix-options",
         "xstate": "^4.31.0"
       },
@@ -404,6 +406,14 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@heroicons/vue": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-1.0.6.tgz",
+      "integrity": "sha512-ng2YcCQrdoQWEFpw+ipFl2rZo8mZ56v0T5+MyfQQvNqfKChwgP6DMloZLW+rl17GEcHkE3H82UTAMKBKZr4+WA==",
+      "peerDependencies": {
+        "vue": ">= 3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -920,6 +930,15 @@
       "peerDependencies": {
         "@pixi/constants": "6.2.0",
         "@pixi/settings": "6.2.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@reactivex/rxjs": {
@@ -2276,6 +2295,11 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
       "dev": true
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -5930,6 +5954,21 @@
         "typescript": "*"
       }
     },
+    "node_modules/vue3-popper": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vue3-popper/-/vue3-popper-1.4.2.tgz",
+      "integrity": "sha512-nc5vM//AJ8/DyNetjrrgkkLv7aKVdSsljvqlQ1tWhAV2lgA8tkn8xE6icDd0/kBt0Yo5Li8Pftf0H0C/hNmu1Q==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "debounce": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.20"
+      }
+    },
     "node_modules/vuse-rx": {
       "version": "0.13.1",
       "resolved": "git+ssh://git@github.com/systeminit/vuse-rx.git#26fcfc6fbea5a749e84dd2a97812affa99e64eb4",
@@ -6359,6 +6398,12 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@heroicons/vue": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-1.0.6.tgz",
+      "integrity": "sha512-ng2YcCQrdoQWEFpw+ipFl2rZo8mZ56v0T5+MyfQQvNqfKChwgP6DMloZLW+rl17GEcHkE3H82UTAMKBKZr4+WA==",
+      "requires": {}
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
@@ -6706,6 +6751,11 @@
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@reactivex/rxjs": {
       "version": "6.6.7",
@@ -7698,6 +7748,11 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
       "dev": true
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.3",
@@ -10224,6 +10279,15 @@
       "dev": true,
       "requires": {
         "@volar/vue-typescript": "0.34.10"
+      }
+    },
+    "vue3-popper": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vue3-popper/-/vue3-popper-1.4.2.tgz",
+      "integrity": "sha512-nc5vM//AJ8/DyNetjrrgkkLv7aKVdSsljvqlQ1tWhAV2lgA8tkn8xE6icDd0/kBt0Yo5Li8Pftf0H0C/hNmu1Q==",
+      "requires": {
+        "@popperjs/core": "^2.9.2",
+        "debounce": "^1.2.1"
       }
     },
     "vuse-rx": {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -18,12 +18,13 @@
     "checks": "npm run eslint; npm run type-check; npm run prettier-check"
   },
   "dependencies": {
-    "@codemirror/state": "^0.19.0",
-    "@codemirror/view": "^0.19.0",
-    "@codemirror/commands": "^0.19.0",
     "@codemirror/basic-setup": "^0.19.0",
+    "@codemirror/commands": "^0.19.0",
     "@codemirror/legacy-modes": "^0.19.0",
+    "@codemirror/state": "^0.19.0",
     "@codemirror/stream-parser": "^0.19.9",
+    "@codemirror/view": "^0.19.0",
+    "@heroicons/vue": "^1.0.6",
     "@pixi/layers": "^1.0.11",
     "@reactivex/rxjs": "^6.6.7",
     "@xstate/vue": "^2.0.0",
@@ -35,6 +36,7 @@
     "rxjs": "^7.5.5",
     "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
     "vue": "^3.2.33",
+    "vue3-popper": "^1.4.2",
     "vuse-rx": "systeminit/vuse-rx#bug/fix-options",
     "xstate": "^4.31.0"
   },

--- a/app/web/src/atoms/SiButtonIcon.vue
+++ b/app/web/src/atoms/SiButtonIcon.vue
@@ -1,0 +1,59 @@
+<template>
+  <Popper :hover="true" :open-delay="500" :content="props.tooltipText">
+    <button
+      :class="buttonStyle"
+      :aria-label="props.tooltipText"
+      :disabled="props.disabled"
+      :style="{ color: props.color }"
+      @click="emit('click')"
+    >
+      <slot></slot>
+    </button>
+  </Popper>
+</template>
+
+<script setup lang="ts">
+import Popper from "vue3-popper";
+import { computed } from "vue";
+
+const emit = defineEmits(["click"]);
+
+const props = defineProps<{
+  disabled?: boolean;
+  color: string;
+  tooltipText: string;
+}>();
+
+const buttonStyle = computed(() => {
+  const results: Record<string, boolean> = {};
+  results["button-standard"] = true;
+  results["text-xs"] = true;
+  if (props.disabled) {
+    results["opacity-50"] = true;
+    results["cursor-not-allowed"] = true;
+  }
+  return results;
+});
+</script>
+
+<style lang="scss" scoped>
+$button-saturation: 1.2;
+$button-brightness: 1.05;
+
+.button-standard {
+  display: flex;
+  width: 20px;
+}
+
+.button-standard:hover {
+  filter: brightness($button-brightness);
+}
+
+.button-standard:focus {
+  outline: none;
+}
+
+.button-standard:active {
+  filter: saturate(1.5) brightness($button-brightness);
+}
+</style>

--- a/app/web/src/d.ts
+++ b/app/web/src/d.ts
@@ -1,0 +1,5 @@
+declare module "vue3-popper" {
+  import { Component } from "vue";
+  const file: Component;
+  export default file;
+}

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -26,121 +26,62 @@
           <LockButton v-model="isPinned" />
         </div>
 
-        <!-- NOTE(nick): old-web adds items-center for this div.
-        More information: https://tailwindcss.com/docs/align-items#center
-        -->
         <div class="flex flex-row items-center">
-          <button
-            class="pl-1 focus:outline-none"
+          <SiButtonIcon
+            tooltip-text="Attribute Viewer"
+            :color="activeView === 'attribute' ? 'cyan' : 'white'"
             @click="setActiveView('attribute')"
           >
-            <VueFeather
-              v-if="activeView === 'attribute'"
-              type="disc"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather v-else type="disc" class="text-gray-300" size="1.1em" />
-          </button>
-          <button
-            class="pl-1 focus:outline-none"
+            <ClipboardListIcon />
+          </SiButtonIcon>
+          <SiButtonIcon
+            tooltip-text="Code Viewer"
+            :color="activeView === 'code' ? 'cyan' : 'white'"
             @click="setActiveView('code')"
           >
-            <VueFeather
-              v-if="activeView === 'code'"
-              type="code"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather v-else type="code" class="text-gray-300" size="1.1em" />
-          </button>
-          <button
-            class="pl-1 focus:outline-none"
+            <CodeIcon />
+          </SiButtonIcon>
+          <SiButtonIcon
+            tooltip-text="Qualification Viewer"
+            :color="activeView === 'qualification' ? 'cyan' : 'white'"
             @click="setActiveView('qualification')"
           >
-            <VueFeather
-              v-if="activeView === 'qualification'"
-              type="check-square"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather
-              v-else
-              type="check-square"
-              class="text-gray-300"
-              size="1.1em"
-            />
-          </button>
+            <ClipboardCheckIcon />
+          </SiButtonIcon>
         </div>
 
-        <!-- NOTE(nick): old-web adds text-white for buttons in this div.
-        More information: https://tailwindcss.com/docs/text-color
-        -->
         <div class="flex flex-row items-center">
-          <button
-            class="pl-1 text-white focus:outline-none"
+          <SiButtonIcon
+            tooltip-text="Connection Viewer (not implemented yet)"
+            :color="activeView === 'connection' ? 'cyan' : 'white'"
             @click="setActiveView('connection')"
           >
-            <VueFeather
-              v-if="activeView === 'connection'"
-              type="link-2"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather
-              v-else
-              type="link-2"
-              class="text-gray-300"
-              size="1.1em"
-            />
-          </button>
-          <button
-            class="pl-1 text-white focus:outline-none"
+            <LinkIcon />
+          </SiButtonIcon>
+          <SiButtonIcon
+            tooltip-text="Discovery Viewer (not implemented yet)"
+            :color="activeView === 'discovery' ? 'cyan' : 'white'"
             @click="setActiveView('discovery')"
           >
-            <VueFeather
-              v-if="activeView === 'discovery'"
-              type="at-sign"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather
-              v-else
-              type="at-sign"
-              class="text-gray-300"
-              size="1.1em"
-            />
-          </button>
+            <AtSymbolIcon />
+          </SiButtonIcon>
         </div>
 
-        <!-- NOTE(nick): old-web removes flex-row in this div and adds text-white for buttons in this div.
-        More information: https://tailwindcss.com/docs/flex-direction#row
-        -->
         <div class="flex items-center">
-          <button
-            class="pl-1 text-white focus:outline-none"
+          <SiButtonIcon
+            tooltip-text="Action Viewer (not implemented yet)"
+            :color="activeView === 'action' ? 'cyan' : 'white'"
             @click="setActiveView('action')"
           >
-            <VueFeather
-              v-if="activeView === 'action'"
-              type="play"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather v-else type="play" class="text-gray-300" size="1.1em" />
-          </button>
-          <button
-            class="pl-1 text-white focus:outline-none"
+            <PlayIcon />
+          </SiButtonIcon>
+          <SiButtonIcon
+            tooltip-text="Resource Viewer"
+            :color="activeView === 'resource' ? 'cyan' : 'white'"
             @click="setActiveView('resource')"
           >
-            <VueFeather
-              v-if="activeView === 'resource'"
-              type="box"
-              stroke="cyan"
-              size="1.1em"
-            />
-            <VueFeather v-else type="box" class="text-gray-300" size="1.1em" />
-          </button>
+            <CubeIcon />
+          </SiButtonIcon>
         </div>
       </div>
     </template>
@@ -203,6 +144,7 @@
 import Panel from "@/molecules/Panel.vue";
 import LockButton from "@/atoms/LockButton.vue";
 import SiSelect from "@/atoms/SiSelect.vue";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
 import { computed, ref } from "vue";
 import { LabelList } from "@/api/sdf/dal/label_list";
 import { refFrom, untilUnmounted } from "vuse-rx";
@@ -213,7 +155,6 @@ import AttributeViewer from "@/organisims/AttributeViewer.vue";
 import QualificationViewer from "@/organisims/QualificationViewer.vue";
 import ResourceViewer from "@/organisims/ResourceViewer.vue";
 import CodeViewer from "@/organisims/CodeViewer.vue";
-import VueFeather from "vue-feather";
 import _ from "lodash";
 import cheechSvg from "@/assets/images/cheech-and-chong.svg";
 import { lastSelectedNode$ } from "./SchematicViewer/state";
@@ -221,6 +162,15 @@ import { ComponentIdentification } from "@/api/sdf/dal/component";
 import { schematicData$ } from "./SchematicViewer/Viewer/scene/observable";
 import { visibility$ } from "@/observable/visibility";
 import { PanelAttributeSubType } from "./PanelTree/panel_types";
+import {
+  ClipboardCheckIcon,
+  ClipboardListIcon,
+  LinkIcon,
+  AtSymbolIcon,
+  PlayIcon,
+  CubeIcon,
+  CodeIcon,
+} from "@heroicons/vue/solid";
 
 const randomString = () => `${Math.floor(Math.random() * 50000)}`;
 const attributeViewerKey = ref(randomString());


### PR DESCRIPTION
I tried to find parity in HeroIcons, and wrote a brief tooltip for each, which might not be ideal. But with this groundwork design+product can iterate quickly on adjustments.

The icon sizing also is kinda weird, but I just used HeroIcons solid default of 20px, as it's supposed to be hardcoded.

Popper open delay and styling also aren't optimal, but they work for now.

- SiButtonIcon have Popper tooltips
- Designed to be used with a child HeroIcon component
- Swapped PanelAttribute VueFeather buttons to it

Before:
<img width="551" alt="Screen Shot 2022-05-04 at 15 03 35" src="https://user-images.githubusercontent.com/6289779/166770811-f514fdc6-beed-4b15-b472-1f87037d1490.png">

After:
<img width="547" alt="Screen Shot 2022-05-04 at 15 23 39" src="https://user-images.githubusercontent.com/6289779/166801044-4194c0fd-cd1d-4022-9632-86978d0123dc.png">

<img src="https://media4.giphy.com/media/10dHotK4K8R0AM/giphy.gif"/>
