### PR TITLE
fix(web): maintain status bar tab index and fix lint flag

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -10,7 +10,7 @@
     "build:pedantically": "npm run build:check && npm run build",
     "watch": "npm run build:watch",
     "lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore src",
-    "lint:fix": "npm run lint --fix",
+    "lint:fix": "npm run lint -- --fix",
     "lint:strict": "STRICT_LINT=1 npm run lint",
     "fmt": "prettier --write ./src",
     "fmt:check": "prettier --check ./src",

--- a/app/web/src/organisms/StatusBar.vue
+++ b/app/web/src/organisms/StatusBar.vue
@@ -16,16 +16,27 @@
       </Tab>
 
       <!-- Edit tabs -->
-      <Tab v-if="!isViewMode" aria-hidden="true" class="hidden" />
-      <Tab v-if="!isViewMode" v-slot="{ selected }">
+      <Tab
+        v-slot="{ selected }"
+        :aria-hidden="isViewMode"
+        :class="[isViewMode ? 'hidden' : '']"
+      >
         <ChangeSetTab :selected="selected" />
       </Tab>
-      <Tab v-if="!isViewMode" v-slot="{ selected }">
+      <Tab
+        v-slot="{ selected }"
+        :aria-hidden="isViewMode"
+        :class="[isViewMode ? 'hidden' : '']"
+      >
         <QualificationTab :selected="selected" />
       </Tab>
 
       <!-- View tabs -->
-      <Tab v-if="isViewMode" v-slot="{ selected }">
+      <Tab
+        v-slot="{ selected }"
+        :aria-hidden="!isViewMode"
+        :class="[isViewMode ? '' : 'hidden']"
+      >
         <StatusBarTab :selected="selected">
           <template #icon><BellIcon class="text-white" /></template>
           <template #name>SLA</template>
@@ -41,7 +52,11 @@
           </template>
         </StatusBarTab>
       </Tab>
-      <Tab v-if="isViewMode" v-slot="{ selected }">
+      <Tab
+        v-slot="{ selected }"
+        :aria-hidden="!isViewMode"
+        :class="[isViewMode ? '' : 'hidden']"
+      >
         <StatusBarTab :selected="selected">
           <template #icon><CreditCardIcon class="text-white" /></template>
           <template #name>Costs</template>
@@ -52,7 +67,11 @@
           </template>
         </StatusBarTab>
       </Tab>
-      <Tab v-if="isViewMode" v-slot="{ selected }">
+      <Tab
+        v-slot="{ selected }"
+        :aria-hidden="!isViewMode"
+        :class="[isViewMode ? '' : 'hidden']"
+      >
         <StatusBarTab :selected="selected">
           <template #icon><BadgeCheckIcon class="text-white" /></template>
           <template #name>Confirmations</template>
@@ -100,20 +119,37 @@
         <TabPanel aria-hidden="true" class="hidden">hidden</TabPanel>
 
         <!-- Edit panels -->
-        <TabPanel v-if="!isViewMode" aria-hidden="true" class="hidden">
-          hidden
-        </TabPanel>
-        <TabPanel v-if="!isViewMode" class="h-full">
+        <TabPanel
+          :aria-hidden="isViewMode"
+          :class="[isViewMode ? 'hidden' : '']"
+          class="h-full"
+        >
           <ChangeSetTabPanel />
         </TabPanel>
-        <TabPanel v-if="!isViewMode" class="h-full">
+        <TabPanel
+          :aria-hidden="isViewMode"
+          :class="[isViewMode ? 'hidden' : '']"
+          class="h-full"
+        >
           <QualificationTabPanel />
         </TabPanel>
 
         <!-- View panels -->
-        <TabPanel v-if="isViewMode" class="h-full bg-shade-100" />
-        <TabPanel v-if="isViewMode" class="h-full bg-shade-100" />
-        <TabPanel v-if="isViewMode" class="h-full bg-shade-100" />
+        <TabPanel
+          :aria-hidden="!isViewMode"
+          :class="[isViewMode ? '' : 'hidden']"
+          class="h-full bg-shade-100"
+        />
+        <TabPanel
+          :aria-hidden="!isViewMode"
+          :class="[isViewMode ? '' : 'hidden']"
+          class="h-full bg-shade-100"
+        />
+        <TabPanel
+          :aria-hidden="!isViewMode"
+          :class="[isViewMode ? '' : 'hidden']"
+          class="h-full bg-shade-100"
+        />
       </TabPanels>
     </Transition>
   </TabGroup>


### PR DESCRIPTION
- Maintain status bar tab index by hiding the tabs rather than deleting
  them
  - Now, the index will be maintained between switching views (i.e.
    there are 5 actionable tabs that are dynamically shown and hidden
    rather than 2 or 3 tabs swapped in and out)
- Fix the "--fix" flag being passed into the npm run script for linting