### PR TITLE
fix(web): ensure qual and changeset tab panels do not flip

### DIFF
--- a/app/web/src/organisms/StatusBar.vue
+++ b/app/web/src/organisms/StatusBar.vue
@@ -16,6 +16,7 @@
       </Tab>
 
       <!-- Edit tabs -->
+      <Tab v-if="!isViewMode" aria-hidden="true" class="hidden" />
       <Tab v-if="!isViewMode" v-slot="{ selected }">
         <ChangeSetTab :selected="selected" />
       </Tab>
@@ -99,6 +100,9 @@
         <TabPanel aria-hidden="true" class="hidden">hidden</TabPanel>
 
         <!-- Edit panels -->
+        <TabPanel v-if="!isViewMode" aria-hidden="true" class="hidden">
+          hidden
+        </TabPanel>
         <TabPanel v-if="!isViewMode" class="h-full">
           <ChangeSetTabPanel />
         </TabPanel>


### PR DESCRIPTION
TLDR: we believe this to be an "off by one" or "messed up index" error since tab changing and selection is based off the index. This is intended to be a temp fix. We should probably change tab by name / enum / list of strings in the future.