### PR TITLE
fix(web) - Start margin for Asset Palette tab got lost in the merge.

### DIFF
--- a/app/web/src/organisms/Workspace/WorkspaceCompose.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceCompose.vue
@@ -4,7 +4,7 @@
       <SiSidebar side="left">
         <ChangeSetPanel class="border-b-2 dark:border-neutral-500 mb-2" />
 
-        <SiTabGroup>
+        <SiTabGroup :start-margin="4">
           <template #tabs>
             <SiTabHeader>Asset Palette</SiTabHeader>
             <!-- <SiTabHeader>Local Assets</SiTabHeader> -->


### PR DESCRIPTION
Signed-off-by: Wendy Bujalski <wendy@systeminit.com>