### PR TITLE
speed up vite first load

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -79,7 +79,7 @@
         "prettier": "~2.6.2",
         "unplugin-icons": "^0.14.8",
         "vite": "^2.9.6",
-        "vite-plugin-eslint": "^1.8.1",
+        "vite-plugin-checker": "^0.5.0",
         "vite-svg-loader": "^3.4.0",
         "vue-tsc": "^0.40.1"
       }
@@ -913,19 +913,6 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
@@ -959,22 +946,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@types/circular-json/-/circular-json-0.4.0.tgz",
       "integrity": "sha512-7+kYB7x5a7nFWW1YPBh3KxhwKfiaI4PbZ1RvzBU91LZy7lWJO822CI+pqzSre/DZ7KsCuMKdHnLHHFu8AyXbQg=="
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true
     },
     "node_modules/@types/feather-icons": {
       "version": "4.7.0",
@@ -5222,6 +5193,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5232,6 +5209,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -6900,6 +6883,12 @@
         "globrex": "^0.1.2"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
+      "dev": true
+    },
     "node_modules/tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -7272,19 +7261,60 @@
         }
       }
     },
-    "node_modules/vite-plugin-eslint": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
-      "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
+    "node_modules/vite-plugin-checker": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.5.0.tgz",
+      "integrity": "sha512-IuCHIpnJwRxDupd+jVNwza07+ajt4jFItwWMFEF2cDDp5E92ePx1eVn91JMsa02XkquR1s6L4VZX8/RTFamD9w==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^4.2.1",
-        "@types/eslint": "^8.4.5",
-        "rollup": "^2.77.2"
+        "@babel/code-frame": "^7.12.13",
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.1",
+        "commander": "^8.0.0",
+        "fast-glob": "^3.2.7",
+        "lodash.debounce": "^4.0.8",
+        "lodash.pick": "^4.4.0",
+        "npm-run-path": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "tiny-invariant": "^1.1.0",
+        "vscode-languageclient": "^7.0.0",
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
       },
       "peerDependencies": {
         "eslint": ">=7",
-        "vite": ">=2"
+        "typescript": "*",
+        "vite": "^2.0.0 || ^3.0.0-0",
+        "vls": "*",
+        "vti": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vls": {
+          "optional": true
+        },
+        "vti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-checker/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/vite-svg-loader": {
@@ -7296,6 +7326,69 @@
         "@vue/compiler-sfc": "^3.2.20",
         "svgo": "^2.7.0"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "engines": {
+        "vscode": "^1.52.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "dev": true,
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dev": true,
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+      "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==",
+      "dev": true
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
+      "dev": true
     },
     "node_modules/vue": {
       "version": "3.2.33",
@@ -8302,16 +8395,6 @@
         }
       }
     },
-    "@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      }
-    },
     "@tailwindcss/forms": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
@@ -8339,22 +8422,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@types/circular-json/-/circular-json-0.4.0.tgz",
       "integrity": "sha512-7+kYB7x5a7nFWW1YPBh3KxhwKfiaI4PbZ1RvzBU91LZy7lWJO822CI+pqzSre/DZ7KsCuMKdHnLHHFu8AyXbQg=="
-    },
-    "@types/eslint": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true
     },
     "@types/feather-icons": {
       "version": "4.7.0",
@@ -11384,6 +11451,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11394,6 +11467,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
       "dev": true
     },
     "log-symbols": {
@@ -12588,6 +12667,12 @@
         "globrex": "^0.1.2"
       }
     },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
+      "dev": true
+    },
     "tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -12832,15 +12917,35 @@
         "rollup": "^2.59.0"
       }
     },
