### PR TITLE
bug(web): fix socket alignment and labels

### DIFF
--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node.ts
@@ -18,10 +18,10 @@ import {
   SchematicOutputSocket,
 } from "@/api/sdf/dal/schematic";
 
-const NODE_WIDTH = 140;
-const NODE_HEIGHT = 100;
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 120;
 
-const INPUT_SOCKET_OFFSET = 45;
+const INPUT_SOCKET_OFFSET = 60;
 // const OUTPUT_SOCKET_OFFSET = 35;
 const SOCKET_SPACING = 20;
 const SOCKET_HEIGHT = 3;
@@ -125,8 +125,8 @@ export class Node extends PIXI.Container {
 
     const status = new QualificationStatus(
       qualified,
-      100,
-      78,
+      118,
+      98,
       NODE_WIDTH,
       this.nodeHeight(),
     );
@@ -143,8 +143,8 @@ export class Node extends PIXI.Container {
     const status = new ResourceStatus(health);
     status.name = "ResourceStatus";
     status.zIndex = 1;
-    status.x = 120;
-    status.y = 78;
+    status.x = 138;
+    status.y = 98;
     this.addChild(status);
 
     oldStatus?.destroy();

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets.ts
@@ -7,11 +7,11 @@ import {
   SchematicOutputSocket,
 } from "@/api/sdf/dal/schematic";
 
-const NODE_WIDTH = 140;
-const NODE_HEIGHT = 100;
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 120;
 
-const INPUT_SOCKET_OFFSET = 45;
-const OUTPUT_SOCKET_OFFSET = 35;
+const INPUT_SOCKET_OFFSET = 60;
+const OUTPUT_SOCKET_OFFSET = 60;
 const SOCKET_SPACING = 20;
 
 export class Sockets extends PIXI.Container {


### PR DESCRIPTION
This fixes the position of sockets, and gives the labels between sockets
room to breath.

![image](https://user-images.githubusercontent.com/4304/173158741-ac1f84e1-c6d6-4a14-bd26-76cec3c0e6a9.png)

It makes the nodes a little bit bigger, and gives the labels more space.