### PR TITLE
bug(web): allow spaces in qualification name

### DIFF
--- a/app/web/src/organisims/QualificationEditor.vue
+++ b/app/web/src/organisims/QualificationEditor.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="flex flex-col w-full h-full px-4 py-2 overflow-hidden mt-2">
-    <SiTextBox2
-      id="qualification-name"
-      v-model="name"
-      class="mb-2 p-2 w-full"
-      title="qualification name"
-      required
-      @blur="save()"
-    />
+    <div @keyup.stop @keydown.stop>
+      <SiTextBox2
+        id="qualification-name"
+        v-model="name"
+        class="mb-2 p-2 w-full"
+        title="qualification name"
+        required
+        @blur="save()"
+      />
+    </div>
 
     <div class="overflow-auto">
       <div


### PR DESCRIPTION
We need to stop emitting the keyup/keydown events, because they are
intercepted by the shortcut manager (which them makes them not appear in
the text box itself.)

<img src="https://media1.giphy.com/media/dfNYKfFIbI1a0/giphy.gif"/>