### PR TITLE
feat(web,sdf,dal): add functional changeset stats

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -13,3 +13,9 @@ export interface ChangeSet extends StandardModelNoVisibility {
   note?: string;
   status: ChangeSetStatus;
 }
+
+export interface ComponentStats {
+  added: number;
+  deleted: number;
+  modified: number;
+}

--- a/app/web/src/atoms/SiSidebar.vue
+++ b/app/web/src/atoms/SiSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- FIXME(nick,victor): find a way to remove z levels from here. This is needed for interaction with the canvas to work. -->
   <div
-    class="z-20 flex flex-col dark:text-white border-neutral-300 dark:border-[#525252] bg-white dark:bg-neutral-800 w-72 xl:w-96 pointer-events-auto relative transition-all"
+    class="z-20 flex flex-col dark:text-white border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 w-72 xl:w-96 pointer-events-auto relative transition-all"
     :class="panelClasses"
   >
     <slot />

--- a/app/web/src/organisms/ChangeSetTab.vue
+++ b/app/web/src/organisms/ChangeSetTab.vue
@@ -1,0 +1,44 @@
+<template>
+  <StatusBarTabPill>
+    Total: <span class="font-bold">&nbsp; {{ total }}</span>
+  </StatusBarTabPill>
+  <StatusBarTabPill class="bg-success-100 text-success-500 font-bold">
+    + {{ stats.added }}
+  </StatusBarTabPill>
+  <StatusBarTabPill class="bg-warning-100 text-warning-500 font-bold">
+    ~ {{ stats.modified }}
+  </StatusBarTabPill>
+  <StatusBarTabPill class="bg-destructive-100 text-destructive-500 font-bold">
+    - {{ stats.deleted }}
+  </StatusBarTabPill>
+</template>
+
+<script setup lang="ts">
+import { ComponentStats } from "@/api/sdf/dal/change_set";
+import StatusBarTabPill from "@/organisms/StatusBar/StatusBarTabPill.vue";
+import { ChangeSetService } from "@/service/change_set";
+import { GlobalErrorService } from "@/service/global_error";
+import { ref } from "vue";
+import { untilUnmounted } from "vuse-rx";
+
+const defaultComponentStats: ComponentStats = {
+  added: 0,
+  deleted: 0,
+  modified: 0,
+};
+
+const stats = ref<ComponentStats>(defaultComponentStats);
+const total = ref<number>(0);
+
+untilUnmounted(ChangeSetService.getStats()).subscribe((response) => {
+  if (response.error) {
+    GlobalErrorService.set(response);
+  } else {
+    stats.value = response.componentStats;
+    total.value =
+      response.componentStats.added +
+      response.componentStats.deleted +
+      response.componentStats.modified;
+  }
+});
+</script>

--- a/app/web/src/organisms/StatusBar.vue
+++ b/app/web/src/organisms/StatusBar.vue
@@ -18,15 +18,7 @@
           <template #icon><ClockIcon class="text-white" /></template>
           <template #name>Changes</template>
           <template #summary>
-            <StatusBarTabPill>
-              Total: <span class="font-bold">&nbsp; 8</span>
-            </StatusBarTabPill>
-            <StatusBarTabPill class="bg-success-100 text-success-500 font-bold">
-              + 3
-            </StatusBarTabPill>
-            <StatusBarTabPill class="bg-[#FDE8E8] text-[#F05252] font-bold">
-              - 5
-            </StatusBarTabPill>
+            <ChangeSetTab />
           </template>
         </StatusBarTab>
       </Tab>
