### PR TITLE
fix(README): add pinga to arch diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ The diagram below illustrates a _very_ high-level overview of SI's calling stack
 There are other components and paradigms that aren't displayed, but this diagram is purely meant to show the overall flow from "mouse-click" onwards.
 
 ```
-┌─────┐   ┌─────┐   ┌─────┐   ┌────┐
+                   ┌───────┐
+                   │ pinga │
+                   └───┬───┘
+                       │   ┌─────────┐
+                       ├───┤ faktory │
+                       │   └─────────┘
+┌─────┐   ┌─────┐   ┌──┴──┐   ┌────┐
 │ web ├───┤ sdf ├───┤ dal ├───┤ db │
 └─────┘   └─────┘   └──┬──┘   └────┘
                        │


### PR DESCRIPTION
Pinga was missing from the arch diagram, think this more or less represents its place in the system.