### PR TITLE
feat(web): add SiTextBox2 and use for signup

### DIFF
--- a/app/web/src/atoms/SiTextBox2.vue
+++ b/app/web/src/atoms/SiTextBox2.vue
@@ -1,0 +1,108 @@
+<template>
+  <label :for="props.id" class="block text-sm font-medium text-gray-200">
+    {{ props.title }}
+  </label>
+
+  <div class="mt-1 w-full relative">
+    <input
+      :id="props.id"
+      :value="modelValue"
+      :data-test="props.id"
+      :placeholder="props.placeholder"
+      :type="type"
+      :name="props.id"
+      :autocomplete="props.id"
+      :aria-invalid="props.error !== undefined"
+      :aria-describedby="ariaDescribedBy"
+      required
+      class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border rounded-sm shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm"
+      :class="textBoxClasses"
+      @input="valueChanged"
+    />
+    <div
+      v-if="props.error"
+      class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none"
+    >
+      <ExclamationCircleIcon class="h-5 w-5 text-red-400" aria-hidden="true" />
+    </div>
+  </div>
+
+  <p :class="descriptionClasses">
+    {{ props.description }}
+  </p>
+  <p v-if="props.error" :id="props.error.id" class="mt-2 text-xs text-red-400">
+    {{ props.error.message }}
+  </p>
+</template>
+
+<script setup lang="ts">
+import { ExclamationCircleIcon } from "@heroicons/vue/solid";
+import { computed } from "vue";
+
+const props = defineProps<{
+  modelValue: string;
+  title: string;
+  id: string;
+  description: string;
+
+  error?: {
+    id: string;
+    message: string;
+  };
+
+  placeholder?: string;
+  password?: boolean;
+}>();
+
+const textBoxClasses = computed((): Record<string, boolean> => {
+  if (props.error) {
+    return {
+      "border-red-400": true,
+      "focus:ring-red-400": true,
+      "focus:border-red-400": true,
+    };
+  }
+  return {
+    "border-gray-600": true,
+    "focus:ring-indigo-200": true,
+    "focus:border-indigo-200": true,
+  };
+});
+
+const descriptionClasses = computed((): Record<string, boolean> => {
+  if (props.error) {
+    return {
+      "mt-2": true,
+      "text-xs": true,
+      "text-gray-300": true,
+    };
+  }
+  // Add extra padding to the bottom where the error message would have been.
+  return {
+    "mt-2": true,
+    "text-xs": true,
+    "text-gray-300": true,
+    "mb-6": true,
+  };
+});
+
+const type = computed((): string => {
+  if (props.password) {
+    return "password";
+  }
+  return "text";
+});
+
+const ariaDescribedBy = computed((): string | undefined => {
+  if (props.error) {
+    return props.error.id;
+  }
+  return undefined;
+});
+
+const emit = defineEmits(["update:modelValue"]);
+const valueChanged = (event: Event) => {
+  const element = event.currentTarget as HTMLInputElement;
+  emit("update:modelValue", element.value);
+};
+</script>

--- a/app/web/src/organisims/SignupForm.vue
+++ b/app/web/src/organisims/SignupForm.vue
@@ -23,123 +23,81 @@
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="bg-gray-800 py-8 px-4 shadow sm:rounded-sm sm:px-10">
-        <div v-if="errorMessage" class="text-white bg-red-500">
+        <div
+          v-if="errorMessage"
+          class="bg-red-600 text-white p-1 mb-6 text-center text-sm font-medium"
+        >
           Error: {{ errorMessage }}
         </div>
 
         <div class="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
           <div class="sm:col-span-6">