-    "vite-plugin-eslint": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
-      "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
+    "vite-plugin-checker": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.5.0.tgz",
+      "integrity": "sha512-IuCHIpnJwRxDupd+jVNwza07+ajt4jFItwWMFEF2cDDp5E92ePx1eVn91JMsa02XkquR1s6L4VZX8/RTFamD9w==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^4.2.1",
-        "@types/eslint": "^8.4.5",
-        "rollup": "^2.77.2"
+        "@babel/code-frame": "^7.12.13",
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.1",
+        "commander": "^8.0.0",
+        "fast-glob": "^3.2.7",
+        "lodash.debounce": "^4.0.8",
+        "lodash.pick": "^4.4.0",
+        "npm-run-path": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "tiny-invariant": "^1.1.0",
+        "vscode-languageclient": "^7.0.0",
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^3.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "dev": true
+        }
       }
     },
     "vite-svg-loader": {
@@ -12852,6 +12957,60 @@
         "@vue/compiler-sfc": "^3.2.20",
         "svgo": "^2.7.0"
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "dev": true
+    },
+    "vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dev": true,
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+      "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
+      "dev": true
     },
     "vue": {
       "version": "3.2.33",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -52,8 +52,8 @@
     "rxjs-spy": "^8.0.2",
     "tailwindcss": "^3.0.24",
     "tinycolor2": "^1.4.2",
-    "typescript": "^4.8.2",
     "tweetnacl-sealedbox-js": "github:systeminit/tweetnacl-sealed-box#master",
+    "typescript": "^4.8.2",
     "validator": "^13.7.0",
     "vue": "^3.2.33",
     "vue-feather": "^2.0.0",
@@ -96,7 +96,7 @@
     "prettier": "~2.6.2",
     "unplugin-icons": "^0.14.8",
     "vite": "^2.9.6",
-    "vite-plugin-eslint": "^1.8.1",
+    "vite-plugin-checker": "^0.5.0",
     "vite-svg-loader": "^3.4.0",
     "vue-tsc": "^0.40.1"
   }

--- a/app/web/src/atoms/SiPanelResizer.vue
+++ b/app/web/src/atoms/SiPanelResizer.vue
@@ -16,7 +16,7 @@
 
 <script setup lang="ts">
 import { DotsVerticalIcon, DotsHorizontalIcon } from "@heroicons/vue/solid";
