### PR TITLE
feat(web): ENG-503 wire up the func editor to the router

### DIFF
--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -60,9 +60,10 @@ const routes: RouteRecordRaw[] = [
                 component: WorkspaceCompose,
               },
               {
-                path: "l",
+                path: "l/:funcId?",
                 name: "workspace-lab",
                 component: WorkspaceLab,
+                props: true,
               },
               {
                 path: "v",


### PR DESCRIPTION
Appending a func id to the workspace lab route will open the func by that id. Func selection is now driven by route pushes.