### PR TITLE
Add kubernetes deployment intelligence test

### DIFF
--- a/lib/dal/src/test/helpers.rs
+++ b/lib/dal/src/test/helpers.rs
@@ -423,4 +423,65 @@ impl ComponentPayload {
             .expect("cannot get component view")
             .properties
     }
+
+    /// Update a [`AttributeValue`](crate::AttributeValue). This only works if the parent
+    /// [`AttributeValue`] for the same context corresponds to an _"object"_ [`Prop`](crate::Prop).
+    pub async fn update_attribute_value_for_prop_name(
+        &self,
+        ctx: &DalContext<'_, '_>,
+        prop_name: impl AsRef<str>,
+        value: Option<Value>,
+    ) -> AttributeValueId {
+        let prop_id = self.get_prop_id(prop_name.as_ref());
+
+        let attribute_value = AttributeValue::find_for_context(
+            ctx,
+            AttributeReadContext {
+                prop_id: Some(prop_id),
+                ..self.base_attribute_read_context
+            },
+        )
+        .await
+        .expect("cannot get attribute value")
+        .expect("attribute value not found");
+
+        let parent_prop = Prop::get_by_id(ctx, &prop_id)
+            .await
+            .expect("could not get prop by id")
+            .expect("prop not found by id")
+            .parent_prop(ctx)
+            .await
+            .expect("could not find parent prop")
+            .expect("parent prop not found or prop does not have parent");
+        let parent_attribute_value = AttributeValue::find_for_context(
+            ctx,
+            AttributeReadContext {
+                prop_id: Some(*parent_prop.id()),
+                ..self.base_attribute_read_context
+            },
+        )
+        .await
+        .expect("cannot get attribute value")
+        .expect("attribute value not found");
+
+        let update_attribute_context =
+            AttributeContextBuilder::from(self.base_attribute_read_context)
+                .set_prop_id(prop_id)
+                .to_context()
+                .expect("could not convert builder to attribute context");
+
+        let (_, updated_attribute_value_id) = AttributeValue::update_for_context(
+            ctx,
+            *attribute_value.id(),
+            Some(*parent_attribute_value.id()),
+            update_attribute_context,
+            value,
+            None,
+        )
+        .await
+        .expect("cannot update value for context");
+
+        // Return the updated attribute value id.
+        updated_attribute_value_id
+    }
 }

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -1,4 +1,3 @@
-mod docker_image_to_kubernetes_deployment;
+mod builtins;
 mod inter_component;
 mod intra_component;
-mod kubernetes_namespace_to_kubernetes_deployment;

