### PR TITLE
feat(web): Pulse edit button to help the user

### DIFF
--- a/app/web/src/molecules/StatusBar.vue
+++ b/app/web/src/molecules/StatusBar.vue
@@ -26,10 +26,11 @@
         {{ changeSet.name }}
       </div>
       <div v-else class="mr-1 text-xs changeset-name">latest</div>
-      <div v-if="editMode" class="mr-1 text-xs changeset-icon">|</div>
+      <div class="mr-1 text-xs changeset-icon">|</div>
       <div v-if="editMode" class="w-6 mr-1 text-xs" :class="editModeClasses()">
         edit
       </div>
+      <div v-else class="w-6 mr-1 text-xs" :class="editModeClasses()">read</div>
     </div>
   </div>
 </template>

--- a/app/web/src/observable/change_set.ts
+++ b/app/web/src/observable/change_set.ts
@@ -42,3 +42,9 @@ eventChangeSetApplied$.next(null);
 export const eventChangeSetCanceled$ =
   new ReplaySubject<WsEvent<WsChangeSetCanceled> | null>(1);
 eventChangeSetCanceled$.next(null);
+
+/**
+ * Fired when the user tries to edit something outside of an edit-session
+ */
+export const editButtonPulseUntil$ = new ReplaySubject<Date>(1);
+editButtonPulseUntil$.next(new Date());

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -99,21 +99,11 @@
       </div>
     </template>
 
-    <template v-if="selectedComponentIdentification" #content>
-      <!-- NOTE(nick): CLion's Vue.js plugin version 213.6461.23 shows an incorrect warning message here.
-      Essentially, the IDE will say that "selectComponentIdentification.componentId" can still be null despite the "v-if" directive
-      checking the "truthiness" of it (either in the div or the viewer declarations). Due to the usage of the directive,
-      we know it will be a number and the warning is incorrect.
-      For more information: https://v3.vuejs.org/guide/conditional.html#v-if
-      -->
-
-      <!-- NOTE(paulo): `npm run type-check` complains about selectedComponetnIdentification.componentId being null
-      if we only check in the template, but checking in the template ensures we can't endup rendering two #content slots
-      so we check on both places
-      -->
+    <template #content>
       <div
         v-if="selectedComponentIdentification"
         class="flex flex-row w-full h-full overflow-auto"
+        @click="attributeViewerClick"
       >
         <AttributeViewer
           v-if="activeView === 'attribute'"
@@ -153,6 +143,11 @@
           <img width="300" :src="cheechSvg" alt="Cheech and Chong!" />
         </div>
       </div>
+      <div
+        v-else
+        class="flex flex-row w-full h-full overflow-auto"
+        @click="attributeViewerClick"
+      ></div>
     </template>
   </Panel>
 </template>
@@ -180,6 +175,8 @@ import { ComponentIdentification } from "@/api/sdf/dal/component";
 import { schematicData$ } from "./SchematicViewer/Viewer/scene/observable";
 import { visibility$ } from "@/observable/visibility";
 import { PanelAttributeSubType } from "./PanelTree/panel_types";
+import { ChangeSetService } from "@/service/change_set";
+import { editButtonPulseUntil$ } from "@/observable/change_set";
 import {
   CheckCircleIcon,
   ClipboardListIcon,
@@ -309,6 +306,13 @@ const selectedComponentIdentification = computed(
     return null;
   },
 );
+
+const editMode = refFrom(ChangeSetService.currentEditMode());
+const attributeViewerClick = () => {
+  if (activeView.value === "attribute" && !editMode.value) {
+    editButtonPulseUntil$.next(new Date(new Date().getTime() + 5000));
+  }
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
- If user clicks attribute sub-panel they probably are confused about being in an edit sesion, so we pulse the edit button
- If the user is not in an edit session the status bar will show "read"

<img src="https://media4.giphy.com/media/sbOMqsd4XxapQ19HNZ/giphy.gif"/>