### PR TITLE
feat(web): add code viewer to new UI

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -20,6 +20,7 @@
         "@tailwindcss/forms": "^0.5.1",
         "@xstate/vue": "^2.0.0",
         "cm6-theme-gruvbox-dark": "^0.1.0",
+        "cm6-theme-gruvbox-light": "^0.1.0",
         "feather-icons": "^4.29.0",
         "floating-vue": "^2.0.0-beta.16",
         "konva": "^8.3.5",
@@ -1792,6 +1793,16 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cm6-theme-gruvbox-dark/-/cm6-theme-gruvbox-dark-0.1.0.tgz",
       "integrity": "sha512-ld4Qo6eoVxVylSD3ZjSZIEDvoj3v6DkHW01H7WeVQxoh3YCMWZzxsK9lY2WvtFZ5mT8czqE6DDM4v8PIxtKHjQ==",
+      "dependencies": {
+        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
+    "node_modules/cm6-theme-gruvbox-light": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cm6-theme-gruvbox-light/-/cm6-theme-gruvbox-light-0.1.0.tgz",
+      "integrity": "sha512-w7erhjTsNKAKuagtXCGR5Bd5l4ukAyFsamRWa8ST9qNkKHPVQzGtIqHXISc3STxBoi/UXJCwAS5L2GxCJEX9/Q==",
       "dependencies": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -7007,6 +7018,16 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cm6-theme-gruvbox-dark/-/cm6-theme-gruvbox-dark-0.1.0.tgz",
       "integrity": "sha512-ld4Qo6eoVxVylSD3ZjSZIEDvoj3v6DkHW01H7WeVQxoh3YCMWZzxsK9lY2WvtFZ5mT8czqE6DDM4v8PIxtKHjQ==",
+      "requires": {
+        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/state": "^0.19.0",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
+    "cm6-theme-gruvbox-light": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cm6-theme-gruvbox-light/-/cm6-theme-gruvbox-light-0.1.0.tgz",
+      "integrity": "sha512-w7erhjTsNKAKuagtXCGR5Bd5l4ukAyFsamRWa8ST9qNkKHPVQzGtIqHXISc3STxBoi/UXJCwAS5L2GxCJEX9/Q==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/state": "^0.19.0",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/forms": "^0.5.1",
     "@xstate/vue": "^2.0.0",
     "cm6-theme-gruvbox-dark": "^0.1.0",
+    "cm6-theme-gruvbox-light": "^0.1.0",
     "feather-icons": "^4.29.0",
     "floating-vue": "^2.0.0-beta.16",
     "konva": "^8.3.5",

--- a/app/web/src/organisms/ComponentDetails.vue
+++ b/app/web/src/organisms/ComponentDetails.vue
@@ -17,9 +17,11 @@
         </div>
       </TabPanel>
       <TabPanel>
-        <div class="text-lg">
-          Code Content for {{ props.componentIdentification.schemaName }}
-        </div>
+        <CodeViewer
+          class="dark:text-neutral-50 text-neutral-900"
+          :component-id="props.componentIdentification.componentId"
+          :schema-name="props.componentIdentification.schemaName"
+        />
       </TabPanel>
     </template>
   </SiTabGroup>
@@ -32,6 +34,7 @@ import { TabPanel } from "@headlessui/vue";
 import AttributeViewer from "@/organisms/AttributeViewer.vue";
 import _ from "lodash";
 import { ComponentIdentification } from "@/api/sdf/dal/component";
+import CodeViewer from "@/organisms/CodeViewer.vue";
 
 const props = defineProps<{
   componentIdentification: ComponentIdentification;


### PR DESCRIPTION
- Add CodeViewer to ComponentDetails
- Add gruvbox-light theme (same version as gruvbox-dark)
- Dynamically change theme with theme observable

<img src="https://media4.giphy.com/media/ZVik7pBtu9dNS/giphy.gif"/>

Fixes ENG-388
Fixes ENG-389