### PR TITLE
feat(web,sdf,dal): add functional changeset tab body picker

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -14,8 +14,13 @@ export interface ChangeSet extends StandardModelNoVisibility {
   status: ChangeSetStatus;
 }
 
+export interface ComponentStatsGroup {
+  component_id: number;
+  component_name: string;
+}
+
 export interface ComponentStats {
-  added: number;
-  deleted: number;
-  modified: number;
+  added: ComponentStatsGroup[];
+  deleted: ComponentStatsGroup[];
+  modified: ComponentStatsGroup[];
 }

--- a/app/web/src/organisms/ChangeSetTab.vue
+++ b/app/web/src/organisms/ChangeSetTab.vue
@@ -1,15 +1,21 @@
 <template>
   <StatusBarTabPill>
-    Total: <span class="font-bold">&nbsp; {{ total }}</span>
+    Total:
+    <span class="font-bold"
+      >&nbsp;
+      {{
+        stats.added.length + stats.modified.length + stats.deleted.length
+      }}</span
+    >
   </StatusBarTabPill>
   <StatusBarTabPill class="bg-success-100 text-success-500 font-bold">
-    + {{ stats.added }}
+    + {{ stats.added.length }}
   </StatusBarTabPill>
   <StatusBarTabPill class="bg-warning-100 text-warning-500 font-bold">
-    ~ {{ stats.modified }}
+    ~ {{ stats.modified.length }}
   </StatusBarTabPill>
   <StatusBarTabPill class="bg-destructive-100 text-destructive-500 font-bold">
-    - {{ stats.deleted }}
+    - {{ stats.deleted.length }}
   </StatusBarTabPill>
 </template>
 
@@ -21,24 +27,17 @@ import { GlobalErrorService } from "@/service/global_error";
 import { ref } from "vue";
 import { untilUnmounted } from "vuse-rx";
 
-const defaultComponentStats: ComponentStats = {
-  added: 0,
-  deleted: 0,
-  modified: 0,
-};
-
-const stats = ref<ComponentStats>(defaultComponentStats);
-const total = ref<number>(0);
+const stats = ref<ComponentStats>({
+  added: [],
+  deleted: [],
+  modified: [],
+});
 
 untilUnmounted(ChangeSetService.getStats()).subscribe((response) => {
   if (response.error) {
     GlobalErrorService.set(response);
   } else {
     stats.value = response.componentStats;
-    total.value =
-      response.componentStats.added +
-      response.componentStats.deleted +
-      response.componentStats.modified;
   }
 });
 </script>

