### PR TITLE
chore(*): typescript types for property editor

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -1,0 +1,90 @@
+// Setting a value cold from a schema
+// * attribute context
+//   * requires a prop id
+// * fundamental data type (string/number/bool/map/array)
+// * require a key/index (map or array)
+
+export enum PropertyEditorPropKind {
+  Array = "array",
+  Boolean = "boolean",
+  Integer = "integer",
+  Object = "object",
+  String = "string",
+  Map = "map",
+}
+
+export enum PropertyEditorPropWidgetKind {
+  Array = "array",
+  Checkbox = "checkbox",
+  Header = "header",
+  Map = "map",
+  SecretSelect = "secretSelect",
+  Text = "text",
+}
+
+export interface PropertyEditorProp {
+  id: number;
+  name: string;
+  kind: PropertyEditorPropKind;
+  widgetKind: PropertyEditorPropWidgetKind;
+  docLink?: string;
+}
+
+export interface PropertyEditorSchema {
+  rootPropId: number;
+  props: { [id: number]: PropertyEditorProp };
+  childProps: {
+    [key: number]: Array<number>;
+  };
+}
+
+export interface PropertyEditorValue {
+  id: number;
+  propId: number;
+  key?: string;
+  value: unknown;
+}
+
+export interface PropertyEditorValues {
+  rootValueId: number;
+  values: { [id: number]: PropertyEditorValue };
+  childValues: {
+    [key: number]: Array<number>;
+  };
+}
+
+export interface PropertyEditorChangeValue {
+  valueId: number;
+  changed: boolean;
+}
+
+export interface PropertyEditorChangeValues {
+  changedValues: {
+    [valueId: number]: PropertyEditorChangeValue;
+  };
+}
+
+export interface PropertyEditorValidationError {
+  message: string;
+  level?: string;
+  kind?: string;
+  link?: string;
+}
+
+export interface PropertyEditorValidation {
+  valueId: number;
+  valid: boolean;
+  errors: Array<PropertyEditorValidationError>;
+}
+
+export interface PropertyEditorValidations {
+  validations: {
+    [valueId: number]: PropertyEditorValidation;
+  };
+}
+
+export interface UpdatedProperty {
+  propId: number;
+  valueId: number;
+  value: unknown;
+}

--- a/app/web/src/atoms/SiTextBox2.vue
+++ b/app/web/src/atoms/SiTextBox2.vue
@@ -62,11 +62,12 @@ const props = defineProps<{
   required?: boolean;
 }>();
 
-const emit = defineEmits(["update:modelValue", "error"]);
+const emit = defineEmits(["update:modelValue", "error", "blur"]);
 
 const dirty = ref<boolean>(false);
 const setDirty = () => {
   dirty.value = true;
+  emit("blur", inputValue);
 };
 
 const inError = ref<boolean>(false);

