### PR TITLE
chore(dal): use id for child attribute values

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -181,11 +181,12 @@ Integration tests from the dal will not have their transactions committed and pe
 If you would like to view the state of the database via a debugger or after test conclusion, you will need to _temporarily_ refactor your test accordingly:
 
 ```rust
+// NOTE: this is likely wrong!
 #[test]
 async fn your_dal_integration_test(
     dal_context_builder: DalContextBuilder,
     jwt_secret_key: &JwtSecretKey,
-    application_id: &NodeId,
+    application_id: ApplicationId,
 ) {
     let mut transactions_starter = dal_context_builder
         .transactions_starter()
@@ -205,7 +206,7 @@ async fn your_dal_integration_test(
         &dal_context_builder,
         &transactions,
         &nba,
-        *application_id,
+        application_id,
     )
     .await;
 

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -225,9 +225,11 @@ impl AttributeValue {
         Ok(())
     }
 
+    /// Returns a list of child [`AttributeValues`](crate::AttributeValue) for a given
+    /// [`AttributeValue`] and [`AttributeReadContext`](crate::AttributeReadContext).
     pub async fn child_attribute_values_in_context(
-        &self,
         ctx: &DalContext<'_, '_>,
+        attribute_value_id: AttributeValueId,
         attribute_read_context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<Self>> {
         let rows = ctx
@@ -237,7 +239,7 @@ impl AttributeValue {
                 &[
                     ctx.read_tenancy(),
                     ctx.visibility(),
-                    self.id(),
+                    &attribute_value_id,
                     &attribute_read_context,
                 ],
             )

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1746,9 +1746,12 @@ async fn edit_field_for_attribute_value(
         WidgetKind::Text => Widget::Text(TextWidget::new()),
         WidgetKind::Array | WidgetKind::Map | WidgetKind::Header => {
             let mut child_edit_fields = vec![];
-            let mut child_attribute_values = attribute_value
-                .child_attribute_values_in_context(ctx, attribute_read_context)
-                .await?;
+            let mut child_attribute_values = AttributeValue::child_attribute_values_in_context(
+                ctx,
+                attribute_value_id,
+                attribute_read_context,
+            )
+            .await?;
             if let Some(index_map) = attribute_value.index_map() {
                 let child_order = index_map.order();
 


### PR DESCRIPTION
- Use id for child attribute values in context function
  - This was found during the insert for context work and is more
    ergonomic by only requiring the id and not self
- Add disclaimer and ApplicationId fix to persistent data in dal
  integration tests guide in DEVELOPING

<img src="https://media3.giphy.com/media/3ornjZLITGcFQVRbxK/giphy.gif"/>

No Linear story needed