### PR TITLE
chore(dal): remove optional providers for connections

### DIFF
--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -29,11 +29,21 @@ async fn get_schematic(ctx: &DalContext<'_, '_>, application_id: ApplicationId) 
         .iter()
         .find(|s| s.edge_kind() == &SocketEdgeKind::Configures && s.name() == "service")
         .expect("cannot find input socket");
+    let explicit_internal_provider = input_socket
+        .internal_provider(ctx)
+        .await
+        .expect("cannot find external provider")
+        .expect("external provider not found");
 
     let output_socket = sockets
         .iter()
         .find(|s| s.edge_kind() == &SocketEdgeKind::Output && s.name() == "service")
         .expect("cannot find output socket");
+    let external_provider = output_socket
+        .external_provider(ctx)
+        .await
+        .expect("cannot find external provider")
+        .expect("external provider not found");
 
     let (_component, node, _) =
         Component::new_for_schema_with_node(ctx, "sc-component-get_schematic", service_schema.id())
@@ -89,10 +99,10 @@ async fn get_schematic(ctx: &DalContext<'_, '_>, application_id: ApplicationId) 
         ctx,
         node2.id(),
         output_socket.id(),
-        None,
+        *explicit_internal_provider.id(),
         node.id(),
         input_socket.id(),
-        None,
+        *external_provider.id(),
     )
     .await
     .expect("could not create connection");
@@ -161,11 +171,21 @@ async fn create_connection(ctx: &DalContext<'_, '_>) {
         .iter()
         .find(|s| s.edge_kind() == &SocketEdgeKind::Configures && s.name() == "service")
         .expect("cannot find input socket");
+    let explicit_internal_provider = input_socket
+        .internal_provider(ctx)
+        .await
+        .expect("cannot find external provider")
+        .expect("external provider not found");
 
     let output_socket = sockets
         .iter()
         .find(|s| s.edge_kind() == &SocketEdgeKind::Output && s.name() == "service")
         .expect("cannot find output socket");
+    let external_provider = output_socket
+        .external_provider(ctx)
+        .await
+        .expect("cannot find external provider")
+        .expect("external provider not found");
 
     let (_head_component, head_node, _) =
         Component::new_for_schema_with_node(ctx, "head", service_schema.id())
@@ -181,10 +201,10 @@ async fn create_connection(ctx: &DalContext<'_, '_>) {
         ctx,
         head_node.id(),
         output_socket.id(),
-        None,
+        *explicit_internal_provider.id(),
         tail_node.id(),
         input_socket.id(),
-        None,
+        *external_provider.id(),
     )
     .await
     .expect("could not create connection");

--- a/lib/sdf/src/server/service/schematic/create_connection.rs
+++ b/lib/sdf/src/server/service/schematic/create_connection.rs
@@ -38,15 +38,14 @@ pub async fn create_connection(
     let txns = txns.start().await?;
     let ctx = builder.build(request_ctx.clone().build(request.visibility), &txns);
 
-    // TODO(nick): pass through the provider ids.
     let connection = Connection::new(
         &ctx,
         &request.head_node_id,
         &request.head_socket_id,
-        Some(request.head_internal_provider_id),
+        request.head_internal_provider_id,
         &request.tail_node_id,
         &request.tail_socket_id,
-        Some(request.tail_external_provider_id),
+        request.tail_external_provider_id,
     )
     .await?;
 


### PR DESCRIPTION
- Remove optional provider ids for inter component connections
- Ensure the integration tests use the providers corresponding to the
  sockets used

<img src="https://media4.giphy.com/media/KCZAgikZIUkK1conAk/giphy.gif"/>

Fixes ENG-282