### PR TITLE
Add ability for workflows to fail

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,53 @@
+# Documentation
+
+This document contains all information related to developer documentation for the contents of this repository.
+
+## How do we generate docs?
+
+For Rust crates, we leverage `rustdoc` for seamless integration with `cargo doc`
+, [IntelliJ Rust](https://www.jetbrains.com/rust/),
+[rust-analyzer](https://rust-analyzer.github.io/), and more.
+
+## Reading Rust Documentation
+
+Build the docs for all of our crates and open the docs in your browser at [dal](./lib/dal) by executing
+the following make target:
+
+```bash
+make docs-open
+```
+
+You can also execute the following:
+
+```bash
+cargo doc --open -p dal
+```
+
+If you would like to live-recompile docs while making changes on your development branch, you can execute the following
+make target:
+
+```bash
+make docs-watch
+```
+
+> Please note: [cargo-watch](https://github.com/watchexec/cargo-watch) needs to be installed before using the above make
+> target.
+>
+> ```bash
+> cargo install --locked cargo-watch
+> ```
+
+## Writing Rust Documentation
+
+We try to follow the
+official ["How to write documentation"](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) guide
+from `rustdoc` as closely as possible.
+Older areas of the codebase may not follow the guide and conventions derived from it.
+We encourage updating older documentation as whilst navigating through SI crates.
+
+### Additional Resources for Rust Documentation
+
+* [RFC-1574](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text):
+  more API documentation conventions for `rust-lang`
+* ["Making Useful Documentation Comments" from "The Book"](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments):
+  a section of "The Book" covering useful documentation in the context of crate publishing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This is a monolithic repository containing the source for System Initiative (SI)
 
 ## Developing and Running the SI Stack
 
-Please refer to the [DEVELOPING](./DEVELOPING.md) guide for more information.
+Please refer to the following documentation for more information:
+
+- **[DEVELOPING](./DEVELOPING.md):** information related to developing and running the SI stack
+- **[DOCUMENTATION](./DOCUMENTATION.md):** information related to developer documentation for the contents of this repository
 
 ## Contributing
 
@@ -29,7 +32,7 @@ Welcome to the team! A few handy links:
 
 ## Architecture
 
-The diagram below illustrates a _very_ high-level overview of SI's calling stack.
+The diagram (created with [asciiflow](https://asciiflow.com)) below illustrates a _very_ high-level overview of SI's calling stack.
 There are other components and paradigms that aren't displayed, but this diagram is purely meant to show the overall flow from "mouse-click" onwards.
 
 ```
@@ -39,16 +42,30 @@ There are other components and paradigms that aren't displayed, but this diagram
                        │   ┌─────────┐
                        ├───┤ faktory │
                        │   └─────────┘
-┌─────┐   ┌─────┐   ┌──┴──┐   ┌────┐
-│ web ├───┤ sdf ├───┤ dal ├───┤ db │
-└─────┘   └─────┘   └──┬──┘   └────┘
+┌─────┐   ┌─────┐   ┌──┴──┐   ┌──────────┐
+│ web ├───┤ sdf ├───┤ dal ├───┤ postgres │
+└─────┘   └─────┘   └──┬──┘   └──────────┘
                        │
       ┌────────────────┘
       │
-┌─────┴────┐   ┌──────────────────┐   ┌─────────┐
-│ veritech ├───┤ deadpool_cyclone ├───┤ cyclone │
-└──────────┘   └──────────────────┘   └─────────┘
+┌─────┴────┐   ┌──────────────────┐   ┌─────────┐      ┌───────────────────┐
+│ veritech ├───┤ deadpool-cyclone ├───┤ cyclone ├ ─ ─> │ execution runtime │
+│          │   │                  │   │         │      │ (e.g. lang-js)    │
+└──────────┘   └──────────────────┘   └─────────┘      └───────────────────┘
 ```
+
+### Definitions for Architectural Components
+
+- **[web](./app/web/):** the primary frontend web application for SI
+- **[sdf](./bin/sdf/):** the backend webserver for communicating with `web`
+- **[dal](./lib/dal/):** the library used by `sdf` routes to "make stuff happen" (the keystone of SI)
+- **[pinga](./bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `faktory`
+- **[faktory](https://github.com/contribsys/faktory):** the job queueing mechanism used by `pinga` to execute non-trivial jobs
+- **[postgres](https://postgresql.org):** the database for storing SI data
+- **[veritech](./bin/veritech/):** a backend webserver for dispatching functions in secure runtime environments
+- **[deadpool-cyclone](./lib/deadpool-cyclone/):** a library used for managing a pool of `cyclone` instances of varying "types" (i.e. HTTP, UDS)
+- **[cyclone](./bin/cyclone/):** the manager for a secure execution runtime environment (e.g. `lang-js`)
+- **[lang-js](./bin/lang-js/):** a secure-ish (don't trust it) execution runtime environment for JS functions
 
 It's worth noting that our database has many stored procedures (i.e. database functions) that perform non-trivial logic.
 While the [dal](./lib/dal) is the primary "data access layer" for the rest of the SI stack, it does not perform _all_ the heavy lifting.

--- a/bin/lang-js/README.md
+++ b/bin/lang-js/README.md
@@ -1,3 +1,11 @@
 # Lang JS
 
-`DEBUG=* npm run run -- qualificationcheck < examples/qualificationCheckTest.json`
+This directory contains `lang-js`.
+
+## Testing Locally
+
+Here is an example of testing `lang-js` locally:
+
+```bash
+DEBUG=* npm run run -- qualificationcheck < examples/qualificationCheckTest.json
+```

--- a/bin/lang-js/examples/commandRunFail.json
+++ b/bin/lang-js/examples/commandRunFail.json
@@ -1,0 +1,5 @@
+{
+  "executionId": "tenz",
+  "handler": "fail",
+  "codeBase64": "ZnVuY3Rpb24gZmFpbCgpIHsKICAgIHRocm93IG5ldyBFcnJvcigid2hlZWVlZWVlZWVlZWVlZWVlIik7Cn0K"
+}

--- a/bin/lang-js/examples/commandRunFailCode.js
+++ b/bin/lang-js/examples/commandRunFailCode.js
@@ -1,0 +1,3 @@
+function fail() {
+    throw new Error("wheeeeeeeeeeeeeeee");
+}

--- a/lib/cyclone-core/src/progress.rs
+++ b/lib/cyclone-core/src/progress.rs
@@ -101,6 +101,8 @@ pub enum FunctionResult<S> {
 pub struct FunctionResultFailure {
     pub execution_id: String,
     pub error: FunctionResultFailureError,
+    // FIXME(nick,wendy): get the Utc::now() shape as well
+    // (perhaps struct Foo { raw: Utc::now(), timestamp: crate::timestamp() } )
     pub timestamp: u64,
 }
 

--- a/lib/cyclone-server/src/execution.rs
+++ b/lib/cyclone-server/src/execution.rs
@@ -105,7 +105,9 @@ where
         self,
         ws: &mut WebSocket,
     ) -> Result<ExecutionStarted<LangServerSuccess, Success>> {
+        // Send start is the initial communication before we read the request.
         Self::ws_send_start(ws).await?;
+        // Now that the server said to start, I am going to read my message!
         let request = Self::read_request(ws).await?;
         let credentials: Vec<SensitiveString> = request.list_secrets(&self.key)?;
 

--- a/lib/cyclone-server/src/handlers.rs
+++ b/lib/cyclone-server/src/handlers.rs
@@ -228,6 +228,8 @@ pub async fn ws_execute_command_run(
     limit_request_guard: LimitRequestGuard,
 ) -> impl IntoResponse {
     let lang_server_path = lang_server_path.as_path().to_path_buf();
+
+    // Hey! Let's upgrade from http communication to websocket communication.
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<CommandRunRequest> = PhantomData;
         let lang_server_success: PhantomData<LangServerCommandRunResultSuccess> = PhantomData;

--- a/lib/dal/src/builtins/func/fail.js
+++ b/lib/dal/src/builtins/func/fail.js
@@ -1,0 +1,3 @@
+function fail() {
+    throw new Error("oopsie!");
+}

--- a/lib/dal/src/builtins/func/fail.json
+++ b/lib/dal/src/builtins/func/fail.json
@@ -1,0 +1,7 @@
+{
+  "name": "fail",
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "fail.js",
+  "code_entrypoint": "fail"
+}

--- a/lib/dal/src/builtins/func/failureWorkflow.js
+++ b/lib/dal/src/builtins/func/failureWorkflow.js
@@ -1,0 +1,11 @@
+async function failure() {
+    return {
+        name: "si:failure",
+        kind: "conditional",
+        steps: [
+            {
+                command: "si:fail",
+            },
+        ],
+    };
+}

--- a/lib/dal/src/builtins/func/failureWorkflow.json
+++ b/lib/dal/src/builtins/func/failureWorkflow.json
@@ -1,0 +1,7 @@
+{
+  "name": "failure",
+  "kind": "JsWorkflow",
+  "response_type": "Workflow",
+  "code_file": "failureWorkflow.js",
+  "code_entrypoint": "failure"
+}

--- a/lib/dal/src/builtins/workflow.rs
+++ b/lib/dal/src/builtins/workflow.rs
@@ -5,6 +5,7 @@ use crate::{
 
 pub async fn migrate(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
     poem(ctx).await?;
+    failure(ctx).await?;
     Ok(())
 }
 
@@ -15,6 +16,24 @@ async fn poem(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
         .pop()
         .ok_or_else(|| SchemaError::FuncNotFound(func_name.to_owned()))?;
     let title = "Lero Lero";
+
+    let context = WorkflowPrototypeContext::default();
+    if WorkflowPrototype::find_by_attr(ctx, "title", &title)
+        .await?
+        .is_empty()
+    {
+        WorkflowPrototype::new(ctx, *func.id(), serde_json::Value::Null, context, title).await?;
+    }
+    Ok(())
+}
+
+async fn failure(ctx: &DalContext<'_, '_, '_>) -> BuiltinsResult<()> {
+    let func_name = "si:failure";
+    let func = Func::find_by_attr(ctx, "name", &func_name)
+        .await?
+        .pop()
+        .ok_or_else(|| SchemaError::FuncNotFound(func_name.to_owned()))?;
+    let title = "Epic Fail!";
 
     let context = WorkflowPrototypeContext::default(); // workspace level
     if WorkflowPrototype::find_by_attr(ctx, "title", &title)

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -4,7 +4,7 @@ use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::mpsc;
-use veritech::{FunctionResult, OutputStream};
+use veritech::{CommandRunResultSuccess, FunctionResult, OutputStream};
 
 use crate::{label_list::ToLabelList, DalContext, Func, FuncId, PropKind, StandardModel};
 
@@ -47,6 +47,8 @@ pub enum FuncBackendError {
     DispatchMissingBase64(FuncId),
     #[error("dispatch func missing code_base64 {0}")]
     DispatchMissingHandler(FuncId),
+    #[error("function result command run error: {0:?}")]
+    FunctionResultCommandRun(FunctionResult<CommandRunResultSuccess>),
 }
 
 pub type FuncBackendResult<T> = Result<T, FuncBackendError>;
@@ -186,6 +188,8 @@ pub trait FuncDispatch: std::fmt::Debug {
         Ok(executor.execute().await?)
     }
 
+    /// This private function creates the "request" to send to veritech in a shape that it
+    /// likes. The request's type is [`Self`].
     fn create(
         context: FuncDispatchContext,
         func: &Func,
@@ -210,15 +214,15 @@ pub trait FuncDispatch: std::fmt::Debug {
     //}
 
     #[instrument(
-        name = "funcdispatch.execute",
-        skip_all,
-        level = "debug",
-        fields(
-            otel.kind = %SpanKind::Client,
-            otel.status_code = Empty,
-            otel.status_message = Empty,
-            si.func.result = Empty
-        )
+    name = "funcdispatch.execute",
+    skip_all,
+    level = "debug",
+    fields(
+    otel.kind = % SpanKind::Client,
+    otel.status_code = Empty,
+    otel.status_message = Empty,
+    si.func.result = Empty
+    )
     )]
     async fn execute(
         self: Box<Self>,
@@ -228,6 +232,7 @@ pub trait FuncDispatch: std::fmt::Debug {
     {
         let span = Span::current();
 
+        // NOTE(nick,wendy): why is a debug output of "self" a valid backend?
         let backend = format!("{:?}", &self);
         let value = match self.dispatch().await.map_err(|err| span.record_err(err))? {
             FunctionResult::Success(check_result) => {
@@ -274,15 +279,15 @@ pub trait FuncBackend {
     }
 
     #[instrument(
-        name = "funcbackend.execute",
-        skip_all,
-        level = "debug",
-        fields(
-            otel.kind = %SpanKind::Client,
-            otel.status_code = Empty,
-            otel.status_message = Empty,
-            si.func.result = Empty
-        )
+    name = "funcbackend.execute",
+    skip_all,
+    level = "debug",
+    fields(
+    otel.kind = % SpanKind::Client,
+    otel.status_code = Empty,
+    otel.status_message = Empty,
+    si.func.result = Empty
+    )
     )]
     async fn execute(
         self: Box<Self>,

--- a/lib/dal/src/func/backend/js_workflow.rs
+++ b/lib/dal/src/func/backend/js_workflow.rs
@@ -33,7 +33,7 @@ impl FuncDispatch for FuncBackendJsWorkflow {
         let request = WorkflowResolveRequest {
             // Once we start tracking the state of these executions, then this id will be useful,
             // but for now it's passed along and back, and is opaue
-            execution_id: "danielfurlan".to_string(),
+            execution_id: "danielfurlanjsworkflow".to_string(),
             handler: handler.into(),
             code_base64: code_base64.into(),
         };

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -185,6 +185,10 @@ impl FuncBinding {
 
     /// Runs [`Self::find_or_create()`] and executes if [`Self`] was newly created or
     /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) could not be found.
+    ///
+    /// Use this function if you would like to receive the
+    /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) for a given
+    /// [`FuncId`](crate::Func) and [`args`](serde_json::Value).
     pub async fn find_or_create_and_execute(
         ctx: &DalContext<'_, '_, '_>,
         args: serde_json::Value,
@@ -228,6 +232,7 @@ impl FuncBinding {
         result: FuncBindingResult,
     );
 
+    // For a given [`FuncBinding`](Self), execute using veritech.
     pub async fn execute(
         &self,
         ctx: &DalContext<'_, '_, '_>,
@@ -244,6 +249,8 @@ impl FuncBinding {
             .await
     }
 
+    /// Perform function execution to veritech for a given [`Func`](crate::Func) and
+    /// [`FuncDispatchContext`](crate::func::backend::FuncDispatchContext).
     pub async fn execute_critical_section(
         &self,
         func: Func,
@@ -387,6 +394,8 @@ impl FuncBinding {
             }
         }
 
+        // NOTE(nick,wendy): why is the state is set to Run immediately after it is set to
+        // Dispatch a few lines above?
         execution
             .set_state(ctx, super::execution::FuncExecutionState::Run)
             .await?;

--- a/lib/dal/src/migrations/U0069__workflow_runner_states.sql
+++ b/lib/dal/src/migrations/U0069__workflow_runner_states.sql
@@ -1,0 +1,75 @@
+CREATE TABLE workflow_runner_states
+(
+    pk                          bigserial PRIMARY KEY,
+    id                          bigserial                NOT NULL,
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids bigint[],
+    tenancy_organization_ids    bigint[],
+    tenancy_workspace_ids       bigint[],
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    workflow_runner_id          bigint                   NOT NULL,
+    status                      text                     NOT NULL,
+    execution_id                text,
+    error_kind                  text,
+    error_message               text
+);
+
+CREATE UNIQUE INDEX unique_workflow_runner_states
+    ON workflow_runner_states (workflow_runner_id,
+                               visibility_change_set_pk,
+                               (visibility_deleted_at IS NULL))
+    WHERE visibility_deleted_at IS NULL;
+
+SELECT standard_model_table_constraints_v1('workflow_runner_states');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('workflow_runner_states', 'model', 'workflow_runner_state', 'Workflow Runner State');
+
+CREATE OR REPLACE FUNCTION workflow_runner_state_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_workflow_runner_id bigint,
+    this_status text,
+    this_execution_id text,
+    this_error_kind text,
+    this_error_message text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           workflow_runner_states%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO workflow_runner_states (tenancy_universal,
+                                        tenancy_billing_account_ids,
+                                        tenancy_organization_ids,
+                                        tenancy_workspace_ids,
+                                        visibility_change_set_pk,
+                                        visibility_deleted_at,
+                                        workflow_runner_id,
+                                        status,
+                                        execution_id,
+                                        error_kind,
+                                        error_message)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at,
+            this_workflow_runner_id,
+            this_status,
+            this_execution_id,
+            this_error_kind,
+            this_error_message)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/workflow_runner_state_find_for_workflow_runner.sql
+++ b/lib/dal/src/queries/workflow_runner_state_find_for_workflow_runner.sql
@@ -1,0 +1,15 @@
+SELECT DISTINCT ON (id) id,
+                        visibility_change_set_pk,
+                        visibility_deleted_at,
+                        row_to_json(workflow_runner_states.*) AS object
+
+FROM workflow_runner_states
+WHERE in_tenancy_v1($1, tenancy_universal, tenancy_billing_account_ids,
+                    tenancy_organization_ids, tenancy_workspace_ids)
+  AND is_visible_v1($2, visibility_change_set_pk,
+                    visibility_deleted_at)
+  AND workflow_runner_id = $3
+
+ORDER BY id,
+         visibility_change_set_pk DESC,
+         visibility_deleted_at DESC NULLS FIRST;

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -107,6 +107,7 @@ impl WorkflowView {
         Self::resolve_inner(ctx, func.name(), args, HashSet::new(), &mut HashMap::new()).await
     }
 
+    /// Run a workflow using veritech.
     async fn veritech_run(
         ctx: &DalContext<'_, '_, '_>,
         func: Func,
@@ -123,6 +124,7 @@ impl WorkflowView {
         )?)
     }
 
+    /// A recursive function to resolve inner workflows in order to build a [`WorkflowTree`].
     #[async_recursion]
     async fn resolve_inner(
         ctx: &DalContext<'_, '_, '_>,
@@ -521,25 +523,4 @@ fn join_task<T>(res: Result<T, tokio::task::JoinError>) -> T {
             }
         }
     }
-}
-
-#[derive(
-    Deserialize,
-    Serialize,
-    Debug,
-    Display,
-    AsRefStr,
-    PartialEq,
-    Eq,
-    EnumIter,
-    EnumString,
-    Clone,
-    Copy,
-)]
-#[serde(rename_all = "camelCase")]
-#[strum(serialize_all = "camelCase")]
-pub enum HistoryWorkflowStatus {
-    Success,
-    Failure,
-    Running,
 }

--- a/lib/dal/src/workflow_resolver.rs
+++ b/lib/dal/src/workflow_resolver.rs
@@ -100,8 +100,9 @@ impl WorkflowResolverContext {
 pk!(WorkflowResolverPk);
 pk!(WorkflowResolverId);
 
-// An WorkflowResolver joins a `FuncBinding` to the context in which
-// its corresponding `FuncBindingResultValue` is consumed.
+/// A [`WorkflowResolver`] joins a [`FuncBinding`](crate::FuncBinding) to the
+/// [`WorkflowResolverContext`] in which its corresponding
+/// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) is consumed.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowResolver {
     pk: WorkflowResolverPk,

--- a/lib/dal/src/workflow_runner/workflow_runner_state.rs
+++ b/lib/dal/src/workflow_runner/workflow_runner_state.rs
@@ -1,0 +1,157 @@
+//! This module contains [`WorkflowRunnerState`], which provides a terminating state (including
+//! a [`status`](WorkflowRunnerStatus)) for the execution of a
+//! [`WorkflowRunner`](crate::workflow_runner::WorkflowRunner).
+
+use serde::{Deserialize, Serialize};
+
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
+
+use crate::standard_model::option_object_from_row;
+use crate::workflow_runner::WorkflowRunnerResult;
+use crate::{
+    impl_standard_model, pk,
+    standard_model::{self},
+    StandardModel, Timestamp, Visibility, WriteTenancy,
+};
+use crate::{DalContext, WorkflowRunnerId};
+
+const FIND_FOR_WORKFLOW_RUNNER: &str =
+    include_str!("../queries/workflow_runner_state_find_for_workflow_runner.sql");
+
+/// The [`WorkflowRunnerStatus`] represents a _terminating_ state for a
+/// [`WorkflowRunner`](crate::workflow_runner::WorkflowRunner).
+#[derive(
+    Deserialize,
+    Serialize,
+    Debug,
+    Display,
+    AsRefStr,
+    PartialEq,
+    Eq,
+    EnumIter,
+    EnumString,
+    Clone,
+    Copy,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum WorkflowRunnerStatus {
+    /// All steps executed via [`WorkflowRunner::run()`](crate::workflow_runner::WorkflowRunner::run())
+    /// were successful.
+    Success,
+    /// At least one step executed via [`WorkflowRunner::run()`](crate::workflow_runner::WorkflowRunner::run())
+    /// was not successful.
+    Failure,
+    /// At least one step executed via [`WorkflowRunner::run()`](crate::workflow_runner::WorkflowRunner::run())
+    /// is still in progress.
+    Running,
+    /// No steps have been executed yet (currently, performed by executing
+    /// [`WorkflowRunner::run()`](crate::workflow_runner::WorkflowRunner::run())).
+    Created,
+}
+
+pk!(WorkflowRunnerStatePk);
+pk!(WorkflowRunnerStateId);
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRunnerState {
+    pk: WorkflowRunnerStatePk,
+    id: WorkflowRunnerStateId,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    visibility: Visibility,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+
+    /// The [`WorkflowRunnerId`](crate::workflow_runner::WorkflowRunner) that this state is for.
+    workflow_runner_id: WorkflowRunnerId,
+    /// The status representing the [`WorkflowRunnerState`].
+    status: WorkflowRunnerStatus,
+    /// The execution ID of the function ran in `cyclone`. Currently, this is only populated
+    /// for failures ([`WorkflowRunnerStatus::Failure`](WorkflowRunnerStatus::Failure)).
+    execution_id: Option<String>,
+    /// The error kind, if the status is [`WorkflowRunnerStatus::Failure`](WorkflowRunnerStatus::Failure).
+    error_kind: Option<String>,
+    /// The error message, if the status is [`WorkflowRunnerStatus::Failure`](WorkflowRunnerStatus::Failure).
+    error_message: Option<String>,
+}
+
+impl_standard_model! {
+    model: WorkflowRunnerState,
+    pk: WorkflowRunnerStatePk,
+    id: WorkflowRunnerStateId,
+    table_name: "workflow_runner_states",
+    history_event_label_base: "workflow_runner_state",
+    history_event_message_name: "Workflow Runner State"
+}
+
+impl WorkflowRunnerState {
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext<'_, '_, '_>,
+        workflow_runner_id: WorkflowRunnerId,
+        status: WorkflowRunnerStatus,
+        execution_id: Option<String>,
+        error_kind: Option<String>,
+        error_message: Option<String>,
+    ) -> WorkflowRunnerResult<Self> {
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM workflow_runner_state_create_v1($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    ctx.write_tenancy(),
+                    ctx.visibility(),
+                    &workflow_runner_id,
+                    &status.as_ref(),
+                    &execution_id,
+                    &error_kind,
+                    &error_message,
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    /// Find [`Self`] for a given [`WorkflowRunnerId`](crate::workflow_runner::WorkflowRunner).
+    pub async fn find_for_workflow_runner(
+        ctx: &DalContext<'_, '_, '_>,
+        workflow_runner_id: WorkflowRunnerId,
+    ) -> WorkflowRunnerResult<Option<Self>> {
+        let row = ctx
+            .txns()
+            .pg()
+            .query_opt(
+                FIND_FOR_WORKFLOW_RUNNER,
+                &[ctx.read_tenancy(), ctx.visibility(), &workflow_runner_id],
+            )
+            .await?;
+        let object: Option<Self> = option_object_from_row(row)?;
+        Ok(object)
+    }
+
+    pub fn workflow_runner_id(&self) -> WorkflowRunnerId {
+        self.workflow_runner_id
+    }
+
+    pub fn status(&self) -> WorkflowRunnerStatus {
+        self.status
+    }
+
+    pub fn execution_id(&self) -> Option<&str> {
+        self.execution_id.as_deref()
+    }
+
+    pub fn error_kind(&self) -> Option<&str> {
+        self.error_kind.as_deref()
+    }
+
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+}

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -69,7 +69,7 @@ pub enum LocalUdsInstanceError {
 type Result<T> = result::Result<T, LocalUdsInstanceError>;
 
 /// A local Cyclone [`Instance`], managed as a spawned child process, communicating over a Unix
-/// domain socket.
+/// domain socket ("Uds").
 #[derive(Debug)]
 pub struct LocalUdsInstance {
     // The `TempPath` type is kept around as an [RAII
@@ -228,6 +228,8 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
         result
     }
 
+    // The request argument is the same as that in the "impl FuncDispatch for
+    // FuncBackendJsCommand" in the dal.
     async fn execute_command_run(
         &mut self,
         request: CommandRunRequest,
@@ -239,6 +241,7 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
+        // Use the websocket client for cyclone to execute command run.
         let result = self.client.execute_command_run(request).await;
         self.count_request();
 

--- a/lib/sdf/src/server/service/workflow.rs
+++ b/lib/sdf/src/server/service/workflow.rs
@@ -56,6 +56,8 @@ pub enum WorkflowError {
     SchemaVariantNotFound(SchemaVariantId),
     #[error("runner not found")]
     RunnerNotFound(WorkflowRunnerId),
+    #[error("runner state not found for runner id: {0}")]
+    RunnerStateNotFound(WorkflowRunnerId),
 }
 
 pub type WorkflowResult<T> = std::result::Result<T, WorkflowError>;

--- a/lib/sdf/src/server/service/workflow/run.rs
+++ b/lib/sdf/src/server/service/workflow/run.rs
@@ -27,7 +27,10 @@ pub async fn run(
     let txns = txns.start().await?;
     let ctx = builder.build(request_ctx.build(request.visibility), &txns);
 
-    let (_, func_binding_return_values) = WorkflowRunner::run(&ctx, request.id).await?;
+    // NOTE(nick,wendy): this looks similar to code insider WorkflowRunner::run(). Do we need to run
+    // it twice?
+    // reference: https://github.com/systeminit/si/blob/87c5cce99d6b972f441358295bbabe27f1d787da/lib/dal/src/workflow_runner.rs#L209-L227
+    let (_, _, func_binding_return_values) = WorkflowRunner::run(&ctx, request.id).await?;
     let mut logs = Vec::new();
     for func_binding_return_value in func_binding_return_values {
         for stream in func_binding_return_value

--- a/lib/veritech/src/server/server.rs
+++ b/lib/veritech/src/server/server.rs
@@ -853,6 +853,7 @@ async fn command_run_request(
         .get()
         .await
         .map_err(|err| ServerError::CyclonePool(Box::new(err)))?;
+
     let mut progress = client
         .execute_command_run(cyclone_request)
         .await?


### PR DESCRIPTION
## Description

Primary:
- Add workflow runner states table and module
  - Currently, there is one state per runner, but this is subject to
    change once runners are created _before_ their execution
- Move HistoryWorkflowStatus to WorkflowRunnerStatus (stored in the new
  WorkflowRunnerState struct and table)
- Use the WorkflowRunnerStatus in the two SDF routes (history and info)
  for runners
- Add fail JsCommand builtin
- Add failure JsWorkflow builtin that uses the fail JsCommand
- Add function failure handling to the JsCommand implementation of
  FuncDispatch (i.e. we no longer ignore failures)
- Add two failure integration tests (WorkflowTree's run and
  WorkflowRunner's run methods)

Secondary:
- Add fail examples to lang-js
- Add, modify and extend documentation comments for workflows and
  related domains

Documentation:
- Add table of contents to DEVELOPING
- Add lang-js section to DEVELOPING
- Move and expand documentation section to a new file called
  DOCUMENTATION (referenced in README)
- Expand architecture diagram to include the execution runtime
- Add definitions for architecture diagram components
- Add context to existing lang-js README contents

## Disclaimer

The "fail" JsCommand is _not_ an async function. After checking in with @fnichol, we decided to punt on using async "throw" in the `lang-js` `wrapCode` logic.

## GIF and Linear

<img src="https://media0.giphy.com/media/y9gcCOXpNX8UfZrp0X/giphy.gif"/>

Fixes ENG-520