### PR TITLE
chore(dal): adjust node colors to match categories

### DIFF
--- a/lib/dal/src/builtins/schema/aws.rs
+++ b/lib/dal/src/builtins/schema/aws.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 // Reference: https://aws.amazon.com/trademark-guidelines/
-const AWS_PRIMARY_COLOR: i64 = 0xFF9900;
+const AWS_NODE_COLOR: i64 = 0xFF9900;
 
 // Documentation URLs.
 const AMI_DOCS_URL: &str =
@@ -39,9 +39,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
 
     // Variant setup. The variant color was taken from the coreos logo.
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant
-        .set_color(ctx, Some(AWS_PRIMARY_COLOR))
-        .await?;
+    schema_variant.set_color(ctx, Some(AWS_NODE_COLOR)).await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;
@@ -118,9 +116,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
 
     // Variant setup. The variant color was taken from the coreos logo.
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant
-        .set_color(ctx, Some(AWS_PRIMARY_COLOR))
-        .await?;
+    schema_variant.set_color(ctx, Some(AWS_NODE_COLOR)).await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;
@@ -271,9 +267,7 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
 
     // Variant setup. The variant color was taken from the coreos logo.
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant
-        .set_color(ctx, Some(AWS_PRIMARY_COLOR))
-        .await?;
+    schema_variant.set_color(ctx, Some(AWS_NODE_COLOR)).await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;
@@ -377,9 +371,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
 
     // Variant setup. The variant color was taken from the coreos logo.
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant
-        .set_color(ctx, Some(AWS_PRIMARY_COLOR))
-        .await?;
+    schema_variant.set_color(ctx, Some(AWS_NODE_COLOR)).await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -10,6 +10,8 @@ use crate::{
     StandardModel,
 };
 
+// Reference: https://getfedora.org/
+const COREOS_NODE_COLOR: i64 = 0xE26B70;
 const BUTANE_DOCS_FCOS_1_4_URL: &str = "https://coreos.github.io/butane/config-fcos-v1_4/";
 
 pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
@@ -28,7 +30,9 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
 
     // Variant setup. The variant color was taken from the coreos logo.
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant.set_color(ctx, Some(0x5590cc)).await?;
+    schema_variant
+        .set_color(ctx, Some(COREOS_NODE_COLOR))
+        .await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -14,6 +14,9 @@ use crate::{
     Socket, StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
 };
 
+// Reference: https://www.docker.com/company/newsroom/media-resources/
+const DOCKER_NODE_COLOR: i64 = 0x4695E7;
+
 pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     docker_hub_credential(ctx).await?;
     docker_image(ctx).await?;
@@ -32,7 +35,9 @@ async fn docker_hub_credential(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?;
 
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant.set_color(ctx, Some(0x1e88d6)).await?;
+    schema_variant
+        .set_color(ctx, Some(DOCKER_NODE_COLOR))
+        .await?;
 
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -109,7 +114,9 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
         };
 
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant.set_color(ctx, Some(0xd61e8c)).await?;
+    schema_variant
+        .set_color(ctx, Some(DOCKER_NODE_COLOR))
+        .await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -19,6 +19,10 @@ mod kubernetes_selector;
 mod kubernetes_spec;
 mod kubernetes_template;
 
+// This node color is purely meant the complement existing node colors. It does not reflect an
+// official branding Kubernetes color.
+const KUBERNETES_NODE_COLOR: i64 = 0x30BA78;
+
 /// The default Kubernetes API version used when creating documentation URLs.
 const DEFAULT_KUBERNETES_API_VERSION: &str = "1.22";
 
@@ -46,7 +50,9 @@ async fn kubernetes_namespace(ctx: &DalContext) -> BuiltinsResult<()> {
         };
 
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant.set_color(ctx, Some(0x1ba97e)).await?;
+    schema_variant
+        .set_color(ctx, Some(KUBERNETES_NODE_COLOR))
+        .await?;
     schema_variant.set_link(ctx, Some("https://v1-22.docs.kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/".to_owned())).await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -204,7 +210,9 @@ async fn kubernetes_deployment(ctx: &DalContext) -> BuiltinsResult<()> {
         };
 
     let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
