### PR TITLE
chore(ci): fix pinga image, change mount syntax

### DIFF
--- a/bin/pinga/Dockerfile
+++ b/bin/pinga/Dockerfile
@@ -38,7 +38,8 @@ FROM debian:stable-slim as final
 ARG BIN=pinga
 
 RUN useradd -ms /bin/bash app \
-  && mkdir -p {/run,/etc,/usr/local/etc,/home/app/.confg}/$BIN
+  && mkdir -p {/run,/etc,/usr/local/etc,/home/app/.confg}/$BIN \
+  && mkdir -p /run/sdf
 WORKDIR /run/$BIN
 COPY --from=builder /usr/src/target/release/$BIN /usr/local/bin/
 COPY --from=builder /usr/src/target/release/$BIN.dbg /usr/local/bin/.debug/

--- a/ci/scripts/readiness-check.sh
+++ b/ci/scripts/readiness-check.sh
@@ -33,7 +33,9 @@ function check-binary {
     fi
 }
 
+echo "::group::Readiness check"
 check-binary curl
 check-binary jq
 readiness-check
 echo "SI is ready!"
+echo "::endgroup::"

--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -2,42 +2,54 @@
 version: "3"
 
 services:
-  sdf:
-    image: "fedora:latest"
-    volumes:
-      - "${REPOPATH:-..}/target/debug/sdf:/usr/local/bin/sdf"
-      - "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/sdf/cyclone_encryption.key:ro"
-    entrypoint:
-      - "/usr/local/bin/sdf"
-
-  veritech:
-    image: "fedora:latest"
-    volumes:
-      - "${REPOPATH:-..}/target/debug/veritech:/usr/local/bin/veritech"
-      - "${REPOPATH:-..}/target/debug/cyclone:/usr/local/bin/cyclone"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key:/run/cyclone/decryption.key:ro"
-      - "${REPOPATH:-..}/bin/lang-js/target/lang-js:/usr/local/bin/lang-js"
-    entrypoint:
-      - "/usr/local/bin/veritech"
-
   web:
     image: "nginx:1.21.4-alpine"
     # NOTE(nick): "dist" is a directory and the other mounts are files. This might help when debugging permissions errors
     # SELinux, volume mounts, etc.
     volumes:
-      - "${REPOPATH:-..}/app/web/dist:/usr/share/nginx/html"
-      - "${REPOPATH:-..}/app/web/nginx.conf:/etc/nginx/conf.d/default.conf"
-      - "${REPOPATH:-..}/app/web/nginx/dhparam.pem:/etc/ssl/certs/dhparam.pem"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt:/etc/ssl/certs/nginx-selfsigned.crt"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key:/etc/ssl/certs/nginx-selfsigned.key"
-      - "${REPOPATH:-..}/app/web/htpasswd:/htpasswd"
-
-  pinga:
-    image: "fedora:latest"
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/dist"
+        target: "/usr/share/nginx/html"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx.conf"
+        target: "/etc/nginx/conf.d/default.conf"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/dhparam.pem"
+        target: "/etc/ssl/certs/dhparam.pem"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt"
+        target: "/etc/ssl/certs/nginx-selfsigned.crt"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key"
+        target: "/etc/ssl/certs/nginx-selfsigned.key"
+        read_only: true
+  sdf:
     volumes:
-      - "${REPOPATH:-..}/target/debug/pinga:/usr/local/bin/pinga"
-      - "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin:/run/pinga/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/pinga/cyclone_encryption.key:ro"
-    entrypoint:
-      - "/usr/local/bin/pinga"
+      - type: bind
+        source: "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true
+  veritech:
+    volumes:
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key"
+        target: "/run/cyclone/decryption.key"
+        read_only: true
+  pinga:
+    volumes:
+      - type: bind 
+        source: "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true

--- a/deploy/scripts/generate-ci-yml.sh
+++ b/deploy/scripts/generate-ci-yml.sh
@@ -32,4 +32,5 @@ else
   cp $REPOPATH/deploy/scripts/partials/docker-compose.ci.yml $REPOPATH/deploy/docker-compose.ci.yml
 fi
 echo "::endgroup::"
+
 exit 0

--- a/deploy/scripts/partials/docker-compose.ci-minimal.yml
+++ b/deploy/scripts/partials/docker-compose.ci-minimal.yml
@@ -7,23 +7,49 @@ services:
     # NOTE(nick): "dist" is a directory and the other mounts are files. This might help when debugging permissions errors
     # SELinux, volume mounts, etc.
     volumes:
-      - "${REPOPATH:-..}/app/web/dist:/usr/share/nginx/html"
-      - "${REPOPATH:-..}/app/web/nginx.conf:/etc/nginx/conf.d/default.conf"
-      - "${REPOPATH:-..}/app/web/nginx/dhparam.pem:/etc/ssl/certs/dhparam.pem"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt:/etc/ssl/certs/nginx-selfsigned.crt"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key:/etc/ssl/certs/nginx-selfsigned.key"
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/dist"
+        target: "/usr/share/nginx/html"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx.conf"
+        target: "/etc/nginx/conf.d/default.conf"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/dhparam.pem"
+        target: "/etc/ssl/certs/dhparam.pem"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt"
+        target: "/etc/ssl/certs/nginx-selfsigned.crt"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key"
+        target: "/etc/ssl/certs/nginx-selfsigned.key"
+        read_only: true
   sdf:
     volumes:
