### PR TITLE
fix(web) - Prevent tab text from wrapping to multiple lines.

### DIFF
--- a/app/web/src/molecules/SiTabHeader.vue
+++ b/app/web/src/molecules/SiTabHeader.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- selectedToFront ? (selected ? 'order-1' : 'order-2') : '' -->
-  <Tab v-slot="{ selected }" class="focus:outline-none" as="template">
+  <Tab
+    v-slot="{ selected }"
+    class="focus:outline-none whitespace-nowrap"
+    as="template"
+  >
     <button
       :class="
         selectedToFront


### PR DESCRIPTION
Signed-off-by: Wendy Bujalski <wendy@systeminit.com>