### PR TITLE
feat(web,dal): Order YAML according to prop order

### DIFF
--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -231,10 +231,7 @@ const qualificationTooltip = computed(() => {
 });
 
 const qualificationColor = computed(() => {
-  if (
-    !componentMetadata.value ||
-    componentMetadata.value.qualified === undefined
-  ) {
+  if (!componentMetadata.value || componentMetadata.value.qualified === null) {
     return "#5b6163";
   } else if (componentMetadata.value.qualified) {
     return "#86f0ad";

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -177,7 +177,7 @@ impl FuncBinding {
         Ok((object, created))
     }
 
-    standard_model_accessor!(args, Json<JsonValue>, FuncBindingResult);
+    standard_model_accessor!(args, PlainJson<JsonValue>, FuncBindingResult);
     standard_model_accessor!(backend_kind, Enum(FuncBackendKind), FuncBindingResult);
     standard_model_belongs_to!(
         lookup_fn: func,

--- a/lib/dal/src/migrations/U0042__funcs.sql
+++ b/lib/dal/src/migrations/U0042__funcs.sql
@@ -32,7 +32,7 @@ CREATE TABLE func_bindings
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
-    args                        jsonb                    NOT NULL,
+    args                        json                     NOT NULL,
     backend_kind                text                     NOT NULL
 );
 SELECT standard_model_table_constraints_v1('func_bindings');
@@ -101,7 +101,7 @@ $$ LANGUAGE PLPGSQL VOLATILE;
 CREATE OR REPLACE FUNCTION func_binding_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
-    this_args jsonb,
+    this_args json,
     this_backend_kind text,
     OUT object json) AS
 $$
@@ -134,7 +134,7 @@ $$ LANGUAGE PLPGSQL VOLATILE;
 CREATE OR REPLACE FUNCTION func_binding_find_or_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
-    this_args jsonb,
+    this_args json,
     this_backend_kind text,
     this_func_id bigint,
     OUT object json, OUT created bool) AS
@@ -154,7 +154,7 @@ BEGIN
     INNER JOIN func_binding_belongs_to_func ON
         func_binding_belongs_to_func.object_id = func_bindings.id
         AND func_binding_belongs_to_func.belongs_to_id = this_func_id
-    WHERE func_bindings.args = this_args
+    WHERE func_bindings.args::jsonb = this_args::jsonb
         AND func_bindings.backend_kind = this_backend_kind
         AND in_tenancy_v1(this_tenancy,
           func_bindings.tenancy_universal,
@@ -183,7 +183,7 @@ BEGIN
       INNER JOIN func_binding_belongs_to_func ON
           func_binding_belongs_to_func.object_id = func_bindings.id
           AND func_binding_belongs_to_func.belongs_to_id = this_func_id
-      WHERE func_bindings.args = this_args
+      WHERE func_bindings.args::jsonb = this_args::jsonb
           AND func_bindings.backend_kind = this_backend_kind
           AND in_tenancy_v1(this_tenancy,
             func_bindings.tenancy_universal,
@@ -213,7 +213,7 @@ BEGIN
       INNER JOIN func_binding_belongs_to_func ON
           func_binding_belongs_to_func.object_id = func_bindings.id
           AND func_binding_belongs_to_func.belongs_to_id = this_func_id
-      WHERE func_bindings.args = this_args
+      WHERE func_bindings.args::jsonb = this_args::jsonb
           AND func_bindings.backend_kind = this_backend_kind
           AND in_tenancy_v1(this_tenancy,
             func_bindings.tenancy_universal,

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -679,4 +679,14 @@ macro_rules! standard_model_accessor {
             $result_type,
         );
     };
+
+    ($column:ident, PlainJson<$value_type:ident>, $result_type:ident $(,)?) => {
+        standard_model_accessor!(@get_column $column, $value_type);
+        standard_model_accessor!(@set_column
+            $column,
+            $value_type,
+            $crate::standard_model::TypeHint::Json,
+            $result_type,
+        );
+    };
 }

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -37,6 +37,7 @@ pub enum TypeHint {
     SmallInt,
     Text,
     JsonB,
+    Json,
 }
 
 #[instrument(skip(ctx))]


### PR DESCRIPTION
This doesn't follow the original spec, which was a hardcoded hack to have sorted fields in the user tests. For now the performance tradeoff when ensuring the js function args are ordered according to what the user sees seems worth it. The problem was that jsonb isn't ordered like the json text is, everywhere else ordering is ensured.

- Change func bindings to json instead of jsonb to preserve order. This may affect performance, but it's a quick way to a significant usability gain that can be optimized if proved a bottleneck
- Create new standard accessor for textual Json, the name PlainJson doesn't seem ideal but we want the default to be JsonB, so let's make using raw Json noisy
- Fix AttributeViewer to properly show executing qualifications.

<img src="https://media1.giphy.com/media/tJMVcTfzDdL1pOGxlk/giphy.gif"/>