--- a/app/web/src/composables/usePropertyEditorIsShown.ts
+++ b/app/web/src/composables/usePropertyEditorIsShown.ts
@@ -1,0 +1,39 @@
+import { Ref, computed } from "vue";
+import _ from "lodash";
+
+export function usePropertyEditorIsShown(
+  name: Ref<string>,
+  path: Ref<string[]>,
+  collapsedPaths: Ref<Array<Array<string>>>,
+) {
+  const isShown = computed(() => {
+    const checkPath = [name.value, ...path.value].reverse();
+    for (const c of collapsedPaths.value) {
+      const reverseCollapsedPath = _.cloneDeep(c);
+      reverseCollapsedPath.reverse();
+      if (checkPath.length >= reverseCollapsedPath.length) {
+        const checkPathSlice = checkPath.slice(0, reverseCollapsedPath.length);
+        if (_.isEqual(checkPathSlice, reverseCollapsedPath)) {
+          if (!_.isEqual(checkPath, reverseCollapsedPath)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  });
+
+  const isCollapsed = computed(() => {
+    const checkPath = [name.value, ...path.value].reverse();
+    for (const c of collapsedPaths.value) {
+      const reverseCollapsedPath = _.cloneDeep(c);
+      reverseCollapsedPath.reverse();
+      if (_.isEqual(checkPath, reverseCollapsedPath)) {
+        return true;
+      }
+    }
+    return false;
+  });
+
+  return { isShown, isCollapsed };
+}

--- a/app/web/src/config.ts
+++ b/app/web/src/config.ts
@@ -10,12 +10,12 @@ export const config: Config = {
     process.env.VUE_APP_SDF_BASE_HTTP_URL ||
       (process.env.NODE_ENV == "production"
         ? "https://app.systeminit.com/api"
-        : "http://localhost:8080/api"),
+        : `${window.location.origin}/api`),
   ),
   sdfBaseWsUrl: new URL(
     process.env.VUE_APP_SDF_BASE_WS_URL ||
       (process.env.NODE_ENV == "production"
         ? "wss://app.systeminit.com/api/ws/billing_account_updates"
-        : "ws://localhost:8080/api/ws/billing_account_updates"),
+        : `ws://${window.location.host}/api/ws/billing_account_updates`),
   ),
 };

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -44,17 +44,20 @@
         </div>
       </div>
     </div>
+
+    <PropertyEditor @updated-property="updateProperty($event)" />
+    <!--
     <EditFormComponent
       v-if="editFields"
       :edit-fields="editFields"
       :component-identification="componentIdentification"
-    />
+    /> -->
   </div>
 </template>
 
 <script setup lang="ts">
 import * as Rx from "rxjs";
-import EditFormComponent from "@/organisims/EditFormComponent.vue";
+//import EditFormComponent from "@/organisims/EditFormComponent.vue";
 import { toRefs, computed } from "vue";
 import { fromRef, refFrom } from "vuse-rx";
 import { GlobalErrorService } from "@/service/global_error";
@@ -74,6 +77,8 @@ import {
   QuestionMarkCircleIcon,
   PencilAltIcon,
 } from "@heroicons/vue/outline";
+import PropertyEditor from "./PropertyEditor.vue";
+import { UpdatedProperty } from "@/api/sdf/dal/property_editor";
 
 // TODO(nick): we technically only need one prop. We're sticking with two to not mess
 // with the reactivity guarentees in place.
@@ -204,6 +209,10 @@ const resourceColor = computed(() => {
     return "#bbbbbb";
   }
 });
+
+const updateProperty = (update: UpdatedProperty) => {
+  console.log("updating", { update });
+};
 </script>
 
 <style scoped>

