### PR TITLE
feat(sdf,dal): initial report job of failures

### DIFF
--- a/lib/dal/src/job_failure.rs
+++ b/lib/dal/src/job_failure.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use si_data::PgError;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor_ro, DalContext, StandardModel,
+    StandardModelError, Timestamp, Visibility, WriteTenancy,
+};
+
+#[derive(Error, Debug)]
+pub enum JobFailureError {
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("standard model error: {0}")]
+    StandardModel(#[from] StandardModelError),
+}
+
+pub type JobFailureResult<T, E = JobFailureError> = Result<T, E>;
+
+pk!(JobFailurePk);
+pk!(JobFailureId);
+
+/// Background tasks, enqueued with `faktory`, executed by `pinga` may fail.
+/// And not all failure can be reported to the user by the regular path, so
+/// any fatal failure, like a panic or an `Err` propagated from the `dal will
+/// be stored in the database in the form of a `JobFailure`
+///
+/// The failure will be set to the user's tenancy and visibility, with the user
+/// as the actor. For now we don't support drastic failures that happen before
+/// `pinga` can obtain this metadata, they will only be logged
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct JobFailure {
+    pk: JobFailurePk,
+    id: JobFailureId,
+    kind: String,
+    message: String,
+    solved: bool,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: JobFailure,
+    pk: JobFailurePk,
+    id: JobFailureId,
+    table_name: "job_failures",
+    history_event_label_base: "job_failure",
+    history_event_message_name: "JobFailure"
+}
+
+impl JobFailure {
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_>,
+        kind: impl AsRef<str>,
+        message: impl AsRef<str>,
+    ) -> JobFailureResult<Self> {
+        let kind = kind.as_ref();
+        let message = message.as_ref();
+
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM job_failure_create_v1($1, $2, $3, $4)",
+                &[ctx.write_tenancy(), ctx.visibility(), &kind, &message],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    standard_model_accessor_ro!(kind, String);
+    standard_model_accessor_ro!(message, String);
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -26,6 +26,7 @@ pub mod func;
 pub mod group;
 pub mod history_event;
 pub mod index_map;
+pub mod job_failure;
 pub mod jwt_key;
 pub mod key_pair;
 pub mod label_list;
@@ -114,6 +115,7 @@ pub use func::{
 pub use group::{Group, GroupError, GroupId, GroupResult};
 pub use history_event::{HistoryActor, HistoryEvent, HistoryEventError};
 pub use index_map::IndexMap;
+pub use job_failure::{JobFailure, JobFailureError, JobFailureResult};
 pub use jwt_key::{create_jwt_key_if_missing, JwtSecretKey};
 pub use key_pair::{KeyPair, KeyPairError, KeyPairResult, PublicKey};
 pub use label_list::{LabelEntry, LabelList, LabelListError};

--- a/lib/dal/src/migrations/U0063__jobs.sql
+++ b/lib/dal/src/migrations/U0063__jobs.sql
@@ -1,0 +1,47 @@
+CREATE TABLE job_failures
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_edit_session_pk  bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    kind                        text                     NOT NULL,
+    message                     text                     NOT NULL,
+    solved                      bool                     NOT NULL DEFAULT false
+);
+SELECT standard_model_table_constraints_v1('job_failures');
+
+CREATE OR REPLACE FUNCTION job_failure_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_kind text,
+    this_message text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           job_failures%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO job_failures (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
+                       tenancy_workspace_ids,
+                       visibility_change_set_pk, visibility_edit_session_pk, visibility_deleted_at,
+                       kind, message)
+    VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_edit_session_pk,
+            this_visibility_record.visibility_deleted_at, this_kind, this_message)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;


### PR DESCRIPTION
Reports job execution failures to the database using the job's
access_builder and visibility. If they can't be extracted we will only
log the failure, as it means a structural problem that shouldn't reach
the user, even with universal write, etc. We need to think about
integrating with error reporting systems.

Also refactors quite a bit of the executor, although it's not there yet,
we need the producer refactor to be merged to conciliate the
implementations.

<img src="https://media1.giphy.com/media/4A1am1JlzkJj2/giphy.gif"/>