### PR TITLE
chore(slack): fix channel for image promo notification

### DIFF
--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
         with:
-          channel: engineering
+          channel: github-notifications
           status: executing
           color: "#ffb74d"
       - id: login
@@ -46,7 +46,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
         with:
           message_id: ${{ steps.notify-slack.outputs.message_id }}
-          channel: engineering
+          channel: github-notifications
           status: succeeded
           color: "#8bc34a"
       - uses: voxmedia/github-action-slack-notify-build@212e9f7a9ca33368c8dd879d6053972128258985 # pin@v1.5.0
@@ -55,6 +55,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
         with:
           message_id: ${{ steps.notify-slack.outputs.message_id }}
-          channel: engineering
+          channel: github-notifications
           status: failed
           color: "#f44336"


### PR DESCRIPTION
Image promotion notifications will now go to github-notifications
channel.