### PR TITLE
feat(web): add booleans/checkbox widgets to property editor

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -15,7 +15,7 @@ export enum PropertyEditorPropKind {
 
 export enum PropertyEditorPropWidgetKind {
   Array = "array",
-  Checkbox = "checkbox",
+  CheckBox = "checkBox",
   Header = "header",
   Map = "map",
   SecretSelect = "secretSelect",

--- a/app/web/src/atoms/SiCheckBox.vue
+++ b/app/web/src/atoms/SiCheckBox.vue
@@ -1,0 +1,142 @@
+<template>
+  <label :for="props.id" class="block text-sm font-medium text-gray-200">
+    {{ props.title }} <span v-if="required">(required)</span>
+  </label>
+
+  <div class="mt-1 w-full relative">
+    <input
+      :id="props.id"
+      v-model="inputValue"
+      :data-test="props.id"
+      type="checkbox"
+      :name="props.id"
+      :autocomplete="props.id"
+      :aria-invalid="inError"
+      :disabled="props.disabled"
+      :indeterminate.prop="isIndeterminate"
+      required
+      class="appearance-none block px-3 py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm checked:bg-gray-900 bg-gray-600 indeterminate:bg-gray-900"
+      :class="checkBoxClasses"
+      @blur="setDirty"
+    />
+    <div
+      v-if="inError"
+      class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none"
+    >
+      <ExclamationCircleIcon class="h-5 w-5 text-red-400" aria-hidden="true" />
+    </div>
+  </div>
+
+  <p v-if="props.docLink" class="mt-2 text-xs text-blue-300">
+    <a :href="props.docLink" target="_blank" class="hover:underline">
+      Documentation
+    </a>
+  </p>
+
+  <p v-if="props.description" class="mt-2 text-xs text-gray-300">
+    {{ props.description }}
+  </p>
+
+  <SiValidation
+    :value="String(inputValue)"
+    :validations="validations"
+    :required="required"
+    :dirty="reallyDirty"
+    class="mt-2"
+    @errors="setInError($event)"
+  />
+</template>
+
+<script setup lang="ts">
+import { ExclamationCircleIcon } from "@heroicons/vue/solid";
+import SiValidation, {
+  ValidatorArray,
+  ErrorsArray,
+} from "@/atoms/SiValidation.vue";
+import { computed, ref } from "vue";
+import _ from "lodash";
+
+const props = defineProps<{
+  modelValue?: boolean;
+  title: string;
+  id: string;
+  description?: string;
+
+  validations?: ValidatorArray;
+  required?: boolean;
+  alwaysValidate?: boolean;
+
+  docLink?: string;
+
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits(["update:modelValue", "error", "blur"]);
+
+const dirty = ref<boolean>(false);
+const setDirty = () => {
+  dirty.value = true;
+  emit("blur", inputValue);
+};
+
+const reallyDirty = computed(() => {
+  if (props.alwaysValidate) {
+    return true;
+  }
+  return dirty.value;
+});
+
+const inError = ref<boolean>(false);
+const setInError = (errors: ErrorsArray) => {
+  let nextInError = false;
+  if (errors.length == 1) {
+    if (_.find(errors, (e) => e.id == "required")) {
+      if (dirty.value) {
+        nextInError = true;
+      }
+    } else {
+      nextInError = true;
+    }
+  } else if (errors.length > 1) {
+    nextInError = true;
+  }
+  inError.value = nextInError;
+  emit("error", inError);
+};
+
+const inputValue = computed<boolean | undefined>({
+  get() {
+    return props.modelValue;
+  },
+  set(value) {
+    emit("update:modelValue", value);
+  },
+});
+
+const isIndeterminate = computed(() => {
+  if (_.isUndefined(props.modelValue)) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
+const checkBoxClasses = computed((): Record<string, boolean> => {
+  if (inError.value) {
+    return {
+      "border-red-400": true,
+      "focus:ring-red-400": true,
+      "focus:border-red-400": true,
+      "checked:border-red-400": true,
+      "indeterminate:border-red-400": true,
+    };
+  }
+  return {
+    "border-gray-600": true,
+    "focus:ring-indigo-200": true,
+    "focus:border-indigo-200": true,
+    "checked:border-gray-600": true,
+    "indeterminate:border-gray-600": true,
+  };
+});
+</script>

--- a/app/web/src/organisims/PropertyEditor.vue
+++ b/app/web/src/organisims/PropertyEditor.vue
@@ -235,9 +235,16 @@ watch(editorContext, (newValue) => {
 //      kind: PropertyEditorPropKind.String,
 //      widgetKind: PropertyEditorPropWidgetKind.Text,
 //    },
+//    25: {
+//      id: 25,
+//      name: "isHip",
+//      kind: PropertyEditorPropKind.Boolean,
+//      widgetKind: PropertyEditorPropWidgetKind.CheckBox,
+//      docLink: "https://www.songfacts.com/facts/tower-of-power/what-is-hip",
+//    },
 //  },
 //  childProps: {
-//    0: [1, 2, 3, 4, 8, 10, 17, 19],
+//    0: [1, 2, 3, 25, 4, 8, 10, 17, 19],
 //    4: [5],
 //    5: [6, 7],
 //    8: [9],
@@ -317,9 +324,14 @@ watch(editorContext, (newValue) => {
 //      propId: 19,
 //      value: {},
 //    },
+//    12: {
+//      id: 12,
+//      propId: 25,
+//      value: {},
+//    },
 //  },
 //  childValues: {
-//    0: [1, 2, 3, 4, 8, 9, 10, 11],
+//    0: [1, 2, 3, 12, 4, 8, 9, 10, 11],
 //    4: [5],
 //    5: [6, 7],
 //  },
@@ -333,6 +345,15 @@ watch(editorContext, (newValue) => {
 //      errors: [
 //        {
 //          message: "You should not be def leppard, dummy",
+//        },
+//      ],
+//    },
+//    [12]: {
+//      valueId: 12,
+//      valid: false,
+//      errors: [
+//        {
+//          message: "You ain't just exactly sure what is hip",
 //        },
 //      ],
 //    },

--- a/app/web/src/organisims/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisims/PropertyEditor/PropertyWidget.vue
@@ -52,6 +52,20 @@
       class="py-4 px-8"
       @updated-property="updatedProperty($event)"
     />
+    <WidgetCheckBox
+      v-else-if="props.schemaProp.widgetKind == 'checkBox'"
+      :name="props.schemaProp.name"
+      :path="path"
+      :collapsed-paths="props.collapsedPaths"
+      :value="props.propValue.value"
+      :prop-id="props.propValue.propId"
+      :value-id="props.propValue.id"
+      :doc-link="props.schemaProp.docLink"
+      :validation="props.validation"
+      :disabled="props.disabled"
+      class="py-4 px-8"
+      @updated-property="updatedProperty($event)"
+    />
     <!--<div v-else>
       <div class="flex">
         {{ props.path }}
@@ -80,6 +94,7 @@ import {
 } from "@/api/sdf/dal/property_editor";
 import WidgetHeader from "./WidgetHeader.vue";
 import WidgetTextBox from "./WidgetTextBox.vue";
+import WidgetCheckBox from "./WidgetCheckBox.vue";
 import WidgetArray from "./WidgetArray.vue";
 import WidgetMap from "./WidgetMap.vue";
 import _ from "lodash";

--- a/app/web/src/organisims/PropertyEditor/WidgetCheckBox.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetCheckBox.vue
@@ -1,0 +1,119 @@
+<template>
+  <div v-show="isShown" class="flex content-center">
+    <div class="flex grow">
+      <div class="w-full">
+        <SiCheckBox
+          :id="fieldId"
+          v-model="currentValue"
+          :title="props.name"
+          :doc-link="docLink"
+          :validations="validations"
+          :disabled="disabled"
+          always-validate
+          @blur="setField"
+        />
+      </div>
+    </div>
+    <div class="flex w-16 h-20 items-center justify-center">
+      <UnsetButton
+        v-if="!disabled"
+        :disabled="disableUnset"
+        @click="unsetField"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, toRefs, computed, watch } from "vue";
+import SiCheckBox from "@/atoms/SiCheckBox.vue";
+import UnsetButton from "./UnsetButton.vue";
+import { usePropertyEditorIsShown } from "@/composables/usePropertyEditorIsShown";
+import {
+  PropertyEditorValidation,
+  UpdatedProperty,
+  PropertyPath,
+} from "@/api/sdf/dal/property_editor";
+import _ from "lodash";
+import { ValidatorArray } from "@/atoms/SiValidation.vue";
+
+const props = defineProps<{
+  name: string;
+  path?: PropertyPath;
+  collapsedPaths: Array<Array<string>>;
+  value: unknown;
+  propId: number;
+  valueId: number;
+  docLink?: string;
+  validation?: PropertyEditorValidation;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "updatedProperty", v: UpdatedProperty): void;
+}>();
+
+const { name, path, collapsedPaths, valueId, propId, value, validation } =
+  toRefs(props);
+
+const currentValue = ref<boolean | undefined>(undefined);
+watch(
+  value,
+  (newValue, oldValue) => {
+    if (oldValue != newValue) {
+      if (_.isBoolean(newValue)) {
+        currentValue.value = newValue;
+      } else {
+        currentValue.value = undefined;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+const disableUnset = computed(() => {
+  if (_.isNull(value.value)) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
+// @ts-ignore
+const fieldId = ref(props.path.triggerPath.join("."));
+
+const { isShown } = usePropertyEditorIsShown(name, collapsedPaths, path);
+
+const setField = () => {
+  if (!_.isNull(currentValue.value)) {
+    emit("updatedProperty", {
+      value: currentValue.value,
+      propId: propId.value,
+      valueId: valueId.value,
+    });
+  }
+};
+
+const unsetField = () => {
+  emit("updatedProperty", {
+    value: null,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+};
+
+const validations = computed(() => {
+  const results: ValidatorArray = [];
+  if (validation?.value) {
+    for (let x = 0; x < validation.value.errors.length; x++) {
+      const error = validation.value.errors[x];
+      results.push({
+        id: `${x}`,
+        message: error.message,
+        check: () => false,
+      });
+    }
+  }
+  return results;
+});
+</script>


### PR DESCRIPTION
This change adds an `SiCheckBox` atom that is similar is scope and
behavior to the `SiTextBox2` for text fields and a primary consuming
component `WidgetCheckBox` to handle the remaining widget behavior.

Note that unlike prior implementations, this checkbox version can accept
a raw value that is `null`, leading to a non-checked (i.e.
false-by-default) checkbox that is set into an [indeterminate state].
While this is primarily a display-only concern (as far as HTML/DOM
goes), it means that we can signal when an unset value is present for a
boolean. Additionally this means that we can set the checkbox state to
checked (i.e. set `true`) or unchecked (i.e. set `false`) and then use
the unset button to set the underlying value to `null`.

[indeterminate state]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>