--- a/app/web/src/organisims/PropertyEditor.vue
+++ b/app/web/src/organisims/PropertyEditor.vue
@@ -1,0 +1,240 @@
+<template>
+  <div class="flex flex-col w-full overflow-auto h-full">
+    <div
+      v-for="pv in propertyValuesInOrder"
+      :key="pv.id"
+      class="flex flex-col w-full"
+    >
+      <PropertyWidget
+        :schema-prop="schemaForPropId(pv.id)"
+        :prop-value="pv"
+        :path="pathForValueId(pv.id)"
+        :collapsed-paths="collapsed"
+        @toggle-collapsed="toggleCollapsed($event)"
+        @updated-property="updatedProperty($event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  PropertyEditorPropKind,
+  PropertyEditorPropWidgetKind,
+  PropertyEditorSchema,
+  PropertyEditorValues,
+  UpdatedProperty,
+} from "@/api/sdf/dal/property_editor";
+import { GlobalErrorService } from "@/service/global_error";
+import PropertyWidget from "./PropertyEditor/PropertyWidget.vue";
+import { ref, computed } from "vue";
+import _ from "lodash";
+
+const emits = defineEmits<{
+  (e: "updatedProperty", v: UpdatedProperty): void;
+}>();
+
+const schema = ref<PropertyEditorSchema>({
+  rootPropId: 0,
+  props: {
+    0: {
+      id: 0,
+      name: "attributes",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    1: {
+      id: 1,
+      name: "name",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    2: {
+      id: 2,
+      name: "love",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    3: {
+      id: 3,
+      name: "bleeds",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    4: {
+      id: 4,
+      name: "snoop",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    5: {
+      id: 5,
+      name: "lion",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    6: {
+      id: 6,
+      name: "death row",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    7: {
+      id: 7,
+      name: "dreams",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+  },
+  childProps: {
+    0: [1, 2, 3, 4],
+    4: [5],
+    5: [6, 7],
+  },
+});
+
+const values = ref<PropertyEditorValues>({
+  rootValueId: 0,
+  values: {
+    0: {
+      id: 0,
+      propId: 0,
+      value: {},
+    },
+    1: {
+      id: 1,
+      propId: 1,
+      value: "def leppard",
+    },
+    2: {
+      id: 2,
+      propId: 2,
+      value: "love bites",
+    },
+    3: {
+      id: 3,
+      propId: 3,
+      value: null,
+    },
+    4: {
+      id: 4,
+      propId: 4,
+      value: {},
+    },
+    5: {
+      id: 5,
+      propId: 5,
+      value: {},
+    },
+    6: {
+      id: 6,
+      propId: 6,
+      value: "too late",
+    },
+    7: {
+      id: 7,
+      propId: 7,
+      value: "for love",
+    },
+  },
+  childValues: {
+    0: [1, 2, 3, 4],
+    4: [5],
+    5: [6, 7],
+  },
+});
+
+const schemaForPropId = (propId: number) => {
+  const schemaForProp = schema.value.props[propId];
+  if (schemaForProp) {
+    return schemaForProp;
+  } else {
+    GlobalErrorService.set({
+      error: {
+        code: 55,
+        message: `Schema not found for prop ${propId}; bug!`,
+        statusCode: 55,
+      },
+    });
+    return {
+      id: propId,
+      name: "error",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    };
+  }
+};
+
+const collapsed = ref<Array<Array<string>>>([["snoop", "attributes"]]);
+const toggleCollapsed = (path: string[]) => {
+  for (let x = 0; x < collapsed.value.length; x++) {
+    const c = collapsed.value[x];
+    if (_.isEqual(c, path)) {
+      collapsed.value = _.filter(collapsed.value, (v) => {
+        return !_.isEqual(v, path);
+      });
+      return;
+    }
+  }
+  collapsed.value.push(path);
+};
+
+const pathForValueId = (valueId: number) => {
+  const path = [];
+  let toCheck: string | null = String(valueId);
+  CHECK: while (toCheck !== null) {
+    for (const [key, childValueIds] of Object.entries(
+      values.value.childValues,
+    )) {
+      for (const childValueId of childValueIds) {
+        if (String(childValueId) == toCheck) {
+          const parentValue = values.value.values[parseInt(key, 10)];
+          if (parentValue) {
+            const schemaProp = schema.value.props[parentValue.propId];
+            if (parentValue.key) {
+              path.push(parentValue.key);
+            } else {
+              path.push(schemaProp.name);
+            }
+            toCheck = key;
+          } else {
+            GlobalErrorService.set({
+              error: {
+                code: 56,
+                message: `missing parent value for value id ${childValueId}; bug!`,
+                statusCode: 55,
+              },
+            });
+          }
+          continue CHECK;
+        }
+      }
+    }
+    toCheck = null;
+  }
+  return path;
+};
+
+const propertyValuesInOrder = computed(() => {
+  const results = [];
+  const lookup = [values.value.rootValueId];
+  while (lookup.length) {
+    const nextValueId = lookup.shift();
+    if (nextValueId !== undefined) {
+      results.push(values.value.values[nextValueId]);
+      const childValuesList = values.value.childValues[nextValueId];
+      if (childValuesList) {
+        for (const childValueId of childValuesList) {
+          lookup.push(childValueId);
+        }
+      }
+    }
+  }
+  return results;
+});
+
+const updatedProperty = (event: UpdatedProperty) => {
+  values.value.values[event.valueId].value = event.value;
+  emits("updatedProperty", event);
+};
+</script>

--- a/app/web/src/organisims/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisims/PropertyEditor/PropertyWidget.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="flex flex-col" @keyup.stop @keydown.stop>
+    <WidgetHeader
+      v-if="props.schemaProp.widgetKind == 'header'"
+      :name="props.schemaProp.name"
+      :path="path"
+      :collapsed-paths="props.collapsedPaths"
+      @toggle-collapsed="setCollapsed($event)"
+    />
+    <WidgetTextBox
+      v-else-if="props.schemaProp.widgetKind == 'text'"
+      :name="props.schemaProp.name"
+      :path="path"
+      :collapsed-paths="props.collapsedPaths"
+      :value="props.propValue.value"
+      :prop-id="props.propValue.propId"
+      :value-id="props.propValue.id"
+      @updated-property="updatedProperty($event)"
+      class="py-4 px-8"
+    />
+    <div v-else>
+      <div class="flex">
+        {{ props.path }}
+      </div>
+      <div class="flex">
+        {{ props.schemaProp }}
+      </div>
+      <div class="flex">
+        {{ props.propValue }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  PropertyEditorProp,
+  PropertyEditorValue,
+  UpdatedProperty,
+} from "@/api/sdf/dal/property_editor";
+import WidgetHeader from "./WidgetHeader.vue";
+import WidgetTextBox from "./WidgetTextBox.vue";
+
+const props = defineProps<{
+  schemaProp: PropertyEditorProp;
+  propValue: PropertyEditorValue;
+  path: Array<string>;
+  collapsedPaths: Array<Array<string>>;
+}>();
+
+const emits = defineEmits<{
+  (e: "toggleCollapsed", path: Array<string>): void;
+  (e: "updatedProperty", v: UpdatedProperty): void;
+}>();
+
+const setCollapsed = (path: string[]) => {
+  emits("toggleCollapsed", path);
+};
+
+const updatedProperty = (event: UpdatedProperty) => {
+  emits("updatedProperty", event);
+};
+</script>

--- a/app/web/src/organisims/PropertyEditor/WidgetHeader.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetHeader.vue
@@ -1,0 +1,55 @@
+<template>
+  <div
+    class="flex flex-row w-full pl-7 pt-1 pb-1 mt-2 text-white cursor-pointer bg-gray-800 items-center h-12"
+    @click="setCollapsed"
+    v-show="isShown"
+  >
+    <div class="text-base font-extrabold">
+      {{ name }}
+    </div>
+    <div
+      v-for="(part, index) of path"
+      :key="index"
+      class="flex flex-row text-sm"
+    >
+      <ChevronLeftIcon class="h-5" /> {{ part }}
+    </div>
+    <div class="flex flex-grow justify-end pr-4">
+      <SiButtonIcon tooltip-text="Expand" v-if="isCollapsed">
+        <ChevronUpIcon />
+      </SiButtonIcon>
+      <SiButtonIcon tooltip-text="Collapse" v-else>
+        <ChevronDownIcon />
+      </SiButtonIcon>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRefs } from "vue";
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import { ChevronLeftIcon } from "@heroicons/vue/outline";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/vue/solid";
+import _ from "lodash";
+import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+
+const props = defineProps<{
+  name: string;
+  path: string[];
+  collapsedPaths: Array<Array<string>>;
+}>();
+const emits = defineEmits<{
+  (e: "toggle-collapsed", path: Array<string>): void;
+}>();
+
+const setCollapsed = () => {
+  emits("toggle-collapsed", [props.name, ...props.path]);
+};
+
+const { name, path, collapsedPaths } = toRefs(props);
+const { isShown, isCollapsed } = usePropertyEditorIsShown(
+  name,
+  path,
+  collapsedPaths,
+);
+</script>

--- a/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
@@ -1,0 +1,66 @@
+<template>
+  <div v-show="isShown">
+    <SiTextBox
+      v-model="fieldValue"
+      :title="props.name"
+      :id="fieldId"
+      @blur="blurCallback"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, toRefs, computed } from "vue";
+import SiTextBox from "@/atoms/SiTextBox2.vue";
+import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+import { UpdatedProperty } from "@/api/sdf/dal/property_editor";
+import _ from "lodash";
+
+const props = defineProps<{
+  name: string;
+  path: string[];
+  collapsedPaths: Array<Array<string>>;
+  value: unknown;
+  propId: number;
+  valueId: number;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: string): void;
+  (e: "updatedProperty", v: UpdatedProperty): void;
+}>();
+
+const { name, path, collapsedPaths, valueId, propId } = toRefs(props);
+const currentValue = ref<string>(String(props.value));
+
+const fieldValue = computed<string>({
+  get(): string {
+    if (_.isString(props.value)) {
+      return props.value;
+    } else {
+      return "";
+    }
+  },
+  set(value) {
+    currentValue.value = value;
+    emit("update:modelValue", value);
+  },
+});
+
+const fieldId = ref([props.name, ...props.path].join("."));
+
+const { isShown } = usePropertyEditorIsShown(name, path, collapsedPaths);
+
+const blurCallback = () => {
+  console.log("updated property", {
+    fv: currentValue.value,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+  emit("updatedProperty", {
+    value: currentValue.value,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+};
+</script>

--- a/lib/dal/src/edit_field/widget.rs
+++ b/lib/dal/src/edit_field/widget.rs
@@ -40,7 +40,9 @@ pub enum Widget {
     Text(TextWidget),
 }
 
-#[derive(AsRefStr, Clone, Deserialize, Serialize, Debug, PartialEq, Eq, Display, EnumString)]
+#[derive(
+    AsRefStr, Clone, Deserialize, Serialize, Debug, PartialEq, Eq, Display, EnumString, Copy,
+)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum WidgetKind {

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -33,6 +33,7 @@ pub mod node_menu;
 pub mod node_position;
 pub mod organization;
 pub mod prop;
+pub mod property_editor;
 pub mod provider;
 pub mod qualification;
 pub mod qualification_check;

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -1,0 +1,168 @@
+//#[derive(Error, Debug)]
+//pub enum PropertyEditorError {
+//}
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use si_data::PgError;
+use thiserror::Error;
+
+use crate::{
+    edit_field::widget::WidgetKind, pk, schema::variant::SchemaVariantError, DalContext, Prop,
+    PropId, PropKind, SchemaVariant, SchemaVariantId, StandardModel, StandardModelError,
+};
+
+const PROPERTY_EDITOR_SCHEMA_FOR_SCHEMA_VARIANT: &str =
+    include_str!("./queries/property_editor_schema_for_schema_variant.sql");
+
+#[derive(Error, Debug)]
+pub enum PropertyEditorError {
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModel(#[from] StandardModelError),
+    #[error("schema variant not found: {0}")]
+    SchemaVariantNotFound(SchemaVariantId),
+    #[error("root prop not found for schema variant")]
+    RootPropNotFound,
+    #[error("schema variant: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+pub type PropertyEditorResult<T> = Result<T, PropertyEditorError>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PropertyEditorPropKind {
+    Array,
+    Boolean,
+    Integer,
+    Object,
+    String,
+    Map,
+}
+
+impl From<&PropKind> for PropertyEditorPropKind {
+    fn from(prop_kind: &PropKind) -> Self {
+        match prop_kind {
+            PropKind::Array => Self::Array,
+            PropKind::Boolean => Self::Boolean,
+            PropKind::Integer => Self::Integer,
+            PropKind::Object => Self::Object,
+            PropKind::String => Self::String,
+            PropKind::Map => Self::Map,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PropertyEditorPropWidgetKind {
+    Array,
+    Checkbox,
+    Header,
+    Map,
+    SecretSelect,
+    Text,
+}
+
+impl From<&WidgetKind> for PropertyEditorPropWidgetKind {
+    fn from(widget_kind: &WidgetKind) -> Self {
+        match widget_kind {
+            WidgetKind::Array => Self::Array,
+            WidgetKind::Checkbox => Self::Checkbox,
+            WidgetKind::Header => Self::Header,
+            WidgetKind::Map => Self::Map,
+            WidgetKind::SecretSelect => Self::SecretSelect,
+            WidgetKind::Text => Self::Text,
+        }
+    }
+}
+
+pk!(PropertyEditorPropId);
+
+impl From<&PropId> for PropertyEditorPropId {
+    fn from(prop_id: &PropId) -> Self {
+        let number: i64 = (*prop_id).into();
+        PropertyEditorPropId(number)
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PropertyEditorProp {
+    pub id: PropertyEditorPropId,
+    pub name: String,
+    pub kind: PropertyEditorPropKind,
+    pub widget_kind: PropertyEditorPropWidgetKind,
+    pub doc_link: Option<String>,
+}
+
+impl From<Prop> for PropertyEditorProp {
+    fn from(prop: Prop) -> PropertyEditorProp {
+        PropertyEditorProp {
+            id: prop.id().into(),
+            name: prop.name().into(),
+            kind: prop.kind().into(),
+            widget_kind: prop.widget_kind().into(),
+            doc_link: prop.doc_link().map(Into::into),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PropertyEditorSchema {
+    pub root_prop_id: PropertyEditorPropId,
+    pub props: HashMap<PropertyEditorPropId, PropertyEditorProp>,
+    pub child_props: HashMap<PropertyEditorPropId, Vec<PropertyEditorPropId>>,
+}
+
+impl PropertyEditorSchema {
+    pub async fn for_schema_variant(
+        ctx: &DalContext<'_, '_>,
+        schema_variant_id: SchemaVariantId,
+    ) -> PropertyEditorResult<Self> {
+        let schema_variant = SchemaVariant::get_by_id(ctx, &schema_variant_id)
+            .await?
+            .ok_or(PropertyEditorError::SchemaVariantNotFound(
+                schema_variant_id,
+            ))?;
+        let root_prop = schema_variant
+            .props(ctx)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(PropertyEditorError::RootPropNotFound)?;
+        let mut props: HashMap<PropertyEditorPropId, PropertyEditorProp> = HashMap::new();
+        let mut child_props: HashMap<PropertyEditorPropId, Vec<PropertyEditorPropId>> =
+            HashMap::new();
+
+        let rows = ctx
+            .pg_txn()
+            .query(
+                PROPERTY_EDITOR_SCHEMA_FOR_SCHEMA_VARIANT,
+                &[ctx.read_tenancy(), ctx.visibility(), &schema_variant.id()],
+            )
+            .await?;
+
+        for row in rows {
+            let json: serde_json::Value = row.try_get("object")?;
+            let prop: Prop = serde_json::from_value(json)?;
+            let property_editor_prop: PropertyEditorProp = prop.into();
+            let maybe_child_prop_ids: Option<Vec<PropertyEditorPropId>> =
+                row.try_get("child_prop_ids")?;
+            if let Some(child_prop_ids) = maybe_child_prop_ids {
+                child_props.insert(property_editor_prop.id, child_prop_ids);
+            }
+            props.insert(property_editor_prop.id, property_editor_prop);
+        }
+
+        Ok(PropertyEditorSchema {
+            root_prop_id: root_prop.id().into(),
+            props,
+            child_props,
+        })
+    }
+}

--- a/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
+++ b/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
@@ -1,0 +1,43 @@
+SELECT DISTINCT ON (props.id, child_prop_ids.belongs_to_id) props.id, 
+                              props.visibility_change_set_pk,
+                              props.visibility_edit_session_pk,
+                              child_prop_ids.child_prop_ids as child_prop_ids,
+                              row_to_json(props.*) AS object
+  FROM props
+  LEFT JOIN (
+    SELECT 
+      prop_belongs_to_prop.belongs_to_id AS belongs_to_id, 
+      array_agg(prop_belongs_to_prop.object_id) AS child_prop_ids 
+      FROM prop_belongs_to_prop 
+      GROUP BY prop_belongs_to_prop.belongs_to_id
+    ) AS child_prop_ids ON child_prop_ids.belongs_to_id = props.id
+  WHERE in_tenancy_v1(
+      $1, 
+      props.tenancy_universal, 
+      props.tenancy_billing_account_ids, 
+      props.tenancy_organization_ids,
+      props.tenancy_workspace_ids
+    )
+    AND is_visible_v1(
+      $2, 
+      props.visibility_change_set_pk, 
+      props.visibility_edit_session_pk, 
+      props.visibility_deleted_at
+    )
+    AND props.id IN (
+      WITH RECURSIVE recursive_props AS (
+          SELECT left_object_id AS prop_id
+            FROM prop_many_to_many_schema_variants
+            WHERE right_object_id = $3
+          UNION ALL
+            SELECT pbp.object_id AS prop_id
+            FROM prop_belongs_to_prop AS pbp
+            JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+        )
+        SELECT prop_id
+          FROM recursive_props
+    )
+ORDER BY props.id, child_prop_ids.belongs_to_id, props.visibility_change_set_pk DESC, props.visibility_edit_session_pk DESC;
+
+
+

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -19,6 +19,7 @@ mod node_menu;
 mod node_position;
 mod organization;
 mod prop;
+mod property_editor;
 mod provider;
 mod qualification_check;
 mod qualification_prototype;

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -1,0 +1,19 @@
+use crate::dal::test;
+use dal::{property_editor::PropertyEditorSchema, DalContext, Schema, StandardModel};
+
+#[test]
+async fn for_schema_variant(ctx: &DalContext<'_, '_>) {
+    let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
+        .await
+        .expect("cannot find docker image schema")
+        .pop()
+        .expect("no docker image schema found");
+    let schema_variant_id = schema
+        .default_schema_variant_id()
+        .expect("missing default schema variant id");
+    let property_editor_schema = PropertyEditorSchema::for_schema_variant(ctx, *schema_variant_id)
+        .await
+        .expect("cannot create property editor schema from schema variant");
+    dbg!(property_editor_schema);
+    // NOTE: Some day, this test should.. test something. For now, though - we'll do it live.
+}


### PR DESCRIPTION
Adds basic types for a property editor that is still generic, but
focused on getting the correct types returned rather than *how* the
types are built.

It also fixes an issue with how we configure what URL to hit for backend
services; it's now based on the URI's host field if you aren't in
production.

Also adds a basic property editor that is "flat".