--- a/lib/dal/tests/integration_test/provider/builtins.rs
+++ b/lib/dal/tests/integration_test/provider/builtins.rs
@@ -1,0 +1,223 @@
+use dal::test::helpers::{
+    find_prop_and_parent_by_name, find_schema_and_default_variant_by_name, ComponentPayload,
+};
+
+use dal::{AttributeReadContext, DalContext, PropId, StandardModel};
+use dal::{Component, SchemaId, SchemaVariantId};
+
+use std::collections::HashMap;
+
+mod docker_image_intelligence;
+mod docker_image_to_kubernetes_deployment;
+mod kubernetes_deployment_intelligence;
+mod kubernetes_namespace_to_kubernetes_deployment;
+
+/// This harness provides methods to create [`Components`](dal::Component) from builtins. All fields
+/// are private since they are purely used to reduce the number of total database queries.
+pub struct ProviderBuiltinsHarness {
+    docker_image_schema_id: Option<SchemaId>,
+    docker_image_schema_variant_id: Option<SchemaVariantId>,
+    docker_image_prop_map: HashMap<&'static str, PropId>,
+
+    kubernetes_namespace_schema_id: Option<SchemaId>,
+    kubernetes_namespace_schema_variant_id: Option<SchemaVariantId>,
+    kubernetes_namespace_prop_map: HashMap<&'static str, PropId>,
+
+    kubernetes_deployment_schema_id: Option<SchemaId>,
+    kubernetes_deployment_schema_variant_id: Option<SchemaVariantId>,
+    kubernetes_deployment_prop_map: HashMap<&'static str, PropId>,
+}
+
+impl Default for ProviderBuiltinsHarness {
+    fn default() -> Self {
+        Self {
+            docker_image_schema_id: None,
+            docker_image_schema_variant_id: None,
+            docker_image_prop_map: HashMap::new(),
+
+            kubernetes_namespace_schema_id: None,
+            kubernetes_namespace_schema_variant_id: None,
+            kubernetes_namespace_prop_map: HashMap::new(),
+
+            kubernetes_deployment_schema_id: None,
+            kubernetes_deployment_schema_variant_id: None,
+            kubernetes_deployment_prop_map: HashMap::new(),
+        }
+    }
+}
+
+impl ProviderBuiltinsHarness {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn create_docker_image(
+        &mut self,
+        ctx: &DalContext<'_, '_>,
+        name: impl AsRef<str>,
+    ) -> ComponentPayload {
+        let (schema_id, schema_variant_id) = match (
+            self.docker_image_schema_id,
+            self.docker_image_schema_variant_id,
+        ) {
+            (Some(schema_id), Some(schema_variant_id)) => (schema_id, schema_variant_id),
+            (_, _) => {
+                // Save them for next time!
+                let (schema_id, schema_variant_id) =
+                    Self::find_schema_and_default_variant_by_name_ids_only(ctx, "docker_image")
+                        .await;
+                self.docker_image_schema_id = Some(schema_id);
+                self.docker_image_schema_variant_id = Some(schema_variant_id);
+                (schema_id, schema_variant_id)
+            }
+        };
+
+        // Add props that you would like to access here! We'll save them if other docker
+        // images are created in addition to the first one.
+        if self.docker_image_prop_map.is_empty() {
+            let (name_prop_id, _) =
+                find_prop_and_parent_by_name(ctx, "name", "si", None, schema_variant_id)
+                    .await
+                    .expect("could not find prop and/or parent");
+            self.docker_image_prop_map
+                .insert("/root/si/name", name_prop_id);
+        }
+
+        Self::create_component_from_schema(
+            ctx,
+            schema_id,
+            schema_variant_id,
+            self.docker_image_prop_map.clone(),
+            name,
+        )
+        .await
+    }
+
+    pub async fn create_kubernetes_namespace(
+        &mut self,
+        ctx: &DalContext<'_, '_>,
+        name: impl AsRef<str>,
+    ) -> ComponentPayload {
+        let (schema_id, schema_variant_id) = match (
+            self.kubernetes_namespace_schema_id,
+            self.kubernetes_namespace_schema_variant_id,
+        ) {
+            (Some(schema_id), Some(schema_variant_id)) => (schema_id, schema_variant_id),
+            (_, _) => {
+                // Save them for next time!
+                let (schema_id, schema_variant_id) =
+                    Self::find_schema_and_default_variant_by_name_ids_only(
+                        ctx,
+                        "kubernetes_namespace",
+                    )
+                    .await;
+                self.kubernetes_namespace_schema_id = Some(schema_id);
+                self.kubernetes_namespace_schema_variant_id = Some(schema_variant_id);
+                (schema_id, schema_variant_id)
+            }
+        };
+
+        // Add props that you would like to access here! We'll save them if other kubernetes
+        // namespace are created in addition to the first one.
+        if self.kubernetes_namespace_prop_map.is_empty() {
+            let (name_prop_id, _) =
+                find_prop_and_parent_by_name(ctx, "name", "metadata", None, schema_variant_id)
+                    .await
+                    .expect("could not find prop and/or parent");
+            self.kubernetes_namespace_prop_map
+                .insert("/root/domain/metadata/name", name_prop_id);
+        }
+
+        Self::create_component_from_schema(
+            ctx,
+            schema_id,
+            schema_variant_id,
+            self.kubernetes_namespace_prop_map.clone(),
+            name,
+        )
+        .await
+    }
+
+    pub async fn create_kubernetes_deployment(
+        &mut self,
+        ctx: &DalContext<'_, '_>,
+        name: impl AsRef<str>,
+    ) -> ComponentPayload {
+        let (schema_id, schema_variant_id) = match (
+            self.kubernetes_deployment_schema_id,
+            self.kubernetes_deployment_schema_variant_id,
+        ) {
+            (Some(schema_id), Some(schema_variant_id)) => (schema_id, schema_variant_id),
+            (_, _) => {
+                // Save them for next time!
+                let (schema_id, schema_variant_id) =
+                    Self::find_schema_and_default_variant_by_name_ids_only(
+                        ctx,
+                        "kubernetes_deployment",
+                    )
+                    .await;
+                self.kubernetes_deployment_schema_id = Some(schema_id);
+                self.kubernetes_deployment_schema_variant_id = Some(schema_variant_id);
+                (schema_id, schema_variant_id)
+            }
+        };
+
+        // Add props that you would like to access here! We'll save them if other kubernetes
+        // deployments are created in addition to the first one.
+        if self.kubernetes_deployment_prop_map.is_empty() {
+            let (name_prop_id, _) =
+                find_prop_and_parent_by_name(ctx, "name", "si", None, schema_variant_id)
+                    .await
+                    .expect("could not find prop and/or parent");
+            self.kubernetes_deployment_prop_map
+                .insert("/root/si/name", name_prop_id);
+        }
+
+        Self::create_component_from_schema(
+            ctx,
+            schema_id,
+            schema_variant_id,
+            self.kubernetes_deployment_prop_map.clone(),
+            name,
+        )
+        .await
+    }
+
+    async fn create_component_from_schema(
+        ctx: &DalContext<'_, '_>,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+        prop_map: HashMap<&'static str, PropId>,
+        name: impl AsRef<str>,
+    ) -> ComponentPayload {
+        let (component, _) = Component::new_for_schema_with_node(ctx, name, &schema_id)
+            .await
+            .expect("unable to create component");
+        ctx.run_enqueued_jobs()
+            .await
+            .expect("cannot run enqueued jobs");
+
+        ComponentPayload {
+            schema_id,
+            schema_variant_id,
+            component_id: *component.id(),
+            prop_map,
+            base_attribute_read_context: AttributeReadContext {
+                prop_id: None,
+                schema_id: Some(schema_id),
+                schema_variant_id: Some(schema_variant_id),
+                component_id: Some(*component.id()),
+                ..AttributeReadContext::default()
+            },
+        }
+    }
+
+    async fn find_schema_and_default_variant_by_name_ids_only(
+        ctx: &DalContext<'_, '_>,
+        schema_name: impl AsRef<str>,
+    ) -> (SchemaId, SchemaVariantId) {
+        let (schema, schema_variant) =
+            find_schema_and_default_variant_by_name(ctx, schema_name).await;
+        (*schema.id(), *schema_variant.id())
+    }
+}

