### PR TITLE
chore(web): tidy status bar and left sidebar with Mark

### DIFF
--- a/app/web/src/atoms/SiDropdownItem.vue
+++ b/app/web/src/atoms/SiDropdownItem.vue
@@ -3,7 +3,7 @@
     <a
       :class="[
         active ? 'bg-action-500' : '',
-        'flex relative items-center text-center whitespace-nowrap px-2 py-2 text-sm text-white cursor-pointer',
+        'flex relative items-center text-center whitespace-nowrap p-2 text-shade-0 cursor-pointer',
       ]"
       @click="emit('select')"
     >

--- a/app/web/src/molecules/SelectMenu.vue
+++ b/app/web/src/molecules/SelectMenu.vue
@@ -2,11 +2,9 @@
   <Listbox v-model="selectedOption" :disabled="disabled" as="div">
     <div class="relative">
       <ListboxButton
-        class="cursor-default relative w-full rounded-[0.1875rem] border border-neutral-300 bg-shade-0 py-[0.3125rem] pl-3 pr-10 text-left text-neutral-900 shadow-sm hover:border-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-50"
+        class="cursor-default relative w-full rounded-[0.1875rem] border border-neutral-300 bg-shade-0 py-[0.4375rem] pl-3 pr-10 text-left text-neutral-900 shadow-sm hover:border-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-50"
       >
-        <span class="block truncate type-regular-xs">{{
-          selectedOption.label
-        }}</span>
+        <span class="block truncate text-sm">{{ selectedOption.label }}</span>
         <span
           class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
         >

--- a/app/web/src/molecules/SiBarButton.vue
+++ b/app/web/src/molecules/SiBarButton.vue
@@ -41,6 +41,11 @@ const props = defineProps<{
   selected?: boolean;
   tooltipText: string;
   dropdownClasses?: string;
+
+  // Fills the entire width with the button (including the selected and hover colors).
+  // It is recommended that the item in the slot uses the "flex flex-row justify-center" classes in
+  // conjunction with this prop.
+  fillEntireWidth?: boolean;
 }>();
 
 const { disabled } = toRefs(props);
@@ -58,6 +63,10 @@ const buttonClasses = (open: boolean) => {
     "px-4": true,
     "hover:bg-black": true,
   };
+
+  if (props.fillEntireWidth) {
+    results["w-full"] = true;
+  }
 
   // Only display "selected" classes if there is a dropdown available
   // or we have explicitly passed in a selected value.

--- a/app/web/src/molecules/SiSearch.vue
+++ b/app/web/src/molecules/SiSearch.vue
@@ -5,23 +5,22 @@
     <label
       class="relative text-neutral-400 focus-within:text-gray-600 block flex-grow"
     >
-      <SearchIcon class="w-3.5 absolute top-2 left-1.5" />
       <input
         v-model="search"
         placeholder="search"
-        class="w-full text-black p-1 pl-6 text-xs rounded-sm border dark:text-black bg-neutral-100 border-neutral-200 placeholder:italic placeholder:text-neutral-400"
+        class="w-full text-black px-1 py-[0.4375rem] pl-2.5 text-sm rounded-sm border dark:text-black bg-neutral-100 border-neutral-200 placeholder:italic placeholder:text-neutral-400"
       />
     </label>
-    <button class="w-5" @click="resetSearch">
-      <XCircleIcon class="w-full" />
+    <button class="w-[2rem] text-action-" @click="performSearch">
+      <SearchIcon class="w-full text-neutral-500" />
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { XCircleIcon, SearchIcon } from "@heroicons/vue/outline";
+import { SearchIcon } from "@heroicons/vue/solid";
 import { ref } from "vue";
 
 let search = ref<string>("");
-const resetSearch = () => (search.value = "");
+const performSearch = () => console.log("perform search with...", search.value);
 </script>

--- a/app/web/src/molecules/VButton.vue
+++ b/app/web/src/molecules/VButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     type="button"
-    class="inline-flex items-center justify-center rounded-[0.1875rem] border type-medium-sm focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50"
+    class="inline-flex items-center justify-center rounded-[0.1875rem] border text-sm focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50"
     :class="buttonClasses"
     :aria-label="label"
     :disabled="disabled"
