### PR TITLE
feature(web): basic property stub editor

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -88,3 +88,19 @@ export interface UpdatedProperty {
   valueId: number;
   value: unknown;
 }
+
+export interface AddToArray {
+  propId: number;
+  valueId: number;
+}
+
+export interface AddToMap {
+  propId: number;
+  valueId: number;
+  key: string;
+}
+
+export interface PropertyPath {
+  displayPath: string[];
+  triggerPath: string[];
+}

--- a/app/web/src/atoms/SiButtonIcon.vue
+++ b/app/web/src/atoms/SiButtonIcon.vue
@@ -3,7 +3,7 @@
     v-tooltip.bottom="tooltipText"
     :class="buttonClasses"
     :aria-label="props.tooltipText"
-    :disabled="props.disabled"
+    :disabled="disabled"
     @click="emit('click')"
   >
     <slot></slot>

--- a/app/web/src/atoms/SiMenu.vue
+++ b/app/web/src/atoms/SiMenu.vue
@@ -3,7 +3,7 @@
     :disabled="props.disabled ?? false"
     :placement="props.isNotRoot ? 'right-start' : 'bottom-start'"
     :triggers="props.isNotRoot ? ['hover'] : ['click']"
-    :hideTriggers="['hover', 'click']"
+    :hide-triggers="['hover', 'click']"
   >
     <button v-if="props.isNotRoot" class="button p-2 flex text-base">
       <div class="grow">{{ props.tree.name }}</div>

--- a/app/web/src/atoms/SiTextBox2.vue
+++ b/app/web/src/atoms/SiTextBox2.vue
@@ -13,8 +13,9 @@
       :name="props.id"
       :autocomplete="props.id"
       :aria-invalid="inError"
+      :disabled="props.disabled"
       required
-      class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border rounded-sm shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm"
+      class="appearance-none block bg-gray-900 text-gray-100 w-full px-3 py-2 border rounded-sm shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm disabled:border-gray-800"
       :class="textBoxClasses"
       @blur="setDirty"
     />
@@ -26,6 +27,12 @@
     </div>
   </div>
 
+  <p v-if="props.docLink" class="mt-2 text-xs text-blue-300">
+    <a :href="props.docLink" target="_blank" class="hover:underline">
+      Documentation
+    </a>
+  </p>
+
   <p v-if="props.description" class="mt-2 text-xs text-gray-300">
     {{ props.description }}
   </p>
@@ -34,7 +41,7 @@
     :value="String(inputValue)"
     :validations="validations"
     :required="required"
-    :dirty="dirty"
+    :dirty="reallyDirty"
     class="mt-2"
     @errors="setInError($event)"
   />
@@ -60,6 +67,11 @@ const props = defineProps<{
 
   validations?: ValidatorArray;
   required?: boolean;
+  alwaysValidate?: boolean;
+
+  docLink?: string;
+
+  disabled?: boolean;
 }>();
 
 const emit = defineEmits(["update:modelValue", "error", "blur"]);
@@ -69,6 +81,13 @@ const setDirty = () => {
   dirty.value = true;
   emit("blur", inputValue);
 };
