### PR TITLE
bug(ci): check for required artifacts before running compose

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -34,6 +34,7 @@ prod: init
 		up -d
 
 ci: init
+	REPOPATH=$(REPOPATH) $(MAKEPATH)/scripts/check-for-artifacts-before-mounting.sh
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) REPOPATH=$(REPOPATH) \
 		docker-compose \
 			-f $(MAKEPATH)/docker-compose.yml \

--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -31,7 +31,6 @@ services:
       - "${REPOPATH:-..}/app/web/nginx/dhparam.pem:/etc/ssl/certs/dhparam.pem"
       - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt:/etc/ssl/certs/nginx-selfsigned.crt"
       - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key:/etc/ssl/certs/nginx-selfsigned.key"
-      - "${REPOPATH:-..}/app/web/htpasswd:/htpasswd"
 
   pinga:
     image: "fedora:latest"

--- a/deploy/scripts/check-for-artifacts-before-mounting.sh
+++ b/deploy/scripts/check-for-artifacts-before-mounting.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+echo "::group::Checking for required artifacts"
+[[ -f "$REPOPATH/target/debug/sdf" ]]
+[[ -f "$REPOPATH/bin/sdf/src/dev.jwt_secret_key.bin" ]]
+[[ -f "$REPOPATH/lib/cyclone/src/dev.encryption.key" ]]
+[[ -f "$REPOPATH/target/debug/veritech" ]]
+[[ -f "$REPOPATH/target/debug/cyclone" ]]
+[[ -f "$REPOPATH/bin/lang-js/target/lang-js" ]]
+[[ -d "$REPOPATH/app/web/dist" ]]
+[[ -f "$REPOPATH/app/web/nginx.conf" ]]
+[[ -f "$REPOPATH/app/web/nginx/dhparam.pem" ]]
+[[ -f "$REPOPATH/app/web/nginx/nginx-selfsigned.crt" ]]
+[[ -f "$REPOPATH/app/web/nginx/nginx-selfsigned.key" ]]
+[[ -f "$REPOPATH/target/debug/pinga" ]]
+[[ -f "$REPOPATH/bin/pinga/src/dev.jwt_secret_key.bin" ]]
+echo "::endgroup::"
+exit 0


### PR DESCRIPTION
We will now fail in CI if we try and run the docker compose step without
the required artifacts being present in the repository. If we fail at
this step, it's likely because some *other* part of CI has failed
(because we failed to build the required artifacts) - but this will stop
the CI runner from having arbitrary root owned directories created when
we try and bind-mount to them.

<img src="https://media3.giphy.com/media/oZrQpzznlJKURw4O0K/giphy.gif"/>

Love,
Adam, Victor and Nick