@@ -92,6 +84,7 @@ import {
 import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
 import StatusBarTab from "./StatusBar/StatusBarTab.vue";
 import StatusBarTabPill from "./StatusBar/StatusBarTabPill.vue";
+import ChangeSetTab from "@/organisms/ChangeSetTab.vue";
 
 const panelOpen = ref(false);
 // Tab 0 is our phantom empty panel

--- a/app/web/src/organisms/Workspace/WorkspaceView.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid h-screen place-items-center dark:bg-[#333333] dark:text-white text-lg font-semibold"
+    class="grid h-screen place-items-center dark:bg-neutral-800 dark:text-white text-lg font-semibold"
   >
     WorkspaceView
   </div>

--- a/app/web/src/service/change_set.ts
+++ b/app/web/src/service/change_set.ts
@@ -14,6 +14,7 @@ import { currentChangeSet } from "./change_set/current_change_set";
 import { currentEditSession } from "./change_set/current_edit_session";
 import { currentEditMode } from "./change_set/current_edit_mode";
 import { updateSelectedChangeSet } from "./change_set/update_selected_change_set";
+import { getStats } from "./change_set/get_stats";
 import {
   changeSet$,
   eventChangeSetApplied$,
@@ -31,6 +32,7 @@ export const ChangeSetService = {
   createChangeSet,
   applyChangeSet,
   getChangeSet,
+  getStats,
   startEditSession,
   cancelEditSession,
   cancelAndStartEditSession,

--- a/app/web/src/service/change_set/get_stats.ts
+++ b/app/web/src/service/change_set/get_stats.ts
@@ -1,0 +1,24 @@
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { ComponentStats } from "@/api/sdf/dal/change_set";
+import { combineLatest, switchMap, Observable, shareReplay } from "rxjs";
+import { standardVisibilityTriggers$ } from "@/observable/visibility";
+
+interface GetStatsResponse {
+  componentStats: ComponentStats;
+}
+
+const changeSetStats$ = combineLatest([standardVisibilityTriggers$]).pipe(
+  switchMap(([[visibility]]) => {
+    const bottle = Bottle.pop("default");
+    const sdf: SDF = bottle.container.SDF;
+    return sdf.get<ApiResponse<GetStatsResponse>>("change_set/get_stats", {
+      ...visibility,
+    });
+  }),
+  shareReplay({ bufferSize: 1, refCount: true }),
+);
+
+export function getStats(): Observable<ApiResponse<GetStatsResponse>> {
+  return changeSetStats$;
+}

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1,3 +1,4 @@
+pub mod stats;
 pub mod view;
 
 pub use view::{ComponentView, ComponentViewError};

--- a/lib/dal/src/component/stats.rs
+++ b/lib/dal/src/component/stats.rs
@@ -1,0 +1,113 @@
+//! This module contains [`ComponentStats`].
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+use telemetry::prelude::*;
+use tokio_postgres::row::RowIndex;
+use tokio_postgres::Row;
+
+use crate::component::ComponentResult;
+use crate::{ComponentId, DalContext, StandardModelResult};
+
+const LIST_MODIFIED: &str = include_str!("../queries/component_stats_list_modified.sql");
+const LIST_ADDED: &str = include_str!("../queries/component_stats_list_added.sql");
+const LIST_DELETED: &str = include_str!("../queries/component_stats_list_deleted.sql");
+
+/// A collection of statistics for [`Components`](crate::Component) in the current
+/// [`ChangeSet`](crate::ChangeSet).
+#[derive(Deserialize, Serialize, Debug, Default)]
+pub struct ComponentStats {
+    added: usize,
+    deleted: usize,
+    modified: usize,
+}
+
+impl ComponentStats {
+    pub async fn new(ctx: &DalContext<'_, '_>) -> ComponentResult<Self> {
+        let component_stats = if ctx.visibility().is_head() {
+            Self::default()
+        } else {
+            let added = Self::list_added(ctx).await?.len();
+            let deleted = Self::list_deleted(ctx).await?.len();
+            let modified = Self::list_modified(ctx).await?.len();
+            Self {
+                added,
+                deleted,
+                modified,
+            }
+        };
+        Ok(component_stats)
+    }
+
+    #[instrument(skip_all)]
+    async fn list_added(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentId>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_ADDED,
+                &[
+                    ctx.read_tenancy(),
+                    &ctx.visibility().change_set_pk,
+                    &ctx.visibility().edit_session_pk,
+                ],
+            )
+            .await?;
+        Ok(Self::component_ids_from_rows_with_idx(rows, "id")?)
+    }
+
+    #[instrument(skip_all)]
+    async fn list_deleted(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentId>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_DELETED,
+                &[
+                    ctx.read_tenancy(),
+                    &ctx.visibility().change_set_pk,
+                    &ctx.visibility().edit_session_pk,
+                ],
+            )
+            .await?;
+        Ok(Self::component_ids_from_rows_with_idx(rows, "id")?)
+    }
+
+    #[instrument(skip_all)]
+    async fn list_modified(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentId>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_MODIFIED,
+                &[
+                    ctx.read_tenancy(),
+                    &ctx.visibility().change_set_pk,
+                    &ctx.visibility().edit_session_pk,
+                ],
+            )
+            .await?;
+        Ok(Self::component_ids_from_rows_with_idx(
+            rows,
+            "attribute_context_component_id",
+        )?)
+    }
+
+    /// Modification of [`standard_model::objects_from_rows()`] for resolving rows to
+    /// [`ComponentIds`](crate::Component).
+    fn component_ids_from_rows_with_idx<I>(
+        rows: Vec<Row>,
+        idx: I,
+    ) -> StandardModelResult<Vec<ComponentId>>
+    where
+        I: RowIndex + fmt::Display,
+    {
+        let mut result = Vec::new();
+        for row in rows.into_iter() {
+            let object: ComponentId = row.try_get(&idx)?;
+            result.push(object);
+        }
+        Ok(result)
+    }
+}

--- a/lib/dal/src/queries/component_stats_list_added.sql
+++ b/lib/dal/src/queries/component_stats_list_added.sql
@@ -1,0 +1,45 @@
+SELECT DISTINCT ON (id) id
+
+FROM components
+
+-- Find components that are not in HEAD
+WHERE id NOT IN (
+    SELECT id
+    FROM components
+    WHERE visibility_change_set_pk = -1
+      AND visibility_edit_session_pk = -1
+      AND visibility_deleted_at IS NULL
+      AND in_tenancy_v1($1,
+                        tenancy_universal,
+                        tenancy_billing_account_ids,
+                        tenancy_organization_ids,
+                        tenancy_workspace_ids))
+
+  -- Compare only to the current change set
+  AND visibility_change_set_pk = $2
+
+  -- Check all edit sessions that should contribute to the count
+  --   'Open'   specific to you
+  --   'Saved'  taken from all edit sessions
+  AND visibility_edit_session_pk in (
+    SELECT id
+    FROM edit_sessions
+    WHERE (status = 'Open' AND visibility_edit_session_pk = $3)
+       OR status = 'Saved'
+        AND in_tenancy_v1($1,
+                          tenancy_universal,
+                          tenancy_billing_account_ids,
+                          tenancy_organization_ids,
+                          tenancy_workspace_ids))
+
+  -- Ensure they are not deleted
+  AND visibility_deleted_at IS NULL
+
+  -- Scope the tenancy one last time
+  AND in_tenancy_v1($1,
+                    tenancy_universal,
+                    tenancy_billing_account_ids,
+                    tenancy_organization_ids,
+                    tenancy_workspace_ids)
+
+ORDER BY id DESC

--- a/lib/dal/src/queries/component_stats_list_deleted.sql
+++ b/lib/dal/src/queries/component_stats_list_deleted.sql
@@ -1,0 +1,32 @@
+SELECT DISTINCT ON (id) id
+
+FROM components
+
+-- Ensure they are deleted
+WHERE visibility_deleted_at IS NOT NULL
+
+  -- Compare only to the current change set
+  AND visibility_change_set_pk = $2
+
+  -- Check all edit sessions that should contribute to the count
+  --   'Open'   specific to you
+  --   'Saved'  taken from all edit sessions
+  AND visibility_edit_session_pk in (
+    SELECT id
+    FROM edit_sessions
+    WHERE (status = 'Open' AND visibility_edit_session_pk = $3)
+       OR status = 'Saved'
+        AND in_tenancy_v1($1,
+                          tenancy_universal,
+                          tenancy_billing_account_ids,
+                          tenancy_organization_ids,
+                          tenancy_workspace_ids))
+
+  -- Scope the tenancy one last time
+  AND in_tenancy_v1($1,
+                    tenancy_universal,
+                    tenancy_billing_account_ids,
+                    tenancy_organization_ids,
+                    tenancy_workspace_ids)
+
+ORDER BY id DESC

--- a/lib/dal/src/queries/component_stats_list_modified.sql
+++ b/lib/dal/src/queries/component_stats_list_modified.sql
@@ -1,0 +1,46 @@
+SELECT DISTINCT ON (attribute_context_component_id) attribute_context_component_id
+
+FROM attribute_values
+
+-- Grab all components on HEAD
+WHERE attribute_context_component_id IN (
+    SELECT id
+    FROM components
+    WHERE visibility_change_set_pk = -1
+      AND visibility_edit_session_pk = -1
+      AND visibility_deleted_at IS NULL
+      AND in_tenancy_v1($1,
+                        tenancy_universal,
+                        tenancy_billing_account_ids,
+                        tenancy_organization_ids,
+                        tenancy_workspace_ids))
+
+  -- Compare only to the current change set
+  AND visibility_change_set_pk = $2
+
+  -- Check all edit sessions that should contribute to the count
+  --   'Open'   specific to you
+  --   'Saved'  taken from all edit sessions
+  AND visibility_edit_session_pk in (
+    SELECT id
+    FROM edit_sessions
+    WHERE (status = 'Open' AND visibility_edit_session_pk = $3)
+       OR status = 'Saved'
+        AND in_tenancy_v1($1,
+                          tenancy_universal,
+                          tenancy_billing_account_ids,
+                          tenancy_organization_ids,
+                          tenancy_workspace_ids))
+
+  -- Ensure they are not deleted
+  AND visibility_deleted_at IS NULL
+
+  -- Scope the tenancy one last time
+  AND in_tenancy_v1($1,
+                    tenancy_universal,
+                    tenancy_billing_account_ids,
+                    tenancy_organization_ids,
+                    tenancy_workspace_ids)
+
+
+ORDER BY attribute_context_component_id DESC

--- a/lib/dal/src/visibility.rs
+++ b/lib/dal/src/visibility.rs
@@ -46,7 +46,7 @@ impl Visibility {
         }
     }
 
