### PR TITLE
bug(dal): Force Docker Image qualification to check linux/amd64

### DIFF
--- a/lib/dal/src/builtins/func/qualificationDockerImageNameInspect.js
+++ b/lib/dal/src/builtins/func/qualificationDockerImageNameInspect.js
@@ -1,6 +1,6 @@
 async function qualificationDockerImageNameInspect(component) {
   console.log(JSON.stringify(component))
-    const child = await siExec.waitUntilEnd("skopeo", ["inspect", "--override-os", "linux", "--override-arch", "amd64", `docker://docker.io/${component.data.properties.domain.image}`]);
+  const child = await siExec.waitUntilEnd("skopeo", ["inspect", "--override-os", "linux", "--override-arch", "amd64", `docker://docker.io/${component.data.properties.domain.image}`]);
   return {
     qualified: child.exitCode === 0,
     // Note: Do we want stdout on success? Do we want both, always? Do we want to filter the output?


### PR DESCRIPTION
When running the app directly on macOS on an M1 processor, `skopeo` would check `darwin/arm64`. This is almost guaranteed to fail to find an image for anything, even if the image has an `arm64` build, as the OS will pretty much always be `linux`, not `darwin`.