### PR TITLE
feat(web): SelectMenu supports multiselect, unstyled Run On selectors

### DIFF
--- a/app/web/src/molecules/SelectMenu.vue
+++ b/app/web/src/molecules/SelectMenu.vue
@@ -1,10 +1,10 @@
 <template>
-  <Listbox v-model="selectedOption" :disabled="disabled" as="div">
+  <Listbox v-model="selectedOptions" :disabled="disabled" as="div">
     <div class="relative">
       <ListboxButton
         class="cursor-default relative w-full rounded-[0.1875rem] border border-neutral-300 bg-shade-0 py-[0.4375rem] pl-3 pr-10 text-left text-neutral-900 shadow-sm hover:border-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-50"
       >
-        <span class="block truncate text-sm">{{ selectedOption.label }}</span>
+        <span class="block truncate text-sm">{{ selectedLabel }}</span>
         <span
           class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
         >
@@ -40,7 +40,9 @@
             >
               <span
                 :class="[
-                  selected ? 'font-semibold' : 'font-normal',
+                  isSelected(option, selected)
+                    ? 'font-semibold'
+                    : 'font-normal',
                   'block truncate',
                 ]"
               >
@@ -48,7 +50,7 @@
               </span>
 
               <span
-                v-if="selected"
+                v-if="isSelected(option, selected)"
                 :class="[
                   active ? 'text-white' : 'text-action-500',
                   'absolute inset-y-0 right-0 flex items-center pr-4',
@@ -83,21 +85,55 @@ const emit = defineEmits(["update:modelValue", "change"]);
 
 const props = defineProps<{
   options: Option[];
-  modelValue?: Option;
+  modelValue: Option | Option[]; // to make this a multiselect, just pass in an array of Option here
+  noneSelectedLabel?: string; // this is only valid in the multiple select case
   disabled?: boolean;
 }>();
 
