### PR TITLE
bug(web): make code show correctly when switching components

### DIFF
--- a/app/web/src/organisms/AssetPalette.vue
+++ b/app/web/src/organisms/AssetPalette.vue
@@ -34,7 +34,7 @@
 import _ from "lodash";
 import SiNodeSprite from "@/molecules/SiNodeSprite.vue";
 import SiCollapsible from "@/organisms/SiCollapsible.vue";
-import SiSearch from "@/molecules/SiSearch.vue";
+//import SiSearch from "@/molecules/SiSearch.vue";
 import { ref } from "vue";
 import { combineLatest, firstValueFrom } from "rxjs";
 import { SchematicService } from "@/service/schematic";

--- a/app/web/src/organisms/ComponentDetails.vue
+++ b/app/web/src/organisms/ComponentDetails.vue
@@ -60,17 +60,20 @@ import { ComponentService } from "@/service/component";
 import { GlobalErrorService } from "@/service/global_error";
 import { combineLatest, from, ReplaySubject, switchMap } from "rxjs";
 import { fromRef, refFrom, untilUnmounted } from "vuse-rx/src";
-import { computed, ref } from "vue";
+import { computed, ref, toRefs } from "vue";
 import { CodeView } from "@/api/sdf/dal/code_view";
 import { eventCodeGenerated$ } from "@/observable/code";
 import { RefreshIcon } from "@heroicons/vue/solid";
 import SiButtonIcon from "@/atoms/SiButtonIcon.vue";
+import { tag } from "rxjs-spy/operators";
 
 const props = defineProps<{
   componentIdentification: ComponentIdentification;
   componentName: string;
 }>();
-const componentIdentification$ = fromRef(props.componentIdentification, {
+
+const { componentIdentification } = toRefs(props);
+const componentIdentification$ = fromRef(componentIdentification, {
   immediate: true,
 });
 
@@ -100,6 +103,7 @@ const codeViews = refFrom<CodeView[]>(
         return from([response.codeViews]);
       }
     }),
+    tag("codeViews"),
   ),
 );
 


### PR DESCRIPTION
We had a bug where the first code that was fetched would be the code
that was displayed for every component. The issue was that we were not
reactive to the use of an internal `prop.componentId` - while `prop`
itself is reactive, its properties are *not*. That means when you use
`prop.componentId` as an input to a reactive function (in this case as
an input to RxJS) - it will work the first time, but capture only *the
initial value*.

Also fixes a few minor lint issues that slipped through CI.