-            <label
-              for="billingAccountName"
-              class="block text-sm font-medium text-gray-200"
-            >
-              Billing Account Name
-            </label>
-            <div class="mt-1 w-full">
-              <input
-                id="billingAccountName"
-                v-model="form.billingAccountName"
-                data-test="billingAccountName"
-                type="text"
-                name="billingAccountName"
-                autocomplete="billingAccountName"
-                required
-                class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border border-gray-600 rounded-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-200 focus:border-indigo-200 sm:text-sm"
-              />
-            </div>
-            <p class="mt-2 text-xs text-gray-300">
-              A name for your account. A company name is a good idea. You can
-              change it later. (You'll need this to sign in!)
-            </p>
-          </div>
+            <SiTextBox2
+              id="billingAccountName"
+              v-model="form.billingAccountName"
+              title="Billing Account Name"
+              description="A name for your account. A company name is a good idea. You can change it later. (You'll need this to sign in!)"
+            />
+            <!--
+            :error="form.billingAccountName === ''"
+            error-id="billing-account-name-error"
+            error-message="Billing account name cannot be an empty string or whitespace."
+          --></div>
 
           <div class="sm:col-span-6">
-            <label
-              for="userName"
-              class="block text-sm font-medium text-gray-200"
-            >
-              Full Name
-            </label>
-            <div class="mt-1 w-full">
-              <input
-                id="userName"
-                v-model="form.userName"
-                data-test="userName"
-                type="text"
-                name="userName"
-                autocomplete="userName"
-                required
-                class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border border-gray-600 rounded-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-200 focus:border-indigo-200 sm:text-sm"
-              />
-            </div>
-            <p class="mt-2 text-xs text-gray-300">Your full name.</p>
-          </div>
+            <SiTextBox2
+              id="userName"
+              v-model="form.userName"
+              title="Full Name"
+              description="Your full name."
+            />
+            <!--
+            :error="false"
+            error-id="name-error"
+            error-message="Full name cannot be an empty string or whitespace."
+          --></div>
 
           <div class="sm:col-span-6">
-            <label
-              for="userEmail"
-              class="block text-sm font-medium text-gray-200"
-            >
-              Email
-            </label>
-            <div class="mt-1 w-full">
-              <input
-                id="userEmail"
-                v-model="form.userEmail"
-                data-test="userEmail"
-                type="email"
-                name="email"
-                autocomplete="email"
-                required
-                class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border border-gray-600 rounded-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-200 focus:border-indigo-200 sm:text-sm"
-              />
-            </div>
-            <p class="mt-2 text-xs text-gray-300">Your email address.</p>
-          </div>
+            <SiTextBox2
+              id="userEmail"
+              v-model="form.userEmail"
+              title="Email"
+              description="Your email address."
+            />
+            <!--
+            :error="false"
+            error-id="email-error"
+            error-message="Email address must include the '@' character."
+          --></div>
 
           <div class="sm:col-span-6">
-            <label
-              for="userPassword"
-              class="block text-sm font-medium text-gray-200"
-            >
-              Password
-            </label>
-            <div class="mt-1 w-full">
-              <input
-                id="userPassword"
-                v-model="form.userPassword"
-                data-test="userPassword"
-                type="password"
-                name="password"
-                required
-                class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border border-gray-600 rounded-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-200 focus:border-indigo-200 sm:text-sm"
-              />
-            </div>
-            <p class="mt-2 text-xs text-gray-300">Your password.</p>
-          </div>
+            <SiTextBox2
+              id="userPassword"
+              v-model="form.userPassword"
+              title="Password"
+              :password="true"
+              description="Your password."
+            />
+            <!--
+            :error="false"
+            error-id="password-error"
+            error-message="Password cannot be an empty string or whitespace."
+          --></div>
 
           <div class="sm:col-span-6">
-            <label
-              for="signupSecret"
-              class="block text-sm font-medium text-gray-200"
-            >
-              Agent Passphrase
-            </label>
-            <div class="mt-1 w-full">
-              <input
-                id="signupSecret"
-                v-model="form.signupSecret"
-                data-test="signupSecret"
-                type="password"
-                name="password"
-                required
-                class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border border-gray-600 rounded-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-200 focus:border-indigo-200 sm:text-sm"
-              />
-            </div>
-            <p class="mt-2 text-xs text-gray-300">
-              The secret agent passphrase provided to you by the Initiative.
-            </p>
-          </div>
+            <SiTextBox2
+              id="signupSecret"
+              v-model="form.signupSecret"
+              title="Agent Passphrase"
+              :password="true"
+              description="The secret agent passphrase provided to you by the Initiative."
+            />
+            <!--
+            :error="false"
+            error-id="agent-passphrase-error"
+            error-message="Agent passphrase cannot be an empty string or whitespace."
+          --></div>
+
           <div class="sm:col-span-6">
             <button
               type="submit"
@@ -161,6 +119,7 @@
 import { ref } from "vue";
 import { CreateAccountRequest, SignupService } from "@/service/signup";
 import siLogoWts from "@/assets/images/si-logo-wts.svg";
+import SiTextBox2 from "@/atoms/SiTextBox2.vue";
 
 const emit = defineEmits(["success", "back-to-login"]);
 

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -68,4 +68,5 @@ tidy-crates:
 
 tidy-web:
 	cd $(REPOPATH)/app/web/; npm run format
+	cd $(REPOPATH)/app/web/; npm run eslint:fix
 .PHONY: tidy-app


### PR DESCRIPTION
- Add SiTextBox2, which will eventually replace SiTextBox
- Add validation display handling within SiTextBox2
  - It will be unused in this commit since it requires an "error" object
    to be passed in a as a prop
- Replace all five signup fields with SiTextBox2
- Add "eslint:fix" to "tidy-web" make target

<img src="https://media1.giphy.com/media/FR6VI9pRlISJX74Wuk/giphy.gif"/>

Fixes ENG-177