### PR TITLE
chore(dal): remove internal provider's consumer field

### DIFF
--- a/app/web/src/api/sdf/dal/provider.ts
+++ b/app/web/src/api/sdf/dal/provider.ts
@@ -5,7 +5,6 @@ export interface InternalProvider extends StandardModel {
   schemaId: number;
   schemaVariantId: number;
   name?: string;
-  internal_consumer: boolean;
   inbound_type_definition?: string;
   outbound_type_definition?: string;
 }

--- a/lib/dal/src/migrations/U0058__internal_providers.sql
+++ b/lib/dal/src/migrations/U0058__internal_providers.sql
@@ -16,7 +16,6 @@ CREATE TABLE internal_providers
     schema_variant_id           bigint                   NOT NULL,
     attribute_prototype_id      bigint,
     name                        text                     NOT NULL,
-    internal_consumer           boolean                  NOT NULL DEFAULT TRUE,
     inbound_type_definition     text,
     outbound_type_definition    text
 );
@@ -35,7 +34,6 @@ CREATE OR REPLACE FUNCTION internal_provider_create_v1(
     this_schema_id bigint,
     this_schema_variant_id bigint,
     this_name text,
-    this_internal_consumer boolean,
     this_inbound_type_definition text,
     this_outbound_type_definition text,
     OUT object json) AS
@@ -59,7 +57,6 @@ BEGIN
                                     schema_id,
                                     schema_variant_id,
                                     name,
-                                    internal_consumer,
                                     inbound_type_definition,
                                     outbound_type_definition)
     VALUES (this_tenancy_record.tenancy_universal,
@@ -73,7 +70,6 @@ BEGIN
             this_schema_id,
             this_schema_variant_id,
             this_name,
-            this_internal_consumer,
             this_inbound_type_definition,
             this_outbound_type_definition)
     RETURNING * INTO this_new_row;

--- a/lib/dal/src/queries/internal_provider_find_explicit_for_schema_variant_and_name.sql
+++ b/lib/dal/src/queries/internal_provider_find_explicit_for_schema_variant_and_name.sql
@@ -9,7 +9,7 @@ WHERE in_tenancy_v1($1, tenancy_universal, tenancy_billing_account_ids,
                     tenancy_organization_ids, tenancy_workspace_ids)
   AND is_visible_v1($2, visibility_change_set_pk, visibility_edit_session_pk,
                     visibility_deleted_at)
-  AND internal_consumer = false
+  AND prop_id = -1
   AND schema_variant_id = $3
   AND name = $4
 

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -191,7 +191,7 @@ impl Connection {
 
         // Check that the explicit internal provider is actually explicit and find its attribute
         // prototype id.
-        if *head_explicit_internal_provider.internal_consumer() {
+        if head_explicit_internal_provider.is_internal_consumer() {
             return Err(SchematicError::FoundImplicitInternalProvider(
                 *head_explicit_internal_provider.id(),
             ));


### PR DESCRIPTION
- Remove "internal_consumer" field from InternalProvider
- Use the "prop_id" field for determining consumer type since that field
  is immutable

<img src="https://media1.giphy.com/media/wXFezFS9sQv4ldb55a/giphy.gif"/>

Fixes ENG-275