### PR TITLE
chore(dal): compile tests with `opt-level = 1`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,5 +3,5 @@ rustflags = [
     "-C", "link-arg=-fuse-ld=lld",
 ]
 
-[profile.test]
-opt-level = 3
+[profile.test.package.dal]
+opt-level = 1


### PR DESCRIPTION
This change makes a slightly more surgical fix to only apply basic
optimizations to the `dal` crate in the `test` profile.

---

Here's the timings of `cargo test --no-run` for `lib/dal` on my Thelio
Major after a `cargo clean`:

global/opt-level = 3
---------------------

real    2m12.534s
user    19m55.849s
sys     1m31.764s

dal/opt-level = 3
-----------------

real    2m12.822s
user    11m58.238s
sys     1m11.743s

dal/opt-level = 1
-----------------

real    1m42.353s
user    8m43.226s
sys     1m9.093s

default (no optimizations)
--------------------------

real    0m58.249s
user    5m59.439s
sys     0m58.131s

<img src="https://media1.giphy.com/media/TU76e2JHkPchG/giphy.gif"/>