-      - "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/sdf/cyclone_encryption.key:ro"
+      - type: bind
+        source: "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true
   veritech:
     volumes:
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key:/run/cyclone/decryption.key:ro"
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key"
+        target: "/run/cyclone/decryption.key"
+        read_only: true
   pinga:
-    image: "fedora:latest"
     volumes:
-      - "${REPOPATH:-..}/target/debug/pinga:/usr/local/bin/pinga"
-      - "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin:/run/pinga/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/pinga/cyclone_encryption.key:ro"
-    entrypoint:
-      - "/usr/local/bin/pinga"
+      - type: bind 
+        source: "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true

--- a/deploy/scripts/partials/docker-compose.ci.yml
+++ b/deploy/scripts/partials/docker-compose.ci.yml
@@ -5,19 +5,40 @@ services:
   sdf:
     image: "fedora:latest"
     volumes:
-      - "${REPOPATH:-..}/target/debug/sdf:/usr/local/bin/sdf"
-      - "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin:/run/sdf/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/sdf/cyclone_encryption.key:ro"
+      - type: bind
+        source: "${REPOPATH:-..}/target/debug/sdf"
+        target: "/usr/local/bin/sdf"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/bin/sdf/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true
     entrypoint:
       - "/usr/local/bin/sdf"
 
   veritech:
     image: "fedora:latest"
     volumes:
-      - "${REPOPATH:-..}/target/debug/veritech:/usr/local/bin/veritech"
-      - "${REPOPATH:-..}/target/debug/cyclone:/usr/local/bin/cyclone"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key:/run/cyclone/decryption.key:ro"
-      - "${REPOPATH:-..}/bin/lang-js/target/lang-js:/usr/local/bin/lang-js"
+      - type: bind
+        source: "${REPOPATH:-..}/target/debug/veritech"
+        target: "/usr/local/bin/veritech"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/target/debug/cyclone"
+        target: "/usr/local/bin/cyclone"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.decryption.key"
+        target: "/run/cyclone/decryption.key"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/bin/lang-js/target/lang-js"
+        target: "/usr/local/bin/lang-js"
+        read_only: true
     entrypoint:
       - "/usr/local/bin/veritech"
 
@@ -26,18 +47,41 @@ services:
     # NOTE(nick): "dist" is a directory and the other mounts are files. This might help when debugging permissions errors
     # SELinux, volume mounts, etc.
     volumes:
-      - "${REPOPATH:-..}/app/web/dist:/usr/share/nginx/html"
-      - "${REPOPATH:-..}/app/web/nginx.conf:/etc/nginx/conf.d/default.conf"
-      - "${REPOPATH:-..}/app/web/nginx/dhparam.pem:/etc/ssl/certs/dhparam.pem"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt:/etc/ssl/certs/nginx-selfsigned.crt"
-      - "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key:/etc/ssl/certs/nginx-selfsigned.key"
-      - "${REPOPATH:-..}/app/web/htpasswd:/htpasswd"
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/dist"
+        target: "/usr/share/nginx/html"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx.conf"
+        target: "/etc/nginx/conf.d/default.conf"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/dhparam.pem"
+        target: "/etc/ssl/certs/dhparam.pem"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.crt"
+        target: "/etc/ssl/certs/nginx-selfsigned.crt"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/app/web/nginx/nginx-selfsigned.key"
+        target: "/etc/ssl/certs/nginx-selfsigned.key"
+        read_only: true
 
   pinga:
     image: "fedora:latest"
     volumes:
-      - "${REPOPATH:-..}/target/debug/pinga:/usr/local/bin/pinga"
-      - "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin:/run/pinga/jwt_secret_key.bin:ro"
-      - "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key:/run/pinga/cyclone_encryption.key:ro"
+      - type: bind 
+        source: "${REPOPATH:-..}/target/debug/pinga"
+        target: "/usr/local/bin/pinga"
+        read_only: true
+      - type: bind 
+        source: "${REPOPATH:-..}/bin/pinga/src/dev.jwt_secret_key.bin"
+        target: "/run/sdf/jwt_secret_key.bin"
+        read_only: true
+      - type: bind
+        source: "${REPOPATH:-..}/lib/cyclone/src/dev.encryption.key"
+        target: "/run/sdf/cyclone_encryption.key"
+        read_only: true
     entrypoint:
       - "/usr/local/bin/pinga"


### PR DESCRIPTION
This fixes up the pinga image so that it will run in docker - because it
hijacks sdf, rather than using the dal directly, it needs its
configuration mounted into the `sdf` directory rather than `pinga`.

We also convert the bind mounts to the "long" syntax, which will error
if the source doesn't exist (rather than creating a directory, as the
short form does). This should cause our job to actually fail
appropriately if pinga doesn't exist and we try to bind mount it.