--- a/lib/dal/tests/integration_test/provider/builtins/docker_image_intelligence.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/docker_image_intelligence.rs
@@ -1,0 +1,103 @@
+use dal::DalContext;
+
+use pretty_assertions_sorted::assert_eq_sorted;
+
+use crate::dal::test;
+use crate::integration_test::provider::builtins::ProviderBuiltinsHarness;
+
+#[test]
+async fn docker_image_intra_component_update(ctx: &DalContext<'_, '_>) {
+    let mut harness = ProviderBuiltinsHarness::new();
+    let soulrender_payload = harness.create_docker_image(ctx, "soulrender").await;
+    let bloodscythe_payload = harness.create_docker_image(ctx, "bloodscythe").await;
+
+    // Ensure that setup worked
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "soulrender"
+            },
+            "si": {
+                "name": "soulrender",
+            },
+        }], // expected
+        soulrender_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "bloodscythe"
+            },
+            "si": {
+                "name": "bloodscythe",
+            },
+        }], // expected
+        bloodscythe_payload.component_view_properties(ctx).await // actual
+    );
+
+    // Update the "/root/si/name" value for "bloodscythe", observe that it worked, and observe
+    // that the "soulrender" component was not updated.
+    bloodscythe_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["bloodscythe-updated"]),
+        )
+        .await;
+
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "soulrender"
+            },
+            "si": {
+                "name": "soulrender",
+            },
+        }], // expected
+        soulrender_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "bloodscythe-updated"
+            },
+            "si": {
+                "name": "bloodscythe-updated",
+            },
+        }], // expected
+        bloodscythe_payload.component_view_properties(ctx).await // actual
+    );
+
+    // Now, the "/root/si/name" value for "soulrender", observe that it worked, and observe
+    // that the "bloodscythe" component was not updated.
+    soulrender_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["soulrender-updated"]),
+        )
+        .await;
+
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "soulrender-updated"
+            },
+            "si": {
+                "name": "soulrender-updated",
+            },
+        }], // expected
+        soulrender_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "bloodscythe-updated"
+            },
+            "si": {
+                "name": "bloodscythe-updated",
+            },
+        }], // expected
+        bloodscythe_payload.component_view_properties(ctx).await // actual
+    );
+}

