### PR TITLE
chore(web): co-locate all attribute panel viewers

### DIFF
--- a/app/web/src/organisims/PanelAttribute.vue
+++ b/app/web/src/organisims/PanelAttribute.vue
@@ -34,6 +34,7 @@
           <SiButtonIcon
             tooltip-text="Attributes"
             :selected="activeView === 'attribute'"
+            class="pl-1"
             @click="setActiveView('attribute')"
           >
             <ClipboardListIcon />
@@ -54,9 +55,7 @@
           >
             <CheckCircleIcon />
           </SiButtonIcon>
-        </div>
 
-        <div class="flex flex-row items-center">
           <!--
           <SiButtonIcon
             tooltip-text="Connection Viewer (not implemented yet)"
@@ -78,13 +77,12 @@
           <SiButtonIcon
             tooltip-text="Providers"
             :selected="activeView === 'provider'"
+            class="pl-1"
             @click="setActiveView('provider')"
           >
             <BeakerIcon />
           </SiButtonIcon>
-        </div>
 
-        <div class="flex items-center">
           <!--
           <SiButtonIcon
             tooltip-text="Action Viewer (not implemented yet)"
@@ -97,6 +95,7 @@
           <SiButtonIcon
             tooltip-text="Resources"
             :selected="activeView === 'resource'"
+            class="pl-1"
             @click="setActiveView('resource')"
           >
             <CubeIcon />


### PR DESCRIPTION
Co-locate all attribute panel viewers since the existing separation is
an artifact from demo v0.4. From our iconography changes and overhauls
to the frontend (and from disabling the unused viewers), we are in a
place where the separation makes little sense currently.

<img src="https://media2.giphy.com/media/1g3roDSU5NmwCDAhSW/giphy.gif"/>

Fixes ENG-223