### PR TITLE
chore(dal): reduce schema ui menu papercuts

### DIFF
--- a/lib/dal/src/builtins/schema/aws.rs
+++ b/lib/dal/src/builtins/schema/aws.rs
@@ -5,7 +5,7 @@ use crate::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
 use crate::qualification_prototype::QualificationPrototypeContext;
 use crate::socket::{SocketArity, SocketEdgeKind, SocketKind};
 use crate::{
-    schema::{SchemaVariant, UiMenu},
+    schema::{SchemaUiMenu, SchemaVariant},
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
     BuiltinsResult, CodeGenerationPrototype, CodeLanguage, DalContext, DiagramKind,
     ExternalProvider, Func, InternalProvider, PropKind, QualificationPrototype, SchemaError,
@@ -56,9 +56,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("ami")).await?;
-    ui_menu.set_category(ctx, Some("aws".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "ami", "aws", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     // Prop creation
@@ -241,9 +239,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("ec2")).await?;
-    ui_menu.set_category(ctx, Some("aws".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "ec2", "aws", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     // Prop creation
@@ -514,9 +510,7 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("region")).await?;
-    ui_menu.set_category(ctx, Some("aws".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "region", "aws", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     // Prop Creation
@@ -618,9 +612,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("key pair")).await?;
-    ui_menu.set_category(ctx, Some("aws".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "key pair", "aws", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     // Prop Creation

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -3,7 +3,7 @@ use crate::builtins::schema::BuiltinSchemaHelpers;
 use crate::socket::{SocketArity, SocketEdgeKind, SocketKind};
 use crate::{
     qualification_prototype::QualificationPrototypeContext,
-    schema::{SchemaVariant, UiMenu},
+    schema::{SchemaUiMenu, SchemaVariant},
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
     BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider, Func, FuncError,
     InternalProvider, PropKind, QualificationPrototype, SchemaError, SchemaKind, Socket,
@@ -45,9 +45,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("butane")).await?;
-    ui_menu.set_category(ctx, Some("coreos".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "butane", "coreos", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     // Prop creation

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -6,7 +6,7 @@ use crate::{
     component::ComponentKind,
     edit_field::widget::*,
     qualification_prototype::QualificationPrototypeContext,
-    schema::{SchemaVariant, UiMenu},
+    schema::{SchemaUiMenu, SchemaVariant},
     socket::SocketArity,
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
     AttributeValueError, BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider,
@@ -97,9 +97,7 @@ async fn docker_hub_credential(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("credential".to_owned())).await?;
-    ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "credential", "docker", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     Ok(())
@@ -128,10 +126,7 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("image")).await?;
-
-    ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "image", "docker", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     let image_prop = Prop::new(ctx, "image", PropKind::String).await?;

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -4,7 +4,7 @@ use crate::socket::{SocketEdgeKind, SocketKind};
 use crate::{
     code_generation_prototype::CodeGenerationPrototypeContext,
     func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs,
-    schema::{SchemaVariant, UiMenu},
+    schema::{SchemaUiMenu, SchemaVariant},
     socket::SocketArity,
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
     AttributeValueError, BuiltinsError, BuiltinsResult, CodeGenerationPrototype, CodeLanguage,
@@ -65,11 +65,7 @@ async fn kubernetes_namespace(ctx: &DalContext) -> BuiltinsResult<()> {
     let diagram_kind = schema
         .diagram_kind()
         .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("namespace")).await?;
-    ui_menu
-        .set_category(ctx, Some("kubernetes".to_owned()))
-        .await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "namespace", "kubernetes", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     let metadata_prop =
@@ -340,14 +336,10 @@ async fn kubernetes_deployment(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    // TODO: abstract this boilerplate away
     let diagram_kind = schema
         .diagram_kind()
         .expect("no diagram kind for schema kind");
-    let mut ui_menu = UiMenu::new(ctx, &diagram_kind).await?;
-    ui_menu.set_name(ctx, Some("deployment".to_owned())).await?;
-
-    ui_menu.set_category(ctx, Some("kubernetes")).await?;
+    let ui_menu = SchemaUiMenu::new(ctx, "deployment", "kubernetes", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
     schema_variant.finalize(ctx).await?;

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 
 use crate::diagram::DiagramResult;
-use crate::schema::UiMenu;
+use crate::schema::SchemaUiMenu;
 use crate::socket::{SocketArity, SocketEdgeKind};
 use crate::{
     DalContext, DiagramError, Node, NodePosition, SchemaError, SchemaVariant, StandardModel,
@@ -155,10 +155,9 @@ impl DiagramNodeView {
             .diagram_kind()
             .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
         let category =
-            match UiMenu::get_by_schema_and_diagram_kind(ctx, *schema.id(), diagram_kind).await? {
-                Some(ui_menu) => ui_menu.category().map(|c| c.to_string()),
-                None => None,
-            };
+            SchemaUiMenu::get_by_schema_and_diagram_kind(ctx, *schema.id(), diagram_kind)
+                .await?
+                .map(|um| um.category().to_string());
 
         Ok(Self {
             id: node.id().to_string(),

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -12,7 +12,7 @@ use crate::socket::SocketError;
 use crate::WriteTenancy;
 use crate::{
     component::ComponentKind, func::binding::FuncBindingError, impl_standard_model, node::NodeKind,
-    pk, schema::ui_menu::UiMenuId, standard_model, standard_model_accessor,
+    pk, schema::ui_menu::SchemaUiMenuId, standard_model, standard_model_accessor,
     standard_model_has_many, standard_model_many_to_many, AttributeContextBuilderError,
     AttributePrototypeError, AttributeValueError, BillingAccount, BillingAccountId,
     CodeGenerationPrototypeError, Component, DalContext, DiagramKind, FuncError, HistoryEventError,
@@ -21,7 +21,7 @@ use crate::{
     WorkspaceId, WsEventError,
 };
 
-pub use ui_menu::UiMenu;
+pub use ui_menu::SchemaUiMenu;
 pub use variant::root_prop::RootProp;
 pub use variant::{SchemaVariant, SchemaVariantId};
 
@@ -78,8 +78,8 @@ pub enum SchemaError {
     Socket(#[from] SocketError),
     #[error("standard model error: {0}")]
     StandardModel(#[from] StandardModelError),
-    #[error("ui menu not found: {0}")]
-    UiMenuNotFound(UiMenuId),
+    #[error("schema ui menu not found: {0}")]
+    SchemaUiMenuNotFound(SchemaUiMenuId),
     #[error("schema variant error: {0}")]
     Variant(#[from] SchemaVariantError),
     #[error("validation prototype error: {0}")]
@@ -226,7 +226,7 @@ impl Schema {
         lookup_fn: ui_menus,
         table: "schema_ui_menu_belongs_to_schema",
         model_table: "schema_ui_menus",
-        returns: UiMenu,
+        returns: SchemaUiMenu,
         result: SchemaResult,
     );
 

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -309,12 +309,6 @@ pub async fn create_schema(ctx: &DalContext, kind: &SchemaKind) -> Schema {
         .expect("cannot create schema")
 }
 
-pub async fn create_schema_ui_menu(ctx: &DalContext) -> schema::UiMenu {
-    schema::UiMenu::new(ctx, &DiagramKind::Configuration)
-        .await
-        .expect("cannot create schema ui menu")
-}
-
 pub async fn create_schema_variant(ctx: &DalContext, schema_id: SchemaId) -> schema::SchemaVariant {
     create_schema_variant_with_root(ctx, schema_id).await.0
 }

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -1,8 +1,8 @@
-use dal::{BillingAccountSignup, DalContext, JwtSecretKey};
+use dal::{BillingAccountSignup, DalContext, DiagramKind, JwtSecretKey};
 
 use crate::dal::test;
-use dal::schema::SchemaKind;
-use dal::test_harness::{billing_account_signup, create_schema, create_schema_ui_menu};
+use dal::schema::{SchemaKind, SchemaUiMenu};
+use dal::test_harness::{billing_account_signup, create_schema};
 use dal::{component::ComponentKind, Schema, StandardModel};
 
 pub mod ui_menu;
@@ -114,7 +114,9 @@ async fn workspaces(ctx: &DalContext, nba: &BillingAccountSignup) {
 #[test]
 async fn ui_menus(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_ui_menu = create_schema_ui_menu(ctx).await;
+    let schema_ui_menu = SchemaUiMenu::new(ctx, "visa", "m.i.a.", &DiagramKind::Configuration)
+        .await
+        .expect("cannot create schema ui menu");
     schema_ui_menu
         .set_schema(ctx, schema.id())
         .await

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -2,26 +2,19 @@ use dal::DalContext;
 
 use crate::dal::test;
 use dal::schema::SchemaKind;
-use dal::test_harness::{create_schema, create_schema_ui_menu};
-use dal::{schema::UiMenu, DiagramKind, HistoryActor, StandardModel, Visibility, WriteTenancy};
+use dal::test_harness::create_schema;
+use dal::{schema::SchemaUiMenu, DiagramKind, StandardModel};
 
 #[test]
-async fn new(ctx: &DalContext) {
-    let _write_tenancy = WriteTenancy::new_universal();
-    let _visibility = Visibility::new_head(false);
-    let _history_actor = HistoryActor::SystemInit;
-    let schema_ui_menu = UiMenu::new(ctx, &DiagramKind::Configuration)
-        .await
-        .expect("cannot create schema ui menu");
-    assert_eq!(schema_ui_menu.name(), None);
-    assert_eq!(schema_ui_menu.category(), None);
-    assert_eq!(schema_ui_menu.diagram_kind(), &DiagramKind::Configuration);
-}
-
-#[test]
-async fn set_schema(ctx: &DalContext) {
+async fn new_and_set_schema(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_ui_menu = create_schema_ui_menu(ctx).await;
+    let schema_ui_menu =
+        SchemaUiMenu::new(ctx, "riot", "awaken, my love!", &DiagramKind::Configuration)
+            .await
+            .expect("cannot create schema ui menu");
+    assert_eq!(schema_ui_menu.name(), "riot");
+    assert_eq!(schema_ui_menu.category(), "awaken, my love!");
+    assert_eq!(schema_ui_menu.diagram_kind(), DiagramKind::Configuration);
 
     schema_ui_menu
         .set_schema(ctx, schema.id())


### PR DESCRIPTION
- Rename UiMenu to SchemaUiMenu for clarity
- Add unique index for SchemaUiMenu table
- Require the name and category fields and add to constructor method
- Remove standard model accessors (currently unused) and replace with read-only "local" accessors
- Consolidate schema ui menu integration tests

Fixes ENG-563