### PR TITLE
feat(dal): add and use SiNavbarButton

### DIFF
--- a/app/web/src/atoms/SiNavbarButton.vue
+++ b/app/web/src/atoms/SiNavbarButton.vue
@@ -1,0 +1,74 @@
+<template>
+  <div :class="bgClasses">
+    <button
+      v-tooltip.bottom="tooltipText"
+      :class="buttonClasses"
+      :aria-label="props.tooltipText"
+      :disabled="disabled"
+      @click="emit('click')"
+    >
+      <slot></slot>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRefs } from "vue";
+
+const emit = defineEmits(["click"]);
+
+const props = defineProps<{
+  disabled?: boolean;
+  selected?: boolean;
+  tooltipText: string;
+  panelSwitcher?: boolean;
+}>();
+const { disabled, selected, tooltipText } = toRefs(props);
+
+const selectedPanelBgColor = "bg-[#2F80ED]";
+const selectedBgColor = "bg-black";
+
+const bgClasses = computed(() => {
+  const results: Record<string, boolean> = {
+    "py-12": true,
+    "px-4": true,
+    "hover:bg-black": true,
+  };
+
+  if (selected?.value) {
+    results["hover:bg-black"] = false;
+    if (props.panelSwitcher) {
+      results[selectedPanelBgColor] = true;
+    } else {
+      results[selectedBgColor] = true;
+    }
+  }
+
+  return results;
+});
+
+const buttonClasses = computed(() => {
+  const results: Record<string, boolean> = {
+    block: true,
+    "w-6": true,
+    "h-6": true,
+    "text-gray-300": true,
+    "hover:text-white": true,
+  };
+  if (disabled?.value) {
+    results["opacity-50"] = true;
+    results["cursor-not-allowed"] = true;
+  } else if (selected?.value) {
+    results["text-white"] = true;
+    results["text-gray-300"] = false;
+    results["hover:text-white"] = false;
+  }
+  return results;
+});
+</script>
+
+<style lang="scss" scoped>
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+</style>

--- a/app/web/src/atoms/SiProfileIcon.vue
+++ b/app/web/src/atoms/SiProfileIcon.vue
@@ -1,9 +1,11 @@
 <template>
-  <MenuButton
-    class="bg-gray-800 flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-  >
+  <MenuButton class="flex text-sm rounded-full border-black border-2">
     <span class="sr-only">Open user menu</span>
-    <img class="h-8 w-8 rounded-full bg-white" :src="CheechSvg" alt="" />
+    <img
+      class="h-8 w-8 rounded-full bg-white"
+      :src="CheechSvg"
+      alt="Cheech and Chong"
+    />
   </MenuButton>
 </template>
 

--- a/app/web/src/atoms/SiSidebarContent.vue
+++ b/app/web/src/atoms/SiSidebarContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="border-r border-gray-200 pt-5 flex flex-col flex-grow bg-white overflow-y-auto"
+    class="border-x border-b border-black pt-5 flex flex-col flex-grow bg-white overflow-y-auto"
   >
     <div class="flex-grow m-5 p-5 items-center flex flex-col">
       {{ props.placeholder }}

--- a/app/web/src/organisims/Navbar.vue
+++ b/app/web/src/organisims/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <Disclosure v-slot="{ open }" as="nav" class="bg-gray-800">
+  <Disclosure v-slot="{ open }" as="nav" :class="bgColor">
     <div class="mx-auto px-4 sm:px-4 lg:px-4">
       <div class="flex items-center justify-between h-16">
         <!-- Left side -->
@@ -19,41 +19,45 @@
         <!-- Center -->
         <div class="flex items-center">
           <div class="hidden sm:block sm:ml-6">
-            <div class="flex space-x-4">
-              <button
-                type="button"
-                class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+            <div class="flex">
+              <SiNavbarButton
+                tooltip-text="Compose yourself, dammit!"
+                :selected="selectedMode === Mode.Compose"
+                :panel-switcher="true"
+                @click="changeMode(Mode.Compose)"
               >
