### PR TITLE
fix(pinga): remove migrations from pinga

### DIFF
--- a/bin/pinga/src/config.rs
+++ b/bin/pinga/src/config.rs
@@ -6,7 +6,7 @@ use si_data::{FaktoryConfig, NatsConfig, PgPoolConfig};
 use si_settings::{CanonicalFile, CanonicalFileError};
 use thiserror::Error;
 
-pub use dal::{CycloneKeyPair, MigrationMode};
+pub use dal::CycloneKeyPair;
 pub use si_settings::{StandardConfig, StandardConfigFile};
 
 #[derive(Debug, Error)]
@@ -32,9 +32,6 @@ pub struct Config {
     #[builder(default = "FaktoryConfig::default()")]
     faktory: FaktoryConfig,
 
-    #[builder(default = "MigrationMode::default()")]
-    migration_mode: MigrationMode,
-
     cyclone_encryption_key_path: CanonicalFile,
 }
 
@@ -47,12 +44,6 @@ impl Config {
     #[must_use]
     pub fn pg_pool(&self) -> &PgPoolConfig {
         &self.pg_pool
-    }
-
-    /// Gets a reference to the config's migration mode.
-    #[must_use]
-    pub fn migration_mode(&self) -> &MigrationMode {
-        &self.migration_mode
     }
 
     /// Gets a reference to the config's nats.
@@ -79,7 +70,6 @@ pub struct ConfigFile {
     pg: PgPoolConfig,
     nats: NatsConfig,
     faktory: FaktoryConfig,
-    migration_mode: MigrationMode,
     cyclone_encryption_key_path: String,
 }
 
@@ -106,7 +96,6 @@ impl Default for ConfigFile {
             pg: Default::default(),
             nats: Default::default(),
             faktory: Default::default(),
-            migration_mode: Default::default(),
             cyclone_encryption_key_path,
         }
     }
@@ -124,7 +113,6 @@ impl TryFrom<ConfigFile> for Config {
         config.pg_pool(value.pg);
         config.nats(value.nats);
         config.faktory(value.faktory);
-        config.migration_mode(value.migration_mode);
         config.cyclone_encryption_key_path(value.cyclone_encryption_key_path.try_into()?);
         config.build().map_err(Into::into)
     }

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -13,8 +13,8 @@ use dal::{
     job::consumer::{JobConsumer, JobConsumerError},
     job::definition::component_post_processing::ComponentPostProcessing,
     job::definition::dependent_values_update::DependentValuesUpdate,
-    CycloneKeyPair, DalContext, DalContextBuilder, JobFailure, JobFailureError, MigrationMode,
-    ServicesContext, TransactionsError,
+    CycloneKeyPair, DalContext, DalContextBuilder, JobFailure, JobFailureError, ServicesContext,
+    TransactionsError,
 };
 use dal::{FaktoryProcessor, JobQueueProcessor};
 use si_data::{NatsClient, PgPool, PgPoolError};
@@ -134,37 +134,6 @@ async fn run(
     let veritech = veritech::Client::new(nats.clone());
 
     let (alive_marker, mut job_processor_shutdown_rx) = mpsc::channel(1);
-
-    if let MigrationMode::Run | MigrationMode::RunAndQuit = config.migration_mode() {
-        info!("Running migrations");
-
-        let faktory_config = faktory_async::Config::from_uri(
-            &config.faktory().url,
-            Some("pinga-migrations".to_string()),
-            None,
-        );
-        let client = Client::new(faktory_config, 128);
-        let job_processor = Box::new(FaktoryProcessor::new(client, alive_marker.clone()))
-            as Box<dyn JobQueueProcessor + Send + Sync>;
-
-        dal::migrate_all(
-            &pg_pool,
-            &nats,
-            job_processor,
-            veritech.clone(),
-            &encryption_key,
-        )
-        .await?;
-        if let MigrationMode::RunAndQuit = config.migration_mode() {
-            info!(
-                "migration mode is {}, shutting down",
-                config.migration_mode()
-            );
-            return Ok(());
-        }
-    } else {
-        trace!("migration mode is skip, not running migrations");
-    }
 
     info!("Creating faktory connection");
     let config = faktory_async::Config::from_uri(


### PR DESCRIPTION
Pinga and SDF could race migrations if they were started at about the
same time. For now let's remove migrations from pinga until we see a
clear need to do them in both.