### PR TITLE
chore(dal): replace "list_for_context" and "pop"

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -356,9 +356,17 @@ impl AttributeValue {
         Ok(standard_model::option_object_from_row(row)?)
     }
 
-    /// List [`AttributeValues`](crate::AttributeValue) for a given
-    /// [`AttributeReadContext`](crate::AttributeReadContext). This does _not_ work for maps and
-    /// arrays! For those objects, please use [`Self::find_with_parent_and_key_for_context()`].
+    /// List [`AttributeValues`](crate::AttributeValue) for a provided
+    /// [`AttributeReadContext`](crate::AttributeReadContext).
+    ///
+    /// If you only anticipate one result to be returned and have an
+    /// [`AttributeReadContext`](crate::AttributeReadContext)
+    /// that is also a valid [`AttributeContext`](crate::AttributeContext), then you should use
+    /// [`Self::find_for_context()`] instead of this method.
+    ///
+    /// This does _not_ work for maps and arrays, barring the _first_ instance of the array or map
+    /// object themselves! For those objects, please use
+    /// [`Self::find_with_parent_and_key_for_context()`].
     pub async fn list_for_context(
         ctx: &DalContext<'_, '_>,
         context: AttributeReadContext,
@@ -374,14 +382,18 @@ impl AttributeValue {
         Ok(standard_model::objects_from_rows(rows)?)
     }
 
-    /// Find one [`AttributeValue`](crate::AttributeValue) for a given
-    /// [`AttributeReadContext`](crate::AttributeReadContext). This does _not_ work for maps and arrays!
-    /// For those objects, please use [`Self::find_with_parent_and_key_for_context()`].
+    /// Find one [`AttributeValue`](crate::AttributeValue) for a provided
+    /// [`AttributeReadContext`](crate::AttributeReadContext).
     ///
-    /// This is a modified version of [`Self::list_for_context()`] that requires an [`AttributeReadContext`](crate::AttributeReadContext)
+    /// This is a modified version of [`Self::list_for_context()`] that requires an
+    /// [`AttributeReadContext`](crate::AttributeReadContext)
     /// that is also a valid [`AttributeContext`](crate::AttributeContext) _and_ "pops" the first
     /// row off the rows found (which are sorted from most to least specific). Thus, the "popped"
     /// row will corresponding to the most specific [`AttributeValue`] found.
+    ///
+    /// This does _not_ work for maps and arrays, barring the _first_ instance of the array or map
+    /// object themselves! For those objects, please use
+    /// [`Self::find_with_parent_and_key_for_context()`].
     pub async fn find_for_context(
         ctx: &DalContext<'_, '_>,
         context: AttributeReadContext,

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -898,9 +898,8 @@ pub async fn create_string_prop_with_default(
         ..AttributeReadContext::default()
     };
 
-    let mut attribute_value = AttributeValue::list_for_context(ctx, attribute_value_context)
+    let mut attribute_value = AttributeValue::find_for_context(ctx, attribute_value_context)
         .await?
-        .pop()
         .ok_or(AttributeValueError::Missing)?;
     attribute_value
         .set_func_binding_id(ctx, *func_binding.id())

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1425,9 +1425,8 @@ impl Component {
             };
 
             return Ok(Some(
-                AttributeValue::list_for_context(ctx, read_context)
+                AttributeValue::find_for_context(ctx, read_context)
                     .await?
-                    .pop()
                     .ok_or(AttributeValueError::Missing)?,
             ));
         };

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -244,10 +244,9 @@ impl Prop {
             prop_id: Some(*self.id()),
             ..AttributeReadContext::default()
         };
-        let our_attribute_value = AttributeValue::list_for_context(ctx, attribute_read_context)
+        let our_attribute_value = AttributeValue::find_for_context(ctx, attribute_read_context)
             .await
             .map_err(|e| PropError::AttributeValue(format!("{e}")))?
-            .pop()
             .ok_or_else(|| {
                 PropError::AttributeValue(format!(
                     "missing attribute value for context: {:?}",
@@ -260,10 +259,9 @@ impl Prop {
             ..AttributeReadContext::default()
         };
         let parent_attribute_value =
-            AttributeValue::list_for_context(ctx, parent_attribute_read_context)
+            AttributeValue::find_for_context(ctx, parent_attribute_read_context)
                 .await
                 .map_err(|e| PropError::AttributeValue(format!("{e}")))?
-                .pop()
                 .ok_or_else(|| {
                     PropError::AttributeValue(format!(
                         "missing attribute value for context: {:?}",

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -56,9 +56,8 @@ impl RootProp {
             .to_context()?;
         let (_, root_value_id, _) = AttributeValue::update_for_context(
             ctx,
-            *AttributeValue::list_for_context(ctx, root_context.into())
+            *AttributeValue::find_for_context(ctx, root_context.into())
                 .await?
-                .pop()
                 .ok_or(AttributeValueError::Missing)?
                 .id(),
             None,
@@ -78,9 +77,8 @@ impl RootProp {
             .to_context()?;
         let (_, si_value_id, _) = AttributeValue::update_for_context(
             ctx,
-            *AttributeValue::list_for_context(ctx, si_context.into())
+            *AttributeValue::find_for_context(ctx, si_context.into())
                 .await?
-                .pop()
                 .ok_or(AttributeValueError::Missing)?
                 .id(),
             Some(root_value_id),
@@ -100,9 +98,8 @@ impl RootProp {
             .to_context()?;
         AttributeValue::update_for_context(
             ctx,
-            *AttributeValue::list_for_context(ctx, si_name_context.into())
+            *AttributeValue::find_for_context(ctx, si_name_context.into())
                 .await?
-                .pop()
                 .ok_or(AttributeValueError::Missing)?
                 .id(),
             Some(si_value_id),
@@ -122,9 +119,8 @@ impl RootProp {
             .to_context()?;
         AttributeValue::update_for_context(
             ctx,
-            *AttributeValue::list_for_context(ctx, domain_context.into())
+            *AttributeValue::find_for_context(ctx, domain_context.into())
                 .await?
-                .pop()
                 .ok_or(AttributeValueError::Missing)?
                 .id(),
             Some(root_value_id),

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -401,10 +401,9 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("cannot create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not fetch domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let bohemian_context = base_attribute_context
@@ -412,10 +411,9 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*bohemian_prop.id())
         .to_context()
         .expect("cannot create bohemian AttributeContext");
-    let bohemian_value = AttributeValue::list_for_context(ctx, bohemian_context.into())
+    let bohemian_value = AttributeValue::find_for_context(ctx, bohemian_context.into())
         .await
         .expect("could not retrieve bohemian AttributeValue")
-        .pop()
         .expect("could not find bohemian AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -433,10 +431,9 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*killer_prop.id())
         .to_context()
         .expect("cannot create killer AttributeContext");
-    let killer_value = AttributeValue::list_for_context(ctx, killer_context.into())
+    let killer_value = AttributeValue::find_for_context(ctx, killer_context.into())
         .await
         .expect("could not retrieve killer AttributeValue")
-        .pop()
         .expect("could not find killer AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -496,10 +493,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("cannot create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not fetch domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let queen_context = base_attribute_context
@@ -507,10 +503,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*queen_prop.id())
         .to_context()
         .expect("cannot create queen AttributeContext");
-    let unset_queen_value = AttributeValue::list_for_context(ctx, queen_context.into())
+    let unset_queen_value = AttributeValue::find_for_context(ctx, queen_context.into())
         .await
         .expect("could not retrieve queen AttributeValue")
-        .pop()
         .expect("could not find queen AttributeValue");
     let (_, queen_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -528,10 +523,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*bohemian_prop.id())
         .to_context()
         .expect("cannot create bohemian AttributeContext");
-    let unset_bohemian_value = AttributeValue::list_for_context(ctx, bohemian_context.into())
+    let unset_bohemian_value = AttributeValue::find_for_context(ctx, bohemian_context.into())
         .await
         .expect("could not retrieve bohemian AttributeValue")
-        .pop()
         .expect("could not find bohemian AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -549,10 +543,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*killer_prop.id())
         .to_context()
         .expect("cannot create killer AttributeContext");
-    let unset_killer_value = AttributeValue::list_for_context(ctx, killer_context.into())
+    let unset_killer_value = AttributeValue::find_for_context(ctx, killer_context.into())
         .await
         .expect("could not retrieve killer AttributeValue")
-        .pop()
         .expect("could not find killer AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -619,10 +612,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("cannot create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not fetch domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeContext");
 
     let queen_context = base_attribute_context
@@ -630,10 +622,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*queen_prop.id())
         .to_context()
         .expect("cannot create queen AttributeContext");
-    let unset_queen_value = AttributeValue::list_for_context(ctx, queen_context.into())
+    let unset_queen_value = AttributeValue::find_for_context(ctx, queen_context.into())
         .await
         .expect("could not fetch queen AttributeValue")
-        .pop()
         .expect("could not find queen AttributeValue");
     let (_, queen_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -651,10 +642,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*bohemian_prop.id())
         .to_context()
         .expect("cannot create bohemian AttributeContext");
-    let unset_bohemian_value = AttributeValue::list_for_context(ctx, bohemian_context.into())
+    let unset_bohemian_value = AttributeValue::find_for_context(ctx, bohemian_context.into())
         .await
         .expect("could not fetch bohemian AttributeValue")
-        .pop()
         .expect("could not find bohemian AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -672,10 +662,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*killer_prop.id())
         .to_context()
         .expect("cannot create killer AttributeContext");
-    let unset_killer_value = AttributeValue::list_for_context(ctx, killer_context.into())
+    let unset_killer_value = AttributeValue::find_for_context(ctx, killer_context.into())
         .await
         .expect("could not fetch killer AttributeValue")
-        .pop()
         .expect("could not find killer AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -693,10 +682,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*pressure_prop.id())
         .to_context()
         .expect("cannot create pressure AttributeContext");
-    let unset_pressure_value = AttributeValue::list_for_context(ctx, pressure_context.into())
+    let unset_pressure_value = AttributeValue::find_for_context(ctx, pressure_context.into())
         .await
         .expect("could not fetch pressure AttributeValue")
-        .pop()
         .expect("could not find pressure AttributeValue");
     let (_, pressure_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -714,10 +702,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*dust_prop.id())
         .to_context()
         .expect("cannot create dust AttributeContext");
-    let unset_dust_value = AttributeValue::list_for_context(ctx, dust_context.into())
+    let unset_dust_value = AttributeValue::find_for_context(ctx, dust_context.into())
         .await
         .expect("could not fetch dust AttributeValue")
-        .pop()
         .expect("could not find dust AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -784,10 +771,9 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("could not create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not retrieve domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let sammy_context = base_attribute_context
@@ -795,10 +781,9 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*sammy_prop.id())
         .to_context()
         .expect("could not create sammy AttributeContext");
-    let unset_sammy_value = AttributeValue::list_for_context(ctx, sammy_context.into())
+    let unset_sammy_value = AttributeValue::find_for_context(ctx, sammy_context.into())
         .await
         .expect("could not retrieve sammy AttributeValue")
-        .pop()
         .expect("could not find sammy AttributeValue");
     let (_, sammy_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -894,10 +879,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("could not create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not fetch domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let unset_sammy_context = unset_attribute_context
@@ -905,10 +889,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*sammy_prop.id())
         .to_context()
         .expect("could not create sammy AttributeContext");
-    let unset_sammy_value = AttributeValue::list_for_context(ctx, unset_sammy_context.into())
+    let unset_sammy_value = AttributeValue::find_for_context(ctx, unset_sammy_context.into())
         .await
         .expect("could not fetch sammy AttributeValue")
-        .pop()
         .expect("could not find sammy AttributeValue");
     let sammy_context = base_attribute_context
         .clone()
@@ -952,10 +935,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         .to_context()
         .expect("could not create album string AttributeContext");
     let unset_album_string_value =
-        AttributeValue::list_for_context(ctx, unset_album_string_context.into())
+        AttributeValue::find_for_context(ctx, unset_album_string_context.into())
             .await
             .expect("could not retrieve album string AttributeValue")
-            .pop()
             .expect("could not find album string AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -974,10 +956,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         .to_context()
         .expect("could not create songs array AttributeContext");
     let unset_songs_array_value =
-        AttributeValue::list_for_context(ctx, unset_songs_array_context.into())
+        AttributeValue::find_for_context(ctx, unset_songs_array_context.into())
             .await
             .expect("could not fetch songs array AttributeValue")
-            .pop()
             .expect("could not find songs array AttributeValue");
     let songs_array_context = base_attribute_context
         .clone()
@@ -1132,10 +1113,9 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("could not create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not retrieve domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let album_context = base_attribute_context
@@ -1143,10 +1123,9 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*album_prop.id())
         .to_context()
         .expect("could not create album AttributeContext");
-    let unset_album_value = AttributeValue::list_for_context(ctx, album_context.into())
+    let unset_album_value = AttributeValue::find_for_context(ctx, album_context.into())
         .await
         .expect("could not retrieve album AttributeValue")
-        .pop()
         .expect("could not find album AttributeValue");
     let (_, album_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -1241,10 +1220,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .set_prop_id(root_prop.domain_prop_id)
         .to_context()
         .expect("could not create domain AttributeContext");
-    let domain_value = AttributeValue::list_for_context(ctx, domain_context.into())
+    let domain_value = AttributeValue::find_for_context(ctx, domain_context.into())
         .await
         .expect("could not fetch domain AttributeValue")
-        .pop()
         .expect("could not find domain AttributeValue");
 
     let sammy_context = base_attribute_context
@@ -1252,10 +1230,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*sammy_prop.id())
         .to_context()
         .expect("could not create sammy AttributeContext");
-    let unset_sammy_value = AttributeValue::list_for_context(ctx, sammy_context.into())
+    let unset_sammy_value = AttributeValue::find_for_context(ctx, sammy_context.into())
         .await
         .expect("could not fetch sammy AttributeValue")
-        .pop()
         .expect("could not find sammy AttributeValue");
     let (_, sammy_value_id, _) = AttributeValue::update_for_context(
         ctx,
@@ -1289,10 +1266,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .to_context()
         .expect("could not create album string AttributeContext");
     let unset_album_string_value =
-        AttributeValue::list_for_context(ctx, album_string_context.into())
+        AttributeValue::find_for_context(ctx, album_string_context.into())
             .await
             .expect("could not fetch album string AttributeValue")
-            .pop()
             .expect("could not find album string AttributeValue");
     AttributeValue::update_for_context(
         ctx,
@@ -1310,10 +1286,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*songs_array_prop.id())
         .to_context()
         .expect("could not create songs array AttributeContext");
-    let unset_songs_array_value = AttributeValue::list_for_context(ctx, songs_array_context.into())
+    let unset_songs_array_value = AttributeValue::find_for_context(ctx, songs_array_context.into())
         .await
         .expect("could not fetch songs array AttributeValue")
-        .pop()
         .expect("could not find songs array AttributeValue");
     let (_, songs_array_value_id, _) = AttributeValue::update_for_context(
         ctx,


### PR DESCRIPTION
- Replace instances of AttributeValue::list_for_context with
  AttributeValue::find_for_context where only one value was required and
  the provided AttributeReadContext was also a valid AttributeContext
- Refactor "list_for_context" and "find_for_context" doc comments for
  clarity and readability

<img src="https://media2.giphy.com/media/hWvG6AtE0N5ZhWiO0A/giphy.gif"/>

Fixes ENG-250