### PR TITLE
ENG-523: attribute functions can set collection types

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1356,7 +1356,8 @@ impl AttributeValue {
     /// `processed_value` to the empty representation of the type (`[]`, or `{}`) and then
     /// recursively populate the nested values (array elements, map values, or object subtrees),
     /// into their own `AttributeValue` objects.
-    pub async fn process_value(&self,
+    pub async fn process_value(
+        &self,
         ctx: &DalContext<'_, '_, '_>,
         fbrv: &mut FuncBindingReturnValue,
     ) -> AttributeValueResult<()> {
@@ -1375,7 +1376,7 @@ impl AttributeValue {
             let processed_value = match prop.kind() {
                 PropKind::Object | PropKind::Map => Some(&empty_object),
                 PropKind::Array => Some(&empty_array),
-                _ => Some(&unprocessed_value)
+                _ => Some(&unprocessed_value),
             };
             fbrv.set_value(ctx, processed_value.cloned()).await?;
 
@@ -1383,12 +1384,8 @@ impl AttributeValue {
                 // todo: the following duplicates database queries for the data we already have
                 // above, should break out a version of the function that takes refs to the structs
                 // instead of ids
-                Self::populate_nested_values(
-                    ctx,
-                    *self.id(),
-                    self.context,
-                    unprocessed_value
-                ).await?;
+                Self::populate_nested_values(ctx, *self.id(), self.context, unprocessed_value)
+                    .await?;
             }
         }
 

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -399,6 +399,7 @@ impl InternalProvider {
             ctx,
             found_attribute_view_context,
             Some(*found_attribute_value.id()),
+            true,
         )
         .await?;
         let (func_binding, func_binding_return_value) = FuncBinding::find_or_create_and_execute(

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -495,7 +495,9 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext<'_, 
             "si": {
                 "name": "Array Component",
             },
-            "domain": {},
+            "domain": {
+               "array_prop": [],
+            },
         }],
         ComponentView::for_context(ctx, base_attribute_read_context)
             .await

--- a/lib/dal/tests/integration_test/attribute/view.rs
+++ b/lib/dal/tests/integration_test/attribute/view.rs
@@ -7,6 +7,12 @@ use dal::{
 };
 use pretty_assertions_sorted::assert_eq_sorted;
 
+// This simplifies making the test more data-driven
+enum ValueType {
+    Str(String),
+    ArrayOfStr(Vec<String>),
+}
+
 #[test]
 async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
     // "name": String
@@ -23,11 +29,54 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
         ..AttributeReadContext::default()
     };
 
-    let name_prop = create_prop_of_kind_with_name(ctx, PropKind::String, "name").await;
-    name_prop
-        .set_parent_prop(ctx, root_prop.domain_prop_id)
-        .await
-        .expect("cannot set parent of name_prop");
+    let mut props = vec![];
+
+    for (name, kind, value) in [
+        (
+            "name".to_string(),
+            PropKind::String,
+            ValueType::Str("toddhoward".to_string()),
+        ),
+        (
+            "geniusoflove".to_string(),
+            PropKind::Array,
+            ValueType::ArrayOfStr(vec![
+                "fun".to_string(),
+                "natural".to_string(),
+                "fun".to_string(),
+            ]),
+        ),
+    ] {
+        match value {
+            ValueType::Str(_) => {
+                let prop = create_prop_of_kind_with_name(ctx, kind, &name).await;
+                prop.set_parent_prop(ctx, root_prop.domain_prop_id)
+                    .await
+                    .expect("cannot set root prop");
+                props.push(((prop, None), name, kind, value));
+            }
+            ValueType::ArrayOfStr(_) => {
+                let array_prop = create_prop_of_kind_with_name(ctx, kind, &name).await;
+                array_prop
+                    .set_parent_prop(ctx, root_prop.domain_prop_id)
+                    .await
+                    .expect("cannot set root prop");
+
+                let elem_prop =
+                    create_prop_of_kind_with_name(ctx, PropKind::String, "elem_ignore").await;
+                elem_prop
+                    .set_parent_prop(ctx, *array_prop.id())
+                    .await
+                    .expect("cannot set root prop of elem prop");
+                props.push((
+                    (array_prop, Some(elem_prop)),
+                    "elem_ignore".to_string(),
+                    kind,
+                    value,
+                ));
+            }
+        }
+    }
 
     SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id())
         .await