-                <span class="sr-only">View notifications</span>
-                <CollectionIcon class="h-6 w-6" aria-hidden="true" />
-              </button>
+                <CollectionIcon />
+              </SiNavbarButton>
 
-              <button
-                type="button"
-                class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+              <SiNavbarButton
+                tooltip-text="Are you a thrill beaker?"
+                :selected="selectedMode === Mode.Beaker"
+                :panel-switcher="true"
+                @click="changeMode(Mode.Beaker)"
               >
-                <span class="sr-only">View notifications</span>
-                <BeakerIcon class="h-6 w-6" aria-hidden="true" />
-              </button>
+                <BeakerIcon />
+              </SiNavbarButton>
 
               <!-- Vertical bar -->
-              <div class="h-8 w-1 bg-gray-400"></div>
+              <div class="w-1 h-8 self-center mx-2 bg-gray-400"></div>
 
-              <button
-                type="button"
-                class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+              <SiNavbarButton
+                tooltip-text="Eye see you"
+                :selected="selectedMode === Mode.Eye"
+                :panel-switcher="true"
+                @click="changeMode(Mode.Eye)"
               >
-                <span class="sr-only">View notifications</span>
-                <EyeIcon class="h-6 w-6" aria-hidden="true" />
-              </button>
+                <EyeIcon />
+              </SiNavbarButton>
 
-              <button
-                type="button"
-                class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+              <SiNavbarButton
+                tooltip-text="Dookie, by Green Play"
+                :selected="selectedMode === Mode.Play"
+                :panel-switcher="true"
+                @click="changeMode(Mode.Play)"
               >
-                <span class="sr-only">View notifications</span>
-                <PlayIcon class="h-6 w-6" aria-hidden="true" />
-              </button>
+                <PlayIcon />
+              </SiNavbarButton>
             </div>
           </div>
         </div>
@@ -61,29 +65,26 @@
         <!-- Right side -->
         <div class="hidden sm:ml-6 sm:block">
           <div class="flex items-center">
-            <button
-              type="button"
-              class="text-sm px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+            <SiNavbarButton
+              tooltip-text="Zoom"
+              :text-mode="true"
+              :selected="selectedButton === SelectableButton.Zoom"
+              @click="changedSelectableButton(SelectableButton.Zoom)"
             >
-              <span class="sr-only">View notifications</span>
-              100%
-            </button>
+              <div class="self-center text-center">100%</div>
+            </SiNavbarButton>
 
-            <button
-              type="button"
-              class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-            >
-              <span class="sr-only">View notifications</span>
-              <LinkIcon class="h-6 w-6" aria-hidden="true" />
-            </button>
+            <SiNavbarButton tooltip-text="Copy link" @click="copyURL">
+              <LinkIcon />
+            </SiNavbarButton>
 
-            <button
-              type="button"
-              class="px-2 py-1 rounded-full text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
+            <SiNavbarButton
+              tooltip-text="Change theme"
+              :selected="selectedButton === SelectableButton.Theme"
+              @click="changedSelectableButton(SelectableButton.Theme)"
             >
-              <span class="sr-only">View notifications</span>
-              <MoonIcon class="h-6 w-6" aria-hidden="true" />
-            </button>
+              <MoonIcon />
+            </SiNavbarButton>
 
             <SiProfile :enable-old-app-switch="true" />
           </div>
