### PR TITLE
fix(dal): fix qualifications_summary_for_tenancy

### DIFF
--- a/lib/dal/src/queries/qualifications_summary_for_tenancy.sql
+++ b/lib/dal/src/queries/qualifications_summary_for_tenancy.sql
@@ -4,6 +4,9 @@ SELECT component_id,
        sum(case when qualification_status = 'true' then 1 else 0 end)  as succeeded,
        sum(case when qualification_status = 'false' then 1 else 0 end) as failed
 FROM (SELECT DISTINCT ON (components.component_id, qualification_prototypes.id, qualification_resolvers.id) components.component_id,
+                                                                                                            components.prop_values -> 'si' ->> 'name'      as component_name,
+                                                                                                            qualification_prototypes.id                    as qualification_id,
+                                                                                                            func_binding_return_values.value ->> 'success' as qualification_status
       FROM components_with_attributes components
                LEFT JOIN qualification_prototypes
                          on components.schema_variant_id = qualification_prototypes.schema_variant_id
@@ -24,11 +27,9 @@ FROM (SELECT DISTINCT ON (components.component_id, qualification_prototypes.id, 
                           components.tenancy_workspace_ids)
         AND is_visible_v1($2, components.visibility_change_set_pk, components.visibility_deleted_at)
         AND is_visible_v1($2, qualification_resolvers.visibility_change_set_pk,
-                          qualification_resolvers.visibility_edit_session_pk,
                           qualification_resolvers.visibility_deleted_at)
         AND schemas.kind != 'concept'
       ORDER BY components.component_id, qualification_prototypes.id, qualification_resolvers.id,
                qualification_prototypes.visibility_change_set_pk DESC,
                qualification_resolvers.visibility_change_set_pk DESC) as qualification_data
 GROUP BY component_id, component_name
-


### PR DESCRIPTION
edit sessions removal pr had a goof in the changes to this query.
Restore previous functionality sans edit_session_pk refs.