### PR TITLE
feat(dal): Populate K8s Deployment container name from Docker Image

### DIFF
--- a/lib/dal/src/builtins/func/dockerImagesToK8sDeploymentContainerSpec.js
+++ b/lib/dal/src/builtins/func/dockerImagesToK8sDeploymentContainerSpec.js
@@ -8,9 +8,12 @@ function dockerImagesToK8sDeploymentContainerSpec(component) {
 
     images.forEach(function (dockerImage) {
         let deploymentContainer = {};
-        deploymentContainer.image = dockerImage.image;
+        // Only allow "valid DNS characters" for the container name, and make sure it doesn't end
+        // with a '-'.
+        deploymentContainer.name = dockerImage.si.name.replace(/[^A-Za-z0-9]/g, '-').replace(/-+$/, '');
+        deploymentContainer.image = dockerImage.domain.image;
         deploymentContainer.ports = [];
-        let exposedPorts = dockerImage.ExposedPorts;
+        let exposedPorts = dockerImage.domain.ExposedPorts;
         if (!(exposedPorts === undefined || exposedPorts === null)) {
             exposedPorts.forEach(function (exposedPort) {
                 if (!(exposedPort === undefined || exposedPorts === null)) {

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -677,13 +677,12 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     )
     .await?;
 
-    // Connect "/root/domain" to the external provider.
-    let domain_implicit_internal_provider =
-        InternalProvider::get_for_prop(ctx, root_prop.domain_prop_id)
-            .await?
-            .ok_or(BuiltinsError::ImplicitInternalProviderNotFoundForProp(
-                root_prop.domain_prop_id,
-            ))?;
+    // Connect "/root" to the external provider.
+    let root_implicit_internal_provider = InternalProvider::get_for_prop(ctx, root_prop.prop_id)
+        .await?
+        .ok_or(BuiltinsError::ImplicitInternalProviderNotFoundForProp(
+            root_prop.prop_id,
+        ))?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *docker_image_external_provider
@@ -694,7 +693,7 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
                 )
             })?,
         "identity".to_string(),
-        *domain_implicit_internal_provider.id(),
+        *root_implicit_internal_provider.id(),
     )
     .await?;
 

--- a/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
@@ -145,6 +145,7 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                             "containers": [
                                 {
                                     "image": "ironsides",
+                                    "name": "ironsides",
                                     "ports": [],
                                 },
                             ],


### PR DESCRIPTION
We now send the full tree of AttributeValues to the ExternalProvider on DockerImage, so that we can get both the domain Props, and the SI Name Prop, when building the Containers array on a K8s Deployment.

This also makes sure that the name for the container only contains letters/numbers/dashes, and that it ends in letters/numbers.