### PR TITLE
Draft: feat(web): Some attribute sub panels cant be reactive to visibility

### DIFF
--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -65,10 +65,10 @@ import { ChangedEditFieldCounterVisitor } from "@/utils/edit_field_visitor";
 import { ComponentIdentification } from "@/api/sdf/dal/component";
 import { componentsMetadata$ } from "@/organisims/SchematicViewer/data/observable";
 import { ComponentMetadata } from "@/service/component/get_components_metadata";
-//import { Visibility } from "@/api/sdf/dal/visibility";
+import { Visibility } from "@/api/sdf/dal/visibility";
 import {
-  standardVisibilityTriggers$,
-  //visibility$,
+  //standardVisibilityTriggers$,
+  visibility$,
 } from "@/observable/visibility";
 import { editSessionWritten$ } from "@/observable/edit_session";
 import SiLink from "@/atoms/SiLink.vue";
@@ -81,7 +81,9 @@ import {
   PencilAltIcon,
 } from "@heroicons/vue/outline";
 
-//const visibility = refFrom<Visibility>(visibility$);
+// We aren't reactive to visibility as we actually depend on visibility+list_component to be sure the selected component still exists
+// Therefore our parent is actually responsible for re-rendering (changing the key) us whenever visibility changes, after cleaning the selection up
+const visibility = refFrom<Visibility>(visibility$);
 
 // TODO(nick): we technically only need one prop. We're sticking with two to not mess
 // with the reactivity guarentees in place.
