### PR TITLE
feat(web) move zoom controls from header bar into diagram

### DIFF
--- a/app/web/src/molecules/VButton/Icon.vue
+++ b/app/web/src/molecules/VButton/Icon.vue
@@ -4,6 +4,7 @@
     <GitCommitIcon v-else-if="icon == 'git-commit'" />
     <GitMergeIcon v-else-if="icon == 'git-merge'" />
     <PlusIcon v-else-if="icon == 'plus'" />
+    <MinusIcon v-else-if="icon == 'minus'" />
     <VueFeather v-else-if="icon == 'plus-square'" type="plus-square" />
     <TrashIcon v-else-if="icon == 'trash'" />
     <XIcon v-else-if="icon == 'x'" />
@@ -14,7 +15,7 @@
 import GitBranchIcon from "@/atoms/CustomIcons/GitBranchIcon.vue";
 import GitCommitIcon from "@/atoms/CustomIcons/GitCommitIcon.vue";
 import GitMergeIcon from "@/atoms/CustomIcons/GitMergeIcon.vue";
-import { XIcon, PlusIcon, TrashIcon } from "@heroicons/vue/solid";
+import { XIcon, PlusIcon, MinusIcon, TrashIcon } from "@heroicons/vue/solid";
 import VueFeather from "vue-feather";
 
 export type IconName =
@@ -22,12 +23,13 @@ export type IconName =
   | "git-commit"
   | "git-merge"
   | "plus"
+  | "minus"
   | "plus-square"
   | "trash"
   | "x";
 
 defineProps<{
   icon: IconName;
-  iconClasses: string[];
+  iconClasses?: string[];
 }>();
 </script>

--- a/app/web/src/organisms/GenericDiagram/DiagramZoomControls.vue
+++ b/app/web/src/organisms/GenericDiagram/DiagramZoomControls.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="absolute flex left-4 bottom-4 z-20 h-8">
+    <div
+      class="rounded-full w-8 h-8 bg-neutral-600 text-white dark:bg-gray-200 dark:text-black p-2 cursor-pointer"
+      @click="adjustZoom('down')"
+    >
+      <Icon icon="minus" />
+    </div>
+
+    <Menu>
+      <MenuButton
+        as="div"
+        class="bg-white border-neutral-300 border text-black dark:bg-black dark:text-white dark:border-black text-center w-20 cursor-pointer mx-2 h-8 flex flex-col justify-center"
+        title="set zoom level"
+      >
+        {{ roundedZoomPercent }}%
+      </MenuButton>
+      <MenuItems as="div" class="absolute mt-[-100%] -top-10 left-6">
+        <SiDropdown>
+          <SiDropdownItem
+            v-for="zoomOptionAmount in ZOOM_LEVEL_OPTIONS"
+            :key="zoomOptionAmount"
+            class="text-sm text-white"
+            @select="emit('update:zoom', zoomOptionAmount / 100)"
+          >
+            {{ zoomOptionAmount }}%
+          </SiDropdownItem>
+        </SiDropdown>
+      </MenuItems>
+    </Menu>
+
+    <div
+      class="rounded-full w-8 h-8 bg-neutral-600 text-white dark:bg-gray-200 dark:text-black p-2 cursor-pointer"
+      @click="adjustZoom('up')"
+    >
+      <Icon icon="plus" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, nextTick, PropType, ref, watch } from "vue";
+import _ from "lodash";
+import Icon from "@/molecules/VButton/Icon.vue";
+import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
+import SiDropdown from "@/molecules/SiDropdown.vue";
+import SiDropdownItem from "@/atoms/SiDropdownItem.vue";
+
+const ZOOM_LEVEL_OPTIONS = [25, 50, 100, 150, 200];
+
+const props = defineProps({
+  zoomLevel: { type: Number, required: true },
+});
+
+const emit = defineEmits<{
+  (e: "update:zoom", newZoom: number): void;
+}>();
+
+function adjustZoom(direction: "up" | "down") {
+  const mult = direction === "down" ? -1 : 1;
+  emit("update:zoom", props.zoomLevel + (10 / 100) * mult);
+}
+
+const roundedZoomPercent = computed(() => Math.round(props.zoomLevel * 100));
+</script>

--- a/app/web/src/organisms/GenericDiagram/diagram_constants.ts
+++ b/app/web/src/organisms/GenericDiagram/diagram_constants.ts
@@ -31,3 +31,6 @@ export const DIAGRAM_FONT_FAMILY = "Inter";
 // color used to show what is selected (currently a nice blue)
 // TODO: pull from tailwind?
 export const SELECTION_COLOR = "#59B7FF";
+
+export const MIN_ZOOM = 0.1; // 10%
+export const MAX_ZOOM = 10; // 1000%

--- a/app/web/src/organisms/NavbarPanelRight.vue
+++ b/app/web/src/organisms/NavbarPanelRight.vue
@@ -1,22 +1,5 @@
 <template>
   <div class="flex items-center h-full">
-    <SiBarButton tooltip-text="Zoom">
-      <template #default="{ hovered, open }">
-        <div class="flex-row flex text-shade-0">
-          100%
-          <SiArrow :nudge="hovered || open" class="ml-1 w-4 text-shade-0" />
-        </div>
-      </template>
-
-      <template #dropdownContent>
-        <SiDropdownItem class="text-sm">200%</SiDropdownItem>
-        <SiDropdownItem class="text-sm">150%</SiDropdownItem>
-        <SiDropdownItem class="text-sm">100%</SiDropdownItem>
-        <SiDropdownItem class="text-sm">50%</SiDropdownItem>
-        <SiDropdownItem class="text-sm">25%</SiDropdownItem>
-      </template>
-    </SiBarButton>
-
     <SiBarButton tooltip-text="Copy link" @click="copyURL">
       <LinkIcon class="w-6" />
     </SiBarButton>


### PR DESCRIPTION
Fixes an issue seen during the user tests: someone could not figure out how to zoom, and tried the zoom menu in the header that was not wired up.

<img src="https://media1.giphy.com/media/3ov9jZafEefHLyTf8c/giphy.webp?cid=ecf05e472nzgl9er3dtr302isx0ptt3mlvdn6z66vukowek4&rid=giphy.webp&ct=g">

This PR moves those non-functional zoom controls from header bar into the diagram.

This move was really initiated because the zoom controls don't really fit with the other elements up there. They are only visible on some modes, and there are no other contextual tools similarly appearing in the header bar. If we do find that each mode has a set of buttons that live up there, we can decide to move it back, but for now I think in the diagram makes sense. 

It also is a bit easier this way since the zoom level can be entirely owned by the diagram rather than having to pass it through many layers or put into more global app state.

The styling is meh, but good enough - will clean up with Mark.

TBH I'm not very happy with the tailwind classes and how it's all set up, but Im trying to reuse our existing tools and it's good enough and functional!



<img width="955" alt="image" src="https://user-images.githubusercontent.com/1158956/185550033-63b9ed44-8b79-414c-9e01-90301beb4520.png">

