### PR TITLE
chore(dal,sdf,web): require componentIdentification

### DIFF
--- a/app/web/src/organisims/EditForm/Widget.vue
+++ b/app/web/src/organisims/EditForm/Widget.vue
@@ -49,8 +49,8 @@
     :attribute-context="attributeContext"
   />
   <div v-else class="text-xs text-red-400">
-    Error: could not create AttributeContext for widget kind
-    {{ props.editField.widget.kind }}
+    Error: WidgetKind not found or could not create AttributeContext for
+    WidgetKind ({{ props.editField.widget.kind }})
   </div>
 </template>
 
@@ -82,22 +82,11 @@ const attributeContext = computed((): AttributeContext | "" => {
   if (!props.editField.baggage) {
     return "";
   }
-
-  // FIXME(nick): this check is required to have the edit fields display properly, but this is straight
-  // up _incorrect_. We need to require "componentIdentification" if we are going to create an "attributeContext",
-  // so this code needs to be addressed sooner rather than later.
   if (!props.componentIdentification) {
-    return {
-      attribute_context_prop_id: props.editField.baggage.prop_id,
-      attribute_context_internal_provider_id: -1,
-      attribute_context_external_provider_id: -1,
-      attribute_context_schema_id: -1,
-      attribute_context_schema_variant_id: -1,
-      attribute_context_component_id: -1,
-      attribute_context_system_id: -1,
-    };
+    // FIXME(nick): we need to ensure we handle the scenario where the WidgetKind requires an AttributeContext, but
+    // this expression is true (i.e. "componentIdentification" is not populated).
+    return "";
   }
-
   return {
     attribute_context_prop_id: props.editField.baggage.prop_id,
     attribute_context_internal_provider_id: -1,

--- a/lib/dal/src/attribute/context.rs
+++ b/lib/dal/src/attribute/context.rs
@@ -3,6 +3,8 @@
 //! The builder ensures the correct order of precedence is maintained whilst setting and unsetting
 //! fields of specificity.
 //!
+//! ## The Order of Precedence
+//!
 //! The order of precedence is as follows (from least to most "specificity"):
 //! - [`PropId`] / [`InternalProviderId`] / [`ExternalProviderId`]
 //! - [`SchemaId`]
@@ -13,6 +15,12 @@
 //! At the level of least "specificity", you can provider have a [`PropId`], an
 //! [`InternalProviderId`], or an [`ExternalProviderId`]. However, you can only provide one and only
 //! one for an [`AttributeContext`] since they are at the same "level" in the order of precedence.
+//!
+//! ## `AttributeContext` vs. `AttributeReadContext`
+//!
+//! While the [`AttributeContext`] can be used for both read and write queries, the
+//! [`AttributeReadContext`](crate::AttributeReadContext) is useful for read-only queries and for
+//! flexibility when searching for objects of varying levels of specificity.
 
 use serde::{Deserialize, Serialize};
 use std::default::Default;

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -342,8 +342,9 @@ impl AttributeValue {
             .await?;
         let mut result = Vec::new();
         for row in rows.into_iter() {
-            let fbrv_json: serde_json::Value = row.try_get("object")?;
-            let fbrv: Option<FuncBindingReturnValue> = serde_json::from_value(fbrv_json)?;
+            let func_binding_return_value_json: serde_json::Value = row.try_get("object")?;
+            let func_binding_return_value: Option<FuncBindingReturnValue> =
+                serde_json::from_value(func_binding_return_value_json)?;
 
             let prop_json: serde_json::Value = row.try_get("prop_object")?;
             let prop: Prop = serde_json::from_value(prop_json)?;
@@ -356,7 +357,7 @@ impl AttributeValue {
 
             result.push(AttributeValuePayload::new(
                 prop,
-                fbrv,
+                func_binding_return_value,
                 attribute_value,
                 parent_attribute_value_id,
             ));
@@ -709,7 +710,7 @@ async fn set_value(
 #[derive(Debug)]
 pub struct AttributeValuePayload {
     pub prop: Prop,
-    pub fbrv: Option<FuncBindingReturnValue>,
+    pub func_binding_return_value: Option<FuncBindingReturnValue>,
     pub attribute_value: AttributeValue,
     pub parent_attribute_value_id: Option<AttributeValueId>,
 }
@@ -717,13 +718,13 @@ pub struct AttributeValuePayload {
 impl AttributeValuePayload {
     pub fn new(
         prop: Prop,
-        fbrv: Option<FuncBindingReturnValue>,
+        func_binding_return_value: Option<FuncBindingReturnValue>,
         attribute_value: AttributeValue,
         parent_attribute_value_id: Option<AttributeValueId>,
     ) -> Self {
         Self {
             prop,
-            fbrv,
+            func_binding_return_value,
             attribute_value,
             parent_attribute_value_id,
         }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -513,8 +513,10 @@ impl Component {
         Ok(())
     }
 
-    /// Creates qualification func binding, an fbrv without a value and a QualificationResolver
-    /// The func is not executed yet, it's just a placeholder for some qualification that will be executed
+    /// Creates a qualification [`FuncBinding`](crate::FuncBinding), a
+    /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) without a value and a
+    /// [`QualificationResolver`](crate::QualificationResolver). The func is not executed yet; it's
+    /// just a placeholder for some qualification that will be executed.
     pub async fn prepare_qualifications_check(
         &self,
         ctx: &DalContext<'_, '_>,
@@ -558,8 +560,8 @@ impl Component {
             )
             .await?;
 
-            // Empty fbrv means the function is still being executed
-            let _fbrv = FuncBindingReturnValue::upsert(
+            // Empty func binding return value means the function is still being executed
+            let _func_binding_return_value = FuncBindingReturnValue::upsert(
                 ctx,
                 None,
                 None,
@@ -697,8 +699,10 @@ impl Component {
         Ok(())
     }
 
-    /// Creates code generation func binding, an fbrv without a value and a CodeGenerationResolver,
-    /// The func is not executed yet, it's just a placeholder for some code generation that will be executed
+    /// Creates code generation [`FuncBinding`](crate::FuncBinding), a
+    /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) without a value and a
+    /// [`CodeGenerationResolver`](crate::CodeGenerationResolver). The func is not executed yet,
+    /// it's just a placeholder for some code generation that will be executed.
     pub async fn prepare_code_generation(
         &self,
         ctx: &DalContext<'_, '_>,
@@ -742,8 +746,8 @@ impl Component {
             )
             .await?;
 
-            // Empty fbrv means the function is still being executed
-            let _fbrv = FuncBindingReturnValue::upsert(
+            // Empty func_binding_return_value means the function is still being executed
+            let _func_binding_return_value = FuncBindingReturnValue::upsert(
                 ctx,
                 None,
                 None,
@@ -1478,13 +1482,13 @@ impl Component {
             .find_attribute_value_by_json_pointer(ctx, json_pointer)
             .await?
         {
-            if let Some(fbrv) = FuncBindingReturnValue::get_by_id(
+            if let Some(func_binding_return_value) = FuncBindingReturnValue::get_by_id(
                 ctx,
                 &attribute_value.func_binding_return_value_id(),
             )
             .await?
             {
-                return Ok(fbrv
+                return Ok(func_binding_return_value
                     .value()
                     .cloned()
                     .map(serde_json::from_value)

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -99,13 +99,13 @@ impl ComponentView {
 
             while let Some(AttributeValuePayload {
                 prop,
-                fbrv,
+                func_binding_return_value,
                 attribute_value,
                 parent_attribute_value_id,
             }) = work_queue.pop()
             {
-                if let Some(fbrv) = fbrv {
-                    if let Some(value) = fbrv.value() {
+                if let Some(func_binding_return_value) = func_binding_return_value {
+                    if let Some(value) = func_binding_return_value.value() {
                         if root_id == parent_attribute_value_id {
                             let insertion_pointer =
                                 if let Some(parent_avi) = parent_attribute_value_id {
@@ -160,7 +160,7 @@ impl ComponentView {
                         } else {
                             unprocessed.push(AttributeValuePayload::new(
                                 prop,
-                                Some(fbrv),
+                                Some(func_binding_return_value),
                                 attribute_value,
                                 parent_attribute_value_id,
                             ));

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -420,7 +420,7 @@ impl FuncBinding {
             }
         };
 
-        let fbrv = FuncBindingReturnValue::upsert(
+        let func_binding_return_value = FuncBindingReturnValue::upsert(
             ctx,
             return_value.clone(),
             return_value,
@@ -430,11 +430,13 @@ impl FuncBinding {
         )
         .await?;
 
-        execution.process_return_value(ctx, &fbrv).await?;
+        execution
+            .process_return_value(ctx, &func_binding_return_value)
+            .await?;
         execution
             .set_state(ctx, super::execution::FuncExecutionState::Success)
             .await?;
 
-        Ok(fbrv)
+        Ok(func_binding_return_value)
     }
 }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -102,6 +102,8 @@ pub use edge::{Edge, EdgeError, EdgeResult};
 pub use edit_session::{
     EditSession, EditSessionError, EditSessionPk, EditSessionStatus, NO_EDIT_SESSION_PK,
 };
+pub use func::binding::FuncBinding;
+pub use func::binding_return_value::FuncBindingReturnValue;
 pub use func::{
     backend::{FuncBackendError, FuncBackendKind, FuncBackendResponseType},
     Func, FuncError, FuncResult,

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -88,9 +88,9 @@ impl QualificationView {
 
     pub async fn new_for_func_binding_return_value(
         ctx: &DalContext<'_, '_>,
-        fbrv: FuncBindingReturnValue,
+        func_binding_return_value: FuncBindingReturnValue,
     ) -> Result<Self, QualificationError> {
-        let output_streams = fbrv.get_output_stream(ctx).await?;
+        let output_streams = func_binding_return_value.get_output_stream(ctx).await?;
         let output = match output_streams {
             Some(streams) => streams
                 .into_iter()
@@ -103,7 +103,7 @@ impl QualificationView {
             None => Vec::with_capacity(0),
         };
 
-        if let Some(qual_result_json) = fbrv.value() {
+        if let Some(qual_result_json) = func_binding_return_value.value() {
             let result = serde_json::from_value(qual_result_json.clone())?;
             Ok(QualificationView {
                 title: "Unknown (no title provided)".to_string(),

--- a/lib/dal/src/resource.rs
+++ b/lib/dal/src/resource.rs
@@ -184,15 +184,19 @@ pub struct ResourceView {
 }
 
 impl From<(Resource, Option<FuncBindingReturnValue>)> for ResourceView {
-    fn from((resource, fbrv): (Resource, Option<FuncBindingReturnValue>)) -> Self {
+    fn from(
+        (resource, func_binding_return_value): (Resource, Option<FuncBindingReturnValue>),
+    ) -> Self {
         // TODO: actually fill all of the data dynamically, most fields don't make much sense for now
 
         // TODO: do we want to have a special case for when the FuncBindingReturnValue is there, but the .value() returns None?
-        if let Some((fbrv, result_json)) = fbrv.and_then(|f| f.value().cloned().map(|v| (f, v))) {
+        if let Some((func_binding_return_value, result_json)) =
+            func_binding_return_value.and_then(|f| f.value().cloned().map(|v| (f, v)))
+        {
             Self {
                 id: *resource.id(),
-                created_at: fbrv.timestamp().created_at,
-                updated_at: fbrv.timestamp().updated_at,
+                created_at: func_binding_return_value.timestamp().created_at,
+                updated_at: func_binding_return_value.timestamp().updated_at,
                 error: Some("Boto Cor de Rosa Spotted at a Party".to_owned()),
                 data: result_json,
                 health: ResourceHealth::Error,

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -122,7 +122,7 @@ async fn process_return_value(ctx: &DalContext<'_, '_>) {
 //         *func.backend_kind(),
 //     )
 //         .await;
-//     let fbrv = func_binding
+//     let func_binding_return_value = func_binding
 //         .execute(&txn, &nats, veritech)
 //         .await
 //         .expect("cannot execute binding");


### PR DESCRIPTION
Changes in dal:
- Add attribute context vs. attribute read context comparison in
  attribute context module documentation
- Split attribute context module documentation into sections by markdown
  headers
- Change all instances of "fbrv" to "func_binding_return_value" for
  readability

Changes in app:
- Ensure attribute context creation requires "componentIdentification"
  for widgets

<img src="https://media4.giphy.com/media/whzQo9wK8OuoiDtAnz/giphy.gif"/>

Fixes ENG-176