### PR TITLE
feat(web): right panel responds to selected node on Canvas

### DIFF
--- a/app/web/src/atoms/SiSidebar.vue
+++ b/app/web/src/atoms/SiSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- FIXME(nick,victor): find a way to remove z levels from here. This is needed for interaction with the canvas to work. -->
   <div
-    class="z-20 flex flex-col dark:text-white border-[#DBDBDB] dark:border-[#525252] bg-white dark:bg-[#333333] w-40 lg:w-56 xl:w-72 pointer-events-auto"
+    class="z-20 flex flex-col dark:text-white border-[#DBDBDB] dark:border-[#525252] bg-white dark:bg-[#333333] w-40 lg:w-56 xl:w-72 pointer-events-auto relative transition-all"
     :class="panelClasses"
   >
     <slot />
@@ -11,16 +11,22 @@
 <script setup lang="ts">
 import { toRef, computed } from "vue";
 
-const props = defineProps<{ side: "right" | "left" }>();
+const props = defineProps<{
+  side: "right" | "left";
+  hidden?: boolean;
+}>();
 const side = toRef(props, "side");
 
 const panelClasses = computed(() => {
   const classes: Record<string, boolean> = {};
   if (side.value == "left") {
     classes["border-r-2"] = true;
+    classes[props.hidden ? "right-72" : "right-0"] = true;
   } else {
     classes["border-l-2"] = true;
+    classes[props.hidden ? "left-72" : "left-0"] = true;
   }
+
   return classes;
 });
 </script>

--- a/app/web/src/organisms/ComponentDetails.vue
+++ b/app/web/src/organisms/ComponentDetails.vue
@@ -1,0 +1,29 @@
+<template>
+  <SiTabGroup>
+    <template #tabs>
+      <SiTabHeader>Attributes</SiTabHeader>
+      <SiTabHeader>Code</SiTabHeader>
+    </template>
+
+    <template #panels>
+      <TabPanel class="flex flex-col overflow-y-hidden">
+        <div class="text-center mt-10">
+          Selected node: {{ activeNode?.name ?? "" }}
+        </div>
+      </TabPanel>
+      <TabPanel>
+        <div>Code Content for {{ activeNode?.name }}</div>
+      </TabPanel>
+    </template>
+  </SiTabGroup>
+</template>
+
+<script setup lang="ts">
+import SiTabGroup from "@/molecules/SiTabGroup.vue";
+import SiTabHeader from "@/molecules/SiTabHeader.vue";
+import { TabPanel } from "@headlessui/vue";
+import { refFrom } from "vuse-rx";
+import { lastSelectedNode$ } from "@/observable/selection";
+
+const activeNode = refFrom(lastSelectedNode$);
+</script>

--- a/app/web/src/organisms/PanelSchematic.vue
+++ b/app/web/src/organisms/PanelSchematic.vue
@@ -102,10 +102,7 @@ import NodeAddMenu from "@/molecules/NodeAddMenu.vue";
 import { ApplicationService } from "@/service/application";
 import { refFrom, untilUnmounted } from "vuse-rx";
 import { ChangeSetService } from "@/service/change_set";
-import {
-  NodeAddEvent,
-  ViewerEventObservable,
-} from "./SiCanvas/viewer_event";
+import { NodeAddEvent, ViewerEventObservable } from "./SiCanvas/viewer_event";
 import { lastSelectedDeploymentNode$ } from "@/observable/selection";
 
 const schematicData = refFrom<Schematic | null>(schematicData$);

--- a/app/web/src/organisms/Workspace/WorkspaceEditor.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full flex pointer-events-none relative">
+  <div class="w-full h-full flex pointer-events-none relative overflow-hidden">
     <!-- FIXME(nick,victor): remove reliance on z index -->
     <SiCanvas
       v-if="lightmode && editorContext"
@@ -34,12 +34,8 @@
       <!-- transparent div that flows through to the canvas -->
       <div class="grow h-full pointer-events-none"></div>
 
-      <SiSidebar side="right">
-        <div class="text-center mt-10">
-          poop canoe
-          <div v-if="props.mutable">(rw)</div>
-          <div v-else>(ro)</div>
-        </div>
+      <SiSidebar side="right" :hidden="activeNode === null">
+        <ComponentDetails />
       </SiSidebar>
     </div>
   </div>
@@ -79,8 +75,10 @@ import { applicationNodeId$ } from "@/observable/application";
 import { ChangeSetService } from "@/service/change_set";
 import { ApplicationService } from "@/service/application";
 import AssetsTabs from "@/organisms/AssetsTabs.vue";
+import { lastSelectedNode$ } from "@/observable/selection";
+import ComponentDetails from "@/organisms/ComponentDetails.vue";
 
-const props = defineProps<{
+defineProps<{
   mutable: boolean;
 }>();
 
@@ -211,6 +209,8 @@ const editorContext = refFrom<EditorContext | null>(
     }),
   ),
 );
+
+const activeNode = refFrom(lastSelectedNode$);
 
 const theme = refFrom<Theme>(ThemeService.currentTheme());
 const lightmode = computed(() => {

--- a/app/web/src/templates/WorkspaceSingle.vue
+++ b/app/web/src/templates/WorkspaceSingle.vue
@@ -5,7 +5,7 @@
   >
     <Navbar />
 
-    <router-view class="overflow-y-hidden" />
+    <router-view class="overflow-hidden" />
 
     <StatusBar class="flex-initial" />
   </div>

--- a/bin/lang-js/package-lock.json
+++ b/bin/lang-js/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "lang-js",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {


### PR DESCRIPTION
Right panel slides in and out when component gets de/selected, and displays minimal info on the active node.

![](https://media.giphy.com/media/7p7z3vxucrNCw/giphy.gif)

