### PR TITLE
feat(dal,sdf,si-data): introduce "cloneable" Postgres transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-postgres",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -28,7 +28,6 @@ telemetry = { path = "../../lib/telemetry-rs" }
 tempfile = "3.2.0"
 thiserror = "1.0.24"
 tokio = { version = "1.2.0", features = ["full"] }
-tokio-postgres = { version = "0.7.0", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.3"
 url = "2.2.2"
 uuid = { version = "1.0.0", features = ["v4"] }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -145,7 +145,7 @@ impl AttributePrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
         func_binding_return_value_id: FuncBindingReturnValueId,
@@ -233,7 +233,7 @@ impl AttributePrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new_with_existing_value(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         context: AttributeContext,
         key: Option<String>,
@@ -293,7 +293,7 @@ impl AttributePrototype {
     /// Caution: this should be used rather than [`StandardModel::delete()`] when deleting an
     /// [`AttributePrototype`]. That method should never be called directly.
     pub async fn remove(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: &AttributePrototypeId,
     ) -> AttributePrototypeResult<()> {
         // Get the prototype for the given id. Once we get its corresponding value, we can delete
@@ -367,7 +367,7 @@ impl AttributePrototype {
 
     #[instrument(skip_all)]
     pub async fn list_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeContext,
     ) -> AttributePrototypeResult<Vec<Self>> {
         let rows = ctx
@@ -389,7 +389,7 @@ impl AttributePrototype {
 
     #[tracing::instrument(skip_all)]
     pub async fn find_with_parent_value_and_key_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value_id: Option<AttributeValueId>,
         key: Option<String>,
         context: AttributeContext,
@@ -414,7 +414,7 @@ impl AttributePrototype {
 
     /// List [`Vec<Self>`] that depend on a provided [`InternalProviderId`](crate::InternalProvider).
     pub async fn list_from_internal_provider_use(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         internal_provider_id: InternalProviderId,
     ) -> AttributePrototypeResult<Vec<Self>> {
         let rows = ctx
@@ -430,7 +430,7 @@ impl AttributePrototype {
     /// List [`Vec<Self>`] that depend on a provided [`ExternalProviderId`](crate::ExternalProvider)
     /// and _tail_ [`ComponentId`](crate::Component).
     pub async fn list_by_head_from_external_provider_use_with_tail(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         external_provider_id: ExternalProviderId,
         tail_component_id: ComponentId,
     ) -> AttributePrototypeResult<Vec<AttributePrototypeGroupByHeadComponentId>> {
@@ -466,7 +466,7 @@ impl AttributePrototype {
     /// and whose context contains the provided [`AttributeReadContext`](crate::AttributeReadContext)
     /// or are "more-specific" than the provided [`AttributeReadContext`](crate::AttributeReadContext).
     pub async fn attribute_values_in_context_or_greater(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         context: AttributeReadContext,
     ) -> AttributePrototypeResult<Vec<AttributeValue>> {
@@ -489,7 +489,7 @@ impl AttributePrototype {
     #[allow(clippy::too_many_arguments)]
     #[async_recursion]
     async fn create_intermediate_proxy_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value_id: Option<AttributeValueId>,
         prototype_id: AttributePrototypeId,
         context: AttributeContext,
@@ -554,7 +554,7 @@ impl AttributePrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn update_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         context: AttributeContext,
         func_id: FuncId,

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -96,7 +96,7 @@ impl AttributePrototypeArgument {
     #[instrument(skip_all)]
     /// Create a new [`AttributePrototypeArgument`] for _intra_ [`Component`](crate::Component) use.
     pub async fn new_for_intra_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         name: impl AsRef<str>,
         internal_provider_id: InternalProviderId,
@@ -133,7 +133,7 @@ impl AttributePrototypeArgument {
     /// Create a new [`AttributePrototypeArgument`] for _inter_ [`Component`](crate::Component) use.
     #[instrument(skip_all)]
     pub async fn new_for_inter_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         name: impl AsRef<str>,
         head_component_id: ComponentId,
@@ -204,7 +204,7 @@ impl AttributePrototypeArgument {
     /// cannot become unset and vice versa.
     pub async fn set_internal_provider_id_safe(
         mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         internal_provider_id: InternalProviderId,
     ) -> AttributePrototypeArgumentResult<()> {
         if self.internal_provider_id != UNSET_ID_VALUE.into()
@@ -230,7 +230,7 @@ impl AttributePrototypeArgument {
     /// cannot become unset and vice versa.
     pub async fn set_external_provider_id_safe(
         mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         external_provider_id: ExternalProviderId,
     ) -> AttributePrototypeArgumentResult<()> {
         if self.external_provider_id != UNSET_ID_VALUE.into()
@@ -256,7 +256,7 @@ impl AttributePrototypeArgument {
     /// cannot become unset and vice versa.
     pub async fn set_tail_component_id_safe(
         mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         tail_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<()> {
         if self.tail_component_id != UNSET_ID_VALUE.into()
@@ -281,7 +281,7 @@ impl AttributePrototypeArgument {
     /// cannot become unset and vice versa.
     pub async fn set_head_component_id_safe(
         mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         head_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<()> {
         if self.head_component_id != UNSET_ID_VALUE.into()
@@ -312,7 +312,7 @@ impl AttributePrototypeArgument {
     /// [`AttributePrototype`](crate::AttributePrototype).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
     ) -> AttributePrototypeArgumentResult<Vec<Self>> {
         let rows = ctx
@@ -336,7 +336,7 @@ impl AttributePrototypeArgument {
     /// the same "name" sharing the same name.
     #[tracing::instrument(skip(ctx))]
     pub async fn list_by_name_for_attribute_prototype_and_head_component_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         head_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<Vec<AttributePrototypeArgumentGroup>> {

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -227,7 +227,7 @@ impl_standard_model! {
 impl AttributeValue {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_binding_id: FuncBindingId,
         func_binding_return_value_id: FuncBindingReturnValueId,
         context: AttributeContext,
@@ -318,7 +318,7 @@ impl AttributeValue {
 
     pub async fn set_parent_attribute_value(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         belongs_to_id: &AttributeValueId,
     ) -> AttributeValueResult<()> {
         if let Some(potential_duplicate) = Self::find_with_parent_and_key_for_context(
@@ -350,7 +350,7 @@ impl AttributeValue {
     /// corresponding to the field on [`Self`].
     pub async fn get_value(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> AttributeValueResult<Option<serde_json::Value>> {
         match FuncBindingReturnValue::get_by_id(ctx, &self.func_binding_return_value_id).await? {
             Some(func_binding_return_value) => Ok(func_binding_return_value.value().cloned()),
@@ -360,7 +360,7 @@ impl AttributeValue {
 
     pub async fn update_stored_index_map(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> AttributeValueResult<()> {
         standard_model::update(
             ctx,
@@ -377,7 +377,7 @@ impl AttributeValue {
     /// Returns a list of child [`AttributeValues`](crate::AttributeValue) for a given
     /// [`AttributeValue`] and [`AttributeReadContext`](crate::AttributeReadContext).
     pub async fn child_attribute_values_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         attribute_read_context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<Self>> {
@@ -398,7 +398,7 @@ impl AttributeValue {
     }
 
     async fn child_attribute_values_for_exact_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         attribute_read_context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<Self>> {
@@ -418,7 +418,7 @@ impl AttributeValue {
         Ok(standard_model::objects_from_rows(rows)?)
     }
     pub async fn find_with_parent_and_prototype_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value_id: Option<AttributeValueId>,
         attribute_prototype_id: AttributePrototypeId,
         context: AttributeContext,
@@ -443,7 +443,7 @@ impl AttributeValue {
 
     /// Find [`Self`] with a given parent value and key.
     pub async fn find_with_parent_and_key_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value_id: Option<AttributeValueId>,
         key: Option<String>,
         context: AttributeReadContext,
@@ -477,7 +477,7 @@ impl AttributeValue {
     /// object themselves! For those objects, please use
     /// [`Self::find_with_parent_and_key_for_context()`].
     pub async fn list_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<Self>> {
         let rows = ctx
@@ -504,7 +504,7 @@ impl AttributeValue {
     /// object themselves! For those objects, please use
     /// [`Self::find_with_parent_and_key_for_context()`].
     pub async fn find_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeReadContext,
     ) -> AttributeValueResult<Option<Self>> {
         AttributeContextBuilder::from(context).to_context()?;
@@ -523,7 +523,7 @@ impl AttributeValue {
     /// Return the [`Prop`] that the [`AttributeValueId`] belongs to,
     /// following the relationship through [`AttributePrototype`].
     pub async fn find_prop_for_value(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<Prop> {
         let row = ctx
@@ -539,7 +539,7 @@ impl AttributeValue {
     }
 
     pub async fn list_payload_for_read_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<AttributeValuePayload>> {
         let schema_variant_id = if let Some(schema_variant_id) = context.schema_variant_id() {
@@ -597,7 +597,7 @@ impl AttributeValue {
     /// - [`PropId`](crate::Prop) must be set to [`None`]
     /// - Both providers fields must be unset
     pub async fn list_payload_for_read_context_and_root(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         root_attribute_value_id: AttributeValueId,
         context: AttributeReadContext,
     ) -> AttributeValueResult<Vec<AttributeValuePayload>> {
@@ -662,7 +662,7 @@ impl AttributeValue {
     /// - the [`Option<serde_json::Value>`] that was passed in
     /// - the updated [`AttributeValueId`](Self)
     pub async fn update_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         parent_attribute_value_id: Option<AttributeValueId>,
         context: AttributeContext,
@@ -683,7 +683,7 @@ impl AttributeValue {
     }
 
     pub async fn update_for_context_without_creating_proxies(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         parent_attribute_value_id: Option<AttributeValueId>,
         context: AttributeContext,
@@ -704,7 +704,7 @@ impl AttributeValue {
     }
 
     async fn update_for_context_raw(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         parent_attribute_value_id: Option<AttributeValueId>,
         context: AttributeContext,
@@ -940,7 +940,7 @@ impl AttributeValue {
     /// [`AttributeValue`] to use.
     #[instrument(skip_all)]
     pub async fn insert_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_context: AttributeContext,
         parent_attribute_value_id: AttributeValueId,
         value: Option<serde_json::Value>,
@@ -959,7 +959,7 @@ impl AttributeValue {
 
     #[instrument(skip_all)]
     pub async fn insert_for_context_without_creating_proxies(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_context: AttributeContext,
         parent_attribute_value_id: AttributeValueId,
         value: Option<serde_json::Value>,
@@ -978,7 +978,7 @@ impl AttributeValue {
 
     #[instrument(skip_all)]
     async fn insert_for_context_raw(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_context: AttributeContext,
         parent_attribute_value_id: AttributeValueId,
         value: Option<serde_json::Value>,
@@ -1110,7 +1110,7 @@ impl AttributeValue {
     #[instrument(skip_all)]
     pub async fn update_parent_index_map(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> AttributeValueResult<()> {
         if let Some(mut parent_value) = self.parent_attribute_value(ctx).await? {
             let parent_prop = Prop::get_by_id(ctx, &parent_value.context.prop_id())
@@ -1141,7 +1141,7 @@ impl AttributeValue {
     #[instrument(skip_all)]
     #[async_recursion]
     async fn vivify_value_and_parent_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<AttributeValueId> {
@@ -1151,7 +1151,7 @@ impl AttributeValue {
     #[instrument(skip_all)]
     #[async_recursion]
     async fn vivify_value_and_parent_values_without_child_proxies(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<AttributeValueId> {
@@ -1161,7 +1161,7 @@ impl AttributeValue {
     #[instrument(skip_all)]
     #[async_recursion]
     async fn vivify_value_and_parent_values_raw(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeContext,
         attribute_value_id: AttributeValueId,
         create_child_proxies: bool,
@@ -1230,7 +1230,7 @@ impl AttributeValue {
 
     #[async_recursion]
     async fn populate_child_proxies_for_value(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         original_attribute_value_id: AttributeValueId,
         previous_write_context: AttributeContext,
         attribute_value_id: AttributeValueId,
@@ -1317,7 +1317,7 @@ impl AttributeValue {
 
     #[async_recursion]
     async fn populate_nested_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value_id: AttributeValueId,
         update_context: AttributeContext,
         mut unprocessed_value: serde_json::Value,
@@ -1486,7 +1486,7 @@ impl AttributeValue {
 
     #[async_recursion]
     async fn remove_value_and_children(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_attribute_value: AttributeValue,
     ) -> AttributeValueResult<()> {
         let child_values = parent_attribute_value.child_attribute_values(ctx).await?;
@@ -1528,7 +1528,7 @@ impl AttributeValue {
         Ok(())
     }
 
-    async fn remove_proxies(&self, ctx: &DalContext<'_, '_>) -> AttributeValueResult<()> {
+    async fn remove_proxies(&self, ctx: &DalContext<'_, '_, '_>) -> AttributeValueResult<()> {
         let _row = ctx
             .txns()
             .pg()
@@ -1600,7 +1600,7 @@ fn as_type<T: serde::de::DeserializeOwned>(json: serde_json::Value) -> Attribute
 }
 
 async fn set_value(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     func_name: &str,
     args: serde_json::Value,
 ) -> AttributeValueResult<(Func, FuncBinding, FuncBindingReturnValue)> {
@@ -1668,7 +1668,7 @@ impl DependentValuesAsyncTasks {
         Ok(())
     }
 
-    pub async fn run_in_ctx(&self, ctx: &DalContext<'_, '_>) -> AttributeValueResult<()> {
+    pub async fn run_in_ctx(&self, ctx: &DalContext<'_, '_, '_>) -> AttributeValueResult<()> {
         // After we have _completely_ updated ourself, we can update our dependent values.
         AttributeValueDependentUpdateHarness::update_dependent_values(ctx, self.attribute_value_id)
             .await?;
@@ -1695,7 +1695,7 @@ pub struct DependentValuesUpdated {
 
 impl WsEvent {
     pub fn updated_dependent_value(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> Self {

--- a/lib/dal/src/attribute/value/dependent_update.rs
+++ b/lib/dal/src/attribute/value/dependent_update.rs
@@ -27,7 +27,7 @@ impl AttributeValueDependentUpdateHarness {
     /// Update dependent_update [`AttributeValues`](crate::AttributeValue) for an updated
     /// [`AttributeValueId`](crate::AttributeValue).
     pub async fn update_dependent_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id_to_update: AttributeValueId,
     ) -> AttributeValueResult<()> {
         let mut attribute_value_that_needs_to_be_updated =
@@ -192,7 +192,7 @@ impl AttributeValueDependentUpdateHarness {
     /// [`AttributePrototypeArgument`](crate::AttributePrototypeArgument) and context of the
     /// [`AttributeValue`] that needs to be updated.
     async fn build_func_binding_argument_value_from_attribute_prototype_argument(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_argument: AttributePrototypeArgument,
         attribute_value_context: AttributeContext,
     ) -> AttributeValueResult<Option<serde_json::Value>> {

--- a/lib/dal/src/attribute/value/dependent_update/collection.rs
+++ b/lib/dal/src/attribute/value/dependent_update/collection.rs
@@ -21,7 +21,7 @@ impl AttributeValueDependentCollectionHarness {
     /// [`AttributeValue`](crate::AttributeValue) (which is where the source
     /// [`AttributeContext`](crate::AttributeContext) is derived from).
     pub async fn collect(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         source_attribute_context: AttributeContext,
     ) -> AttributeValueResult<Vec<AttributeValue>> {
         match source_attribute_context.least_specific_field_kind()? {
@@ -49,7 +49,7 @@ impl AttributeValueDependentCollectionHarness {
     /// provided source [`AttributeContext`](crate::AttributeContext) whose least specific field
     /// specified is a [`PropId`](crate::Prop).
     async fn collect_for_least_specific_kind_prop(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         source_attribute_context: AttributeContext,
     ) -> AttributeValueResult<Vec<AttributeValue>> {
         let mut attribute_values_that_need_to_be_updated = Vec::new();
@@ -113,7 +113,7 @@ impl AttributeValueDependentCollectionHarness {
     /// provided source [`AttributeContext`](crate::AttributeContext) whose least specific field
     /// specified is an [`InternalProviderId`](crate::InternalProvider).
     async fn collect_for_least_specific_kind_internal_provider(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         source_attribute_context: AttributeContext,
     ) -> AttributeValueResult<Vec<AttributeValue>> {
         let mut attribute_values_that_need_to_be_updated = Vec::new();
@@ -191,7 +191,7 @@ impl AttributeValueDependentCollectionHarness {
     /// provided source [`AttributeContext`](crate::AttributeContext) whose least specific field
     /// specified is an [`ExternalProviderId`](crate::ExternalProvider).
     async fn collect_for_least_specific_kind_external_provider(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         source_attribute_context: AttributeContext,
     ) -> AttributeValueResult<Vec<AttributeValue>> {
         let mut attribute_values_that_need_to_be_updated = Vec::new();
@@ -248,7 +248,7 @@ impl AttributeValueDependentCollectionHarness {
     /// the provided [`AttributePrototypes`](crate::AttributePrototype) and the source
     /// [`AttributeContext`](crate::AttributeContext).
     async fn find_or_create_attribute_values_that_need_to_be_updated(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototypes: Vec<AttributePrototype>,
         source_attribute_context: AttributeContext,
     ) -> AttributeValueResult<Vec<AttributeValue>> {

--- a/lib/dal/src/attribute/value/view.rs
+++ b/lib/dal/src/attribute/value/view.rs
@@ -33,7 +33,7 @@ impl AttributeView {
     /// the [`SchemaVariant`](crate::SchemaVariant) is known and you only desire to generate a view
     /// for the entire value, you do not need to provide the root.
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_read_context: AttributeReadContext,
         root_attribute_value_id: Option<AttributeValueId>,
     ) -> AttributeValueResult<Self> {

--- a/lib/dal/src/billing_account.rs
+++ b/lib/dal/src/billing_account.rs
@@ -89,7 +89,7 @@ impl_standard_model! {
 impl BillingAccount {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         description: Option<&String>,
     ) -> BillingAccountResult<Self> {
@@ -134,7 +134,7 @@ impl BillingAccount {
     );
 
     pub async fn signup(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         billing_account_name: impl AsRef<str>,
         user_name: impl AsRef<str>,
         user_email: impl AsRef<str>,
@@ -214,7 +214,7 @@ impl BillingAccount {
     }
 
     pub async fn find_by_name(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
     ) -> BillingAccountResult<Option<BillingAccount>> {
         let name = name.as_ref();
@@ -231,7 +231,7 @@ impl BillingAccount {
     }
 
     pub async fn get_defaults(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         id: &BillingAccountId,
     ) -> BillingAccountResult<BillingAccountDefaults> {
         let row = ctx

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -87,7 +87,7 @@ pub enum BuiltinsError {
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;
 
 /// Migrate all "builtin" [`Funcs`](crate::Func) and [`Schemas`](crate::Schema) (in that order).
-pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     func::migrate(ctx).await?;
     schema::migrate(ctx).await?;
     workflow::migrate(ctx).await?;

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -27,7 +27,7 @@ struct FunctionMetadata {
 /// A private constant representing "/si/lib/dal".
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
-pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let extension_regex = Regex::new(r#"(?P<name>.*)\.(?P<extension>.*)"#)?;
     let mut path = PathBuf::from(CARGO_MANIFEST_DIR);
     path.push("src/builtins/func");

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -36,7 +36,7 @@ mod kubernetes_template;
 
 use self::kubernetes_deployment::kubernetes_deployment;
 
-pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     system(ctx).await?;
     kubernetes_deployment(ctx).await?;
     kubernetes_namespace(ctx).await?;
@@ -46,7 +46,7 @@ pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     Ok(())
 }
 
-async fn system(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+async fn system(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let name = "system".to_string();
     let mut schema = match create_schema(ctx, &name, &SchemaKind::System).await? {
         Some(schema) => schema,
@@ -79,7 +79,7 @@ async fn system(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     Ok(())
 }
 
-async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+async fn kubernetes_namespace(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let name = "kubernetes_namespace".to_string();
     let mut schema = match create_schema(ctx, &name, &SchemaKind::Configuration).await? {
         Some(schema) => schema,
@@ -232,7 +232,7 @@ async fn kubernetes_namespace(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     Ok(())
 }
 
-async fn docker_hub_credential(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+async fn docker_hub_credential(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let name = "docker_hub_credential".to_string();
     let mut schema = match create_schema(ctx, &name, &SchemaKind::Configuration).await? {
         Some(schema) => schema,
@@ -310,7 +310,7 @@ async fn docker_hub_credential(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
     Ok(())
 }
 
-async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+async fn docker_image(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let name = "docker_image".to_string();
     let mut schema = match create_schema(ctx, &name, &SchemaKind::Configuration).await? {
         Some(schema) => schema,
@@ -493,7 +493,7 @@ async fn docker_image(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
 }
 
 async fn create_schema(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     schema_name: &str,
     schema_kind: &SchemaKind,
 ) -> BuiltinsResult<Option<Schema>> {
@@ -522,7 +522,7 @@ async fn create_schema(
 /// only used when a parent [`PropId`] is provided.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     prop_name: &str,
     prop_kind: PropKind,
     parent_prop_id: Option<PropId>,
@@ -535,7 +535,7 @@ pub async fn create_prop(
 }
 
 pub async fn create_string_prop_with_default(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     prop_name: &str,
     default_string: String,
     parent_prop_id: Option<PropId>,
@@ -605,7 +605,7 @@ pub async fn create_string_prop_with_default(
 
 /// Get the "si:identity" [`Func`](crate::Func) and execute (if necessary).
 pub async fn setup_identity_func(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> BuiltinsResult<(FuncId, FuncBindingId, FuncBindingReturnValueId)> {
     let identity_func_name = "si:identity".to_string();
     let identity_func: Func = Func::find_by_attr(ctx, "name", &identity_func_name)
@@ -630,7 +630,7 @@ pub async fn setup_identity_func(
 ///
 /// _Use with caution!_
 pub async fn find_child_prop_by_name(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     prop_id: PropId,
     child_prop_name: &str,
 ) -> BuiltinsResult<Prop> {

--- a/lib/dal/src/builtins/schema/kubernetes_deployment.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_deployment.rs
@@ -20,7 +20,7 @@ use super::{
     setup_identity_func,
 };
 
-pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let name = "kubernetes_deployment".to_string();
     let mut schema = match create_schema(ctx, &name, &SchemaKind::Configuration).await? {
         Some(schema) => schema,
@@ -292,7 +292,7 @@ pub async fn kubernetes_deployment(ctx: &DalContext<'_, '_>) -> BuiltinsResult<(
 }
 
 async fn create_deployment_spec_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut spec_prop = create_prop(ctx, "spec", PropKind::Object, Some(parent_prop_id)).await?;
@@ -323,7 +323,7 @@ async fn create_deployment_spec_prop(
 }
 
 async fn create_pod_template_spec_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut template_prop =
@@ -350,7 +350,7 @@ async fn create_pod_template_spec_prop(
 }
 
 async fn create_pod_spec_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut spec_prop = create_prop(ctx, "spec", PropKind::Object, Some(parent_prop_id)).await?;
@@ -379,7 +379,7 @@ async fn create_pod_spec_prop(
 }
 
 async fn create_container_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut container_prop =
@@ -431,7 +431,7 @@ async fn create_container_prop(
 }
 
 async fn create_container_port_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut port_prop = create_prop(ctx, "port", PropKind::Object, Some(parent_prop_id)).await?;

--- a/lib/dal/src/builtins/schema/kubernetes_metadata.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_metadata.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::kubernetes::doc_url;
 
 pub async fn create_metadata_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     is_name_required: bool,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {

--- a/lib/dal/src/builtins/schema/kubernetes_selector.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_selector.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::kubernetes::doc_url;
 
 pub async fn create_selector_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let mut selector_prop =

--- a/lib/dal/src/builtins/schema/kubernetes_spec.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_spec.rs
@@ -5,7 +5,7 @@ use crate::{
 
 #[allow(dead_code)]
 pub async fn create_spec_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: PropId,
 ) -> BuiltinsResult<Prop> {
     let spec_prop = create_prop(ctx, "spec", PropKind::Object, Some(parent_prop_id)).await?;

--- a/lib/dal/src/builtins/schema/kubernetes_template.rs
+++ b/lib/dal/src/builtins/schema/kubernetes_template.rs
@@ -12,7 +12,7 @@ use crate::{
 #[allow(clippy::too_many_arguments)]
 #[allow(dead_code)]
 pub async fn create_template_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     parent_prop_id: Option<PropId>,
 ) -> BuiltinsResult<Prop> {
     let template_prop = create_prop(ctx, "template", PropKind::Object, parent_prop_id).await?;

--- a/lib/dal/src/builtins/workflow.rs
+++ b/lib/dal/src/builtins/workflow.rs
@@ -3,12 +3,12 @@ use crate::{
     WorkflowPrototypeContext,
 };
 
-pub async fn migrate(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     poem(ctx).await?;
     Ok(())
 }
 
-async fn poem(ctx: &DalContext<'_, '_>) -> BuiltinsResult<()> {
+async fn poem(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     let func_name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &func_name)
         .await?

--- a/lib/dal/src/capability.rs
+++ b/lib/dal/src/capability.rs
@@ -55,7 +55,7 @@ impl_standard_model! {
 impl Capability {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         subject: impl AsRef<str>,
         action: impl AsRef<str>,
     ) -> CapabilityResult<Self> {

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -68,7 +68,7 @@ pub struct ChangeSet {
 impl ChangeSet {
     #[instrument(skip(ctx, name, note))]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         note: Option<&String>,
     ) -> ChangeSetResult<Self> {
@@ -98,7 +98,7 @@ impl ChangeSet {
     }
 
     #[instrument(skip(ctx))]
-    pub async fn apply(&mut self, ctx: &DalContext<'_, '_>) -> ChangeSetResult<()> {
+    pub async fn apply(&mut self, ctx: &DalContext<'_, '_, '_>) -> ChangeSetResult<()> {
         let actor = serde_json::to_value(ctx.history_actor())?;
         let row = ctx
             .txns()
@@ -123,7 +123,9 @@ impl ChangeSet {
     }
 
     #[instrument(skip_all)]
-    pub async fn list_open(ctx: &DalContext<'_, '_>) -> ChangeSetResult<LabelList<ChangeSetPk>> {
+    pub async fn list_open(
+        ctx: &DalContext<'_, '_, '_>,
+    ) -> ChangeSetResult<LabelList<ChangeSetPk>> {
         let rows = ctx
             .txns()
             .pg()
@@ -135,7 +137,7 @@ impl ChangeSet {
 
     #[instrument(skip_all)]
     pub async fn get_by_pk(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         pk: &ChangeSetPk,
     ) -> ChangeSetResult<Option<ChangeSet>> {
         let row = ctx
@@ -149,19 +151,19 @@ impl ChangeSet {
 }
 
 impl WsEvent {
-    pub fn change_set_created(ctx: &DalContext<'_, '_>, change_set: &ChangeSet) -> Self {
+    pub fn change_set_created(ctx: &DalContext<'_, '_, '_>, change_set: &ChangeSet) -> Self {
         WsEvent::new(ctx, WsPayload::ChangeSetCreated(change_set.pk))
     }
 
-    pub fn change_set_applied(ctx: &DalContext<'_, '_>, change_set: &ChangeSet) -> Self {
+    pub fn change_set_applied(ctx: &DalContext<'_, '_, '_>, change_set: &ChangeSet) -> Self {
         WsEvent::new(ctx, WsPayload::ChangeSetApplied(change_set.pk))
     }
 
-    pub fn change_set_canceled(ctx: &DalContext<'_, '_>, change_set: &ChangeSet) -> Self {
+    pub fn change_set_canceled(ctx: &DalContext<'_, '_, '_>, change_set: &ChangeSet) -> Self {
         WsEvent::new(ctx, WsPayload::ChangeSetCanceled(change_set.pk))
     }
 
-    pub fn change_set_written(ctx: &DalContext<'_, '_>) -> Self {
+    pub fn change_set_written(ctx: &DalContext<'_, '_, '_>) -> Self {
         WsEvent::new(
             ctx,
             WsPayload::ChangeSetWritten(ctx.visibility().change_set_pk),

--- a/lib/dal/src/code_generation_prototype.rs
+++ b/lib/dal/src/code_generation_prototype.rs
@@ -133,7 +133,7 @@ impl CodeGenerationPrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         args: serde_json::Value,
         format: CodeLanguage,
@@ -162,7 +162,7 @@ impl CodeGenerationPrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/code_generation_resolver.rs
+++ b/lib/dal/src/code_generation_resolver.rs
@@ -126,7 +126,7 @@ impl CodeGenerationResolver {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         code_generation_prototype_id: CodeGenerationPrototypeId,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
@@ -162,7 +162,7 @@ impl CodeGenerationResolver {
     );
 
     pub async fn find_for_prototype_and_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         code_generation_prototype_id: &CodeGenerationPrototypeId,
         component_id: &ComponentId,
     ) -> CodeGenerationResolverResult<Vec<Self>> {
@@ -193,7 +193,7 @@ pub struct CodeGenerationId {
 
 impl WsEvent {
     pub fn code_generated(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> Self {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -243,7 +243,7 @@ impl_standard_model! {
 impl Component {
     #[instrument(skip_all)]
     pub async fn new_for_schema_with_node(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         schema_id: &SchemaId,
     ) -> ComponentResult<(Self, Node)> {
@@ -260,7 +260,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn new_for_schema_variant_with_node(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         schema_variant_id: &SchemaVariantId,
     ) -> ComponentResult<(Self, Node)> {
@@ -306,7 +306,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn add_to_system(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<(EdgeId, ResourceId)> {
         let system_sockets =
@@ -378,7 +378,7 @@ impl Component {
     /// [`SocketEdgeKind`](crate::socket::SocketEdgeKind).
     #[instrument(skip_all)]
     pub async fn list_sockets_for_kind(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         socket_edge_kind: SocketEdgeKind,
     ) -> ComponentResult<Vec<Socket>> {
@@ -401,7 +401,7 @@ impl Component {
     /// Find [`Self`] with a provided [`NodeId`](crate::Node).
     #[instrument(skip_all)]
     pub async fn find_for_node(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         node_id: NodeId,
     ) -> ComponentResult<Option<Self>> {
         let row = ctx
@@ -417,7 +417,7 @@ impl Component {
 
     pub async fn check_validations(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
         value: &Option<serde_json::Value>,
     ) -> ComponentResult<()> {
@@ -488,7 +488,7 @@ impl Component {
     /// just a placeholder for some qualification that will be executed.
     pub async fn prepare_qualification_check(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
         qualification_prototype_id: QualificationPrototypeId,
     ) -> ComponentResult<()> {
@@ -558,7 +558,7 @@ impl Component {
     /// just a placeholder for some qualification that will be executed.
     pub async fn prepare_qualifications_check(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<()> {
         let schema = self
@@ -646,7 +646,7 @@ impl Component {
 
     pub async fn check_qualification(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
         prototype_id: QualificationPrototypeId,
     ) -> ComponentResult<()> {
@@ -708,7 +708,7 @@ impl Component {
 
     pub async fn check_qualifications(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<()> {
         let schema = self
@@ -796,7 +796,7 @@ impl Component {
     /// it's just a placeholder for some code generation that will be executed.
     pub async fn prepare_code_generation(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<()> {
         let schema = self
@@ -884,7 +884,7 @@ impl Component {
 
     pub async fn generate_code(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<()> {
         let schema = self
@@ -969,7 +969,10 @@ impl Component {
     }
 
     #[instrument(skip_all)]
-    pub async fn is_in_tenancy(ctx: &DalContext<'_, '_>, id: ComponentId) -> ComponentResult<bool> {
+    pub async fn is_in_tenancy(
+        ctx: &DalContext<'_, '_, '_>,
+        id: ComponentId,
+    ) -> ComponentResult<bool> {
         let row = ctx
             .pg_txn()
             .query_opt(
@@ -986,7 +989,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn list_validations_as_qualification_for_component_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<QualificationView> {
@@ -1001,7 +1004,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn list_code_generated_by_component_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<Vec<CodeView>> {
@@ -1060,7 +1063,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn list_qualifications(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<Vec<QualificationView>> {
         Self::list_qualifications_by_component_id(ctx, *self.id(), system_id).await
@@ -1068,7 +1071,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn list_qualifications_by_component_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<Vec<QualificationView>> {
@@ -1150,7 +1153,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn get_resource_by_component_and_system(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<Option<ResourceView>> {
@@ -1186,7 +1189,7 @@ impl Component {
 
     pub async fn veritech_code_generation_component(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<ComponentView> {
         let schema = self
@@ -1212,7 +1215,7 @@ impl Component {
 
     pub async fn veritech_resource_sync_component(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<ComponentView> {
         let schema = self
@@ -1238,7 +1241,7 @@ impl Component {
 
     pub async fn veritech_qualification_check_component(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<veritech::QualificationCheckComponent> {
         let schema = self
@@ -1288,7 +1291,7 @@ impl Component {
 
     #[instrument(skip_all)]
     pub async fn list_for_schema_variant(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> ComponentResult<Vec<Component>> {
         let rows = ctx
@@ -1330,7 +1333,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn sync_resource(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: SystemId,
     ) -> ComponentResult<()> {
         // Note(paulo): we don't actually care about the Resource here, we only care about the ResourcePrototype, is this wrong?
@@ -1414,7 +1417,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn set_value_by_json_pointer<T: Serialize + std::fmt::Debug + std::clone::Clone>(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         json_pointer: &str,
         value: Option<T>,
     ) -> ComponentResult<Option<T>> {
@@ -1468,7 +1471,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn find_prop_by_json_pointer(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         json_pointer: &str,
     ) -> ComponentResult<Option<Prop>> {
         let schema_variant = self
@@ -1502,7 +1505,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn find_attribute_value_by_json_pointer(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         json_pointer: &str,
     ) -> ComponentResult<Option<AttributeValue>> {
         if let Some(prop) = self.find_prop_by_json_pointer(ctx, json_pointer).await? {
@@ -1537,7 +1540,7 @@ impl Component {
     #[instrument(skip_all)]
     pub async fn find_value_by_json_pointer<T: serde::de::DeserializeOwned + std::fmt::Debug>(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         json_pointer: &str,
     ) -> ComponentResult<Option<T>> {
         let schema = self

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -34,8 +34,8 @@ pub struct ComponentDiff {
 
 impl ComponentDiff {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
-        head_ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
+        head_ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
     ) -> ComponentResult<Self> {
         if ctx.visibility().is_head() || !head_ctx.visibility().is_head() {

--- a/lib/dal/src/component/stats.rs
+++ b/lib/dal/src/component/stats.rs
@@ -2,9 +2,9 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use si_data::PgRow;
 use strum_macros::{AsRefStr, Display, EnumString};
 use telemetry::prelude::*;
-use tokio_postgres::Row;
 
 use crate::component::ComponentResult;
 use crate::{ComponentId, DalContext};
@@ -22,7 +22,7 @@ pub struct ComponentStats {
 }
 
 impl ComponentStats {
-    pub async fn new(ctx: &DalContext<'_, '_>) -> ComponentResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>) -> ComponentResult<Self> {
         let component_stats = if ctx.visibility().is_head() {
             Self::default()
         } else {
@@ -40,7 +40,7 @@ impl ComponentStats {
     }
 
     #[instrument(skip_all)]
-    async fn list_added(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentStatsGroup>> {
+    async fn list_added(ctx: &DalContext<'_, '_, '_>) -> ComponentResult<Vec<ComponentStatsGroup>> {
         let rows = ctx
             .txns()
             .pg()
@@ -53,7 +53,9 @@ impl ComponentStats {
     }
 
     #[instrument(skip_all)]
-    async fn list_deleted(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentStatsGroup>> {
+    async fn list_deleted(
+        ctx: &DalContext<'_, '_, '_>,
+    ) -> ComponentResult<Vec<ComponentStatsGroup>> {
         let rows = ctx
             .txns()
             .pg()
@@ -66,7 +68,9 @@ impl ComponentStats {
     }
 
     #[instrument(skip_all)]
-    async fn list_modified(ctx: &DalContext<'_, '_>) -> ComponentResult<Vec<ComponentStatsGroup>> {
+    async fn list_modified(
+        ctx: &DalContext<'_, '_, '_>,
+    ) -> ComponentResult<Vec<ComponentStatsGroup>> {
         let rows = ctx
             .txns()
             .pg()
@@ -101,7 +105,7 @@ pub struct ComponentStatsGroup {
 
 impl ComponentStatsGroup {
     pub fn new_from_rows(
-        rows: Vec<Row>,
+        rows: Vec<PgRow>,
         component_status: ComponentStatus,
     ) -> ComponentResult<Vec<Self>> {
         let mut result = Vec::new();

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -42,7 +42,7 @@ impl Default for ComponentView {
 
 impl ComponentView {
     pub async fn for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeReadContext,
     ) -> ComponentResult<ComponentView> {
         let component_id = match context.component_id() {
@@ -114,7 +114,7 @@ impl ComponentView {
     }
 
     pub async fn reencrypt_secrets(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component: &mut veritech::ComponentView,
     ) -> Result<(), ComponentViewError> {
         if component.kind != veritech::ComponentKind::Credential {

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -89,7 +89,7 @@ impl Diagram {
     /// Assemble a [`Diagram`](Self) based on existing [`Nodes`](crate::Node) and
     /// [`Connections`](crate::Connection).
     pub async fn assemble(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         system_id: Option<SystemId>,
     ) -> DiagramResult<Self> {
         let connections = Connection::list(ctx).await?;

--- a/lib/dal/src/diagram/connection.rs
+++ b/lib/dal/src/diagram/connection.rs
@@ -25,7 +25,7 @@ pub struct Connection {
 impl Connection {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         from_node_id: NodeId,
         from_socket_id: SocketId,
         to_node_id: NodeId,
@@ -37,7 +37,7 @@ impl Connection {
         Ok(Connection::from_edge(&edge))
     }
 
-    pub async fn list(ctx: &DalContext<'_, '_>) -> DiagramResult<Vec<Self>> {
+    pub async fn list(ctx: &DalContext<'_, '_, '_>) -> DiagramResult<Vec<Self>> {
         let edges = Edge::list(ctx).await?;
         let connections = edges.iter().map(Self::from_edge).collect::<Vec<Self>>();
         Ok(connections)

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -61,7 +61,7 @@ pub struct SocketView {
 
 impl SocketView {
     pub async fn list(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         node: &Node,
         schema_variant: &SchemaVariant,
     ) -> DiagramResult<Vec<Self>> {
@@ -132,7 +132,7 @@ pub struct DiagramNodeView {
 
 impl DiagramNodeView {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         node: &Node,
         position: &NodePosition,
         schema_variant: &SchemaVariant,

--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -123,7 +123,7 @@ impl Edge {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         kind: EdgeKind,
         head_node_id: NodeId,
         head_object_kind: VertexObjectKind,
@@ -170,7 +170,7 @@ impl Edge {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new_for_connection(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         head_node_id: NodeId,
         head_socket_id: SocketId,
         tail_node_id: NodeId,
@@ -234,7 +234,7 @@ impl Edge {
     standard_model_accessor!(tail_socket_id, Pk(SocketId), EdgeResult);
 
     pub async fn list_parents_for_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         head_component_id: ComponentId,
     ) -> EdgeResult<Vec<ComponentId>> {
         let rows = ctx
@@ -253,7 +253,7 @@ impl Edge {
     }
 
     pub async fn include_component_in_system(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         diagram_kind: DiagramKind,
         system_id: SystemId,
@@ -284,7 +284,7 @@ impl Edge {
     /// - _"head":_ where the connection is going to
     /// - _"tail":_ where the connection is coming from
     pub async fn connect_providers_for_components(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         head_explicit_internal_provider_id: InternalProviderId,
         head_component_id: ComponentId,

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -94,7 +94,7 @@ impl_standard_model! {
 impl Func {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         backend_kind: FuncBackendKind,
         backend_response_type: FuncBackendResponseType,
@@ -118,7 +118,7 @@ impl Func {
         Ok(object)
     }
 
-    pub async fn set_id(&mut self, ctx: &DalContext<'_, '_>, id: &FuncId) -> FuncResult<()> {
+    pub async fn set_id(&mut self, ctx: &DalContext<'_, '_, '_>, id: &FuncId) -> FuncResult<()> {
         let updated_at = standard_model::update(
             ctx,
             Self::table_name(),
@@ -153,7 +153,7 @@ impl Func {
 
     pub async fn set_code_plaintext(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         code: Option<&'_ str>,
     ) -> FuncResult<()> {
         self.set_code_base64(ctx, code.as_ref().map(|code| base64::encode(&code)))

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -153,7 +153,7 @@ pub struct FuncDispatchContext {
 }
 
 impl FuncDispatchContext {
-    pub fn new(ctx: &DalContext<'_, '_>) -> (Self, mpsc::Receiver<OutputStream>) {
+    pub fn new(ctx: &DalContext<'_, '_, '_>) -> (Self, mpsc::Receiver<OutputStream>) {
         let (output_tx, rx) = mpsc::channel(64);
         (
             Self {

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -107,7 +107,7 @@ impl FuncBinding {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         args: serde_json::Value,
         func_id: FuncId,
         backend_kind: FuncBackendKind,
@@ -137,7 +137,7 @@ impl FuncBinding {
 
     #[instrument(skip_all)]
     pub async fn find_or_create(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         args: serde_json::Value,
         func_id: FuncId,
         backend_kind: FuncBackendKind,
@@ -186,7 +186,7 @@ impl FuncBinding {
     /// Runs [`Self::find_or_create()`] and executes if [`Self`] was newly created or
     /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) could not be found.
     pub async fn find_or_create_and_execute(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         args: serde_json::Value,
         func_id: FuncId,
     ) -> FuncBindingResult<(Self, FuncBindingReturnValue)> {
@@ -230,7 +230,7 @@ impl FuncBinding {
 
     pub async fn execute(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> FuncBindingResult<FuncBindingReturnValue> {
         let (func, execution, context, mut rx) = self.prepare_execution(ctx).await?;
         let value = self.execute_critical_section(func.clone(), context).await?;
@@ -307,7 +307,7 @@ impl FuncBinding {
 
     pub async fn postprocess_execution(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         output_stream: Vec<OutputStream>,
         func: &Func,
         (unprocessed_value, processed_value): (
@@ -340,7 +340,7 @@ impl FuncBinding {
 
     pub async fn prepare_execution(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> FuncBindingResult<(
         Func,
         FuncExecution,

--- a/lib/dal/src/func/binding_return_value.rs
+++ b/lib/dal/src/func/binding_return_value.rs
@@ -89,7 +89,7 @@ impl FuncBindingReturnValue {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         unprocessed_value: Option<serde_json::Value>,
         value: Option<serde_json::Value>,
         func_id: FuncId,
@@ -120,7 +120,7 @@ impl FuncBindingReturnValue {
 
     pub async fn get_output_stream(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> FuncBindingReturnValueResult<Option<Vec<OutputStream>>> {
         if self.func_execution_pk == FuncExecutionPk::from(-1) {
             return Ok(None);
@@ -144,7 +144,7 @@ impl FuncBindingReturnValue {
     // }
 
     pub async fn get_by_attribute_value_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_value_id: AttributeValueId,
     ) -> FuncBindingReturnValueResult<Option<Self>> {
         let row = ctx
@@ -161,7 +161,7 @@ impl FuncBindingReturnValue {
 
     /// Attempts to retrieve [`Self`] by [`FuncBindingId`].
     pub async fn get_by_func_binding_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_binding_id: FuncBindingId,
     ) -> FuncBindingReturnValueResult<Option<Self>> {
         let row = ctx
@@ -180,7 +180,7 @@ impl FuncBindingReturnValue {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn upsert(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         unprocessed_value: Option<serde_json::Value>,
         value: Option<serde_json::Value>,
         func_id: FuncId,

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -89,7 +89,7 @@ impl FuncExecution {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func: &Func,
         func_binding: &FuncBinding,
     ) -> FuncExecutionResult<Self> {
@@ -124,7 +124,7 @@ impl FuncExecution {
 
     pub async fn set_state(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         state: FuncExecutionState,
     ) -> FuncExecutionResult<()> {
         let row = ctx
@@ -146,7 +146,7 @@ impl FuncExecution {
     /// Takes the receiver stream from a Veritech function execution, and stores the output.
     pub async fn process_output(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         mut rx: Receiver<OutputStream>,
     ) -> FuncExecutionResult<()> {
         // Right now, we consume everything. This should really be happening in a separate thread altogether, and
@@ -169,7 +169,7 @@ impl FuncExecution {
 
     pub async fn set_output_stream(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         output_stream: Vec<OutputStream>,
     ) -> FuncExecutionResult<()> {
         let output_stream_json = serde_json::to_value(&output_stream)?;
@@ -191,7 +191,7 @@ impl FuncExecution {
     /// Take the return value of a function binding, and store its results.
     pub async fn process_return_value(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_binding_return_value: &FuncBindingReturnValue,
     ) -> FuncExecutionResult<()> {
         let row = ctx
@@ -221,7 +221,7 @@ impl FuncExecution {
 
     #[instrument(skip(ctx))]
     pub async fn get_by_pk(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         pk: &FuncExecutionPk,
     ) -> FuncExecutionResult<Self> {
         let row = ctx

--- a/lib/dal/src/group.rs
+++ b/lib/dal/src/group.rs
@@ -54,7 +54,7 @@ impl_standard_model! {
 
 impl Group {
     #[instrument(skip_all)]
-    pub async fn new(ctx: &DalContext<'_, '_>, name: impl AsRef<str>) -> GroupResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, name: impl AsRef<str>) -> GroupResult<Self> {
         let name = name.as_ref();
         let row = ctx
             .txns()

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -59,7 +59,7 @@ pub struct HistoryEvent {
 impl HistoryEvent {
     #[instrument(skip(ctx, label, message))]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         label: impl AsRef<str>,
         message: impl AsRef<str>,
         data: &serde_json::Value,

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -83,7 +83,7 @@ pub trait JobConsumer: std::fmt::Debug + Sync {
     fn access_builder(&self) -> AccessBuilder;
     fn visibility(&self) -> Visibility;
 
-    async fn run(&self, ctx: &DalContext<'_, '_>) -> JobConsumerResult<()>;
+    async fn run(&self, ctx: &DalContext<'_, '_, '_>) -> JobConsumerResult<()>;
 
     async fn run_job(&self, ctx_builder: Arc<DalContextBuilder>) -> JobConsumerResult<()> {
         let mut txns = ctx_builder.transactions_starter().await?;

--- a/lib/dal/src/job/definition/code_generation.rs
+++ b/lib/dal/src/job/definition/code_generation.rs
@@ -40,7 +40,7 @@ pub struct CodeGeneration {
 
 impl CodeGeneration {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<Box<Self>> {
@@ -107,7 +107,7 @@ impl JobConsumer for CodeGeneration {
         self.visibility
     }
 
-    async fn run(&self, ctx: &DalContext<'_, '_>) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &DalContext<'_, '_, '_>) -> JobConsumerResult<()> {
         let component = Component::get_by_id(ctx, &self.component_id)
             .await?
             .ok_or(ComponentError::NotFound(self.component_id))?;

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -32,7 +32,7 @@ pub struct DependentValuesUpdate {
 }
 
 impl DependentValuesUpdate {
-    pub fn new(ctx: &DalContext<'_, '_>, attribute_value_id: AttributeValueId) -> Box<Self> {
+    pub fn new(ctx: &DalContext<'_, '_, '_>, attribute_value_id: AttributeValueId) -> Box<Self> {
         let access_builder = AccessBuilder::from(ctx.clone());
         let visibility = *ctx.visibility();
 
@@ -89,7 +89,7 @@ impl JobConsumer for DependentValuesUpdate {
         self.visibility
     }
 
-    async fn run(&self, ctx: &DalContext<'_, '_>) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &DalContext<'_, '_, '_>) -> JobConsumerResult<()> {
         AttributeValueDependentUpdateHarness::update_dependent_values(ctx, self.attribute_value_id)
             .await?;
         Ok(())

--- a/lib/dal/src/job/definition/qualification.rs
+++ b/lib/dal/src/job/definition/qualification.rs
@@ -42,7 +42,7 @@ pub struct Qualification {
 
 impl Qualification {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         prototype_id: QualificationPrototypeId,
         system_id: SystemId,
@@ -111,7 +111,7 @@ impl JobConsumer for Qualification {
         self.visibility
     }
 
-    async fn run(&self, ctx: &DalContext<'_, '_>) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &DalContext<'_, '_, '_>) -> JobConsumerResult<()> {
         let component = Component::get_by_id(ctx, &self.component_id)
             .await?
             .ok_or(ComponentError::NotFound(self.component_id))?;

--- a/lib/dal/src/job/definition/qualifications.rs
+++ b/lib/dal/src/job/definition/qualifications.rs
@@ -39,7 +39,7 @@ pub struct Qualifications {
 
 impl Qualifications {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ComponentResult<Box<Self>> {
@@ -108,7 +108,7 @@ impl JobConsumer for Qualifications {
         self.visibility
     }
 
-    async fn run(&self, ctx: &DalContext<'_, '_>) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &DalContext<'_, '_, '_>) -> JobConsumerResult<()> {
         let component = Component::get_by_id(ctx, &self.component_id)
             .await?
             .ok_or(ComponentError::NotFound(self.component_id))?;

--- a/lib/dal/src/job/processor.rs
+++ b/lib/dal/src/job/processor.rs
@@ -20,7 +20,11 @@ pub type JobQueueProcessorResult<T> = Result<T, JobQueueProcessorError>;
 
 #[async_trait]
 pub trait JobQueueProcessor: std::fmt::Debug + DynClone {
-    async fn enqueue_job(&self, job: Box<dyn JobProducer + Send + Sync>, ctx: &DalContext<'_, '_>);
+    async fn enqueue_job(
+        &self,
+        job: Box<dyn JobProducer + Send + Sync>,
+        ctx: &DalContext<'_, '_, '_>,
+    );
     async fn process_queue(&self) -> JobQueueProcessorResult<()>;
 }
 

--- a/lib/dal/src/job/processor/faktory_processor.rs
+++ b/lib/dal/src/job/processor/faktory_processor.rs
@@ -49,7 +49,7 @@ impl JobQueueProcessor for FaktoryProcessor {
     async fn enqueue_job(
         &self,
         job: Box<dyn JobProducer + Send + Sync>,
-        _ctx: &DalContext<'_, '_>,
+        _ctx: &DalContext<'_, '_, '_>,
     ) {
         self.queue.enqueue_job(job).await
     }

--- a/lib/dal/src/job/processor/sync_processor.rs
+++ b/lib/dal/src/job/processor/sync_processor.rs
@@ -16,7 +16,11 @@ impl SyncProcessor {
 
 #[async_trait]
 impl JobQueueProcessor for SyncProcessor {
-    async fn enqueue_job(&self, job: Box<dyn JobProducer + Send + Sync>, ctx: &DalContext<'_, '_>) {
+    async fn enqueue_job(
+        &self,
+        job: Box<dyn JobProducer + Send + Sync>,
+        ctx: &DalContext<'_, '_, '_>,
+    ) {
         job.run(ctx)
             .await
             .unwrap_or_else(|e| panic!("Failure processing background job:\n  {:?}\n\n{}", job, e));

--- a/lib/dal/src/job_failure.rs
+++ b/lib/dal/src/job_failure.rs
@@ -60,7 +60,7 @@ impl_standard_model! {
 impl JobFailure {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         kind: impl AsRef<str>,
         message: impl AsRef<str>,
     ) -> JobFailureResult<Self> {

--- a/lib/dal/src/jwt_key.rs
+++ b/lib/dal/src/jwt_key.rs
@@ -131,7 +131,7 @@ impl JwtSecretKey {
 
 #[instrument(skip_all)]
 pub async fn get_jwt_validation_key(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     jwt_id: impl AsRef<str>,
 ) -> JwtKeyResult<RS256PublicKey> {
     let jwt_id = jwt_id.as_ref();
@@ -156,7 +156,7 @@ pub async fn get_jwt_validation_key(
 
 #[instrument(skip_all)]
 pub async fn validate_bearer_token(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     bearer_token: impl AsRef<str>,
 ) -> JwtKeyResult<JWTClaims<UserClaim>> {
     let bearer_token = bearer_token.as_ref();
@@ -187,7 +187,7 @@ pub async fn validate_bearer_token(
 
 #[instrument(skip_all)]
 pub async fn validate_bearer_token_api_client(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     bearer_token: impl AsRef<str>,
 ) -> JwtKeyResult<JWTClaims<ApiClaim>> {
     let bearer_token = bearer_token.as_ref();
@@ -212,7 +212,7 @@ pub async fn validate_bearer_token_api_client(
 
 #[instrument(skip_all)]
 pub async fn get_jwt_signing_key(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     jwt_secret_key: &JwtSecretKey,
 ) -> JwtKeyResult<RS256KeyPair> {
     let row = ctx

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -65,7 +65,7 @@ impl_standard_model! {
 }
 
 impl KeyPair {
-    pub async fn new(ctx: &DalContext<'_, '_>, name: impl AsRef<str>) -> KeyPairResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, name: impl AsRef<str>) -> KeyPairResult<Self> {
         let name = name.as_ref();
         let (public_key, secret_key) = box_::gen_keypair();
 
@@ -96,7 +96,7 @@ impl KeyPair {
     }
 
     pub async fn get_current(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         billing_account_id: &BillingAccountId,
     ) -> KeyPairResult<Self> {
         let row = ctx
@@ -165,7 +165,7 @@ pub struct PublicKey {
 
 impl PublicKey {
     pub async fn get_current(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         billing_account_id: &BillingAccountId,
     ) -> KeyPairResult<Self> {
         let row = ctx

--- a/lib/dal/src/label_list.rs
+++ b/lib/dal/src/label_list.rs
@@ -1,8 +1,10 @@
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use si_data::PgError;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use si_data::{PgError, PgRow};
 use strum::IntoEnumIterator;
 use thiserror::Error;
 
@@ -48,7 +50,7 @@ impl<V> LabelList<V>
 where
     V: Debug + DeserializeOwned + Serialize + postgres_types::FromSqlOwned,
 {
-    pub fn from_rows(rows: Vec<tokio_postgres::Row>) -> LabelListResult<LabelList<V>> {
+    pub fn from_rows(rows: Vec<PgRow>) -> LabelListResult<LabelList<V>> {
         let mut results = Vec::new();
         for row in rows.into_iter() {
             let name: String = row.try_get("name")?;

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -94,7 +94,7 @@ impl_standard_model! {
 
 impl Node {
     #[instrument(skip_all)]
-    pub async fn new(ctx: &DalContext<'_, '_>, kind: &NodeKind) -> NodeResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, kind: &NodeKind) -> NodeResult<Self> {
         let row = ctx
             .txns()
             .pg()
@@ -143,7 +143,7 @@ pub struct NodeTemplate {
 
 impl NodeTemplate {
     pub async fn new_from_schema_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
     ) -> NodeResult<Self> {
         let schema = Schema::get_by_id(ctx, &schema_id)

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -211,7 +211,10 @@ pub struct GenerateMenuItem {
 
 impl GenerateMenuItem {
     /// Generates raw items and initializes menu items as an empty vec.
-    pub async fn new(ctx: &DalContext<'_, '_>, diagram_kind: DiagramKind) -> NodeMenuResult<Self> {
+    pub async fn new(
+        ctx: &DalContext<'_, '_, '_>,
+        diagram_kind: DiagramKind,
+    ) -> NodeMenuResult<Self> {
         let mut item_list = Vec::new();
         let rows = ctx
             .txns()

--- a/lib/dal/src/node_position.rs
+++ b/lib/dal/src/node_position.rs
@@ -59,7 +59,7 @@ impl NodePosition {
     /// [`NodeId`](crate::Node).
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         node_id: NodeId,
         diagram_kind: DiagramKind,
         system_id: Option<SystemId>,
@@ -87,7 +87,7 @@ impl NodePosition {
     }
 
     pub async fn list_for_node(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         node_id: NodeId,
         system_id: Option<SystemId>,
     ) -> NodePositionResult<Vec<Self>> {
@@ -104,7 +104,7 @@ impl NodePosition {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn upsert_by_node_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         diagram_kind: DiagramKind,
         system_id: Option<SystemId>,
         node_id: NodeId,

--- a/lib/dal/src/organization.rs
+++ b/lib/dal/src/organization.rs
@@ -52,7 +52,10 @@ impl_standard_model! {
 
 impl Organization {
     #[instrument(skip_all)]
-    pub async fn new(ctx: &DalContext<'_, '_>, name: impl AsRef<str>) -> OrganizationResult<Self> {
+    pub async fn new(
+        ctx: &DalContext<'_, '_, '_>,
+        name: impl AsRef<str>,
+    ) -> OrganizationResult<Self> {
         let name = name.as_ref();
         let row = ctx
             .txns()

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -133,7 +133,7 @@ impl Prop {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         kind: PropKind,
     ) -> PropResult<Self> {
@@ -202,7 +202,7 @@ impl Prop {
     /// is ignored.
     pub async fn set_parent_prop(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         parent_prop_id: PropId,
     ) -> PropResult<()> {
         let parent_prop = Prop::get_by_id(ctx, &parent_prop_id)
@@ -255,7 +255,7 @@ impl Prop {
     /// Returns the root [`Prop`] for a given [`SchemaVariantId`](crate::SchemaVariant). Returns
     /// [`None`] if no [`Props`](Self) have been created for the [`SchemaVariant`](crate::SchemaVariant).
     pub async fn find_root_for_schema_variant(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> PropResult<Option<Prop>> {
         let row = ctx
@@ -270,7 +270,7 @@ impl Prop {
 
     /// Returns the given [`Prop`] and all ancestor [`Props`](crate::Prop) back to the root.
     pub async fn all_ancestor_props(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop_id: PropId,
     ) -> PropResult<Vec<Self>> {
         let rows = ctx
@@ -284,7 +284,7 @@ impl Prop {
     }
 
     pub async fn create_default_prototypes_and_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop_id: PropId,
     ) -> PropResult<()> {
         #[derive(Debug)]

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -84,7 +84,7 @@ pub enum PropertyEditorPropWidgetKind {
 
 impl PropertyEditorPropWidgetKind {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         widget_kind: WidgetKind,
     ) -> PropertyEditorResult<Self> {
         Ok(match widget_kind {
@@ -127,7 +127,7 @@ pub struct PropertyEditorProp {
 
 impl PropertyEditorProp {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop: Prop,
     ) -> PropertyEditorResult<PropertyEditorProp> {
         Ok(PropertyEditorProp {
@@ -150,7 +150,7 @@ pub struct PropertyEditorSchema {
 
 impl PropertyEditorSchema {
     pub async fn for_schema_variant(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> PropertyEditorResult<Self> {
         let schema_variant = SchemaVariant::get_by_id(ctx, &schema_variant_id)
@@ -217,7 +217,7 @@ pub struct PropertyEditorValues {
 
 impl PropertyEditorValues {
     pub async fn for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         context: AttributeReadContext,
     ) -> PropertyEditorResult<Self> {
         let mut root_value_id = None;
@@ -302,7 +302,7 @@ pub struct PropertyEditorValidations {
 
 impl PropertyEditorValidations {
     pub async fn for_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> PropertyEditorResult<Self> {

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -103,7 +103,7 @@ impl ExternalProvider {
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(ctx, name))]
     pub async fn new_with_socket(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
         name: impl AsRef<str>,
@@ -193,7 +193,7 @@ impl ExternalProvider {
     /// Find all [`Self`] for a given [`SchemaVariant`](crate::SchemaVariant).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> ExternalProviderResult<Vec<Self>> {
         let rows = ctx
@@ -210,7 +210,7 @@ impl ExternalProvider {
     /// Find [`Self`] with a provided [`SocketId`](crate::Socket).
     #[instrument(skip_all)]
     pub async fn find_for_socket(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         socket_id: SocketId,
     ) -> ExternalProviderResult<Option<Self>> {
         let row = ctx
@@ -227,7 +227,7 @@ impl ExternalProvider {
     /// Find [`Self`] with a provided name.
     #[instrument(skip_all)]
     pub async fn find_for_schema_variant_and_name(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
         name: impl AsRef<str>,
     ) -> ExternalProviderResult<Option<Self>> {
@@ -251,7 +251,7 @@ impl ExternalProvider {
     /// Find all [`Self`] for a given [`AttributePrototypeId`](crate::AttributePrototype).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype_with_tail_component_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
         tail_component_id: ComponentId,
     ) -> ExternalProviderResult<Vec<Self>> {
@@ -276,7 +276,7 @@ impl ExternalProvider {
     /// [`InternalProviderId`](crate::InternalProvider).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_from_internal_provider_use(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         internal_provider_id: InternalProviderId,
     ) -> ExternalProviderResult<Vec<Self>> {
         let rows = ctx

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -142,7 +142,7 @@ pub struct InternalProvider {
 impl InternalProvider {
     #[tracing::instrument(skip(ctx))]
     pub async fn new_implicit(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop_id: PropId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
@@ -217,7 +217,7 @@ impl InternalProvider {
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(ctx, name))]
     pub async fn new_explicit_with_socket(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
         name: impl AsRef<str>,
@@ -332,7 +332,7 @@ impl InternalProvider {
     ///   field on [`Self`]
     pub async fn implicit_emit(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         consume_attribute_context: AttributeContext,
     ) -> InternalProviderResult<AttributeValue> {
         if !self.is_internal_consumer() {
@@ -480,7 +480,7 @@ impl InternalProvider {
     /// Find all [`Self`] for a given [`SchemaVariant`](crate::SchemaVariant).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> InternalProviderResult<Vec<Self>> {
         let rows = ctx
@@ -497,7 +497,7 @@ impl InternalProvider {
     /// Find [`Self`] with a provided name.
     #[instrument(skip_all)]
     pub async fn find_explicit_for_schema_variant_and_name(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
         name: impl AsRef<str>,
     ) -> InternalProviderResult<Option<Self>> {
@@ -521,7 +521,7 @@ impl InternalProvider {
     /// Find [`Self`] with a provided [`SocketId`](crate::Socket).
     #[instrument(skip_all)]
     pub async fn find_explicit_for_socket(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         socket_id: SocketId,
     ) -> InternalProviderResult<Option<Self>> {
         let row = ctx
@@ -538,7 +538,7 @@ impl InternalProvider {
     /// Find all [`Self`] for a given [`AttributePrototypeId`](crate::AttributePrototype).
     #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         attribute_prototype_id: AttributePrototypeId,
     ) -> InternalProviderResult<Vec<Self>> {
         let rows = ctx
@@ -569,7 +569,7 @@ impl InternalProvider {
     /// Gets [`Self`] for a given [`PropId`](crate::Prop). This will only work for
     /// implicit [`InternalProviders`](Self).
     pub async fn get_for_prop(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop_id: PropId,
     ) -> InternalProviderResult<Option<Self>> {
         let row = ctx

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use si_data::PgError;
 use thiserror::Error;
 
 use veritech::QualificationSubCheck;
@@ -39,8 +40,8 @@ pub struct QualificationSummary {
 #[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum QualificationSummaryError {
-    #[error("error accessing database")]
-    PgError(#[from] tokio_postgres::Error),
+    #[error("pg error: {0}")]
+    PgError(#[from] PgError),
     #[error("error loading component validations: {0}")]
     ComponentError(#[from] component::ComponentError),
 }
@@ -49,7 +50,7 @@ pub type QualificationSummaryResult<T> = Result<T, QualificationSummaryError>;
 
 impl QualificationSummary {
     pub async fn get_summary(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> QualificationSummaryResult<QualificationSummary> {
         let rows = ctx
             .txns()
@@ -194,7 +195,7 @@ impl QualificationView {
     }
 
     pub async fn new_for_func_binding_return_value(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prototype: QualificationPrototype,
         func_metadata: FuncMetadataView,
         func_binding_return_value: FuncBindingReturnValue,
@@ -236,7 +237,7 @@ pub struct QualificationCheckId {
 
 impl WsEvent {
     pub fn checked_qualifications(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prototype_id: QualificationPrototypeId,
         component_id: ComponentId,
         system_id: SystemId,

--- a/lib/dal/src/qualification_check.rs
+++ b/lib/dal/src/qualification_check.rs
@@ -50,7 +50,7 @@ impl_standard_model! {
 
 impl QualificationCheck {
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
     ) -> QualificationCheckResult<Self> {
         let name = name.as_ref();

--- a/lib/dal/src/qualification_prototype.rs
+++ b/lib/dal/src/qualification_prototype.rs
@@ -206,7 +206,7 @@ impl QualificationPrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         context: QualificationPrototypeContext,
     ) -> QualificationPrototypeResult<Self> {
@@ -243,7 +243,7 @@ impl QualificationPrototype {
 
     pub async fn set_id(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         id: &QualificationPrototypeId,
     ) -> QualificationPrototypeResult<()> {
         let updated_at = standard_model::update(
@@ -273,7 +273,7 @@ impl QualificationPrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
@@ -299,7 +299,7 @@ impl QualificationPrototype {
     }
 
     pub async fn find_for_func(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: &FuncId,
     ) -> QualificationPrototypeResult<Vec<Self>> {
         let rows = ctx
@@ -325,7 +325,7 @@ impl QualificationPrototype {
     }
 
     async fn create_missing_prototypes(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: &FuncId,
         existing_for_field: &[QualificationPrototypeContextField],
         desired_for_field: &[QualificationPrototypeContextField],
@@ -394,7 +394,7 @@ impl QualificationPrototype {
     pub async fn associate_prototypes_with_func_and_objects<
         T: Into<QualificationPrototypeContextField> + Copy,
     >(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: &FuncId,
         prototype_context_field_ids: &[T],
     ) -> QualificationPrototypeResult<Vec<Self>> {

--- a/lib/dal/src/qualification_resolver.rs
+++ b/lib/dal/src/qualification_resolver.rs
@@ -127,7 +127,7 @@ impl QualificationResolver {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         qualification_prototype_id: QualificationPrototypeId,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
@@ -163,7 +163,7 @@ impl QualificationResolver {
     );
 
     pub async fn find_for_prototype_and_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         qualification_prototype_id: &QualificationPrototypeId,
         component_id: &ComponentId,
     ) -> QualificationResolverResult<Vec<Self>> {

--- a/lib/dal/src/resource.rs
+++ b/lib/dal/src/resource.rs
@@ -71,7 +71,7 @@ impl Resource {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: &ComponentId,
         system_id: &SystemId,
     ) -> ResourceResult<Self> {
@@ -115,7 +115,7 @@ impl Resource {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn get_by_component_id_and_system_id(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: &ComponentId,
         system_id: &SystemId,
     ) -> ResourceResult<Option<Self>> {
@@ -142,7 +142,7 @@ impl Resource {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn upsert(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: &ComponentId,
         system_id: &SystemId,
     ) -> ResourceResult<Self> {
@@ -225,7 +225,7 @@ pub struct ResourceSyncId {
 
 impl WsEvent {
     pub fn resource_synced(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> Self {

--- a/lib/dal/src/resource_prototype.rs
+++ b/lib/dal/src/resource_prototype.rs
@@ -131,7 +131,7 @@ impl ResourcePrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         args: serde_json::Value,
         context: ResourcePrototypeContext,
@@ -162,7 +162,7 @@ impl ResourcePrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn get_for_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/resource_resolver.rs
+++ b/lib/dal/src/resource_resolver.rs
@@ -124,7 +124,7 @@ impl ResourceResolver {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         resource_prototype_id: ResourcePrototypeId,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
@@ -156,7 +156,7 @@ impl ResourceResolver {
     standard_model_accessor!(func_binding_id, Pk(FuncBindingId), ResourceResolverResult);
 
     pub async fn get_for_prototype_and_component(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         resource_prototype_id: &ResourcePrototypeId,
         component_id: &ComponentId,
     ) -> ResourceResolverResult<Option<Self>> {

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -148,7 +148,7 @@ impl Schema {
     #[instrument(skip_all)]
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         kind: &SchemaKind,
         component_kind: &ComponentKind,
@@ -262,7 +262,10 @@ impl Schema {
         result: SchemaResult,
     );
 
-    pub async fn default_variant(&self, ctx: &DalContext<'_, '_>) -> SchemaResult<SchemaVariant> {
+    pub async fn default_variant(
+        &self,
+        ctx: &DalContext<'_, '_, '_>,
+    ) -> SchemaResult<SchemaVariant> {
         match self.default_schema_variant_id() {
             Some(schema_variant_id) => Ok(SchemaVariant::get_by_id(ctx, schema_variant_id)
                 .await?
@@ -272,7 +275,7 @@ impl Schema {
     }
 
     pub async fn default_schema_variant_id_for_name(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
     ) -> SchemaResult<SchemaVariantId> {
         let name = name.as_ref();

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -37,7 +37,10 @@ impl_standard_model! {
 
 impl UiMenu {
     #[instrument(skip_all)]
-    pub async fn new(ctx: &DalContext<'_, '_>, diagram_kind: &DiagramKind) -> SchemaResult<Self> {
+    pub async fn new(
+        ctx: &DalContext<'_, '_, '_>,
+        diagram_kind: &DiagramKind,
+    ) -> SchemaResult<Self> {
         let row = ctx
             .txns()
             .pg()
@@ -71,7 +74,7 @@ impl UiMenu {
 
     /// A menu item is unusable when it doesn't have the fields set yet that
     /// enable it to show up in a menu.
-    pub async fn usable_in_menu(&self, ctx: &DalContext<'_, '_>) -> SchemaResult<bool> {
+    pub async fn usable_in_menu(&self, ctx: &DalContext<'_, '_, '_>) -> SchemaResult<bool> {
         if self.name().is_none() || self.category().is_none() || self.schema(ctx).await?.is_none() {
             Ok(false)
         } else {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -97,7 +97,7 @@ impl_standard_model! {
 impl SchemaVariant {
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
         name: impl AsRef<str>,
     ) -> SchemaVariantResult<(Self, RootProp)> {
@@ -129,7 +129,7 @@ impl SchemaVariant {
     ///
     /// This method **MUST** be called once all the [`Props`](Prop) have been created for the
     /// [`SchemaVariant`]. This method should only be called once, as it is not fully idempotent.
-    pub async fn finalize(&self, ctx: &DalContext<'_, '_>) -> SchemaVariantResult<()> {
+    pub async fn finalize(&self, ctx: &DalContext<'_, '_, '_>) -> SchemaVariantResult<()> {
         let schema = self
             .schema(ctx)
             .await?
@@ -148,7 +148,7 @@ impl SchemaVariant {
     /// This method is idempotent, and may be safely called multiple times before
     /// [`SchemaVariant.finalize(ctx)`](SchemaVariant#finalize()) is called.
     pub async fn create_default_prototypes_and_values(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<()> {
         let root_prop = match Prop::find_root_for_schema_variant(ctx, schema_variant_id).await? {
@@ -163,7 +163,7 @@ impl SchemaVariant {
     /// to every [`Prop`](crate::Prop) in the [`SchemaVariant`] that is not a descendant of an array
     /// or a map.
     async fn create_implicit_internal_providers(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<()> {
@@ -235,7 +235,7 @@ impl SchemaVariant {
     );
 
     #[instrument(skip_all)]
-    pub async fn all_props(&self, ctx: &DalContext<'_, '_>) -> SchemaVariantResult<Vec<Prop>> {
+    pub async fn all_props(&self, ctx: &DalContext<'_, '_, '_>) -> SchemaVariantResult<Vec<Prop>> {
         let rows = ctx
             .txns()
             .pg()
@@ -249,7 +249,7 @@ impl SchemaVariant {
     }
 
     /// Find the root [`Prop`](crate::Prop) for [`Self`](Self).
-    pub async fn root_prop(&self, ctx: &DalContext<'_, '_>) -> SchemaVariantResult<Prop> {
+    pub async fn root_prop(&self, ctx: &DalContext<'_, '_, '_>) -> SchemaVariantResult<Prop> {
         // FIXME(nick): this is an inefficient solution that would be better suited by a database query.
         for prop in self.all_props(ctx).await? {
             if prop.parent_prop(ctx).await?.is_none() && prop.name() == "root" {

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -23,7 +23,7 @@ impl RootProp {
     /// Creates and returns a [`RootProp`] for a [`SchemaVariant`](crate::SchemaVariant).
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<Self> {
         let root_prop = Prop::new(ctx, "root", PropKind::Object).await?;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -83,7 +83,7 @@ impl Secret {
     // `secrets` view
     pub async fn set_name(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         value: impl Into<String>,
     ) -> SecretResult<()> {
         let value = value.into();
@@ -202,7 +202,7 @@ impl EncryptedSecret {
     /// Creates a new encypted secret and returns a corresponding [`Secret`] representation.
     #[allow(clippy::too_many_arguments, clippy::new_ret_no_self)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         object_type: SecretObjectType,
         kind: SecretKind,
@@ -260,7 +260,7 @@ impl EncryptedSecret {
 
     /// Decrypts the encrypted secret with its associated [`KeyPair`] and returns a
     /// [`DecryptedSecret`].
-    pub async fn decrypt(self, ctx: &DalContext<'_, '_>) -> SecretResult<DecryptedSecret> {
+    pub async fn decrypt(self, ctx: &DalContext<'_, '_, '_>) -> SecretResult<DecryptedSecret> {
         let key_pair = self
             .key_pair(ctx)
             .await?

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -116,7 +116,7 @@ impl_standard_model! {
 impl Socket {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         kind: SocketKind,
         edge_kind: &SocketEdgeKind,

--- a/lib/dal/src/standard_accessors.rs
+++ b/lib/dal/src/standard_accessors.rs
@@ -16,7 +16,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $lookup_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
         ) -> $result_type<Vec<$returns>> {
             let other: Option<&$right_id> = None;
             let r = $crate::standard_model::many_to_many(
@@ -34,7 +34,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $associate_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
             right_id: &$right_id,
         ) -> $result_type<()> {
             let _r = $crate::standard_model::associate_many_to_many(
@@ -57,7 +57,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $disassociate_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
             right_id: &$right_id,
         ) -> $result_type<()> {
             let _r = $crate::standard_model::disassociate_many_to_many(
@@ -93,7 +93,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $lookup_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
         ) -> $result_type<Vec<$returns>> {
             let other: Option<&$left_id> = None;
             let r = $crate::standard_model::many_to_many(
@@ -111,7 +111,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $associate_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
             left_id: &$left_id,
         ) -> $result_type<()> {
             let _r = $crate::standard_model::associate_many_to_many(
@@ -134,7 +134,7 @@ macro_rules! standard_model_many_to_many {
         #[telemetry::tracing::instrument(skip_all)]
         pub async fn $disassociate_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
             left_id: &$left_id,
         ) -> $result_type<()> {
             let _r = $crate::standard_model::disassociate_many_to_many(
@@ -168,7 +168,7 @@ macro_rules! standard_model_has_many {
         #[telemetry::tracing::instrument(skip(ctx))]
         pub async fn $lookup_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
         ) -> $result_type<Vec<$has_many>> {
             let r =
                 $crate::standard_model::has_many(ctx, $table, $retrieve_table, &self.id()).await?;
@@ -192,7 +192,7 @@ macro_rules! standard_model_belongs_to {
         #[telemetry::tracing::instrument(skip(ctx))]
         pub async fn $lookup_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
         ) -> $result_type<Option<$belongs_to>> {
             let r = $crate::standard_model::belongs_to(
                 ctx,
@@ -207,7 +207,7 @@ macro_rules! standard_model_belongs_to {
         #[telemetry::tracing::instrument(skip(ctx))]
         pub async fn $set_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
             belongs_to_id: &$belongs_to_id,
         ) -> $result_type<()> {
             $crate::standard_model::set_belongs_to(
@@ -230,7 +230,7 @@ macro_rules! standard_model_belongs_to {
         #[telemetry::tracing::instrument(skip(ctx))]
         pub async fn $unset_fn(
             &self,
-            ctx: &$crate::DalContext<'_, '_>,
+            ctx: &$crate::DalContext<'_, '_, '_>,
         ) -> $result_type<()> {
             $crate::standard_model::unset_belongs_to(
                 ctx,
@@ -266,7 +266,7 @@ macro_rules! standard_model_accessor {
             #[telemetry::tracing::instrument(skip_all)]
             pub async fn [<set_ $column>](
                 &mut self,
-                ctx: &$crate::DalContext<'_, '_>,
+                ctx: &$crate::DalContext<'_, '_, '_>,
                 value: impl Into<$value_type>,
             ) -> $result_type<()> {
                 let value: $value_type = value.into();
@@ -302,7 +302,7 @@ macro_rules! standard_model_accessor {
             #[telemetry::tracing::instrument(skip_all)]
             pub async fn [<set_ $column>](
                 &mut self,
-                ctx: &$crate::DalContext<'_, '_>,
+                ctx: &$crate::DalContext<'_, '_, '_>,
                 value: impl Into<$value_type>,
             ) -> $result_type<()> {
                 let value: $value_type = value.into();
@@ -338,7 +338,7 @@ macro_rules! standard_model_accessor {
             #[telemetry::tracing::instrument(skip_all)]
             pub async fn [<set_ $column>](
                 &mut self,
-                ctx: &$crate::DalContext<'_, '_>,
+                ctx: &$crate::DalContext<'_, '_, '_>,
                 value: Option<impl Into<$value_type>>,
             ) -> $result_type<()> {
                 let value: Option<$value_type> = value.map(Into::into);
@@ -373,7 +373,7 @@ macro_rules! standard_model_accessor {
             #[telemetry::tracing::instrument(skip(ctx, value))]
             pub async fn [<set_ $column>](
                 &mut self,
-                ctx: &$crate::DalContext<'_, '_>,
+                ctx: &$crate::DalContext<'_, '_, '_>,
                 value: impl Into<$value_type>,
             ) -> $result_type<()> {
                 let value: $value_type = value.into();
@@ -408,7 +408,7 @@ macro_rules! standard_model_accessor {
             #[telemetry::tracing::instrument(skip_all)]
             pub async fn [<set_ $column>](
                 &mut self,
-                ctx: &$crate::DalContext<'_, '_>,
+                ctx: &$crate::DalContext<'_, '_, '_>,
                 value: Option<impl Into<$value_type>>,
             ) -> $result_type<()> {
                 let value: Option<$value_type> = value.map(Into::into);

--- a/lib/dal/src/system.rs
+++ b/lib/dal/src/system.rs
@@ -59,7 +59,7 @@ impl_standard_model! {
 }
 
 impl System {
-    pub async fn new(ctx: &DalContext<'_, '_>, name: impl AsRef<str>) -> SystemResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, name: impl AsRef<str>) -> SystemResult<Self> {
         let name = name.as_ref();
         let row = ctx
             .txns()
@@ -118,7 +118,7 @@ impl System {
 
     #[instrument(skip_all)]
     pub async fn new_with_node(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         workspace_id: &WorkspaceId,
     ) -> SystemResult<(Self, Node)> {
@@ -143,7 +143,7 @@ impl System {
 
     #[instrument(skip_all)]
     pub async fn list_for_workspace(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         wid: &WorkspaceId,
     ) -> SystemResult<LabelList<SystemId>> {
         let system_labels: Vec<_> = Workspace::get_by_id(ctx, wid)

--- a/lib/dal/src/test.rs
+++ b/lib/dal/src/test.rs
@@ -39,40 +39,40 @@ lazy_static! {
 ///
 /// To use a borrowed `DalContext` version, use [`DalContextHeadRef`].
 /// To use mutably borrowed `DalContext` version, use [`DalContextHeadMutRef`].
-pub struct DalContextHead<'a, 'b>(pub DalContext<'a, 'b>);
+pub struct DalContextHead<'a, 'b, 'c>(pub DalContext<'a, 'b, 'c>);
 
 /// A reference to a [`DalContext`] for a workspace in a billing account which is not in a change
 /// set nor an edit session.
 ///
 /// To use an owned `DalContext` version, use [`DalContextHead`].
 /// To use mutably borrowed `DalContext` version, use [`DalContextHeadMutRef`].
-pub struct DalContextHeadRef<'a, 'b, 'c>(pub &'a DalContext<'b, 'c>);
+pub struct DalContextHeadRef<'a, 'b, 'c, 'd>(pub &'a DalContext<'b, 'c, 'd>);
 
 /// A mutable reference to a [`DalContext`] for a workspace in a billing account which is not in a
 /// change set nor an edit session.
 ///
 /// To use an owned `DalContext` version, use [`DalContextHead`].
 /// To use a borrowed `DalContext` version, use [`DalContextHeadRef`].
-pub struct DalContextHeadMutRef<'a, 'b, 'c>(pub &'a mut DalContext<'b, 'c>);
+pub struct DalContextHeadMutRef<'a, 'b, 'c, 'd>(pub &'a mut DalContext<'b, 'c, 'd>);
 
 /// A [`DalContext`] with universal read/write tenancies and a head visibility.
 ///
 /// To use a borrowed `DalContext` version, use [`DalContextUniversalHeadRef`].
 /// To use mutably borrowed `DalContext` version, use [`DalContextUniversalHeadMutRef`].
-pub struct DalContextUniversalHead<'a, 'b>(pub DalContext<'a, 'b>);
+pub struct DalContextUniversalHead<'a, 'b, 'c>(pub DalContext<'a, 'b, 'c>);
 
 /// A reference to a [`DalContext`] with universal read/write tenancies and a head visibility.
 ///
 /// To use an owned `DalContext` version, use [`DalContextUniversalHead`].
 /// To use mutably borrowed `DalContext` version, use [`DalContextUniversalHeadMutRef`].
-pub struct DalContextUniversalHeadRef<'a, 'b, 'c>(pub &'a DalContext<'b, 'c>);
+pub struct DalContextUniversalHeadRef<'a, 'b, 'c, 'd>(pub &'a DalContext<'b, 'c, 'd>);
 
 /// A mutable reference to a [`DalContext`] with universal read/write tenancies and a head
 /// visibility.
 ///
 /// To use an owned `DalContext` version, use [`DalContextUniversalHead`].
 /// To use a borrowed `DalContext` version, use [`DalContextUniversalHeadRef`].
-pub struct DalContextUniversalHeadMutRef<'a, 'b, 'c>(pub &'a mut DalContext<'b, 'c>);
+pub struct DalContextUniversalHeadMutRef<'a, 'b, 'c, 'd>(pub &'a mut DalContext<'b, 'c, 'd>);
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/lib/dal/src/test/helpers/builtins.rs
+++ b/lib/dal/src/test/helpers/builtins.rs
@@ -62,7 +62,7 @@ impl BuiltinsHarness {
     /// [`Builtin`](Builtin).
     pub async fn create_component(
         &mut self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         builtin: Builtin,
     ) -> ComponentPayload {
@@ -104,7 +104,7 @@ impl BuiltinsHarness {
     /// Private function to build a [`PropMap`](PropMap) for a given [`Builtin`](Builtin). This
     /// function will populate the map differently depending on the [`Builtin`](Builtin) provided.
     async fn build_prop_map(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         builtin: Builtin,
         schema_variant_id: SchemaVariantId,
     ) -> PropMap {
@@ -133,7 +133,7 @@ impl BuiltinsHarness {
     /// Private method to create a [`Component`](crate::Component) and assemble a
     /// [`ComponentPayload`](crate::test::helpers::ComponentPayload).
     async fn perform_component_creation_and_payload_assembly(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
         prop_map: HashMap<&'static str, PropId>,

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -205,7 +205,7 @@ pub fn generate_fake_name() -> String {
     Generator::with_naming(Name::Numbered).next().unwrap()
 }
 
-pub async fn create_change_set(ctx: &DalContext<'_, '_>) -> ChangeSet {
+pub async fn create_change_set(ctx: &DalContext<'_, '_, '_>) -> ChangeSet {
     let name = generate_fake_name();
     ChangeSet::new(ctx, &name, None)
         .await
@@ -221,7 +221,7 @@ pub fn create_visibility_head() -> Visibility {
 }
 
 pub async fn create_billing_account_with_name(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     name: impl AsRef<str>,
 ) -> BillingAccount {
     BillingAccount::new(ctx, &name, None)
@@ -229,33 +229,33 @@ pub async fn create_billing_account_with_name(
         .expect("cannot create billing_account")
 }
 
-pub async fn create_billing_account(ctx: &DalContext<'_, '_>) -> BillingAccount {
+pub async fn create_billing_account(ctx: &DalContext<'_, '_, '_>) -> BillingAccount {
     let name = generate_fake_name();
     create_billing_account_with_name(ctx, name).await
 }
 
-pub async fn create_organization(ctx: &DalContext<'_, '_>) -> Organization {
+pub async fn create_organization(ctx: &DalContext<'_, '_, '_>) -> Organization {
     let name = generate_fake_name();
     Organization::new(ctx, &name)
         .await
         .expect("cannot create organization")
 }
 
-pub async fn create_workspace(ctx: &DalContext<'_, '_>) -> Workspace {
+pub async fn create_workspace(ctx: &DalContext<'_, '_, '_>) -> Workspace {
     let name = generate_fake_name();
     Workspace::new(ctx, &name)
         .await
         .expect("cannot create workspace")
 }
 
-pub async fn create_key_pair(ctx: &DalContext<'_, '_>) -> KeyPair {
+pub async fn create_key_pair(ctx: &DalContext<'_, '_, '_>) -> KeyPair {
     let name = generate_fake_name();
     KeyPair::new(ctx, &name)
         .await
         .expect("cannot create key_pair")
 }
 
-pub async fn create_user(ctx: &DalContext<'_, '_>) -> User {
+pub async fn create_user(ctx: &DalContext<'_, '_, '_>) -> User {
     let name = generate_fake_name();
     User::new(
         ctx,
@@ -267,13 +267,13 @@ pub async fn create_user(ctx: &DalContext<'_, '_>) -> User {
     .expect("cannot create user")
 }
 
-pub async fn create_group(ctx: &DalContext<'_, '_>) -> Group {
+pub async fn create_group(ctx: &DalContext<'_, '_, '_>) -> Group {
     let name = generate_fake_name();
     Group::new(ctx, &name).await.expect("cannot create group")
 }
 
 pub async fn billing_account_signup(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     jwt_secret_key: &JwtSecretKey,
 ) -> (BillingAccountSignup, String) {
     let _write_tenancy = WriteTenancy::new_universal();
@@ -301,28 +301,28 @@ pub async fn billing_account_signup(
     (nba, auth_token)
 }
 
-pub async fn create_schema(ctx: &DalContext<'_, '_>, kind: &SchemaKind) -> Schema {
+pub async fn create_schema(ctx: &DalContext<'_, '_, '_>, kind: &SchemaKind) -> Schema {
     let name = generate_fake_name();
     Schema::new(ctx, &name, kind, &ComponentKind::Standard)
         .await
         .expect("cannot create schema")
 }
 
-pub async fn create_schema_ui_menu(ctx: &DalContext<'_, '_>) -> schema::UiMenu {
+pub async fn create_schema_ui_menu(ctx: &DalContext<'_, '_, '_>) -> schema::UiMenu {
     schema::UiMenu::new(ctx, &DiagramKind::Configuration)
         .await
         .expect("cannot create schema ui menu")
 }
 
 pub async fn create_schema_variant(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     schema_id: SchemaId,
 ) -> schema::SchemaVariant {
     create_schema_variant_with_root(ctx, schema_id).await.0
 }
 
 pub async fn create_schema_variant_with_root(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     schema_id: SchemaId,
 ) -> (schema::SchemaVariant, schema::RootProp) {
     let name = generate_fake_name();
@@ -387,7 +387,7 @@ pub async fn create_schema_variant_with_root(
     (variant, root)
 }
 
-pub async fn create_component_and_schema(ctx: &DalContext<'_, '_>) -> Component {
+pub async fn create_component_and_schema(ctx: &DalContext<'_, '_, '_>) -> Component {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema_variant
@@ -403,7 +403,7 @@ pub async fn create_component_and_schema(ctx: &DalContext<'_, '_>) -> Component 
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_component_for_schema_variant(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     schema_variant_id: &SchemaVariantId,
 ) -> Component {
     let name = generate_fake_name();
@@ -415,7 +415,7 @@ pub async fn create_component_for_schema_variant(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_component_for_schema(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     schema_id: &SchemaId,
 ) -> Component {
     let name = generate_fake_name();
@@ -425,23 +425,23 @@ pub async fn create_component_for_schema(
     component
 }
 
-pub async fn create_node(ctx: &DalContext<'_, '_>, node_kind: &NodeKind) -> Node {
+pub async fn create_node(ctx: &DalContext<'_, '_, '_>, node_kind: &NodeKind) -> Node {
     Node::new(ctx, node_kind).await.expect("cannot create node")
 }
 
-pub async fn create_qualification_check(ctx: &DalContext<'_, '_>) -> QualificationCheck {
+pub async fn create_qualification_check(ctx: &DalContext<'_, '_, '_>) -> QualificationCheck {
     let name = generate_fake_name();
     QualificationCheck::new(ctx, name)
         .await
         .expect("cannot create qualification check")
 }
 
-pub async fn create_system(ctx: &DalContext<'_, '_>) -> System {
+pub async fn create_system(ctx: &DalContext<'_, '_, '_>) -> System {
     let name = generate_fake_name();
     System::new(ctx, name).await.expect("cannot create system")
 }
 
-pub async fn create_prop(ctx: &DalContext<'_, '_>) -> Prop {
+pub async fn create_prop(ctx: &DalContext<'_, '_, '_>) -> Prop {
     let name = generate_fake_name();
     Prop::new(ctx, name, PropKind::String)
         .await
@@ -449,7 +449,7 @@ pub async fn create_prop(ctx: &DalContext<'_, '_>) -> Prop {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_prop_of_kind(ctx: &DalContext<'_, '_>, prop_kind: PropKind) -> Prop {
+pub async fn create_prop_of_kind(ctx: &DalContext<'_, '_, '_>, prop_kind: PropKind) -> Prop {
     let name = generate_fake_name();
     Prop::new(ctx, name, prop_kind)
         .await
@@ -458,7 +458,7 @@ pub async fn create_prop_of_kind(ctx: &DalContext<'_, '_>, prop_kind: PropKind) 
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_prop_of_kind_with_name(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     prop_kind: PropKind,
     name: impl AsRef<str>,
 ) -> Prop {
@@ -470,7 +470,7 @@ pub async fn create_prop_of_kind_with_name(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_prop_of_kind_and_set_parent_with_name(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     prop_kind: PropKind,
     name: impl AsRef<str>,
     parent_prop_id: PropId,
@@ -486,7 +486,7 @@ pub async fn create_prop_of_kind_and_set_parent_with_name(
     new_prop
 }
 
-pub async fn create_func(ctx: &DalContext<'_, '_>) -> Func {
+pub async fn create_func(ctx: &DalContext<'_, '_, '_>) -> Func {
     let name = generate_fake_name();
     Func::new(
         ctx,
@@ -500,7 +500,7 @@ pub async fn create_func(ctx: &DalContext<'_, '_>) -> Func {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_func_binding(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     args: serde_json::Value,
     func_id: FuncId,
     backend_kind: FuncBackendKind,
@@ -511,7 +511,7 @@ pub async fn create_func_binding(
 }
 
 pub async fn encrypt_message(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     key_pair_id: KeyPairId,
     message: &serde_json::Value,
 ) -> Vec<u8> {
@@ -528,7 +528,7 @@ pub async fn encrypt_message(
 }
 
 pub async fn create_secret(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     key_pair_id: KeyPairId,
     billing_account_id: BillingAccountId,
 ) -> Secret {
@@ -550,7 +550,7 @@ pub async fn create_secret(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_secret_with_message(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     key_pair_id: KeyPairId,
     message: &serde_json::Value,
     billing_account_id: BillingAccountId,

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -75,7 +75,7 @@ impl User {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: impl AsRef<str>,
         email: impl AsRef<str>,
         password: impl AsRef<str>,
@@ -117,7 +117,7 @@ impl User {
     );
 
     pub async fn find_by_email(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         email: impl AsRef<str>,
     ) -> UserResult<Option<User>> {
         let email = email.as_ref();
@@ -133,7 +133,7 @@ impl User {
         Ok(result)
     }
 
-    pub async fn authorize(ctx: &DalContext<'_, '_>, user_id: &UserId) -> UserResult<bool> {
+    pub async fn authorize(ctx: &DalContext<'_, '_, '_>, user_id: &UserId) -> UserResult<bool> {
         let _row = ctx
             .txns()
             .pg()
@@ -147,7 +147,7 @@ impl User {
 
     pub async fn login(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         jwt_secret_key: &JwtSecretKey,
         billing_account_id: &BillingAccountId,
         password: impl Into<String>,
@@ -190,7 +190,7 @@ impl UserClaim {
     }
 
     pub async fn from_bearer_token(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         token: impl AsRef<str>,
     ) -> UserResult<UserClaim> {
         let claims = crate::jwt_key::validate_bearer_token(ctx, &token).await?;

--- a/lib/dal/src/validation_prototype.rs
+++ b/lib/dal/src/validation_prototype.rs
@@ -126,7 +126,7 @@ impl ValidationPrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         args: serde_json::Value,
         context: ValidationPrototypeContext,
@@ -158,7 +158,7 @@ impl ValidationPrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_prop(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prop_id: PropId,
         system_id: SystemId,
     ) -> ValidationPrototypeResult<Vec<Self>> {

--- a/lib/dal/src/validation_resolver.rs
+++ b/lib/dal/src/validation_resolver.rs
@@ -90,7 +90,7 @@ impl ValidationResolver {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         validation_prototype_id: ValidationPrototypeId,
         attribute_value_id: AttributeValueId,
         func_binding_id: FuncBindingId,
@@ -122,7 +122,7 @@ impl ValidationResolver {
     standard_model_accessor!(func_binding_id, Pk(FuncBindingId), ValidationResolverResult);
 
     pub async fn find_status(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         system_id: SystemId,
     ) -> ValidationResolverResult<Vec<ValidationStatus>> {

--- a/lib/dal/src/visibility.rs
+++ b/lib/dal/src/visibility.rs
@@ -79,7 +79,7 @@ impl Visibility {
     #[instrument(skip(ctx))]
     pub async fn is_visible_to(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         check_visibility: &Visibility,
     ) -> VisibilityResult<bool> {
         let row = ctx

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -98,14 +98,17 @@ impl WorkflowView {
         }
     }
 
-    pub async fn resolve(ctx: &DalContext<'_, '_>, func: &Func) -> WorkflowResult<WorkflowTree> {
+    pub async fn resolve(
+        ctx: &DalContext<'_, '_, '_>,
+        func: &Func,
+    ) -> WorkflowResult<WorkflowTree> {
         // TODO: add args
         let args = vec![];
         Self::resolve_inner(ctx, func.name(), args, HashSet::new(), &mut HashMap::new()).await
     }
 
     async fn veritech_run(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func: Func,
         args: FuncBackendJsWorkflowArgs,
     ) -> WorkflowResult<Self> {
@@ -122,7 +125,7 @@ impl WorkflowView {
 
     #[async_recursion]
     async fn resolve_inner(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         name: &str,
         _args: Vec<serde_json::Value>,
         mut recursion_marker: HashSet<String>,
@@ -216,7 +219,7 @@ pub struct FuncToExecute {
 impl WorkflowTree {
     pub async fn run(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> WorkflowResult<Vec<FuncBindingReturnValue>> {
         let (map, rxs) = self.prepare(ctx).await?;
 
@@ -295,7 +298,7 @@ impl WorkflowTree {
     #[async_recursion]
     async fn prepare(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> WorkflowResult<(
         HashMap<FuncBindingId, FuncToExecute>,
         HashMap<FuncBindingId, mpsc::Receiver<OutputStream>>,
@@ -413,7 +416,7 @@ impl WorkflowTree {
 
     async fn postprocess(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         map: HashMap<FuncBindingId, FuncToExecute>,
         mut outputs: HashMap<FuncBindingId, Vec<OutputStream>>,
     ) -> WorkflowResult<Vec<FuncBindingReturnValue>> {
@@ -462,7 +465,7 @@ pub struct WorkflowTreeView {
 impl WorkflowTreeView {
     // We need to stop recursing so much
     #[async_recursion]
-    pub async fn new(ctx: &DalContext<'_, '_>, tree: WorkflowTree) -> WorkflowResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, tree: WorkflowTree) -> WorkflowResult<Self> {
         let mut view = WorkflowTreeView {
             name: tree.name,
             kind: tree.kind,
@@ -497,7 +500,7 @@ pub struct CommandOutput {
 }
 
 impl WsEvent {
-    pub fn command_output(ctx: &DalContext<'_, '_>, output: String) -> Self {
+    pub fn command_output(ctx: &DalContext<'_, '_, '_>, output: String) -> Self {
         WsEvent::new(ctx, WsPayload::CommandOutput(CommandOutput { output }))
     }
 }

--- a/lib/dal/src/workflow_prototype.rs
+++ b/lib/dal/src/workflow_prototype.rs
@@ -150,7 +150,7 @@ impl WorkflowPrototype {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         func_id: FuncId,
         args: serde_json::Value,
         context: WorkflowPrototypeContext,
@@ -191,7 +191,7 @@ impl WorkflowPrototype {
 
     pub async fn resolve(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> WorkflowPrototypeResult<WorkflowResolver> {
         let mut context = WorkflowResolverContext::new();
         context.set_component_id(self.component_id);
@@ -244,7 +244,7 @@ impl WorkflowPrototype {
 
     #[allow(clippy::too_many_arguments)]
     pub async fn find_for_context(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         component_id: ComponentId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/workflow_resolver.rs
+++ b/lib/dal/src/workflow_resolver.rs
@@ -132,7 +132,7 @@ impl WorkflowResolver {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         workflow_prototype_id: WorkflowPrototypeId,
         func_id: FuncId,
         func_binding_id: FuncBindingId,
@@ -155,7 +155,7 @@ impl WorkflowResolver {
         Ok(object)
     }
 
-    pub async fn tree(&self, ctx: &DalContext<'_, '_>) -> WorkflowResolverResult<WorkflowTree> {
+    pub async fn tree(&self, ctx: &DalContext<'_, '_, '_>) -> WorkflowResolverResult<WorkflowTree> {
         let func_binding = FuncBinding::get_by_id(ctx, &self.func_binding_id())
             .await?
             .ok_or_else(|| WorkflowResolverError::FuncBindingNotFound(self.func_binding_id()))?;
@@ -176,7 +176,7 @@ impl WorkflowResolver {
     standard_model_accessor!(func_binding_id, Pk(FuncBindingId), WorkflowResolverResult);
 
     pub async fn find_for_prototype(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         workflow_prototype_id: &WorkflowPrototypeId,
         context: WorkflowResolverContext,
     ) -> WorkflowResolverResult<Vec<Self>> {

--- a/lib/dal/src/workflow_runner.rs
+++ b/lib/dal/src/workflow_runner.rs
@@ -148,7 +148,7 @@ impl WorkflowRunner {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub async fn new(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         workflow_prototype_id: WorkflowPrototypeId,
         workflow_resolver_id: WorkflowResolverId,
         func_id: FuncId,
@@ -179,7 +179,7 @@ impl WorkflowRunner {
     }
 
     pub async fn run(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         prototype_id: WorkflowPrototypeId,
     ) -> WorkflowRunnerResult<(Self, Vec<FuncBindingReturnValue>)> {
         let prototype = WorkflowPrototype::get_by_id(ctx, &prototype_id)
@@ -249,7 +249,7 @@ impl WorkflowRunner {
     standard_model_accessor!(func_binding_id, Pk(FuncBindingId), WorkflowRunnerResult);
 
     pub async fn find_for_prototype(
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
         workflow_prototype_id: &WorkflowPrototypeId,
         context: WorkflowRunnerContext,
     ) -> WorkflowRunnerResult<Vec<Self>> {

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -53,7 +53,7 @@ impl_standard_model! {
 
 impl Workspace {
     #[instrument(skip_all)]
-    pub async fn new(ctx: &DalContext<'_, '_>, name: impl AsRef<str>) -> WorkspaceResult<Self> {
+    pub async fn new(ctx: &DalContext<'_, '_, '_>, name: impl AsRef<str>) -> WorkspaceResult<Self> {
         let name = name.as_ref();
         let row = ctx
             .txns()

--- a/lib/dal/src/write_tenancy.rs
+++ b/lib/dal/src/write_tenancy.rs
@@ -118,7 +118,7 @@ impl WriteTenancy {
 
     pub async fn clone_into_read_tenancy(
         &self,
-        ctx: &DalContext<'_, '_>,
+        ctx: &DalContext<'_, '_, '_>,
     ) -> Result<ReadTenancy, ReadTenancyError> {
         let read_tenancy = if self.workspace_ids.is_empty() {
             if self.organization_ids.is_empty() {

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -44,7 +44,7 @@ pub struct WsEvent {
 }
 
 impl WsEvent {
-    pub fn new(ctx: &DalContext<'_, '_>, payload: WsPayload) -> Self {
+    pub fn new(ctx: &DalContext<'_, '_, '_>, payload: WsPayload) -> Self {
         let billing_account_ids = Self::billing_account_id_from_tenancy(ctx.read_tenancy());
         let history_actor = ctx.history_actor().clone();
         WsEvent {
@@ -72,7 +72,7 @@ impl WsEvent {
         tenancy.billing_accounts().into()
     }
 
-    pub async fn publish(&self, ctx: &DalContext<'_, '_>) -> WsEventResult<()> {
+    pub async fn publish(&self, ctx: &DalContext<'_, '_, '_>) -> WsEventResult<()> {
         for billing_account_id in self.billing_account_ids.iter() {
             let subject = format!("si.billing_account_id.{}.event", billing_account_id);
             ctx.nats_txn().publish(subject, &self).await?;

--- a/lib/dal/tests/database.rs
+++ b/lib/dal/tests/database.rs
@@ -12,6 +12,8 @@ const UNSET_ID_VALUE: i64 = -1;
 
 /// Smoke test to ensure the database is running and setup worked (migrations, etc.).
 #[test]
-async fn database_smoke(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn database_smoke(
+    DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>,
+) {
     assert!(System::get_by_id(ctx, &UNSET_ID_VALUE.into()).await.is_ok())
 }

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -15,7 +15,7 @@ use dal::{
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image")
@@ -80,7 +80,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
+async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
 
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
@@ -341,7 +341,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext<'_, '_>) {
 
 /// Test attribute prototype removal corresponding to a least specific context.
 #[test]
-async fn remove_least_specific(ctx: &DalContext<'_, '_>) {
+async fn remove_least_specific(ctx: &DalContext<'_, '_, '_>) {
     let prop = create_prop_of_kind_with_name(ctx, PropKind::String, "toddhoward").await;
 
     let context = AttributeContextBuilder::new()
@@ -367,7 +367,7 @@ async fn remove_least_specific(ctx: &DalContext<'_, '_>) {
 
 /// Test attribute prototype removal corresponding to a component-specific context.
 #[test]
-async fn remove_component_specific(ctx: &DalContext<'_, '_>) {
+async fn remove_component_specific(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -12,7 +12,7 @@ use dal::test_harness::create_prop_of_kind_and_set_parent_with_name;
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
-async fn create_and_list_for_attribute_prototype(ctx: &DalContext<'_, '_>) {
+async fn create_and_list_for_attribute_prototype(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -10,7 +10,7 @@ use pretty_assertions_sorted::assert_eq_sorted;
 use crate::dal::test;
 
 #[test]
-async fn update_for_context_simple(ctx: &DalContext<'_, '_>) {
+async fn update_for_context_simple(ctx: &DalContext<'_, '_, '_>) {
     // "name": String
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
@@ -143,7 +143,7 @@ async fn update_for_context_simple(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn insert_for_context_simple(ctx: &DalContext<'_, '_>) {
+async fn insert_for_context_simple(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -230,7 +230,7 @@ async fn insert_for_context_simple(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn update_for_context_object(ctx: &DalContext<'_, '_>) {
+async fn update_for_context_object(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -453,7 +453,7 @@ async fn update_for_context_object(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext<'_, '_>) {
+async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema

--- a/lib/dal/tests/integration_test/attribute/view.rs
+++ b/lib/dal/tests/integration_test/attribute/view.rs
@@ -8,7 +8,7 @@ use dal::{
 use pretty_assertions_sorted::assert_eq_sorted;
 
 #[test]
-async fn schema_variant_specific(ctx: &DalContext<'_, '_>) {
+async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
     // "name": String
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;

--- a/lib/dal/tests/integration_test/billing_account.rs
+++ b/lib/dal/tests/integration_test/billing_account.rs
@@ -9,7 +9,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn new(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>) {
     let name = generate_fake_name();
     let billing_account = BillingAccount::new(ctx, &name, Some(&"coheed and cambria".to_string()))
         .await
@@ -22,7 +22,7 @@ async fn new(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_,
 }
 
 #[test]
-async fn get_by_pk(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn get_by_pk(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>) {
     let billing_account = create_billing_account(ctx).await;
 
     let retrieved = BillingAccount::get_by_pk(ctx, billing_account.pk())
@@ -33,7 +33,7 @@ async fn get_by_pk(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'
 }
 
 #[test]
-async fn get_by_id(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn get_by_id(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>) {
     let billing_account = create_billing_account(ctx).await;
 
     let retrieved = BillingAccount::get_by_id(ctx, billing_account.id())
@@ -45,7 +45,7 @@ async fn get_by_id(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'
 }
 
 #[test]
-async fn set_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn set_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>) {
     let mut billing_account = create_billing_account(ctx).await;
 
     let new_name = generate_fake_name();
@@ -58,7 +58,9 @@ async fn set_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_
 }
 
 #[test]
-async fn set_description(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn set_description(
+    DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>,
+) {
     let mut billing_account = create_billing_account(ctx).await;
 
     billing_account
@@ -69,7 +71,7 @@ async fn set_description(DalContextUniversalHeadRef(ctx): DalContextUniversalHea
 }
 
 #[test]
-async fn find_by_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_>) {
+async fn find_by_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_, '_, '_, '_>) {
     let billing_account = create_billing_account(ctx).await;
 
     let name_billing_account = BillingAccount::find_by_name(ctx, &billing_account.name())
@@ -83,7 +85,7 @@ async fn find_by_name(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRe
 }
 
 #[test]
-async fn get_defaults(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn get_defaults(ctx: &mut DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let defaults = BillingAccount::get_defaults(ctx, nba.billing_account.id())
         .await
         .expect("cannot get defaults for billing account");

--- a/lib/dal/tests/integration_test/capability.rs
+++ b/lib/dal/tests/integration_test/capability.rs
@@ -3,7 +3,7 @@ use dal::{BillingAccountId, Capability, DalContext, StandardModel};
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn new(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let _capability = Capability::new(ctx, "monkey", "*")

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -10,7 +10,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>) {
+async fn new(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_, '_>) {
     let change_set = ChangeSet::new(
         ctx,
         "mastodon rocks",
@@ -28,7 +28,7 @@ async fn new(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>) {
 }
 
 #[test]
-async fn apply(ctx: &mut DalContext<'_, '_>) {
+async fn apply(ctx: &mut DalContext<'_, '_, '_>) {
     let mut change_set = ChangeSet::get_by_pk(ctx, &ctx.visibility().change_set_pk)
         .await
         .unwrap()
@@ -56,7 +56,10 @@ async fn apply(ctx: &mut DalContext<'_, '_>) {
 }
 
 #[test]
-async fn list_open(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>, bid: BillingAccountId) {
+async fn list_open(
+    DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_, '_>,
+    bid: BillingAccountId,
+) {
     let a_change_set = create_change_set(ctx, bid).await;
     let b_change_set = create_change_set(ctx, bid).await;
     let mut c_change_set = create_change_set(ctx, bid).await;
@@ -96,7 +99,10 @@ async fn list_open(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>, bid: B
 }
 
 #[test]
-async fn get_by_pk(DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>, bid: BillingAccountId) {
+async fn get_by_pk(
+    DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_, '_>,
+    bid: BillingAccountId,
+) {
     let change_set = create_change_set(ctx, bid).await;
     let result = ChangeSet::get_by_pk(ctx, &change_set.pk)
         .await

--- a/lib/dal/tests/integration_test/code_generation_prototype.rs
+++ b/lib/dal/tests/integration_test/code_generation_prototype.rs
@@ -9,7 +9,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "kubernetes_deployment".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -49,7 +49,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_component(ctx: &DalContext<'_, '_>, _nba: BillingAccountSignup) {
+async fn find_for_component(ctx: &DalContext<'_, '_, '_>, _nba: BillingAccountSignup) {
     // TODO: This test is brittle, because it relies on the behavior of kubernetes_deployment. I'm okay
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)

--- a/lib/dal/tests/integration_test/code_generation_resolver.rs
+++ b/lib/dal/tests/integration_test/code_generation_resolver.rs
@@ -10,7 +10,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -65,7 +65,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
+async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -16,12 +16,12 @@ use crate::dal::test;
 mod view;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _component = create_component_and_schema(ctx).await;
 }
 
 #[test]
-async fn new_for_schema_variant_with_node(ctx: &DalContext<'_, '_>, wid: WorkspaceId) {
+async fn new_for_schema_variant_with_node(ctx: &DalContext<'_, '_, '_>, wid: WorkspaceId) {
     let (system, _system_node) = create_system_with_node(ctx, &wid).await;
 
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
@@ -81,14 +81,14 @@ async fn new_for_schema_variant_with_node(ctx: &DalContext<'_, '_>, wid: Workspa
 }
 
 #[test]
-async fn schema_relationships(ctx: &DalContext<'_, '_>) {
+async fn schema_relationships(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     let _component = create_component_for_schema_variant(ctx, schema_variant.id()).await;
 }
 
 #[test]
-async fn qualification_view(ctx: &DalContext<'_, '_>) {
+async fn qualification_view(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
 
@@ -133,7 +133,7 @@ async fn qualification_view(ctx: &DalContext<'_, '_>) {
 // to prove what we want right now. Figuring out a test that is less brittle is a great idea, but I'm choosing
 // expediency.
 #[test]
-async fn list_qualifications(ctx: &DalContext<'_, '_>) {
+async fn list_qualifications(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image schema")
@@ -156,7 +156,7 @@ async fn list_qualifications(ctx: &DalContext<'_, '_>) {
 
 // Also brittle, same reason
 #[test]
-async fn list_qualifications_by_component_id(ctx: &DalContext<'_, '_>) {
+async fn list_qualifications_by_component_id(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image schema")
@@ -179,7 +179,7 @@ async fn list_qualifications_by_component_id(ctx: &DalContext<'_, '_>) {
 
 // Also brittle, same reason
 #[test]
-async fn get_resource_by_component_id(ctx: &DalContext<'_, '_>, wid: WorkspaceId) {
+async fn get_resource_by_component_id(ctx: &DalContext<'_, '_, '_>, wid: WorkspaceId) {
     let (system, _system_node) = create_system_with_node(ctx, &wid).await;
 
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 /// { "queen": { "bohemian_rhapsody": "", "killer_queen": ""} }
 /// ```
 pub async fn create_schema_with_object_and_string_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (Schema, SchemaVariant, Prop, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
@@ -65,7 +65,7 @@ pub async fn create_schema_with_object_and_string_prop(
 /// { "queen": { "bohemian_rhapsody": "", "killer_queen": "", "under_pressure": { "another_one_bites_the_dust": "" }} }
 /// ```
 pub async fn create_schema_with_nested_objects_and_string_prop(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (
     Schema,
     SchemaVariant,
@@ -141,7 +141,7 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
 /// { "bohemian_rhapsody": "", "killer_queen": "" }
 /// ```
 pub async fn create_schema_with_string_props(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (Schema, SchemaVariant, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
@@ -178,7 +178,7 @@ pub async fn create_schema_with_string_props(
 /// { "sammy_hagar": ["standing hampton", "voa"] }
 /// ```
 pub async fn create_schema_with_array_of_string_props(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (Schema, SchemaVariant, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
@@ -219,7 +219,7 @@ pub async fn create_schema_with_array_of_string_props(
 /// }
 /// ```
 pub async fn create_schema_with_nested_array_objects(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (
     Schema,
     SchemaVariant,
@@ -297,7 +297,7 @@ pub async fn create_schema_with_nested_array_objects(
 /// }
 /// ```
 pub async fn create_simple_map(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (Schema, SchemaVariant, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
@@ -337,7 +337,7 @@ pub async fn create_simple_map(
 /// }
 /// ```
 pub async fn create_schema_with_nested_array_objects_and_a_map(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) -> (
     Schema,
     SchemaVariant,
@@ -416,7 +416,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 }
 
 #[test]
-async fn only_string_props(ctx: &DalContext<'_, '_>) {
+async fn only_string_props(ctx: &DalContext<'_, '_, '_>) {
     let (schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
     let (component, _) =
@@ -508,7 +508,7 @@ async fn only_string_props(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn one_object_prop(ctx: &DalContext<'_, '_>) {
+async fn one_object_prop(ctx: &DalContext<'_, '_, '_>) {
     let (schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
     let (component, _) =
@@ -619,7 +619,7 @@ async fn one_object_prop(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
+async fn nested_object_prop(ctx: &DalContext<'_, '_, '_>) {
     let (
         schema,
         schema_variant,
@@ -785,7 +785,7 @@ async fn nested_object_prop(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
+async fn simple_array_of_strings(ctx: &DalContext<'_, '_, '_>) {
     let (schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
@@ -883,7 +883,7 @@ async fn simple_array_of_strings(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
+async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_, '_>) {
     let (
         schema,
         schema_variant,
@@ -1143,7 +1143,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn simple_map(ctx: &DalContext<'_, '_>) {
+async fn simple_map(ctx: &DalContext<'_, '_, '_>) {
     let (schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
     let (component, _) = Component::new_for_schema_variant_with_node(
@@ -1242,7 +1242,7 @@ async fn simple_map(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
+async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_, '_>) {
     let (
         schema,
         schema_variant,
@@ -1426,7 +1426,7 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn cyclone_crypto_e2e(ctx: &DalContext<'_, '_>) {
+async fn cyclone_crypto_e2e(ctx: &DalContext<'_, '_, '_>) {
     let (tx, _rx) = mpsc::channel(64);
     let secret_value = "Beware Cuca will catch you";
     let secret = serde_json::to_string(&serde_json::json!({

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -9,7 +9,7 @@ use dal::{
 use dal::{DiagramEdgeView, SchemaVariant};
 
 #[test]
-async fn get_diagram_and_create_connection(ctx: &DalContext<'_, '_>) {
+async fn get_diagram_and_create_connection(ctx: &DalContext<'_, '_, '_>) {
     let mut harness = BuiltinsHarness::new();
     let from_docker_hub_credential = harness
         .create_component(ctx, "from", Builtin::DockerHubCredential)

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -10,7 +10,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let mut harness = BuiltinsHarness::new();
     let credential_payload = harness
         .create_component(ctx, "tail", Builtin::DockerHubCredential)
@@ -77,7 +77,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 
 #[test]
 async fn include_component_in_system_on_head(
-    DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_>,
+    DalContextHeadRef(ctx): DalContextHeadRef<'_, '_, '_, '_>,
     wid: WorkspaceId,
 ) {
     let edge_kind = "system".to_string();
@@ -144,7 +144,7 @@ async fn include_component_in_system_on_head(
 
 #[test]
 async fn include_component_in_system_with_edit_sessions(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     wid: WorkspaceId,
 ) {
     let edge_kind = "system".to_string();

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -14,7 +14,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -29,7 +29,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_new(ctx: &DalContext<'_, '_>) {
+async fn func_binding_new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -42,7 +42,7 @@ async fn func_binding_new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_find_or_create_head(ctx: &DalContext<'_, '_>) {
+async fn func_binding_find_or_create_head(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -66,7 +66,7 @@ async fn func_binding_find_or_create_head(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_find_or_create_change_set(ctx: &DalContext<'_, '_>) {
+async fn func_binding_find_or_create_change_set(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("floop".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
@@ -119,7 +119,7 @@ async fn func_binding_find_or_create_change_set(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_return_value_new(ctx: &DalContext<'_, '_>) {
+async fn func_binding_return_value_new(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("funky".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
@@ -143,7 +143,7 @@ async fn func_binding_return_value_new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_execute(ctx: &DalContext<'_, '_>) {
+async fn func_binding_execute(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = serde_json::to_value(FuncBackendStringArgs::new("funky".to_string()))
         .expect("cannot serialize args to json");
@@ -162,7 +162,7 @@ async fn func_binding_execute(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn func_binding_execute_unset(ctx: &DalContext<'_, '_>) {
+async fn func_binding_execute_unset(ctx: &DalContext<'_, '_, '_>) {
     let name = dal::test_harness::generate_fake_name();
     let func = Func::new(
         ctx,

--- a/lib/dal/tests/integration_test/func_execution.rs
+++ b/lib/dal/tests/integration_test/func_execution.rs
@@ -11,7 +11,7 @@ use dal::{
 use veritech::OutputStream;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("slayer".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
@@ -23,7 +23,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_state(ctx: &DalContext<'_, '_>) {
+async fn set_state(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("slayer".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
@@ -40,7 +40,7 @@ async fn set_state(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_output_stream(ctx: &DalContext<'_, '_>) {
+async fn set_output_stream(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("slayer".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");
@@ -71,7 +71,7 @@ async fn set_output_stream(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn process_return_value(ctx: &DalContext<'_, '_>) {
+async fn process_return_value(ctx: &DalContext<'_, '_, '_>) {
     let func = create_func(ctx).await;
     let args = FuncBackendStringArgs::new("slayer".to_string());
     let args_json = serde_json::to_value(args).expect("cannot serialize args to json");

--- a/lib/dal/tests/integration_test/group.rs
+++ b/lib/dal/tests/integration_test/group.rs
@@ -6,14 +6,14 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn new(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let _group = Group::new(ctx, "funky").await.expect("cannot create group");
 }
 
 #[test]
-async fn add_user(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn add_user(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let group = create_group(ctx).await;
@@ -31,7 +31,7 @@ async fn add_user(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
 }
 
 #[test]
-async fn remove_user(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn remove_user(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let group = create_group(ctx).await;
@@ -58,7 +58,7 @@ async fn remove_user(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
 }
 
 #[test]
-async fn users(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn users(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let group = create_group(ctx).await;

--- a/lib/dal/tests/integration_test/history_event.rs
+++ b/lib/dal/tests/integration_test/history_event.rs
@@ -4,7 +4,7 @@ use dal::DalContext;
 use dal::{HistoryActor, HistoryEvent};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let history_event = HistoryEvent::new(
         ctx,
         "change_set.opened",

--- a/lib/dal/tests/integration_test/jwt_key.rs
+++ b/lib/dal/tests/integration_test/jwt_key.rs
@@ -7,14 +7,14 @@ use jwt_simple::algorithms::RSAKeyPairLike;
 // {get_jwt_signing_key, get_jwt_validation_key};
 
 #[test]
-async fn get_jwt_signing_key(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn get_jwt_signing_key(ctx: &DalContext<'_, '_, '_>, jwt_secret_key: &JwtSecretKey) {
     let _signing_key = jwt_key::get_jwt_signing_key(ctx, jwt_secret_key)
         .await
         .expect("cannot get jwt signing key");
 }
 
 #[test]
-async fn get_jwt_validation_key(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn get_jwt_validation_key(ctx: &DalContext<'_, '_, '_>, jwt_secret_key: &JwtSecretKey) {
     let signing_key = jwt_key::get_jwt_signing_key(ctx, jwt_secret_key)
         .await
         .expect("cannot get jwt signing key");

--- a/lib/dal/tests/integration_test/key_pair.rs
+++ b/lib/dal/tests/integration_test/key_pair.rs
@@ -6,14 +6,14 @@ use dal::test_harness::{create_billing_account, create_key_pair};
 use dal::{BillingAccount, KeyPair, StandardModel};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _key_pair = KeyPair::new(ctx, "funky")
         .await
         .expect("cannot create key_pair");
 }
 
 #[test]
-async fn belongs_to(ctx: &DalContext<'_, '_>) {
+async fn belongs_to(ctx: &DalContext<'_, '_, '_>) {
     let billing_account = create_billing_account(ctx).await;
     let key_pair = create_key_pair(ctx).await;
 
@@ -45,7 +45,7 @@ async fn belongs_to(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn public_key_get_current(ctx: &DalContext<'_, '_>) {
+async fn public_key_get_current(ctx: &DalContext<'_, '_, '_>) {
     let billing_account = create_billing_account(ctx).await;
     let first_key_pair = create_key_pair(ctx).await;
     first_key_pair

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -8,7 +8,7 @@ use dal::test_harness::{
 use dal::{HistoryActor, Node, SchemaKind, StandardModel, Visibility, WriteTenancy};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -18,7 +18,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn component_relationships(ctx: &DalContext<'_, '_>) {
+async fn component_relationships(ctx: &DalContext<'_, '_, '_>) {
     let component = create_component_and_schema(ctx).await;
     let node = create_node(ctx, &NodeKind::Configuration).await;
     node.set_component(ctx, component.id())
@@ -33,7 +33,7 @@ async fn component_relationships(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn new_node_template(ctx: &DalContext<'_, '_>) {
+async fn new_node_template(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema

--- a/lib/dal/tests/integration_test/node_menu.rs
+++ b/lib/dal/tests/integration_test/node_menu.rs
@@ -5,7 +5,7 @@ use dal::{DalContext, DiagramKind};
 use crate::dal::test;
 
 #[test]
-async fn get_node_menu(ctx: &DalContext<'_, '_>) {
+async fn get_node_menu(ctx: &DalContext<'_, '_, '_>) {
     let mut harness = BuiltinsHarness::new();
     let _docker_image_payload = harness
         .create_component(ctx, "valorant", Builtin::DockerImage)

--- a/lib/dal/tests/integration_test/node_position.rs
+++ b/lib/dal/tests/integration_test/node_position.rs
@@ -3,7 +3,7 @@ use dal::DalContext;
 use dal::{node::NodeKind, test_harness::create_node, DiagramKind, NodePosition, StandardModel};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let node = create_node(ctx, &NodeKind::Configuration).await;
     let node_position = NodePosition::new(
         ctx,
@@ -32,7 +32,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_node_position(ctx: &DalContext<'_, '_>) {
+async fn set_node_position(ctx: &DalContext<'_, '_, '_>) {
     let node = create_node(ctx, &NodeKind::Configuration).await;
 
     let node_position = NodePosition::upsert_by_node_id(

--- a/lib/dal/tests/integration_test/organization.rs
+++ b/lib/dal/tests/integration_test/organization.rs
@@ -4,7 +4,7 @@ use crate::dal::test;
 use dal::{HistoryActor, Organization, WriteTenancy};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _history_actor = HistoryActor::SystemInit;
     let _organization = Organization::new(ctx, "iron maiden")

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -7,7 +7,7 @@ use pretty_assertions_sorted::assert_eq;
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -19,7 +19,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn schema_variants(ctx: &DalContext<'_, '_>) {
+async fn schema_variants(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     let prop = create_prop(ctx).await;
@@ -46,7 +46,7 @@ async fn schema_variants(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn parent_props(ctx: &DalContext<'_, '_>) {
+async fn parent_props(ctx: &DalContext<'_, '_, '_>) {
     let parent_prop = create_prop_of_kind(ctx, PropKind::Object).await;
     let child_prop = create_prop_of_kind(ctx, PropKind::String).await;
     child_prop
@@ -68,7 +68,7 @@ async fn parent_props(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn parent_props_wrong_prop_kinds(ctx: &DalContext<'_, '_>) {
+async fn parent_props_wrong_prop_kinds(ctx: &DalContext<'_, '_, '_>) {
     let parent_prop = create_prop_of_kind(ctx, PropKind::String).await;
     let child_prop = create_prop_of_kind(ctx, PropKind::Object).await;
 

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -5,7 +5,7 @@ use dal::{
 };
 
 #[test]
-async fn schema_for_schema_variant(ctx: &DalContext<'_, '_>) {
+async fn schema_for_schema_variant(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image schema")
@@ -21,7 +21,7 @@ async fn schema_for_schema_variant(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn value_for_context(ctx: &DalContext<'_, '_>) {
+async fn value_for_context(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image schema")

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -12,7 +12,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new_external(ctx: &DalContext<'_, '_>) {
+async fn new_external(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, _root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -48,7 +48,7 @@ async fn new_external(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn new_implicit_internal(ctx: &DalContext<'_, '_>) {
+async fn new_implicit_internal(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, _root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema

--- a/lib/dal/tests/integration_test/provider/builtins/docker_image_intelligence.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/docker_image_intelligence.rs
@@ -5,7 +5,7 @@ use pretty_assertions_sorted::assert_eq_sorted;
 use crate::dal::test;
 
 #[test]
-async fn docker_image_intra_component_update(ctx: &DalContext<'_, '_>) {
+async fn docker_image_intra_component_update(ctx: &DalContext<'_, '_, '_>) {
     let mut harness = BuiltinsHarness::new();
     let soulrender_payload = harness
         .create_component(ctx, "soulrender", Builtin::DockerImage)

--- a/lib/dal/tests/integration_test/provider/builtins/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/docker_image_to_kubernetes_deployment.rs
@@ -5,7 +5,9 @@ use pretty_assertions_sorted::assert_eq_sorted;
 use crate::dal::test;
 
 #[test]
-async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalContext<'_, '_>) {
+async fn docker_image_to_kubernetes_deployment_inter_component_update(
+    ctx: &DalContext<'_, '_, '_>,
+) {
     let mut harness = BuiltinsHarness::new();
     let tail_docker_image_payload = harness
         .create_component(ctx, "image", Builtin::DockerImage)

--- a/lib/dal/tests/integration_test/provider/builtins/kubernetes_deployment_intelligence.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/kubernetes_deployment_intelligence.rs
@@ -7,7 +7,7 @@ use crate::dal::test;
 // Oh yeah, it's big brain time.
 #[ignore]
 #[test]
-async fn kubernetes_deployment_intelligence(ctx: &DalContext<'_, '_>) {
+async fn kubernetes_deployment_intelligence(ctx: &DalContext<'_, '_, '_>) {
     let mut harness = BuiltinsHarness::new();
     let tail_fedora_payload = harness
         .create_component(ctx, "fedora", Builtin::DockerImage)

--- a/lib/dal/tests/integration_test/provider/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/provider/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -6,7 +6,7 @@ use crate::dal::test;
 
 #[test]
 async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
 ) {
     let mut harness = BuiltinsHarness::new();
     let tail_namespace_payload = harness

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::dal::test;
 
 #[test]
-async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
+async fn inter_component_identity_update(ctx: &DalContext<'_, '_, '_>) {
     // Setup both components used for inter component identity update.
     let esp_payload = setup_esp(ctx).await;
     let swings_payload = setup_swings(ctx).await;
@@ -287,7 +287,7 @@ async fn inter_component_identity_update(ctx: &DalContext<'_, '_>) {
 }
 
 // 38.805354552534816, -77.05091482877533
-async fn setup_esp(ctx: &DalContext<'_, '_>) -> ComponentPayload {
+async fn setup_esp(ctx: &DalContext<'_, '_, '_>) -> ComponentPayload {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -374,7 +374,7 @@ async fn setup_esp(ctx: &DalContext<'_, '_>) -> ComponentPayload {
 }
 
 // 38.82091849697006, -77.05236860190759
-async fn setup_swings(ctx: &DalContext<'_, '_>) -> ComponentPayload {
+async fn setup_swings(ctx: &DalContext<'_, '_, '_>) -> ComponentPayload {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -425,7 +425,7 @@ async fn setup_swings(ctx: &DalContext<'_, '_>) -> ComponentPayload {
 }
 
 #[test]
-async fn with_deep_data_structure(ctx: &DalContext<'_, '_>) {
+async fn with_deep_data_structure(ctx: &DalContext<'_, '_, '_>) {
     let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
         setup_identity_func(ctx).await;
 

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -11,7 +11,7 @@ use dal::{AttributeReadContext, DalContext, Func, PropKind, SchemaKind, Standard
 use pretty_assertions_sorted::assert_eq_sorted;
 
 #[test]
-async fn intra_component_identity_update(ctx: &DalContext<'_, '_>) {
+async fn intra_component_identity_update(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
@@ -294,7 +294,7 @@ async fn intra_component_identity_update(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn docker_image_intra_component_update(ctx: &DalContext<'_, '_>) {
+async fn docker_image_intra_component_update(ctx: &DalContext<'_, '_, '_>) {
     let schema_name = "docker_image".to_string();
     let schema: Schema = Schema::find_by_attr(ctx, "name", &schema_name)
         .await

--- a/lib/dal/tests/integration_test/qualification_check.rs
+++ b/lib/dal/tests/integration_test/qualification_check.rs
@@ -6,7 +6,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -17,7 +17,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn schema_variants(ctx: &DalContext<'_, '_>) {
+async fn schema_variants(ctx: &DalContext<'_, '_, '_>) {
     let qualification_check = create_qualification_check(ctx).await;
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let variant = create_schema_variant(ctx, *schema.id()).await;

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -12,7 +12,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -39,7 +39,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_component(ctx: &DalContext<'_, '_>) {
+async fn find_for_component(ctx: &DalContext<'_, '_, '_>) {
     // TODO: This test is brittle, because it relies on the behavior of docker_image. I'm okay
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)
@@ -93,7 +93,7 @@ async fn find_for_component(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn associate_prototypes_with_func_and_objects(ctx: &DalContext<'_, '_>) {
+async fn associate_prototypes_with_func_and_objects(ctx: &DalContext<'_, '_, '_>) {
     let mut schema = Schema::new(
         ctx,
         "dingue",

--- a/lib/dal/tests/integration_test/qualification_resolver.rs
+++ b/lib/dal/tests/integration_test/qualification_resolver.rs
@@ -10,7 +10,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -65,7 +65,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
+async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/read_tenancy.rs
+++ b/lib/dal/tests/integration_test/read_tenancy.rs
@@ -8,7 +8,7 @@ use dal::{
 
 #[test]
 async fn check_organization_specific_billing_account(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -24,7 +24,7 @@ async fn check_organization_specific_billing_account(
 
 #[test]
 async fn check_organization_in_billing_account(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -43,7 +43,7 @@ async fn check_organization_in_billing_account(
 
 #[test]
 async fn check_workspace_specific_billing_account(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -59,7 +59,7 @@ async fn check_workspace_specific_billing_account(
 
 #[test]
 async fn check_workspace_in_billing_account(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -82,7 +82,7 @@ async fn check_workspace_in_billing_account(
 
 #[test]
 async fn check_workspace_specific_organization(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -105,7 +105,7 @@ async fn check_workspace_specific_organization(
 
 #[test]
 async fn check_workspace_in_organization(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     nba: &BillingAccountSignup,
     _jwt_secret_key: &JwtSecretKey,
 ) {
@@ -123,7 +123,7 @@ async fn check_workspace_in_organization(
 }
 
 #[test]
-async fn check_universal(ctx: &DalContext<'_, '_>) {
+async fn check_universal(ctx: &DalContext<'_, '_, '_>) {
     let read_tenancy = ReadTenancy::new_billing_account(vec![BillingAccountId::from(-1)]);
 
     let write_tenancy = WriteTenancy::new_billing_account(1.into());
@@ -170,7 +170,7 @@ async fn check_universal(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn check_billing_account_pk_identical(ctx: &DalContext<'_, '_>) {
+async fn check_billing_account_pk_identical(ctx: &DalContext<'_, '_, '_>) {
     let read_tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
     let write_tenancy = WriteTenancy::new_billing_account(1.into());
 
@@ -182,7 +182,7 @@ async fn check_billing_account_pk_identical(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn check_billing_account_pk_overlapping(ctx: &DalContext<'_, '_>) {
+async fn check_billing_account_pk_overlapping(ctx: &DalContext<'_, '_, '_>) {
     let read_tenancy = ReadTenancy::new_billing_account(vec![
         1.into(),
         2.into(),
@@ -201,7 +201,7 @@ async fn check_billing_account_pk_overlapping(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn check_billing_account_pk_mismatched(ctx: &DalContext<'_, '_>) {
+async fn check_billing_account_pk_mismatched(ctx: &DalContext<'_, '_, '_>) {
     let read_tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
     let write_tenancy = WriteTenancy::new_billing_account(2.into());
 
@@ -213,7 +213,7 @@ async fn check_billing_account_pk_mismatched(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn check_billing_account_pk_mismatched_level(ctx: &DalContext<'_, '_>) {
+async fn check_billing_account_pk_mismatched_level(ctx: &DalContext<'_, '_, '_>) {
     let read_tenancy = ReadTenancy::new_billing_account(vec![1.into()]);
     let write_tenancy = WriteTenancy::new_organization(1.into());
 
@@ -225,7 +225,7 @@ async fn check_billing_account_pk_mismatched_level(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn check_organization_pk_identical(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn check_organization_pk_identical(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let read_tenancy =
         ReadTenancy::new_organization(ctx.pg_txn(), vec![*nba.organization.id()], ctx.visibility())
             .await
@@ -241,7 +241,7 @@ async fn check_organization_pk_identical(ctx: &DalContext<'_, '_>, nba: &Billing
 
 #[test]
 async fn check_organization_pk_overlapping(
-    ctx: &DalContext<'_, '_>,
+    ctx: &DalContext<'_, '_, '_>,
     jwt_secret_key: &JwtSecretKey,
 ) {
     let (nba, _) = billing_account_signup(ctx, jwt_secret_key).await;
@@ -268,7 +268,10 @@ async fn check_organization_pk_overlapping(
 }
 
 #[test]
-async fn check_organization_pk_mismatched(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn check_organization_pk_mismatched(
+    ctx: &DalContext<'_, '_, '_>,
+    jwt_secret_key: &JwtSecretKey,
+) {
     let (nba, _) = billing_account_signup(ctx, jwt_secret_key).await;
     let read_tenancy =
         ReadTenancy::new_organization(ctx.pg_txn(), vec![*nba.organization.id()], ctx.visibility())
@@ -284,7 +287,7 @@ async fn check_organization_pk_mismatched(ctx: &DalContext<'_, '_>, jwt_secret_k
 }
 
 #[test]
-async fn check_workspace_pk_identical(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn check_workspace_pk_identical(ctx: &DalContext<'_, '_, '_>, jwt_secret_key: &JwtSecretKey) {
     let (nba, _) = billing_account_signup(ctx, jwt_secret_key).await;
     let read_tenancy =
         ReadTenancy::new_workspace(ctx.pg_txn(), vec![*nba.workspace.id()], ctx.visibility())
@@ -300,7 +303,10 @@ async fn check_workspace_pk_identical(ctx: &DalContext<'_, '_>, jwt_secret_key: 
 }
 
 #[test]
-async fn check_workspace_pk_overlapping(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn check_workspace_pk_overlapping(
+    ctx: &DalContext<'_, '_, '_>,
+    jwt_secret_key: &JwtSecretKey,
+) {
     let (nba, _) = billing_account_signup(ctx, jwt_secret_key).await;
     let (nba2, _) = billing_account_signup(ctx, jwt_secret_key).await;
     let (nba3, _) = billing_account_signup(ctx, jwt_secret_key).await;
@@ -325,7 +331,10 @@ async fn check_workspace_pk_overlapping(ctx: &DalContext<'_, '_>, jwt_secret_key
 }
 
 #[test]
-async fn check_workspace_pk_mismatched(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn check_workspace_pk_mismatched(
+    ctx: &DalContext<'_, '_, '_>,
+    jwt_secret_key: &JwtSecretKey,
+) {
     let (nba, _) = billing_account_signup(ctx, jwt_secret_key).await;
     let read_tenancy =
         ReadTenancy::new_workspace(ctx.pg_txn(), vec![*nba.workspace.id()], ctx.visibility())

--- a/lib/dal/tests/integration_test/resource.rs
+++ b/lib/dal/tests/integration_test/resource.rs
@@ -5,7 +5,7 @@ use dal::test_harness::create_component_and_schema;
 use dal::{Resource, StandardModel, System};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let component = create_component_and_schema(ctx).await;
     let system = System::new(ctx, "production system")
         .await
@@ -17,7 +17,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn get_by_component_and_system_id(ctx: &DalContext<'_, '_>) {
+async fn get_by_component_and_system_id(ctx: &DalContext<'_, '_, '_>) {
     let mastodon_component = create_component_and_schema(ctx).await;
     let blue_oyster_component = create_component_and_schema(ctx).await;
 

--- a/lib/dal/tests/integration_test/resource_prototype.rs
+++ b/lib/dal/tests/integration_test/resource_prototype.rs
@@ -8,7 +8,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -47,7 +47,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_component(ctx: &DalContext<'_, '_>) {
+async fn find_for_component(ctx: &DalContext<'_, '_, '_>) {
     // TODO: This test is brittle, because it relies on the behavior of docker_image. I'm okay
     // with that for now, but not for long. If it breaks before we fix it - future person, I'm
     // sorry. ;)

--- a/lib/dal/tests/integration_test/resource_resolver.rs
+++ b/lib/dal/tests/integration_test/resource_resolver.rs
@@ -10,7 +10,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await
@@ -65,7 +65,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
+async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
     let name = "docker_image".to_string();
     let schema = Schema::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -9,7 +9,7 @@ pub mod ui_menu;
 pub mod variant;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _schema = Schema::new(
         ctx,
         "mastodon",
@@ -21,7 +21,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn billing_accounts(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKey) {
+async fn billing_accounts(ctx: &DalContext<'_, '_, '_>, jwt_secret_key: &JwtSecretKey) {
     let (nba, _token) = billing_account_signup(ctx, jwt_secret_key).await;
     let schema = Schema::new(
         ctx,
@@ -54,7 +54,7 @@ async fn billing_accounts(ctx: &DalContext<'_, '_>, jwt_secret_key: &JwtSecretKe
 }
 
 #[test]
-async fn organizations(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn organizations(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let schema = Schema::new(
         ctx,
         "mastodon",
@@ -86,7 +86,7 @@ async fn organizations(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn workspaces(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn workspaces(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let schema = Schema::new(
         ctx,
         "mastodon",
@@ -112,7 +112,7 @@ async fn workspaces(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn ui_menus(ctx: &DalContext<'_, '_>) {
+async fn ui_menus(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_ui_menu = create_schema_ui_menu(ctx).await;
     schema_ui_menu

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -6,7 +6,7 @@ use dal::test_harness::{create_schema, create_schema_ui_menu};
 use dal::{schema::UiMenu, DiagramKind, HistoryActor, StandardModel, Visibility, WriteTenancy};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
@@ -19,7 +19,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_schema(ctx: &DalContext<'_, '_>) {
+async fn set_schema(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let schema_ui_menu = create_schema_ui_menu(ctx).await;
 

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -3,7 +3,7 @@ use dal::DalContext;
 use dal::{schema::SchemaVariant, test_harness::create_schema, SchemaKind, StandardModel};
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
 
     let (variant, _) = SchemaVariant::new(ctx, *schema.id(), "ringo")
@@ -13,7 +13,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_schema(ctx: &DalContext<'_, '_>) {
+async fn set_schema(ctx: &DalContext<'_, '_, '_>) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (variant, _) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -7,7 +7,7 @@ use dal::{
 use dal::{BillingAccountSignup, DalContext};
 
 #[test]
-async fn new_encrypted_secret(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn new_encrypted_secret(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let name = generate_fake_name();
 
     let secret = EncryptedSecret::new(
@@ -37,7 +37,7 @@ async fn new_encrypted_secret(ctx: &DalContext<'_, '_>, nba: &BillingAccountSign
 }
 
 #[test]
-async fn secret_get_by_id(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn secret_get_by_id(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let og_secret = create_secret(ctx, *nba.key_pair.id(), *nba.billing_account.id()).await;
 
     let secret = Secret::get_by_id(ctx, og_secret.id())
@@ -48,7 +48,7 @@ async fn secret_get_by_id(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) 
 }
 
 #[test]
-async fn encrypted_secret_get_by_id(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn encrypted_secret_get_by_id(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let secret = create_secret(ctx, *nba.key_pair.id(), *nba.billing_account.id()).await;
 
     let encrypted_secret = EncryptedSecret::get_by_id(ctx, secret.id())
@@ -63,7 +63,7 @@ async fn encrypted_secret_get_by_id(ctx: &DalContext<'_, '_>, nba: &BillingAccou
 }
 
 #[test]
-async fn secret_update_name(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn secret_update_name(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let mut secret = create_secret(ctx, *nba.key_pair.id(), *nba.billing_account.id()).await;
 
     let original_name = secret.name().to_string();
@@ -77,7 +77,7 @@ async fn secret_update_name(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup
 }
 
 #[test]
-async fn encrypt_decrypt_round_trip(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn encrypt_decrypt_round_trip(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let pkey = nba.key_pair.public_key();
     let name = generate_fake_name();
 

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -7,7 +7,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let socket = Socket::new(
         ctx,
         "jane",
@@ -24,7 +24,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_required(ctx: &DalContext<'_, '_>) {
+async fn set_required(ctx: &DalContext<'_, '_, '_>) {
     let mut socket = Socket::new(
         ctx,
         generate_fake_name(),

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -13,7 +13,7 @@ use dal::{BillingAccountSignup, ChangeSet, DalContext, Func, WriteTenancy};
 use crate::dal::test;
 
 #[test]
-async fn get_by_pk(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn get_by_pk(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let retrieved = standard_model::get_by_pk(ctx, "billing_accounts", nba.billing_account.pk())
         .await
         .expect("cannot get billing account by pk");
@@ -22,7 +22,7 @@ async fn get_by_pk(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn get_by_id(ctx: &DalContext<'_, '_>) {
+async fn get_by_id(ctx: &DalContext<'_, '_, '_>) {
     let billing_account = create_billing_account_with_name(ctx, "coheed").await;
     let head_visibility = create_visibility_head();
     let head_ctx = ctx.clone_with_new_visibility(head_visibility);
@@ -66,7 +66,7 @@ async fn get_by_id(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn list(ctx: &DalContext<'_, '_>) {
+async fn list(ctx: &DalContext<'_, '_, '_>) {
     let _coheed_billing_account = create_billing_account_with_name(ctx, "coheed").await;
     let _spiritbox_billing_account = create_billing_account_with_name(ctx, "spiritbox").await;
     let _zeal_billing_account = create_billing_account_with_name(ctx, "zeal and ardor").await;
@@ -108,7 +108,7 @@ async fn list(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn update(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn update(ctx: &mut DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     // Guess what--a billing account's tenancy is universal! So let's make sure our DalContext is
     // appropriately set up
     ctx.update_write_tenancy(WriteTenancy::new_universal());
@@ -126,7 +126,7 @@ async fn update(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn delete(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn delete(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let _updated_at = standard_model::delete(ctx, "billing_accounts", nba.billing_account.pk())
         .await
         .expect("cannot delete field");
@@ -143,7 +143,7 @@ async fn delete(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn undelete(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn undelete(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let _updated_at = standard_model::delete(ctx, "billing_accounts", nba.billing_account.pk())
         .await
         .expect("cannot delete field");
@@ -174,7 +174,7 @@ async fn undelete(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
 }
 
 #[test]
-async fn set_belongs_to(ctx: &DalContext<'_, '_>) {
+async fn set_belongs_to(ctx: &DalContext<'_, '_, '_>) {
     let first_billing_account = create_billing_account_with_name(ctx, "coheed").await;
     let second_billing_account = create_billing_account_with_name(ctx, "cambria").await;
     let key_pair = create_key_pair(ctx).await;
@@ -207,7 +207,7 @@ async fn set_belongs_to(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn unset_belongs_to(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn unset_belongs_to(ctx: &DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     let key_pair = create_key_pair(ctx).await;
 
     standard_model::set_belongs_to(
@@ -225,7 +225,7 @@ async fn unset_belongs_to(ctx: &DalContext<'_, '_>, nba: &BillingAccountSignup) 
 }
 
 #[test]
-async fn belongs_to(ctx: &DalContext<'_, '_>) {
+async fn belongs_to(ctx: &DalContext<'_, '_, '_>) {
     let billing_account = create_billing_account_with_name(ctx, "coheed").await;
     let key_pair = create_key_pair(ctx).await;
 
@@ -305,7 +305,7 @@ async fn belongs_to(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn has_many(ctx: &DalContext<'_, '_>) {
+async fn has_many(ctx: &DalContext<'_, '_, '_>) {
     let billing_account = create_billing_account_with_name(ctx, "coheed").await;
     let a_key_pair = create_key_pair(ctx).await;
     standard_model::set_belongs_to(
@@ -351,7 +351,7 @@ async fn has_many(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn associate_many_to_many(ctx: &DalContext<'_, '_>) {
+async fn associate_many_to_many(ctx: &DalContext<'_, '_, '_>) {
     let group = create_group(ctx).await;
     let user_one = create_user(ctx).await;
     let user_two = create_user(ctx).await;
@@ -374,7 +374,7 @@ async fn associate_many_to_many(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn disassociate_many_to_many(ctx: &DalContext<'_, '_>) {
+async fn disassociate_many_to_many(ctx: &DalContext<'_, '_, '_>) {
     let group = create_group(ctx).await;
     let user_one = create_user(ctx).await;
     let user_two = create_user(ctx).await;
@@ -405,7 +405,7 @@ async fn disassociate_many_to_many(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn many_to_many(ctx: &DalContext<'_, '_>) {
+async fn many_to_many(ctx: &DalContext<'_, '_, '_>) {
     let group_one = create_group(ctx).await;
     let group_two = create_group(ctx).await;
 
@@ -518,7 +518,7 @@ async fn many_to_many(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn associate_many_to_many_no_repeat_entries(ctx: &DalContext<'_, '_>) {
+async fn associate_many_to_many_no_repeat_entries(ctx: &DalContext<'_, '_, '_>) {
     let group = create_group(ctx).await;
     let user_one = create_user(ctx).await;
     standard_model::associate_many_to_many(
@@ -540,7 +540,7 @@ async fn associate_many_to_many_no_repeat_entries(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_by_attr(ctx: &mut DalContext<'_, '_>) {
+async fn find_by_attr(ctx: &mut DalContext<'_, '_, '_>) {
     let _billing_account = create_billing_account(ctx).await;
     ctx.update_to_universal_head();
 
@@ -572,7 +572,7 @@ async fn find_by_attr(ctx: &mut DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_by_attr_in(ctx: &mut DalContext<'_, '_>) {
+async fn find_by_attr_in(ctx: &mut DalContext<'_, '_, '_>) {
     let _billing_account = create_billing_account(ctx).await;
     ctx.update_to_universal_head();
 
@@ -633,7 +633,7 @@ async fn find_by_attr_in(ctx: &mut DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_by_attr_not_in(ctx: &mut DalContext<'_, '_>) {
+async fn find_by_attr_not_in(ctx: &mut DalContext<'_, '_, '_>) {
     let _billing_account = create_billing_account(ctx).await;
     ctx.update_to_universal_head();
 

--- a/lib/dal/tests/integration_test/system.rs
+++ b/lib/dal/tests/integration_test/system.rs
@@ -6,7 +6,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let system = System::new(ctx, "jonas-brothers-why-oh-why")
         .await
         .expect("cannot create system");
@@ -14,7 +14,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn set_workspace(ctx: &DalContext<'_, '_>) {
+async fn set_workspace(ctx: &DalContext<'_, '_, '_>) {
     let system = create_system(ctx).await;
     let workspace = create_workspace(ctx).await;
 

--- a/lib/dal/tests/integration_test/user.rs
+++ b/lib/dal/tests/integration_test/user.rs
@@ -6,7 +6,7 @@ use dal::{
 use crate::dal::test;
 
 #[test]
-async fn new(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn new(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let _user = User::new(
@@ -20,7 +20,11 @@ async fn new(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
 }
 
 #[test]
-async fn login(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId, jwt_secret_key: &JwtSecretKey) {
+async fn login(
+    ctx: &mut DalContext<'_, '_, '_>,
+    bid: BillingAccountId,
+    jwt_secret_key: &JwtSecretKey,
+) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let password = "snakesOnAPlane123";
@@ -35,7 +39,7 @@ async fn login(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId, jwt_secret_k
 }
 
 #[test]
-async fn find_by_email(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
+async fn find_by_email(ctx: &mut DalContext<'_, '_, '_>, bid: BillingAccountId) {
     ctx.update_to_billing_account_tenancies(bid);
 
     let password = "snakesOnAPlane123";
@@ -64,7 +68,7 @@ async fn find_by_email(ctx: &mut DalContext<'_, '_>, bid: BillingAccountId) {
 }
 
 #[test]
-async fn authorize(ctx: &mut DalContext<'_, '_>, nba: &BillingAccountSignup) {
+async fn authorize(ctx: &mut DalContext<'_, '_, '_>, nba: &BillingAccountSignup) {
     ctx.update_to_billing_account_tenancies(*nba.billing_account.id());
 
     let worked = User::authorize(ctx, nba.user.id())

--- a/lib/dal/tests/integration_test/validation_prototype.rs
+++ b/lib/dal/tests/integration_test/validation_prototype.rs
@@ -8,7 +8,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image")
@@ -51,7 +51,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prop(ctx: &DalContext<'_, '_>, _nba: &BillingAccountSignup) {
+async fn find_for_prop(ctx: &DalContext<'_, '_, '_>, _nba: &BillingAccountSignup) {
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -12,7 +12,7 @@ use dal::{
 const UNSET_ID_VALUE: i64 = -1;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image")
@@ -105,7 +105,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_errors(ctx: &DalContext<'_, '_>) {
+async fn find_errors(ctx: &DalContext<'_, '_, '_>) {
     let unset_system_id: SystemId = UNSET_ID_VALUE.into();
 
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())

--- a/lib/dal/tests/integration_test/visibility.rs
+++ b/lib/dal/tests/integration_test/visibility.rs
@@ -4,7 +4,7 @@ use dal::DalContext;
 use dal::Visibility;
 
 #[test]
-async fn head_is_visibile_to_head(ctx: &DalContext<'_, '_>) {
+async fn head_is_visibile_to_head(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_head(false);
     let check_visibility = visibility;
 
@@ -16,7 +16,7 @@ async fn head_is_visibile_to_head(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn head_is_visible_to_change_set(ctx: &DalContext<'_, '_>) {
+async fn head_is_visible_to_change_set(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_head(false);
     let check_visibility = Visibility::new_change_set(1.into(), false);
 
@@ -28,7 +28,7 @@ async fn head_is_visible_to_change_set(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn head_is_invisibile_to_deleted_head(ctx: &DalContext<'_, '_>) {
+async fn head_is_invisibile_to_deleted_head(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_head(true);
     let check_visibility = Visibility::new_head(false);
 
@@ -40,7 +40,7 @@ async fn head_is_invisibile_to_deleted_head(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn delted_head_is_visibile_to_deleted_head(ctx: &DalContext<'_, '_>) {
+async fn delted_head_is_visibile_to_deleted_head(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_head(true);
     let check_visibility = Visibility::new_head(true);
 
@@ -52,7 +52,7 @@ async fn delted_head_is_visibile_to_deleted_head(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn change_set_is_not_visible_to_head(ctx: &DalContext<'_, '_>) {
+async fn change_set_is_not_visible_to_head(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_head(false);
 
@@ -64,7 +64,7 @@ async fn change_set_is_not_visible_to_head(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn change_set_is_visible_to_change_set(ctx: &DalContext<'_, '_>) {
+async fn change_set_is_visible_to_change_set(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_change_set(1.into(), false);
 
@@ -76,7 +76,7 @@ async fn change_set_is_visible_to_change_set(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn change_set_is_invisible_to_different_change_set(ctx: &DalContext<'_, '_>) {
+async fn change_set_is_invisible_to_different_change_set(ctx: &DalContext<'_, '_, '_>) {
     let visibility = Visibility::new_change_set(1.into(), false);
     let check_visibility = Visibility::new_change_set(2.into(), false);
 

--- a/lib/dal/tests/integration_test/workflow.rs
+++ b/lib/dal/tests/integration_test/workflow.rs
@@ -2,7 +2,11 @@ use crate::dal::test;
 use dal::{DalContext, Func, FuncBinding, StandardModel, WorkflowTree, WorkflowView};
 use serde_json::json;
 
-async fn fb(ctx: &DalContext<'_, '_>, name: &str, args: serde_json::Value) -> serde_json::Value {
+async fn fb(
+    ctx: &DalContext<'_, '_, '_>,
+    name: &str,
+    args: serde_json::Value,
+) -> serde_json::Value {
     let func = Func::find_by_attr(ctx, "name", &name)
         .await
         .expect("unable to find func")
@@ -16,7 +20,7 @@ async fn fb(ctx: &DalContext<'_, '_>, name: &str, args: serde_json::Value) -> se
 }
 
 #[test]
-async fn resolve(ctx: &DalContext<'_, '_>) {
+async fn resolve(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &name)
         .await
@@ -62,7 +66,7 @@ async fn resolve(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn run(ctx: &DalContext<'_, '_>) {
+async fn run(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/workflow_prototype.rs
+++ b/lib/dal/tests/integration_test/workflow_prototype.rs
@@ -7,7 +7,7 @@ use dal::{
 use serde_json::json;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poem".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
@@ -27,7 +27,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_context(ctx: &DalContext<'_, '_>) {
+async fn find_for_context(ctx: &DalContext<'_, '_, '_>) {
     let func = Func::find_by_attr(ctx, "name", &"si:poem".to_string())
         .await
         .expect("got func")
@@ -63,7 +63,11 @@ async fn find_for_context(ctx: &DalContext<'_, '_>) {
     assert_eq!(found.func_id(), *func.id());
 }
 
-async fn fb(ctx: &DalContext<'_, '_>, name: &str, args: serde_json::Value) -> serde_json::Value {
+async fn fb(
+    ctx: &DalContext<'_, '_, '_>,
+    name: &str,
+    args: serde_json::Value,
+) -> serde_json::Value {
     let func = Func::find_by_attr(ctx, "name", &name)
         .await
         .expect("unable to find func")
@@ -77,7 +81,7 @@ async fn fb(ctx: &DalContext<'_, '_>, name: &str, args: serde_json::Value) -> se
 }
 
 #[test]
-async fn resolve(ctx: &DalContext<'_, '_>) {
+async fn resolve(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &name)
         .await
@@ -123,7 +127,7 @@ async fn resolve(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn run(ctx: &DalContext<'_, '_>) {
+async fn run(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/workflow_resolver.rs
+++ b/lib/dal/tests/integration_test/workflow_resolver.rs
@@ -8,7 +8,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poem".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
@@ -42,7 +42,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
+async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poem".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await

--- a/lib/dal/tests/integration_test/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/workflow_runner.rs
@@ -9,7 +9,7 @@ use dal::{
 };
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poem".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
@@ -44,7 +44,7 @@ async fn new(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
+async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poem".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
@@ -90,7 +90,7 @@ async fn find_for_prototype(ctx: &DalContext<'_, '_>) {
 }
 
 #[test]
-async fn run(ctx: &DalContext<'_, '_>) {
+async fn run(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:poem";
     let func = Func::find_by_attr(ctx, "name", &name)
         .await

--- a/lib/dal/tests/integration_test/workspace.rs
+++ b/lib/dal/tests/integration_test/workspace.rs
@@ -5,7 +5,7 @@ use crate::dal::test;
 use dal::Workspace;
 
 #[test]
-async fn new(ctx: &DalContext<'_, '_>) {
+async fn new(ctx: &DalContext<'_, '_, '_>) {
     let _ = Workspace::new(ctx, "iron maiden")
         .await
         .expect("cannot create workspace");

--- a/lib/sdf/src/server/extract.rs
+++ b/lib/sdf/src/server/extract.rs
@@ -108,7 +108,7 @@ where
 }
 
 impl PgRwTxn {
-    pub async fn start(&mut self) -> Result<pg::PgTxn<'_>, pg::Error> {
+    pub async fn start(&mut self) -> Result<pg::PgTxn<'_>, pg::PgError> {
         self.0.transaction().await
     }
 }
@@ -129,7 +129,7 @@ where
 }
 
 impl PgRoTxn {
-    pub async fn start(&mut self) -> Result<pg::PgTxn<'_>, pg::Error> {
+    pub async fn start(&mut self) -> Result<pg::PgTxn<'_>, pg::PgError> {
         self.0.build_transaction().read_only(true).start().await
     }
 }

--- a/lib/sdf/src/server/routes.rs
+++ b/lib/sdf/src/server/routes.rs
@@ -149,7 +149,7 @@ pub enum AppError {
     #[error(transparent)]
     Nats(#[from] nats::Error),
     #[error(transparent)]
-    Pg(#[from] pg::Error),
+    Pg(#[from] pg::PgError),
     #[error(transparent)]
     Server(#[from] ServerError),
 }

--- a/lib/si-data/src/lib.rs
+++ b/lib/si-data/src/lib.rs
@@ -22,7 +22,7 @@ pub use faktory::FaktoryConfig;
 #[cfg(feature = "pg")]
 pub mod pg;
 #[cfg(feature = "pg")]
-pub use pg::{Error as PgError, PgPool, PgPoolConfig, PgPoolError, PgTxn};
+pub use pg::{PgError, PgPool, PgPoolConfig, PgPoolError, PgRow, PgTxn};
 
 #[cfg(feature = "nats")]
 pub mod nats;


### PR DESCRIPTION
This change alters some of the internal details of our `pg` module in
`si-data` which is an adapter layer on top of the `tokio-postgres` and
`deadpool-postgres` crates.

The change is largely in the `InstrumentedTransaction` type which now
holds an `Arc<Mutex<Transaction<'a>>` (formerly this would have held a
`Transaction<'a>`) allowing the type to derive `Clone`. Now we have a
way of "cloning" an in-flight database transaction and pass ownership to
other functions, Tokio tasks, etc. The key here is that all copies are
sharing the same mutex-guarded `Transaction<'a>` type and so the
consumers of these copies are coordinating within the singular
transaction. As the synchronized access is all internal to
`InstrumentedTransaction`, the external API did not change.

*However*, there are 2 reasons leading to signature changes which
consequently resulted in a large number of small changes across the dal,
sdf, and si-data crates:

1. The signature of `DalContext` needs an additional explicit (but often
   anonymous) lifetime. Sorry! Initially when developing the
   `DalContext` type, the borrowed `Transactions` type used the *same*
   lifetime for the borrow and for the internal lifetime of the type.
   That is, prior to this change the field signature was `txns: &'t
   Transactions<'t>` which was fine because the internals of
   `Transactions` need to live at least as long as the borrow of
   `Transactions` itself. With this new change we occasionally need to
   describe the lifetime inside `Transactions` separately from its
   borrowed lifetime. That is, the field signature is now `txns: &'t
   Transactions<'a>` where, if necessary, the lifetimes `'a: 't` apply.
   This means that `'a` need to live *at least* as long as `'t` but
   could live longer. It is this tweak that allows our existing
   `txns.commit().await` to work as the `txns` is borrowed into our
   `DalContext`. Cool? Maybe not, but that's why! Speaking of
   `commit`...
2. The caller of a `pg_txn.commit().await` needs to ensure that there
   are no other copies of `pg_txn` that are still in scope. The prior
   implementation makes this possible as there was no way to clone
   transactions and importantly the underlying `tokio-postgres` crate's
   `Transaction.commit` signature consumes `self`. Our upgraded
   `InstrumentedTransaction` now wraps this transaction with
   `Arc<Mutex<...>>`, meaning we will need to also consume these data
   types in `commit` (note that this applies equally to the `rollback`
   method). To accomplish this in `commit` we are asserting that there
   are no more `Arc` copies and we only have 1 remaining (there is a way
   in Rust you can ask an `Arc` for it's "strong count" of references)
   and if this holds true we can safely unwrap the `Arc` and then
   consume the inner `Mutex` resulting in a fully consumable
   `Transaction` type. While this change sounds potentially troubling,
   in practice so far no code needed to be modified for the correct
   behavior of the codebase and test suites. It's my assertion that any
   error messages coming back on `commit` and/or `rollback` that are
   related to these assertion checks/unwraps are either a concurrent
   race calling `commit` just before other `Arc` copies are fully
   dropped, or it's a straight-up programmer error. See the
   documentation for `InstrumentedTransaction.commit` and `rollback` for
   more details. Unfortunately, these 2 new error conditions (one each
   for `commit` and `rollback`) meant introducing a proper error type
   which wrapped over `tokio_postgres::Error` and updating other parts
   of the codebase that we referring directly to the
   `tokio_postgres::Error` type. A nice side effect was finding that
   once this refactoring was done, there was no longer a reason for
   `lib/dal` to take a direct dependency on `tokio-postgres` which felt
   good and right.

<img src="https://media2.giphy.com/media/ToMjGpmGUC7axrjBAmQ/giphy.gif"/>

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>