### PR TITLE
style(bytes-lines-codec): address an "unecessary `let` binding" lint

### DIFF
--- a/lib/bytes-lines-codec/src/lib.rs
+++ b/lib/bytes-lines-codec/src/lib.rs
@@ -342,12 +342,11 @@ mod tests {
 
         stream.send(req).await.expect("client failed to send msg");
 
-        let res = stream
+        stream
             .try_next()
             .await
             .expect("client failed to get msg")
-            .expect("there was no msg");
-        res
+            .expect("there was no msg")
     }
 
     #[tokio::test]


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/nipcLOFWst1FRfe1Ws/giphy-downsized-medium.gif"/>