### PR TITLE
feat(web): Pulse edit button when add component button is clicked in read mode

### DIFF
--- a/app/web/src/atoms/SiButton.vue
+++ b/app/web/src/atoms/SiButton.vue
@@ -187,4 +187,7 @@ $button-brightness: 1.05;
 .button-cancel:active {
   filter: saturate($button-saturation) brightness($button-brightness);
 }
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
 </style>

--- a/app/web/src/atoms/SiButtonIcon.vue
+++ b/app/web/src/atoms/SiButtonIcon.vue
@@ -44,3 +44,9 @@ const buttonClasses = computed(() => {
   return results;
 });
 </script>
+
+<style lang="scss" scoped>
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+</style>

--- a/app/web/src/atoms/SiIcon.vue
+++ b/app/web/src/atoms/SiIcon.vue
@@ -4,7 +4,6 @@
     :class="classes"
     :style="{ color: props.color }"
     :aria-label="props.tooltipText"
-    :disabled="props.disabled"
   >
     <slot></slot>
   </span>
@@ -14,11 +13,10 @@
 import { computed, toRefs } from "vue";
 
 const props = defineProps<{
-  disabled?: boolean;
   color?: string;
   tooltipText: string;
 }>();
-const { disabled, tooltipText } = toRefs(props);
+const { tooltipText } = toRefs(props);
 
 const classes = computed(() => {
   const results: Record<string, boolean> = {
@@ -28,10 +26,6 @@ const classes = computed(() => {
     "text-gray-300": true,
     "hover:text-gray-100": true,
   };
-  if (disabled?.value) {
-    results["opacity-50"] = true;
-    results["cursor-not-allowed"] = true;
-  }
   return results;
 });
 </script>

--- a/app/web/src/molecules/NodeAddMenu.vue
+++ b/app/web/src/molecules/NodeAddMenu.vue
@@ -12,11 +12,12 @@
         'text-gray-200': !isOpen,
         'menu-selected': isOpen,
         'text-gray-600': props.disabled ?? false,
+        'opacity-50': props.disabled ?? false,
+        'cursor-not-allowed': props.disabled ?? false,
       }"
       size="xs"
       data-cy="editor-schematic-node-add-button"
-      :disabled="props.disabled ?? false"
-      @click="isOpen = !isOpen"
+      @click="addMenuClick"
     />
 
     <NodeAddMenuCategory
@@ -36,9 +37,21 @@ import { onBeforeUnmount, ref } from "vue";
 import { refFrom, fromRef } from "vuse-rx";
 import _ from "lodash";
 import { SchematicService } from "@/service/schematic";
+import { ChangeSetService } from "@/service/change_set";
 import { GlobalErrorService } from "@/service/global_error";
 import { combineLatest, from, switchMap } from "rxjs";
 import SiButton from "@/atoms/SiButton.vue";
+import { editButtonPulse$ } from "@/observable/change_set";
+
+const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
+
+const addMenuClick = () => {
+  if (!editMode.value) {
+    editButtonPulse$.next(true);
+  } else if (!props.disabled) {
+    isOpen.value = !isOpen.value;
+  }
+};
 
 const props = defineProps<{
   disabled?: boolean;
@@ -140,4 +153,7 @@ onBeforeUnmount(() => {
 /* .menu-category:hover .category-items { */
 /*   visibility: visible; */
 /* } */
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
 </style>

--- a/app/web/src/observable/change_set.ts
+++ b/app/web/src/observable/change_set.ts
@@ -46,5 +46,5 @@ eventChangeSetCanceled$.next(null);
 /**
  * Fired when the user tries to edit something outside of an edit-session
  */
-export const editButtonPulseUntil$ = new ReplaySubject<Date>(1);
-editButtonPulseUntil$.next(new Date());
+export const editButtonPulse$ = new ReplaySubject<boolean>(1);
+editButtonPulse$.next(false);

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -176,7 +176,7 @@ import { schematicData$ } from "./SchematicViewer/Viewer/scene/observable";
 import { visibility$ } from "@/observable/visibility";
 import { PanelAttributeSubType } from "./PanelTree/panel_types";
 import { ChangeSetService } from "@/service/change_set";
-import { editButtonPulseUntil$ } from "@/observable/change_set";
+import { editButtonPulse$ } from "@/observable/change_set";
 import {
   CheckCircleIcon,
   ClipboardListIcon,
@@ -310,7 +310,7 @@ const selectedComponentIdentification = computed(
 const editMode = refFrom(ChangeSetService.currentEditMode());
 const attributeViewerClick = () => {
   if (activeView.value === "attribute" && !editMode.value) {
-    editButtonPulseUntil$.next(new Date(new Date().getTime() + 5000));
+    editButtonPulse$.next(true);
   }
 };
 </script>


### PR DESCRIPTION
- Fixes cursor-not-allowed where it was used (we aren't including it with tailwind), I'm lacking understanding on how to config tailwind to properly fix this
- Hack around SiButton, we want to make it appear disabled, but trigger @click on NodeAddMenu to pulse the edit button
- Change how edit pulse logic works, move timing logic to ChangeSetWidget instead of the caller
- Document timing hack to ensure reactivity, I'm lacking understanding in RxJs to properly use it to trigger that timed change

<img src="https://media4.giphy.com/media/l2Jejt7O03eXaRQre/giphy.gif"/>