### PR TITLE
fix(cyclone): fix new named argument warning with debug format in rust 1.64

### DIFF
--- a/lib/cyclone-server/src/decryption_key.rs
+++ b/lib/cyclone-server/src/decryption_key.rs
@@ -13,7 +13,7 @@ pub enum DecryptionKeyError {
     DecryptionFailed,
     #[error("encrypted secret not found")]
     EncryptedSecretNotFound,
-    #[error("json pointer not found: {1} at {:0?}")]
+    #[error("json pointer not found: {1} at {0}")]
     JSONPointerNotFound(serde_json::Value, String),
     #[error("failed to load key from bytes")]
     KeyParse,


### PR DESCRIPTION
Fixes the following warning:

```
warning: named argument `field__1` is not used by name
  --> lib/cyclone-server/src/decryption_key.rs:16:13
   |
16 |       #[error("json pointer not found: {1} at {:0?}")]
   |  _____________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^_-
   | |             |
   | |             this named argument is referred to by position in formatting string
17 | |     JSONPointerNotFound(serde_json::Value, String),
   | |___- this formatting argument uses named argument `field__1` by position
   |
   = note: `#[warn(named_arguments_used_positionally)]` on by default
help: use the named argument by name to avoid ambiguity
   |
16 |     #[error("json pointer not found: {1} at {:0?}")]field__1  JSONPointerNotFound(serde_json::Value, String),
   |                                                     ++++++++
```

Seems like a bug in thiserror introduced by rust 1.64?