-const selectedOption = computed<Option>({
+const isSelected = (option: Option, selected: boolean) =>
+  selected ||
+  ("length" in props.modelValue && props.modelValue.includes(option));
+
+const toggleSelection = (selection: Option) => {
+  if (!("length" in props.modelValue)) {
+    return [];
+  }
+
+  if (props.modelValue.includes(selection)) {
+    return props.modelValue.filter((option) => option !== selection);
+  } else {
+    return props.modelValue.concat([selection]);
+  }
+};
+
+const selectedOptions = computed<Option | Option[]>({
   get() {
-    return props.modelValue ?? { label: "", value: "" };
+    return props.modelValue;
   },
   set(value) {
-    if (value.value == "") {
-      emit("update:modelValue", null);
-    } else {
-      emit("update:modelValue", value);
+    if ("value" in value && value.value == "") {
+      emit("update:modelValue", value.value == "" ? null : value);
+    } else if ("length" in props.modelValue) {
+      emit("update:modelValue", toggleSelection(value as Option));
     }
     emit("change", value);
   },
+});
+
+const selectedLabel = computed<string>(() => {
+  if ("length" in selectedOptions.value) {
+    switch (selectedOptions.value.length) {
+      case 0:
+        return props.noneSelectedLabel ?? "select an option...";
+      case 1:
+        return selectedOptions.value[0].label;
+      default:
+        return `${selectedOptions.value[0].label} (+${
+          selectedOptions.value.length - 1
+        })`;
+    }
+  }
+
+  return selectedOptions.value.label;
 });
 </script>

--- a/app/web/src/organisms/FuncEditor/FuncDetails.vue
+++ b/app/web/src/organisms/FuncEditor/FuncDetails.vue
@@ -31,28 +31,28 @@
           </SiCollapsible>
           <SiCollapsible label="Run On" :default-open="true">
             <h1
-              class="mb-[0.3125rem] text-neutral-700 type-bold-sm dark:text-neutral-50"
+              class="mb-[0.3125rem] pt-5 text-neutral-700 type-bold-sm dark:text-neutral-50"
             >
               Run on Component:
             </h1>
-            <SelectMenu
-              v-model="selectedComponent"
-              class="flex-grow"
+            <FuncRunOnSelector
+              v-model="selectedComponents"
+              none-selected-label="select component(s)"
+              none-selected-blurb="None selected. Select component(s) above..."
               :options="components"
               :disabled="editingFunc.origFunc.isBuiltin"
-              @change="selectComponent"
             />
             <h1
               class="mb-[0.3125rem] text-neutral-700 type-bold-sm dark:text-neutral-50"
             >
               Run on Schema Variant:
             </h1>
-            <SelectMenu
-              v-model="selectedVariant"
-              class="flex-grow"
+            <FuncRunOnSelector
+              v-model="selectedVariants"
+              none-selected-label="select schema variant(s)"
+              none-selected-blurb="None selected. Select schema variant(s) above..."
               :options="schemaVariants"
               :disabled="editingFunc.origFunc.isBuiltin"
-              @change="selectVariant"
             />
           </SiCollapsible>
         </TabPanel>
@@ -61,7 +61,14 @@
     <div
       class="absolute bottom-0 w-full h-12 text-right p-2 border-t border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800"
     >
-      <SiButton icon="save" kind="save" label="Save Qualifications" size="lg" />
+      <SiButton
+        icon="save"
+        kind="save"
+        label="Save Qualifications"
+        size="lg"
+        :disabled="editingFunc.origFunc.isBuiltin"
+        @click="saveQualification"
+      />
     </div>
   </div>
   <div v-else class="p-2 text-center text-neutral-400 dark:text-neutral-300">
@@ -73,7 +80,7 @@
 import SiTabGroup from "@/molecules/SiTabGroup.vue";
 import SiTextBox from "@/atoms/SiTextBox.vue";
 import SiButton from "@/atoms/SiButton.vue";
-import SelectMenu, { Option } from "@/molecules/SelectMenu.vue";
+import { Option } from "@/molecules/SelectMenu.vue";
 import SiCollapsible from "@/organisms/SiCollapsible.vue";
 import { TabPanel } from "@headlessui/vue";
 import { ref, toRef, watch } from "vue";
@@ -84,6 +91,7 @@ import SiTabHeader from "@/molecules/SiTabHeader.vue";
 import { SchematicService } from "@/service/schematic";
 import { EditingFunc, funcState$ } from "@/observable/func";
 import { ComponentService } from "@/service/component";
+import FuncRunOnSelector from "./FuncRunOnSelector.vue";
 
 const props = defineProps<{
   funcId: number;
@@ -91,21 +99,16 @@ const props = defineProps<{
 
 const funcId = toRef(props, "funcId", -1);
 const funcId$ = fromRef(funcId);
-const noVariantSelected: Option = { label: "- none -", value: -1 };
-const selectedVariant = ref<Option>(noVariantSelected);
-const selectedComponent = ref<Option>(noVariantSelected);
 
 const schemaVariants = refFrom<Option[]>(
   SchematicService.listSchemaVariants().pipe(
     map((schemaVariants) =>
       schemaVariants.error
         ? []
-        : [noVariantSelected].concat(
-            schemaVariants.map((v) => ({
-              label: v.schemaName,
-              value: v.id,
-            })),
-          ),
+        : schemaVariants.map((v) => ({
+            label: v.schemaName,
+            value: v.id,
+          })),
     ),
   ),
   [],
@@ -116,12 +119,10 @@ const components = refFrom<Option[]>(
     map((components) =>
       components.error
         ? []
-        : [noVariantSelected].concat(
-            components.list.map((c) => ({
-              label: c.label,
-              value: c.value.componentId,
-            })) as Option[],
-          ),
+        : components.list.map((c) => ({
+            label: c.label,
+            value: c.value.componentId,
+          })),
     ),
   ),
   [],
@@ -137,35 +138,36 @@ const editingFunc = refFrom<EditingFunc>(
   nullEditingFunc,
 );
 
+const selectedVariants = ref<Option[]>([]);
+const selectedComponents = ref<Option[]>([]);
+
+const toOptionValues = (options: Option[], ids: number[]): Option[] =>
+  options.filter((opt) =>
+    typeof opt.value === "number" ? ids.includes(opt.value) : false,
+  );
+
 watch(
   () => editingFunc.value,
   (editingFunc) => {
-    selectedVariant.value =
-      schemaVariants.value.find(
-        (opt) =>
-          opt.value === (editingFunc.modifiedFunc.schemaVariants[0] ?? -1),
-      ) ?? noVariantSelected;
+    selectedVariants.value = toOptionValues(
+      schemaVariants.value,
+      editingFunc.modifiedFunc.schemaVariants ?? [],
+    );
 
-    selectedComponent.value =
-      components.value.find(
-        (opt) => opt.value === (editingFunc.modifiedFunc.components[0] ?? -1),
-      ) ?? noVariantSelected;
+    selectedComponents.value =
+      toOptionValues(components.value, editingFunc.modifiedFunc.components) ??
+      [];
   },
 );
-
-const selectVariant = (option: Option) =>
-  changeFunc({
-    ...editingFunc.value.modifiedFunc,
-    schemaVariants: [typeof option.value === "string" ? -1 : option.value],
-  });
-
-const selectComponent = (option: Option) =>
-  changeFunc({
-    ...editingFunc.value.modifiedFunc,
-    components: [typeof option.value === "string" ? -1 : option.value],
-  });
 
 const updateFunc = () => {
   changeFunc({ ...editingFunc.value.modifiedFunc });
 };
+
+const saveQualification = () =>
+  changeFunc({
+    ...editingFunc.value.modifiedFunc,
+    components: selectedComponents.value.map(({ value }) => value as number),
+    schemaVariants: selectedVariants.value.map(({ value }) => value as number),
+  });
 </script>

--- a/app/web/src/organisms/FuncEditor/FuncRunOnSelector.vue
+++ b/app/web/src/organisms/FuncEditor/FuncRunOnSelector.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="px-2 pb-5">
+    <div class="flex items-center">
+      <SelectMenu
+        v-model="optionsState"
+        class="w-4/5"
+        :none-selected-label="noneSelectedLabel"
+        :options="options"
+        :disabled="disabled"
+      />
+      <SiButton
+        label="Add"
+        icon-style="alone"
+        icon="plus"
+        :disabled="disabled"
+        @click="addOptions"
+      />
+    </div>
+    <div>
+      <h2>Selected components</h2>
+      <h3 v-if="props.modelValue.length == 0">
+        {{ noneSelectedBlurb }}
+      </h3>
+      <ul v-else>
+        <li v-for="option in modelValue" :key="option.value">
+          {{ option.label }}
+          <SiButton
+            label=""
+            icon-style="alone"
+            icon="cancel"
+            :disabled="disabled"
+            @click="removeOption(option)"
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import SelectMenu, { Option } from "@/molecules/SelectMenu.vue";
+import SiButton from "@/atoms/SiButton.vue";
+
+const props = defineProps<{
+  options: Option[];
+  modelValue: Option[];
+  noneSelectedLabel: string;
+  noneSelectedBlurb: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: Option[]): void;
+  (e: "change", v: Option[]): void;
+}>();
+
+const optionsState = ref<Option[]>([]);
+
+const addOptions = () => {
+  const newOptions = Array.from(
+    new Set(props.modelValue.concat(optionsState.value)),
+  );
+
+  emit("update:modelValue", newOptions);
+  optionsState.value = [];
+};
+
+const removeOption = (remove: Option) => {
+  const newOptions = props.modelValue.filter((opt) => opt !== remove);
+
+  emit("update:modelValue", newOptions);
+  emit("change", newOptions);
+};
+</script>


### PR DESCRIPTION
Pass an array as the modelvalue to SelectMenu and it becomes a multiple select box. 

Shift + click unsupported right now (have to think hard about how to make that happen with the headlessui component).

Ugly but functional FuncRunOnSelector component.