### PR TITLE
feat(web): Change most icons to SiButtonIcon or SiIcon

### DIFF
--- a/app/web/src/atoms/SiIcon.vue
+++ b/app/web/src/atoms/SiIcon.vue
@@ -1,0 +1,37 @@
+<template>
+  <span
+    v-tooltip.bottom="tooltipText"
+    :class="classes"
+    :style="{ color: props.color }"
+    :aria-label="props.tooltipText"
+    :disabled="props.disabled"
+  >
+    <slot></slot>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed, toRefs } from "vue";
+
+const props = defineProps<{
+  disabled?: boolean;
+  color?: string;
+  tooltipText: string;
+}>();
+const { disabled, tooltipText } = toRefs(props);
+
+const classes = computed(() => {
+  const results: Record<string, boolean> = {
+    block: true,
+    "w-5": true,
+    "h-5": true,
+    "text-gray-300": true,
+    "hover:text-gray-100": true,
+  };
+  if (disabled?.value) {
+    results["opacity-50"] = true;
+    results["cursor-not-allowed"] = true;
+  }
+  return results;
+});
+</script>

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -7,16 +7,19 @@
         {{ componentMetadata.schemaName }}
       </div>
 
-      <div class="ml-2 text-base">
-        <VueFeather
-          type="check-square"
-          size="1em"
-          :class="qualificationStatus"
-        />
+      <div class="ml-2 flex">
+        <SiIcon
+          :tooltip-text="qualificationTooltip"
+          :color="qualificationColor"
+        >
+          <CheckCircleIcon />
+        </SiIcon>
       </div>
 
-      <div class="ml-2 text-base">
-        <VueFeather type="box" size="1em" :stroke="resourceSyncStatusStroke" />
+      <div class="ml-2 flex">
+        <SiIcon :tooltip-text="resourceTooltip" :color="resourceColor">
+          <CubeIcon />
+        </SiIcon>
       </div>
 
       <div
@@ -26,13 +29,17 @@
           v-if="componentMetadata?.schemaLink"
           :uri="componentMetadata.schemaLink"
           :blank-target="true"
-          class="m-2 text-base"
+          class="m-2 flex"
         >
-          <VueFeather type="help-circle" size="1em" />
+          <SiButtonIcon tooltip-text="Go to documentation">
+            <QuestionMarkCircleIcon />
+          </SiButtonIcon>
         </SiLink>
 
         <div class="flex flex-row items-center">
-          <VueFeather type="edit" size="0.75rem" class="gold-bars-icon" />
+          <SiIcon tooltip-text="Number of edit fields" color="#ce7f3e">
+            <PencilAltIcon />
+          </SiIcon>
           <div v-if="editCount" class="ml-1 text-center">{{ editCount }}</div>
         </div>
       </div>
@@ -51,7 +58,6 @@ import EditFormComponent from "@/organisims/EditFormComponent.vue";
 import { toRefs, computed } from "vue";
 import { fromRef, refFrom } from "vuse-rx";
 import { GlobalErrorService } from "@/service/global_error";
-import VueFeather from "vue-feather";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
 import { EditFieldService } from "@/service/edit_field";
 import { ResourceHealth } from "@/api/sdf/dal/resource";
@@ -66,6 +72,14 @@ import {
 } from "@/observable/visibility";
 import { editSessionWritten$ } from "@/observable/edit_session";
 import SiLink from "@/atoms/SiLink.vue";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import SiIcon from "@/atoms/SiIcon.vue";
+import {
+  CheckCircleIcon,
+  CubeIcon,
+  QuestionMarkCircleIcon,
+  PencilAltIcon,
+} from "@heroicons/vue/outline";
 
 //const visibility = refFrom<Visibility>(visibility$);
 
@@ -135,24 +149,53 @@ const editCount = computed(() => {
   }
 });
 