@@ -100,10 +102,11 @@ const componentId$ = fromRef<number>(componentId, { immediate: true });
 const editFields = refFrom<EditFields | undefined>(
   Rx.combineLatest([
     componentId$,
-    standardVisibilityTriggers$,
+    //standardVisibilityTriggers$,
     editSessionWritten$,
   ]).pipe(
-    Rx.switchMap(([componentId, [visibility]]) => {
+    //Rx.switchMap(([componentId, [visibility]]) => {
+    Rx.switchMap(([componentId]) => {
       return EditFieldService.getEditFields({
         id: componentId,
         objectKind: EditFieldObjectKind.Component,

--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -114,6 +114,7 @@
         />
         <QualificationViewer
           v-else-if="activeView === 'qualification'"
+          :key="attributeViewerKey"
           :component-id="selectedComponentIdentification.componentId"
         />
         <ResourceViewer
@@ -174,7 +175,7 @@ import cheechSvg from "@/assets/images/cheech-and-chong.svg";
 import { lastSelectedNode$ } from "./SchematicViewer/state";
 import { ComponentIdentification } from "@/api/sdf/dal/component";
 import { schematicData$ } from "./SchematicViewer/Viewer/scene/observable";
-import { visibility$ } from "@/observable/visibility";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
 import { PanelAttributeSubType } from "./PanelTree/panel_types";
 import { ChangeSetService } from "@/service/change_set";
 import { editButtonPulse$ } from "@/observable/change_set";
@@ -192,7 +193,9 @@ const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | "">("");
 
 let visibilityChanged = false;
-visibility$.pipe(untilUnmounted).subscribe(() => (visibilityChanged = true));
+standardVisibilityTriggers$
+  .pipe(untilUnmounted)
+  .subscribe(() => (visibilityChanged = true));
 
 schematicData$.pipe(untilUnmounted).subscribe((schematic) => {
   if (!schematic || selectedComponentId.value === "") {

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -140,7 +140,13 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from "@heroicons/vue/outline";
+import { visibility$ } from "@/observable/visibility";
+import { Visibility } from "@/api/sdf/dal/visibility";
 //import { ListQualificationsResponse } from "@/service/component/list_qualifications";
+
+// We aren't reactive to visibility as we actually depend on visibility+list_component to be sure the selected component still exists
+// Therefore our parent is actually responsible for re-rendering (changing the key) us whenever visibility changes, after cleaning the selection up
+const visibility = refFrom<Visibility>(visibility$);
 
 const editMode = refFrom<boolean>(ChangeSetService.currentEditMode());
 
@@ -294,6 +300,8 @@ const allQualifications = refFrom<Array<Qualification> | null>(
       currentQualifiedState.value = QualifiedState.Unknown;
       return ComponentService.listQualifications({
         componentId: componentId,
+        // We aren't reactive to visibility as our parent will retrigger this by updating componentId or our key
+        ...visibility.value,
       });
     }),
     Rx.switchMap((reply) => {

--- a/app/web/src/service/component/list_qualifications.ts
+++ b/app/web/src/service/component/list_qualifications.ts
@@ -1,6 +1,6 @@
 import { ApiResponse, SDF } from "@/api/sdf";
 import { combineLatest, from, Observable, shareReplay } from "rxjs";
-import { standardVisibilityTriggers$ } from "@/observable/visibility";
+//import { standardVisibilityTriggers$ } from "@/observable/visibility";
 import Bottle from "bottlejs";
 import { switchMap } from "rxjs/operators";
 import { Visibility } from "@/api/sdf/dal/visibility";
@@ -8,13 +8,11 @@ import { Qualification } from "@/api/sdf/dal/qualification";
 import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
 
-export interface ListQualificationsArgs {
+export interface ListQualificationsArgs extends Visibility {
   componentId: number;
 }
 
-export interface ListQualificationsRequest
-  extends ListQualificationsArgs,
-    Visibility {
+export interface ListQualificationsRequest extends ListQualificationsArgs {
   workspaceId: number;
 }
 
@@ -31,10 +29,10 @@ export function listQualifications(
     return listQualificationsCollection[args.componentId];
   }
   listQualificationsCollection[args.componentId] = combineLatest([
-    standardVisibilityTriggers$,
+    //standardVisibilityTriggers$,
     workspace$,
   ]).pipe(
-    switchMap(([[visibility], workspace]) => {
+    switchMap(([workspace]) => {
       const bottle = Bottle.pop("default");
       const sdf: SDF = bottle.container.SDF;
       if (_.isNull(workspace)) {
@@ -52,7 +50,7 @@ export function listQualifications(
         "component/list_qualifications",
         {
           ...args,
-          ...visibility,
+          //...visibility,
           workspaceId: workspace.id,
         },
       );

--- a/app/web/src/service/edit_field/get_edit_fields.ts
+++ b/app/web/src/service/edit_field/get_edit_fields.ts
@@ -6,7 +6,7 @@ import { Visibility } from "@/api/sdf/dal/visibility";
 import { EditFieldObjectKind, EditFields } from "@/api/sdf/dal/edit_field";
 import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
-import { standardVisibilityTriggers$ } from "@/observable/visibility";
+//import { standardVisibilityTriggers$ } from "@/observable/visibility";
 
 export interface GetEditFieldsArgs extends Visibility {
   objectKind: EditFieldObjectKind;
@@ -41,12 +41,14 @@ export function getEditFields(
   }
   getEditFieldsCollection[args.objectKind][args.id] = combineLatest([
     workspace$,
-    standardVisibilityTriggers$,
+    //standardVisibilityTriggers$,
   ]).pipe(
-    switchMap(([workspace, [visibility]]) => {
+    //switchMap(([workspace, [visibility]]) => {
+    switchMap(([workspace]) => {
       const bottle = Bottle.pop("default");
       const sdf: SDF = bottle.container.SDF;
-      const request: GetEditFieldsRequest = { ...args, ...visibility };
+      //const request: GetEditFieldsRequest = { ...args, ...visibility };
+      const request: GetEditFieldsRequest = { ...args };
       if (args.objectKind === EditFieldObjectKind.Component) {
         if (_.isNull(workspace)) {
           return from([


### PR DESCRIPTION
Their parents actually are responsible for re-mounting them when
visibility changes, as they depend on Component selection and with the
visibility change the selection might not exist, but they don't have
enough information to find-out. Their parents do.

So the parent monitors for visibility changes, if the selected component
is gone it de-selects, and only then retriggers queries like
getEditFields and listQualifications in the sub-panels, by either
updating the selected component, or changing its vue key.

Fixes the old implementation that ignored edit session changes, so it
wasn't properly refreshing the fields when fields were edited, now it does.

I commented out the reactivity logic in the sub-panels as I understand
this isn't a great approach, but it works and it's there, if we ever
decide that it's a bad one we can easily revert.

@adamhjk you seemed very displeased with a solution like this, if you have any objections with merging this I can re-factor it, but since the code was still there, just unused I figured restoring it was the quickest approach to fixing the bug, but we might regret it.

<img src="https://media3.giphy.com/media/OU1fdwqFnwnZMy79Xy/giphy.gif"/>