-import { computed, defineEmits, onBeforeUnmount, ref } from "vue";
+import { computed, onBeforeUnmount, ref } from "vue";
 
 const props = withDefaults(
   defineProps<{

--- a/app/web/src/organisms/Secret/SecretList.vue
+++ b/app/web/src/organisms/Secret/SecretList.vue
@@ -46,7 +46,6 @@ import { from, switchMap } from "rxjs";
 import { Secret } from "@/api/sdf/dal/secret";
 import { SecretService } from "@/service/secret";
 import { GlobalErrorService } from "@/service/global_error";
-import { colors } from "../../utils/design_token_values";
 
 const secrets = refFrom<Secret[] | undefined>(
   SecretService.listSecrets().pipe(

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -8,39 +8,28 @@ import {
 import _ from "lodash";
 import { config } from "@/config";
 import { SessionService } from "@/service/session";
-import NotFoundPage from "@/pages/NotFound.vue";
-import Authenticate from "@/pages/Authenticate.vue";
-import Login from "@/templates/Login.vue";
-import Signup from "@/templates/Signup.vue";
-import Home from "@/pages/Home.vue";
-import WorkspaceSingle from "@/templates/WorkspaceSingle.vue";
-import WorkspaceMultiple from "@/templates/WorkspaceMultiple.vue";
-import WorkspaceRuntime from "@/organisms/Workspace/WorkspaceRuntime.vue";
-import WorkspaceCompose from "@/organisms/Workspace/WorkspaceCompose.vue";
-import WorkspaceLab from "@/organisms/Workspace/WorkspaceLab.vue";
-import DiagramDemoPage from "@/organisms/GenericDiagram/DiagramDemoPage.vue";
 
 const routes: RouteRecordRaw[] = [
   {
     path: "/diagram",
     name: "diagram",
-    component: DiagramDemoPage,
+    component: () => import("@/organisms/GenericDiagram/DiagramDemoPage.vue"),
   },
   {
     path: "/",
     name: "home",
-    component: Home,
+    component: () => import("@/pages/Home.vue"),
     children: [
       {
         path: "w",
         name: "workspace-multiple",
-        component: WorkspaceMultiple,
+        component: () => import("@/templates/WorkspaceMultiple.vue"),
         redirect: { name: "home" },
         children: [
           {
             name: "workspace-single",
             path: ":workspaceId",
-            component: WorkspaceSingle,
+            component: () => import("@/templates/WorkspaceSingle.vue"),
             redirect: { name: "workspace-compose" },
             props: (route) => {
               let workspaceId;
@@ -57,23 +46,27 @@ const routes: RouteRecordRaw[] = [
               {
                 path: "c",
                 name: "workspace-compose",
-                component: WorkspaceCompose,
+                component: () =>
+                  import("@/organisms/Workspace/WorkspaceCompose.vue"),
               },
               {
                 path: "l/:funcId?",
                 name: "workspace-lab",
-                component: WorkspaceLab,
                 props: true,
+                component: () =>
+                  import("@/organisms/Workspace/WorkspaceLab.vue"),
               },
               {
                 path: "v",
                 name: "workspace-view",
-                component: WorkspaceCompose,
+                component: () =>
+                  import("@/organisms/Workspace/WorkspaceCompose.vue"),
               },
               {
                 path: "r",
                 name: "workspace-runtime",
-                component: WorkspaceRuntime,
+                component: () =>
+                  import("@/organisms/Workspace/WorkspaceRuntime.vue"),
               },
             ],
           },
@@ -84,26 +77,26 @@ const routes: RouteRecordRaw[] = [
   {
     path: "/authenticate",
     name: "authenticate",
-    component: Authenticate,
+    component: () => import("@/pages/Authenticate.vue"),
     // redirect: { name: "login" },
     redirect: { name: "signup" },
     children: [
       {
         path: "login",
         name: "login",
-        component: Login,
+        component: () => import("@/templates/Login.vue"),
       },
       {
         path: "signup",
         name: "signup",
-        component: Signup,
+        component: () => import("@/templates/Signup.vue"),
       },
     ],
   },
   {
     path: "/404",
     name: "notFound",
-    component: NotFoundPage,
+    component: () => import("@/pages/NotFound.vue"),
   },
   {
     path: "/:catchAll(.*)",

--- a/app/web/src/utils/typescriptLinter.ts
+++ b/app/web/src/utils/typescriptLinter.ts
@@ -1,4 +1,4 @@
-import ts, { DiagnosticMessageChain, System } from "typescript";
+import { DiagnosticMessageChain, System } from "typescript";
 import {
   createSystem,
   createDefaultMapFromCDN,
@@ -17,6 +17,9 @@ let fsMap: Map<string, string>;
 let vfsSystem: System;
 
 export const createLintSource = async (): Promise<AsyncLintSource> => {
+  // we lazy load typescript to help speed things up
+  const ts = await import("typescript");
+
   if (!fsMap && !vfsSystem) {
     fsMap = await createDefaultMapFromCDN(
       { target: ts.ScriptTarget.ES2015 },

--- a/app/web/tsconfig.node.json
+++ b/app/web/tsconfig.node.json
@@ -3,7 +3,13 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["vite.config.ts", ".eslintrc.js", "./*.mjs"]
+  "include": [
+    "vite.config.ts",
+    ".eslintrc.js",
+    "package.json",
+    "./*.mjs"
+  ]
 }

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -1,9 +1,10 @@
 import path from "path";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-import eslintPlugin from "vite-plugin-eslint";
+import checkerPlugin from "vite-plugin-checker";
 import svgLoaderPlugin from "vite-svg-loader";
 import IconsPlugin from "unplugin-icons/vite";
+import packageJson from "./package.json";
 
 import postcss from "./postcss.config.mjs";
 
@@ -13,7 +14,12 @@ export default defineConfig({
     vue(),
     svgLoaderPlugin(),
     IconsPlugin({ compiler: "vue3" }),
-    eslintPlugin(),
+    checkerPlugin({
+      vueTsc: true,
+      eslint: {
+        lintCommand: packageJson.scripts.lint,
+      },
+    }),
   ],
   css: {
     postcss,


### PR DESCRIPTION
🚀  zoom zoom. Much much faster.

The main problem was actually `vite-plugin-eslint`, which had been made much worse by all the new rules I added recently. This plugin has been replaced by [vite-plugin-checker](https://github.com/fi3ework/vite-plugin-checker) which seems to work much better anyway.

While investigating, I also set up route-level code splitting (each route is lazy loaded) and I'm specifically lazy loading typescript, since it's massive. We'll likely need some further adjustments for doing production builds, but all this stuff should help!

