### PR TITLE
update tsconfig and readme

### DIFF
--- a/app/web/README.md
+++ b/app/web/README.md
@@ -39,14 +39,18 @@ npm run fmt
 
 This template should help get you started developing with Vue 3 and Typescript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 
-## Recommended IDE Setup
-
-- [VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
-
-## Type Support For `.vue` Imports in TS
-
-Since TypeScript cannot handle type information for `.vue` imports, they are shimmed to be a generic Vue component type by default. In most cases this is fine if you don't really care about component prop types outside of templates. However, if you wish to get actual prop types in `.vue` imports (for example to get props validation when using manual `h(...)` calls), you can enable Volar's `.vue` type support plugin by following instructions [here](https://github.com/johnsoncodehk/volar/discussions/471). TLDR is:
-- run "Extensions: Show built-in extensions" from command pallete
-- search for "@builtin typescript" in extensions panel
-- find "Typescript + Javascript Language Features", click gear and "Disable (Workspace)"
-
+## IDE Setup Instructions
+### [VSCode](https://code.visualstudio.com/) (preferred)
+  - Install [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) plugin
+    - and disable Vetur if installed
+  - Enable TS "takeover mode" (see [here](https://github.com/johnsoncodehk/volar/discussions/471))
+    - run "Extensions: Show built-in extensions" from command pallete
+    - search for "@builtin typescript" in extensions panel
+    - find "Typescript + Javascript Language Features", click gear and "Disable (Workspace)"
+  - Use workspace's typescript version
+    - run "Volar: Select Typescript Version" from command pallete
+    - select "Use workspace version"
+  - Install [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) plugin
+  - Enable format on save (recommended)
+    - add `"editor.formatOnSave": true` to `.vscode/settings.json` file
+    - add `"[vue][typescript][javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }` to `.vscode/settings.json` file

--- a/app/web/src/d.ts
+++ b/app/web/src/d.ts
@@ -1,5 +1,0 @@
-declare module "vue3-popper" {
-  import { Component } from "vue";
-  const file: Component;
-  export default file;
-}

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -1,49 +1,28 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "jsx": "preserve",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "importHelpers": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,  
-    // "explainFiles": true,
-    // "extendedDiagnostics": true,
-    // "noErrorTruncation": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    "pretty": true,
+    "jsx": "preserve",
     "sourceMap": true,
-    "baseUrl": ".",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM", "dom.iterable"],
+    "skipLibCheck": true,
+    
+    "baseUrl": "./",
     "paths": {
-      "@/*": [
-        "src/*"
-      ] 
+      "@/*": ["src/*"] 
     },
-    "lib": [
-      "esnext",
-      "dom",
-      "dom.iterable",
-      "scripthost"
-    ],
-    "types": ["node", "unplugin-icons/types/vue"],
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
+    "types": ["unplugin-icons/types/vue"],
+    
+    "pretty": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue"
-  ],
-  "exclude": [
-    "node_modules",
-    "src/ignore/**/*.ts",
-    "src/ignore/**/*.tsx",
-    "src/ignore/**/*.vue",
-  ]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }],
 }

--- a/app/web/tsconfig.node.json
+++ b/app/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", ".eslintrc.js"]
+}


### PR DESCRIPTION
was digging into the ts check errors (see https://linear.app/system-initiative/issue/ENG-493/fix-ts-check-inconsistencies-on-ci)

currently unable to reproduce, but did some related cleanup

- updated tsconfig to more closely match latest generated by vite's scaffold tools
- improved readme for VScode setup instructions