@@ -111,10 +111,10 @@ const aloneIconClasses = computed(() => {
 });
 
 const sizeClasses: { [key in ButtonSize]: string[] } = {
-  lg: ["px-[0.3125rem]", "py-2.5"],
-  md: ["px-[0.3125rem]", "py-2"],
-  sm: ["px-[0.3125rem]", "py-1.5"],
-  xs: ["px-[0.3125rem]", "py-1"],
+  lg: ["px-[0.3125rem]", "py-[0.4375rem]"],
+  md: ["px-[0.3125rem]", "py-[0.4375rem]"],
+  sm: ["px-[0.3125rem]", "py-[0.4375rem]"],
+  xs: ["px-[0.3125rem]", "py-[0.4375rem]"],
 };
 
 const buttonRankClasses: { [key in ButtonRank]: string[] } = {

--- a/app/web/src/organisms/AssetPalette.vue
+++ b/app/web/src/organisms/AssetPalette.vue
@@ -2,10 +2,10 @@
   <SiSearch />
 
   <p
-    class="border-b-2 dark:border-neutral-600 text-xs font-light leading-tight px-3 py-1"
+    class="border-b-2 dark:border-neutral-600 text-sm leading-tight p-2.5 text-neutral-500"
   >
-    Get Started by dragging the assets that you wish to include in your
-    application into the canvas to the right
+    Drag the assets that you wish to include in your application into the canvas
+    to the right.
   </p>
 
   <ul class="overflow-y-auto">

--- a/app/web/src/organisms/ChangeSetPanel.vue
+++ b/app/web/src/organisms/ChangeSetPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <section class="px-[0.9375rem]">
+    <section class="px-[0.9375rem] my-[0.625rem]">
       <h1
         class="mb-[0.3125rem] text-neutral-900 type-bold-sm dark:text-neutral-50"
       >

--- a/app/web/src/organisms/Navbar.vue
+++ b/app/web/src/organisms/Navbar.vue
@@ -10,7 +10,7 @@
             alt="SI Logo"
           />
 
-          <SiBarButton tooltip-text="Workspaces" :text-mode="true">
+          <SiBarButton tooltip-text="Workspaces">
             <template #default="{ hovered, open }">
               <div class="flex-col flex text-left">
                 <div class="text-xs font-medium">WORKSPACE:</div>
@@ -22,7 +22,7 @@
             </template>
 
             <template #dropdownContent>
-              <SiDropdownItem checked>{{
+              <SiDropdownItem checked class="text-sm">{{
                 selectedWorkspaceName
               }}</SiDropdownItem>
             </template>

--- a/app/web/src/organisms/NavbarPanelRight.vue
+++ b/app/web/src/organisms/NavbarPanelRight.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="flex items-center h-full">
-    <SiBarButton :text-mode="true" tooltip-text="Zoom">
+    <SiBarButton tooltip-text="Zoom">
       <template #default="{ hovered, open }">
-        <div class="flex-row flex text-white">
+        <div class="flex-row flex text-shade-0">
           100%
-          <SiArrow :nudge="hovered || open" class="ml-1 w-4 text-white" />
+          <SiArrow :nudge="hovered || open" class="ml-1 w-4 text-shade-0" />
         </div>
       </template>
 
       <template #dropdownContent>
-        <SiDropdownItem>200%</SiDropdownItem>
-        <SiDropdownItem>150%</SiDropdownItem>
-        <SiDropdownItem>100%</SiDropdownItem>
-        <SiDropdownItem>50%</SiDropdownItem>
-        <SiDropdownItem>25%</SiDropdownItem>
+        <SiDropdownItem class="text-sm">200%</SiDropdownItem>
+        <SiDropdownItem class="text-sm">150%</SiDropdownItem>
+        <SiDropdownItem class="text-sm">100%</SiDropdownItem>
+        <SiDropdownItem class="text-sm">50%</SiDropdownItem>
+        <SiDropdownItem class="text-sm">25%</SiDropdownItem>
       </template>
     </SiBarButton>
 
@@ -37,7 +37,9 @@
       </template>
 
       <template #dropdownContent>
-        <SiDropdownItem @select="onLogout">Logout</SiDropdownItem>
+        <SiDropdownItem class="text-sm" @select="onLogout"
+          >Logout</SiDropdownItem
+        >
       </template>
     </SiBarButton>
   </div>

--- a/app/web/src/organisms/SiThemeSwitcher.vue
+++ b/app/web/src/organisms/SiThemeSwitcher.vue
@@ -10,18 +10,21 @@
 
     <template #dropdownContent>
       <SiDropdownItem
+        class="text-sm"
         :checked="theme?.source === 'system'"
         @select="ThemeService.resetToSystems"
       >
         System theme
       </SiDropdownItem>
       <SiDropdownItem
+        class="text-sm"
         :checked="theme?.source === 'user' && theme?.value === 'light'"
         @select="ThemeService.setTo('light')"
       >
         Light theme
       </SiDropdownItem>
       <SiDropdownItem
+        class="text-sm"
         :checked="theme?.source === 'user' && theme?.value === 'dark'"
         @select="ThemeService.setTo('dark')"
       >

--- a/app/web/src/organisms/StatusBar.vue
+++ b/app/web/src/organisms/StatusBar.vue
@@ -72,7 +72,7 @@
       <TabPanels
         v-if="panelOpen"
         as="div"
-        class="flex flex-col w-full h-52 lg:h-80 min-h-fit text-white"
+        class="flex flex-col w-full h-80 min-h-fit text-white"
       >
         <TabPanel class="hidden" aria-hidden="true">hidden</TabPanel>
         <TabPanel class="h-full">
@@ -130,7 +130,7 @@ const barClasses = computed(() => {
   const result: Record<string, boolean> = {};
   if (panelOpen.value === true) {
     result["border-b"] = true;
-    result["border-black"] = true;
+    result["border-shade-100"] = true;
   }
   return result;
 });

--- a/app/web/src/organisms/StatusBarTabs/ChangeSet/ChangeSetTabPanel.vue
+++ b/app/web/src/organisms/StatusBarTabs/ChangeSet/ChangeSetTabPanel.vue
@@ -2,16 +2,17 @@
   <div class="flex flex-row h-full w-full">
     <!-- Filter button and list of components -->
     <div
-      class="w-64 border-r-[1px] border-black text-center h-full flex flex-col"
+      class="w-80 border-r-[1px] border-shade-100 text-center h-full flex flex-col"
     >
       <!-- Filter button and its dropdown -->
       <SiBarButton
-        class="h-10 border-b-[1px] border-black"
+        class="h-10 border-b-[1px] text-shade-0 text-[1rem] border-shade-100"
         dropdown-classes="top-1 left-4"
         tooltip-text="Filter"
+        fill-entire-width
       >
         <template #default="{ hovered, open }">
-          <div class="flex-row flex">
+          <div class="flex flex-row justify-center">
             {{ filterTitle }}
             <SiArrow :nudge="hovered || open" class="ml-1 w-4" />
           </div>
@@ -46,7 +47,7 @@
         <div
           v-for="statsGroup in list"
           :key="statsGroup.component_id"
-          class="flex flex-col text-sm"
+          class="flex flex-col"
         >
           <div
             :class="
@@ -54,16 +55,9 @@
                 ? 'bg-action-500'
                 : 'hover:bg-black'
             "
-            class="py-2 text-left text-ellipsis truncate cursor-pointer flex flex-row"
+            class="py-2 pl-5 text-ellipsis truncate cursor-pointer flex flex-row"
             @click="updateSelectedComponent(statsGroup)"
           >
-            <div class="w-5 ml-1 mr-2">
-              <CheckIcon
-                v-if="
-                  selectedComponent?.component_id === statsGroup.component_id
-                "
-              />
-            </div>
             {{ statsGroup.component_name }}
           </div>
         </div>
@@ -71,7 +65,10 @@
     </div>
 
     <!-- Selected component view -->
-    <div v-if="selectedComponent" class="w-full h-full flex flex-col">
+    <div
+      v-if="selectedComponent"
+      class="w-full h-full flex flex-col bg-shade-100"
+    >
       <div
         v-if="selectedComponentGroup === 'added'"
         class="flex flex-row items-center text-center w-full h-full"
@@ -97,7 +94,7 @@
                1024 is the "min-width" for "lg" in tailwind, so we (maybe) should use it to detect if we need to add a height. -->
           <CodeViewer
             font-size="13px"
-            height="260px"
+            height="250px"
             :component-id="selectedComponent.component_id"
             class="text-neutral-50 mx-5"
             :code="codeRecord[title]"
@@ -111,7 +108,10 @@
         </div>
       </div>
     </div>
-    <div v-else class="flex flex-row items-center text-center w-full h-full">
+    <div
+      v-else
+      class="flex flex-row items-center text-center w-full h-full bg-shade-100"
+    >
       <p class="w-full text-3xl text-neutral-500">No Component Selected</p>
     </div>
   </div>
@@ -134,7 +134,6 @@ import { combineLatest } from "rxjs";
 import { ComponentService } from "@/service/component";
 import { ComponentDiff } from "@/api/sdf/dal/component";
 import _ from "lodash";
-import { CheckIcon } from "@heroicons/vue/solid";
 
 export type ChangeSetTabPanelFilter = "all" | "added" | "deleted" | "modified";
 

--- a/app/web/src/organisms/StatusBarTabs/Qualification/QualificationTabPanel.vue
+++ b/app/web/src/organisms/StatusBarTabs/Qualification/QualificationTabPanel.vue
@@ -2,16 +2,17 @@
   <div class="flex flex-row h-full w-full">
     <!-- Filter button and list of components -->
     <div
-      class="w-64 border-r-[1px] border-black text-center h-full flex flex-col"
+      class="w-80 border-r-[1px] border-black text-center h-full flex flex-col"
     >
       <!-- Filter button and its dropdown -->
       <SiBarButton
         class="h-10 border-b-[1px] border-black"
         dropdown-classes="top-1 left-4"
         tooltip-text="Filter"
+        fill-entire-width
       >
         <template #default="{ hovered, open }">
-          <div class="flex-row flex">
+          <div class="flex-row flex justify-center">
             {{ filterTitle }}
             <SiArrow :nudge="hovered || open" class="ml-1 w-4" />
           </div>
@@ -69,7 +70,10 @@
       :component-name="selectedComponent.componentName"
       :component-qualification-status="iconStatus(selectedComponent)"
     />
-    <div v-else class="flex flex-row items-center text-center w-full h-full">
+    <div
+      v-else
+      class="flex flex-row items-center text-center w-full h-full bg-shade-100"
+    >
       <p class="w-full text-3xl text-neutral-500">No Component Selected</p>
     </div>
   </div>

--- a/app/web/src/organisms/StatusBarTabs/Qualification/QualificationViewerMultiple.vue
+++ b/app/web/src/organisms/StatusBarTabs/Qualification/QualificationViewerMultiple.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full flex flex-col">
+  <div class="w-full h-full flex flex-col bg-shade-100">
     <div class="overflow-y-auto flex flex-row mt-4 mx-2 flex-wrap">
       <!-- Note(victor): The only reason there's this extra Div here is to allow us to have margins between -->
       <!-- QualificationViews while using flex-basis to keep stuff responsive. We should revisit this and tune -->


### PR DESCRIPTION
Left SiSideBar:
- Align search bar and change set bar and buttons with Mark's design in
  Figma
  - Ensure buttons, fonts and padding are the same size (~2rem)
  - Remove interior search icon and flip the purpose of the exterior
    icon for the search bar (delete to perform search)
  - Add better default text, switching padding and text sizes and
    colors, etc.

SiBarButton:
- Fix bug where SiBarButton could not fill the entire width when used in
  the StatusBar tab bodies
- Remove "text-mode" usages (no longer a prop and hasn't been for
  awhile)
- Add "fill-entire-width" prop for filling the entire with the button
  (and its hovered and selection classes)
- Remove text size assertion

StatusBar:
- Ensure the height is consistent regardless of window size

ChangeSetTabPanel and QualificationTabPanel:
- Increase width of components list
- Remove check from ChangeSetTabPanel components list (when selected)
- Use "fill-entire-width" for SiBarButton to fix bug where the button
  was not filling the space
- Ensure background is "shade-100" to match the selected tab (want it to
  all flow as one)

Misc:
- Remove usages of "black" with "shade-100" and usages of "white" with
  "shade-0" where found
- Slightly decrease ChangeSetTabPanel's CodeViewer height

<img src="https://media1.giphy.com/media/26CaLWA2dcqz6hS4U/giphy.gif"/>

Fixes ENG-460