### PR TITLE
feat(web): Improve node usability

### DIFF
--- a/app/web/src/organisims/PropertyEditor.vue
+++ b/app/web/src/organisims/PropertyEditor.vue
@@ -545,7 +545,7 @@ const determineOrder = (
 const propertyValuesInOrder = computed(() => {
   const results = determineOrder([], [values.value.rootValueId]);
 
-  console.log("property results", { results });
+  //console.log("property results", { results });
   return results;
 });
 
@@ -625,7 +625,7 @@ const arrayIndex = computed(() => {
       result[propValue.id] = length;
     }
   }
-  console.log("array index", { result });
+  //console.log("array index", { result });
   return result;
 });
 

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
@@ -80,8 +80,8 @@ export class ConnectingManager {
         x: (data.global.x - offset.x) * (1 / this.zoomFactor),
         y: (data.global.y - offset.y) * (1 / this.zoomFactor),
       },
-      "none",
-      "none",
+      sourceSocket.name,
+      destinationSocket.name,
       true,
     );
   }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
@@ -41,6 +41,7 @@ export class Node extends PIXI.Container {
   connections: Array<Connection>;
   panelKind: SchematicKind;
   selection?: SelectionStatus;
+  socketCount: number;
 
   constructor(
     n: SchematicNode,
@@ -75,10 +76,11 @@ export class Node extends PIXI.Container {
 
     // Card object
     const size = Math.max(v.inputSockets.length, v.outputSockets.length);
-    this.setCard(size);
+    this.socketCount = size;
+    this.setCard();
 
     // Selection status
-    this.setSelectionStatus(size);
+    this.setSelectionStatus();
 
     this.setSockets(v.inputSockets, v.outputSockets);
 
@@ -89,10 +91,10 @@ export class Node extends PIXI.Container {
     this.setShadows();
   }
 
-  setCard(socketCount: number): void {
+  setCard(): void {
     const card = new Card(
       NODE_WIDTH,
-      this.nodeHeight(socketCount),
+      this.nodeHeight(this.socketCount),
       6,
       this.title,
       this.name,
@@ -109,10 +111,10 @@ export class Node extends PIXI.Container {
     this.alpha = 0.3;
   }
 
-  setSelectionStatus(socketCount: number): void {
+  setSelectionStatus(): void {
     const status = new SelectionStatus(
       NODE_WIDTH,
-      this.nodeHeight(socketCount),
+      this.nodeHeight(this.socketCount),
       6,
     );
     status.zIndex = 1;
@@ -124,11 +126,15 @@ export class Node extends PIXI.Container {
   setQualificationStatus(qualified?: boolean): void {
     const oldStatus = this.getChildByName("QualificationStatus");
 
-    const status = new QualificationStatus(qualified);
+    const status = new QualificationStatus(
+      qualified,
+      100,
+      78,
+      NODE_WIDTH,
+      this.nodeHeight(this.socketCount),
+    );
     status.name = "QualificationStatus";
     status.zIndex = 1;
-    status.x = 100;
-    status.y = 78;
     this.addChild(status);
 
     oldStatus?.destroy();
@@ -152,6 +158,7 @@ export class Node extends PIXI.Container {
     outputs: SchematicOutputSocket[],
   ): void {
     const sockets = new Sockets(this.id, inputs, outputs, this.panelKind);
+    sockets.name = "Sockets";
     sockets.zIndex = 2;
     this.addChild(sockets);
   }
@@ -183,10 +190,10 @@ export class Node extends PIXI.Container {
     this.connections.push(c);
   }
 
-  nodeHeight(socketCount: number): number {
+  nodeHeight(): number {
     const height =
       INPUT_SOCKET_OFFSET +
-      (SOCKET_HEIGHT + SOCKET_SPACING) * socketCount -
+      (SOCKET_HEIGHT + SOCKET_SPACING) * this.socketCount -
       SOCKET_SPACING * 0.65;
     return Math.max(height, NODE_HEIGHT);
   }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/connector.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/connector.ts
@@ -9,6 +9,7 @@ export class Connector extends PIXI.Graphics {
   id: string;
   type: SocketType;
   kind: string;
+  color: number;
 
   constructor(id: string, type: SocketType, color: number) {
     super();
@@ -17,9 +18,21 @@ export class Connector extends PIXI.Graphics {
     this.type = type;
     this.kind = "socket";
     this.name = id;
+    this.color = color;
+    this.setDisconnected();
+  }
 
-    this.beginFill(color);
+  setConnected() {
+    this.clear();
+    this.beginFill(this.color);
     this.drawCircle(0, 0, 6);
+    this.endFill();
+  }
+
+  setDisconnected() {
+    this.clear();
+    this.lineStyle(2, this.color);
+    this.drawCircle(0, 0, 5.4);
     this.endFill();
     this.interactive = true;
   }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/socket.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/socket.ts
@@ -18,6 +18,7 @@ export class Socket extends PIXI.Container {
   kind: string;
   type: SocketType;
   id: number;
+  socketId: number;
   labelText: string | null;
 
   constructor(
@@ -49,7 +50,13 @@ export class Socket extends PIXI.Container {
 
   createConnector(id: string, type: SocketType, color: number): void {
     const socket = new Connector(id, type, color);
+    socket.name = "Connector";
     this.addChild(socket);
+  }
+
+  setConnected() {
+    const connector = this.getChildByName("Connector");
+    if (connector) connector.setConnected();
   }
 
   createLabel(text: string): void {

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/status/qualification.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/status/qualification.ts
@@ -3,7 +3,13 @@ import * as PIXI from "pixi.js";
 import * as feather from "feather-icons";
 
 export class QualificationStatus extends PIXI.Container {
-  constructor(status?: boolean) {
+  constructor(
+    status?: boolean,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ) {
     super();
     const icon = feather.icons["check-square"];
 
@@ -30,6 +36,17 @@ export class QualificationStatus extends PIXI.Container {
     sprite.scale.x = 0.235;
     sprite.scale.y = 0.235;
 
+    sprite.x = x;
+    sprite.y = y;
     this.addChild(sprite);
+
+    if (!status) {
+      const color = 0xf08686;
+      const box = new PIXI.Graphics()
+        .lineStyle(2, color, 1, 0, false)
+        .drawRoundedRect(-4, -4, width + 8, height + 8, 6);
+      box.zIndex = 1;
+      this.addChild(box);
+    }
   }
 }

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/status/selection.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/status/selection.ts
@@ -5,7 +5,7 @@ export class SelectionStatus extends PIXI.Container {
     super();
 
     const status = new PIXI.Graphics()
-      .lineStyle(1, 0x4dfaff, 1, 0, false)
+      .lineStyle(2, 0x4dfaff, 1, 0, false)
       .drawRoundedRect(0, 0, width, height, radius);
     status.zIndex = 1;
     this.addChild(status);

--- a/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/scene/sceneManager.ts
@@ -51,8 +51,6 @@ export class SceneManager {
       connections: new ConnectionGroup("connections", 20),
       nodes: new NodeGroup("nodes", 30),
     };
-    this.root.addChild(this.group.nodes);
-    this.root.addChild(this.group.connections);
 
     this.initializeSceneData();
     this.setBackgroundGrid(renderer.width, renderer.height);
@@ -207,6 +205,17 @@ export class SceneManager {
       const conn = c as OBJ.Connection;
       if (conn.name === connection.name) {
         isConnectionUnique = false;
+      }
+    }
+
+    for (const node of this.group.nodes.children) {
+      const sockets = node.getChildByName("Sockets");
+      if (sockets) {
+        const source = sockets.getChildByName(sourceSocketId);
+        if (source) source.setConnected();
+
+        const destination = sockets.getChildByName(destinationSocketId);
+        if (destination) destination.setConnected();
       }
     }
 


### PR DESCRIPTION
- Add red outline on node when qualification fails
- Change sizing of selection outline
- Make sockets hollow when disconnected
- Fix bug where connections appear twice (only the one of them moved on dragging)

The UI is kinda cursed tho.

![image](https://user-images.githubusercontent.com/6289779/171949539-f0f3ed75-cd3e-4f59-9a0e-346915610c88.png)

<img src="https://media0.giphy.com/media/kvBORxb51QwkIFU4D2/giphy.gif"/>
