### PR TITLE
feat(web,dal,sdf): resolve and run workflows e2e

### DIFF
--- a/app/web/src/molecules/SiWorkflowSprite.vue
+++ b/app/web/src/molecules/SiWorkflowSprite.vue
@@ -1,0 +1,22 @@
+<template>
+  <div
+    class="flex flex-row items-center gap-2.5 px-4 py-4 text-xs relative"
+    :class="classes"
+  >
+    <div class="w-full text-ellipsis whitespace-nowrap overflow-hidden">
+      {{ props.name }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  color: string;
+  name?: string;
+  class?: string;
+}>();
+
+const classes = computed(() => props.class);
+</script>

--- a/app/web/src/molecules/VButton/Icon.vue
+++ b/app/web/src/molecules/VButton/Icon.vue
@@ -14,6 +14,7 @@
     <XIcon v-else-if="icon === 'x'" :class="iconClasses" />
     <ChevronDownIcon v-else-if="icon === 'chevron-down'" :class="iconClasses" />
     <SaveIcon v-else-if="icon === 'save'" :class="iconClasses" />
+    <PlayIcon v-else-if="icon === 'play'" :class="iconClasses" />
   </div>
 </template>
 
@@ -25,6 +26,7 @@ import {
   SaveIcon,
   TrashIcon,
   XIcon,
+  PlayIcon,
 } from "@heroicons/vue/solid";
 import VueFeather from "vue-feather";
 import GitBranchIcon from "@/atoms/CustomIcons/GitBranchIcon.vue";
@@ -41,7 +43,8 @@ export type IconName =
   | "trash"
   | "chevron-down"
   | "save"
