### PR TITLE
feat(dal): cache attribute view on veritech calls

### DIFF
--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -39,7 +39,7 @@ async function main() {
   try {
     const requestJson = fs.readFileSync(0, "utf8");
     const request = JSON.parse(requestJson);
-    debug({ request });
+    debug({ request, data: JSON.stringify(request?.data) });
     if (request.executionId) {
       executionId = request.executionId;
     } else {

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -53,7 +53,7 @@ impl RootProp {
         let root_context = AttributeContext::builder()
             .set_prop_id(*root_prop.id())
             .to_context()?;
-        let (_, root_value_id, _) = AttributeValue::update_for_context(
+        let (_, root_value_id, task) = AttributeValue::update_for_context(
             ctx,
             *AttributeValue::find_for_context(ctx, root_context.into())
                 .await?
@@ -65,11 +65,12 @@ impl RootProp {
             None,
         )
         .await?;
+        task.run_updates_in_ctx(ctx).await?;
 
         let si_context = AttributeContext::builder()
             .set_prop_id(*si_specific_prop.id())
             .to_context()?;
-        let (_, si_value_id, _) = AttributeValue::update_for_context(
+        let (_, si_value_id, task) = AttributeValue::update_for_context(
             ctx,
             *AttributeValue::find_for_context(ctx, si_context.into())
                 .await?
@@ -81,11 +82,12 @@ impl RootProp {
             None,
         )
         .await?;
+        task.run_updates_in_ctx(ctx).await?;
 
         let si_name_context = AttributeContext::builder()
             .set_prop_id(*si_name_prop.id())
             .to_context()?;
-        let _ = AttributeValue::update_for_context(
+        let (_, _, task) = AttributeValue::update_for_context(
             ctx,
             *AttributeValue::find_for_context(ctx, si_name_context.into())
                 .await?
@@ -97,11 +99,12 @@ impl RootProp {
             None,
         )
         .await?;
+        task.run_updates_in_ctx(ctx).await?;
 
         let domain_context = AttributeContext::builder()
             .set_prop_id(*domain_specific_prop.id())
             .to_context()?;
-        let _ = AttributeValue::update_for_context(
+        let (_, _, task) = AttributeValue::update_for_context(
             ctx,
             *AttributeValue::find_for_context(ctx, domain_context.into())
                 .await?
@@ -113,6 +116,7 @@ impl RootProp {
             None,
         )
         .await?;
+        task.run_updates_in_ctx(ctx).await?;
 
         Ok(Self {
             prop_id: *root_prop.id(),

--- a/lib/dal/src/test/helpers.rs
+++ b/lib/dal/src/test/helpers.rs
@@ -279,8 +279,7 @@ pub async fn update_attribute_value_for_prop_and_context(
     )
     .await
     .expect("cannot update value for context");
-    let _ = task
-        .run_updates_in_ctx(ctx)
+    task.run_updates_in_ctx(ctx)
         .await
         .expect("unable to run dependent values async task");
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -404,10 +404,13 @@ pub async fn create_component_for_schema_variant(
     schema_variant_id: &SchemaVariantId,
 ) -> Component {
     let name = generate_fake_name();
-    let (component, _, _) =
+    let (component, _, task) =
         Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
             .await
             .expect("cannot create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("cannot run async updates");
     component
 }
 

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -379,9 +379,18 @@ async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
     prop.set_parent_prop(ctx, root.domain_prop_id)
         .await
         .expect("cannot set parent of prop");
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "toddhoward", schema.id())
+
+    // Now, we can setup providers.
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers");
+
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "toddhoward", schema.id())
         .await
         .expect("cannot create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async updates");
 
     let read_context = AttributeReadContext {
         prop_id: None,

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -49,6 +49,9 @@ pub async fn create_schema_with_object_and_string_prop(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (
         schema,
@@ -122,6 +125,9 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (
         schema,
@@ -167,6 +173,9 @@ pub async fn create_schema_with_string_props(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (schema, schema_variant, bohemian_prop, killer_prop, root)
 }
@@ -203,6 +212,9 @@ pub async fn create_schema_with_array_of_string_props(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (schema, schema_variant, sammy_prop, album_string_prop, root)
 }
@@ -272,6 +284,9 @@ pub async fn create_schema_with_nested_array_objects(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (
         schema,
@@ -320,6 +335,9 @@ pub async fn create_simple_map(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (schema, schema_variant, album_prop, album_item_prop, root)
 }
@@ -395,6 +413,9 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
         .expect("cannot create default prototypes & values for SchemaVariant");
+    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+        .await
+        .expect("unable to create implicit internal providers for schema variant");
 
     (
         schema,
@@ -413,10 +434,13 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 async fn only_string_props(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
-    let (component, _, _) =
+    let (component, _, task) =
         Component::new_for_schema_variant_with_node(ctx, "capoeira", schema_variant.id())
             .await
             .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -443,7 +467,7 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve bohemian AttributeValue")
         .expect("could not find bohemian AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *bohemian_value.id(),
         Some(*domain_value.id()),
@@ -453,6 +477,9 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update bohemian prop value");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let killer_context = base_attribute_context
         .clone()
@@ -463,7 +490,7 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve killer AttributeValue")
         .expect("could not find killer AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *killer_value.id(),
         Some(*domain_value.id()),
@@ -473,6 +500,9 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update bohemian prop value");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -505,10 +535,13 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
 async fn one_object_prop(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
-    let (component, _, _) =
+    let (component, _, task) =
         Component::new_for_schema_variant_with_node(ctx, "santos dumont", schema_variant.id())
             .await
             .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -535,7 +568,7 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve queen AttributeValue")
         .expect("could not find queen AttributeValue");
-    let (_, queen_value_id, _) = AttributeValue::update_for_context(
+    let (_, queen_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_queen_value.id(),
         Some(*domain_value.id()),
@@ -545,6 +578,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update queen AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let bohemian_context = base_attribute_context
         .clone()
@@ -555,7 +591,7 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve bohemian AttributeValue")
         .expect("could not find bohemian AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *unset_bohemian_value.id(),
         Some(queen_value_id),
@@ -565,6 +601,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update bohemian AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let killer_context = base_attribute_context
         .clone()
@@ -575,7 +614,7 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve killer AttributeValue")
         .expect("could not find killer AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *unset_killer_value.id(),
         Some(queen_value_id),
@@ -585,6 +624,9 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update killer AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -624,10 +666,13 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         dust_prop,
         root_prop,
     ) = create_schema_with_nested_objects_and_string_prop(ctx).await;
-    let (component, _, _) =
+    let (component, _, task) =
         Component::new_for_schema_variant_with_node(ctx, "free ronaldinho", schema_variant.id())
             .await
             .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -654,7 +699,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch queen AttributeValue")
         .expect("could not find queen AttributeValue");
-    let (_, queen_value_id, _) = AttributeValue::update_for_context(
+    let (_, queen_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_queen_value.id(),
         Some(*domain_value.id()),
@@ -664,6 +709,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update queen AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let bohemian_context = base_attribute_context
         .clone()
@@ -674,7 +722,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch bohemian AttributeValue")
         .expect("could not find bohemian AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *unset_bohemian_value.id(),
         Some(queen_value_id),
@@ -684,6 +732,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update bohemian AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let killer_context = base_attribute_context
         .clone()
@@ -694,7 +745,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch killer AttributeValue")
         .expect("could not find killer AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *unset_killer_value.id(),
         Some(queen_value_id),
@@ -704,6 +755,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update killer AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let pressure_context = base_attribute_context
         .clone()
@@ -714,7 +768,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch pressure AttributeValue")
         .expect("could not find pressure AttributeValue");
-    let (_, pressure_value_id, _) = AttributeValue::update_for_context(
+    let (_, pressure_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_pressure_value.id(),
         Some(queen_value_id),
@@ -724,6 +778,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update pressure AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let dust_context = base_attribute_context
         .clone()
@@ -734,7 +791,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch dust AttributeValue")
         .expect("could not find dust AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *unset_dust_value.id(),
         Some(pressure_value_id),
@@ -744,6 +801,9 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update dust AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -783,10 +843,13 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
-    let (component, _, _) =
+    let (component, _, task) =
         Component::new_for_schema_variant_with_node(ctx, "tim maia", schema_variant.id())
             .await
             .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -813,7 +876,7 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve sammy AttributeValue")
         .expect("could not find sammy AttributeValue");
-    let (_, sammy_value_id, _) = AttributeValue::update_for_context(
+    let (_, sammy_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_sammy_value.id(),
         Some(*domain_value.id()),
@@ -823,13 +886,16 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update sammy AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_context = base_attribute_context
         .clone()
         .set_prop_id(*album_prop.id())
         .to_context()
         .expect("could not create album AttributeContext");
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         album_context,
         sammy_value_id,
@@ -838,7 +904,11 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert album AttributeValue");
-    let _ = AttributeValue::insert_for_context(
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
+
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         album_context,
         sammy_value_id,
@@ -847,6 +917,9 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert album AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -887,13 +960,16 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         song_name_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects(ctx).await;
-    let (component, _, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, task) = Component::new_for_schema_variant_with_node(
         ctx,
         "An Integralist Doesn't Run, It Flies",
         schema_variant.id(),
     )
     .await
     .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut unset_attribute_context = AttributeContext::builder();
     unset_attribute_context
@@ -926,7 +1002,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
         .set_prop_id(*sammy_prop.id())
         .to_context()
         .expect("could not create sammy AttributeContext");
-    let (_, sammy_value_id, _) = AttributeValue::update_for_context(
+    let (_, sammy_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_sammy_value.id(),
         Some(*domain_value.id()),
@@ -936,13 +1012,16 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update sammy AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_object_context = base_attribute_context
         .clone()
         .set_prop_id(*album_object_prop.id())
         .to_context()
         .expect("could not create album object AttributeContext");
-    let (standing_hampton_album_value_id, _) = AttributeValue::insert_for_context(
+    let (standing_hampton_album_value_id, task) = AttributeValue::insert_for_context(
         ctx,
         album_object_context,
         sammy_value_id,
@@ -951,6 +1030,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert album object AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_string_context = base_attribute_context
         .clone()
@@ -966,7 +1048,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     .await
     .expect("could not retrieve album string AttributeValue")
     .expect("could not find album string AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *standing_hampton_album_string_value.id(),
         Some(standing_hampton_album_value_id),
@@ -976,6 +1058,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update standing hampton album string AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let songs_array_context = base_attribute_context
         .clone()
@@ -991,7 +1076,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     .await
     .expect("could not fetch songs array AttributeValue")
     .expect("could not find songs array AttributeValue");
-    let (_, standing_hampton_songs_array_value_id, _) = AttributeValue::update_for_context(
+    let (_, standing_hampton_songs_array_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *standing_hampton_songs_array_value.id(),
         Some(standing_hampton_album_value_id),
@@ -1001,13 +1086,16 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update standing hampton songs array AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let song_name_context = base_attribute_context
         .clone()
         .set_prop_id(*song_name_prop.id())
         .to_context()
         .expect("could not create song name AttributeContext");
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_name_context,
         standing_hampton_songs_array_value_id,
@@ -1016,7 +1104,11 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert fall in love again in standing hampton songs array");
-    let _ = AttributeValue::insert_for_context(
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
+
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_name_context,
         standing_hampton_songs_array_value_id,
@@ -1025,8 +1117,11 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert surrender in standing hampton songs array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
-    let (voa_album_value_id, _) = AttributeValue::insert_for_context(
+    let (voa_album_value_id, task) = AttributeValue::insert_for_context(
         ctx,
         album_object_context,
         sammy_value_id,
@@ -1035,6 +1130,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert voa album object into albums array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let voa_album_string_value = AttributeValue::find_with_parent_and_key_for_context(
         ctx,
@@ -1045,7 +1143,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     .await
     .expect("could not retrieve voa album string AttributeValue")
     .expect("could not find voa album string AttributeValue");
-    let _ = AttributeValue::update_for_context(
+    let (_, _, task) = AttributeValue::update_for_context(
         ctx,
         *voa_album_string_value.id(),
         Some(voa_album_value_id),
@@ -1055,6 +1153,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not set voa album string AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let voa_songs_array_value = AttributeValue::find_with_parent_and_key_for_context(
         ctx,
@@ -1065,7 +1166,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     .await
     .expect("could not fetch songs array AttributeValue")
     .expect("could not find songs array AttributeValue");
-    let (_, voa_songs_value_id, _) = AttributeValue::update_for_context(
+    let (_, voa_songs_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *voa_songs_array_value.id(),
         Some(voa_album_value_id),
@@ -1075,8 +1176,11 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update voa songs array AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_name_context,
         voa_songs_value_id,
@@ -1085,8 +1189,11 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert eagles fly into voa songs array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_name_context,
         voa_songs_value_id,
@@ -1095,6 +1202,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert can't drive 55 into voa songs array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -1138,13 +1248,16 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
 async fn simple_map(ctx: &DalContext<'_, '_>) {
     let (schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
-    let (component, _, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, task) = Component::new_for_schema_variant_with_node(
         ctx,
         "E como isso afeta o Grêmio?",
         schema_variant.id(),
     )
     .await
     .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -1171,7 +1284,7 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not retrieve album AttributeValue")
         .expect("could not find album AttributeValue");
-    let (_, album_value_id, _) = AttributeValue::update_for_context(
+    let (_, album_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_album_value.id(),
         Some(*domain_value.id()),
@@ -1181,13 +1294,16 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update album AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_item_context = base_attribute_context
         .clone()
         .set_prop_id(*album_item_prop.id())
         .to_context()
         .expect("could not create album item AttributeContext");
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         album_item_context,
         album_value_id,
@@ -1196,7 +1312,11 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert album item");
-    let _ = AttributeValue::insert_for_context(
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
+
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         album_item_context,
         album_value_id,
@@ -1205,6 +1325,9 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert album item");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,
@@ -1245,13 +1368,16 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         song_map_item_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects_and_a_map(ctx).await;
-    let (component, _, _) = Component::new_for_schema_variant_with_node(
+    let (component, _, task) = Component::new_for_schema_variant_with_node(
         ctx,
         "E como isso afeta o Grêmio?",
         schema_variant.id(),
     )
     .await
     .expect("Unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context
@@ -1278,7 +1404,7 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch sammy AttributeValue")
         .expect("could not find sammy AttributeValue");
-    let (_, sammy_value_id, _) = AttributeValue::update_for_context(
+    let (_, sammy_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_sammy_value.id(),
         Some(*domain_value.id()),
@@ -1288,13 +1414,16 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update sammy AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_object_context = base_attribute_context
         .clone()
         .set_prop_id(*album_object_prop.id())
         .to_context()
         .expect("could not create album object context");
-    let (standing_hampton_value_id, _) = AttributeValue::insert_for_context(
+    let (standing_hampton_value_id, task) = AttributeValue::insert_for_context(
         ctx,
         album_object_context,
         sammy_value_id,
@@ -1303,6 +1432,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert standing_hampton into albums array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let album_string_context = base_attribute_context
         .clone()
@@ -1334,7 +1466,7 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
         .await
         .expect("could not fetch songs array AttributeValue")
         .expect("could not find songs array AttributeValue");
-    let (_, songs_array_value_id, _) = AttributeValue::update_for_context(
+    let (_, songs_array_value_id, task) = AttributeValue::update_for_context(
         ctx,
         *unset_songs_array_value.id(),
         Some(standing_hampton_value_id),
@@ -1344,13 +1476,16 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not update songs array AttributeValue");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let song_map_context = base_attribute_context
         .clone()
         .set_prop_id(*song_map_prop.id())
         .to_context()
         .expect("could not create song map AttributeContext");
-    let (song_map_value_id, _) = AttributeValue::insert_for_context(
+    let (song_map_value_id, task) = AttributeValue::insert_for_context(
         ctx,
         song_map_context,
         songs_array_value_id,
@@ -1359,13 +1494,16 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert song map into songs array");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let song_map_item_context = base_attribute_context
         .clone()
         .set_prop_id(*song_map_item_prop.id())
         .to_context()
         .expect("could not create song map item AttributeContext");
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_map_item_context,
         song_map_value_id,
@@ -1374,8 +1512,11 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert fall in love again into standing hampton songs map");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
-    let _ = AttributeValue::insert_for_context(
+    let (_, task) = AttributeValue::insert_for_context(
         ctx,
         song_map_item_context,
         song_map_value_id,
@@ -1384,6 +1525,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
     )
     .await
     .expect("could not insert surrender into standing hampton song map");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     let component_view = ComponentView::for_context(
         ctx,

--- a/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/docker_image_to_kubernetes_deployment.rs
@@ -172,9 +172,12 @@ async fn setup_docker_image(ctx: &DalContext<'_, '_>) -> ComponentPayload {
         .default_schema_variant_id()
         .expect("default schema variant id not found");
 
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "image", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "image", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*schema.id()),
@@ -210,9 +213,12 @@ async fn setup_kubernetes_deployment(ctx: &DalContext<'_, '_>) -> ComponentPaylo
         .default_schema_variant_id()
         .expect("default schema variant id not found");
 
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "deployment", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "deployment", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*schema.id()),

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -335,9 +335,12 @@ async fn setup_esp(ctx: &DalContext<'_, '_>) -> ComponentPayload {
     SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
         .await
         .expect("could not create internal providers for schema variant");
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "esp", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "esp", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
@@ -405,9 +408,12 @@ async fn setup_swings(ctx: &DalContext<'_, '_>) -> ComponentPayload {
     SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
         .await
         .expect("could not create internal providers for schema variant");
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "swings", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "swings", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
 
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
@@ -581,10 +587,13 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
     .await
     .expect("cannot create prototype argument for destination");
 
-    let (source_component, _, _) =
+    let (source_component, _, task) =
         Component::new_for_schema_with_node(ctx, "Source Component", source_schema.id())
             .await
             .expect("Unable to create source component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let source_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*source_schema.id()),
@@ -608,10 +617,13 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
             .properties,
     );
 
-    let (destination_component, _, _) =
+    let (destination_component, _, task) =
         Component::new_for_schema_with_node(ctx, "Destination Component", destination_schema.id())
             .await
             .expect("Unable to create destination component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let destination_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*destination_schema.id()),

--- a/lib/dal/tests/integration_test/provider/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -171,9 +171,12 @@ async fn setup_kubernetes_namespace(ctx: &DalContext<'_, '_>) -> ComponentPayloa
         .default_schema_variant_id()
         .expect("default schema variant id not found");
 
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "namespace", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "namespace", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*schema.id()),
@@ -209,9 +212,12 @@ async fn setup_kubernetes_deployment(ctx: &DalContext<'_, '_>) -> ComponentPaylo
         .default_schema_variant_id()
         .expect("default schema variant id not found");
 
-    let (component, _, _) = Component::new_for_schema_with_node(ctx, "deployment", schema.id())
+    let (component, _, task) = Component::new_for_schema_with_node(ctx, "deployment", schema.id())
         .await
         .expect("unable to create component");
+    task.run_updates_in_ctx(ctx)
+        .await
+        .expect("unable to run async tasks");
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
         schema_id: Some(*schema.id()),


### PR DESCRIPTION
Instead of generating an attribute view every time we call veritech we
get the attribute value of the root prop's internal provider.

- Removes unused veritech call
- Adds more debug information to lang-js
- Creates implicit internal providers for tests schema variants
- Call async tasks in root prop creation and tests

Turns out the stale cache data I was seeing since friday was caused by multiple requests racing, so not exactly a bug just a weird behavior caused by the slowness of property setting.

<img src="https://media0.giphy.com/media/G1ifnX4d5tYFACktp9/giphy.gif"/>