-const qualificationStatus = computed(() => {
-  let style: Record<string, boolean> = {};
-
+const qualificationTooltip = computed(() => {
   if (
     !componentMetadata.value ||
     componentMetadata.value.qualified === undefined
   ) {
-    style["unknown"] = true;
+    return "Qualification is unknown";
   } else if (componentMetadata.value.qualified) {
-    style["ok"] = true;
+    return "Qualification succeeded";
   } else {
-    style["error"] = true;
+    return "Qualification failed";
   }
-
-  return style;
 });
 
-const resourceSyncStatusStroke = computed(() => {
+const qualificationColor = computed(() => {
+  if (
+    !componentMetadata.value ||
+    componentMetadata.value.qualified === undefined
+  ) {
+    return "#5b6163";
+  } else if (componentMetadata.value.qualified) {
+    return "#86f0ad";
+  } else {
+    return "#f08686";
+  }
+});
+
+const resourceTooltip = computed(() => {
+  if (
+    !componentMetadata.value ||
+    componentMetadata.value.resourceHealth === undefined
+  ) {
+    return "Resource Health Status is: Unknown";
+  }
+
+  const health = componentMetadata.value.resourceHealth;
+  if (health == ResourceHealth.Ok) {
+    return "Resource Health Status is: Ok";
+  } else if (health == ResourceHealth.Warning) {
+    return "Resource Health Status is: Warning";
+  } else if (health == ResourceHealth.Error) {
+    return "Resource Health Status is: Error";
+  } else {
+    return "Resource Health Status is: Unknown";
+  }
+});
+
+const resourceColor = computed(() => {
   if (
     !componentMetadata.value ||
     componentMetadata.value.resourceHealth === undefined
@@ -183,27 +226,7 @@ const resourceSyncStatusStroke = computed(() => {
   display: none; /*chrome, opera, and safari */
 }
 
-.gold-bars-icon {
-  color: #ce7f3e;
-}
-
 .property-section-bg-color {
   background-color: #292c2d;
-}
-
-.ok {
-  color: #86f0ad;
-}
-
-.warning {
-  color: #f0d286;
-}
-
-.error {
-  color: #f08686;
-}
-
-.unknown {
-  color: #5b6163;
 }
 </style>

--- a/app/web/src/organisims/CodeViewer.vue
+++ b/app/web/src/organisims/CodeViewer.vue
@@ -6,22 +6,17 @@
       <div class="text-lg">Component ID {{ props.componentId }} Code</div>
 
       <div class="flex">
-        <button class="ml-2 text-base" @click="copyCode">
-          <VueFeather type="copy" size="1em" />
-        </button>
+        <SiButtonIcon tooltip-text="Copy code to clipboard" @click="copyCode">
+          <ClipboardCopyIcon />
+        </SiButtonIcon>
 
-        <button
+        <SiButtonIcon
           v-if="editMode"
-          class="pl-1 focus:outline-none sync-button ml-2"
+          tooltip-text="Re-generate code"
           @click="generateCode"
         >
-          <VueFeather
-            type="refresh-cw"
-            class="text-sm"
-            size="1.1em"
-            :class="refreshClasses"
-          />
-        </button>
+          <RefreshIcon :class="refreshClasses" />
+        </SiButtonIcon>
       </div>
     </div>
     <div class="w-full h-full overflow-auto">
@@ -39,7 +34,6 @@
 import _ from "lodash";
 import * as Rx from "rxjs";
 import { ref, onMounted, toRefs, computed } from "vue";
-import VueFeather from "vue-feather";
 import { EditorState, EditorView, basicSetup } from "@codemirror/basic-setup";
 import { yaml } from "@codemirror/legacy-modes/mode/yaml";
 import { StreamLanguage } from "@codemirror/stream-parser";
@@ -53,6 +47,8 @@ import { GlobalErrorService } from "@/service/global_error";
 import { Compartment } from "@codemirror/state";
 import { ChangeSetService } from "@/service/change_set";
 import { system$ } from "@/observable/system";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import { ClipboardCopyIcon, RefreshIcon } from "@heroicons/vue/solid";
 
 const props = defineProps<{
   componentId: number;
@@ -157,8 +153,12 @@ const refreshClasses = computed(() => {
   const classes: { [key: string]: boolean } = {};
   if (currentSyncAnimate.value) {
     classes["animate-spin"] = true;
+    classes["transform"] = true;
+    classes["rotate-180"] = true;
   } else {
     classes["animate-spin"] = false;
+    classes["transform"] = false;
+    classes["rotate-180"] = false;
   }
   return classes;
 });

--- a/app/web/src/organisims/Nav.vue
+++ b/app/web/src/organisims/Nav.vue
@@ -24,7 +24,9 @@
         id="workspace-selector"
         class="flex items-center w-full h-4 mt-3 ml-6 justify-left"
       >
-        <VueFeather type="menu" class="color-grey-medium" />
+        <SiIcon tooltip-text="Menu">
+          <MenuIcon class="color-grey-medium" />
+        </SiIcon>
         <div
           v-if="currentWorkspace"
           v-show="isLinkTitleVisible"
@@ -42,19 +44,19 @@
         <div class="flex flex-col">
           <!-- Dashboard Link -->
           <div class="container-link">
-            <VueFeather type="activity" size="1.1rem" class="" />
+            <SiIcon tooltip-text="Dashboard">
+              <LightningBoltIcon class="color-grey-medium" />
+            </SiIcon>
             <div v-show="isLinkTitleVisible" class="link-title">Dashboard</div>
           </div>
 
           <!-- Applications Link -->
           <div class="container-link">
-            <router-link
-              :to="{
-                name: 'application-list',
-              }"
-            >
+            <router-link :to="{ name: 'application-list' }">
               <div class="flex items-center justify-start cursor-pointer">
-                <VueFeather type="code" size="1.1rem" class="" />
+                <SiButtonIcon tooltip-text="Applications">
+                  <CodeIcon class="color-grey-medium" />
+                </SiButtonIcon>
                 <div v-show="isLinkTitleVisible" class="link-title">
                   Applications
                 </div>
@@ -65,11 +67,9 @@
           <!-- Systems Link -->
           <div class="container-link">
             <div class="flex items-center justify-start">
-              <VueFeather
-                type="share-2"
-                size="1.1rem"
-                class="transform rotate-90"
-              />
+              <SiIcon tooltip-text="Systems">
+                <ShareIcon class="color-grey-medium transform rotate-90" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">Systems</div>
             </div>
           </div>
@@ -77,7 +77,9 @@
           <!-- Components Link -->
           <div class="container-link">
             <div class="flex items-center justify-start">
-              <VueFeather type="box" size="1.1rem" class="" />
+              <SiIcon tooltip-text="Components">
+                <CubeIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">
                 Components
               </div>
@@ -87,7 +89,9 @@
           <!-- Resources Link -->
           <div class="container-link">
             <div class="flex items-center justify-start">
-              <VueFeather type="grid" size="1.1rem" class="" />
+              <SiIcon tooltip-text="Resources">
+                <ViewGridIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">
                 Resources
               </div>
@@ -97,7 +101,9 @@
           <!-- Environment Link  AKA computing environment -->
           <div class="container-link">
             <div class="flex items-center justify-start">
-              <VueFeather type="layers" size="1.1rem" class="" />
+              <SiIcon tooltip-text="Environment">
+                <CollectionIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">
                 Environment
               </div>
@@ -107,40 +113,32 @@
           <!-- Catalogue Link -->
           <div class="container-link">
             <div class="flex items-center justify-start">
-              <VueFeather type="book-open" size="1.1rem" class="" />
+              <SiIcon tooltip-text="Catalogue">
+                <BookOpenIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">
                 Catalogue
               </div>
             </div>
           </div>
-
           <!-- Secrets Link -->
           <div class="container-link">
-            <!-- <router-link
-          class="w-9/12"
-          data-cy="secret-nav-link"
-          :to="{
-            name: 'secret',
-            params: {
-              organizationId: organization.id,
-              workspaceId: workspace.id,
-            },
-          }"
-          > -->
+            <!-- <router-link class="w-9/12" data-cy="secret-nav-link" :to="{ name: 'secret', params: { organizationId: organization.id, workspaceId: workspace.id, }, }" > -->
             <router-link
               v-if="currentOrganization && currentWorkspace"
               data-cy="secret-nav-link"
               to="notFound"
             >
               <div class="flex items-center justify-start cursor-pointer">
-                <VueFeather type="key" size="1.1rem" class="" />
+                <SiButtonIcon tooltip-text="Secrets">
+                  <KeyIcon class="color-grey-medium" />
+                </SiButtonIcon>
                 <div v-show="isLinkTitleVisible" class="link-title">
                   Secrets
                 </div>
               </div>
             </router-link>
           </div>
-
           <!-- Clients Link -->
           <div class="container-link">
             <!-- <router-link
@@ -154,8 +152,10 @@
             },
           }"
           > -->
-            <div class="flex items-center justify-start cursor-pointer">
-              <VueFeather type="hexagon" size="1.1rem" class="" />
+            <div class="flex items-center justify-start">
+              <SiIcon tooltip-text="Clients">
+                <GlobeAltIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">Clients</div>
             </div>
             <!-- </router-link> -->
@@ -169,7 +169,9 @@
               :to="{ name: 'schema' }"
             >
               <div class="flex items-center justify-start cursor-pointer">
-                <VueFeather type="moon" size="1rem" class="" />
+                <SiButtonIcon tooltip-text="Schema">
+                  <MoonIcon class="color-grey-medium" />
+                </SiButtonIcon>
                 <div v-show="isLinkTitleVisible" class="link-title">Schema</div>
               </div>
             </router-link>
@@ -179,10 +181,10 @@
         <div class="flex flex-col justify-end flex-grow">
           <!-- Settings Link -->
           <div class="container-link">
-            <div
-              class="flex items-center justify-start cursor-pointer focus:text-white"
-            >
-              <VueFeather type="settings" size="1.1rem" class="" />
+            <div class="flex items-center justify-start focus:text-white">
+              <SiIcon tooltip-text="Settings">
+                <CogIcon class="color-grey-medium" />
+              </SiIcon>
               <div v-show="isLinkTitleVisible" class="link-title">Settings</div>
             </div>
           </div>
@@ -194,13 +196,9 @@
       </div>
 
       <div class="flex items-center w-full mx-6 my-4 color-grey-medium">
-        <button data-test="logout" aria-label="Logout" @click="onLogout">
-          <VueFeather
-            type="log-out"
-            size="1.1rem"
-            class="text-center cursor-pointer logout-button"
-          />
-        </button>
+        <SiButtonIcon tooltip-text="Logout" @click="onLogout">
+          <LogoutIcon class="color-grey-medium" />
+        </SiButtonIcon>
       </div>
     </div>
   </nav>
@@ -209,13 +207,29 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { refFrom } from "vuse-rx";
-import VueFeather from "vue-feather";
 import SysinitIcon from "@/atoms/SysinitIcon.vue";
 import { SessionService } from "@/service/session";
 import { useRouter } from "vue-router";
 import { organization$ } from "@/observable/organization";
 import { Workspace } from "@/api/sdf/dal/workspace";
 import { WorkspaceService } from "@/service/workspace";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import SiIcon from "@/atoms/SiIcon.vue";
+import {
+  CodeIcon,
+  MoonIcon,
+  BookOpenIcon,
+  ViewGridIcon,
+  CubeIcon,
+  MenuIcon,
+  CollectionIcon,
+  ShareIcon,
+  LightningBoltIcon,
+  GlobeAltIcon,
+  CogIcon,
+  KeyIcon,
+  LogoutIcon,
+} from "@heroicons/vue/solid";
 
 const isMaximized = ref(false);
 const currentWorkspace = refFrom<Workspace | null>(

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -71,7 +71,7 @@
           -->
           <SiButtonIcon
             tooltip-text="Provider Viewer"
-            :color="activeView === 'provider' ? 'cyan' : 'white'"
+            :selected="activeView === 'provider'"
             @click="setActiveView('provider')"
           >
             <BeakerIcon />

--- a/app/web/src/organisims/ResourceViewer.vue
+++ b/app/web/src/organisims/ResourceViewer.vue
@@ -8,19 +8,16 @@
       </div>
 
       <div class="flex pl-1">
-        <button
+        <SiButtonIcon
           v-if="!editMode"
-          class="flex items-center focus:outline-none button"
+          tooltip-text="Sync Resource"
           @click="runSync()"
         >
-          <VueFeather
-            type="refresh-cw"
-            :stroke="healthColor"
-            size="1em"
-            :class="refreshClasses"
-          />
-        </button>
-        <VueFeather v-else type="box" :stroke="healthColor" size="1em" />
+          <RefreshIcon :class="refreshClasses" />
+        </SiButtonIcon>
+        <SiIcon :tooltip-text="resourceTooltip" :color="healthColor">
+          <CubeIcon />
+        </SiIcon>
       </div>
     </div>
 
@@ -28,7 +25,9 @@
       <div class="w-full h-full pt-2">
         <div class="flex flex-row mx-2 my-1">
           <div class="text-xs">
-            <VueFeather type="heart" :stroke="healthColor" size="1.25em" />
+            <SiIcon :tooltip-text="resourceTooltip" :color="healthColor">
+              <HeartIcon />
+            </SiIcon>
           </div>
 
           <div class="ml-2 text-xs">
@@ -56,9 +55,12 @@ import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import { ChangeSetService } from "@/service/change_set";
 import { fromRef, refFrom, untilUnmounted } from "vuse-rx";
-import VueFeather from "vue-feather";
 import { system$ } from "@/observable/system";
 import { eventResourceSynced$ } from "@/observable/resource";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import SiIcon from "@/atoms/SiIcon.vue";
+import { CubeIcon, HeartIcon } from "@heroicons/vue/outline";
+import { RefreshIcon } from "@heroicons/vue/solid";
 
 const props = defineProps<{
   componentId: number;
@@ -82,14 +84,32 @@ const healthColor = computed(() => {
   }
   return "#bbbbbb";
 });
+const resourceTooltip = computed(() => {
+  if (resource.value) {
+    if (resource.value.health == ResourceHealth.Ok) {
+      return "Resource Health: Ok";
+    } else if (resource.value.health == ResourceHealth.Warning) {
+      return "Resource Health: Warning";
+    } else if (resource.value.health == ResourceHealth.Error) {
+      return "Resource Health: Error";
+    } else if (resource.value.health == ResourceHealth.Unknown) {
+      return "Resource Health: Unknwon";
+    }
+  }
+  return "Resource Missing";
+});
 
 const refreshAnimate = ref<boolean>(false);
 const refreshClasses = computed(() => {
   const classes: { [key: string]: boolean } = {};
   if (refreshAnimate.value) {
     classes["animate-spin"] = true;
+    classes["transform"] = true;
+    classes["rotate-180"] = true;
   } else {
     classes["animate-spin"] = false;
+    classes["transform"] = false;
+    classes["rotate-180"] = false;
   }
   return classes;
 });


### PR DESCRIPTION
Icons visible to the user tests were changed to use the new Si atoms, that contain a tooltip and handle default color.

The buttons became SiButtonIcon, the plain icons became SiIcon.

Buttons use heroicons/solid, plain icons use heroicons/outline

<img src="https://media2.giphy.com/media/gg9LCtsjjBninkG52i/giphy.gif"/>