### PR TITLE
fix(web): Fix panels reactivity

### DIFF
--- a/app/web/src/observable/qualification.ts
+++ b/app/web/src/observable/qualification.ts
@@ -1,4 +1,4 @@
-import { ReplaySubject } from "rxjs";
+import { Subject } from "rxjs";
 import { WsCheckedQualifications, WsEvent } from "@/api/sdf/dal/ws_event";
 
 export interface CheckedQualificationId {
@@ -11,5 +11,5 @@ export interface CheckedQualificationId {
  * Fired with the ids of the component and the system
  */
 export const eventCheckedQualifications$ =
-  new ReplaySubject<WsEvent<WsCheckedQualifications> | null>(1);
+  new Subject<WsEvent<WsCheckedQualifications> | null>();
 eventCheckedQualifications$.next(null);

--- a/app/web/src/organisims/AttributeViewer.vue
+++ b/app/web/src/organisims/AttributeViewer.vue
@@ -66,7 +66,7 @@
 import * as Rx from "rxjs";
 //import EditFormComponent from "@/organisims/EditFormComponent.vue";
 import { toRefs, computed } from "vue";
-import { fromRef, refFrom } from "vuse-rx";
+import { fromRef, refFrom, untilUnmounted } from "vuse-rx";
 import { GlobalErrorService } from "@/service/global_error";
 import { ResourceHealth } from "@/api/sdf/dal/resource";
 import { ComponentIdentification } from "@/api/sdf/dal/component";
@@ -198,6 +198,11 @@ const componentMetadata = refFrom<ComponentMetadata | null>(
     }),
   ),
 );
+
+componentId$.pipe(untilUnmounted).subscribe(() => {
+  editorContext.value = undefined;
+  componentMetadata.value = null;
+});
 
 const editCount = computed(() => {
   return 0;

--- a/app/web/src/organisims/QualificationViewer.vue
+++ b/app/web/src/organisims/QualificationViewer.vue
@@ -335,11 +335,13 @@ const props = defineProps<{
 }>();
 const { componentId } = toRefs(props);
 const componentId$ = fromRef<number>(componentId, { immediate: true });
-componentId$
-  .pipe(untilUnmounted)
-  .subscribe(() => (editingQualificationId.value = undefined));
 
 const scheduledToasts = ref<number[]>([]);
+
+componentId$.pipe(untilUnmounted).subscribe(() => {
+  scheduledToasts.value = [];
+  editingQualificationId.value = undefined;
+});
 
 const checkedQualifications$ = new Rx.ReplaySubject<true>();
 checkedQualifications$.next(true); // We must fetch on setup

--- a/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/socket.ts
+++ b/app/web/src/organisims/SchematicViewer/Viewer/obj/node/sockets/socket.ts
@@ -87,7 +87,7 @@ export class Socket extends PIXI.Container {
       align: "left",
     });
     label.position.x = 10;
-    label.position.y = -5;
+    label.position.y = -7.5;
     label.zIndex = 1;
     label.interactive = false;
     this.addChild(label);

--- a/app/web/src/service/ws_event.ts
+++ b/app/web/src/service/ws_event.ts
@@ -1,5 +1,5 @@
 import { WsEvent, WsPayloadKinds } from "@/api/sdf/dal/ws_event";
-import { BehaviorSubject, ReplaySubject } from "rxjs";
+import { BehaviorSubject, ReplaySubject, Subject } from "rxjs";
 import {
   eventChangeSetApplied$,
   eventChangeSetCanceled$,
@@ -12,8 +12,12 @@ import { eventCodeGenerated$ } from "@/observable/code";
 import { eventSecretCreated$ } from "@/observable/secret";
 
 const eventMap: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [E in WsPayloadKinds["kind"]]: BehaviorSubject<any> | ReplaySubject<any>;
+  [E in WsPayloadKinds["kind"]]:  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | BehaviorSubject<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | ReplaySubject<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | Subject<any>;
 } = {
   ChangeSetCreated: eventChangeSetCreated$,
   ChangeSetApplied: eventChangeSetApplied$,


### PR DESCRIPTION
Also fix socket alignment after recent UI changes

It currently ignores writes in attribute views if component is changed
before blur, with the current architecture there isn't really a nice way
of keeping the PropertyEditor component living long enough with the old
component id for it to trigger blur. The parents just swap it out.

Instead of swapping and then blurring we clear the local data and swap
to avoid the blur on the wrong component.

Changed websocket event to not be Replay as it was retriggering the
toast even without changes.

<img src="https://media3.giphy.com/media/j7JDp8MO9BZJL7Hqfs/giphy.gif"/>