### PR TITLE
fix(web): Hide unset button for name.si.root

### DIFF
--- a/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
+++ b/app/web/src/organisims/PropertyEditor/WidgetTextBox.vue
@@ -15,7 +15,7 @@
         />
       </div>
     </div>
-    <div class="flex w-16 h-20 items-center justify-center">
+    <div v-if="canUnset" class="flex w-16 h-20 items-center justify-center">
       <UnsetButton
         v-if="!disabled"
         :disabled="disableUnset"
@@ -133,4 +133,8 @@ const triggerBlur = (event: KeyboardEvent) => {
     event.target.blur();
   }
 };
+
+const canUnset = computed(() => {
+  return (props.path?.triggerPath ?? []).join(".") !== "name.si.root";
+});
 </script>


### PR DESCRIPTION
Horrible hack that ensures you can't remove a node name, as it's used by
the interface.

Eventually we should think about a MustBeSetTextWidget or whatever that
ensures a Prop can't be unset (will require a default AttributePrototype).

<img src="https://media3.giphy.com/media/lp3GUtG2waC88/giphy.gif"/>