@@ -53,6 +102,7 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
             ..base_context
         },
         Some(*root_attribute_value.id()),
+        false,
     )
     .await
     .expect("could not create attribute view");
@@ -61,6 +111,28 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
         serde_json::json![
             {
                 "domain": {},
+                "si": {}
+            }
+        ], // expected
+        view.value().clone(), // actual
+    );
+
+    let view = AttributeView::new(
+        ctx,
+        AttributeReadContext {
+            prop_id: None,
+            ..base_context
+        },
+        Some(*root_attribute_value.id()),
+        true,
+    )
+    .await
+    .expect("could not create attribute view");
+
+    assert_eq_sorted!(
+        serde_json::json![
+            {
+                "domain": { "geniusoflove": [], },
                 "si": {}
             }
         ], // expected
@@ -78,32 +150,79 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
     .expect("cannot find attribute value")
     .expect("attribute value not found");
 
-    let name_attribute_value = AttributeValue::find_for_context(
-        ctx,
-        AttributeReadContext {
-            prop_id: Some(*name_prop.id()),
-            ..base_context
-        },
-    )
-    .await
-    .expect("cannot find attribute value")
-    .expect("attribute value not found");
+    let mut new_leaf_props = vec![];
 
-    let update_context = AttributeContextBuilder::from(base_context)
-        .set_prop_id(*name_prop.id())
-        .to_context()
-        .expect("could not convert builder to attribute context");
-    let update_value = Some(serde_json::to_value("toddhoward").expect("could not create value"));
-    let (_, updated_name_attribute_value_id) = AttributeValue::update_for_context(
-        ctx,
-        *name_attribute_value.id(),
-        Some(*domain_attribute_value.id()),
-        update_context,
-        update_value,
-        None,
-    )
-    .await
-    .expect("could not update attribute value");
+    for ((prop, maybe_elem_prop), name, _, value) in &props {
+        let av = AttributeValue::find_for_context(
+            ctx,
+            AttributeReadContext {
+                prop_id: Some(*prop.id()),
+                ..base_context
+            },
+        )
+        .await
+        .expect("db error fetching AttributeValue")
+        .expect("AttributeValue not there");
+
+        let update_context = AttributeContextBuilder::from(base_context)
+            .set_prop_id(*prop.id())
+            .to_context()
+            .expect("could not convert builder to attribute context");
+
+        match value {
+            ValueType::Str(string) => {
+                let json_value = serde_json::to_value(string).expect("json value creation");
+                let (_, updated_av_id) = AttributeValue::update_for_context(
+                    ctx,
+                    *av.id(),
+                    Some(*domain_attribute_value.id()),
+                    update_context,
+                    Some(json_value.clone()),
+                    None,
+                )
+                .await
+                .unwrap_or_else(|_| panic!("could not update attribute value \"{}\"", name));
+
+                new_leaf_props.push((updated_av_id, json_value));
+            }
+            ValueType::ArrayOfStr(strings) => {
+                // create empty array for array value
+                let (_, updated_av_id) = AttributeValue::update_for_context(
+                    ctx,
+                    *av.id(),
+                    Some(*domain_attribute_value.id()),
+                    update_context,
+                    Some(serde_json::json![[]]),
+                    None,
+                )
+                .await
+                .unwrap_or_else(|_| panic!("could not update attribute value \"{}\"", name));
+
+                let elem_prop = maybe_elem_prop.clone().unwrap();
+                let elem_update_context = AttributeContextBuilder::from(base_context)
+                    .set_prop_id(*elem_prop.id())
+                    .to_context()
+                    .expect("create element update context");
+
+                for elem_value in strings {
+                    AttributeValue::insert_for_context(
+                        ctx,
+                        elem_update_context,
+                        updated_av_id,
+                        Some(serde_json::to_value(elem_value).expect("jsonification")),
+                        None,
+                    )
+                    .await
+                    .expect("could not insert array element");
+                }
+
+                new_leaf_props.push((
+                    updated_av_id,
+                    serde_json::to_value(strings).expect("jsonificatin'"),
+                ));
+            }
+        }
+    }
 
     let view = AttributeView::new(
         ctx,
@@ -112,6 +231,7 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
             ..base_context
         },
         Some(*root_attribute_value.id()),
+        false,
     )
     .await
     .expect("could not create attribute view");
