### PR TITLE
fix(dal): Ensure selected AttributePrototypeArguments point to correct Component

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -17,8 +17,8 @@ use crate::{
 
 const LIST_FOR_ATTRIBUTE_PROTOTYPE: &str =
     include_str!("../../queries/attribute_prototype_argument_list_for_attribute_prototype.sql");
-const LIST_BY_NAME_FOR_ATTRIBUTE_PROTOTYPE: &str = include_str!(
-    "../../queries/attribute_prototype_argument_list_by_name_for_attribute_prototype.sql"
+const LIST_BY_NAME_FOR_ATTRIBUTE_PROTOTYPE_AND_HEAD_COMPONENT_ID: &str = include_str!(
+    "../../queries/attribute_prototype_argument_list_by_name_for_attribute_prototype_and_head_component_id.sql"
 );
 
 #[derive(Error, Debug)]
@@ -336,19 +336,21 @@ impl AttributePrototypeArgument {
     /// [`Self::list_for_attribute_prototype()`] if the caller needs to group arguments that share
     /// the same "name" sharing the same name.
     #[tracing::instrument(skip(ctx))]
-    pub async fn list_by_name_for_attribute_prototype(
+    pub async fn list_by_name_for_attribute_prototype_and_head_component_id(
         ctx: &DalContext<'_, '_>,
         attribute_prototype_id: AttributePrototypeId,
+        head_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<Vec<AttributePrototypeArgumentGroup>> {
         let rows = ctx
             .txns()
             .pg()
             .query(
-                LIST_BY_NAME_FOR_ATTRIBUTE_PROTOTYPE,
+                LIST_BY_NAME_FOR_ATTRIBUTE_PROTOTYPE_AND_HEAD_COMPONENT_ID,
                 &[
                     ctx.read_tenancy(),
                     ctx.visibility(),
                     &attribute_prototype_id,
+                    &head_component_id,
                 ],
             )
             .await?;

--- a/lib/dal/src/attribute/value/dependent_update.rs
+++ b/lib/dal/src/attribute/value/dependent_update.rs
@@ -52,11 +52,15 @@ impl AttributeValueDependentUpdateHarness {
         // - If one argument in group --> FuncBinding arg --> { name: value }
         // - If two arguments in group --> FuncBinding arg --> { name: [ value1, value2 ] }
         let mut func_binding_args: HashMap<String, Option<serde_json::Value>> = HashMap::new();
-        for mut argument_group in AttributePrototypeArgument::list_by_name_for_attribute_prototype(
-            ctx,
-            *attribute_prototype.id(),
-        )
-        .await?
+        for mut argument_group in
+            AttributePrototypeArgument::list_by_name_for_attribute_prototype_and_head_component_id(
+                ctx,
+                *attribute_prototype.id(),
+                attribute_value_that_needs_to_be_updated
+                    .context
+                    .component_id(),
+            )
+            .await?
         {
             #[allow(clippy::comparison_chain)]
             if argument_group.arguments.len() == 1 {

--- a/lib/dal/src/queries/attribute_prototype_argument_list_by_name_for_attribute_prototype_and_head_component_id.sql
+++ b/lib/dal/src/queries/attribute_prototype_argument_list_by_name_for_attribute_prototype_and_head_component_id.sql
@@ -20,6 +20,11 @@ FROM (SELECT DISTINCT ON (attribute_prototype_arguments.id) attribute_prototype_
         AND is_visible_v1($2, attribute_prototype_arguments.visibility_change_set_pk,
                           attribute_prototype_arguments.visibility_deleted_at)
         AND attribute_prototype_arguments.attribute_prototype_id = $3
+        AND CASE WHEN external_provider_id != -1 THEN
+                head_component_id = $4
+            ELSE
+                TRUE
+            END
 
       ORDER BY attribute_prototype_arguments.id,
                visibility_change_set_pk DESC,


### PR DESCRIPTION
In the case where we're trying to build up the arguments for the `AttributePrototype` of an `InternalProvder` that is fetching data from `ExternalProviders`, we need to make sure that the `AttributePrototypeArgument`s have a `head_component_id` that matches the `ComponentId` of our `AttributeWriteContext` from the `AttributeValue` that we are trying to update.

If we don't ensure that the `AttributePrototypeArgument`s that we are collecting are "pointing at" the correct `ComponentId`, then we end up collecting _all_ `AttributePrototypeArgument` that are pointing at the same `InternalProvider` for any `Component` of the same `SchemaVariant`, which is definitely not what we want here.