### PR TITLE
feat(web,dal,sdf): add provider ids to round trip through frontend 

### DIFF
--- a/app/web/src/api/sdf/dal/schematic.ts
+++ b/app/web/src/api/sdf/dal/schematic.ts
@@ -25,6 +25,7 @@ export interface EditorContext {
 export type SchematicProviderMetadata = string;
 
 export interface SchematicOutputProvider {
+  id: number;
   ty: SchematicProviderMetadata;
   color: number;
 }
@@ -37,6 +38,7 @@ export interface SchematicOutputSocket {
 }
 
 export interface SchematicInputProvider {
+  id: number;
   ty: SchematicProviderMetadata;
   color: number;
 }

--- a/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/interaction/connecting.ts
@@ -131,8 +131,10 @@ export class ConnectingManager {
       const destinationSocketId = parseInt(destinationSocketStr[1]);
 
       const sourceSocket = await outputSocketById(sourceSocketId);
+      const sourceProviderId = sourceSocket.provider.id;
 
       const destinationSocket = await inputSocketById(destinationSocketId);
+      const destinationProviderId = destinationSocket.provider.id;
 
       if (_.isEqual(sourceSocket.provider.ty, destinationSocket.provider.ty)) {
         sceneManager.createConnection(
@@ -161,8 +163,10 @@ export class ConnectingManager {
         this.dataManager.createConnection({
           sourceNodeId,
           sourceSocketId,
+          sourceProviderId,
           destinationNodeId,
           destinationSocketId,
+          destinationProviderId,
         });
       }
     }

--- a/app/web/src/organisims/SchematicViewer/data/dataManager.ts
+++ b/app/web/src/organisims/SchematicViewer/data/dataManager.ts
@@ -56,8 +56,10 @@ export class SchematicDataManager {
     SchematicService.createConnection({
       headSocketId: connection.destinationSocketId,
       headNodeId: connection.destinationNodeId,
+      headInternalProviderId: connection.destinationProviderId,
       tailSocketId: connection.sourceSocketId,
       tailNodeId: connection.sourceNodeId,
+      tailExternalProviderId: connection.sourceProviderId,
     }).subscribe((response) => {
       if (response.error) {
         GlobalErrorService.set(response);

--- a/app/web/src/organisims/SchematicViewer/data/event.ts
+++ b/app/web/src/organisims/SchematicViewer/data/event.ts
@@ -9,6 +9,8 @@ export interface NodeCreate {
 export interface ConnectionCreate {
   sourceNodeId: number;
   sourceSocketId: number;
+  sourceProviderId: number;
   destinationNodeId: number;
   destinationSocketId: number;
+  destinationProviderId: number;
 }

--- a/app/web/src/service/schematic/create_connection.ts
+++ b/app/web/src/service/schematic/create_connection.ts
@@ -11,8 +11,10 @@ import { editSessionWritten$ } from "@/observable/edit_session";
 export interface CreateConnectionArgs {
   headNodeId: number;
   headSocketId: number;
+  headInternalProviderId: number;
   tailNodeId: number;
   tailSocketId: number;
+  tailExternalProviderId: number;
 }
 
 export interface CreateConnectionRequest

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 use crate::func::binding::FuncBindingError;
 use crate::func::binding_return_value::FuncBindingReturnValueError;
+use crate::provider::external::ExternalProviderError;
 use crate::provider::internal::InternalProviderError;
 use crate::schema::variant::SchemaVariantError;
 use crate::socket::SocketError;
@@ -37,6 +38,8 @@ pub enum BuiltinsError {
     FuncBinding(#[from] FuncBindingError),
     #[error("func binding return value error: {0}")]
     FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
+    #[error("external provider error: {0}")]
+    ExternalProvider(#[from] ExternalProviderError),
     #[error("implicit internal provider not found for prop: {0}")]
     ImplicitInternalProviderNotFoundForProp(PropId),
     #[error("internal provider error: {0}")]

--- a/lib/dal/src/migrations/U0034__sockets.sql
+++ b/lib/dal/src/migrations/U0034__sockets.sql
@@ -12,6 +12,7 @@ CREATE TABLE sockets
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     name                        text                     NOT NULL,
+    kind                        text                     NOT NULL,
     edge_kind                   text                     NOT NULL,
     arity                       text                     NOT NULL,
     schematic_kind              text                     NOT NULL,
@@ -29,6 +30,7 @@ CREATE OR REPLACE FUNCTION socket_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
     this_name text,
+    this_kind text,
     this_edge_kind text,
     this_arity text,
     this_schematic_kind text,
@@ -45,11 +47,11 @@ BEGIN
     INSERT INTO sockets (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                          tenancy_workspace_ids,
                          visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted_at,
-                         name, edge_kind, arity, schematic_kind)
+                         name, kind, edge_kind, arity, schematic_kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
-            this_visibility_record.visibility_deleted_at, this_name, this_edge_kind, this_arity, this_schematic_kind)
+            this_visibility_record.visibility_deleted_at, this_name, this_kind, this_edge_kind, this_arity, this_schematic_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/migrations/U0058__internal_providers.sql
+++ b/lib/dal/src/migrations/U0058__internal_providers.sql
@@ -15,15 +15,17 @@ CREATE TABLE internal_providers
     schema_id                   bigint                   NOT NULL,
     schema_variant_id           bigint                   NOT NULL,
     attribute_prototype_id      bigint,
-    name                        text,
+    name                        text                     NOT NULL,
     internal_consumer           boolean                  NOT NULL DEFAULT TRUE,
     inbound_type_definition     text,
     outbound_type_definition    text
 );
 SELECT standard_model_table_constraints_v1('internal_providers');
+SELECT belongs_to_table_create_v1('socket_belongs_to_internal_provider', 'sockets', 'internal_providers');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
-VALUES ('internal_providers', 'model', 'internal_provider', 'Input Provider');
+VALUES ('internal_providers', 'model', 'internal_provider', 'Input Provider'),
+       ('socket_belongs_to_internal_provider', 'belongs_to', 'socket.internal_provider', 'Socket <> Internal Provider');
 
 -- We do not want to set the attribute prototype id upon creation because we need an internal provider id for the prototype's context. --
 CREATE OR REPLACE FUNCTION internal_provider_create_v1(

--- a/lib/dal/src/migrations/U0059__external_providers.sql
+++ b/lib/dal/src/migrations/U0059__external_providers.sql
@@ -14,13 +14,15 @@ CREATE TABLE external_providers
     schema_id                   bigint                   NOT NULL,
     schema_variant_id           bigint                   NOT NULL,
     attribute_prototype_id      bigint,
-    name                        text,
+    name                        text                     NOT NULL,
     type_definition             text
 );
 SELECT standard_model_table_constraints_v1('external_providers');
+SELECT belongs_to_table_create_v1('socket_belongs_to_external_provider', 'sockets', 'external_providers');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
-VALUES ('external_providers', 'model', 'external_provider', 'Output Provider');
+VALUES ('external_providers', 'model', 'external_provider', 'Output Provider'),
+       ('socket_belongs_to_external_provider', 'belongs_to', 'socket.external_provider', 'Socket <> External Provider');
 
 CREATE OR REPLACE FUNCTION external_provider_create_v1(
     this_tenancy jsonb,

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -99,9 +99,11 @@ impl Connection {
         ctx: &DalContext<'_, '_>,
         head_node_id: &NodeId,
         head_socket_id: &SocketId,
+        // TODO(fnichol): remove `Option` from type--this is now a requirement
         head_explicit_internal_provider_id: Option<InternalProviderId>,
         tail_node_id: &NodeId,
         tail_socket_id: &SocketId,
+        // TODO(fnichol): remove `Option` from type--this is now a requirement
         tail_external_provider_id: Option<ExternalProviderId>,
     ) -> SchematicResult<Self> {
         let head_node = Node::get_by_id(ctx, head_node_id)

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -6,8 +6,10 @@ use thiserror::Error;
 
 use crate::{
     impl_standard_model, label_list::ToLabelList, pk, standard_model, standard_model_accessor,
-    standard_model_many_to_many, DalContext, HistoryEventError, SchemaVariant, SchemaVariantId,
-    SchematicKind, StandardModel, StandardModelError, Timestamp, Visibility, WriteTenancy,
+    standard_model_belongs_to, standard_model_many_to_many, DalContext, ExternalProvider,
+    ExternalProviderId, HistoryEventError, InternalProvider, InternalProviderId, SchemaVariant,
+    SchemaVariantId, SchematicKind, StandardModel, StandardModelError, Timestamp, Visibility,
+    WriteTenancy,
 };
 
 #[derive(Error, Debug)]
@@ -26,6 +28,25 @@ pub type SocketResult<T> = Result<T, SocketError>;
 
 pk!(SocketPk);
 pk!(SocketId);
+
+#[derive(
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SocketKind {
+    Provider,
+}
 
 #[derive(
     AsRefStr, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
@@ -59,6 +80,7 @@ pub struct Socket {
     pk: SocketPk,
     id: SocketId,
     name: String,
+    kind: SocketKind,
     edge_kind: SocketEdgeKind,
     schematic_kind: SchematicKind,
     color: Option<i64>,
@@ -86,6 +108,7 @@ impl Socket {
     pub async fn new(
         ctx: &DalContext<'_, '_>,
         name: impl AsRef<str>,
+        kind: SocketKind,
         edge_kind: &SocketEdgeKind,
         arity: &SocketArity,
         schematic_kind: &SchematicKind,
@@ -95,11 +118,12 @@ impl Socket {
             .txns()
             .pg()
             .query_one(
-                "SELECT object FROM socket_create_v1($1, $2, $3, $4, $5, $6)",
+                "SELECT object FROM socket_create_v1($1, $2, $3, $4, $5, $6, $7)",
                 &[
                     ctx.write_tenancy(),
                     ctx.visibility(),
                     &name,
+                    &kind.as_ref(),
                     &edge_kind.as_ref(),
                     &arity.as_ref(),
                     &schematic_kind.as_ref(),
@@ -112,6 +136,7 @@ impl Socket {
     }
 
     standard_model_accessor!(name, String, SocketResult);
+    standard_model_accessor!(kind, Enum(SocketKind), SocketResult);
     standard_model_accessor!(edge_kind, Enum(SocketEdgeKind), SocketResult);
     standard_model_accessor!(arity, Enum(SocketArity), SocketResult);
     standard_model_accessor!(schematic_kind, Enum(SchematicKind), SocketResult);
@@ -129,6 +154,28 @@ impl Socket {
         right_id: SchemaVariantId,
         which_table_is_this: "left",
         returns: SchemaVariant,
+        result: SocketResult,
+    );
+
+    standard_model_belongs_to!(
+        lookup_fn: internal_provider,
+        set_fn: set_internal_provider,
+        unset_fn: unset_internal_provider,
+        table: "socket_belongs_to_internal_provider",
+        model_table: "internal_providers",
+        belongs_to_id: InternalProviderId,
+        returns: InternalProvider,
+        result: SocketResult,
+    );
+
+    standard_model_belongs_to!(
+        lookup_fn: external_provider,
+        set_fn: set_external_provider,
+        unset_fn: unset_external_provider,
+        table: "socket_belongs_to_external_provider",
+        model_table: "external_providers",
+        belongs_to_id: ExternalProviderId,
+        returns: ExternalProvider,
         result: SocketResult,
     );
 }

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -16,7 +16,7 @@ use crate::{
     key_pair::KeyPairId,
     node::NodeKind,
     schema,
-    socket::{Socket, SocketArity, SocketEdgeKind},
+    socket::{Socket, SocketArity, SocketEdgeKind, SocketKind},
     BillingAccount, BillingAccountId, ChangeSet, Component, DalContext, EditSession,
     EncryptedSecret, Func, FuncBackendKind, FuncBackendResponseType, Group, HistoryActor, KeyPair,
     Node, Organization, Prop, PropId, PropKind, QualificationCheck, Schema, SchemaId, SchemaKind,
@@ -343,6 +343,7 @@ pub async fn create_schema_variant_with_root(
     let input_socket = Socket::new(
         ctx,
         "input",
+        SocketKind::Provider,
         &SocketEdgeKind::Configures,
         &SocketArity::Many,
         &schema.kind().into(),
@@ -357,6 +358,7 @@ pub async fn create_schema_variant_with_root(
     let output_socket = Socket::new(
         ctx,
         "output",
+        SocketKind::Provider,
         &SocketEdgeKind::Output,
         &SocketArity::Many,
         &schema.kind().into(),
@@ -371,6 +373,7 @@ pub async fn create_schema_variant_with_root(
     let includes_socket = Socket::new(
         ctx,
         "includes",
+        SocketKind::Provider,
         &SocketEdgeKind::Includes,
         &SocketArity::Many,
         &schema.kind().into(),

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -2,13 +2,14 @@ use dal::attribute::context::AttributeContextBuilder;
 use dal::func::binding::FuncBindingId;
 use dal::func::binding_return_value::FuncBindingReturnValueId;
 
+use dal::socket::SocketArity;
 use dal::test_harness::{
     create_prop_of_kind_and_set_parent_with_name, create_schema, create_schema_variant_with_root,
 };
 use dal::{
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue, Connection,
     DalContext, ExternalProvider, Func, FuncBinding, FuncId, InternalProvider, PropKind,
-    SchemaKind, StandardModel,
+    SchemaKind, SchematicKind, StandardModel,
 };
 use dal::{
     Component, ComponentId, ComponentView, PropId, SchemaId, SchemaVariant, SchemaVariantId,
@@ -113,15 +114,17 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     .expect("could not update attribute value");
 
     // Create the "esp" external provider for inter component connection.
-    let esp_external_provider = ExternalProvider::new(
+    let (esp_external_provider, _socket) = ExternalProvider::new_with_socket(
         ctx,
         esp_payload.schema_id,
         esp_payload.schema_variant_id,
-        None,
+        "output",
         None,
         identity_func_id,
         identity_func_binding_id,
         identity_func_binding_return_value_id,
+        SocketArity::Many,
+        SchematicKind::Component,
     )
     .await
     .expect("could not create external provider");
@@ -158,14 +161,16 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
         .set_func_id(ctx, identity_func_id)
         .await
         .expect("could not set func id on attribute prototype");
-    let swings_explicit_internal_provider = InternalProvider::new_explicit(
+    let (swings_explicit_internal_provider, _socket) = InternalProvider::new_explicit_with_socket(
         ctx,
         swings_payload.schema_id,
         swings_payload.schema_variant_id,
-        None,
+        "swings",
         identity_func_id,
         identity_func_binding_id,
         identity_func_binding_return_value_id,
+        SocketArity::Many,
+        SchematicKind::Component,
     )
     .await
     .expect("could not create explicit internal provider");

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -1,16 +1,17 @@
-use crate::dal::test;
-use dal::test::helpers::generate_fake_name;
-use dal::DalContext;
 use dal::{
-    socket::{Socket, SocketArity, SocketEdgeKind},
-    SchematicKind,
+    socket::{Socket, SocketArity, SocketEdgeKind, SocketKind},
+    test::helpers::generate_fake_name,
+    DalContext, SchematicKind,
 };
+
+use crate::dal::test;
 
 #[test]
 async fn new(ctx: &DalContext<'_, '_>) {
     let socket = Socket::new(
         ctx,
         "jane",
+        SocketKind::Provider,
         &SocketEdgeKind::Component,
         &SocketArity::Many,
         &SchematicKind::Component,
@@ -27,6 +28,7 @@ async fn set_required(ctx: &DalContext<'_, '_>) {
     let mut socket = Socket::new(
         ctx,
         generate_fake_name(),
+        SocketKind::Provider,
         &SocketEdgeKind::Configures,
         &SocketArity::One,
         &SchematicKind::Component,

--- a/lib/sdf/src/server/service/schematic.rs
+++ b/lib/sdf/src/server/service/schematic.rs
@@ -3,6 +3,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
+use dal::socket::{SocketError, SocketId};
 use dal::{
     node::NodeId, schema::variant::SchemaVariantError, ComponentError, NodeError, NodeKind,
     NodeMenuError, NodePositionError, ReadTenancyError, SchemaError as DalSchemaError,
@@ -40,6 +41,12 @@ pub enum SchematicError {
     NodeMenu(#[from] NodeMenuError),
     #[error("node error: {0}")]
     Node(#[from] NodeError),
+    #[error("socket error: {0}")]
+    Socket(#[from] SocketError),
+    #[error("external provider not found for socket id: {0}")]
+    ExternalProviderNotFoundForSocket(SocketId),
+    #[error("internal provider not found for socket id: {0}")]
+    InternalProviderNotFoundForSocket(SocketId),
     #[error("invalid request")]
     InvalidRequest,
     #[error("schema variant error: {0}")]

--- a/lib/sdf/src/server/service/schematic/create_connection.rs
+++ b/lib/sdf/src/server/service/schematic/create_connection.rs
@@ -1,18 +1,22 @@
+use axum::Json;
+use dal::{
+    node::NodeId, socket::SocketId, Connection, ExternalProviderId, InternalProviderId, Visibility,
+    WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
 use super::SchematicResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
-use axum::Json;
-use dal::node::NodeId;
-use dal::socket::SocketId;
-use dal::{Connection, Visibility, WorkspaceId};
-use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateConnectionRequest {
     pub head_node_id: NodeId,
     pub head_socket_id: SocketId,
+    pub head_internal_provider_id: InternalProviderId,
     pub tail_node_id: NodeId,
     pub tail_socket_id: SocketId,
+    pub tail_external_provider_id: ExternalProviderId,
     pub workspace_id: WorkspaceId,
     #[serde(flatten)]
     pub visibility: Visibility,
@@ -37,10 +41,10 @@ pub async fn create_connection(
         &ctx,
         &request.head_node_id,
         &request.head_socket_id,
-        None,
+        Some(request.head_internal_provider_id),
         &request.tail_node_id,
         &request.tail_socket_id,
-        None,
+        Some(request.tail_external_provider_id),
     )
     .await?;
 


### PR DESCRIPTION
his change ships relevant provider IDs from SDF via
`schematic/list_schema_varants` to the frontend so they can be provided
when calling `schematic/create_connection`.

Sockets and Providers (ImplicitInternal and Explicit) now have a similar
relationship between Nodes and Components. In other words, a Socket is
updated to be a generic connecting point on a Node that fronts for a
more concrete domain concept, in this case either an ExternalProvider or
an ExplicityInternalProvider. As a result, the constructors for these
providers now also construct a related socket and their function names
are updated to reflect this. Sockets now have an additional `kind` field
which is similar to the Node's `kind` field so that we will know what
the Socket is fronting for.

Future Work
-----------

* Sockets don't need a name field anymore, assuming that each
  corresponding underlying type has a name, so we should remove them.
  For the moment when a Provider-backed Socket is created, both names
  are set to the same value.
* The `Includes` Socket side of a Component was left alone in the schema
  builtins--I'm not 100% sure what we do here, but at the moment these
  Sockets have nothing behind them.
* In `app/web`, the `SchematicInputSocket` and `SchematicOutputSocket`
  types are tightly coupled to providers which we can fix in a way
  similar to the `Node`/`Component` relationship, that is with some
  either types that have different fields depending on `kind`.

<img src="https://media1.giphy.com/media/jbKbdoKJOFusHTjl80/giphy-downsized-medium.gif"/>