-    schema_variant.set_color(ctx, Some(0x921ed6)).await?;
+    schema_variant
+        .set_color(ctx, Some(KUBERNETES_NODE_COLOR))
+        .await?;
     schema_variant
         .set_link(
             ctx,

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -30,7 +30,7 @@ pub enum ComponentViewError {
     StandardModel(#[from] StandardModelError),
     #[error("secret not found: {0}")]
     SecretNotFound(SecretId),
-    #[error("json pointer not found: {1} at {:0?}")]
+    #[error("json pointer not found: {1:?} at {0}")]
     JSONPointerNotFound(serde_json::Value, String),
     #[error("bad attribute read context {0}")]
     BadAttributeReadContext(String),

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -70,11 +70,13 @@ impl SocketView {
     ) -> DiagramResult<Vec<Self>> {
         let node_id = *node.id();
         let node_id: i64 = node_id.into();
+
+        // NOTE(nick): filter out system sockets since we only have the configuration diagram kind.
         Ok(schema_variant
             .sockets(ctx)
             .await?
             .into_iter()
-            .filter(|socket| socket.name() != "includes")
+            .filter(|socket| socket.name() != "system")
             .map(|socket| {
                 let socket_id = *socket.id();
                 let socket_id: i64 = socket_id.into();

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -211,7 +211,11 @@ impl GenerateMenuItem {
     /// Generates raw items and initializes menu items as an empty vec.
     pub async fn new(ctx: &DalContext, diagram_kind: DiagramKind) -> NodeMenuResult<Self> {
         let mut item_list = Vec::new();
-        let ui_menus = UiMenu::list_for_diagram_kind(ctx, diagram_kind).await?;
+        let mut ui_menus = UiMenu::list_for_diagram_kind(ctx, diagram_kind).await?;
+
+        // Ensure the names and categories are alphabetically sorted.
+        ui_menus.sort_by(|a, b| a.name().cmp(&b.name()));
+        ui_menus.sort_by(|a, b| a.category().cmp(&b.category()));
 
         for ui_menu in ui_menus.into_iter() {
             if ui_menu.usable_in_menu(ctx).await? {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -76,6 +76,7 @@ pub struct SchemaVariant {
     id: SchemaVariantId,
     name: String,
     link: Option<String>,
+    // NOTE(nick): we should consider whether or not we want to keep the color.
     color: Option<i64>,
     #[serde(flatten)]
     tenancy: WriteTenancy,


### PR DESCRIPTION
## Commit Description

- Adjust node colors to builtin schemas to match categories
  - AWS, Docker, and CoreOS use official colors
  - Kubernetes uses a complimentary color that was purely chosen for
    aethestics (imprecise, not based on triads, etc.)
- Hide system sockets in the configuration diagram
- Ensure categories are alphabetically ordered (as well as options
  within each category)

## Screenshots

Alphabetical ordering (category and contents of each category) and new colors:

<img width="486" alt="Screen Shot 2022-09-21 at 7 30 50 PM" src="https://user-images.githubusercontent.com/39320683/191627715-ef0cf0db-0d80-4405-b733-04a7f1b0e8a8.png">
<img width="472" alt="Screen Shot 2022-09-21 at 7 30 45 PM" src="https://user-images.githubusercontent.com/39320683/191627716-54f2e6ef-09b3-412c-b5f1-2a929680a5af.png">

New node colors and system sockets hidden (light mode):

<img width="731" alt="Screen Shot 2022-09-21 at 7 33 05 PM" src="https://user-images.githubusercontent.com/39320683/191627842-32b03082-95ad-4053-9f0f-2a84914b01ef.png">

New node colors and system sockets hidden (dark mode):

<img width="729" alt="Screen Shot 2022-09-21 at 7 33 37 PM" src="https://user-images.githubusercontent.com/39320683/191627880-984969f7-360a-46a6-99b0-c926b2860800.png">

## Linear

Fixes ENG-550