### PR TITLE
chore(dal): Create SchemaVariant.finalize() & ensure it is used everywhere

### DIFF
--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -65,7 +65,7 @@ async fn system(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
         .set_default_schema_variant_id(ctx, Some(*variant.id()))
         .await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
+    variant.finalize(ctx).await?;
 
     let identity_func = setup_identity_func(ctx).await?;
 
@@ -115,7 +115,7 @@ async fn application(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
         .set_default_schema_variant_id(ctx, Some(*variant.id()))
         .await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
+    variant.finalize(ctx).await?;
 
     let identity_func = setup_identity_func(ctx).await?;
 
@@ -408,9 +408,7 @@ async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     .await?;
     variant.add_socket(ctx, includes_socket.id()).await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
-    // Now, we can setup providers.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *variant.id()).await?;
+    variant.finalize(ctx).await?;
 
     // Connect the "/root/si/name" field to the "/root/domain/metadata/name" field.
     let base_attribute_read_context = AttributeReadContext {
@@ -522,7 +520,7 @@ async fn docker_hub_credential(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
 
     let identity_func = setup_identity_func(ctx).await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
+    variant.finalize(ctx).await?;
 
     let (_output_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
@@ -706,8 +704,8 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     )
     .await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *variant.id()).await?;
+    variant.finalize(ctx).await?;
+
     let base_attribute_read_context = AttributeReadContext {
         schema_id: Some(*schema.id()),
         schema_variant_id: Some(*variant.id()),
@@ -916,7 +914,7 @@ async fn bobao(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
         .set_widget_kind(ctx, WidgetKind::SecretSelect)
         .await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
+    variant.finalize(ctx).await?;
 
     let includes_socket = Socket::new(
         ctx,

--- a/lib/dal/src/builtins/schema/kubernetes_deployment.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_deployment.rs
@@ -201,9 +201,8 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<(
         .add_root_schematic(ctx, application_schema.id())
         .await?;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *variant.id()).await?;
-    // Now, we can setup providers.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *variant.id()).await?;
+    variant.finalize(ctx).await?;
+
     let base_attribute_read_context = AttributeReadContext {
         schema_id: Some(*schema.id()),
         schema_variant_id: Some(*variant.id()),

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -380,10 +380,10 @@ async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot set parent of prop");
 
-    // Now, we can setup providers.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("unable to create implicit internal providers");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) = Component::new_for_schema_with_node(ctx, "toddhoward", schema.id())
         .await

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -26,12 +26,10 @@ async fn update_for_context_simple(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot set parent of name_prop");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
         .await
@@ -169,12 +167,10 @@ async fn insert_for_context_simple(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot set parent of array_element");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
         .await
@@ -287,10 +283,10 @@ async fn update_for_context_object(ctx: &DalContext<'_, '_>) {
         .await
         .expect("cannot set parent of tags child prop");
 
-    // Now, we can setup providers.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("unable to create implicit internal providers");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
         .await
@@ -486,12 +482,10 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext<'_, 
         .await
         .expect("cannot set parent of array_element");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prop AttributePrototypes");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
         .await

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -89,9 +89,10 @@ async fn qualification_view(ctx: &DalContext<'_, '_>) {
         .await
         .expect("Unable to set some_property parent to root.domain");
 
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("unable to create implicit internal providers");
+        .expect("cannot finalize SchemaVariant");
 
     let (component, _) =
         Component::new_for_schema_variant_with_node(ctx, "mastodon", schema_variant.id())

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -47,12 +47,10 @@ pub async fn create_schema_with_object_and_string_prop(
         .await
         .expect("cannot set parent prop");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (
         schema,
@@ -123,12 +121,10 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
         .await
         .expect("cannot set parent prop");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (
         schema,
@@ -171,12 +167,10 @@ pub async fn create_schema_with_string_props(
         .await
         .expect("cannot set parent prop");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (schema, schema_variant, bohemian_prop, killer_prop, root)
 }
@@ -210,12 +204,10 @@ pub async fn create_schema_with_array_of_string_props(
         .await
         .expect("cannot set parent");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (schema, schema_variant, sammy_prop, album_string_prop, root)
 }
@@ -282,12 +274,10 @@ pub async fn create_schema_with_nested_array_objects(
         .await
         .expect("cannot set parent");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (
         schema,
@@ -333,12 +323,10 @@ pub async fn create_simple_map(
         .await
         .expect("cannot set parent");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (schema, schema_variant, album_prop, album_item_prop, root)
 }
@@ -411,12 +399,10 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
         .await
         .expect("cannot set parent");
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes & values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("unable to create implicit internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
 
     (
         schema,

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -329,13 +329,11 @@ async fn setup_esp(ctx: &DalContext<'_, '_>) -> ComponentPayload {
     prop_map.insert("/root/domain/object/source", *source_prop.id());
     prop_map.insert("/root/domain/object/intermediate", *intermediate_prop.id());
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    // Create the internal providers for a schema variant. Afterwards, we can create the component.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("could not create internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
+
     let (component, _) = Component::new_for_schema_with_node(ctx, "esp", schema.id())
         .await
         .expect("unable to create component");
@@ -400,13 +398,11 @@ async fn setup_swings(ctx: &DalContext<'_, '_>) -> ComponentPayload {
     let mut prop_map = HashMap::new();
     prop_map.insert("/root/domain/destination", *destination_prop.id());
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    // Create the internal providers for a schema variant. Afterwards, we can create the component.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("could not create internal providers for schema variant");
+        .expect("cannot finalize SchemVariant");
+
     let (component, _) = Component::new_for_schema_with_node(ctx, "swings", schema.id())
         .await
         .expect("unable to create component");
@@ -460,16 +456,12 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
         .set_parent_prop(ctx, *source_object_prop.id())
         .await
         .expect("cannot set parent of bar_string");
-    SchemaVariant::create_default_prototypes_and_values(ctx, *source_schema_variant.id())
+
+    source_schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(
-        ctx,
-        *source_schema.id(),
-        *source_schema_variant.id(),
-    )
-    .await
-    .expect("cannot create internal providers for source schema");
+        .expect("cannot finalize source SchemaVariant");
+
     let (source_external_provider, _socket) = ExternalProvider::new_with_socket(
         ctx,
         *source_schema.id(),
@@ -531,16 +523,12 @@ async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
         .set_parent_prop(ctx, *destination_object_prop.id())
         .await
         .expect("cannot set parent of bar_string");
-    SchemaVariant::create_default_prototypes_and_values(ctx, *destination_schema_variant.id())
+
+    destination_schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    SchemaVariant::create_implicit_internal_providers(
-        ctx,
-        *destination_schema.id(),
-        *destination_schema_variant.id(),
-    )
-    .await
-    .expect("cannot create internal providers for destination schema");
+        .expect("cannot finalize destination SchemaVariant");
+
     let destination_object_value = AttributeValue::find_for_context(
         ctx,
         AttributeReadContext {

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -47,13 +47,11 @@ async fn intra_component_identity_update(ctx: &DalContext<'_, '_>) {
     )
     .await;
 
-    SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
+    schema_variant
+        .finalize(ctx)
         .await
-        .expect("cannot create default prototypes and values for SchemaVariant");
-    // Create the internal providers for a schema variant. Afterwards, we can create the component.
-    SchemaVariant::create_implicit_internal_providers(ctx, *schema.id(), *schema_variant.id())
-        .await
-        .expect("could not create internal providers for schema variant");
+        .expect("cannot finalize SchemaVariant");
+
     let (component, _) = Component::new_for_schema_with_node(ctx, "starfield", schema.id())
         .await
         .expect("unable to create component");


### PR DESCRIPTION
Previously, it was a little too easy to forget to call both `SchemaVariant::create_default_prototypes_and_values()` and `SchemaVariant::create_implicit_internal_providers()` when "finalizing" a  `SchemaVariant`. This adds a `schema_variant.finalize()` method that encapsulates calling both, so that there is only a single method that needs to be called.

`SchemaVariant::create_default_prototypes_and_values()` is still a `pub` method, because our helper method for the builtins to create a prop with a default value does not work appropriately if the parent prototypes & values for the Prop that will be created do not already exist.

Anywhere that we were calling `SchemaVariant::create_default_prototypes_and_values()` to "finalize" a `SchemaVariant` now uses this new `schema_variant.finalize()` method, instead.