### PR TITLE
chore(ci): temporarily disable web testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,8 @@ test//lib/si-settings//RTESTDEPS: test//lib/veritech//TEST test//lib/cyclone//TE
 
 test//bin/lang-js//RTESTDEPS: test//lib/cyclone
 
-test//app/web//TESTDEPS: build//app/web build//bin/pinga deploy//web
+test//app/web//TESTDEPS: build//app/web
+# FIXME(nick): temporarily dropped --> build//bin/pinga deploy//web
 
 %//RUN:
 	@echo "::group::$@"

--- a/app/web/Makefile
+++ b/app/web/Makefile
@@ -8,9 +8,12 @@ IMG := systeminit/web
 
 test: node_modules ## Tests the TypeScript package
 	@echo "--- [$(shell basename ${CURDIR})] $@"
-ifeq ($(CI),true)
-	env CYPRESS_BASE_URL='https://localhost' npm run cypress:run || exit 0
-else
-	npm run cypress:run
-endif
+	@echo "do nothing!"
 .PHONY: test
+
+# FIXME(nick): temporarily removed the test contents.
+#ifeq ($(CI),true)
+#	env CYPRESS_BASE_URL='https://localhost' npm run cypress:run || exit 0
+#else
+#	npm run cypress:run
+#endif


### PR DESCRIPTION
Due to the containers being flaky and the current tests providing low
  value, we are temporarily disabling them.