### PR TITLE
chore(dal): move RootProp to its own module

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1522,8 +1522,9 @@ impl EditFieldAble for Component {
     }
 }
 
-/// Find the root [`EditField`] for a given [`ComponentId`]. This will also find all of its child
-/// edit fields, which are accessed via each field`s [`Widget`], if applicable.
+/// Find the root [`EditField`](crate::EditField) for a given [`ComponentId`]. This will also find
+/// all of its child edit fields, which are accessed via each field's
+/// [`Widget`](crate::edit_field::widget::Widget), if applicable.
 async fn get_root_edit_field(
     ctx: &DalContext<'_, '_>,
     id: &ComponentId,
@@ -1591,6 +1592,13 @@ async fn get_root_edit_field(
     Ok(root_edit_field)
 }
 
+/// This recursive function creates an [`EditField`](crate::EditField) for a given set of
+/// information, particularly an [`AttributeValue`](crate::AttributeValue) and its parent
+/// [`AttributeValue`]. Recursion happens if our
+/// [`WidgetKind`](crate::edit_field::widget::WidgetKind) is an array, map or header. In that
+/// instance, we collect all the child [`AttributeValues`](crate::AttributeValue) for the current
+/// [`AttributeValue`](crate::AttributeValue), ensure they are correctly ordered via an index map,
+/// and then recursively call this function for each child.
 #[allow(clippy::too_many_arguments)]
 #[async_recursion]
 async fn edit_field_for_attribute_value(

--- a/lib/dal/src/edit_field.rs
+++ b/lib/dal/src/edit_field.rs
@@ -1,6 +1,10 @@
-pub mod widget;
-
-pub use widget::{ToSelectWidget, Widget};
+//! [`EditFields`](crate::EditField) are data bags that contain information for visualization and
+//! rendering for a given attribute at a specific [`AttributeContext`](crate::AttributeContext).
+//! Their [`EditFieldBaggage`] contains the [`AttributeValues`](crate::AttributeValue) to perform
+//! the actual CRUD-like operations for a given [`EditField`]. Essentially these fields are
+//! purely wrappers around [`AttributeValues`](crate::AttributeValue) that retain their lineage and
+//! ordering (important for [`Maps`](EditFieldDataType::Map) and
+//! [`Arrays`](EditFieldDataType::Array)).
 
 use serde::{Deserialize, Serialize};
 use std::{future::Future, pin::Pin};
@@ -10,6 +14,10 @@ use thiserror::Error;
 use crate::PropId;
 use crate::{func::backend::validation::ValidationError, LabelListError, PropKind, Visibility};
 use crate::{AttributeValueId, DalContext};
+
+pub use widget::{ToSelectWidget, Widget};
+
+pub mod widget;
 
 #[derive(Error, Debug)]
 pub enum EditFieldError {

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -5,10 +5,10 @@ use strum_macros::{AsRefStr, Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use self::variant::{SchemaVariantError, SchemaVariantResult};
 use crate::func::binding_return_value::FuncBindingReturnValueError;
 use crate::provider::external::ExternalProviderError;
 use crate::provider::internal::InternalProviderError;
+use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};
 use crate::socket::SocketError;
 use crate::WriteTenancy;
 use crate::{
@@ -32,6 +32,7 @@ use crate::{
 };
 
 pub use ui_menu::UiMenu;
+pub use variant::root_prop::RootProp;
 pub use variant::{SchemaVariant, SchemaVariantId};
 
 pub mod builtins;

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -1,0 +1,158 @@
+//! This module contains (and is oriented around) the [`RootProp`]. This object is not persisted
+//! to the database.
+
+use telemetry::prelude::*;
+
+use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};
+use crate::{
+    func::binding::FuncBinding, Func, Prop, PropId, PropKind, SchemaVariantId, StandardModel,
+};
+use crate::{
+    AttributeContext, AttributeReadContext, AttributeValue, AttributeValueError, DalContext,
+    SchemaId,
+};
+
+/// Contains the the si-specific [`PropId`](crate::Prop) and domain-specific [`PropId`](crate::Prop)
+/// corresponding to a [`SchemaVariant`](crate::SchemaVariant). In addition, these correspond to the
+/// "root" [`Props`](crate::Prop) on the [`ComponentView`](crate::ComponentView) "properties" field.
+pub struct RootProp {
+    pub si_prop_id: PropId,
+    pub domain_prop_id: PropId,
+}
+
+impl RootProp {
+    /// Creates and returns a [`RootProp`] for a [`SchemaVariant`](crate::SchemaVariant).
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_>,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+    ) -> SchemaVariantResult<Self> {
+        let mut base_context_builder = AttributeContext::builder();
+        base_context_builder
+            .set_schema_id(schema_id)
+            .set_schema_variant_id(schema_variant_id);
+
+        let func_name = "si:setPropObject".to_string();
+        let mut funcs = Func::find_by_attr(ctx, "name", &func_name).await?;
+        let func = funcs
+            .pop()
+            .ok_or(SchemaVariantError::MissingFunc(func_name))?;
+
+        let (func_binding, created) = FuncBinding::find_or_create(
+            ctx,
+            // Shortcut to creating the FuncBackendPropObjectArgs.
+            serde_json::json!({ "value": {} }),
+            *func.id(),
+            *func.backend_kind(),
+        )
+        .await?;
+
+        if created {
+            func_binding.execute(ctx).await?;
+        }
+
+        let root_prop = Prop::new(ctx, "root", PropKind::Object).await?;
+        root_prop
+            .add_schema_variant(ctx, &schema_variant_id)
+            .await?;
+
+        let root_context = base_context_builder
+            .clone()
+            .set_prop_id(*root_prop.id())
+            .to_context()?;
+        let (_, root_value_id) = AttributeValue::update_for_context(
+            ctx,
+            *AttributeValue::find_for_context(ctx, root_context.into())
+                .await?
+                .pop()
+                .ok_or(AttributeValueError::Missing)?
+                .id(),
+            None,
+            root_context,
+            Some(serde_json::json![{}]),
+            None,
+        )
+        .await?;
+
+        let base_attribute_read_context = AttributeReadContext {
+            schema_id: Some(schema_id),
+            schema_variant_id: Some(schema_variant_id),
+            ..AttributeReadContext::default()
+        };
+
+        let si_specific_prop = Prop::new(ctx, "si", PropKind::Object).await?;
+        si_specific_prop
+            .set_parent_prop(ctx, *root_prop.id(), base_attribute_read_context)
+            .await?;
+
+        let si_context = base_context_builder
+            .clone()
+            .set_prop_id(*si_specific_prop.id())
+            .to_context()?;
+        let (_, si_value_id) = AttributeValue::update_for_context(
+            ctx,
+            *AttributeValue::find_for_context(ctx, si_context.into())
+                .await?
+                .pop()
+                .ok_or(AttributeValueError::Missing)?
+                .id(),
+            Some(root_value_id),
+            si_context,
+            Some(serde_json::json![{}]),
+            None,
+        )
+        .await?;
+
+        let si_name_prop = Prop::new(ctx, "name", PropKind::String).await?;
+        si_name_prop
+            .set_parent_prop(ctx, *si_specific_prop.id(), base_attribute_read_context)
+            .await?;
+
+        let si_name_context = base_context_builder
+            .clone()
+            .set_prop_id(*si_name_prop.id())
+            .to_context()?;
+        AttributeValue::update_for_context(
+            ctx,
+            *AttributeValue::find_for_context(ctx, si_name_context.into())
+                .await?
+                .pop()
+                .ok_or(AttributeValueError::Missing)?
+                .id(),
+            Some(si_value_id),
+            si_name_context,
+            None,
+            None,
+        )
+        .await?;
+
+        let domain_specific_prop = Prop::new(ctx, "domain", PropKind::Object).await?;
+        domain_specific_prop
+            .set_parent_prop(ctx, *root_prop.id(), base_attribute_read_context)
+            .await?;
+
+        let domain_context = base_context_builder
+            .clone()
+            .set_prop_id(*domain_specific_prop.id())
+            .to_context()?;
+        AttributeValue::update_for_context(
+            ctx,
+            *AttributeValue::find_for_context(ctx, domain_context.into())
+                .await?
+                .pop()
+                .ok_or(AttributeValueError::Missing)?
+                .id(),
+            Some(root_value_id),
+            domain_context,
+            Some(serde_json::json![{}]),
+            None,
+        )
+        .await?;
+
+        Ok(Self {
+            si_prop_id: *si_specific_prop.id(),
+            domain_prop_id: *domain_specific_prop.id(),
+        })
+    }
+}

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -333,7 +333,7 @@ pub async fn create_schema_variant(
 pub async fn create_schema_variant_with_root(
     ctx: &DalContext<'_, '_>,
     schema_id: SchemaId,
-) -> (schema::SchemaVariant, schema::builtins::RootProp) {
+) -> (schema::SchemaVariant, schema::RootProp) {
     let name = generate_fake_name();
     let (variant, root) = schema::SchemaVariant::new(ctx, schema_id, name)
         .await

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1,7 +1,7 @@
 use crate::dal::test;
 use dal::DalContext;
 use dal::{
-    schema::builtins::RootProp,
+    schema::RootProp,
     test_harness::{create_prop_of_kind_with_name, create_schema, create_schema_variant_with_root},
     AttributeContext, AttributeReadContext, AttributeValue, Component, ComponentView, Prop,
     PropKind, Schema, SchemaKind, SchemaVariant, StandardModel,


### PR DESCRIPTION
## Context

This PR was birthed after some pairing with @fnichol on EditField insertion.
It exists to put RootProp in a location corresponding to its domain in practice as well as add doc comments in all areas that developers will encounter when working with EditFields.

## Description

- Move RootProp to its own module under SchemaVariant
  - It previously existed under "built-ins", but was used in multiple
    areas of the codebase
- Add module doc comments to EditField, Schema "built-ins", and the new
  RootProp module
- Add doc comments to Component functions related to EditFields
  - We need to indicate to developers that EditFields are data bags that
    leverage AttributeValues for meaningful operations

<img src="https://media1.giphy.com/media/l4FGrYKtP0pBGpBAY/giphy.gif"/>

Fixes ENG-173