### PR TITLE
feat(web): add node-add to the asset palette

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -5559,12 +5559,12 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.14.tgz",
-      "integrity": "sha512-wAO6zF9zxA3u+7AkMPqw9LjoUCjSxfFvINQj3E/DceTt6uEz1XZLraDhdg2EYmvVwTBSGlLYsUw8bDmx0754Mw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "dev": true,
       "dependencies": {
-        "@vue/devtools-api": "^6.0.0"
+        "@vue/devtools-api": "^6.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
@@ -9618,12 +9618,12 @@
       "requires": {}
     },
     "vue-router": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.14.tgz",
-      "integrity": "sha512-wAO6zF9zxA3u+7AkMPqw9LjoUCjSxfFvINQj3E/DceTt6uEz1XZLraDhdg2EYmvVwTBSGlLYsUw8bDmx0754Mw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "dev": true,
       "requires": {
-        "@vue/devtools-api": "^6.0.0"
+        "@vue/devtools-api": "^6.1.4"
       }
     },
     "vue-tsc": {

--- a/app/web/src/atoms/SiSidebar.vue
+++ b/app/web/src/atoms/SiSidebar.vue
@@ -1,6 +1,7 @@
 <template>
+  <!-- FIXME(nick,victor): find a way to remove z levels from here. This is needed for interaction with the canvas to work. -->
   <div
-    class="flex flex-col dark:text-white border-[#DBDBDB] dark:border-[#525252] bg-white dark:bg-[#333333] w-40 lg:w-56 xl:w-72 pointer-events-auto"
+    class="z-20 flex flex-col dark:text-white border-[#DBDBDB] dark:border-[#525252] bg-white dark:bg-[#333333] w-40 lg:w-56 xl:w-72 pointer-events-auto"
     :class="panelClasses"
   >
     <slot />

--- a/app/web/src/molecules/SiDropdown.vue
+++ b/app/web/src/molecules/SiDropdown.vue
@@ -1,6 +1,7 @@
 <template>
+  <!-- FIXME(nick,victor): remove reliance on z index -->
   <MenuItems
-    class="z-10 absolute rounded-md shadow-lg py-1ring-1 py-1 ring-black ring-opacity-5 focus:outline-none mt-1 bg-black min-w-full"
+    class="z-30 absolute rounded-md shadow-lg py-1ring-1 py-1 ring-black ring-opacity-5 focus:outline-none mt-1 bg-black min-w-full"
   >
     <slot />
   </MenuItems>

--- a/app/web/src/observable/schematic.ts
+++ b/app/web/src/observable/schematic.ts
@@ -1,9 +1,9 @@
-import * as Rx from "rxjs";
+import { ReplaySubject } from "rxjs";
 import { Schematic, SchematicSchemaVariants } from "@/api/sdf/dal/schematic";
 
-export const schematicData$ = new Rx.ReplaySubject<Schematic | null>(1);
+export const schematicData$ = new ReplaySubject<Schematic | null>(1);
 schematicData$.next(null);
 
 export const schematicSchemaVariants$ =
-  new Rx.ReplaySubject<SchematicSchemaVariants | null>(1);
+  new ReplaySubject<SchematicSchemaVariants | null>(1);
 schematicSchemaVariants$.next(null);

--- a/app/web/src/organisims/AssetsTabs.vue
+++ b/app/web/src/organisims/AssetsTabs.vue
@@ -8,7 +8,7 @@
 
     <template #panels>
       <TabPanel class="flex flex-col overflow-y-hidden">
-        <AssetPalette />
+        <AssetPalette :viewer-event$="props.viewerEvent$" />
       </TabPanel>
       <TabPanel>Local Assets</TabPanel>
       <TabPanel>Panel</TabPanel>
@@ -21,4 +21,9 @@ import SiTabGroup from "@/molecules/SiTabGroup.vue";
 import SiTabHeader from "@/molecules/SiTabHeader.vue";
 import { TabPanel } from "@headlessui/vue";
 import AssetPalette from "@/organisims/AssetPalette.vue";
+import { ViewerEventObservable } from "./SchematicViewer/viewer_event";
+
+const props = defineProps<{
+  viewerEvent$: ViewerEventObservable["viewerEvent$"];
+}>();
 </script>

--- a/app/web/src/organisims/SchematicViewer/Viewer.vue
+++ b/app/web/src/organisims/SchematicViewer/Viewer.vue
@@ -142,7 +142,7 @@ onMounted(async () => {
 
   const renderer = new Renderer({
     view: canvas.element.value,
-    resolution: window.devicePixelRatio * 3 || 1,
+    resolution: window.devicePixelRatio || 1,
     width: container.element.value.offsetWidth,
     height: container.element.value.offsetHeight,
     autoDensity: true,

--- a/app/web/src/organisims/Workspace/WorkspaceEditor.vue
+++ b/app/web/src/organisims/Workspace/WorkspaceEditor.vue
@@ -1,81 +1,209 @@
 <template>
   <div class="w-full h-full flex pointer-events-none relative">
-    <!--  TODO(victor): `absolute -z-10` are only being passed here because otherwise it would break the old interface. When that's retired, that should probably go inside the Viewer component   -->
+    <!-- FIXME(nick,victor): remove reliance on z index -->
     <Viewer
-      v-if="lightmode"
+      v-if="lightmode && editorContext"
+      light-mode
       :schematic-viewer-id="schematicViewerId"
       :viewer-state="viewerState"
-      :viewer-event$="viewerEventObservable.viewerEvent$"
-      :schematic-data="schematicData"
       :editor-context="editorContext"
-      :schematic-kind="schematicKind"
-      :deployment-node-selected="deploymentNodeSelected"
-      :light-mode="true"
-      class="pointer-events-auto absolute -z-10"
+      :schematic-data="schematicData"
+      :viewer-event$="viewerEventObservable.viewerEvent$"
+      :schematic-kind="SchematicKind.Deployment"
+      :deployment-node-selected="null"
+      class="pointer-events-auto absolute z-10"
     />
     <Viewer
-      v-else
+      v-else-if="editorContext"
       :schematic-viewer-id="schematicViewerId"
       :viewer-state="viewerState"
-      :viewer-event$="viewerEventObservable.viewerEvent$"
-      :schematic-data="schematicData"
       :editor-context="editorContext"
-      :schematic-kind="schematicKind"
-      :deployment-node-selected="deploymentNodeSelected"
-      :light-mode="false"
-      class="pointer-events-auto absolute -z-10"
+      :schematic-data="schematicData"
+      :viewer-event$="viewerEventObservable.viewerEvent$"
+      :schematic-kind="SchematicKind.Deployment"
+      :deployment-node-selected="null"
+      class="pointer-events-auto absolute z-10"
     />
 
     <div class="flex flex-row w-full bg-transparent">
       <SiSidebar side="left">
         <SiChangesetForm />
-        <AssetsTabs />
+        <AssetsTabs :viewer-event$="viewerEventObservable.viewerEvent$" />
       </SiSidebar>
+
       <!-- transparent div that flows through to the canvas -->
       <div class="grow h-full pointer-events-none"></div>
+
       <SiSidebar side="right">
-        <SiChangesetForm />
-        <AssetsTabs />
+        <div class="text-center mt-10">
+          poop canoe
+          <div v-if="props.mutable">(rw)</div>
+          <div v-else>(ro)</div>
+        </div>
       </SiSidebar>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { SchematicKind } from "@/api/sdf/dal/schematic";
+import {
+  EditorContext,
+  Schematic,
+  SchematicKind,
+  SchematicSchemaVariants,
+} from "@/api/sdf/dal/schematic";
 import Viewer from "@/organisims/SchematicViewer/Viewer.vue";
 import * as VE from "@/organisims/SchematicViewer/viewer_event";
 import _ from "lodash";
 import { ViewerStateMachine } from "@/organisims/SchematicViewer/state_machine";
 import SiSidebar from "@/atoms/SiSidebar.vue";
 import { ThemeService } from "@/service/theme";
-import { refFrom } from "vuse-rx/src";
-import { computed } from "vue";
+import { refFrom, untilUnmounted } from "vuse-rx";
+import { computed, ref } from "vue";
 import { Theme } from "@/observable/theme";
 import SiChangesetForm from "@/organisims/SiChangesetForm.vue";
+import { combineLatest, forkJoin, from, map, switchMap, take } from "rxjs";
+import { GetSchematicArgs } from "@/service/schematic/get_schematic";
+import {
+  standardVisibilityTriggers$,
+  visibility$,
+} from "@/observable/visibility";
+import { SchematicService } from "@/service/schematic";
+import { GlobalErrorService } from "@/service/global_error";
+import {
+  schematicData$,
+  schematicSchemaVariants$,
+} from "@/observable/schematic";
+import { system$ } from "@/observable/system";
+import { applicationNodeId$ } from "@/observable/application";
+import { ChangeSetService } from "@/service/change_set";
+import { ApplicationService } from "@/service/application";
 import AssetsTabs from "@/organisims/AssetsTabs.vue";
 
 const props = defineProps<{
   mutable: boolean;
 }>();
 
-const canoe = computed(() => {
-  if (props.mutable) {
-    return "compose canoe";
-  }
-  return "view canoe";
-});
-
 const schematicViewerId = _.uniqueId();
 const viewerState = new ViewerStateMachine();
 const viewerEventObservable = new VE.ViewerEventObservable();
-const schematicData = {
-  nodes: [],
-  connections: [],
-};
-const editorContext = null;
-const schematicKind = SchematicKind.Component;
-const deploymentNodeSelected = null;
+const schematicData = ref<Schematic>({ nodes: [], connections: [] });
+
+schematicData$.subscribe((schematic) => {
+  if (schematic) {
+    schematicData.value = schematic;
+  } else {
+    schematicData.value = { nodes: [], connections: [] };
+  }
+});
+
+let oldSchematic: Schematic | undefined;
+combineLatest([
+  system$.pipe(
+    map((system) => {
+      const request: GetSchematicArgs = {};
+      if (system) {
+        request.systemId = system.id;
+      }
+      return request;
+    }),
+  ),
+  standardVisibilityTriggers$,
+])
+  .pipe(
+    switchMap(([request]) => {
+      const variants = SchematicService.listSchemaVariants().pipe(take(1));
+      const schematic = SchematicService.getSchematic(request).pipe(take(1));
+      return from([[variants, schematic]]);
+    }),
+    switchMap((calls) => {
+      return forkJoin(calls);
+    }),
+  )
+  .pipe(untilUnmounted)
+  .subscribe(([variants, schematic]) => {
+    if (variants.error) {
+      GlobalErrorService.set(variants);
+      return from([]);
+    }
+
+    if (schematic.error) {
+      GlobalErrorService.set(schematic);
+      return from([]);
+    }
+
+    // If the schematic didn't change, but standard visibility triggers forced a refetch, we have to ignore it
+    // We avoid passing this stale data around (it races making nodes teleport right after a move, as the local data is more up to date)
+    if (!oldSchematic || !_.isEqual(oldSchematic, schematic)) {
+      oldSchematic = schematic as Schematic;
+      schematicData$.next(schematic as Schematic);
+      schematicSchemaVariants$.next(variants as SchematicSchemaVariants);
+    }
+  });
+
+// FIXME(nick,adam): create an application and a changeset when the editor is loaded.
+// We need both in order to create and drag nodes.
+
+ApplicationService.currentApplication().subscribe((application) => {
+  if (application === null) {
+    ApplicationService.createApplication({
+      name: "poop",
+    }).subscribe((response) => {
+      if (response.error) {
+        console.log("oopsie poopsie! we could not create an application!");
+        GlobalErrorService.set(response);
+        return;
+      }
+
+      ApplicationService.clearCurrentApplication();
+      ApplicationService.setCurrentApplication({
+        applicationId: response.application.id,
+      }).subscribe((response) => {
+        if (response.error) {
+          console.log("could not set current application to poop!");
+          GlobalErrorService.set(response);
+          return;
+        }
+      });
+    });
+  }
+});
+
+ChangeSetService.currentChangeSet().subscribe((changeSet) => {
+  if (changeSet === null) {
+    ChangeSetService.createChangeSet({ changeSetName: "canoe" }).subscribe(
+      (response) => {
+        if (response.error) {
+          console.log("oopsie poopsie! we could not create a change set!");
+          GlobalErrorService.set(response);
+          return;
+        }
+
+        ChangeSetService.startEditSession({
+          changeSetPk: response.changeSet.pk,
+        }).subscribe((response) => {
+          if (response.error) {
+            console.log("could not start edit session!");
+            GlobalErrorService.set(response);
+            return;
+          }
+        });
+      },
+    );
+  }
+});
+
+const editorContext = refFrom<EditorContext | null>(
+  combineLatest([system$, applicationNodeId$, visibility$]).pipe(
+    switchMap(([system, applicationNodeId]) => {
+      if (applicationNodeId) {
+        return from([{ systemId: system?.id, applicationNodeId }]);
+      } else {
+        return from([null]);
+      }
+    }),
+  ),
+);
 
 const theme = refFrom<Theme>(ThemeService.currentTheme());
 const lightmode = computed(() => {

--- a/ci/scripts/readiness-check.sh
+++ b/ci/scripts/readiness-check.sh
@@ -6,12 +6,6 @@ RETRY_COUNT=0
 
 function readiness-check {
     while true; do
-        RETRY_COUNT=$(( RETRY_COUNT + 1 ))
-        if [[ $RETRY_COUNT -ge $MAX_RETRIES ]]; then
-            echo "hit max retry count: $MAX_RETRIES"
-            exit 1
-        fi
-
         # NOTE(nick): declare VALUE as local first so that we capture the subshell output.
         # Then, ensure that we allow curl to fail as needed.
         local VALUE
@@ -22,6 +16,14 @@ function readiness-check {
         if [ "$VALUE" = "true" ]; then
             return
         fi
+
+        RETRY_COUNT=$(( RETRY_COUNT + 1 ))
+        if [[ $RETRY_COUNT -ge $MAX_RETRIES ]]; then
+            echo "hit max retry count: $MAX_RETRIES"
+            exit 1
+        fi
+
+        echo "sleeping and retrying..."
         sleep 1
     done
 }


### PR DESCRIPTION
Primary:
- Add node-add to the asset palette
- Create an application and changeset when WorkspaceEditor is created
  (only if they existed)
- Temporarily rely on z levels for the canvas, the sidebars and the
  navbar dropdowns to play nicely together

Misc:
- Upgrade "vue-router" due to hitting the following bug:
  https://github.com/vuejs/router/issues/1338
- Add additional message to readiness check

<img src="https://media0.giphy.com/media/26BRFp2P7qrLHtywg/giphy.gif"/>

Fixes ENG-360
Fixes ENG-376