### PR TITLE
feat(web,langjs,cyc,ver,dal,sdf): Create/update resources from commands

### DIFF
--- a/app/web/src/organisms/WorkflowRunner/WorkflowPicker.vue
+++ b/app/web/src/organisms/WorkflowRunner/WorkflowPicker.vue
@@ -37,7 +37,7 @@
                           : ''
                       "
                       class="border dark:border-neutral-600 dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300"
-                      @click="select(workflow)"
+                      @click="select(workflow, null)"
                     />
                   </span>
                 </template>
@@ -59,7 +59,7 @@
                             : ''
                         "
                         class="border dark:border-neutral-600 dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300"
-                        @click="select(workflow)"
+                        @click="select(workflow, String(component))"
                       />
                     </span>
                   </SiCollapsible>
@@ -122,15 +122,15 @@ const groupedFilteredList = computed(() => {
   for (const el of filteredList) {
     if (el.schemaName) {
       if (!group[el.schemaName]) group[el.schemaName] = {};
-      if (el.componentNames.length === 0) {
+      if (el.components.length === 0) {
         continue;
       } else if (!Array.isArray(group[el.schemaName])) {
-        for (const componentName of el.componentNames) {
-          if (!group[el.schemaName][componentName]) {
-            group[el.schemaName][componentName] = [];
+        for (const component of el.components) {
+          if (!group[el.schemaName][component.name]) {
+            group[el.schemaName][component.name] = [];
           }
 
-          group[el.schemaName][componentName].push(el);
+          group[el.schemaName][component.name].push(el);
         }
       }
     } else {
@@ -142,10 +142,11 @@ const groupedFilteredList = computed(() => {
 });
 
 const emits = defineEmits<{
-  (e: "selected", v: ListedWorkflowView): void;
+  (e: "selected", v: ListedWorkflowView, componentId: number | null): void;
 }>();
 
-const select = (w: ListedWorkflowView) => {
-  emits("selected", w);
+const select = (w: ListedWorkflowView, componentName: string | null) => {
+  const componentId = w.components.find((c) => c.name === componentName)?.id ?? null;
+  emits("selected", w, componentId);
 };
 </script>

--- a/app/web/src/organisms/WorkflowRunner/WorkflowResolver.vue
+++ b/app/web/src/organisms/WorkflowRunner/WorkflowResolver.vue
@@ -24,16 +24,19 @@ import { WorkflowResolveResponse } from "@/service/workflow/resolve";
 import CodeViewer from "@/organisms/CodeViewer.vue";
 
 const props = defineProps<{
-  selectedId: number;
+  selected: { id: number, componentId: number | null };
 }>();
 
-const selectedId = toRef(props, "selectedId", 0);
-const selectedId$ = fromRef(selectedId, { immediate: true });
+const selected = toRef(props, "selected");
+const selected$ = fromRef(selected, { immediate: true });
 
 const workflowTree = refFrom<WorkflowResolveResponse | null>(
-  combineLatest([selectedId$]).pipe(
-    switchMap(([id]) => {
-      return WorkflowService.resolve({ id });
+  combineLatest([selected$]).pipe(
+    switchMap(([selected]) => {
+      return WorkflowService.resolve({
+        id: selected.id,
+        componentId: selected.componentId
+      });
     }),
   ),
 );

--- a/app/web/src/organisms/Workspace/WorkspaceRuntime.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceRuntime.vue
@@ -14,7 +14,7 @@
     <div
       class="grow overflow-hidden h-full dark:bg-neutral-800 dark:text-white text-lg font-semi-bold px-2 pt-2 flex flex-col"
     >
-      <WorkflowResolver v-if="selected" :selected-id="selected.id">
+      <WorkflowResolver v-if="selected" :selected="selected">
         <template #runButton>
           <VButton
             icon="play"
@@ -69,10 +69,10 @@ import SiPanel from "@/atoms/SiPanel.vue";
 import { WorkflowStatus } from "@/molecules/WorkflowStatusIcon.vue";
 import WorkflowOutput from "../WorkflowRunner/WorkflowOutput.vue";
 
-const selected = ref<ListedWorkflowView | null>(null);
-const select = (w: ListedWorkflowView | null) => {
+const selected = ref<{ id: number, componentId: number | null } | null>(null);
+const select = (w: ListedWorkflowView, componentId: number | null) => {
   logs.value = null;
-  selected.value = w;
+  selected.value = { id: w.id, componentId };
 };
 
 const logs = ref<string[] | null>(null);
@@ -80,7 +80,10 @@ const runWorkflow = async () => {
   if (selected.value) {
     logs.value = null;
     currentWorkflowStatus.value = "running";
-    const outputs = await WorkflowService.run({ id: selected.value.id });
+    const outputs = await WorkflowService.run({
+      id: selected.value.id,
+      componentId: selected.value.componentId,
+    });
     currentWorkflowStatus.value =
       outputs?.workflowRunnerState.status || "failure";
     logs.value = outputs?.logs ?? null;

--- a/app/web/src/service/workflow/list.ts
+++ b/app/web/src/service/workflow/list.ts
@@ -9,7 +9,10 @@ export interface ListedWorkflowView {
   title: string;
   description: string | null;
   link: string | null;
-  componentNames: string[];
+  components: Array<{
+    id: number;
+    name: string;
+  }>;
   schemaName: string | null;
   schemaVariantName: string | null;
 }

--- a/app/web/src/service/workflow/resolve.ts
+++ b/app/web/src/service/workflow/resolve.ts
@@ -6,6 +6,7 @@ import { visibility$ } from "@/observable/visibility";
 
 export interface WorkflowResolveRequest {
   id: number;
+  componentId: number | null;
 }
 
 export enum WorkflowKind {
@@ -41,7 +42,8 @@ export const resolve: (
 
   const response = await firstValueFrom(
     sdf.post<ApiResponse<WorkflowResolveResponse>>("workflow/resolve", {
-      ...arg,
+      id: arg.id,
+      componentId: arg.componentId ?? -1,
       ...visibility,
     }),
   );

--- a/app/web/src/service/workflow/run.ts
+++ b/app/web/src/service/workflow/run.ts
@@ -7,6 +7,7 @@ import { WorkflowStatus } from "@/molecules/WorkflowStatusIcon.vue";
 
 export interface WorkflowRunRequest {
   id: number;
+  componentId: number | null;
 }
 
 export interface WorkflowRunnerState {
@@ -32,7 +33,8 @@ export const run: (
 
   const response = await firstValueFrom(
     sdf.post<ApiResponse<WorkflowRunResponse>>("workflow/run", {
-      ...arg,
+      id: arg.id,
+      componentId: arg.componentId ?? -1,
       ...visibility,
     }),
   );

--- a/bin/lang-js/package-lock.json
+++ b/bin/lang-js/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lang-js",
       "version": "0.1.0",
       "license": "Proprietary",
       "dependencies": {

--- a/bin/lang-js/src/sandbox.ts
+++ b/bin/lang-js/src/sandbox.ts
@@ -38,7 +38,11 @@ const codeGenerationSandbox = {
 
 const workflowResolveSandbox = {};
 
-const commandRunSandbox = {};
+function commandRunSandbox(executionId: string): Sandbox {
+  return {
+    siExec: makeExec(executionId),
+  };
+}
 
 function qualificationCheckSandbox(executionId: string): Sandbox {
   return {
@@ -83,7 +87,7 @@ export function createSandbox(
     case FunctionKind.CommandRun:
       return {
         ...commonSandbox(executionId),
-        ...commandRunSandbox,
+        ...commandRunSandbox(executionId),
       };
     default:
       throw new UnknownSandboxKind(kind);

--- a/bin/lang-js/src/sandbox/console.ts
+++ b/bin/lang-js/src/sandbox/console.ts
@@ -1,38 +1,43 @@
 import { OutputLine } from "../function";
 
+const normalizeMessage = (message: unknown): string => {
+  if (typeof(message) === typeof("")) return message as string;
+  return JSON.stringify(message ?? "");
+}
+
 export const makeConsole = (executionId: string) => {
-  function debug(message: string, data: unknown): void {
+  function debug(message: unknown, data: unknown): void {
     emitOutputLine({
       protocol: "output",
       executionId,
       stream: "stdout",
       level: "debug",
       group: "log",
-      message,
+      message: normalizeMessage(message),
       data,
     });
   }
 
-  function error(message: string, data: unknown): void {
+  function error(message: unknown, data: unknown): void {
     emitOutputLine({
       protocol: "output",
       executionId,
       stream: "stderr",
       level: "error",
       group: "log",
-      message,
+      message: normalizeMessage(message),
       data,
     });
   }
 
-  function log(message: string, data: unknown): void {
+  function log(message: unknown, data: unknown): void {
     emitOutputLine({
       protocol: "output",
       executionId,
       stream: "stdout",
       level: "info",
       group: "log",
-      message,
+      message: normalizeMessage(message),
       data,
     });
   }

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -1,7 +1,10 @@
 #![recursion_limit = "256"]
 
 use color_eyre::Result;
-use sdf::{Config, FaktoryProcessor, IncomingStream, JobQueueProcessor, MigrationMode, Server};
+use sdf::{
+    Config, FaktoryProcessor, IncomingStream, JobQueueProcessor, MigrationMode, Server,
+    SyncProcessor,
+};
 use telemetry::{
     start_tracing_level_signal_handler_task,
     tracing::{debug, error, info, trace},
@@ -150,7 +153,7 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
             Server::start_resource_sync_scheduler(
                 pg_pool,
                 nats,
-                job_processor,
+                Box::new(SyncProcessor::new()),
                 veritech,
                 encryption_key,
                 shutdown_broadcast_rx,
@@ -175,7 +178,7 @@ async fn run(args: args::Args, mut telemetry: telemetry::Client) -> Result<()> {
             Server::start_resource_sync_scheduler(
                 pg_pool,
                 nats,
-                job_processor,
+                Box::new(SyncProcessor::new()),
                 veritech,
                 encryption_key,
                 shutdown_broadcast_rx,

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -738,17 +738,20 @@ mod tests {
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 parents: vec![
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                 ],
             },
@@ -829,17 +832,20 @@ mod tests {
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 parents: vec![
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                 ],
             },
@@ -919,6 +925,7 @@ mod tests {
                     properties: serde_json::json!({ "si": { "name": "Aipim Frito" } }),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 codes: Vec::new(),
                 parents: Vec::new(),
@@ -1010,6 +1017,7 @@ mod tests {
                     properties: serde_json::json!({ "si": { "name": "Aipim Frito" } }),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 codes: Vec::new(),
                 parents: Vec::new(),
@@ -1096,6 +1104,7 @@ mod tests {
             properties: serde_json::json!({}),
             system: None,
             kind: ComponentKind::Standard,
+            resources: Default::default(),
         };
         let req = ResourceSyncRequest {
             execution_id: "1234".to_string(),
@@ -1177,6 +1186,7 @@ mod tests {
             properties: serde_json::json!({}),
             system: None,
             kind: ComponentKind::Standard,
+            resources: Default::default(),
         };
         let req = ResourceSyncRequest {
             execution_id: "1234".to_string(),
@@ -1256,6 +1266,7 @@ mod tests {
             properties: serde_json::json!({ "si": { "name": "Ablublubé"}}),
             system: None,
             kind: ComponentKind::Standard,
+            resources: Default::default(),
         };
         let req = CodeGenerationRequest {
             execution_id: "1234".to_string(),
@@ -1285,7 +1296,7 @@ mod tests {
                 assert_eq!(
                     serde_json::from_str::<serde_json::Value>(&output.message)
                         .expect("Unable to serialize output to json"),
-                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard" })
+                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard", "resources": [] })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -1345,6 +1356,7 @@ mod tests {
             properties: serde_json::json!({ "si": { "name": "Ablublubé"}}),
             system: None,
             kind: ComponentKind::Standard,
+            resources: Default::default(),
         };
         let req = CodeGenerationRequest {
             execution_id: "1234".to_string(),
@@ -1374,7 +1386,7 @@ mod tests {
                 assert_eq!(
                     serde_json::from_str::<serde_json::Value>(&output.message)
                         .expect("Unable to serialize output to json"),
-                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard" })
+                    serde_json::json!({"properties": { "si": { "name": "Ablublubé" } }, "system": null, "kind": "standard", "resources": [] })
                 )
             }
             Some(Ok(unexpected)) => panic!("unexpected msg kind: {:?}", unexpected),
@@ -1431,6 +1443,7 @@ mod tests {
         let req = WorkflowResolveRequest {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
+            args: Default::default(),
             code_base64: base64::encode(
                 r#"function workit() {
                     console.log('first');
@@ -1505,6 +1518,7 @@ mod tests {
         let req = WorkflowResolveRequest {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
+            args: Default::default(),
             code_base64: base64::encode(
                 r#"function workit() {
                     console.log('first');
@@ -1578,6 +1592,7 @@ mod tests {
         let req = CommandRunRequest {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
+            args: Default::default(),
             code_base64: base64::encode(
                 r#"function workit() {
                     console.log('first');
@@ -1651,6 +1666,7 @@ mod tests {
         let req = CommandRunRequest {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
+            args: Default::default(),
             code_base64: base64::encode(
                 r#"function workit() {
                     console.log('first');

--- a/lib/cyclone-core/src/command_run.rs
+++ b/lib/cyclone-core/src/command_run.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -6,12 +7,15 @@ pub struct CommandRunRequest {
     pub execution_id: String,
     pub handler: String,
     pub code_base64: String,
+    pub args: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandRunResultSuccess {
     pub execution_id: String,
+    pub updated: HashMap<String, serde_json::Value>,
+    pub created: HashMap<String, serde_json::Value>,
     // Collects the error if the function throws
     pub error: Option<String>,
 }

--- a/lib/cyclone-core/src/component_view.rs
+++ b/lib/cyclone-core/src/component_view.rs
@@ -20,12 +20,19 @@ pub struct SystemView {
     pub name: String,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ResourceView {
+    pub key: String,
+    pub data: serde_json::Value,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentView {
     pub system: Option<SystemView>,
     pub kind: ComponentKind,
     pub properties: Value,
+    pub resources: Vec<ResourceView>,
 }
 
 impl Default for ComponentView {
@@ -34,6 +41,7 @@ impl Default for ComponentView {
             system: Default::default(),
             kind: Default::default(),
             properties: serde_json::json!({}),
+            resources: Default::default(),
         }
     }
 }

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -29,7 +29,7 @@ mod workflow_resolve;
 pub use canonical_command::{CanonicalCommand, CanonicalCommandError};
 pub use code_generation::{CodeGenerated, CodeGenerationRequest, CodeGenerationResultSuccess};
 pub use command_run::{CommandRunRequest, CommandRunResultSuccess};
-pub use component_view::{ComponentKind, ComponentView, SystemView};
+pub use component_view::{ComponentKind, ComponentView, ResourceView, SystemView};
 pub use encryption_key::{EncryptionKey, EncryptionKeyError};
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use progress::{

--- a/lib/cyclone-core/src/workflow_resolve.rs
+++ b/lib/cyclone-core/src/workflow_resolve.rs
@@ -6,6 +6,7 @@ pub struct WorkflowResolveRequest {
     pub execution_id: String,
     pub handler: String,
     pub code_base64: String,
+    pub args: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/cyclone-server/src/request.rs
+++ b/lib/cyclone-server/src/request.rs
@@ -355,6 +355,7 @@ mod tests {
         let secrets = ComponentView {
             system: None,
             kind: ComponentKind::Credential,
+            resources: Default::default(),
             properties: serde_json::json!({
                 "secret": {
                     "name": "ufo",
@@ -390,6 +391,7 @@ mod tests {
         let json = ComponentView {
             system: None,
             kind: ComponentKind::Credential,
+            resources: Default::default(),
             properties: serde_json::json!({
                 "secret": {
                     "name": "ufo",
@@ -413,6 +415,7 @@ mod tests {
                     "message": secret_json,
                 },
             },
+            "resources": []
         });
         assert_eq!(json, decrypted_json);
     }

--- a/lib/cyclone-server/src/result/command_run.rs
+++ b/lib/cyclone-server/src/result/command_run.rs
@@ -1,10 +1,15 @@
 use cyclone_core::CommandRunResultSuccess;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LangServerCommandRunResultSuccess {
     pub execution_id: String,
+    #[serde(default)]
+    pub updated: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub created: HashMap<String, serde_json::Value>,
     // Collects the error if the function throws
     #[serde(default)]
     pub error: Option<String>,
@@ -15,6 +20,8 @@ impl From<LangServerCommandRunResultSuccess> for CommandRunResultSuccess {
         Self {
             execution_id: value.execution_id,
             error: value.error,
+            updated: value.updated,
+            created: value.created,
         }
     }
 }

--- a/lib/dal/src/builtins/func/dockerImageRefreshCommand.js
+++ b/lib/dal/src/builtins/func/dockerImageRefreshCommand.js
@@ -1,0 +1,18 @@
+async function refresh(component) {
+  console.log(component);
+
+  const child = await siExec.waitUntilEnd("skopeo", ["inspect", "--override-os", "linux", "--override-arch", "amd64", `docker://docker.io/${component.properties.domain.image}`]);
+  if (child.exitCode !== 0) {
+    throw new Error(child.stderr);
+  }
+
+  console.log(child.stdout);
+  const object = JSON.parse(child.stdout);
+  const key = object.Name;
+
+  if (component.resources.find((r) => r.key === key)) {
+    return { updated: { [key]: object } };
+  } else {
+    return { created: { [key]: object } };
+  }
+}

--- a/lib/dal/src/builtins/func/dockerImageRefreshCommand.json
+++ b/lib/dal/src/builtins/func/dockerImageRefreshCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "dockerImageRefreshCommand.js",
+  "code_entrypoint": "refresh"
+}

--- a/lib/dal/src/builtins/func/dockerImageRefreshWorkflow.js
+++ b/lib/dal/src/builtins/func/dockerImageRefreshWorkflow.js
@@ -1,0 +1,12 @@
+async function refresh(arg) {
+  return {
+    name: "si:dockerImageRefreshWorkflow",
+    kind: "conditional",
+    steps: [
+      {
+        command: "si:dockerImageRefreshCommand",
+        args: [arg],
+      },
+    ],
+  };
+}

--- a/lib/dal/src/builtins/func/dockerImageRefreshWorkflow.json
+++ b/lib/dal/src/builtins/func/dockerImageRefreshWorkflow.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsWorkflow",
+  "response_type": "Workflow",
+  "code_file": "dockerImageRefreshWorkflow.js",
+  "code_entrypoint": "refresh"
+}

--- a/lib/dal/src/builtins/func/qualificationDockerImageNameInspect.js
+++ b/lib/dal/src/builtins/func/qualificationDockerImageNameInspect.js
@@ -1,8 +1,7 @@
 async function qualificationDockerImageNameInspect(component) {
-  console.log(JSON.stringify(component))
   const child = await siExec.waitUntilEnd("skopeo", ["inspect", "--override-os", "linux", "--override-arch", "amd64", `docker://docker.io/${component.data.properties.domain.image}`]);
   return {
-    qualified: child.exitCode !== 0,
+    qualified: child.exitCode === 0,
     // Note: Do we want stdout on success? Do we want both, always? Do we want to filter the output?
     message: child.exitCode == 0 ? child.stdout : child.stderr,
   };

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -103,6 +103,7 @@ impl BuiltinSchemaHelpers {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: veritech::ComponentKind::Standard,
+                        resources: vec![],
                     },
                     parents: vec![],
                 },

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -185,7 +185,7 @@ pub trait FuncDispatch: std::fmt::Debug {
 
     // TODO: re-enable encryption
     //{
-    //    for view in value.extract() {
+    //    for view in value.extract()? {
     //        ComponentView::reencrypt_secrets(ctx, view).await?;
     //    }
     //}
@@ -213,7 +213,7 @@ pub trait FuncDispatch: std::fmt::Debug {
         let backend = format!("{:?}", &self);
         let value = match self.dispatch().await.map_err(|err| span.record_err(err))? {
             FunctionResult::Success(check_result) => {
-                let payload = serde_json::to_value(check_result.extract())?;
+                let payload = serde_json::to_value(check_result.extract()?)?;
                 (Some(payload.clone()), Some(payload))
             }
             FunctionResult::Failure(failure) => {
@@ -287,5 +287,5 @@ pub trait FuncBackend {
 pub trait ExtractPayload {
     type Payload: std::fmt::Debug;
 
-    fn extract(self) -> Self::Payload;
+    fn extract(self) -> FuncBackendResult<Self::Payload>;
 }

--- a/lib/dal/src/func/backend/js_attribute.rs
+++ b/lib/dal/src/func/backend/js_attribute.rs
@@ -59,7 +59,7 @@ impl FuncDispatch for FuncBackendJsAttribute {
 impl ExtractPayload for ResolverFunctionResultSuccess {
     type Payload = serde_json::Value;
 
-    fn extract(self) -> Self::Payload {
-        self.data
+    fn extract(self) -> FuncBackendResult<Self::Payload> {
+        Ok(self.data)
     }
 }

--- a/lib/dal/src/func/backend/js_code_generation.rs
+++ b/lib/dal/src/func/backend/js_code_generation.rs
@@ -51,7 +51,7 @@ impl FuncDispatch for FuncBackendJsCodeGeneration {
 impl ExtractPayload for CodeGenerationResultSuccess {
     type Payload = CodeGenerated;
 
-    fn extract(self) -> Self::Payload {
-        self.data
+    fn extract(self) -> FuncBackendResult<Self::Payload> {
+        Ok(self.data)
     }
 }

--- a/lib/dal/src/func/backend/js_qualification.rs
+++ b/lib/dal/src/func/backend/js_qualification.rs
@@ -78,12 +78,12 @@ impl FuncDispatch for FuncBackendJsQualification {
 impl ExtractPayload for QualificationCheckResultSuccess {
     type Payload = QualificationResult;
 
-    fn extract(self) -> Self::Payload {
-        QualificationResult {
+    fn extract(self) -> FuncBackendResult<Self::Payload> {
+        Ok(QualificationResult {
             success: self.qualified,
             title: self.title,
             link: self.link,
             sub_checks: self.sub_checks,
-        }
+        })
     }
 }

--- a/lib/dal/src/func/backend/js_resource.rs
+++ b/lib/dal/src/func/backend/js_resource.rs
@@ -51,7 +51,7 @@ impl FuncDispatch for FuncBackendJsResourceSync {
 impl ExtractPayload for ResourceSyncResultSuccess {
     type Payload = Self;
 
-    fn extract(self) -> Self::Payload {
-        self
+    fn extract(self) -> FuncBackendResult<Self::Payload> {
+        Ok(self)
     }
 }

--- a/lib/dal/src/migrations/U0049__resource.sql
+++ b/lib/dal/src/migrations/U0049__resource.sql
@@ -8,6 +8,9 @@ CREATE TABLE resources
     tenancy_workspace_ids       bigint[],
     visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
     visibility_deleted_at       timestamp with time zone,
+    key                         text                     NOT NULL,
+    data                        jsonb                    NOT NULL,
+    refresh_workflow_id         bigint                   NOT NULL,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW()
 );
@@ -23,6 +26,9 @@ VALUES ('resources', 'model', 'resource', 'Resource'),
 CREATE OR REPLACE FUNCTION resource_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
+    this_key text,
+    this_data jsonb,
+    this_refresh_workflow_id bigint,
     OUT object json) AS
 $$
 DECLARE
@@ -38,13 +44,19 @@ BEGIN
                            tenancy_organization_ids,
                            tenancy_workspace_ids,
                            visibility_change_set_pk,
-                           visibility_deleted_at)
+                           visibility_deleted_at,
+                           key,
+                           data,
+                           refresh_workflow_id)
     VALUES (this_tenancy_record.tenancy_universal,
             this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids,
             this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk,
-            this_visibility_record.visibility_deleted_at)
+            this_visibility_record.visibility_deleted_at,
+            this_key,
+            this_data,
+            this_refresh_workflow_id)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/queries/resource_find_by_key.sql
+++ b/lib/dal/src/queries/resource_find_by_key.sql
@@ -1,0 +1,23 @@
+SELECT DISTINCT ON (resources.id) resources.id,
+                                  resources.visibility_change_set_pk,
+                                  resources.visibility_deleted_at,
+                                  row_to_json(resources.*) AS object
+FROM resources
+  INNER JOIN resource_belongs_to_component
+    ON resources.id = resource_belongs_to_component.object_id
+      AND resources.tenancy_universal = resource_belongs_to_component.tenancy_universal
+      AND resources.tenancy_billing_account_ids = resource_belongs_to_component.tenancy_billing_account_ids
+      AND resources.tenancy_organization_ids = resource_belongs_to_component.tenancy_organization_ids
+      AND resources.tenancy_workspace_ids = resource_belongs_to_component.tenancy_workspace_ids
+  INNER JOIN resource_belongs_to_system
+    ON resources.id = resource_belongs_to_system.object_id
+      AND resources.tenancy_universal = resource_belongs_to_system.tenancy_universal
+      AND resources.tenancy_billing_account_ids = resource_belongs_to_system.tenancy_billing_account_ids
+      AND resources.tenancy_organization_ids = resource_belongs_to_system.tenancy_organization_ids
+      AND resources.tenancy_workspace_ids = resource_belongs_to_system.tenancy_workspace_ids
+WHERE in_tenancy_and_visible_v1($1, $2, resources)
+  AND resource_belongs_to_component.belongs_to_id = $3
+  AND resources.key = $4
+ORDER BY resources.id,
+         resources.visibility_change_set_pk DESC,
+         resources.visibility_deleted_at DESC NULLS FIRST;

--- a/lib/dal/src/queries/resource_list_by_component_and_system.sql
+++ b/lib/dal/src/queries/resource_list_by_component_and_system.sql
@@ -11,7 +11,7 @@ FROM resources
                        resources.tenancy_billing_account_ids = resource_belongs_to_component.tenancy_billing_account_ids
                         AND resources.tenancy_organization_ids = resource_belongs_to_component.tenancy_organization_ids
                         AND resources.tenancy_workspace_ids = resource_belongs_to_component.tenancy_workspace_ids
-         INNER JOIN resource_belongs_to_system
+         LEFT OUTER JOIN resource_belongs_to_system
                     ON resources.id = resource_belongs_to_system.object_id
                         AND resources.tenancy_universal = resource_belongs_to_system.tenancy_universal
                         AND
@@ -21,7 +21,7 @@ FROM resources
 
 WHERE in_tenancy_and_visible_v1($1, $2, resources)
   AND resource_belongs_to_component.belongs_to_id = $3
-  AND resource_belongs_to_system.belongs_to_id = $4
+  AND (resource_belongs_to_system IS NULL OR resource_belongs_to_system.belongs_to_id = $4)
 
 ORDER BY resources.id,
          resources.visibility_change_set_pk DESC,

--- a/lib/dal/src/resource_scheduler.rs
+++ b/lib/dal/src/resource_scheduler.rs
@@ -56,6 +56,7 @@ impl ResourceScheduler {
                 },
                 _ = self.start_task() => {}
             }
+            info!("Resource Syncing stopped");
         });
     }
 

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1453,6 +1453,7 @@ async fn cyclone_crypto_e2e(ctx: &DalContext<'_, '_, '_>) {
                         },
                     },
                 }),
+                resources: Default::default(),
             },
             parents: Vec::new(),
         },

--- a/lib/dal/tests/integration_test/resource.rs
+++ b/lib/dal/tests/integration_test/resource.rs
@@ -2,60 +2,41 @@ use dal::DalContext;
 
 use crate::dal::test;
 use dal::test_harness::create_component_and_schema;
-use dal::{Resource, StandardModel, System};
+use dal::{Resource, StandardModel, SystemId, WorkflowPrototypeId};
 
 #[test]
 async fn new(ctx: &DalContext<'_, '_, '_>) {
     let component = create_component_and_schema(ctx).await;
-    let system = System::new(ctx, "production system")
-        .await
-        .expect("cannot create system");
 
-    let _resource = Resource::new(ctx, component.id(), system.id())
-        .await
-        .expect("cannot create resource for component/system");
+    let _resource = Resource::new(
+        ctx,
+        *component.id(),
+        SystemId::NONE,
+        "key".to_owned(),
+        serde_json::Value::Null,
+        WorkflowPrototypeId::NONE,
+    )
+    .await
+    .expect("cannot create resource for component/system");
 }
 
 #[test]
-async fn get_by_component_and_system_id(ctx: &DalContext<'_, '_, '_>) {
-    let mastodon_component = create_component_and_schema(ctx).await;
-    let blue_oyster_component = create_component_and_schema(ctx).await;
+async fn list_by_component(ctx: &DalContext<'_, '_, '_>) {
+    let component = create_component_and_schema(ctx).await;
 
-    let production_system = System::new(ctx, "production system")
-        .await
-        .expect("cannot create system");
-    let staging_system = System::new(ctx, "staging system")
-        .await
-        .expect("cannot create staging system");
-    let original_resource = Resource::new(ctx, mastodon_component.id(), production_system.id())
-        .await
-        .expect("cannot create resource for component/system");
-
-    // None of the following should be found by `Resource::get_by_component_id_and_system_id`.
-    let _different_component_in_same_system =
-        Resource::new(ctx, blue_oyster_component.id(), production_system.id())
-            .await
-            .expect("cannot create resource for different component in same system");
-    let _same_component_in_different_system =
-        Resource::new(ctx, mastodon_component.id(), staging_system.id())
-            .await
-            .expect("cannot create resource for same component in different system");
-    let _different_component_in_different_system =
-        Resource::new(ctx, blue_oyster_component.id(), staging_system.id())
-            .await
-            .expect("cannot create resource for different component in different system");
-
-    let found_resource = Resource::get_by_component_id_and_system_id(
+    let resource = Resource::new(
         ctx,
-        mastodon_component.id(),
-        production_system.id(),
+        *component.id(),
+        SystemId::NONE,
+        "key".to_owned(),
+        serde_json::Value::Null,
+        WorkflowPrototypeId::NONE,
     )
     .await
-    .expect("cannot retrieve resource for component/system");
-
-    let found_resource = found_resource.expect("unable to get resource from component and system");
-    assert_eq!(
-        original_resource, found_resource,
-        "Resource::get_by_component_id_and_system_id needs to find the same resource we created"
-    )
+    .expect("cannot create resource for component/system");
+    let resources = Resource::list_by_component(ctx, *component.id(), SystemId::NONE)
+        .await
+        .expect("unable to list resources");
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0], resource);
 }

--- a/lib/dal/tests/integration_test/workflow.rs
+++ b/lib/dal/tests/integration_test/workflow.rs
@@ -1,5 +1,6 @@
 use crate::dal::test;
-use dal::{DalContext, Func, FuncBinding, StandardModel, WorkflowTree, WorkflowView};
+use dal::{DalContext, Func, FuncBinding, StandardModel, WorkflowView};
+use pretty_assertions_sorted::assert_eq;
 use serde_json::json;
 
 async fn fb(
@@ -27,10 +28,13 @@ async fn resolve(ctx: &DalContext<'_, '_, '_>) {
         .expect("unable to find func")
         .pop()
         .unwrap_or_else(|| panic!("function not found: {}", name));
-    let tree = WorkflowView::resolve(ctx, &func)
-        .await
-        .expect("unable to resolve workflow");
-    // TODO: fix args propagation
+    let tree = WorkflowView::resolve(
+        ctx,
+        &func,
+        serde_json::Value::String("Domingos Passos".to_owned()),
+    )
+    .await
+    .expect("unable to resolve workflow");
     let expected_json = json!({
         "name": "si:poemWorkflow",
         "kind": "conditional",
@@ -39,30 +43,31 @@ async fn resolve(ctx: &DalContext<'_, '_, '_>) {
             //    "name": "si:exceptionalWorkflow",
             //    "kind": "exceptional",
             //    "steps": [
-            //        { "func_binding": fb(ctx, "si:leroLeroTitle1Command", json!([])).await },
-            //        { "func_binding": fb(ctx, "si:leroLeroTitle2Command", json!([])).await },
+            //        { "func_binding": fb(ctx, "si:leroLeroTitle1Command", serde_json::Value::Null).await },
+            //        { "func_binding": fb(ctx, "si:leroLeroTitle2Command", serde_json::Value::Null).await },
             //    ],
             //},
-            { "func_binding": fb(ctx, "si:leroLeroStanza1Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza2Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza3Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza4Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza5Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza6Command", json!([])).await },
-            { "func_binding": fb(ctx, "si:leroLeroStanza7Command", json!([])).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza1Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza2Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza3Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza4Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza5Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza6Command", serde_json::Value::Null).await },
+            { "func_binding": fb(ctx, "si:leroLeroStanza7Command", serde_json::Value::Null).await },
             {
                 "name": "si:finalizingWorkflow",
                 "kind": "parallel",
                 "steps": [
-                    { "func_binding": fb(ctx, "si:leroLeroQuestionCommand", json!([null])).await },
-                    { "func_binding": fb(ctx, "si:leroLeroByeCommand", json!([])).await },
+                    { "func_binding": fb(ctx, "si:leroLeroQuestionCommand", json!(["Domingos Passos".to_owned()])).await },
+                    { "func_binding": fb(ctx, "si:leroLeroByeCommand", serde_json::Value::Null).await },
                 ],
             },
         ],
     });
-    let expected: WorkflowTree =
-        serde_json::from_value(expected_json).expect("unable to serialize expected workflow tree");
-    assert_eq!(tree, expected);
+    assert_eq!(
+        expected_json,
+        serde_json::to_value(tree).expect("unable to serialize tree")
+    );
 }
 
 #[test]
@@ -73,10 +78,14 @@ async fn run(ctx: &DalContext<'_, '_, '_>) {
         .expect("unable to find func")
         .pop()
         .unwrap_or_else(|| panic!("function not found: {}", name));
-    let tree = WorkflowView::resolve(ctx, &func)
-        .await
-        .expect("unable to resolve workflow");
-    // TODO: fix args propagation
-    // TODO: confirm output
+    let tree = WorkflowView::resolve(
+        ctx,
+        &func,
+        serde_json::Value::String("Domingos Passos".to_owned()),
+    )
+    .await
+    .expect("unable to resolve workflow");
+
+    // Text output is checked at WorkflowRunner tests as they actually order it
     tree.run(ctx).await.expect("unable to run workflow");
 }

--- a/lib/dal/tests/integration_test/workflow_resolver.rs
+++ b/lib/dal/tests/integration_test/workflow_resolver.rs
@@ -1,4 +1,3 @@
-use dal::func::backend::js_workflow::FuncBackendJsWorkflowArgs;
 use dal::DalContext;
 use dal::{
     func::binding::FuncBinding, workflow_resolver::WorkflowResolverContext, Func, StandardModel,
@@ -17,7 +16,7 @@ async fn new(ctx: &DalContext<'_, '_, '_>) {
         .pop()
         .expect("Missing builtin function si:poemWorkflow");
 
-    let args = FuncBackendJsWorkflowArgs;
+    let args = serde_json::Value::Null;
     let func_binding = FuncBinding::new(
         ctx,
         serde_json::to_value(args).expect("cannot turn args into json"),
@@ -53,7 +52,7 @@ async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
         .pop()
         .expect("Missing builtin function si:poemWorkflow");
 
-    let args = FuncBackendJsWorkflowArgs;
+    let args = serde_json::Value::Null;
     let func_binding = FuncBinding::new(
         ctx,
         serde_json::to_value(args.clone()).expect("cannot turn args into json"),

--- a/lib/dal/tests/integration_test/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/workflow_runner.rs
@@ -1,26 +1,25 @@
 use crate::dal::test;
-use dal::func::backend::js_workflow::FuncBackendJsWorkflowArgs;
 use dal::workflow_runner::workflow_runner_state::WorkflowRunnerStatus;
 
 use dal::DalContext;
 use dal::{
     func::binding::FuncBinding, workflow_prototype::WorkflowPrototypeContext,
-    workflow_runner::WorkflowRunnerContext, Func, StandardModel, WorkflowPrototype,
-    WorkflowPrototypeId, WorkflowResolverId, WorkflowRunner,
+    workflow_runner::WorkflowRunnerContext, AttributeReadContext, Component, ComponentId,
+    ComponentView, Func, Schema, StandardModel, SystemId, WorkflowPrototype, WorkflowPrototypeId,
+    WorkflowResolverId, WorkflowRunner,
 };
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn new(ctx: &DalContext<'_, '_, '_>) {
     let func_name = "si:poemWorkflow".to_string();
-    let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
+    let func = Func::find_by_attr(ctx, "name", &func_name)
         .await
-        .expect("Error fetching builtin function");
-    let func = funcs
+        .expect("Error fetching builtin function")
         .pop()
         .expect("Missing builtin function si:poemWorkflow");
 
-    let args = FuncBackendJsWorkflowArgs;
+    let args = serde_json::Value::Null;
     let func_binding = FuncBinding::new(
         ctx,
         serde_json::to_value(args).expect("cannot turn args into json"),
@@ -57,7 +56,7 @@ async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
         .pop()
         .expect("Missing builtin function si:poemWorkflow");
 
-    let args = FuncBackendJsWorkflowArgs;
+    let args = serde_json::Value::Null;
     let func_binding = FuncBinding::new(
         ctx,
         serde_json::to_value(args.clone()).expect("cannot turn args into json"),
@@ -96,31 +95,6 @@ async fn find_for_prototype(ctx: &DalContext<'_, '_, '_>) {
 }
 
 #[test]
-async fn run(ctx: &DalContext<'_, '_, '_>) {
-    let name = "si:poemWorkflow";
-    let func = Func::find_by_attr(ctx, "name", &name)
-        .await
-        .expect("unable to find func")
-        .pop()
-        .unwrap_or_else(|| panic!("function not found: {}", name));
-
-    let prototype_context = WorkflowPrototypeContext::new();
-    let prototype = WorkflowPrototype::new(
-        ctx,
-        *func.id(),
-        serde_json::Value::Null,
-        prototype_context,
-        "prototype",
-    )
-    .await
-    .expect("cannot create new prototype");
-    let (_, state, _) = WorkflowRunner::run(ctx, *prototype.id())
-        .await
-        .expect("unable to run workflow");
-    assert_eq!(state.status(), WorkflowRunnerStatus::Success);
-}
-
-#[test]
 async fn fail(ctx: &DalContext<'_, '_, '_>) {
     let name = "si:failureWorkflow";
     let func = Func::find_by_attr(ctx, "name", &name)
@@ -140,7 +114,7 @@ async fn fail(ctx: &DalContext<'_, '_, '_>) {
     .await
     .expect("cannot create new prototype");
 
-    let (_, state, _) = WorkflowRunner::run(ctx, *prototype.id())
+    let (_, state, _) = WorkflowRunner::run(ctx, *prototype.id(), ComponentId::NONE)
         .await
         .expect("unable to run workflow");
     assert_eq!(
@@ -148,4 +122,53 @@ async fn fail(ctx: &DalContext<'_, '_, '_>) {
         "oopsie!"
     );
     assert_eq!(state.status(), WorkflowRunnerStatus::Failure);
+}
+
+#[test]
+async fn run(ctx: &DalContext<'_, '_, '_>) {
+    let title = "Docker Image Resource Refresh";
+    let prototype = WorkflowPrototype::find_by_attr(ctx, "title", &title)
+        .await
+        .expect("unable to find workflow by attr")
+        .pop()
+        .expect("unable to find docker image resource refresh workflow prototype");
+
+    let schema = Schema::find_by_attr(ctx, "name", &"docker_image")
+        .await
+        .expect("unable to find docker image schema")
+        .pop()
+        .expect("unable to find docker image");
+    let schema_variant = schema
+        .default_variant(ctx)
+        .await
+        .expect("unable to find default schema variant");
+    let (component, _) =
+        Component::new_for_schema_with_node(ctx, "systeminit/whiskers", schema.id())
+            .await
+            .expect("cannot create component");
+
+    let context = AttributeReadContext {
+        prop_id: None,
+        schema_id: Some(*schema.id()),
+        schema_variant_id: Some(*schema_variant.id()),
+        component_id: Some(*component.id()),
+        system_id: Some(SystemId::NONE),
+        ..AttributeReadContext::default()
+    };
+
+    let component_view = ComponentView::for_context(ctx, context)
+        .await
+        .expect("unable to generate component view for docker image component");
+    assert_eq!(component_view.resources.len(), 0);
+
+    let (_runner, state, _func_bindings) =
+        WorkflowRunner::run(ctx, *prototype.id(), *component.id())
+            .await
+            .expect("unable to run workflow runner");
+    assert_eq!(state.status(), WorkflowRunnerStatus::Success);
+
+    let component_view = ComponentView::for_context(ctx, context)
+        .await
+        .expect("unable to generate component view for docker image component");
+    assert_eq!(component_view.resources.len(), 1);
 }

--- a/lib/sdf/src/lib.rs
+++ b/lib/sdf/src/lib.rs
@@ -16,4 +16,5 @@ mod server;
 pub use server::{
     build_service, service, Config, ConfigError, ConfigFile, FaktoryProcessor, IncomingStream,
     JobQueueProcessor, JwtSecretKey, MigrationMode, Server, StandardConfig, StandardConfigFile,
+    SyncProcessor,
 };

--- a/lib/sdf/src/server.rs
+++ b/lib/sdf/src/server.rs
@@ -2,7 +2,9 @@ pub use config::{
     Config, ConfigBuilder, ConfigError, ConfigFile, IncomingStream, JwtSecretKey, StandardConfig,
     StandardConfigFile,
 };
-pub use dal::job::processor::{faktory_processor::FaktoryProcessor, JobQueueProcessor};
+pub use dal::job::processor::{
+    faktory_processor::FaktoryProcessor, sync_processor::SyncProcessor, JobQueueProcessor,
+};
 pub use dal::MigrationMode;
 pub use routes::{routes, AppError, AppResult};
 pub use server::{build_service, Server};

--- a/lib/sdf/src/server/service/component/get_components_metadata.rs
+++ b/lib/sdf/src/server/service/component/get_components_metadata.rs
@@ -64,12 +64,12 @@ pub async fn get_components_metadata(
             .reduce(|q, acc| acc.and_then(|acc| q.map(|q| acc && q)))
             .and_then(|opt| opt);
 
-        let resource = if system_id.is_none() {
+        /*let resource = if system_id.is_none() {
             None
         } else {
             Component::get_resource_by_component_and_system(&ctx, *component.id(), system_id)
                 .await?
-        };
+        };*/
 
         metadata.push(ComponentMetadata {
             schema_name: schema.name().to_owned(),
@@ -78,7 +78,7 @@ pub async fn get_components_metadata(
                 .await?
                 .and_then(|v| v.link().map(ToOwned::to_owned)),
             qualified,
-            resource_health: resource.map(|r| r.health),
+            resource_health: None, //resource.map(|r| r.health),
             component_id: *component.id(),
         });
     }

--- a/lib/sdf/src/server/service/component/get_resource.rs
+++ b/lib/sdf/src/server/service/component/get_resource.rs
@@ -1,6 +1,6 @@
 use axum::extract::Query;
 use axum::Json;
-use dal::{Component, ComponentId, ResourceView, SystemId, Visibility, WorkspaceId};
+use dal::{ComponentId, ResourceView, SystemId, Visibility, WorkspaceId};
 use serde::{Deserialize, Serialize};
 
 use super::{ComponentError, ComponentResult};
@@ -32,19 +32,20 @@ pub async fn get_resource(
     }
 
     let txns = txns.start().await?;
-    let ctx = builder.build(request_ctx.build(request.visibility), &txns);
+    let _ctx = builder.build(request_ctx.build(request.visibility), &txns);
 
-    let resource = Component::get_resource_by_component_and_system(
-        &ctx,
-        request.component_id,
-        request.system_id,
-    )
-    .await?
-    .ok_or(ComponentError::ResourceNotFound(
-        request.component_id,
-        request.system_id,
-    ))?;
-
+    //let resource = Component::get_resource_by_component_and_system(
+    //    &ctx,
+    //    request.component_id,
+    //    request.system_id,
+    //)
+    //.await?
+    //.ok_or(
     txns.commit().await?;
-    Ok(Json(GetResourceResponse { resource }))
+    Err(ComponentError::ResourceNotFound(
+        request.component_id,
+        request.system_id,
+    ))
+
+    //Ok(Json(GetResourceResponse { resource }))
 }

--- a/lib/sdf/src/server/service/workflow/list.rs
+++ b/lib/sdf/src/server/service/workflow/list.rs
@@ -2,7 +2,7 @@ use super::{WorkflowError, WorkflowResult};
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use axum::{extract::Query, Json};
 use dal::{
-    Component, Schema, SchemaVariant, StandardModel, Visibility, WorkflowPrototype,
+    Component, ComponentId, Schema, SchemaVariant, StandardModel, Visibility, WorkflowPrototype,
     WorkflowPrototypeId,
 };
 use serde::{Deserialize, Serialize};
@@ -16,12 +16,19 @@ pub struct ListWorkflowsRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ListedWorkflowComponentView {
+    id: ComponentId,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ListedWorkflowView {
     id: WorkflowPrototypeId,
     title: String,
     description: Option<String>,
     link: Option<String>,
-    component_names: Vec<String>,
+    components: Vec<ListedWorkflowComponentView>,
     schema_name: Option<String>,
     schema_variant_name: Option<String>,
 }
@@ -39,30 +46,34 @@ pub async fn list(
     let prototypes = WorkflowPrototype::list(&ctx).await?;
     let mut views = Vec::with_capacity(prototypes.len());
     for proto in prototypes {
-        let component_names = if proto.context().component_id.is_some() {
+        let components = if proto.context().component_id.is_some() {
             let component = Component::get_by_id(&ctx, &proto.context().component_id)
                 .await?
                 .ok_or_else(|| WorkflowError::ComponentNotFound(proto.context().component_id))?;
-            vec![component
-                .find_value_by_json_pointer::<String>(&ctx, "/root/si/name")
-                .await?
-                .ok_or_else(|| WorkflowError::ComponentNameNotFound(*component.id()))?]
+            vec![ListedWorkflowComponentView {
+                id: *component.id(),
+                name: component
+                    .find_value_by_json_pointer::<String>(&ctx, "/root/si/name")
+                    .await?
+                    .ok_or_else(|| WorkflowError::ComponentNameNotFound(*component.id()))?,
+            }]
         } else {
-            let mut names = Vec::new();
+            let mut components = Vec::new();
             if proto.context().schema_variant_id.is_some() {
                 for component in
                     Component::list_for_schema_variant(&ctx, proto.context().schema_variant_id)
                         .await?
                 {
-                    names.push(
-                        component
+                    components.push(ListedWorkflowComponentView {
+                        id: *component.id(),
+                        name: component
                             .find_value_by_json_pointer::<String>(&ctx, "/root/si/name")
                             .await?
                             .ok_or_else(|| WorkflowError::ComponentNameNotFound(*component.id()))?,
-                    );
+                    });
                 }
             }
-            names
+            components
         };
 
         let schema_name = if proto.context().schema_id.is_some() {
@@ -90,7 +101,7 @@ pub async fn list(
             title: proto.title().to_owned(),
             description: proto.description().map(Into::into),
             link: proto.link().map(Into::into),
-            component_names,
+            components,
             schema_name,
             schema_variant_name,
         });

--- a/lib/sdf/src/server/service/workflow/run.rs
+++ b/lib/sdf/src/server/service/workflow/run.rs
@@ -4,14 +4,15 @@ use serde::{Deserialize, Serialize};
 use super::WorkflowResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use dal::{
-    workflow_runner::workflow_runner_state::WorkflowRunnerState, Visibility, WorkflowPrototypeId,
-    WorkflowRunner,
+    workflow_runner::workflow_runner_state::WorkflowRunnerState, ComponentId, Visibility,
+    WorkflowPrototypeId, WorkflowRunner,
 };
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowRunRequest {
     pub id: WorkflowPrototypeId,
+    pub component_id: ComponentId,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -35,7 +36,7 @@ pub async fn run(
     // it twice?
     // reference: https://github.com/systeminit/si/blob/87c5cce99d6b972f441358295bbabe27f1d787da/lib/dal/src/workflow_runner.rs#L209-L227
     let (_, workflow_runner_state, func_binding_return_values) =
-        WorkflowRunner::run(&ctx, request.id).await?;
+        WorkflowRunner::run(&ctx, request.id, request.component_id).await?;
     let mut logs = Vec::new();
     for func_binding_return_value in func_binding_return_values {
         for stream in func_binding_return_value

--- a/lib/veritech/src/client.rs
+++ b/lib/veritech/src/client.rs
@@ -505,17 +505,20 @@ mod tests {
                     properties: serde_json::json!({}),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 parents: vec![
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                     ComponentView {
                         properties: serde_json::json!({}),
                         system: None,
                         kind: ComponentKind::Standard,
+                        resources: Default::default(),
                     },
                 ],
             },
@@ -563,6 +566,7 @@ mod tests {
                     properties: serde_json::json!({"image": "systeminit/whiskers"}),
                     system: None,
                     kind: ComponentKind::Standard,
+                    resources: Default::default(),
                 },
                 codes: vec![CodeGenerated {
                     format: "yaml".to_owned(),
@@ -672,6 +676,7 @@ mod tests {
             properties: serde_json::json!({"image": "abc"}),
             system: None,
             kind: ComponentKind::Standard,
+            resources: Default::default(),
         };
 
         // Now update the request to re-run an unqualified check (i.e. qualification returning
@@ -713,6 +718,7 @@ mod tests {
                 properties: serde_json::json!({"pkg": "cider"}),
                 system: None,
                 kind: ComponentKind::Standard,
+                resources: Default::default(),
             },
             code_base64: base64::encode("function syncItOut(component) { return {}; }"),
         };
@@ -754,6 +760,7 @@ mod tests {
                 properties: serde_json::json!({"pkg": "cider"}),
                 system: None,
                 kind: ComponentKind::Standard,
+                    resources: Default::default(),
             },
             code_base64: base64::encode("function generateItOut(component) { return { format: 'yaml', code: YAML.stringify(component.properties) }; }"),
         };
@@ -799,6 +806,7 @@ mod tests {
             handler: "workItOut".to_string(),
             // TODO(fnichol): rewrite this function once we settle on contract
             code_base64: base64::encode("function workItOut() { return { name: 'mc fioti', kind: 'vacina butantan - https://www.youtube.com/watch?v=yQ8xJHuW7TY', steps: [] }; }"),
+            args: Default::default(),
         };
 
         let result = client

--- a/lib/veritech/src/lib.rs
+++ b/lib/veritech/src/lib.rs
@@ -32,7 +32,7 @@ pub use cyclone_core::{
     FunctionResult, FunctionResultFailure, OutputStream, QualificationCheckComponent,
     QualificationCheckRequest, QualificationCheckResultSuccess, QualificationSubCheck,
     QualificationSubCheckStatus, ResolverFunctionComponent, ResolverFunctionRequest,
-    ResolverFunctionResultSuccess, ResourceSyncRequest, ResourceSyncResultSuccess,
+    ResolverFunctionResultSuccess, ResourceSyncRequest, ResourceSyncResultSuccess, ResourceView,
     SensitiveContainer, SystemView, WorkflowResolveRequest, WorkflowResolveResultSuccess,
 };
 


### PR DESCRIPTION
- Workflow get the component view of the component in question (if any), and can propagate it to the command function
- Command function can return updated and created fields, with the key and data of a resource
- WorkflowRunner will create the update the resources specified by the command function
- Docker Image now has refresh workflow that upserts resource containing the returned stdout of skopeo

Some old resource logic has been commented out because they are still being churned through, it didn't made sense to support it, but neither to delete as they might reappear in the next PRs (we still have to update resource syncing to use the specified refresh_workflow_id to sync it).

<img src="https://media1.giphy.com/media/BoxPZaNgTabmdOq729/giphy-downsized-medium.gif"/>