### PR TITLE
feat(web): Ignore invalid visibility in some queries

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -108,7 +108,6 @@
       >
         <AttributeViewer
           v-if="activeView === 'attribute'"
-          :key="attributeViewerKey"
           :component-id="selectedComponentIdentification.componentId"
           :component-identification="selectedComponentIdentification"
         />
@@ -186,32 +185,19 @@ import {
   BeakerIcon,
 } from "@heroicons/vue/solid";
 
-const randomString = () => `${Math.floor(Math.random() * 50000)}`;
-const attributeViewerKey = ref(randomString());
 const isPinned = ref<boolean>(false);
 const selectedComponentId = ref<number | "">("");
 
-let visibilityChanged = false;
-visibility$.pipe(untilUnmounted).subscribe(() => (visibilityChanged = true));
-
 schematicData$.pipe(untilUnmounted).subscribe((schematic) => {
   if (!schematic || selectedComponentId.value === "") {
-    visibilityChanged = false;
     return;
   }
 
   for (const node of schematic.nodes) {
     if (selectedComponentId.value === node.kind.componentId) {
-      // Horrible hack to ensure we refetch the edit fields when visibility changes
-      // It will flash the screen, but I don't see a better way right now (I'm fixing other schematic panel bugs)
-      if (visibilityChanged) {
-        attributeViewerKey.value = randomString();
-        visibilityChanged = false;
-      }
       return;
     }
   }
-  visibilityChanged = false;
 
   isPinned.value = false;
   selectedComponentId.value = "";

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -297,7 +297,12 @@ const allQualifications = refFrom<Array<Qualification> | null>(
       });
     }),
     Rx.switchMap((reply) => {
-      if (reply.error) {
+      if (
+        reply.error?.statusCode === 404 &&
+        reply.error?.message === "invalid visibility"
+      ) {
+        return Rx.from([null]);
+      } else if (reply.error) {
         GlobalErrorService.set(reply);
         return Rx.from([null]);
       } else {

--- a/app/web/src/service/edit_field/get_edit_fields.ts
+++ b/app/web/src/service/edit_field/get_edit_fields.ts
@@ -8,12 +8,12 @@ import { workspace$ } from "@/observable/workspace";
 import _ from "lodash";
 import { standardVisibilityTriggers$ } from "@/observable/visibility";
 
-export interface GetEditFieldsArgs extends Visibility {
+export interface GetEditFieldsArgs {
   objectKind: EditFieldObjectKind;
   id: number;
 }
 
-export interface GetEditFieldsRequest extends GetEditFieldsArgs {
+export interface GetEditFieldsRequest extends GetEditFieldsArgs, Visibility {
   workspaceId?: number;
 }
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -888,6 +888,22 @@ impl Component {
     }
 
     #[instrument(skip_all)]
+    pub async fn is_in_tenancy(ctx: &DalContext<'_, '_>, id: ComponentId) -> ComponentResult<bool> {
+        let row = ctx
+            .pg_txn()
+            .query_opt(
+                "SELECT id FROM components WHERE id = $1 AND in_tenancy_v1($2, components.tenancy_universal, components.tenancy_billing_account_ids,
+                                                                           components.tenancy_organization_ids, components.tenancy_workspace_ids) LIMIT 1",
+                &[
+                    &id,
+                    ctx.read_tenancy(),
+                ],
+            )
+            .await?;
+        Ok(row.is_some())
+    }
+
+    #[instrument(skip_all)]
     pub async fn list_validations_as_qualification_for_component_id(
         ctx: &DalContext<'_, '_>,
         component_id: ComponentId,

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -32,8 +32,6 @@ pub enum ComponentError {
     InvalidRequest,
     #[error(transparent)]
     Nats(#[from] si_data::NatsError),
-    #[error("not found")]
-    NotFound,
     #[error(transparent)]
     Pg(#[from] si_data::PgError),
     #[error("read tenancy error: {0}")]
@@ -58,6 +56,8 @@ pub enum ComponentError {
     Transactions(#[from] TransactionsError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
+    #[error("invalid visibility")]
+    InvalidVisibility,
 }
 
 pub type ComponentResult<T> = std::result::Result<T, ComponentError>;
@@ -65,8 +65,8 @@ pub type ComponentResult<T> = std::result::Result<T, ComponentError>;
 impl IntoResponse for ComponentError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
-            ComponentError::NotFound => (StatusCode::NOT_FOUND, self.to_string()),
             ComponentError::SchemaNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            ComponentError::InvalidVisibility => (StatusCode::NOT_FOUND, self.to_string()),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf/src/server/service/edit_field.rs
+++ b/lib/sdf/src/server/service/edit_field.rs
@@ -44,13 +44,18 @@ pub enum EditFieldError {
     MissingAttributeContext,
     #[error("read tenancy error: {0}")]
     ReadTenancy(#[from] ReadTenancyError),
+    #[error("invalid visibility")]
+    InvalidVisibility,
 }
 
 pub type EditFieldResult<T> = std::result::Result<T, EditFieldError>;
 
 impl IntoResponse for EditFieldError {
     fn into_response(self) -> Response {
-        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+        let (status, error_message) = match self {
+            EditFieldError::InvalidVisibility => (StatusCode::NOT_FOUND, self.to_string()),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
 
         let body = Json(serde_json::json!({
             "error": {


### PR DESCRIPTION
Before when visibility changed and the selected component wasn't visible
anymore the user would get an error, but it's an acceptable state, we
just have to ignore the failure.

With that in mind we changed getEditFields and listQualifications to
ignore when the tenancy is correct but the visibility is not, as the
cache might be stale.

Also removed the old reactivity hack we had to solve this in the
frontend instead of the backend

<img src="https://media4.giphy.com/media/MXywxyJ5UyvtgoF94a/giphy.gif"/>