### PR TITLE
chore(dal): use impl AsRef<str> for provider funcs

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -99,7 +99,7 @@ impl AttributePrototypeArgument {
     pub async fn new_for_intra_component(
         ctx: &DalContext<'_, '_>,
         attribute_prototype_id: AttributePrototypeId,
-        name: String,
+        name: impl AsRef<str>,
         internal_provider_id: InternalProviderId,
     ) -> AttributePrototypeArgumentResult<Self> {
         // Ensure the value fields are what we expect.
@@ -110,6 +110,7 @@ impl AttributePrototypeArgument {
             return Err(AttributePrototypeArgumentError::RequiredValueFieldsUnset);
         }
 
+        let name = name.as_ref();
         let row = ctx
             .txns()
             .pg()
@@ -135,7 +136,7 @@ impl AttributePrototypeArgument {
     pub async fn new_for_inter_component(
         ctx: &DalContext<'_, '_>,
         attribute_prototype_id: AttributePrototypeId,
-        name: String,
+        name: impl AsRef<str>,
         external_provider_id: ExternalProviderId,
         tail_component_id: ComponentId,
         head_component_id: ComponentId,
@@ -149,6 +150,7 @@ impl AttributePrototypeArgument {
             return Err(AttributePrototypeArgumentError::RequiredValueFieldsUnset);
         }
 
+        let name = name.as_ref();
         let row = ctx
             .txns()
             .pg()

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -440,7 +440,7 @@ async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *metadata_name_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *si_name_internal_provider.id(),
     )
     .await?;
@@ -460,7 +460,7 @@ async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        "identity".to_string(),
+        "identity",
         *metadata_name_implicit_internal_provider.id(),
     )
     .await?;
@@ -733,7 +733,7 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *image_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *si_name_internal_provider.id(),
     )
     .await?;
@@ -753,7 +753,7 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
                     *docker_image_external_provider.id(),
                 )
             })?,
-        "identity".to_string(),
+        "identity",
         *root_implicit_internal_provider.id(),
     )
     .await?;

--- a/lib/dal/src/builtins/schema/kubernetes_deployment.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_deployment.rs
@@ -230,7 +230,7 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<(
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *domain_namespace_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *kubernetes_namespace_explicit_internal_provider.id(),
     )
     .await?;
@@ -261,7 +261,7 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<(
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *template_namespace_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *kubernetes_namespace_explicit_internal_provider.id(),
     )
     .await?;
@@ -296,7 +296,7 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<(
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *containers_attribute_prototype.id(),
-        "images".to_string(),
+        "images",
         *docker_image_explicit_internal_provider.id(),
     )
     .await?;

--- a/lib/dal/src/schematic.rs
+++ b/lib/dal/src/schematic.rs
@@ -121,10 +121,9 @@ impl Connection {
             .ok_or(SchematicError::Node(NodeError::ComponentIsNone))?;
 
         // TODO(nick): allow for non-identity inter component connections.
-        let name = "identity".to_string();
         Self::connect_providers(
             ctx,
-            name,
+            "identity",
             tail_external_provider_id,
             *tail_component.id(),
             head_explicit_internal_provider_id,
@@ -161,7 +160,7 @@ impl Connection {
     /// latter is why this function is public.
     pub async fn connect_providers(
         ctx: &DalContext<'_, '_>,
-        name: String,
+        name: impl AsRef<str>,
         tail_external_provider_id: ExternalProviderId,
         tail_component_id: ComponentId,
         head_explicit_internal_provider_id: InternalProviderId,

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -86,7 +86,7 @@ async fn create_and_list_for_attribute_prototype(ctx: &DalContext<'_, '_>) {
     let argument = AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *attribute_prototype.id(),
-        "title".to_string(),
+        "title",
         *internal_provider.id(),
     )
     .await

--- a/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
@@ -74,7 +74,7 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
     // Finally, create the inter component connection.
     Connection::connect_providers(
         ctx,
-        "identity".to_string(),
+        "identity",
         *tail_external_provider.id(),
         tail_docker_image_payload.component_id,
         *head_explicit_internal_provider.id(),

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -75,7 +75,7 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *intermediate_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *source_internal_provider.id(),
     )
     .await
@@ -142,7 +142,7 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
         *esp_external_provider
             .attribute_prototype_id()
             .expect("no attribute prototype id for external provider"),
-        "identity".to_string(),
+        "identity",
         *esp_intermediate_internal_provider.id(),
     )
     .await
@@ -181,7 +181,7 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *swings_destination_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *swings_explicit_internal_provider.id(),
     )
     .await
@@ -217,7 +217,7 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
     // Connect the two components.
     Connection::connect_providers(
         ctx,
-        "identity".to_string(),
+        "identity",
         *esp_external_provider.id(),
         esp_payload.component_id,
         *swings_explicit_internal_provider.id(),
@@ -481,7 +481,7 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
         *source_external_provider
             .attribute_prototype_id()
             .expect("no attribute prototype id for external provider"),
-        "identity".to_string(),
+        "identity",
         *source_internal_provider.id(),
     )
     .await
@@ -563,7 +563,7 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *destination_object_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *destination_internal_provider.id(),
     )
     .await
@@ -625,7 +625,7 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
 
     Connection::connect_providers(
         ctx,
-        "identity".to_string(),
+        "identity",
         *source_external_provider.id(),
         *source_component.id(),
         *destination_internal_provider.id(),

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -207,7 +207,7 @@ async fn intra_component_identity_update(ctx: &DalContext<'_, '_>) {
     let _argument = AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *destination_attribute_prototype.id(),
-        "identity".to_string(),
+        "identity",
         *source_internal_provider.id(),
     )
     .await

--- a/lib/dal/tests/integration_test/provider/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -76,7 +76,7 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(
     // Finally, create the inter component connection.
     Connection::connect_providers(
         ctx,
-        "identity".to_string(),
+        "identity",
         *tail_external_provider.id(),
         tail_namespace_payload.component_id,
         *head_explicit_internal_provider.id(),


### PR DESCRIPTION
- Use "impl AsRef<str>" instead of "String" for provider-related
  functions
- Remove unnecessary heap allocated strings in integration tests

<img src="https://media2.giphy.com/media/o67a2cJ3GLelEROWYz/giphy.gif"/>

Fixes ENG-295