-    /// Constructs a new head `Visibility`.
+    /// Constructs a new head [`Visibility`].
     #[instrument]
     pub fn new_head(deleted: bool) -> Self {
         let deleted_at = match deleted {
@@ -56,9 +56,16 @@ impl Visibility {
         Visibility::new(NO_CHANGE_SET_PK, NO_EDIT_SESSION_PK, deleted_at)
     }
 
-    /// Converts this `Visibility` to a new head `Visibility`.
+    /// Converts this [`Visibility`] to a new head [`Visibility`].
     pub fn to_head(&self) -> Self {
         Self::new_head(self.deleted_at.is_some())
+    }
+
+    /// Determines if this [`Visibility`] is a head [`Visibility`].
+    pub fn is_head(&self) -> bool {
+        self.change_set_pk == NO_CHANGE_SET_PK
+            && self.edit_session_pk == NO_EDIT_SESSION_PK
+            && self.deleted_at == None
     }
 
     /// Constructs a new change set `Visibility`.

--- a/lib/sdf/src/server/service/change_set.rs
+++ b/lib/sdf/src/server/service/change_set.rs
@@ -5,7 +5,8 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    ChangeSetError as DalChangeSetError, EditSessionError, StandardModelError, TransactionsError,
+    ChangeSetError as DalChangeSetError, ComponentError as DalComponentError, EditSessionError,
+    StandardModelError, TransactionsError,
 };
 use thiserror::Error;
 
@@ -14,6 +15,7 @@ pub mod cancel_and_start_edit_session;
 pub mod cancel_edit_session;
 pub mod create_change_set;
 pub mod get_change_set;
+pub mod get_stats;
 pub mod list_open_change_sets;
 pub mod save_and_start_edit_session;
 pub mod save_edit_session;
@@ -31,6 +33,8 @@ pub enum ChangeSetError {
     StandardModel(#[from] StandardModelError),
     #[error(transparent)]
     ChangeSet(#[from] DalChangeSetError),
+    #[error(transparent)]
+    Component(#[from] DalComponentError),
     #[error(transparent)]
     ContextError(#[from] TransactionsError),
     #[error(transparent)]
@@ -70,6 +74,7 @@ pub fn routes() -> Router {
             post(create_change_set::create_change_set),
         )
         .route("/get_change_set", get(get_change_set::get_change_set))
+        .route("/get_stats", get(get_stats::get_stats))
         .route(
             "/apply_change_set",
             post(apply_change_set::apply_change_set),

--- a/lib/sdf/src/server/service/change_set/get_stats.rs
+++ b/lib/sdf/src/server/service/change_set/get_stats.rs
@@ -1,0 +1,39 @@
+use super::ChangeSetResult;
+use crate::server::extract::{AccessBuilder, HandlerContext};
+
+use axum::extract::Query;
+use axum::Json;
+use dal::component::stats::ComponentStats;
+use dal::Visibility;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetStatsRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetStatsResponse {
+    pub component_stats: ComponentStats,
+}
+
+/// Gather statistics for the _current_ change set.
+pub async fn get_stats(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<GetStatsRequest>,
+) -> ChangeSetResult<Json<GetStatsResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    let component_stats = ComponentStats::new(&ctx).await?;
+
+    // TODO(nick,fletcher): determine whether or not we should commit on accessor queries.
+    // We will commit for now in case something eventually does get mutated in the DB.
+    txns.commit().await?;
+
+    Ok(Json(GetStatsResponse { component_stats }))
+}


### PR DESCRIPTION
## Description

Primary:
- Add added, deleted, modified stats for the ChangeSet status bar tab
- Move the ChangSet status bar tab to its own component
- Create the service, module and queries to generate stats in dal and
  sdf
- Add ComponentStats to dal

Misc:
- Add visibility helpers
- Replace hardcoded colors

## GIF and Linear

<img src="https://media0.giphy.com/media/3o6Zt6fzS6qEbLhKWQ/giphy.gif"/>

Fixes ENG-421
Fixes ENG-422
Fixes ENG-423
Fixes ENG-433