### PR TITLE
fix(web): Fix crash on drag, hide editfields icon if 0

### DIFF
--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -36,11 +36,11 @@
           </SiButtonIcon>
         </SiLink>
 
-        <div class="flex flex-row items-center">
+        <div v-if="editCount" class="flex flex-row items-center">
           <SiIcon tooltip-text="Number of edit fields" color="#ce7f3e">
             <PencilAltIcon />
           </SiIcon>
-          <div v-if="editCount" class="ml-1 text-center">{{ editCount }}</div>
+          <div class="ml-1 text-center">{{ editCount }}</div>
         </div>
       </div>
     </div>
@@ -141,7 +141,7 @@ const componentMetadata = refFrom<ComponentMetadata | null>(
 
 const editCount = computed(() => {
   if (editFields.value === undefined) {
-    return undefined;
+    return 0;
   } else {
     const counter = new ChangedEditFieldCounterVisitor();
     counter.visitEditFields(editFields.value);

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -67,7 +67,12 @@ export class SchematicDataManager {
   async updateNodePosition(nodeUpdate: NodeUpdate | null): Promise<void> {
     const editorContext = await Rx.firstValueFrom(this.editorContext$);
     const schematicKind = await Rx.firstValueFrom(this.schematicKind$);
-    if (nodeUpdate && editorContext && schematicKind) {
+    if (
+      nodeUpdate &&
+      editorContext &&
+      schematicKind &&
+      nodeUpdate.nodeId !== -1
+    ) {
       SchematicService.setNodePosition({
         deploymentNodeId:
           schematicKind !== SchematicKind.Deployment

--- a/app/web/src/utils/edit_field_visitor.ts
+++ b/app/web/src/utils/edit_field_visitor.ts
@@ -123,6 +123,11 @@ export class ChangedEditFieldCounterVisitor implements EditFieldVisitor {
   }
 
   visitString(field: StringEditField) {
+    // Horrible hack to ensure the initial name setting isn't counted
+    // We don't have enough metadata to be sure name is the actual root.si.name, so it might conflict eventually
+    if (field.name === "name" && String(field.value).match(/^si-\d+$/)) {
+      return;
+    }
     this.countIfChanged(field.visibility_diff);
   }
 }


### PR DESCRIPTION
- setNodePosition was triggered on fake nodes (before creation, so node id -1), this caused an error message
- edit count is now hidden on 0 changes
- edit count used to count initial name setting of component as a change, now we hack around that by ignoring fields with name "name" and value in the pattern"si-{number}"

<img src="https://media3.giphy.com/media/6mGzvKGJGsYH6/giphy.gif"/>