### PR TITLE
fix(web): fix visibility change in func editor tabs

### DIFF
--- a/app/web/src/molecules/SiTabHeader.vue
+++ b/app/web/src/molecules/SiTabHeader.vue
@@ -9,7 +9,7 @@
     <button
       :class="
         selectedToFront
-          ? selected
+          ? selected && $el && $el.nextElementSibling
             ? moveTabToFrontIfOverflowing($el.nextElementSibling)
             : 'order-2'
           : ''

--- a/app/web/src/organisms/Workspace/WorkspaceLab.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceLab.vue
@@ -111,6 +111,7 @@ const createFunc = async ({
 
 visibility$.subscribe(() => {
   clearFuncs();
+  routeToFunc(); // route to no func
 });
 
 saveFuncToBackend$


### PR DESCRIPTION
The tab rearrangement logic broke a bit when switching changesets. This fixes that!

https://media.giphy.com/media/1X7lCRp8iE0yrdZvwd/giphy.gif