+
+const reallyDirty = computed(() => {
+  if (props.alwaysValidate) {
+    return true;
+  }
+  return dirty.value;
+});
 
 const inError = ref<boolean>(false);
 const setInError = (errors: ErrorsArray) => {

--- a/app/web/src/composables/usePropertyEditorIsShown.ts
+++ b/app/web/src/composables/usePropertyEditorIsShown.ts
@@ -1,21 +1,33 @@
 import { Ref, computed } from "vue";
 import _ from "lodash";
+import { PropertyPath } from "@/api/sdf/dal/property_editor";
 
 export function usePropertyEditorIsShown(
   name: Ref<string>,
-  path: Ref<string[]>,
   collapsedPaths: Ref<Array<Array<string>>>,
+  path?: Ref<PropertyPath | undefined>,
+  isHeader?: boolean,
 ) {
   const isShown = computed(() => {
-    const checkPath = [name.value, ...path.value].reverse();
-    for (const c of collapsedPaths.value) {
-      const reverseCollapsedPath = _.cloneDeep(c);
-      reverseCollapsedPath.reverse();
-      if (checkPath.length >= reverseCollapsedPath.length) {
-        const checkPathSlice = checkPath.slice(0, reverseCollapsedPath.length);
-        if (_.isEqual(checkPathSlice, reverseCollapsedPath)) {
-          if (!_.isEqual(checkPath, reverseCollapsedPath)) {
-            return false;
+    if (path && path.value) {
+      const checkPath = _.cloneDeep(path.value.triggerPath);
+      checkPath.reverse();
+      for (const c of collapsedPaths.value) {
+        const reverseCollapsedPath = _.cloneDeep(c);
+        reverseCollapsedPath.reverse();
+        if (checkPath.length >= reverseCollapsedPath.length) {
+          const checkPathSlice = checkPath.slice(
+            0,
+            reverseCollapsedPath.length,
+          );
+          if (_.isEqual(checkPathSlice, reverseCollapsedPath)) {
+            if (isHeader) {
+              if (!_.isEqual(checkPath, reverseCollapsedPath)) {
+                return false;
+              }
+            } else {
+              return false;
+            }
           }
         }
       }
@@ -24,12 +36,15 @@ export function usePropertyEditorIsShown(
   });
 
   const isCollapsed = computed(() => {
-    const checkPath = [name.value, ...path.value].reverse();
-    for (const c of collapsedPaths.value) {
-      const reverseCollapsedPath = _.cloneDeep(c);
-      reverseCollapsedPath.reverse();
-      if (_.isEqual(checkPath, reverseCollapsedPath)) {
-        return true;
+    if (path && path.value) {
+      const checkPath = _.cloneDeep(path.value.triggerPath);
+      checkPath.reverse();
+      for (const c of collapsedPaths.value) {
+        const reverseCollapsedPath = _.cloneDeep(c);
+        reverseCollapsedPath.reverse();
+        if (_.isEqual(checkPath, reverseCollapsedPath)) {
+          return true;
+        }
       }
     }
     return false;

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -87,7 +87,7 @@ const props = defineProps<{
   componentIdentification: ComponentIdentification;
 }>();
 
-const { componentId, componentIdentification } = toRefs(props);
+const { componentId } = toRefs(props);
 
 // We need an observable stream of props.componentId. We also want
 // that stream to emit a value immediately (the first value, as well as all

--- a/app/web/src/organisims/PropertyEditor.vue
+++ b/app/web/src/organisims/PropertyEditor.vue
@@ -1,17 +1,23 @@
 <template>
-  <div class="flex flex-col w-full overflow-auto h-full">
+  <div class="flex flex-col w-full overflow-auto h-full pb-5">
     <div
       v-for="pv in propertyValuesInOrder"
       :key="pv.id"
       class="flex flex-col w-full"
     >
       <PropertyWidget
-        :schema-prop="schemaForPropId(pv.id)"
+        :schema-prop="schemaForPropId(pv.propId)"
         :prop-value="pv"
-        :path="pathForValueId(pv.id)"
+        :path="paths[pv.id]"
         :collapsed-paths="collapsed"
+        :validation="validationForValueId(pv.id)"
+        :disabled="disabled"
+        :array-index="arrayIndex[pv.id]"
+        :array-length="arrayLength[pv.propId]"
         @toggle-collapsed="toggleCollapsed($event)"
         @updated-property="updatedProperty($event)"
+        @add-to-array="addToArray($event)"
+        @add-to-map="addToMap($event)"
       />
     </div>
   </div>
@@ -23,16 +29,34 @@ import {
   PropertyEditorPropWidgetKind,
   PropertyEditorSchema,
   PropertyEditorValues,
+  PropertyEditorValue,
+  PropertyEditorValidations,
   UpdatedProperty,
+  AddToArray,
+  AddToMap,
+  PropertyPath,
 } from "@/api/sdf/dal/property_editor";
 import { GlobalErrorService } from "@/service/global_error";
 import PropertyWidget from "./PropertyEditor/PropertyWidget.vue";
 import { ref, computed } from "vue";
 import _ from "lodash";
+import { ChangeSetService } from "@/service/change_set";
+import { refFrom } from "vuse-rx";
+import { switchMap, from } from "rxjs";
 
 const emits = defineEmits<{
   (e: "updatedProperty", v: UpdatedProperty): void;
+  (e: "addToArray", v: AddToArray): void;
+  (e: "addToMap", v: AddToMap): void;
 }>();
+
+const disabled = refFrom<boolean>(
+  ChangeSetService.currentEditMode().pipe(
+    switchMap((value) => {
+      return from([!value]);
+    }),
+  ),
+);
 
 const schema = ref<PropertyEditorSchema>({
   rootPropId: 0,
@@ -48,6 +72,7 @@ const schema = ref<PropertyEditorSchema>({
       name: "name",
       kind: PropertyEditorPropKind.String,
       widgetKind: PropertyEditorPropWidgetKind.Text,
+      docLink: "http://slashdot.org",
     },
     2: {
       id: 2,
@@ -85,11 +110,122 @@ const schema = ref<PropertyEditorSchema>({
       kind: PropertyEditorPropKind.String,
       widgetKind: PropertyEditorPropWidgetKind.Text,
     },
+    8: {
+      id: 8,
+      name: "songs",
+      kind: PropertyEditorPropKind.Array,
+      widgetKind: PropertyEditorPropWidgetKind.Array,
+    },
+    9: {
+      id: 9,
+      name: "song name",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    10: {
+      id: 10,
+      name: "books",
+      kind: PropertyEditorPropKind.Array,
+      widgetKind: PropertyEditorPropWidgetKind.Array,
+    },
+    11: {
+      id: 11,
+      name: "book",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    12: {
+      id: 12,
+      name: "author",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    13: {
+      id: 13,
+      name: "title",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    14: {
+      id: 14,
+      name: "volumes",
+      kind: PropertyEditorPropKind.Array,
+      widgetKind: PropertyEditorPropWidgetKind.Array,
+    },
+    15: {
+      id: 15,
+      name: "volume",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    16: {
+      id: 16,
+      name: "thingyboober",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    17: {
+      id: 17,
+      name: "env",
+      kind: PropertyEditorPropKind.Map,
+      widgetKind: PropertyEditorPropWidgetKind.Map,
+    },
+    18: {
+      id: 18,
+      name: "value",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    19: {
+      id: 19,
+      name: "slayer songs",
+      kind: PropertyEditorPropKind.Map,
+      widgetKind: PropertyEditorPropWidgetKind.Map,
+    },
+    20: {
+      id: 20,
+      name: "slayer song",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: PropertyEditorPropWidgetKind.Header,
+    },
+    21: {
+      id: 21,
+      name: "kills it",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    22: {
+      id: 22,
+      name: "every time",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
+    23: {
+      id: 23,
+      name: "reasons",
+      kind: PropertyEditorPropKind.Array,
+      widgetKind: PropertyEditorPropWidgetKind.Array,
+    },
+    24: {
+      id: 24,
+      name: "reason",
+      kind: PropertyEditorPropKind.String,
+      widgetKind: PropertyEditorPropWidgetKind.Text,
+    },
   },
   childProps: {
-    0: [1, 2, 3, 4],
+    0: [1, 2, 3, 4, 8, 10, 17, 19],
     4: [5],
     5: [6, 7],
+    8: [9],
+    10: [11],
+    11: [12, 13, 14],
+    14: [15],
+    15: [16],
+    17: [18],
+    19: [20],
+    20: [21, 22, 23],
+    23: [24],
   },
 });
 
@@ -136,13 +272,53 @@ const values = ref<PropertyEditorValues>({
       propId: 7,
       value: "for love",
     },
+    8: {
+      // strings
+      id: 8,
+      propId: 8,
+      value: [],
+    },
+    9: {
+      // books
+      id: 9,
+      propId: 10,
+      value: [],
+    },
+    10: {
+      id: 10,
+      propId: 17,
+      value: {},
+    },
+    11: {
+      id: 11,
+      propId: 19,
+      value: {},
+    },
   },
   childValues: {
-    0: [1, 2, 3, 4],
+    0: [1, 2, 3, 4, 8, 9, 10, 11],
     4: [5],
     5: [6, 7],
   },
 });
+
+const validations = ref<PropertyEditorValidations>({
+  validations: {
+    [1]: {
+      valueId: 1,
+      valid: false,
+      errors: [
+        {
+          message: "You should not be def leppard, dummy",
+        },
+      ],
+    },
+  },
+});
+
+const validationForValueId = (valueId: number) => {
+  return validations.value.validations[valueId];
+};
 
 const schemaForPropId = (propId: number) => {
   const schemaForProp = schema.value.props[propId];
@@ -165,7 +341,7 @@ const schemaForPropId = (propId: number) => {
   }
 };
 
-const collapsed = ref<Array<Array<string>>>([["snoop", "attributes"]]);
+const collapsed = ref<Array<Array<string>>>([]);
 const toggleCollapsed = (path: string[]) => {
   for (let x = 0; x < collapsed.value.length; x++) {
     const c = collapsed.value[x];
@@ -177,64 +353,267 @@ const toggleCollapsed = (path: string[]) => {
     }
   }
   collapsed.value.push(path);
+  console.log("new collapsed", { collapsed: JSON.stringify(collapsed.value) });
 };
 
-const pathForValueId = (valueId: number) => {
-  const path = [];
-  let toCheck: string | null = String(valueId);
-  CHECK: while (toCheck !== null) {
-    for (const [key, childValueIds] of Object.entries(
-      values.value.childValues,
-    )) {
-      for (const childValueId of childValueIds) {
-        if (String(childValueId) == toCheck) {
-          const parentValue = values.value.values[parseInt(key, 10)];
-          if (parentValue) {
-            const schemaProp = schema.value.props[parentValue.propId];
-            if (parentValue.key) {
-              path.push(parentValue.key);
-            } else {
-              path.push(schemaProp.name);
-            }
-            toCheck = key;
-          } else {
-            GlobalErrorService.set({
-              error: {
-                code: 56,
-                message: `missing parent value for value id ${childValueId}; bug!`,
-                statusCode: 55,
-              },
-            });
-          }
-          continue CHECK;
+const findParentProp = (propId: number) => {
+  for (const [parentPropId, childPropIds] of Object.entries(
+    schema.value.childProps,
+  )) {
+    for (const childProp of childPropIds) {
+      if (childProp == propId) {
+        const parentProp = schema.value.props[parseInt(parentPropId, 10)];
+        if (parentProp) {
+          return parentProp;
+        } else {
+          return undefined;
         }
       }
     }
-    toCheck = null;
   }
-  return path;
+};
+
+const pathPartForValueId = (valueId: number) => {
+  let displayPathPart = "bug";
+  let triggerPathPart = "bug";
+  const currentValue = values.value.values[valueId];
+  const currentProp = schema.value.props[currentValue.propId];
+  const parentProp = findParentProp(currentValue.propId);
+
+  if (currentValue && currentProp) {
+    if (parentProp) {
+      if (parentProp.kind == "array") {
+        const index = findArrayIndex(currentValue.id);
+        if (!_.isUndefined(index)) {
+          if (currentProp.kind == "object") {
+            displayPathPart = `[${index}](${currentProp.name})`;
+            triggerPathPart = `[${index}]`;
+          } else {
+            displayPathPart = `[${index}]`;
+            triggerPathPart = `[${index}]`;
+          }
+          return { displayPathPart, triggerPathPart };
+        }
+      } else if (parentProp.kind == "map") {
+        if (currentProp.kind == "object") {
+          displayPathPart = `{${currentValue.key}}(${currentProp.name})`;
+          triggerPathPart = `{${currentValue.key}}`;
+        } else {
+          displayPathPart = `{${currentValue.key}}`;
+          triggerPathPart = `{${currentValue.key}}`;
+        }
+        return { displayPathPart, triggerPathPart };
+      }
+    }
+    if (currentProp.kind == "array") {
+      const childCount = values.value.childValues[valueId];
+      let arrayLength = childCount ? childCount.length : 0;
+      displayPathPart = `${currentProp.name}[${arrayLength}]`;
+      triggerPathPart = `${currentProp.name}[]`;
+    } else if (currentProp.kind == "object") {
+      displayPathPart = currentProp.name;
+      triggerPathPart = currentProp.name;
+    } else if (currentProp.kind == "map") {
+      const childCount = values.value.childValues[valueId];
+      let mapLength = childCount ? childCount.length : 0;
+      displayPathPart = `${currentProp.name}{${mapLength}}`;
+      triggerPathPart = `${currentProp.name}{}`;
+    } else {
+      displayPathPart = currentProp.name;
+      triggerPathPart = currentProp.name;
+    }
+  }
+  return { displayPathPart, triggerPathPart };
+};
+
+const findParentPath = (
+  displayPath: string[],
+  triggerPath: string[],
+  valueId: number,
+) => {
+  for (const [parentValueId, childValueIds] of Object.entries(
+    values.value.childValues,
+  )) {
+    for (const childValueId of childValueIds) {
+      if (childValueId == valueId) {
+        const pathPart = pathPartForValueId(parseInt(parentValueId, 10));
+        displayPath.push(pathPart.displayPathPart);
+        triggerPath.push(pathPart.triggerPathPart);
+        findParentPath(displayPath, triggerPath, parseInt(parentValueId, 10));
+      }
+    }
+  }
+};
+
+const paths = computed<{ [valueId: number]: PropertyPath | undefined }>(() => {
+  const result: { [valueId: number]: PropertyPath } = {};
+  for (const propValue of Object.values(values.value.values)) {
+    // First, do ourselves - then our parents
+    const pathPart = pathPartForValueId(propValue.id);
+    const displayPath: string[] = [pathPart.displayPathPart];
+    const triggerPath: string[] = [pathPart.triggerPathPart];
+    findParentPath(displayPath, triggerPath, propValue.id);
+    result[propValue.id] = {
+      displayPath,
+      triggerPath,
+    };
+  }
+  return result;
+});
+
+const determineOrder = (
+  order: PropertyEditorValue[],
+  childValueIds: number[],
+): PropertyEditorValue[] => {
+  for (const childValueId of childValueIds) {
+    const child = values.value.values[childValueId];
+    order.push(child);
+    const childValuesList = values.value.childValues[childValueId];
+    if (childValuesList) {
+      determineOrder(order, childValuesList);
+    }
+  }
+  return order;
 };
 
 const propertyValuesInOrder = computed(() => {
-  const results = [];
-  const lookup = [values.value.rootValueId];
-  while (lookup.length) {
-    const nextValueId = lookup.shift();
-    if (nextValueId !== undefined) {
-      results.push(values.value.values[nextValueId]);
-      const childValuesList = values.value.childValues[nextValueId];
-      if (childValuesList) {
-        for (const childValueId of childValuesList) {
-          lookup.push(childValueId);
-        }
-      }
-    }
-  }
+  const results = determineOrder([], [values.value.rootValueId]);
+
+  console.log("property results", { results });
   return results;
 });
 
 const updatedProperty = (event: UpdatedProperty) => {
+  console.log("property editor sets field", { event });
   values.value.values[event.valueId].value = event.value;
   emits("updatedProperty", event);
 };
+
+let newArrayIds = 100;
+
+const generateValuesForPropId = (
+  propId: number,
+  valueId: number,
+  key?: string,
+) => {
+  const prop = schema.value.props[propId];
+  if (prop) {
+    for (const childPropId of schema.value.childProps[prop.id]) {
+      if (childPropId) {
+        const childProp = schema.value.props[childPropId];
+        if (childProp) {
+          let value;
+          if (childProp.kind == "array") {
+            key = "0";
+            value = [];
+          } else if (childProp.kind == "object" || childProp.kind == "map") {
+            value = {};
+          } else {
+            value = null;
+          }
+          newArrayIds = newArrayIds + 1;
+          const newValue: PropertyEditorValue = {
+            id: newArrayIds,
+            propId: childProp.id,
+            key,
+            value,
+          };
+          values.value.values[newValue.id] = newValue;
+          if (values.value.childValues[valueId]) {
+            values.value.childValues[valueId].push(newValue.id);
+          } else {
+            values.value.childValues[valueId] = [newValue.id];
+          }
+          if (childProp.kind == "object") {
+            generateValuesForPropId(childPropId, newArrayIds);
+          }
+        }
+      }
+    }
+  }
+};
+
+const addToArray = (event: AddToArray) => {
+  generateValuesForPropId(event.propId, event.valueId);
+  console.log("property editor adds to array", { event });
+  emits("addToArray", event);
+};
+
+const addToMap = (event: AddToMap) => {
+  generateValuesForPropId(event.propId, event.valueId, event.key);
+  console.log("property editor adds to map", { event });
+  emits("addToMap", event);
+};
+
+const findArrayIndex = (valueId: number) => {
+  let parentProp;
+  let index;
+  for (const [parentValueId, childValues] of Object.entries(
+    values.value.childValues,
+  )) {
+    for (let x = 0; x < childValues.length; x++) {
+      const cv = childValues[x];
+      if (cv == valueId) {
+        index = x;
+        const parentValue = values.value.values[parseInt(parentValueId, 10)];
+        if (parentValue) {
+          parentProp = schema.value.props[parentValue.propId];
+        }
+        break;
+      }
+    }
+  }
+  console.log("lets try this", { index, parentProp, valueId });
+  if (parentProp?.kind == "array") {
+    return index;
+  } else {
+    return undefined;
+  }
+};
+
+const findArrayLength = (propId: number) => {
+  const prop = schema.value.props[propId];
+  if (prop) {
+    if (prop.kind == "array") {
+      const arrayValue = _.find(values.value.values, ["propId", propId]);
+      if (arrayValue) {
+        const childrenOfArray = values.value.childValues[arrayValue.id];
+        if (childrenOfArray) {
+          return childrenOfArray.length;
+        } else {
+          return 0;
+        }
+      } else {
+        return undefined;
+      }
+    } else {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+};
+
+const arrayIndex = computed(() => {
+  const result: { [valueId: number]: number } = {};
+  for (const propValue of Object.values(values.value.values)) {
+    const length = findArrayIndex(propValue.id);
+    if (!_.isUndefined(length)) {
+      result[propValue.id] = length;
+    }
+  }
+  console.log("array index", { result });
+  return result;
+});
+
+const arrayLength = computed(() => {
+  const result: { [propId: number]: number } = {};
+  for (const propId in Object.keys(schema.value.props)) {
+    const length = findArrayLength(parseInt(propId, 10));
+    if (!_.isUndefined(length)) {
+      result[propId] = length;
+    }
+  }
+  return result;
+});
 </script>

--- a/app/web/src/organisims/PropertyEditor/UnsetButton.vue
+++ b/app/web/src/organisims/PropertyEditor/UnsetButton.vue
@@ -1,0 +1,10 @@
+<template>
+  <SiButtonIcon tooltip-text="Unset field">
+    <XCircleIcon />
+  </SiButtonIcon>
+</template>
+
+<script setup lang="ts">
+import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import { XCircleIcon } from "@heroicons/vue/solid";
+</script>

--- a/app/web/src/organisims/PropertyEditor/WidgetArray.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetArray.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <WidgetHeader
+      :name="props.name"
+      :path="props.path"
+      :collapsed-paths="props.collapsedPaths"
+      @toggle-collapsed="setCollapsed($event)"
+    />
+    <div
+      v-show="isShown && !isCollapsed && !props.disabled"
+      class="flex pl-8 pt-4 w-full"
+    >
+      <SiButton
+        kind="standard"
+        label="Add to array"
+        icon="plus"
+        @click="addToArray()"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from "vue";
+import SiButton from "@/atoms/SiButton.vue";
+import _ from "lodash";
+import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+import { AddToArray, PropertyPath } from "@/api/sdf/dal/property_editor";
+import WidgetHeader from "./WidgetHeader.vue";
+
+const props = defineProps<{
+  name: string;
+  path?: PropertyPath;
+  collapsedPaths: Array<Array<string>>;
+  disabled?: boolean;
+  propId: number;
+  valueId: number;
+  arrayLength?: number;
+}>();
+const emits = defineEmits<{
+  (e: "toggle-collapsed", path: Array<string>): void;
+  (e: "addToArray", v: AddToArray): void;
+}>();
+
+const setCollapsed = (path: Array<string>) => {
+  emits("toggle-collapsed", path);
+};
+
+const { name, path, collapsedPaths } = toRefs(props);
+const { isShown, isCollapsed } = usePropertyEditorIsShown(
+  name,
+  collapsedPaths,
+  path,
+  true,
+);
+
+const addToArray = () => {
+  emits("addToArray", {
+    propId: props.propId,
+    valueId: props.valueId,
+  });
+};
+</script>

--- a/app/web/src/organisims/PropertyEditor/WidgetHeader.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetHeader.vue
@@ -1,24 +1,26 @@
 <template>
   <div
+    v-show="isShown"
     class="flex flex-row w-full pl-7 pt-1 pb-1 mt-2 text-white cursor-pointer bg-gray-800 items-center h-12"
     @click="setCollapsed"
-    v-show="isShown"
   >
-    <div class="text-base font-extrabold">
-      {{ name }}
-    </div>
     <div
-      v-for="(part, index) of path"
+      v-for="(part, index) of displayPath"
       :key="index"
-      class="flex flex-row text-sm"
+      class="flex flex-row items-center"
     >
-      <ChevronLeftIcon class="h-5" /> {{ part }}
+      <span v-if="index == 0" class="text-base font-extrabold">
+        {{ part }}
+      </span>
+      <span v-else class="text-sm">
+        <ChevronLeftIcon class="pl-2 h-5 inline" /> {{ part }}
+      </span>
     </div>
     <div class="flex flex-grow justify-end pr-4">
-      <SiButtonIcon tooltip-text="Expand" v-if="isCollapsed">
+      <SiButtonIcon v-if="isCollapsed" tooltip-text="Expand">
         <ChevronUpIcon />
       </SiButtonIcon>
-      <SiButtonIcon tooltip-text="Collapse" v-else>
+      <SiButtonIcon v-else tooltip-text="Collapse">
         <ChevronDownIcon />
       </SiButtonIcon>
     </div>
@@ -32,10 +34,11 @@ import { ChevronLeftIcon } from "@heroicons/vue/outline";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/vue/solid";
 import _ from "lodash";
 import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+import { PropertyPath } from "@/api/sdf/dal/property_editor";
 
 const props = defineProps<{
   name: string;
-  path: string[];
+  path?: PropertyPath;
   collapsedPaths: Array<Array<string>>;
 }>();
 const emits = defineEmits<{
@@ -43,13 +46,26 @@ const emits = defineEmits<{
 }>();
 
 const setCollapsed = () => {
-  emits("toggle-collapsed", [props.name, ...props.path]);
+  if (props.path) {
+    console.log("collapsing", { triggerPath: props.path.triggerPath });
+    emits("toggle-collapsed", props.path.triggerPath);
+  }
 };
 
 const { name, path, collapsedPaths } = toRefs(props);
+
+const displayPath = computed(() => {
+  if (path && path.value) {
+    return path.value.displayPath;
+  } else {
+    return [];
+  }
+});
+
 const { isShown, isCollapsed } = usePropertyEditorIsShown(
   name,
-  path,
   collapsedPaths,
+  path,
+  true,
 );
 </script>

--- a/app/web/src/organisims/PropertyEditor/WidgetMap.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetMap.vue
@@ -1,0 +1,78 @@
+<template>
+  <div>
+    <WidgetHeader
+      :name="props.name"
+      :path="props.path"
+      :collapsed-paths="props.collapsedPaths"
+      @toggle-collapsed="setCollapsed($event)"
+    />
+    <div
+      v-show="isShown && !isCollapsed && !props.disabled"
+      class="pl-8 flex flex-col w-full pt-4"
+    >
+      <div class="w-full pr-24">
+        <SiTextBox :id="newKeyId" v-model="newKey" title="key" />
+      </div>
+      <div class="flex pt-4 pr-16">
+        <SiButton
+          kind="standard"
+          label="Add to map"
+          icon="plus"
+          :disabled="submitDisabled"
+          @click="addToMap()"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, toRefs, computed } from "vue";
+import SiTextBox from "@/atoms/SiTextBox2.vue";
+import SiButton from "@/atoms/SiButton.vue";
+import _ from "lodash";
+import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+import { AddToMap, PropertyPath } from "@/api/sdf/dal/property_editor";
+import WidgetHeader from "./WidgetHeader.vue";
+
+const props = defineProps<{
+  name: string;
+  path?: PropertyPath;
+  collapsedPaths: Array<Array<string>>;
+  disabled?: boolean;
+  propId: number;
+  valueId: number;
+  arrayLength?: number;
+}>();
+const emits = defineEmits<{
+  (e: "toggle-collapsed", path: Array<string>): void;
+  (e: "addToMap", v: AddToMap): void;
+}>();
+
+const setCollapsed = (path: Array<string>) => {
+  emits("toggle-collapsed", path);
+};
+
+const newKeyId = ref<string>(`newMap${props.valueId}`);
+const newKey = ref<string>("");
+const submitDisabled = computed(() => {
+  return newKey.value == "";
+});
+
+const { name, path, collapsedPaths } = toRefs(props);
+const { isShown, isCollapsed } = usePropertyEditorIsShown(
+  name,
+  collapsedPaths,
+  path,
+  true,
+);
+
+const addToMap = () => {
+  emits("addToMap", {
+    propId: props.propId,
+    valueId: props.valueId,
+    key: newKey.value,
+  });
+  newKey.value = "";
+};
+</script>

--- a/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
@@ -1,66 +1,129 @@
 <template>
-  <div v-show="isShown">
-    <SiTextBox
-      v-model="fieldValue"
-      :title="props.name"
-      :id="fieldId"
-      @blur="blurCallback"
-    />
+  <div v-show="isShown" class="flex content-center">
+    <div class="flex grow">
+      <div class="w-full">
+        <SiTextBox
+          :id="fieldId"
+          v-model="currentValue"
+          :title="props.name"
+          :doc-link="docLink"
+          :validations="validations"
+          :disabled="disabled"
+          always-validate
+          @blur="setField"
+        />
+      </div>
+    </div>
+    <div class="flex w-16 h-20 items-center justify-center">
+      <UnsetButton
+        v-if="!disabled"
+        :disabled="disableUnset"
+        @click="unsetField"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, toRefs, computed } from "vue";
+import { ref, toRefs, computed, watch } from "vue";
 import SiTextBox from "@/atoms/SiTextBox2.vue";
+import UnsetButton from "./UnsetButton.vue";
 import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
-import { UpdatedProperty } from "@/api/sdf/dal/property_editor";
+import {
+  PropertyEditorValidation,
+  UpdatedProperty,
+  PropertyPath,
+} from "@/api/sdf/dal/property_editor";
 import _ from "lodash";
+import { ValidatorArray } from "@/atoms/SiValidation.vue";
 
 const props = defineProps<{
   name: string;
-  path: string[];
+  path?: PropertyPath;
   collapsedPaths: Array<Array<string>>;
   value: unknown;
   propId: number;
   valueId: number;
+  docLink?: string;
+  validation?: PropertyEditorValidation;
+  disabled?: boolean;
 }>();
 
 const emit = defineEmits<{
-  (e: "update:modelValue", v: string): void;
   (e: "updatedProperty", v: UpdatedProperty): void;
 }>();
 
-const { name, path, collapsedPaths, valueId, propId } = toRefs(props);
-const currentValue = ref<string>(String(props.value));
+const { name, path, collapsedPaths, valueId, propId, value, validation } =
+  toRefs(props);
 
-const fieldValue = computed<string>({
-  get(): string {
-    if (_.isString(props.value)) {
-      return props.value;
-    } else {
-      return "";
+const currentValue = ref<string>("");
+watch(
+  value,
+  (newValue, oldValue) => {
+    if (oldValue != newValue) {
+      if (_.isString(newValue)) {
+        currentValue.value = newValue;
+      } else {
+        currentValue.value = "";
+      }
     }
   },
-  set(value) {
-    currentValue.value = value;
-    emit("update:modelValue", value);
-  },
+  { immediate: true },
+);
+
+const disableUnset = computed(() => {
+  if (_.isNull(value.value)) {
+    return true;
+  } else {
+    return false;
+  }
 });
 
-const fieldId = ref([props.name, ...props.path].join("."));
+// @ts-ignore
+const fieldId = ref(props.path.triggerPath.join("."));
 
-const { isShown } = usePropertyEditorIsShown(name, path, collapsedPaths);
+const { isShown } = usePropertyEditorIsShown(name, collapsedPaths, path);
 
-const blurCallback = () => {
-  console.log("updated property", {
+const setField = () => {
+  console.log("set field", {
+    fv: currentValue.value,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+  if (!_.isNull(currentValue.value)) {
+    emit("updatedProperty", {
+      value: currentValue.value,
+      propId: propId.value,
+      valueId: valueId.value,
+    });
+  }
+};
+
+const unsetField = () => {
+  console.log("unset field", {
     fv: currentValue.value,
     propId: propId.value,
     valueId: valueId.value,
   });
   emit("updatedProperty", {
-    value: currentValue.value,
+    value: null,
     propId: propId.value,
     valueId: valueId.value,
   });
 };
+
+const validations = computed(() => {
+  const results: ValidatorArray = [];
+  if (validation?.value) {
+    for (let x = 0; x < validation.value.errors.length; x++) {
+      const error = validation.value.errors[x];
+      results.push({
+        id: `${x}`,
+        message: error.message,
+        check: () => false,
+      });
+    }
+  }
+  return results;
+});
 </script>


### PR DESCRIPTION
This PR has a basic stub of a property editor, that implements a "flat"
editing structure. It uses labels on headers to denote nesting of
elements, rather than trying to nest the property editor itself using
whitespace.

It is not hooked up to the backend yet - but it does have examples of
updating values, adding to maps and arrays, and having complex
properties. It's ready to be hooked up to real data.

Shoutout to @fnichol, who helped write most of this.