### PR TITLE
fix(web,dal,cyclone,langjs): qualification display

### DIFF
--- a/app/web/src/api/sdf/dal/qualification.ts
+++ b/app/web/src/api/sdf/dal/qualification.ts
@@ -1,6 +1,5 @@
 export interface Qualification {
-  name: string;
-  title?: string;
+  title: string;
   link?: string;
   description?: string;
   result?: QualificationResult;
@@ -11,7 +10,7 @@ export interface QualificationResult {
   title?: string;
   link?: string;
   success: boolean;
-  sub_checks?: Array<{
+  sub_checks: Array<{
     status: "Success" | "Failure" | "Unknown";
     description: string;
   }>;

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -30,11 +30,11 @@
         <div class="flex flex-col w-full">
           <div
             v-for="q in allQualifications"
-            :key="q.name"
+            :key="q.title"
             class="flex flex-col py-1 mx-2 mt-2 text-sm border qualification-section"
           >
             <div class="flex flex-row items-center w-full pl-4 my-1">
-              <div v-if="qualificationStarting(q.name)" class="flex">
+              <div v-if="qualificationStarting(q.title)" class="flex">
                 <VueLoading
                   class="inline-flex"
                   type="cylon"
@@ -79,10 +79,10 @@
               >
                 <button
                   class="focus:outline-none"
-                  @click="toggleShowDescription(q.name)"
+                  @click="toggleShowDescription(q.title)"
                 >
                   <SiIcon
-                    v-if="showDescriptionMap[q.name] === true"
+                    v-if="showDescriptionMap[q.title] === true"
                     tooltip-text="Show description"
                   >
                     <ChevronDownIcon />
@@ -95,7 +95,7 @@
             </div>
 
             <div
-              v-if="showDescriptionMap[q.name] === true"
+              v-if="showDescriptionMap[q.title] === true"
               class="flex flex-col w-full"
             >
               <!-- NOTE(nick): output is optional and can be empty. -->
@@ -258,8 +258,8 @@ const toggleShowDescription = (name: string) => {
 
 const populateShowDescription = (qualifications: Array<Qualification>) => {
   for (const q of qualifications) {
-    if (!showDescriptionMap.value[q.name]) {
-      showDescriptionMap.value[q.name] = false;
+    if (!showDescriptionMap.value[q.title]) {
+      showDescriptionMap.value[q.title] = false;
     }
   }
 };

--- a/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
+++ b/app/web/src/organisims/QualificationViewer/QualificationOutput.vue
@@ -55,7 +55,7 @@ const props = defineProps<{
 }>();
 
 const subChecks = computed(() => {
-  if (props.result.sub_checks) {
+  if (props.result.sub_checks.length > 0) {
     return props.result.sub_checks;
   } else if (props.result.success) {
     return [

--- a/bin/lang-js/src/qualification_check.ts
+++ b/bin/lang-js/src/qualification_check.ts
@@ -39,7 +39,7 @@ export interface QualificationCheckResultSuccess extends ResultSuccess {
   qualified: boolean;
   title?: string;
   link?: string;
-  subChecks?: Array<{
+  subChecks: Array<{
     status: "Success" | "Failure" | "Unknown",
     description: string,
   }>,
@@ -137,7 +137,7 @@ async function execute(
     executionId,
     title: qualificationCheckResult["title"],
     link: qualificationCheckResult["link"],
-    subChecks: qualificationCheckResult["subChecks"],
+    subChecks: qualificationCheckResult["subChecks"] ?? [],
     qualified: qualificationCheckResult["qualified"],
   };
   if (qualificationCheckResult["message"]) {

--- a/lib/cyclone/src/qualification_check.rs
+++ b/lib/cyclone/src/qualification_check.rs
@@ -48,7 +48,7 @@ pub struct QualificationCheckResultSuccess {
     pub qualified: bool,
     pub title: Option<String>,
     pub link: Option<String>,
-    pub sub_checks: Option<Vec<QualificationSubCheck>>,
+    pub sub_checks: Vec<QualificationSubCheck>,
     pub message: Option<String>,
     pub timestamp: u64,
 }
@@ -64,7 +64,7 @@ pub(crate) mod server {
         pub qualified: bool,
         pub title: Option<String>,
         pub link: Option<String>,
-        pub sub_checks: Option<Vec<QualificationSubCheck>>,
+        pub sub_checks: Vec<QualificationSubCheck>,
         pub message: Option<String>,
     }
 

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -24,7 +24,7 @@ pub struct QualificationResult {
     pub success: bool,
     pub title: Option<String>,
     pub link: Option<String>,
-    pub sub_checks: Option<Vec<QualificationSubCheck>>,
+    pub sub_checks: Vec<QualificationSubCheck>,
 }
 
 /// A view on "OutputStream" from cyclone.
@@ -66,7 +66,7 @@ impl QualificationView {
                 success,
                 title: None,
                 link: None,
-                sub_checks: Some(sub_checks),
+                sub_checks,
             }),
         }
     }


### PR DESCRIPTION
- QualificationView has a title, not a name, and it's required
- Make QualificationView::sub_checks into a required vec

Before we were inconsistent, some qualifications returned empty
array for the sub_checks, others null, so the front-end was
treating them differently. Now if not there, it's empty.

<img src="https://media2.giphy.com/media/KgDzEYbC4eG5eXPMJy/giphy.gif"/>