@@ -116,4 +117,38 @@ import {
 import { PlayIcon, BeakerIcon, CollectionIcon } from "@heroicons/vue/solid";
 import SiProfile from "@/molecules/SiProfile.vue";
 import SiLogoWts from "@/assets/images/si-logo-wts.svg";
+import SiNavbarButton from "@/atoms/SiNavbarButton.vue";
+import { refFrom } from "vuse-rx";
+
+const bgColor = "bg-[#333333]";
+
+const copyURL = () => {
+  navigator.clipboard.writeText(window.location.href);
+};
+
+enum Mode {
+  Compose,
+  Beaker,
+  Eye,
+  Play,
+}
+const selectedMode = refFrom<Mode>(Mode.Compose);
+const changeMode = (mode: Mode) => {
+  selectedMode.value = mode;
+};
+
+enum SelectableButton {
+  Zoom,
+  Theme,
+}
+const selectedButton = refFrom<SelectableButton | "">("");
+const changedSelectableButton = (selectableButton: SelectableButton) => {
+  if (selectedButton.value === "") {
+    selectedButton.value = selectableButton;
+  } else {
+    // Flip the selection to "unset" if the same button is clicked again.
+    // FIXME(nick): this is temporary until dropdown menus are implemented for selectable buttons.
+    selectedButton.value = "";
+  }
+};
 </script>

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -130,8 +130,8 @@ onMounted(async () => {
 
   let backgroundColor = 0x282828;
   if (props.lightMode) {
-    // RGB(245,244,244)
-    backgroundColor = 0xf5f4f4;
+    // RGB(244,244,244)
+    backgroundColor = 0xf4f4f4;
   }
 
   const renderer = new Renderer({

--- a/app/web/src/organisims/StatusBar.vue
+++ b/app/web/src/organisims/StatusBar.vue
@@ -1,6 +1,7 @@
 <template>
-  <Disclosure v-slot="{ open }" as="status" class="bg-gray-800">
-    <div class="mx-auto px-4 max-w-fit">
+  <Disclosure v-slot="{ open }" as="status" :class="bgColor">
+    <!-- NOTE(nick): class might be needed, max-w-fit -->
+    <div class="mx-auto px-4">
       <div class="flex items-end justify-end h-12">
         <!-- Tabs location -->
         <div class="flex items-center">
@@ -15,7 +16,7 @@
         <!-- Mobile menu button -->
         <div class="-mr-2 flex sm:hidden">
           <DisclosureButton
-            class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
+            class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-black focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
           >
             <span class="sr-only">Open main menu</span>
             <MenuIcon v-if="!open" class="block h-6 w-6" aria-hidden="true" />
@@ -32,4 +33,6 @@ import { Disclosure, DisclosureButton } from "@headlessui/vue";
 import { MenuIcon, XIcon } from "@heroicons/vue/outline";
 import SiFlyoutTab from "@/molecules/SiFlyoutTab.vue";
 import { SiFlyoutKind } from "@/molecules/SiFlyoutTab/types";
+
+const bgColor = "bg-[#333333]";
 </script>

--- a/app/web/src/organisims/Workspace/WorkspaceView.vue
+++ b/app/web/src/organisims/Workspace/WorkspaceView.vue
@@ -11,12 +11,13 @@
   />
   <SiSidebar :placeholder="'Component Panel'" />
 
-  <!-- NOTE(nick): we use a large z index to ensure that the profile dropdown is displayed -->
-  <SiSidebar
+  <!-- NOTE(nick): we will likely need to use a large z index to ensure that the profile dropdown is displayed -->
+  <!-- The property panel should only be displayed when working with a node/component/object -->
+  <!-- <SiSidebar
     :place-right="true"
     :placeholder="'Property Panel'"
     class="z-900"
-  />
+  /> -->
   <StatusBar />
 </template>
 


### PR DESCRIPTION
Navbar changes:
- Add SiNavbarButton for both "mode" buttons and ...well, "button"
  buttons
  - Mode buttons are for switching views
  - "Button" buttons are for general use, regardless of view
- Add selection state for both "mode" buttons and "button" buttons
- Ensure Navbar and StatusBar are using the correct background color
  (#333333)
- Ensure SiProfileIcon has a black outline and no longer has focus
  classes
  - Add alt text to the placeholder svg while we are here
- Ensure vertical splitter works with SiNavbarButton
- Add copy URL functionality to copy link button

Sidebar changes:
- Add left border and ensure border is black for SiSidebarContent
- Remove property panel sidebar because it requires a selected node,
  component or "object"

Misc changes:
- Fix Viewer light mode color
- Move StatusBar tabs to the right

https://www.youtube.com/watch?v=MO336pQzvwg

Fixes ENG-313