-  | "x";
+  | "x"
+  | "play";
 
 defineProps<{
   icon: IconName;

--- a/app/web/src/organisms/WorkflowRunner/WorkflowPicker.vue
+++ b/app/web/src/organisms/WorkflowRunner/WorkflowPicker.vue
@@ -1,0 +1,151 @@
+<template>
+  <SiTabGroup :selected-index="0">
+    <template #tabs>
+      <SiTabHeader :key="0">WORKFLOWS</SiTabHeader>
+    </template>
+    <template #dropdownitems>
+      <SiDropdownItem>WORKFLOWS</SiDropdownItem>
+    </template>
+    <template #panels>
+      <TabPanel :key="0" class="h-full overflow-auto">
+        <SiSearch
+          placeholder="search workflows"
+          auto-search
+          @search="onSearch"
+        />
+        <div class="w-full text-neutral-400 dark:text-neutral-300 text-sm p-2">
+          Select a workflow from the lists below to view or edit it.
+        </div>
+        <ul class="overflow-y-auto">
+          <span v-for="(groups, schema) in groupedFilteredList" :key="schema">
+            <SiCollapsible
+              :label="String(schema)"
+              as="li"
+              content-as="ul"
+              default-open
+              class="w-full"
+            >
+              <span v-for="(workflows, component) in groups" :key="component">
+                <template v-if="component === ''">
+                  <span v-for="workflow in workflows" :key="workflow.id">
+                    <SiWorkflowSprite
+                      :name="workflow.title"
+                      color="#921ed6"
+                      :class="
+                        selectedId === workflow.id
+                          ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
+                          : ''
+                      "
+                      class="border dark:border-neutral-600 dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300"
+                      @click="select(workflow)"
+                    />
+                  </span>
+                </template>
+                <li v-else>
+                  <SiCollapsible
+                    :label="String(component)"
+                    as="li"
+                    content-as="ul"
+                    default-open
+                    class="w-full"
+                  >
+                    <span v-for="workflow in workflows" :key="workflow.id">
+                      <SiWorkflowSprite
+                        :name="workflow.title"
+                        color="#921ed6"
+                        :class="
+                          selectedId === workflow.id
+                            ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
+                            : ''
+                        "
+                        class="border dark:border-neutral-600 dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300"
+                        @click="select(workflow)"
+                      />
+                    </span>
+                  </SiCollapsible>
+                </li>
+              </span>
+            </SiCollapsible>
+          </span>
+        </ul>
+      </TabPanel>
+    </template>
+  </SiTabGroup>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from "vue";
+import { TabPanel } from "@headlessui/vue";
+import SiWorkflowSprite from "@/molecules/SiWorkflowSprite.vue";
+import SiTabGroup from "@/molecules/SiTabGroup.vue";
+import SiTabHeader from "@/molecules/SiTabHeader.vue";
+import SiCollapsible from "@/organisms/SiCollapsible.vue";
+import SiDropdownItem from "@/atoms/SiDropdownItem.vue";
+import {
+  ListedWorkflowView,
+  ListWorkflowsResponse,
+} from "@/service/workflow/list";
+import SiSearch from "@/molecules/SiSearch.vue";
+
+const searchString = ref("");
+
+const onSearch = (search: string) => {
+  searchString.value = search.trim().toLocaleLowerCase();
+};
+
+const props = defineProps<{
+  list: ListWorkflowsResponse;
+  selectedId: number | null;
+}>();
+
+const selected = computed(() =>
+  props.list.find((f) => f.id === props.selectedId),
+);
+
+const groupedFilteredList = computed(() => {
+  const filteredList =
+    searchString.value.length > 0
+      ? props.list.filter((w) =>
+          w.title.toLocaleLowerCase().includes(searchString.value),
+        )
+      : props.list;
+
+  if (selected.value && !filteredList.includes(selected.value)) {
+    filteredList.push(selected.value);
+  }
+  if (filteredList.length === 0) return {};
+
+  const group: {
+    [key: string]: { [key: string]: ListedWorkflowView[] };
+  } = { Workspace: { "": [] } };
+
+  for (const el of filteredList) {
+    if (el.schemaName) {
+      if (!group[el.schemaName]) group[el.schemaName] = {};
+      if (el.componentNames.length === 0) {
+        continue;
+      } else if (!Array.isArray(group[el.schemaName])) {
+        for (const componentName of el.componentNames) {
+          if (!group[el.schemaName][componentName]) {
+            group[el.schemaName][componentName] = [];
+          }
+
+          group[el.schemaName][componentName].push(el);
+        }
+      }
+    } else {
+      group.Workspace[""].push(el);
+    }
+  }
+
+  return group;
+});
+
+const emits = defineEmits<{
+  (e: "selected", v: ListedWorkflowView): void;
+}>();
+
+const select = (w: ListedWorkflowView) => {
+  emits("selected", w);
+};
+</script>

--- a/app/web/src/organisms/WorkflowRunner/WorkflowResolver.vue
+++ b/app/web/src/organisms/WorkflowRunner/WorkflowResolver.vue
@@ -1,0 +1,36 @@
+<template>
+  <CodeViewer
+    :code="workflowTree?.json ?? '// Resolving Workflow'"
+    code-language="json"
+  >
+    <template #title>
+      <span class="text-lg ml-4">
+        {{ JSON.parse(workflowTree?.json ?? "{}")?.name }} Plan
+      </span>
+    </template>
+  </CodeViewer>
+</template>
+
+<script lang="ts" setup>
+import { toRef } from "vue";
+import { fromRef, refFrom } from "vuse-rx";
+import { combineLatest, switchMap } from "rxjs";
+import { WorkflowService } from "@/service/workflow";
+import { WorkflowResolveResponse } from "@/service/workflow/resolve";
+import CodeViewer from "@/organisms/CodeViewer.vue";
+
+const props = defineProps<{
+  selectedId: number;
+}>();
+
+const selectedId = toRef(props, "selectedId", 0);
+const selectedId$ = fromRef(selectedId, { immediate: true });
+
+const workflowTree = refFrom<WorkflowResolveResponse | null>(
+  combineLatest([selectedId$]).pipe(
+    switchMap(([id]) => {
+      return WorkflowService.resolve({ id });
+    }),
+  ),
+);
+</script>

--- a/app/web/src/organisms/Workspace/WorkspaceRuntime.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceRuntime.vue
@@ -1,7 +1,76 @@
 <template>
-  <div
-    class="grid h-screen place-items-center dark:bg-neutral-800 dark:text-white text-lg font-semibold"
-  >
-    WorkspaceRuntime
+  <div class="flex flex-row w-full h-full bg-transparent overflow-hidden">
+    <SiSidebar side="left" class="h-full pb-12" width-classes="shrink-0 w-96">
+      <WorkflowPicker
+        :list="list"
+        :selected-id="selected?.id ?? null"
+        @selected="select"
+      />
+    </SiSidebar>
+    <div
+      class="grow overflow-x-hidden overflow-y-hidden dark:bg-neutral-800 dark:text-white text-lg font-semi-bold px-2 pt-2 flex flex-col"
+    >
+      <span v-if="selected">
+        <div class="w-full flex flex-row-reverse">
+          <VButton
+            icon="play"
+            label="Run"
+            size="lg"
+            class="w-48"
+            @click="runWorkflow()"
+          />
+        </div>
+        <WorkflowResolver :selected-id="selected.id" />
+      </span>
+      <div
+        v-else
+        class="p-2 text-center text-neutral-400 dark:text-neutral-300"
+      >
+        Select a workflow to resolve.
+      </div>
+    </div>
+    <SiSidebar
+      :hidden="false"
+      side="right"
+      class="h-full"
+      width-classes="shrink-0 w-80"
+    >
+      <span v-if="logs" class="overflow-auto">
+        <p class="text-lg">Output:</p>
+        <p v-for="(log, index) in logs" :key="index">{{ log }}</p>
+      </span>
+      <!-- if hiding is added later, condition is selectedFuncId < 1 -->
+      <!--<FuncDetails :func-id="selectedFunc.id" />-->
+    </SiSidebar>
   </div>
 </template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import { refFrom } from "vuse-rx/src";
+import SiSidebar from "@/atoms/SiSidebar.vue";
+import WorkflowPicker from "@/organisms/WorkflowRunner/WorkflowPicker.vue";
+import WorkflowResolver from "@/organisms/WorkflowRunner/WorkflowResolver.vue";
+import { WorkflowService } from "@/service/workflow";
+import {
+  ListedWorkflowView,
+  ListWorkflowsResponse,
+} from "@/service/workflow/list";
+import VButton from "@/molecules/VButton.vue";
+
+const selected = ref<ListedWorkflowView | null>(null);
+const select = (w: ListedWorkflowView | null) => {
+  logs.value = null;
+  selected.value = w;
+};
+
+const logs = ref<string[] | null>(null);
+const runWorkflow = async () => {
+  if (selected.value) {
+    const outputs = await WorkflowService.run({ id: selected.value.id });
+    logs.value = outputs?.logs ?? null;
+  }
+};
+
+const list = refFrom<ListWorkflowsResponse>(WorkflowService.list(), []);
+</script>

--- a/app/web/src/service/workflow.ts
+++ b/app/web/src/service/workflow.ts
@@ -1,0 +1,9 @@
+import { list } from "./workflow/list";
+import { resolve } from "./workflow/resolve";
+import { run } from "./workflow/run";
+
+export const WorkflowService = {
+  list,
+  resolve,
+  run,
+};

--- a/app/web/src/service/workflow/list.ts
+++ b/app/web/src/service/workflow/list.ts
@@ -1,0 +1,41 @@
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { ApiResponse } from "@/api/sdf";
+import { memoizedVisibilitySdfPipe } from "@/utils/memoizedVisibilitySdfPipes";
+import { GlobalErrorService } from "@/service/global_error";
+
+export interface ListedWorkflowView {
+  id: number;
+  title: string;
+  description: string | null;
+  link: string | null;
+  componentNames: string[];
+  schemaName: string | null;
+  schemaVariantName: string | null;
+}
+
+export type ListWorkflowsResponse = ListedWorkflowView[];
+
+const memo: {
+  [key: string]: Observable<ListWorkflowsResponse>;
+} = {};
+
+export const list: () => Observable<ListWorkflowsResponse> =
+  memoizedVisibilitySdfPipe(
+    (visibility, sdf) =>
+      sdf
+        .get<ApiResponse<ListWorkflowsResponse>>("workflow/list", {
+          ...visibility,
+        })
+        .pipe(
+          map((response) => {
+            if (response.error) {
+              GlobalErrorService.set(response);
+              return [];
+            }
+
+            return response as ListWorkflowsResponse;
+          }),
+        ),
+    memo,
+  );

--- a/app/web/src/service/workflow/resolve.ts
+++ b/app/web/src/service/workflow/resolve.ts
@@ -1,0 +1,54 @@
+import { firstValueFrom } from "rxjs";
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { GlobalErrorService } from "@/service/global_error";
+import { visibility$ } from "@/observable/visibility";
+
+export interface WorkflowResolveRequest {
+  id: number;
+}
+
+export enum WorkflowKind {
+  Conditional = "conditional",
+  Exceptional = "exceptional",
+  Parallel = "parallel",
+}
+
+export interface WorkflowCommandStep {
+  command: string;
+  args: unknown;
+}
+
+export type WorkflowStep = WorkflowCommandStep | WorkflowTree;
+
+export interface WorkflowTree {
+  name: string;
+  kind: WorkflowKind;
+  steps: WorkflowStep[];
+  args: unknown;
+}
+
+export interface WorkflowResolveResponse {
+  json: string;
+}
+
+export const resolve: (
+  arg: WorkflowResolveRequest,
+) => Promise<WorkflowResolveResponse | null> = async (arg) => {
+  const visibility = await firstValueFrom(visibility$);
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+
+  const response = await firstValueFrom(
+    sdf.post<ApiResponse<WorkflowResolveResponse>>("workflow/resolve", {
+      ...arg,
+      ...visibility,
+    }),
+  );
+
+  if (response.error) {
+    GlobalErrorService.set(response);
+    return null;
+  }
+  return response as WorkflowResolveResponse;
+};

--- a/app/web/src/service/workflow/run.ts
+++ b/app/web/src/service/workflow/run.ts
@@ -1,0 +1,34 @@
+import { firstValueFrom } from "rxjs";
+import Bottle from "bottlejs";
+import { ApiResponse, SDF } from "@/api/sdf";
+import { GlobalErrorService } from "@/service/global_error";
+import { visibility$ } from "@/observable/visibility";
+
+export interface WorkflowRunRequest {
+  id: number;
+}
+
+export interface WorkflowRunResponse {
+  logs: string[];
+}
+
+export const run: (
+  arg: WorkflowRunRequest,
+) => Promise<WorkflowRunResponse | null> = async (arg) => {
+  const visibility = await firstValueFrom(visibility$);
+  const bottle = Bottle.pop("default");
+  const sdf: SDF = bottle.container.SDF;
+
+  const response = await firstValueFrom(
+    sdf.post<ApiResponse<WorkflowRunResponse>>("workflow/run", {
+      ...arg,
+      ...visibility,
+    }),
+  );
+
+  if (response.error) {
+    GlobalErrorService.set(response);
+    return null;
+  }
+  return response as WorkflowRunResponse;
+};

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -15,10 +15,12 @@ use crate::{
     AttributeReadContext, AttributeValueError, CodeGenerationPrototypeError, DalContext,
     ExternalProviderId, FuncError, PropError, PropId, QualificationPrototypeError,
     ResourcePrototypeError, SchemaError, StandardModelError, ValidationPrototypeError,
+    WorkflowPrototypeError,
 };
 
 mod func;
 mod schema;
+mod workflow;
 
 #[derive(Error, Debug)]
 pub enum BuiltinsError {
@@ -72,6 +74,8 @@ pub enum BuiltinsError {
     StandardModel(#[from] StandardModelError),
     #[error("validation prototype error: {0}")]
     ValidationPrototype(#[from] ValidationPrototypeError),
+    #[error(transparent)]
+    WorkflowPrototype(#[from] WorkflowPrototypeError),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;
@@ -80,5 +84,6 @@ pub type BuiltinsResult<T> = Result<T, BuiltinsError>;
 pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     func::migrate(ctx).await?;
     schema::migrate(ctx).await?;
+    workflow::migrate(ctx).await?;
     Ok(())
 }

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -22,10 +22,12 @@ pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     si_qualification_yaml_kubeval(ctx).await?;
     si_qualification_docker_hub_login(ctx).await?;
 
+    si_what_is_love_workflow(ctx).await?;
     si_poem_workflow(ctx).await?;
     si_exceptional_workflow(ctx).await?;
     si_finalizing_workflow(ctx).await?;
 
+    si_baby_dont_hurt_me_command(ctx).await?;
     si_title_command(ctx).await?;
     si_title2_command(ctx).await?;
     si_first_stanza_command(ctx).await?;
@@ -414,6 +416,34 @@ async fn si_qualification_docker_hub_login(ctx: &DalContext<'_, '_>) -> Builtins
     Ok(())
 }
 
+async fn si_what_is_love_workflow(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+    let func_name = "si:whatIsLove".to_string();
+    let existing_func = Func::find_by_attr(ctx, "name", &func_name).await?;
+    if existing_func.is_empty() {
+        let mut new_func = Func::new(
+            ctx,
+            &func_name,
+            FuncBackendKind::JsWorkflow,
+            FuncBackendResponseType::Workflow,
+        )
+        .await
+        .expect("cannot create func");
+
+        let workflow_code = base64::encode(include_str!("./func/whatIsLoveWorkflow.js"));
+
+        new_func
+            .set_handler(ctx, Some("whatIsLove".to_string()))
+            .await
+            .expect("cannot set handler");
+        new_func
+            .set_code_base64(ctx, Some(workflow_code))
+            .await
+            .expect("cannot set code");
+    }
+
+    Ok(())
+}
+
 async fn si_poem_workflow(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     let func_name = "si:poem".to_string();
     let existing_func = Func::find_by_attr(ctx, "name", &func_name).await?;
@@ -487,6 +517,34 @@ async fn si_finalizing_workflow(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> 
 
         new_func
             .set_handler(ctx, Some("finalizing".to_string()))
+            .await
+            .expect("cannot set handler");
+        new_func
+            .set_code_base64(ctx, Some(workflow_code))
+            .await
+            .expect("cannot set code");
+    }
+
+    Ok(())
+}
+
+async fn si_baby_dont_hurt_me_command(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+    let func_name = "si:babyDontHurtMe".to_string();
+    let existing_func = Func::find_by_attr(ctx, "name", &func_name).await?;
+    if existing_func.is_empty() {
+        let mut new_func = Func::new(
+            ctx,
+            &func_name,
+            FuncBackendKind::JsCommand,
+            FuncBackendResponseType::Command,
+        )
+        .await
+        .expect("cannot create func");
+
+        let workflow_code = base64::encode(include_str!("./func/babyDontHurtMeCommand.js"));
+
+        new_func
+            .set_handler(ctx, Some("babyDontHurtMe".to_string()))
             .await
             .expect("cannot set handler");
         new_func

--- a/lib/dal/src/builtins/func/babyDontHurtMeCommand.js
+++ b/lib/dal/src/builtins/func/babyDontHurtMeCommand.js
@@ -1,0 +1,5 @@
+async function babyDontHurtMe() {
+  console.log("Oh baby, don't hurt me");
+  console.log("Don't hurt me");
+  console.log("No more");
+}

--- a/lib/dal/src/builtins/func/leroLeroByeCommand.js
+++ b/lib/dal/src/builtins/func/leroLeroByeCommand.js
@@ -1,6 +1,6 @@
 async function bye(arg) {
   const millis = Math.floor(Math.random() * 100);
-  console.log(`Bye is waiting ${millis} seconds, arg = ${arg}`);
+  console.log(`Bye is waiting ${millis} millis, arg = ${arg}`);
   await new Promise(resolve => setTimeout(resolve, millis));
   console.log("bye");
 }

--- a/lib/dal/src/builtins/func/leroLeroFirstStanzaCommand.js
+++ b/lib/dal/src/builtins/func/leroLeroFirstStanzaCommand.js
@@ -1,6 +1,6 @@
 async function firstStanza() {
   const millis = Math.floor(Math.random() * 100);
-  console.log(`First stanza is waiting ${secs} seconds\n`);
+  console.log(`First stanza is waiting ${millis} millis\n`);
   await new Promise(resolve => setTimeout(resolve, millis));
   console.log("I'm Brazilian, of median stature");
   console.log("I really like Fulana, but Sicrana is the one who wants me");

--- a/lib/dal/src/builtins/func/leroLeroQuestionCommand.js
+++ b/lib/dal/src/builtins/func/leroLeroQuestionCommand.js
@@ -1,6 +1,6 @@
 async function question(personName, arg) {
   const millis = Math.floor(Math.random() * 100);
-  console.log(`Question is waiting ${secs} seconds, arg = ${arg}`);
+  console.log(`Question is waiting ${millis} millis, arg = ${arg}`);
   await new Promise(resolve => setTimeout(resolve, millis));
   console.log(`What about you, are you a brazilian of median stature ${personName}?`);
 }

--- a/lib/dal/src/builtins/func/whatIsLoveWorkflow.js
+++ b/lib/dal/src/builtins/func/whatIsLoveWorkflow.js
@@ -1,0 +1,11 @@
+async function whatIsLove() {
+  return {
+    name: "si:whatIsLove",
+    kind: "conditional",
+    steps: [
+      {
+        command: "si:babyDontHurtMe",
+      },
+    ],
+  };
+}

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -23,6 +23,7 @@ use crate::{
     DalContext, ExternalProvider, Func, FuncBackendKind, FuncBackendResponseType, FuncError,
     FuncId, InternalProvider, Prop, PropError, PropId, PropKind, QualificationPrototype,
     ResourcePrototype, Schema, SchemaError, SchemaKind, SchematicKind, StandardModel,
+    WorkflowPrototype, WorkflowPrototypeContext,
 };
 
 mod kubernetes;
@@ -462,6 +463,17 @@ async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
         *metadata_name_implicit_internal_provider.id(),
     )
     .await?;
+
+    let mut context = WorkflowPrototypeContext::new(); // workspace level
+    context.schema_id = *schema.id();
+    context.schema_variant_id = *variant.id();
+    let title = "What Is Love";
+    let func_name = "si:whatIsLove";
+    let func = Func::find_by_attr(ctx, "name", &func_name)
+        .await?
+        .pop()
+        .ok_or_else(|| SchemaError::FuncNotFound(func_name.to_owned()))?;
+    WorkflowPrototype::new(ctx, *func.id(), serde_json::Value::Null, context, title).await?;
 
     Ok(())
 }

--- a/lib/dal/src/builtins/workflow.rs
+++ b/lib/dal/src/builtins/workflow.rs
@@ -1,0 +1,27 @@
+use crate::{
+    BuiltinsResult, DalContext, Func, SchemaError, StandardModel, WorkflowPrototype,
+    WorkflowPrototypeContext,
+};
+
+pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+    poem(ctx).await?;
+    Ok(())
+}
+
+async fn poem(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+    let func_name = "si:poem";
+    let func = Func::find_by_attr(ctx, "name", &func_name)
+        .await?
+        .pop()
+        .ok_or_else(|| SchemaError::FuncNotFound(func_name.to_owned()))?;
+    let title = "Lero Lero";
+
+    let context = WorkflowPrototypeContext::default(); // workspace level
+    if WorkflowPrototype::find_by_attr(ctx, "title", &title)
+        .await?
+        .is_empty()
+    {
+        WorkflowPrototype::new(ctx, *func.id(), serde_json::Value::Null, context, title).await?;
+    }
+    Ok(())
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -63,6 +63,8 @@ pub mod validation_prototype;
 pub mod validation_resolver;
 pub mod visibility;
 pub mod workflow;
+pub mod workflow_prototype;
+pub mod workflow_resolver;
 pub mod workspace;
 pub mod write_tenancy;
 pub mod ws_event;
@@ -108,7 +110,7 @@ pub use edge::{Edge, EdgeError, EdgeResult};
 pub use func::binding_return_value::FuncBindingReturnValue;
 pub use func::{
     backend::{FuncBackendError, FuncBackendKind, FuncBackendResponseType},
-    binding::{FuncBinding, FuncBindingError},
+    binding::{FuncBinding, FuncBindingError, FuncBindingId},
     Func, FuncError, FuncId, FuncResult,
 };
 pub use group::{Group, GroupError, GroupId, GroupResult};
@@ -170,6 +172,10 @@ pub use workflow::{
     WorkflowError, WorkflowKind, WorkflowResult, WorkflowStep, WorkflowTree, WorkflowTreeStep,
     WorkflowView,
 };
+pub use workflow_prototype::{
+    WorkflowPrototype, WorkflowPrototypeContext, WorkflowPrototypeError, WorkflowPrototypeId,
+};
+pub use workflow_resolver::{WorkflowResolver, WorkflowResolverError, WorkflowResolverId};
 pub use workspace::{Workspace, WorkspaceError, WorkspaceId, WorkspacePk, WorkspaceResult};
 pub use write_tenancy::{WriteTenancy, WriteTenancyError};
 pub use ws_event::{WsEvent, WsEventError, WsPayload};

--- a/lib/dal/src/migrations/U0065__workflow_prototypes.sql
+++ b/lib/dal/src/migrations/U0065__workflow_prototypes.sql
@@ -1,0 +1,78 @@
+CREATE TABLE workflow_prototypes
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    func_id                     bigint                   NOT NULL,
+    args                        jsonb                    NOT NULL,
+    title                       text                     NOT NULL,
+    description                 text,
+    link                        text,
+    component_id                bigint                   NOT NULL,
+    schema_id                   bigint                   NOT NULL,
+    schema_variant_id           bigint                   NOT NULL,
+    system_id                   bigint                   NOT NULL
+);
+SELECT standard_model_table_constraints_v1('workflow_prototypes');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('workflow_prototypes', 'model', 'workflow_prototype', 'Workflow Prototype');
+
+CREATE OR REPLACE FUNCTION workflow_prototype_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id bigint,
+    this_args jsonb,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    this_title text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           workflow_prototypes%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO workflow_prototypes (tenancy_universal,
+                                          tenancy_billing_account_ids,
+                                          tenancy_organization_ids,
+                                          tenancy_workspace_ids,
+                                          visibility_change_set_pk,
+                                          visibility_deleted_at,
+                                          func_id,
+                                          args,
+                                          title,
+                                          component_id,
+                                          schema_id,
+                                          schema_variant_id,
+                                          system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at,
+            this_func_id,
+            this_args,
+            this_title,
+            this_component_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/migrations/U0066__workflow_resolvers.sql
+++ b/lib/dal/src/migrations/U0066__workflow_resolvers.sql
@@ -1,0 +1,76 @@
+CREATE TABLE workflow_resolvers
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    workflow_prototype_id       bigint                   NOT NULL,
+    func_id                     bigint                   NOT NULL,
+    func_binding_id             bigint                   NOT NULL,
+    component_id                bigint                   NOT NULL,
+    schema_id                   bigint                   NOT NULL,
+    schema_variant_id           bigint                   NOT NULL,
+    system_id                   bigint                   NOT NULL
+);
+SELECT standard_model_table_constraints_v1('workflow_resolvers');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('workflow_resolvers', 'model', 'workflow_resolver', 'workflow Resolver');
+
+CREATE OR REPLACE FUNCTION workflow_resolver_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_workflow_prototype_id bigint,
+    this_func_id bigint,
+    this_func_binding_id bigint,
+    this_component_id bigint,
+    this_schema_id bigint,
+    this_schema_variant_id bigint,
+    this_system_id bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           workflow_resolvers%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO workflow_resolvers (tenancy_universal,
+                                         tenancy_billing_account_ids,
+                                         tenancy_organization_ids,
+                                         tenancy_workspace_ids,
+                                         visibility_change_set_pk,
+                                         visibility_deleted_at,
+                                         workflow_prototype_id,
+                                         func_id,
+                                         func_binding_id,
+                                         component_id,
+                                         schema_id,
+                                         schema_variant_id,
+                                         system_id)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at,
+            this_workflow_prototype_id,
+            this_func_id,
+            this_func_binding_id,
+            this_component_id,
+            this_schema_id,
+            this_schema_variant_id,
+            this_system_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/workflow_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/workflow_prototype_find_for_context.sql
@@ -1,0 +1,26 @@
+SELECT DISTINCT ON (qualification_prototypes.id) qualification_prototypes.id,
+                                                 qualification_prototypes.component_id,
+                                                 qualification_prototypes.schema_id,
+                                                 qualification_prototypes.schema_variant_id,
+                                                 qualification_prototypes.system_id,
+                                                 qualification_prototypes.visibility_change_set_pk,
+
+                                                 row_to_json(qualification_prototypes.*) AS object
+FROM qualification_prototypes
+WHERE in_tenancy_v1($1, qualification_prototypes.tenancy_universal,
+                    qualification_prototypes.tenancy_billing_account_ids,
+                    qualification_prototypes.tenancy_organization_ids,
+                    qualification_prototypes.tenancy_workspace_ids)
+  AND is_visible_v1($2, qualification_prototypes.visibility_change_set_pk,
+                    qualification_prototypes.visibility_deleted_at)
+  AND (qualification_prototypes.schema_id = $6
+    OR qualification_prototypes.schema_variant_id = $5
+    OR qualification_prototypes.component_id = $3)
+  AND (qualification_prototypes.system_id = $4 OR qualification_prototypes.system_id = -1)
+ORDER BY qualification_prototypes.id,
+         visibility_change_set_pk DESC,
+         component_id DESC,
+         func_id DESC,
+         system_id DESC,
+         schema_variant_id DESC,
+         schema_id DESC;

--- a/lib/dal/src/queries/workflow_resolver_find_for_prototype.sql
+++ b/lib/dal/src/queries/workflow_resolver_find_for_prototype.sql
@@ -1,0 +1,25 @@
+SELECT DISTINCT ON (workflow_resolvers.id) workflow_resolvers.id,
+                                                workflow_resolvers.visibility_change_set_pk,
+
+                                                workflow_resolvers.component_id,
+                                                workflow_resolvers.schema_id,
+                                                workflow_resolvers.schema_variant_id,
+                                                workflow_resolvers.system_id,
+                                                row_to_json(workflow_resolvers.*) as object
+FROM workflow_resolvers
+WHERE in_tenancy_v1($1, workflow_resolvers.tenancy_universal, workflow_resolvers.tenancy_billing_account_ids,
+                    workflow_resolvers.tenancy_organization_ids,
+                    workflow_resolvers.tenancy_workspace_ids)
+  AND is_visible_v1($2, workflow_resolvers.visibility_change_set_pk, workflow_resolvers.visibility_deleted_at)
+  AND workflow_resolvers.workflow_prototype_id = $3
+  AND (workflow_resolvers.component_id = $4
+       OR workflow_resolvers.schema_id = $5
+       OR workflow_resolvers.schema_variant_id = $6
+       OR workflow_resolvers.system_id = $7)
+ORDER BY workflow_resolvers.id,
+         visibility_change_set_pk DESC,
+         component_id DESC,
+         system_id DESC,
+         schema_variant_id DESC,
+         schema_id DESC;
+

--- a/lib/dal/src/timestamp.rs
+++ b/lib/dal/src/timestamp.rs
@@ -7,7 +7,7 @@ pub enum TimestampError {}
 
 pub type TimestampResult<T> = Result<T, TimestampError>;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Timestamp {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/lib/dal/src/workflow_prototype.rs
+++ b/lib/dal/src/workflow_prototype.rs
@@ -1,0 +1,300 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use si_data::{NatsError, PgError};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::FuncId,
+    impl_standard_model, pk,
+    standard_model::{self, objects_from_rows},
+    standard_model_accessor,
+    workflow_resolver::WorkflowResolverContext,
+    ComponentId, DalContext, Func, FuncBinding, FuncBindingError, HistoryEventError, SchemaId,
+    SchemaVariantId, StandardModel, StandardModelError, SystemId, Timestamp, Visibility,
+    WorkflowError, WorkflowResolver, WorkflowResolverError, WorkflowView, WriteTenancy, WsEvent,
+    WsEventError,
+};
+
+#[derive(Error, Debug)]
+pub enum WorkflowPrototypeError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+    #[error("component not found: {0}")]
+    ComponentNotFound(ComponentId),
+    #[error(transparent)]
+    Workflow(#[from] WorkflowError),
+    #[error(transparent)]
+    WorkflowResolver(#[from] WorkflowResolverError),
+    #[error(transparent)]
+    FuncBinding(#[from] FuncBindingError),
+    #[error(transparent)]
+    WsEvent(#[from] WsEventError),
+    #[error("component error: {0}")]
+    Component(String),
+    #[error("schema not found")]
+    SchemaNotFound,
+    #[error("schema variant not found")]
+    SchemaVariantNotFound,
+    #[error("func not found {0}")]
+    FuncNotFound(FuncId),
+}
+
+pub type WorkflowPrototypeResult<T> = Result<T, WorkflowPrototypeError>;
+
+const FIND_FOR_CONTEXT: &str = include_str!("./queries/workflow_prototype_find_for_context.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowPrototypeContext {
+    pub component_id: ComponentId,
+    pub schema_id: SchemaId,
+    pub schema_variant_id: SchemaVariantId,
+    pub system_id: SystemId,
+}
+
+// Hrm - is this a universal resolver context? -- Adam
+impl Default for WorkflowPrototypeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkflowPrototypeContext {
+    pub fn new() -> Self {
+        Self {
+            component_id: ComponentId::NONE,
+            schema_id: SchemaId::NONE,
+            schema_variant_id: SchemaVariantId::NONE,
+            system_id: SystemId::NONE,
+        }
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(WorkflowPrototypePk);
+pk!(WorkflowPrototypeId);
+
+// An WorkflowPrototype joins a `Func` to the context in which
+// the component that is created with it can use to generate a WorkflowResolver.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowPrototype {
+    pk: WorkflowPrototypePk,
+    id: WorkflowPrototypeId,
+    func_id: FuncId,
+    args: serde_json::Value,
+    title: String,
+    description: Option<String>,
+    link: Option<String>,
+    component_id: ComponentId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: WorkflowPrototype,
+    pk: WorkflowPrototypePk,
+    id: WorkflowPrototypeId,
+    table_name: "workflow_prototypes",
+    history_event_label_base: "workflow_prototype",
+    history_event_message_name: "Workflow Prototype"
+}
+
+impl WorkflowPrototype {
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_>,
+        func_id: FuncId,
+        args: serde_json::Value,
+        context: WorkflowPrototypeContext,
+        title: impl Into<String>,
+    ) -> WorkflowPrototypeResult<Self> {
+        let title = title.into();
+        let row = ctx.txns().pg().query_one(
+                "SELECT object FROM workflow_prototype_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[ctx.write_tenancy(), ctx.visibility(),
+                    &func_id,
+                    &args,
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                    &title,
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(func_id, Pk(FuncId), WorkflowPrototypeResult);
+    standard_model_accessor!(args, Json<JsonValue>, WorkflowPrototypeResult);
+    standard_model_accessor!(title, String, WorkflowPrototypeResult);
+    standard_model_accessor!(description, Option<String>, WorkflowPrototypeResult);
+    standard_model_accessor!(link, Option<String>, WorkflowPrototypeResult);
+    standard_model_accessor!(schema_id, Pk(SchemaId), WorkflowPrototypeResult);
+    standard_model_accessor!(
+        schema_variant_id,
+        Pk(SchemaVariantId),
+        WorkflowPrototypeResult
+    );
+    standard_model_accessor!(component_id, Pk(ComponentId), WorkflowPrototypeResult);
+
+    standard_model_accessor!(system_id, Pk(SystemId), WorkflowPrototypeResult);
+
+    pub async fn resolve(
+        &self,
+        ctx: &DalContext<'_, '_>,
+    ) -> WorkflowPrototypeResult<WorkflowResolver> {
+        let mut context = WorkflowResolverContext::new();
+        context.set_component_id(self.component_id);
+        context.set_schema_id(self.schema_id);
+        context.set_schema_variant_id(self.schema_variant_id);
+        context.set_system_id(self.system_id);
+        match WorkflowResolver::find_for_prototype(ctx, self.id(), context.clone())
+            .await?
+            .pop()
+        {
+            Some(resolver) => Ok(resolver),
+            None => {
+                let identity = Func::find_by_attr(ctx, "name", &"si:identity")
+                    .await?
+                    .pop()
+                    .ok_or_else(|| WorkflowError::MissingWorkflow("si:identity".to_owned()))?;
+                let (func_binding, _) = FuncBinding::find_or_create(
+                    ctx,
+                    serde_json::Value::Null,
+                    *identity.id(),
+                    *identity.backend_kind(),
+                )
+                .await?;
+                let mut resolver = WorkflowResolver::new(
+                    ctx,
+                    self.id,
+                    *identity.id(),
+                    *func_binding.id(),
+                    context.clone(),
+                )
+                .await?;
+
+                let func = Func::get_by_id(ctx, &self.func_id())
+                    .await?
+                    .ok_or_else(|| WorkflowPrototypeError::FuncNotFound(self.func_id()))?;
+                let tree = WorkflowView::resolve(ctx, &func).await?;
+
+                let args = serde_json::json!({ "identity": serde_json::to_value(tree)? });
+                let (func_binding, _) = FuncBinding::find_or_create(
+                    ctx,
+                    args,
+                    *identity.id(),
+                    *identity.backend_kind(),
+                )
+                .await?;
+                func_binding.execute(ctx).await?;
+                resolver
+                    .set_func_binding_id(ctx, *func_binding.id())
+                    .await?;
+
+                WsEvent::change_set_written(ctx).publish(ctx).await?;
+
+                Ok(resolver)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_for_context(
+        ctx: &DalContext<'_, '_>,
+        component_id: ComponentId,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+        system_id: SystemId,
+    ) -> WorkflowPrototypeResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                FIND_FOR_CONTEXT,
+                &[
+                    ctx.read_tenancy(),
+                    ctx.visibility(),
+                    &component_id,
+                    &system_id,
+                    &schema_variant_id,
+                    &schema_id,
+                ],
+            )
+            .await?;
+        let object = objects_from_rows(rows)?;
+        Ok(object)
+    }
+
+    pub fn context(&self) -> WorkflowPrototypeContext {
+        let mut context = WorkflowPrototypeContext::new();
+        context.set_component_id(self.component_id);
+        context.set_schema_id(self.schema_id);
+        context.set_schema_variant_id(self.schema_variant_id);
+        context.set_system_id(self.system_id);
+
+        context
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::WorkflowPrototypeContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = WorkflowPrototypeContext::new();
+        c.set_component_id(22.into());
+        assert_eq!(c.component_id(), 22.into());
+    }
+}

--- a/lib/dal/src/workflow_resolver.rs
+++ b/lib/dal/src/workflow_resolver.rs
@@ -1,0 +1,196 @@
+use crate::DalContext;
+use serde::{Deserialize, Serialize};
+use si_data::{NatsError, PgError};
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::{binding::FuncBindingId, FuncId},
+    impl_standard_model, pk,
+    standard_model::{self, objects_from_rows},
+    standard_model_accessor, ComponentId, HistoryEventError, SchemaId, SchemaVariantId,
+    StandardModel, StandardModelError, SystemId, Timestamp, Visibility, WorkflowPrototypeId,
+    WriteTenancy,
+};
+
+#[derive(Error, Debug)]
+pub enum WorkflowResolverError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+}
+
+pub type WorkflowResolverResult<T> = Result<T, WorkflowResolverError>;
+
+pub const UNSET_ID_VALUE: i64 = -1;
+const FIND_FOR_PROTOTYPE: &str = include_str!("./queries/workflow_resolver_find_for_prototype.sql");
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowResolverContext {
+    component_id: ComponentId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    system_id: SystemId,
+}
+
+// Hrm - is this a universal resolver context? -- Adam
+impl Default for WorkflowResolverContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkflowResolverContext {
+    pub fn new() -> Self {
+        WorkflowResolverContext {
+            component_id: UNSET_ID_VALUE.into(),
+            schema_id: UNSET_ID_VALUE.into(),
+            schema_variant_id: UNSET_ID_VALUE.into(),
+            system_id: UNSET_ID_VALUE.into(),
+        }
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_id(&self) -> SchemaId {
+        self.schema_id
+    }
+
+    pub fn set_schema_id(&mut self, schema_id: SchemaId) {
+        self.schema_id = schema_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+
+    pub fn system_id(&self) -> SystemId {
+        self.system_id
+    }
+
+    pub fn set_system_id(&mut self, system_id: SystemId) {
+        self.system_id = system_id;
+    }
+}
+
+pk!(WorkflowResolverPk);
+pk!(WorkflowResolverId);
+
+// An WorkflowResolver joins a `FuncBinding` to the context in which
+// its corresponding `FuncBindingResultValue` is consumed.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowResolver {
+    pk: WorkflowResolverPk,
+    id: WorkflowResolverId,
+    workflow_prototype_id: WorkflowPrototypeId,
+    func_id: FuncId,
+    func_binding_id: FuncBindingId,
+    #[serde(flatten)]
+    context: WorkflowResolverContext,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: WorkflowResolver,
+    pk: WorkflowResolverPk,
+    id: WorkflowResolverId,
+    table_name: "workflow_resolvers",
+    history_event_label_base: "workflow_resolver",
+    history_event_message_name: "Workflow Resolver"
+}
+
+impl WorkflowResolver {
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_>,
+        workflow_prototype_id: WorkflowPrototypeId,
+        func_id: FuncId,
+        func_binding_id: FuncBindingId,
+        context: WorkflowResolverContext,
+    ) -> WorkflowResolverResult<Self> {
+        let row = ctx.txns().pg().query_one(
+                "SELECT object FROM workflow_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                &[ctx.write_tenancy(), ctx.visibility(),
+                    &workflow_prototype_id,
+                    &func_id,
+                    &func_binding_id,
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(
+        workflow_prototype_id,
+        Pk(WorkflowPrototypeId),
+        WorkflowResolverResult
+    );
+    standard_model_accessor!(func_id, Pk(FuncId), WorkflowResolverResult);
+    standard_model_accessor!(func_binding_id, Pk(FuncBindingId), WorkflowResolverResult);
+
+    pub async fn find_for_prototype(
+        ctx: &DalContext<'_, '_>,
+        workflow_prototype_id: &WorkflowPrototypeId,
+        context: WorkflowResolverContext,
+    ) -> WorkflowResolverResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                FIND_FOR_PROTOTYPE,
+                &[
+                    ctx.read_tenancy(),
+                    ctx.visibility(),
+                    workflow_prototype_id,
+                    &context.component_id(),
+                    &context.schema_id(),
+                    &context.schema_variant_id(),
+                    &context.system_id(),
+                ],
+            )
+            .await?;
+        let object = objects_from_rows(rows)?;
+        Ok(object)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::WorkflowResolverContext;
+
+    #[test]
+    fn context_builder() {
+        let mut c = WorkflowResolverContext::new();
+        c.set_component_id(15.into());
+        assert_eq!(c.component_id(), 15.into());
+    }
+}

--- a/lib/dal/tests/integration_test/workflow.rs
+++ b/lib/dal/tests/integration_test/workflow.rs
@@ -18,7 +18,13 @@ async fn fb(ctx: &DalContext<'_, '_>, name: &str, args: serde_json::Value) -> se
 
 #[test]
 async fn resolve(ctx: &DalContext<'_, '_>) {
-    let tree = WorkflowView::resolve(ctx, "si:poem")
+    let name = "si:poem";
+    let func = Func::find_by_attr(ctx, "name", &name)
+        .await
+        .expect("unable to find func")
+        .pop()
+        .unwrap_or_else(|| panic!("function not found: {}", name));
+    let tree = WorkflowView::resolve(ctx, &func)
         .await
         .expect("unable to resolve workflow");
     // TODO: fix args propagation
@@ -62,7 +68,13 @@ async fn resolve(ctx: &DalContext<'_, '_>) {
 
 #[test]
 async fn run(ctx: &DalContext<'_, '_>) {
-    let tree = WorkflowView::resolve(ctx, "si:poem")
+    let name = "si:poem";
+    let func = Func::find_by_attr(ctx, "name", &name)
+        .await
+        .expect("unable to find func")
+        .pop()
+        .unwrap_or_else(|| panic!("function not found: {}", name));
+    let tree = WorkflowView::resolve(ctx, &func)
         .await
         .expect("unable to resolve workflow");
     // TODO: fix args propagation

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -103,6 +103,7 @@ pub fn routes(
         .nest("/api/session", crate::server::service::session::routes())
         .nest("/api/signup", crate::server::service::signup::routes())
         .nest("/api/system", crate::server::service::system::routes())
+        .nest("/api/workflow", crate::server::service::workflow::routes())
         .nest("/api/ws", crate::server::service::ws::routes());
     router = test_routes(router);
     router = router

--- a/lib/sdf/src/server/service.rs
+++ b/lib/sdf/src/server/service.rs
@@ -11,4 +11,5 @@ pub mod session;
 pub mod signup;
 pub mod system;
 pub mod test;
+pub mod workflow;
 pub mod ws;

--- a/lib/sdf/src/server/service/func/list_funcs.rs
+++ b/lib/sdf/src/server/service/func/list_funcs.rs
@@ -38,7 +38,7 @@ pub async fn list_funcs(
     let qualification_funcs = Func::find_by_attr(
         &ctx,
         "backend_kind",
-        &FuncBackendKind::JsQualification.as_ref().to_string(),
+        &FuncBackendKind::JsQualification.as_ref(),
     )
     .await?
     .iter()

--- a/lib/sdf/src/server/service/workflow.rs
+++ b/lib/sdf/src/server/service/workflow.rs
@@ -1,0 +1,73 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+
+use dal::{
+    func::binding_return_value::FuncBindingReturnValueError, ComponentError, ComponentId,
+    FuncBindingError, FuncBindingId, FuncId, SchemaId, SchemaVariantId, StandardModelError,
+    TransactionsError, WorkflowPrototypeError, WorkflowPrototypeId,
+};
+
+use thiserror::Error;
+
+mod list;
+mod resolve;
+mod run;
+
+#[derive(Error, Debug)]
+pub enum WorkflowError {
+    #[error(transparent)]
+    Transactions(#[from] TransactionsError),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+    #[error(transparent)]
+    Workflow(#[from] dal::WorkflowError),
+    #[error(transparent)]
+    FuncBinding(#[from] FuncBindingError),
+    #[error(transparent)]
+    FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error("prototype not found {0}")]
+    PrototypeNotFound(WorkflowPrototypeId),
+    #[error("function not found {0}")]
+    FuncNotFound(FuncId),
+    #[error("function binding not found {0}")]
+    FuncBindingNotFound(FuncBindingId),
+    #[error(transparent)]
+    WorkflowPrototype(#[from] WorkflowPrototypeError),
+    #[error(transparent)]
+    Component(#[from] ComponentError),
+    #[error("component not found")]
+    ComponentNotFound(ComponentId),
+    #[error("component name not found")]
+    ComponentNameNotFound(ComponentId),
+    #[error("schema not found")]
+    SchemaNotFound(SchemaId),
+    #[error("schema variant not found")]
+    SchemaVariantNotFound(SchemaVariantId),
+}
+
+pub type WorkflowResult<T> = std::result::Result<T, WorkflowError>;
+
+impl IntoResponse for WorkflowError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        let body = Json(
+            serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),
+        );
+
+        (status, body).into_response()
+    }
+}
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/list", get(list::list))
+        .route("/resolve", post(resolve::resolve))
+        .route("/run", post(run::run))
+}

--- a/lib/sdf/src/server/service/workflow/list.rs
+++ b/lib/sdf/src/server/service/workflow/list.rs
@@ -1,0 +1,102 @@
+use super::{WorkflowError, WorkflowResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use axum::{extract::Query, Json};
+use dal::{
+    Component, Schema, SchemaVariant, StandardModel, Visibility, WorkflowPrototype,
+    WorkflowPrototypeId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListWorkflowsRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListedWorkflowView {
+    id: WorkflowPrototypeId,
+    title: String,
+    description: Option<String>,
+    link: Option<String>,
+    component_names: Vec<String>,
+    schema_name: Option<String>,
+    schema_variant_name: Option<String>,
+}
+
+pub type ListWorkflowsResponse = Vec<ListedWorkflowView>;
+
+pub async fn list(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<ListWorkflowsRequest>,
+) -> WorkflowResult<Json<ListWorkflowsResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    let prototypes = WorkflowPrototype::list(&ctx).await?;
+    let mut views = Vec::with_capacity(prototypes.len());
+    for proto in prototypes {
+        let component_names = if proto.context().component_id.is_some() {
+            let component = Component::get_by_id(&ctx, &proto.context().component_id)
+                .await?
+                .ok_or_else(|| WorkflowError::ComponentNotFound(proto.context().component_id))?;
+            vec![component
+                .find_value_by_json_pointer::<String>(&ctx, "/root/si/name")
+                .await?
+                .ok_or_else(|| WorkflowError::ComponentNameNotFound(*component.id()))?]
+        } else {
+            let mut names = Vec::new();
+            if proto.context().schema_variant_id.is_some() {
+                for component in
+                    Component::list_for_schema_variant(&ctx, proto.context().schema_variant_id)
+                        .await?
+                {
+                    names.push(
+                        component
+                            .find_value_by_json_pointer::<String>(&ctx, "/root/si/name")
+                            .await?
+                            .ok_or_else(|| WorkflowError::ComponentNameNotFound(*component.id()))?,
+                    );
+                }
+            }
+            names
+        };
+
+        let schema_name = if proto.context().schema_id.is_some() {
+            let schema = Schema::get_by_id(&ctx, &proto.context().schema_id)
+                .await?
+                .ok_or_else(|| WorkflowError::SchemaNotFound(proto.context().schema_id))?;
+            Some(schema.name().to_owned())
+        } else {
+            None
+        };
+
+        let schema_variant_name = if proto.context().schema_variant_id.is_some() {
+            let schema_variant = SchemaVariant::get_by_id(&ctx, &proto.context().schema_variant_id)
+                .await?
+                .ok_or_else(|| {
+                    WorkflowError::SchemaVariantNotFound(proto.context().schema_variant_id)
+                })?;
+            Some(schema_variant.name().to_owned())
+        } else {
+            None
+        };
+
+        views.push(ListedWorkflowView {
+            id: proto.id().to_owned(),
+            title: proto.title().to_owned(),
+            description: proto.description().map(Into::into),
+            link: proto.link().map(Into::into),
+            component_names,
+            schema_name,
+            schema_variant_name,
+        });
+    }
+
+    txns.commit().await?;
+
+    Ok(Json(views))
+}

--- a/lib/sdf/src/server/service/workflow/resolve.rs
+++ b/lib/sdf/src/server/service/workflow/resolve.rs
@@ -1,0 +1,51 @@
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use super::{WorkflowError, WorkflowResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use dal::{
+    workflow::WorkflowTreeView, FuncBinding, FuncBindingReturnValue, StandardModel, Visibility,
+    WorkflowPrototype, WorkflowPrototypeId, WorkflowTree,
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowResolveRequest {
+    pub id: WorkflowPrototypeId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowResolveResponse {
+    json: String,
+}
+
+pub async fn resolve(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<WorkflowResolveRequest>,
+) -> WorkflowResult<Json<WorkflowResolveResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    let resolver = WorkflowPrototype::get_by_id(&ctx, &request.id)
+        .await?
+        .ok_or(WorkflowError::PrototypeNotFound(request.id))?
+        .resolve(&ctx)
+        .await?;
+    let func_binding = FuncBinding::get_by_id(&ctx, &resolver.func_binding_id())
+        .await?
+        .ok_or_else(|| WorkflowError::FuncBindingNotFound(resolver.func_binding_id()))?;
+    let value = FuncBindingReturnValue::get_by_func_binding_id(&ctx, *func_binding.id()).await?;
+    let value = value.as_ref().and_then(|v| v.value());
+    let tree = WorkflowTree::deserialize(value.unwrap_or(&serde_json::Value::Null))?;
+    let view = WorkflowTreeView::new(&ctx, tree).await?;
+
+    txns.commit().await?;
+
+    Ok(Json(WorkflowResolveResponse {
+        json: serde_json::to_string_pretty(&view)?,
+    }))
+}

--- a/lib/sdf/src/server/service/workflow/run.rs
+++ b/lib/sdf/src/server/service/workflow/run.rs
@@ -1,0 +1,66 @@
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use super::{WorkflowError, WorkflowResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use dal::{
+    FuncBinding, FuncBindingReturnValue, StandardModel, Visibility, WorkflowPrototype,
+    WorkflowPrototypeId, WorkflowTree,
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunRequest {
+    pub id: WorkflowPrototypeId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunResponse {
+    logs: Vec<String>,
+}
+
+pub async fn run(
+    HandlerContext(builder, mut txns): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<WorkflowRunRequest>,
+) -> WorkflowResult<Json<WorkflowRunResponse>> {
+    let txns = txns.start().await?;
+    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+
+    let resolver = WorkflowPrototype::get_by_id(&ctx, &request.id)
+        .await?
+        .ok_or(WorkflowError::PrototypeNotFound(request.id))?
+        .resolve(&ctx)
+        .await?;
+    let func_binding = FuncBinding::get_by_id(&ctx, &resolver.func_binding_id())
+        .await?
+        .ok_or_else(|| WorkflowError::FuncBindingNotFound(resolver.func_binding_id()))?;
+    let value = FuncBindingReturnValue::get_by_func_binding_id(&ctx, *func_binding.id()).await?;
+    let value = value.as_ref().and_then(|v| v.value());
+    let tree = WorkflowTree::deserialize(value.unwrap_or(&serde_json::Value::Null))?;
+    let func_binding_return_values = tree.run(&ctx).await?;
+    let mut logs = Vec::new();
+    for func_binding_return_value in func_binding_return_values {
+        for stream in func_binding_return_value
+            .get_output_stream(&ctx)
+            .await?
+            .unwrap_or_default()
+        {
+            match stream.data {
+                Some(data) => logs.push(format!(
+                    "{} {}",
+                    stream.message,
+                    serde_json::to_string_pretty(&data)?
+                )),
+                None => logs.push(stream.message),
+            }
+        }
+    }
+
+    txns.commit().await?;
+
+    Ok(Json(WorkflowRunResponse { logs }))
+}


### PR DESCRIPTION
Implement WorkflowRunner tab, allows you to pick a global workflow or a workflow for a specific component. Resolves the workflow, showing the execution plan. Allows you to run the workflow, consuming the output.

Currently everything is sync, no jobs get scheduled so resolve although cacheable waits on the HTTP request, running also waits on the HTTP request. We need a better way of informing the user the command they ran finished, in a appropriate interface to avoid mixing output runs in the current output sidebar.

Add sdf routes to list, resolve and run workflows.

Implement WorkflowPrototype that ties a context to a func. Implement WorkflowResolver that handles the workflow resolution (dry run), and caches it if the arguments stay the same.

Create builtins WorkflowPrototypes, for the workspace and kubernetes_deployments.

Workflow run output is sorted by execution start, not timestamp (as we don't have the timestamp granularity to properly sort it, but we could use index + timestamp eventually).

![image](https://user-images.githubusercontent.com/6289779/186732219-82161c33-b681-4354-888d-7f657cdda089.png)

![image](https://user-images.githubusercontent.com/6289779/186732252-cdca6e92-a1a4-454b-a9dc-f955b7cb9d49.png)

<img src="https://media0.giphy.com/media/EaoPSZC1r7g3oUcHmj/giphy-downsized-medium.gif"/>