### PR TITLE
ENG-467 mark builtins as readonly, don't allow edits

### DIFF
--- a/app/web/src/atoms/SiChip.vue
+++ b/app/web/src/atoms/SiChip.vue
@@ -1,0 +1,26 @@
+<template>
+  <div
+    class="inline-block border-solid border rounded py-1 px-1"
+    :class="colorClasses"
+  >
+    {{ text }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+const props = defineProps<{
+  text: string;
+  variant?: "warning" | "neutral";
+}>();
+
+const colorClasses = computed(() => {
+  switch (props.variant) {
+    case "warning":
+      return "border-warning-700 text-warning-700 bg-warning-100";
+    default: // neutral is default
+      return "border-action-700 text-action-700 bg-action-100";
+  }
+});
+</script>

--- a/app/web/src/molecules/SiFuncSprite.vue
+++ b/app/web/src/molecules/SiFuncSprite.vue
@@ -4,19 +4,25 @@
     :class="classes"
   >
     <FuncSkeleton class="flex-shrink-0" />
-    <span class=""> {{ name }} </span>
+    <span class=""> {{ props.name }} </span>
+    <SiChip
+      :text="props.isBuiltin ? 'read-only' : 'custom'"
+      :variant="props.isBuiltin ? 'warning' : 'neutral'"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 
+import SiChip from "@/atoms/SiChip.vue";
 import FuncSkeleton from "@/atoms/FuncSkeleton.vue";
 
 const props = defineProps<{
   color: string;
   name?: string;
   class?: string;
+  isBuiltin?: boolean;
 }>();
 
 const classes = computed(() => props.class);

--- a/app/web/src/organisms/FuncEditor/FuncEditor.vue
+++ b/app/web/src/organisms/FuncEditor/FuncEditor.vue
@@ -18,8 +18,8 @@
 
 <script lang="ts" setup>
 import { onMounted, ref, toRef, computed } from "vue";
-import { EditorState } from "@codemirror/state";
-import { EditorView, keymap } from "@codemirror/view";
+import { EditorState, EditorView } from "@codemirror/basic-setup";
+import { keymap } from "@codemirror/view";
 import { defaultKeymap } from "@codemirror/commands";
 import { funcState, changeFunc, nullEditingFunc } from "./func_state";
 
@@ -46,7 +46,11 @@ const mountEditor = () => {
 
   const editorState = EditorState.create({
     doc: editingFunc.value.modifiedFunc.code,
-    extensions: [keymap.of(defaultKeymap), updateListener],
+    extensions: [
+      keymap.of(defaultKeymap),
+      EditorView.editable.of(!editingFunc.value.origFunc.isBuiltin),
+      updateListener,
+    ],
   });
 
   view.value = new EditorView({

--- a/app/web/src/organisms/FuncEditor/FuncEditorTabs.vue
+++ b/app/web/src/organisms/FuncEditor/FuncEditorTabs.vue
@@ -1,9 +1,9 @@
 <template>
   <!-- border-b border-neutral-300 dark:border-neutral-600 -->
   <SiTabGroup
+    :key="tabGroupRerenderKey"
     :selected-index="selectedTab"
     @change="changeTab"
-    :key="tabGroupRerenderKey"
   >
     <template #tabs>
       <SiTabHeader v-for="func in funcList" :key="func.id">
@@ -74,6 +74,7 @@ const funcList = computed(() =>
     handler: modifiedFunc.handler,
     name: modifiedFunc.name,
     kind: modifiedFunc.kind,
+    isBuiltin: origFunc.isBuiltin,
   })),
 );
 

--- a/app/web/src/organisms/FuncEditor/FuncPicker.vue
+++ b/app/web/src/organisms/FuncEditor/FuncPicker.vue
@@ -19,8 +19,9 @@
               <SiFuncSprite
                 :name="func.name"
                 color="#921ed6"
-                :class="selectedFuncId == func.id ? 'bg-action-500' : ''"
+                :class="props.selectedFuncId == func.id ? 'bg-action-500' : ''"
                 class="border-b-2 dark:border-neutral-600 hover:bg-action-500 dark:text-white hover:text-white hover:cursor-pointer"
+                :is-builtin="func.isBuiltin"
                 @click="selectFunc(func)"
               />
             </li>
@@ -52,7 +53,7 @@ import { ListedFuncView, ListFuncsResponse } from "@/service/func/list_funcs";
 import SiSearch from "@/molecules/SiSearch.vue";
 import { TabPanel } from "@headlessui/vue";
 
-defineProps<{
+const props = defineProps<{
   funcList: ListFuncsResponse;
   selectedFuncId: number;
 }>();

--- a/app/web/src/organisms/FuncEditor/func_state.ts
+++ b/app/web/src/organisms/FuncEditor/func_state.ts
@@ -2,10 +2,11 @@ import { reactive } from "vue";
 import { Func, FuncBackendKind } from "@/api/sdf/dal/func";
 import { saveFuncToBackend$ } from "@/observable/func";
 import { SaveFuncRequest } from "@/service/func/save_func";
+import { GetFuncResponse } from "@/service/func/get_func";
 
 export interface EditingFunc {
-  modifiedFunc: Func;
-  origFunc: Func;
+  modifiedFunc: GetFuncResponse;
+  origFunc: GetFuncResponse;
   id: number;
 }
 
@@ -16,6 +17,7 @@ export const nullEditingFunc: EditingFunc = {
     kind: FuncBackendKind.Unset,
     name: "",
     code: "",
+    isBuiltin: false,
   },
   modifiedFunc: {
     id: 0,
@@ -23,13 +25,14 @@ export const nullEditingFunc: EditingFunc = {
     kind: FuncBackendKind.Unset,
     name: "",
     code: "",
+    isBuiltin: false,
   },
   id: 0,
 };
 
 export const funcState = reactive<{ funcs: EditingFunc[] }>({ funcs: [] });
 
-export const insertFunc = (func: Func) => {
+export const insertFunc = (func: GetFuncResponse) => {
   if (!funcState.funcs.find((f) => f.id === func.id)) {
     funcState.funcs.push({
       origFunc: func,
@@ -44,7 +47,7 @@ export const funcById = (funcId: number) =>
 
 export const funcExists = (funcId: number) => !!funcById(funcId);
 
-export const changeFunc = (func: Func) => {
+export const changeFunc = (func: GetFuncResponse) => {
   const currentFuncIdx = funcState.funcs.findIndex((f) => f.id === func.id);
 
   if (currentFuncIdx == -1) {

--- a/app/web/src/organisms/Workspace/WorkspaceLab.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceLab.vue
@@ -69,6 +69,7 @@ const createFunc = async () => {
     kind: func.kind,
     name: func.name,
     handler: func.handler,
+    isBuiltin: false,
   };
 
   funcList.value.qualifications.push(newFunc);

--- a/app/web/src/service/func/get_func.ts
+++ b/app/web/src/service/func/get_func.ts
@@ -9,7 +9,9 @@ export interface GetFuncArgs {
   id: number;
 }
 
-export type GetFuncResponse = Func;
+export interface GetFuncResponse extends Func {
+  isBuiltin: boolean;
+}
 
 const memo: {
   [key: string]: Observable<GetFuncResponse>;
@@ -43,4 +45,5 @@ export const nullFunc: GetFuncResponse = {
   kind: FuncBackendKind.Unset,
   name: "",
   code: undefined,
+  isBuiltin: false,
 };

--- a/app/web/src/service/func/list_funcs.ts
+++ b/app/web/src/service/func/list_funcs.ts
@@ -5,7 +5,9 @@ import { GlobalErrorService } from "@/service/global_error";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 
-export type ListedFuncView = Omit<Func, "code">;
+export interface ListedFuncView extends Omit<Func, "code"> {
+  isBuiltin: boolean;
+}
 
 export interface ListFuncsResponse {
   qualifications: ListedFuncView[];
@@ -16,6 +18,7 @@ export const nullListFunc: ListedFuncView = {
   handler: "",
   kind: FuncBackendKind.Unset,
   name: "",
+  isBuiltin: false,
 };
 
 const memo: {

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     node::NodeId,
     BillingAccountId, HistoryActor, OrganizationId, ReadTenancy, ReadTenancyError, StandardModel,
-    Visibility, WorkspaceId, WriteTenancy, WriteTenancyError
+    Visibility, WorkspaceId, WriteTenancy, WriteTenancyError,
 };
 
 /// A context type which contains handles to common core service dependencies.
@@ -339,8 +339,8 @@ impl DalContext<'_, '_> {
     }
 
     /// Determines if a standard model object matches the write tenancy of the current context and
-    /// is in the same visibility. If both match, it's safe to modify it in this context.
-    pub async fn check_standard_model_write_access<T: StandardModel>(
+    /// is in the same visibility.
+    pub async fn check_standard_model_tenancy_and_visibility_match<T: StandardModel>(
         &self,
         object: &T,
     ) -> Result<bool, TransactionsError> {

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -513,6 +513,15 @@ pub trait StandardModel {
         .await?;
         Ok(())
     }
+
+    /// Builtin objects have universal tenancy and are at the HEAD changeset
+    #[instrument(skip_all)]
+    fn is_builtin(&self) -> bool
+    where
+        Self: Send + Sync + Sized,
+    {
+        self.tenancy().universal() && self.visibility().is_head()
+    }
 }
 
 #[macro_export]

--- a/lib/sdf/src/server/service/func/get_func.rs
+++ b/lib/sdf/src/server/service/func/get_func.rs
@@ -20,6 +20,7 @@ pub struct GetFuncResponse {
     pub kind: FuncBackendKind,
     pub name: String,
     pub code: Option<String>,
+    pub is_builtin: bool,
 }
 
 pub async fn get_func(
@@ -42,5 +43,6 @@ pub async fn get_func(
         kind: func.backend_kind().to_owned(),
         name: func.name().to_owned(),
         code: func.code_plaintext()?,
+        is_builtin: func.is_builtin(),
     }))
 }

--- a/lib/sdf/src/server/service/func/list_funcs.rs
+++ b/lib/sdf/src/server/service/func/list_funcs.rs
@@ -18,6 +18,7 @@ pub struct ListedFuncView {
     pub handler: Option<String>,
     pub kind: FuncBackendKind,
     pub name: String,
+    pub is_builtin: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -46,6 +47,7 @@ pub async fn list_funcs(
         handler: func.handler().map(|handler| handler.to_owned()),
         kind: func.backend_kind().to_owned(),
         name: func.name().to_owned(),
+        is_builtin: func.is_builtin(),
     })
     .collect();
 

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -35,7 +35,10 @@ pub async fn save_func(
         .ok_or(FuncError::FuncNotFound)?;
 
     // Don't modify builtins or objects in another tenancy/visibility
-    if !ctx.check_standard_model_write_access(&func).await? {
+    if !ctx
+        .check_standard_model_tenancy_and_visibility_match(&func)
+        .await?
+    {
         return Err(FuncError::NotWritable);
     }
 


### PR DESCRIPTION
Indicates function modifiability and prevents edits to builtins. Adds a helper to the `StandardModel` trait to indicate if an object is a builtin (has universal tenancy and is at the head changeset), as well as a function to the `DalContext` for determining if an object is out of our changeset in any way (tenancy or visibility). 