--- a/lib/dal/tests/integration_test/provider/builtins/kubernetes_deployment_intelligence.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/kubernetes_deployment_intelligence.rs
@@ -1,0 +1,437 @@
+use dal::{Connection, DalContext, ExternalProvider, InternalProvider, StandardModel};
+
+use pretty_assertions_sorted::assert_eq_sorted;
+
+use crate::dal::test;
+use crate::integration_test::provider::builtins::ProviderBuiltinsHarness;
+
+// Oh yeah, it's big brain time.
+#[test]
+async fn kubernetes_deployment_intelligence(ctx: &DalContext<'_, '_>) {
+    let mut harness = ProviderBuiltinsHarness::new();
+    let tail_fedora_payload = harness.create_docker_image(ctx, "fedora").await;
+    let tail_alpine_payload = harness.create_docker_image(ctx, "alpine").await;
+    let tail_namespace_payload = harness.create_kubernetes_namespace(ctx, "namespace").await;
+    let head_deployment_spongebob_payload =
+        harness.create_kubernetes_deployment(ctx, "spongebob").await;
+    let head_deployment_squidward_payload =
+        harness.create_kubernetes_deployment(ctx, "squidward").await;
+
+    // Initialize the tail component primary fields
+    tail_fedora_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["fedora"]),
+        )
+        .await;
+    tail_alpine_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["alpine"]),
+        )
+        .await;
+    tail_namespace_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/metadata/name",
+            Some(serde_json::json!["rancher-system"]),
+        )
+        .await;
+    ctx.run_enqueued_jobs()
+        .await
+        .expect("cannot run enqueued jobs");
+
+    // Ensure setup worked.
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "fedora"
+            },
+            "si": {
+                "name": "fedora"
+            }
+        }], // expected
+        tail_fedora_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "alpine"
+            },
+            "si": {
+                "name": "alpine"
+            }
+        }], // expected
+        tail_alpine_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "metadata": {
+                    "name": "rancher-system"
+                }
+            },
+            "si": {
+                "name": "namespace"
+            }
+        }], // expected
+        tail_namespace_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+            },
+            "si": {
+                "name": "spongebob"
+            }
+        }], // expected
+        head_deployment_spongebob_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+            },
+            "si": {
+                "name": "squidward"
+            }
+        }], // expected
+        head_deployment_squidward_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+
+    // Collect the explicit internal providers we want from the deployments.
+    let head_deployment_spongebob_docker_image_provider =
+        InternalProvider::find_explicit_for_schema_variant_and_name(
+            ctx,
+            head_deployment_spongebob_payload.schema_variant_id,
+            "docker_image",
+        )
+        .await
+        .expect("cannot find explicit internal provider")
+        .expect("explicit internal provider not found");
+    let head_deployment_kubernetes_namespace_provider =
+        InternalProvider::find_explicit_for_schema_variant_and_name(
+            ctx,
+            head_deployment_spongebob_payload.schema_variant_id,
+            "kubernetes_namespace",
+        )
+        .await
+        .expect("cannot find explicit internal provider")
+        .expect("explicit internal provider not found");
+    let head_deployment_squidward_docker_image_provider =
+        InternalProvider::find_explicit_for_schema_variant_and_name(
+            ctx,
+            head_deployment_squidward_payload.schema_variant_id,
+            "docker_image",
+        )
+        .await
+        .expect("cannot find explicit internal provider")
+        .expect("explicit internal provider not found");
+
+    // Connect fedora to the deployment.
+    let tail_fedora_provider = ExternalProvider::find_for_schema_variant_and_name(
+        ctx,
+        tail_fedora_payload.schema_variant_id,
+        "docker_image",
+    )
+    .await
+    .expect("cannot find external provider")
+    .expect("external provider not found");
+    Connection::connect_providers(
+        ctx,
+        "identity".to_string(),
+        *tail_fedora_provider.id(),
+        tail_fedora_payload.component_id,
+        *head_deployment_spongebob_docker_image_provider.id(),
+        head_deployment_spongebob_payload.component_id,
+    )
+    .await
+    .expect("could not connect providers");
+
+    // Perform one update.
+    tail_fedora_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["fedora-updated"]),
+        )
+        .await;
+    ctx.run_enqueued_jobs()
+        .await
+        .expect("cannot run enqueued jobs");
+
+    // Check that the update worked.
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "fedora-updated"
+            },
+            "si": {
+                "name": "fedora-updated"
+            }
+        }], // expected
+        tail_fedora_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "alpine"
+            },
+            "si": {
+                "name": "alpine"
+            }
+        }], // expected
+        tail_alpine_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "metadata": {
+                    "name": "rancher-system"
+                }
+            },
+            "si": {
+                "name": "namespace"
+            }
+        }], // expected
+        tail_namespace_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "image": "fedora-updated",
+                                    "name": "fedora-updated",
+                                    "ports": [],
+                                },
+                            ],
+                        },
+                    }
+                },
+            },
+            "si": {
+                "name": "spongebob"
+            }
+        }], // expected
+        head_deployment_spongebob_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+            },
+            "si": {
+                "name": "squidward"
+            }
+        }], // expected
+        head_deployment_squidward_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+
+    // After the first update, let's connect alpine to the spongebob deployment.
+    let tail_alpine_provider = ExternalProvider::find_for_schema_variant_and_name(
+        ctx,
+        tail_alpine_payload.schema_variant_id,
+        "docker_image",
+    )
+    .await
+    .expect("cannot find external provider")
+    .expect("external provider not found");
+    Connection::connect_providers(
+        ctx,
+        "identity".to_string(),
+        *tail_alpine_provider.id(),
+        tail_alpine_payload.component_id,
+        *head_deployment_spongebob_docker_image_provider.id(),
+        head_deployment_spongebob_payload.component_id,
+    )
+    .await
+    .expect("could not connect providers");
+
+    // Then, connect namespace to the deployment.
+    let tail_namespace_provider = ExternalProvider::find_for_schema_variant_and_name(
+        ctx,
+        tail_namespace_payload.schema_variant_id,
+        "kubernetes_namespace",
+    )
+    .await
+    .expect("cannot find external provider")
+    .expect("external provider not found");
+    Connection::connect_providers(
+        ctx,
+        "identity".to_string(),
+        *tail_namespace_provider.id(),
+        tail_namespace_payload.component_id,
+        *head_deployment_kubernetes_namespace_provider.id(),
+        head_deployment_spongebob_payload.component_id,
+    )
+    .await
+    .expect("could not connect providers");
+
+    // Finally, connect fedora to the squidward deployment.
+    Connection::connect_providers(
+        ctx,
+        "identity".to_string(),
+        *tail_fedora_provider.id(),
+        tail_fedora_payload.component_id,
+        *head_deployment_squidward_docker_image_provider.id(),
+        head_deployment_squidward_payload.component_id,
+    )
+    .await
+    .expect("could not connect providers");
+
+    // Perform three updates and assert afterwards.
+    tail_alpine_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["alpine-updated"]),
+        )
+        .await;
+    tail_namespace_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/metadata/name",
+            Some(serde_json::json!["rancher-system-updated"]),
+        )
+        .await;
+    tail_fedora_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/si/name",
+            Some(serde_json::json!["fedora-updated-twice"]),
+        )
+        .await;
+    ctx.run_enqueued_jobs()
+        .await
+        .expect("cannot run enqueued jobs");
+
+    // Observed that it worked.
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "fedora-updated-twice"
+            },
+            "si": {
+                "name": "fedora-updated-twice"
+            }
+        }], // expected
+        tail_fedora_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "image": "alpine-updated"
+            },
+            "si": {
+                "name": "alpine-updated"
+            }
+        }], // expected
+        tail_alpine_payload.component_view_properties(ctx).await // actual
+    );
+    assert_eq_sorted!(
+        serde_json::json![{
+            "domain": {
+                "metadata": {
+                    "name": "rancher-system-updated"
+                }
+            },
+            "si": {
+                "name": "namespace"
+            }
+        }], // expected
+        tail_namespace_payload.component_view_properties(ctx).await // actual
+    );
+    // We cannot use "assert_eq_sorted" here because the containers array order should be stable,
+    // but we should not assert a guaranteed order.
+    assert_eq!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                    "namespace": "rancher-system-updated"
+                },
+                "spec": {
+                    "template": {
+                        "metadata": {
+                            "namespace": "rancher-system-updated"
+                        },
+                        "spec": {
+                            "containers": [
+                                {
+                                    "image": "fedora-updated-twice",
+                                    "name": "fedora-updated-twice",
+                                    "ports": [],
+                                },
+                                {
+                                    "image": "alpine-updated",
+                                    "name": "alpine-updated",
+                                    "ports": [],
+                                },
+                            ],
+                        },
+                    }
+                },
+            },
+            "si": {
+                "name": "spongebob"
+            }
+        }], // expected
+        head_deployment_spongebob_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "domain": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                    "namespace": "rancher-system-updated"
+                },
+                "spec": {
+                    "template": {
+                        "metadata": {
+                            "namespace": "rancher-system-updated"
+                        },
+                        "spec": {
+                            "containers": [
+                                {
+                                    "image": "fedora-updated-twice",
+                                    "name": "fedora-updated-twice",
+                                    "ports": [],
+                                },
+                            ],
+                        },
+                    }
+                },
+            },
+            "si": {
+                "name": "squidward"
+            }
+        }], // expected
+        head_deployment_squidward_payload
+            .component_view_properties(ctx)
+            .await // actual
+    );
+}

