### PR TITLE
feat(web): filter container child value types from api

### DIFF
--- a/app/web/src/organisims/PropertyEditor.vue
+++ b/app/web/src/organisims/PropertyEditor.vue
@@ -587,7 +587,6 @@ const findArrayIndex = (valueId: number) => {
       }
     }
   }
-  console.log("lets try this", { index, parentProp, valueId });
   if (parentProp?.kind == "array") {
     return index;
   } else {


### PR DESCRIPTION
This change removes child entries in
`propertyEditorContext.values.childValues` whose entries are *not*
elements of the parent array or map values of the parent map.

Ideally the backend api should filter these out, but until then the
front end will by looking for children of arrays and maps that have a
`null` key (meaning that they are not element/value members of the
collection--neat trick, no?).

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>

<img src="https://media1.giphy.com/media/MXpVk1PmdSvAmNjvUg/giphy.gif"/>