@@ -120,7 +240,8 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
         serde_json::json![
             {
                 "domain": {
-                    "name": "toddhoward"
+                    "name": "toddhoward",
+                    "geniusoflove": ["fun", "natural", "fun"],
                 },
                 "si": {}
             }
@@ -129,18 +250,44 @@ async fn schema_variant_specific(ctx: &DalContext<'_, '_, '_>) {
     );
 
     // Ensure that leaf generation works as well.
+    for (av_id, value) in &new_leaf_props {
+        let view = AttributeView::new(
+            ctx,
+            AttributeReadContext {
+                prop_id: None,
+                ..base_context
+            },
+            Some(*av_id),
+            false,
+        )
+        .await
+        .expect("could not create attribute view");
+        assert_eq_sorted!(
+            value.clone(),        // expected
+            view.value().clone(), // actual
+        );
+    }
+
+    // Can we generate a view of *just* the domain?
     let view = AttributeView::new(
         ctx,
         AttributeReadContext {
             prop_id: None,
             ..base_context
         },
-        Some(updated_name_attribute_value_id),
+        Some(*domain_attribute_value.id()),
+        false,
     )
     .await
-    .expect("could not create attribute view");
+    .expect("could not create attribute view for domain");
+
     assert_eq_sorted!(
-        serde_json::json!["toddhoward"], // expected
-        view.value().clone(),            // actual
+        serde_json::json![
+            {
+                "name": "toddhoward",
+                "geniusoflove": ["fun", "natural", "fun"],
+            }
+        ], // expected
+        view.value().clone(), // actual
     );
 }

--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -9,8 +9,8 @@ use dal::{
     attribute::context::AttributeContextBuilderError, AttributeContext, AttributeContextError,
     AttributePrototype, AttributePrototypeError, AttributeValue, AttributeValueError,
     AttributeValueId, ComponentError, DalContext, Func, FuncBackendKind, FuncBinding,
-    FuncBindingError, Prop, PropError, PropKind, QualificationPrototypeError, ReadTenancyError,
-    StandardModel, StandardModelError, TransactionsError, WriteTenancyError, WsEventError,
+    FuncBindingError, PropError, QualificationPrototypeError, ReadTenancyError, StandardModel,
+    StandardModelError, TransactionsError, WriteTenancyError, WsEventError,
 };
 
 use dal::attribute::value::dependent_update::collection::AttributeValueDependentCollectionHarness;
@@ -161,9 +161,7 @@ async fn update_attribute_value_by_func_for_context(
     attribute_value
         .set_func_binding_return_value_id(ctx, *fbrv.id())
         .await?;
-    attribute_value.process_value(ctx, &mut fbrv).await?; 
-
-
+    attribute_value.process_value(ctx, &mut fbrv).await?;
 
     AttributePrototype::update_for_context(
         ctx,

--- a/lib/sdf/src/server/service/func/create_func.rs
+++ b/lib/sdf/src/server/service/func/create_func.rs
@@ -164,8 +164,13 @@ async fn create_default_attribute_func(
         system_id: context.system_id(),
     };
 
-    let current_value_view =
-        AttributeView::new(ctx, context_without_specificity, Some(current_value_id)).await?;
+    let current_value_view = AttributeView::new(
+        ctx,
+        context_without_specificity,
+        Some(current_value_id),
+        true,
+    )
+    .await?;
 
     let current_value_value = current_value_view.value();
     let default_code = DEFAULT_ATTRIBUTE_CODE_TEMPLATE.replace(
@@ -174,7 +179,7 @@ async fn create_default_attribute_func(
     );
     let default_code = default_code.replace(
         ATTRIBUTE_CODE_RETURN_VALUE_PLACEHOLDER,
-        &serde_json::to_string_pretty(&current_value_value)?,
+        &serde_json::to_string(&current_value_value)?,
     );
 
     let mut func = Func::new(


### PR DESCRIPTION
Includes a change to AttributeView that optionally expands collection types on views to the empty value (`{}` or `[]`) so that the collection type shows up on a default view of the object.