--- a/app/web/src/organisms/ChangeSetTabPanel.vue
+++ b/app/web/src/organisms/ChangeSetTabPanel.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="flex flex-row">
+    <!-- Filter button and list of components -->
+    <div class="w-32 border-r-[1px] border-black text-center">
+      <!-- Filter button and its dropdown -->
+      <SiNavbarButton
+        class="h-10 border-b-[1px] border-black"
+        dropdown-classes="top-1 left-4"
+        tooltip-text="Filter"
+      >
+        <template #default="{ hovered, open }">
+          <div class="flex-row flex">
+            {{ filterTitle }}
+            <SiArrow :nudge="hovered || open" class="ml-1 w-4" />
+          </div>
+        </template>
+
+        <template #dropdownContent>
+          <SiDropdownItem
+            :checked="filter === 'all'"
+            @select="changeFilter('all')"
+            >All</SiDropdownItem
+          >
+          <SiDropdownItem
+            :checked="filter === 'added'"
+            @select="changeFilter('added')"
+            >Added</SiDropdownItem
+          >
+          <SiDropdownItem
+            :checked="filter === 'deleted'"
+            @select="changeFilter('deleted')"
+            >Deleted</SiDropdownItem
+          >
+          <SiDropdownItem
+            :checked="filter === 'modified'"
+            @select="changeFilter('modified')"
+            >Modified</SiDropdownItem
+          >
+        </template>
+      </SiNavbarButton>
+
+      <!-- List of components -->
+      <div class="overflow-y-auto">
+        <div
+          v-for="group in list"
+          :key="group.component_id"
+          class="flex flex-col text-sm"
+        >
+          <div
+            v-if="selectedComponentId === group.component_id"
+            class="bg-action-500 py-2"
+            @click="updateSelectedComponentId(group.component_id)"
+          >
+            {{ group.component_name }}
+          </div>
+
+          <div
+            v-else
+            class="hover:bg-black py-2"
+            @click="updateSelectedComponentId(group.component_id)"
+          >
+            {{ group.component_name }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Selected component view -->
+    <div class="text-center text-xl p-2">
+      Selected componentId: {{ selectedComponentId }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ComponentStats } from "@/api/sdf/dal/change_set";
+import { lastSelectedNode$ } from "@/observable/selection";
+import { ChangeSetService } from "@/service/change_set";
+import { GlobalErrorService } from "@/service/global_error";
+import { firstValueFrom } from "rxjs";
+import { computed, ref } from "vue";
+import { untilUnmounted } from "vuse-rx";
+import { Node } from "@/organisms/SiCanvas/canvas/obj/node";
+import SiDropdownItem from "@/atoms/SiDropdownItem.vue";
+import SiNavbarButton from "@/molecules/SiNavbarButton.vue";
+import SiArrow from "@/atoms/SiArrow.vue";
+
+const filter = ref<"all" | "added" | "deleted" | "modified">("all");
+const changeFilter = (newFilter: "all" | "added" | "deleted" | "modified") => {
+  filter.value = newFilter;
+};
+const filterTitle = computed(() => {
+  if (filter.value === "all") {
+    return "All";
+  } else if (filter.value === "added") {
+    return "Added";
+  } else if (filter.value === "deleted") {
+    return "Deleted";
+  }
+  return "Modified";
+});
+
+const list = computed(() => {
+  if (filter.value === "all") {
+    return total.value;
+  } else if (filter.value === "added") {
+    return stats.value.added;
+  } else if (filter.value === "deleted") {
+    return stats.value.deleted;
+  }
+  return stats.value.modified;
+});
+
+const total = computed(() => {
+  return stats.value.added.concat(
+    stats.value.deleted.concat(stats.value.modified),
+  );
+});
+
+const stats = ref<ComponentStats>({
+  added: [],
+  deleted: [],
+  modified: [],
+});
+
+untilUnmounted(ChangeSetService.getStats()).subscribe((response) => {
+  if (response.error) {
+    GlobalErrorService.set(response);
+  } else {
+    stats.value = response.componentStats;
+  }
+});
+
+const selectedComponentId = ref<number | false>(false);
+const updateSelectedComponentId = (componentId: number) => {
+  selectedComponentId.value = componentId;
+};
+
+const updateSelection = (node: Node | null) => {
+  const componentId = node?.nodeKind?.componentId;
+
+  // Ignores deselection and fake nodes, as they don't have any attributes
+  if (!componentId || componentId === -1) return;
+
+  selectedComponentId.value = componentId;
+};
+lastSelectedNode$
+  .pipe(untilUnmounted)
+  .subscribe((node) => updateSelection(node));
+firstValueFrom(lastSelectedNode$).then((last) => updateSelection(last));
+</script>

--- a/app/web/src/organisms/StatusBar.vue
+++ b/app/web/src/organisms/StatusBar.vue
@@ -65,7 +65,9 @@
         class="flex flex-col w-full h-52 lg:h-80 min-h-fit text-white"
       >
         <TabPanel class="hidden" aria-hidden="true">hidden</TabPanel>
-        <TabPanel> Changes </TabPanel>
+        <TabPanel>
+          <ChangeSetTabPanel />
+        </TabPanel>
         <TabPanel> Qualifications </TabPanel>
       </TabPanels>
     </Transition>
@@ -82,9 +84,10 @@ import {
   ClockIcon,
 } from "@heroicons/vue/solid";
 import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
-import StatusBarTab from "./StatusBar/StatusBarTab.vue";
-import StatusBarTabPill from "./StatusBar/StatusBarTabPill.vue";
+import StatusBarTab from "@/organisms/StatusBar/StatusBarTab.vue";
+import StatusBarTabPill from "@/organisms/StatusBar/StatusBarTabPill.vue";
 import ChangeSetTab from "@/organisms/ChangeSetTab.vue";
+import ChangeSetTabPanel from "@/organisms/ChangeSetTabPanel.vue";
 
 const panelOpen = ref(false);
 // Tab 0 is our phantom empty panel

--- a/lib/dal/src/queries/component_stats_list_added.sql
+++ b/lib/dal/src/queries/component_stats_list_added.sql
@@ -1,9 +1,10 @@
-SELECT DISTINCT ON (id) id
+SELECT DISTINCT ON (component_id) component_id,
+                                  components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM components
+FROM components_with_attributes AS components
 
 -- Find components that are not in HEAD
-WHERE id NOT IN (
+WHERE component_id NOT IN (
     SELECT id
     FROM components
     WHERE visibility_change_set_pk = -1
@@ -42,4 +43,5 @@ WHERE id NOT IN (
                     tenancy_organization_ids,
                     tenancy_workspace_ids)
 
-ORDER BY id DESC
+ORDER BY component_id DESC,
+         component_name DESC

--- a/lib/dal/src/queries/component_stats_list_deleted.sql
+++ b/lib/dal/src/queries/component_stats_list_deleted.sql
@@ -1,6 +1,7 @@
-SELECT DISTINCT ON (id) id
+SELECT DISTINCT ON (component_id) component_id,
+                                  components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM components
+FROM components_with_attributes AS components
 
 -- Ensure they are deleted
 WHERE visibility_deleted_at IS NOT NULL
@@ -29,4 +30,5 @@ WHERE visibility_deleted_at IS NOT NULL
                     tenancy_organization_ids,
                     tenancy_workspace_ids)
 
-ORDER BY id DESC
+ORDER BY component_id DESC,
+         component_name DESC

--- a/lib/dal/src/queries/component_stats_list_modified.sql
+++ b/lib/dal/src/queries/component_stats_list_modified.sql
@@ -1,46 +1,63 @@
-SELECT DISTINCT ON (attribute_context_component_id) attribute_context_component_id
+SELECT DISTINCT ON (component_id) component_id,
+                                  components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM attribute_values
+FROM components_with_attributes AS components
 
--- Grab all components on HEAD
-WHERE attribute_context_component_id IN (
-    SELECT id
-    FROM components
-    WHERE visibility_change_set_pk = -1
-      AND visibility_edit_session_pk = -1
+         -- Collect all unique component ids
+         INNER JOIN (
+    SELECT DISTINCT ON (attribute_context_component_id) attribute_context_component_id
+    FROM attribute_values
+
+         -- Grab all components on HEAD
+    WHERE attribute_context_component_id IN (
+        SELECT id
+        FROM components
+        WHERE visibility_change_set_pk = -1
+          AND visibility_edit_session_pk = -1
+          AND visibility_deleted_at IS NULL
+          AND in_tenancy_v1($1,
+                            tenancy_universal,
+                            tenancy_billing_account_ids,
+                            tenancy_organization_ids,
+                            tenancy_workspace_ids))
+
+      -- Compare only to the current change set
+      AND visibility_change_set_pk = $2
+
+      -- Check all edit sessions that should contribute to the count
+      --   'Open'   specific to you
+      --   'Saved'  taken from all edit sessions
+      AND visibility_edit_session_pk in (
+        SELECT id
+        FROM edit_sessions
+        WHERE (status = 'Open' AND visibility_edit_session_pk = $3)
+           OR status = 'Saved'
+            AND in_tenancy_v1($1,
+                              tenancy_universal,
+                              tenancy_billing_account_ids,
+                              tenancy_organization_ids,
+                              tenancy_workspace_ids))
+
+      -- Ensure they are not deleted
       AND visibility_deleted_at IS NULL
+
+      -- Scope the tenancy one last time
       AND in_tenancy_v1($1,
                         tenancy_universal,
                         tenancy_billing_account_ids,
                         tenancy_organization_ids,
-                        tenancy_workspace_ids))
+                        tenancy_workspace_ids)
 
-  -- Compare only to the current change set
-  AND visibility_change_set_pk = $2
 
-  -- Check all edit sessions that should contribute to the count
-  --   'Open'   specific to you
-  --   'Saved'  taken from all edit sessions
-  AND visibility_edit_session_pk in (
-    SELECT id
-    FROM edit_sessions
-    WHERE (status = 'Open' AND visibility_edit_session_pk = $3)
-       OR status = 'Saved'
-        AND in_tenancy_v1($1,
-                          tenancy_universal,
-                          tenancy_billing_account_ids,
-                          tenancy_organization_ids,
-                          tenancy_workspace_ids))
+    ORDER BY attribute_context_component_id DESC
+) AS attribute_values
+                    ON components.component_id = attribute_values.attribute_context_component_id
 
-  -- Ensure they are not deleted
-  AND visibility_deleted_at IS NULL
-
-  -- Scope the tenancy one last time
-  AND in_tenancy_v1($1,
+WHERE in_tenancy_v1($1,
                     tenancy_universal,
                     tenancy_billing_account_ids,
                     tenancy_organization_ids,
                     tenancy_workspace_ids)
 
-
-ORDER BY attribute_context_component_id DESC
+ORDER BY component_id DESC,
+         component_name DESC


### PR DESCRIPTION
## Description

- Add functional changeset tab body picker for components
- Add filter for filtering what kind of components appear
- Collect and return component metadata groups instead of
  component ids for component statistics
- Add ComponentStatsGroup for collecting metadata for each relevant
  component

## Screenshots

Default! All the things!

<img width="424" alt="Screen Shot 2022-08-03 at 7 25 59 PM" src="https://user-images.githubusercontent.com/39320683/182729546-124fbd96-7647-4bf0-8b5e-1f8ff1336605.png">

Filter changed to "modified".

<img width="387" alt="Screen Shot 2022-08-03 at 7 26 16 PM" src="https://user-images.githubusercontent.com/39320683/182729545-f84febfe-6cc6-467d-bf0f-d496e9a2b2ad.png">

## Known Issues

- The filter hover and selected does not expand to the full width of the tab
- Some jank here and there

## GIF and Linear

<img src="https://media3.giphy.com/media/XkxfezUB7Rj4k/giphy.gif"/>

Fixes ENG-430
Fixes ENG-431