### PR TITLE
chore(dal): Clean up clippy warnings

### DIFF
--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -295,7 +295,7 @@ mod test {
             .insert_menu_item(&Vec::new(), MenuItem::category("application"))
             .expect("cannot insert menu item");
         let item = menu_items
-            .item_for_path(&vec!["application".to_string()])
+            .item_for_path(&["application".to_string()])
             .expect("cannot find application in menu");
         assert_eq!(item.borrow().name(), "application");
     }
@@ -305,12 +305,12 @@ mod test {
         let menu_items = MenuItems::new();
         menu_items
             .insert_menu_item(
-                &vec!["application".to_string(), "snakes".to_string()],
+                &["application".to_string(), "snakes".to_string()],
                 MenuItem::item("ninjas", 1.into()),
             )
             .expect("cannot insert menu item");
         let item = menu_items
-            .item_for_path(&vec![
+            .item_for_path(&[
                 "application".to_string(),
                 "snakes".to_string(),
                 "ninjas".to_string(),
@@ -324,18 +324,18 @@ mod test {
         let menu_items = MenuItems::new();
         menu_items
             .insert_menu_item(
-                &vec!["application".to_string(), "snakes".to_string()],
+                &["application".to_string(), "snakes".to_string()],
                 MenuItem::item("ninjas", 1.into()),
             )
             .expect("cannot insert menu item");
         menu_items
             .insert_menu_item(
-                &vec!["application".to_string(), "snakes".to_string()],
+                &["application".to_string(), "snakes".to_string()],
                 MenuItem::item("dragons", 1.into()),
             )
             .expect("cannot insert menu item");
         let ninjas = menu_items
-            .item_for_path(&vec![
+            .item_for_path(&[
                 "application".to_string(),
                 "snakes".to_string(),
                 "ninjas".to_string(),
@@ -343,7 +343,7 @@ mod test {
             .expect("cannot find application.snakes in menu");
         assert_eq!(ninjas.borrow().name(), "ninjas".to_string());
         let dragons = menu_items
-            .item_for_path(&vec![
+            .item_for_path(&[
                 "application".to_string(),
                 "snakes".to_string(),
                 "dragons".to_string(),

--- a/lib/dal/tests/database.rs
+++ b/lib/dal/tests/database.rs
@@ -13,7 +13,5 @@ const UNSET_ID_VALUE: i64 = -1;
 /// Smoke test to ensure the database is running and setup worked (migrations, etc.).
 #[test]
 async fn database_smoke(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
-    assert!(System::get_by_id(&ctx, &UNSET_ID_VALUE.into())
-        .await
-        .is_ok())
+    assert!(System::get_by_id(ctx, &UNSET_ID_VALUE.into()).await.is_ok())
 }

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -438,14 +438,11 @@ async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
             .await
             .expect("could not get attribute values");
         for value in values {
-            let parent_value_id = match value
+            let parent_value_id = value
                 .parent_attribute_value(ctx)
                 .await
                 .expect("could not get parent attribute_value")
-            {
-                Some(parent) => Some(*parent.id()),
-                None => None,
-            };
+                .map(|parent| *parent.id());
 
             let _ = AttributeValue::update_for_context(
                 ctx,
@@ -504,7 +501,7 @@ async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
             // been deleted.
             for confirm_deletion_prototype_id in &confirm_deletion_prototype_ids {
                 assert!(
-                    AttributePrototype::get_by_id(ctx, &confirm_deletion_prototype_id)
+                    AttributePrototype::get_by_id(ctx, confirm_deletion_prototype_id)
                         .await
                         .expect("could not get attribute prototype by id")
                         .is_none()

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -4,7 +4,7 @@ use dal::{
     test::helpers::process_job_queue,
     test_harness::{create_prop_of_kind_with_name, create_schema, create_schema_variant_with_root},
     AttributeContext, AttributeReadContext, AttributeValue, Component, DalContext, PropKind,
-    SchemaKind, SchemaVariant, StandardModel, SystemId,
+    SchemaKind, StandardModel, SystemId,
 };
 use pretty_assertions_sorted::assert_eq_sorted;
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -5,8 +5,8 @@ use dal::{
         create_component_and_schema, create_component_for_schema_variant, create_schema,
         create_schema_variant, create_schema_variant_with_root,
     },
-    Component, DalContext, Prop, PropKind, Resource, Schema, SchemaKind, SchemaVariant,
-    StandardModel, WorkspaceId,
+    Component, DalContext, Prop, PropKind, Resource, Schema, SchemaKind, StandardModel,
+    WorkspaceId,
 };
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 use serde_json::json;
@@ -38,7 +38,7 @@ async fn new_for_schema_variant_with_node(ctx: &DalContext<'_, '_>, wid: Workspa
         .expect("cannot retrieve resource for Component & System");
     assert!(resource.is_none());
 
-    let _ = component
+    component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add node to system");
@@ -184,7 +184,7 @@ async fn get_resource_by_component_id(ctx: &DalContext<'_, '_>, wid: WorkspaceId
         .expect("cannot create ash component");
     process_job_queue(ctx).await;
 
-    let _ = component
+    component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add component to system");

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -926,7 +926,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
     unset_attribute_context
         .set_schema_id(*schema.id())
         .set_schema_variant_id(*schema_variant.id());
-    let mut base_attribute_context = unset_attribute_context.clone();
+    let mut base_attribute_context = unset_attribute_context;
     base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -85,7 +85,7 @@ async fn include_component_in_system(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 1);
 
-    let _ = first_component
+    first_component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add component to system");
@@ -105,7 +105,7 @@ async fn include_component_in_system(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 3);
 
-    let _ = second_component
+    second_component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add component to system");
@@ -156,7 +156,7 @@ async fn include_component_in_system_with_edit_sessions(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 1);
 
-    let _ = first_component
+    first_component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add component to system");
@@ -176,7 +176,7 @@ async fn include_component_in_system_with_edit_sessions(
         .expect("cannot retrieve edges from edit session");
     assert_eq!(edges.len(), 3);
 
-    let _ = second_component
+    second_component
         .add_to_system(ctx, system.id())
         .await
         .expect("failed to add component to system");

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -55,17 +55,14 @@ async fn func_binding_find_or_create_head(ctx: &DalContext<'_, '_>) {
         FuncBinding::find_or_create(ctx, args_json.clone(), *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, true,
-        "must create a new func binding when one is absent"
-    );
+    assert!(created, "must create a new func binding when one is absent");
 
     let (_func_binding, created) =
         FuncBinding::find_or_create(ctx, args_json, *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, false,
+    assert!(
+        !created,
         "must not create a new func binding when one is present"
     );
 }
@@ -85,17 +82,14 @@ async fn func_binding_find_or_create_edit_session(ctx: &DalContext<'_, '_>) {
         FuncBinding::find_or_create(ctx, args_json.clone(), *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, true,
-        "must create a new func binding when one is absent"
-    );
+    assert!(created, "must create a new func binding when one is absent");
 
     let (edit_session_func_binding_again, created) =
         FuncBinding::find_or_create(ctx, args_json.clone(), *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, false,
+    assert!(
+        !created,
         "must not create a new func binding when one is present"
     );
     assert_eq!(
@@ -117,8 +111,8 @@ async fn func_binding_find_or_create_edit_session(ctx: &DalContext<'_, '_>) {
         FuncBinding::find_or_create(ctx, args_json.clone(), *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, false,
+    assert!(
+        !created,
         "must not create a new func binding when one is present"
     );
     assert_eq!(
@@ -142,8 +136,8 @@ async fn func_binding_find_or_create_edit_session(ctx: &DalContext<'_, '_>) {
         FuncBinding::find_or_create(ctx, args_json, *func.id(), *func.backend_kind())
             .await
             .expect("cannot create func binding");
-    assert_eq!(
-        created, false,
+    assert!(
+        !created,
         "must not create a new func binding when one is present"
     );
     assert_eq!(

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -33,7 +33,7 @@ async fn set_state(ctx: &DalContext<'_, '_>) {
         .expect("cannot create a new func execution");
     assert_eq!(execution.state(), FuncExecutionState::Start);
     execution
-        .set_state(&ctx, FuncExecutionState::Dispatch)
+        .set_state(ctx, FuncExecutionState::Dispatch)
         .await
         .expect("cannot set state");
     assert_eq!(execution.state(), FuncExecutionState::Dispatch);

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -9,7 +9,7 @@ use dal::test_harness::{
 use dal::{
     socket::SocketArity, AttributeContext, AttributePrototypeArgument, AttributeReadContext,
     AttributeValue, Component, ComponentView, Connection, DalContext, ExternalProvider,
-    InternalProvider, PropKind, SchemaKind, SchemaVariant, SchematicKind, StandardModel,
+    InternalProvider, PropKind, SchemaKind, SchematicKind, StandardModel,
 };
 use pretty_assertions_sorted::assert_eq_sorted;
 use std::collections::HashMap;

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -6,9 +6,7 @@ use dal::test::helpers::{find_prop_and_parent_by_name, process_job_queue};
 use dal::test_harness::{
     create_prop_of_kind_and_set_parent_with_name, create_schema, create_schema_variant_with_root,
 };
-use dal::{
-    AttributePrototypeArgument, AttributeValue, Component, ComponentView, Schema, SchemaVariant,
-};
+use dal::{AttributePrototypeArgument, AttributeValue, Component, ComponentView, Schema};
 use dal::{AttributeReadContext, DalContext, Func, PropKind, SchemaKind, StandardModel};
 use pretty_assertions_sorted::assert_eq_sorted;
 

--- a/lib/dal/tests/integration_test/schematic.rs
+++ b/lib/dal/tests/integration_test/schematic.rs
@@ -107,7 +107,7 @@ async fn get_schematic(ctx: &DalContext<'_, '_>, application_id: ApplicationId) 
     .await
     .expect("could not create connection");
 
-    let schematic = Schematic::find(&ctx, Some(*system.id()))
+    let schematic = Schematic::find(ctx, Some(*system.id()))
         .await
         .expect("cannot find schematic");
 

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -40,5 +40,5 @@ async fn set_required(ctx: &DalContext<'_, '_>) {
         .set_required(ctx, true)
         .await
         .expect("cannot set required");
-    assert_eq!(socket.required(), true);
+    assert!(socket.required());
 }

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -13,7 +13,7 @@ use dal::{
 
 #[test]
 async fn get_by_pk(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
-    let retrieved = standard_model::get_by_pk(&ctx, "billing_accounts", nba.billing_account.pk())
+    let retrieved = standard_model::get_by_pk(ctx, "billing_accounts", nba.billing_account.pk())
         .await
         .expect("cannot get billing account by pk");
 
@@ -276,7 +276,7 @@ async fn set_belongs_to(ctx: &DalContext<'_, '_>) {
     let key_pair = create_key_pair(ctx).await;
 
     standard_model::set_belongs_to(
-        &ctx,
+        ctx,
         "key_pair_belongs_to_billing_account",
         key_pair.id(),
         first_billing_account.id(),
@@ -286,7 +286,7 @@ async fn set_belongs_to(ctx: &DalContext<'_, '_>) {
 
     // You cannot replace the existing belongs to relationship by calling it again with a new id
     match standard_model::set_belongs_to(
-        &ctx,
+        ctx,
         "key_pair_belongs_to_billing_account",
         key_pair.id(),
         second_billing_account.id(),
@@ -307,7 +307,7 @@ async fn unset_belongs_to(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) 
     let key_pair = create_key_pair(ctx).await;
 
     standard_model::set_belongs_to(
-        &ctx,
+        ctx,
         "key_pair_belongs_to_billing_account",
         key_pair.id(),
         nba.billing_account.id(),
@@ -315,7 +315,7 @@ async fn unset_belongs_to(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) 
     .await
     .expect("cannot set billing account for key pair");
 
-    standard_model::unset_belongs_to(&ctx, "key_pair_belongs_to_billing_account", key_pair.id())
+    standard_model::unset_belongs_to(ctx, "key_pair_belongs_to_billing_account", key_pair.id())
         .await
         .expect("cannot set billing account for key pair");
 }
@@ -702,7 +702,7 @@ async fn associate_many_to_many_no_repeat_entries(ctx: &DalContext<'_, '_>) {
 
 #[test]
 async fn find_by_attr(ctx: &DalContext<'_, '_>) {
-    let _billing_account = create_billing_account(&ctx).await;
+    let _billing_account = create_billing_account(ctx).await;
     let change_set = create_change_set(ctx).await;
     let edit_session = create_edit_session(ctx, &change_set).await;
     let edit_session_visibility = create_visibility_edit_session(&change_set, &edit_session);

--- a/lib/dal/tests/integration_test/user.rs
+++ b/lib/dal/tests/integration_test/user.rs
@@ -70,7 +70,7 @@ async fn authorize(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
     let worked = User::authorize(ctx, nba.user.id())
         .await
         .expect("admin group user should be authorized");
-    assert_eq!(worked, true, "authorized admin group user returns true");
+    assert!(worked, "authorized admin group user returns true");
 
     let password = "snakesOnAPlane123";
     let user_no_group = User::new(ctx, "funky", "bobotclown@systeminit.com", &password)
@@ -78,9 +78,8 @@ async fn authorize(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
         .expect("cannot create user");
 
     let f = User::authorize(ctx, user_no_group.id()).await;
-    assert_eq!(
+    assert!(
         f.is_err(),
-        true,
         "user that is not in the admin group should fail"
     );
 }


### PR DESCRIPTION
This cleans up all of the warnings that show up in `cargo clippy --all-targets` other than those in `lib/bytes-lines-codec`. @adamhjk / @fnichol I wanted to sync up with you to see what we wanted to do about the two clippy warnings in there. One is about using `panic!(...)`, and the other is about the `unwrap()`.