--- a/lib/dal/tests/integration_test/provider/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -1,11 +1,10 @@
-use dal::test::helpers::{
-    find_prop_and_parent_by_name, update_attribute_value_for_prop_and_context, ComponentPayload,
-};
+use dal::test::helpers::{find_prop_and_parent_by_name, ComponentPayload};
 use dal::Component;
 use dal::{
     AttributeReadContext, Connection, DalContext, ExternalProvider, InternalProvider, Schema,
     StandardModel,
 };
+
 use pretty_assertions_sorted::assert_eq_sorted;
 use std::collections::HashMap;
 
@@ -19,13 +18,13 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(
     let head_deployment_payload = setup_kubernetes_deployment(ctx).await;
 
     // Initialize the tail "/root/domain/metadata/name" field.
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        tail_namespace_payload.get_prop_id("/root/domain/metadata/name"),
-        Some(serde_json::json!["tail"]),
-        tail_namespace_payload.base_attribute_read_context,
-    )
-    .await;
+    tail_namespace_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/metadata/name",
+            Some(serde_json::json!["tail"]),
+        )
+        .await;
 
     // Ensure setup worked.
     assert_eq_sorted!(
@@ -113,13 +112,13 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(
     );
 
     // Perform update!
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        tail_namespace_payload.get_prop_id("/root/domain/metadata/name"),
-        Some(serde_json::json!["look-at-me-mom-i-updated"]),
-        tail_namespace_payload.base_attribute_read_context,
-    )
-    .await;
+    tail_namespace_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/metadata/name",
+            Some(serde_json::json!["look-at-me-mom-i-updated"]),
+        )
+        .await;
 
     // Observed that it worked.
     assert_eq_sorted!(

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -1,6 +1,4 @@
-use dal::test::helpers::{
-    setup_identity_func, update_attribute_value_for_prop_and_context, ComponentPayload,
-};
+use dal::test::helpers::{setup_identity_func, ComponentPayload};
 use dal::test_harness::{
     create_prop_of_kind_and_set_parent_with_name, create_prop_of_kind_with_name, create_schema,
     create_schema_variant_with_root,
@@ -82,13 +80,13 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     .expect("could not create attribute prototype argument");
 
     // Update the "esp" field, "source", to see if the intra component connection continues to work.
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        esp_payload.get_prop_id("/root/domain/object/source"),
-        Some(serde_json::json!["one"]),
-        esp_payload.base_attribute_read_context,
-    )
-    .await;
+    esp_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/object/source",
+            Some(serde_json::json!["one"]),
+        )
+        .await;
 
     // Ensure that they look as we expect.
     assert_eq_sorted!(
@@ -252,13 +250,13 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     );
 
     // Update the "esp" field, "source", again.
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        esp_payload.get_prop_id("/root/domain/object/source"),
-        Some(serde_json::json!["two"]),
-        esp_payload.base_attribute_read_context,
-    )
-    .await;
+    esp_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/object/source",
+            Some(serde_json::json!["two"]),
+        )
+        .await;
 
     // Observe that inter component identity updating work.
     assert_eq_sorted!(
@@ -342,41 +340,41 @@ async fn setup_esp(ctx: &DalContext<'_, '_>) -> ComponentPayload {
         .await
         .expect("cannot run enqueued jobs");
 
-    // This context can also be used for generating component views.
-    let base_attribute_read_context = AttributeReadContext {
-        prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
-        component_id: Some(*component.id()),
-        ..AttributeReadContext::default()
-    };
-
-    // Initialize the value corresponding to the "source" prop.
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        *source_prop.id(),
-        Some(serde_json::json!["zero-source"]),
-        base_attribute_read_context,
-    )
-    .await;
-
-    // Initialize the value corresponding to the "intermediate" prop.
-    update_attribute_value_for_prop_and_context(
-        ctx,
-        *intermediate_prop.id(),
-        Some(serde_json::json!["zero-intermediate"]),
-        base_attribute_read_context,
-    )
-    .await;
-
-    // Return the payload.
-    ComponentPayload {
+    // The base attribute read context can also be used for generating component views.
+    let component_payload = ComponentPayload {
         schema_id: *schema.id(),
         schema_variant_id: *schema_variant.id(),
         component_id: *component.id(),
         prop_map,
-        base_attribute_read_context,
-    }
+        base_attribute_read_context: AttributeReadContext {
+            prop_id: None,
+            schema_id: Some(*schema.id()),
+            schema_variant_id: Some(*schema_variant.id()),
+            component_id: Some(*component.id()),
+            ..AttributeReadContext::default()
+        },
+    };
+
+    // Initialize the value corresponding to the "source" prop.
+    component_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/object/source",
+            Some(serde_json::json!["zero-source"]),
+        )
+        .await;
+
+    // Initialize the value corresponding to the "intermediate" prop.
+    component_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/object/intermediate",
+            Some(serde_json::json!["zero-intermediate"]),
+        )
+        .await;
+
+    // Return the payload.
+    component_payload
 }
 
 // 38.82091849697006, -77.05236860190759


### PR DESCRIPTION
Integration tests:
- Combine docker image and kubernetes namespace inteliigence concepts
  for kubernetes deployment into one test
- Create harness for builtins provider tests
- Refactor provider integration tests to be split by builtin and
  mechanism

Test helpers:
- Move "AttributeValue::update_for_context" test helper wrapper into the
  ComponentPayload impl as a method

Connections:
- Remove optional providers for connections

<img src="https://media0.giphy.com/media/KCZAgikZIUkK1conAk/giphy.gif"/>

Fixes ENG-293