### PR TITLE
chore(dal,sdf): Increase stack size for Tokio runtime itself

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,3 @@
 rustflags = [
     "-C", "link-arg=-fuse-ld=lld",
 ]
-
-[profile.test.package.dal]
-opt-level = 1

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -11,11 +11,15 @@ mod args;
 const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
 
 fn main() -> Result<()> {
-    tokio::runtime::Builder::new_multi_thread()
-        .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
-        .enable_all()
-        .build()?
-        .block_on(async_main())
+    let thread_builder = ::std::thread::Builder::new().stack_size(RT_DEFAULT_THREAD_STACK_SIZE);
+    let thread_handler = thread_builder.spawn(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
+            .enable_all()
+            .build()?
+            .block_on(async_main())
+    })?;
+    thread_handler.join().unwrap()
 }
 
 async fn async_main() -> Result<()> {

--- a/lib/si-test-macros/src/dal_test.rs
+++ b/lib/si-test-macros/src/dal_test.rs
@@ -65,8 +65,12 @@ pub(crate) fn expand(item: ItemFn, _args: AttributeArgs) -> TokenStream {
 
             #tracing_init
 
-            #[allow(clippy::expect_used)]
-            #rt.block_on(imp())
+            let thread_builder = ::std::thread::Builder::new().stack_size(#thread_stack_size);
+            let thread_handler = thread_builder.spawn(|| {
+                #[allow(clippy::expect_used)]
+                #rt.block_on(imp())
+            }).unwrap();
+            thread_handler.join().unwrap();
         }
     }
 }


### PR DESCRIPTION
We were already increasing the stack size for any tasks/threads that Tokio would spawn, but the size of the stack for the thread that Tokio itself was running in was still the default size. Now we spawn a new thread that is configured to have the same stack size that Tokio will use for threads that it creates, and start the Tokio runtime in that new thread.

This does mean that we have an "extra" parent thread sitting around doing nothing other than waiting for Tokio's thread to end, but threads are cheap enough that this shouldn't really matter.

Now that Tokio itself is running in a thread with a larger stack size, we no longer need the tests to run with a higher-than-default optimization level to reduce the size of Tokio's stack usage.