### PR TITLE
feat(web,sdf,dal): add widget options

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -37,6 +37,10 @@ export interface PropertyEditorPropWidgetKindInteger {
 }
 export interface PropertyEditorPropWidgetKindSelect {
   kind: "select";
+  options?: JSON;
+}
+export interface PropertyEditorPropWidgetKindSecretSelect {
+  kind: "secretSelect";
   options: LabelList<string | number>;
 }
 export type PropertyEditorPropWidgetKind =
@@ -46,7 +50,8 @@ export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindInteger
   | PropertyEditorPropWidgetKindHeader
   | PropertyEditorPropWidgetKindArray
-  | PropertyEditorPropWidgetKindSelect;
+  | PropertyEditorPropWidgetKindSelect
+  | PropertyEditorPropWidgetKindSecretSelect;
 
 export interface PropertyEditorProp {
   id: number;

--- a/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
@@ -40,8 +40,12 @@
       @add-to-map="addToMap($event)"
       @toggle-collapsed="setCollapsed($event)"
     />
+    <!-- TODO(nick): until we use the "options" for select, let's just ignore them for now and force a text box  -->
     <WidgetTextBox
-      v-else-if="props.schemaProp.widgetKind.kind === 'text'"
+      v-else-if="
+        props.schemaProp.widgetKind.kind === 'text' ||
+        props.schemaProp.widgetKind.kind === 'select'
+      "
       :name="props.schemaProp.name"
       :path="path"
       :collapsed-paths="props.collapsedPaths"
@@ -71,7 +75,7 @@
       @updated-property="updatedProperty($event)"
     />
     <WidgetSelectBox
-      v-else-if="props.schemaProp.widgetKind.kind === 'select'"
+      v-else-if="props.schemaProp.widgetKind.kind === 'secretSelect'"
       :name="props.schemaProp.name"
       :options="props.schemaProp.widgetKind.options"
       :path="path"

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -55,6 +55,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "variant",
         PropKind::String,
+        None,
         Some(root_prop.domain_prop_id),
         Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
     )
@@ -63,6 +64,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "version",
         PropKind::String,
+        None,
         Some(root_prop.domain_prop_id),
         Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
     )
@@ -71,6 +73,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "systemd",
         PropKind::Object,
+        None,
         Some(root_prop.domain_prop_id),
         Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
     )
@@ -79,6 +82,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "units",
         PropKind::Array,
+        None,
         Some(*systemd_prop.id()),
         Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
     )
@@ -87,6 +91,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "unit",
         PropKind::Object,
+        None,
         Some(*units_prop.id()),
         Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
     )
@@ -96,6 +101,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
             ctx,
             "name",
             PropKind::String,
+            None,
             Some(*unit_prop.id()),
             Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
         )
@@ -104,6 +110,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
             ctx,
             "enabled",
             PropKind::Boolean,
+            None,
             Some(*unit_prop.id()),
             Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
         )
@@ -112,6 +119,7 @@ async fn butane(ctx: &DalContext) -> BuiltinsResult<()> {
             ctx,
             "contents",
             PropKind::String,
+            None,
             Some(*unit_prop.id()),
             Some(BUTANE_DOCS_FCOS_1_4_URL.to_string()),
         )

--- a/lib/dal/src/builtins/schema/data/aws_regions.json
+++ b/lib/dal/src/builtins/schema/data/aws_regions.json
@@ -1,0 +1,94 @@
+[
+  {
+    "region_name": "US East (N. Virginia)",
+    "region_value": "us-east-1"
+  },
+  {
+    "region_name": "US East (Ohio)",
+    "region_value": "us-east-2"
+  },
+  {
+    "region_name": "US West (N. California)",
+    "region_value": "us-west-1"
+  },
+  {
+    "region_name": "US West (Oregon)",
+    "region_value": "us-west-2"
+  },
+  {
+    "region_name": "Africa (Cape Town)",
+    "region_value": "af-south-1"
+  },
+  {
+    "region_name": "Asia Pacific (Hong Kong)",
+    "region_value": "ap-east-1"
+  },
+  {
+    "region_name": "Asia Pacific (Jakarta)",
+    "region_value": "ap-southeast-3"
+  },
+  {
+    "region_name": "Asia Pacific (Mumbai)",
+    "region_value": "ap-south-1"
+  },
+  {
+    "region_name": "Asia Pacific (Osaka)",
+    "region_value": "ap-northeast-3"
+  },
+  {
+    "region_name": "Asia Pacific (Seoul)",
+    "region_value": "ap-northeast-2"
+  },
+  {
+    "region_name": "Asia Pacific (Singapore)",
+    "region_value": "ap-southeast-1"
+  },
+  {
+    "region_name": "Asia Pacific (Sydney)",
+    "region_value": "ap-southeast-2"
+  },
+  {
+    "region_name": "Asia Pacific (Tokyo)",
+    "region_value": "ap-northeast-1"
+  },
+  {
+    "region_name": "Canada (Central)",
+    "region_value": "ca-central-1"
+  },
+  {
+    "region_name": "Europe (Frankfurt)",
+    "region_value": "eu-central-1"
+  },
+  {
+    "region_name": "Europe (Ireland)",
+    "region_value": "eu-west-1"
+  },
+  {
+    "region_name": "Europe (London)",
+    "region_value": "eu-west-2"
+  },
+  {
+    "region_name": "Europe (Milan)",
+    "region_value": "eu-south-1"
+  },
+  {
+    "region_name": "Europe (Paris)",
+    "region_value": "eu-west-3"
+  },
+  {
+    "region_name": "Europe (Stockholm)",
+    "region_value": "eu-north-1"
+  },
+  {
+    "region_name": "Middle East (Bahrain)",
+    "region_value": "me-south-1"
+  },
+  {
+    "region_name": "Middle East (UAE)",
+    "region_value": "me-central-1"
+  },
+  {
+    "region_name": "South America (Sao Paulo)",
+    "region_value": "me-central-1"
+  }
+]

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -43,7 +43,7 @@ async fn docker_hub_credential(ctx: &DalContext) -> BuiltinsResult<()> {
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;
 
-    let mut secret_prop = Prop::new(ctx, "secret", PropKind::Integer).await?;
+    let mut secret_prop = Prop::new(ctx, "secret", PropKind::Integer, None).await?;
     secret_prop
         .set_parent_prop(ctx, root_prop.domain_prop_id)
         .await?;
@@ -134,17 +134,17 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
     ui_menu.set_category(ctx, Some("docker".to_owned())).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
-    let image_prop = Prop::new(ctx, "image", PropKind::String).await?;
+    let image_prop = Prop::new(ctx, "image", PropKind::String, None).await?;
     image_prop
         .set_parent_prop(ctx, root_prop.domain_prop_id)
         .await?;
 
     // TODO: required, validate regex: "\\d+\\/(tcp|udp)", message: "invalid exposed port entry; must be [numeric]/(tcp|udp)",
-    let exposed_ports_prop = Prop::new(ctx, "ExposedPorts", PropKind::Array).await?;
+    let exposed_ports_prop = Prop::new(ctx, "ExposedPorts", PropKind::Array, None).await?;
     exposed_ports_prop
         .set_parent_prop(ctx, root_prop.domain_prop_id)
         .await?;
-    let exposed_port_prop = Prop::new(ctx, "ExposedPort", PropKind::String).await?;
+    let exposed_port_prop = Prop::new(ctx, "ExposedPort", PropKind::String, None).await?;
     exposed_port_prop
         .set_parent_prop(ctx, *exposed_ports_prop.id())
         .await?;

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -231,6 +231,7 @@ async fn kubernetes_deployment(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "apiVersion",
         PropKind::String,
+        None,
         Some(root_prop.domain_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/deployment-v1/#Deployment",
@@ -241,6 +242,7 @@ async fn kubernetes_deployment(ctx: &DalContext) -> BuiltinsResult<()> {
         ctx,
         "kind",
         PropKind::String,
+        None,
         Some(root_prop.domain_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/deployment-v1/#Deployment",

--- a/lib/dal/src/builtins/schema/kubernetes/kubernetes_deployment_spec.rs
+++ b/lib/dal/src/builtins/schema/kubernetes/kubernetes_deployment_spec.rs
@@ -14,6 +14,7 @@ pub async fn create_deployment_spec_prop(
         ctx,
         "spec",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec",
@@ -25,6 +26,7 @@ pub async fn create_deployment_spec_prop(
         ctx,
         "replicas",
         PropKind::Integer,
+        None,
         Some(*spec_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec",
@@ -46,6 +48,7 @@ async fn create_pod_template_spec_prop(
         ctx,
         "template",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec",
@@ -70,6 +73,7 @@ async fn create_pod_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         ctx,
         "spec",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#PodSpec",
@@ -81,6 +85,7 @@ async fn create_pod_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         ctx,
         "containers",
         PropKind::Array,
+        None,
         Some(*spec_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#containers",
@@ -97,6 +102,7 @@ async fn create_container_prop(ctx: &DalContext, parent_prop_id: PropId) -> Buil
         ctx,
         "container",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#Container",
@@ -108,6 +114,7 @@ async fn create_container_prop(ctx: &DalContext, parent_prop_id: PropId) -> Buil
         ctx,
         "name",
         PropKind::String,
+        None,
         Some(*container_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#Container",
@@ -119,6 +126,7 @@ async fn create_container_prop(ctx: &DalContext, parent_prop_id: PropId) -> Buil
         ctx,
         "image",
         PropKind::String,
+        None,
         Some(*container_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#image",
@@ -130,6 +138,7 @@ async fn create_container_prop(ctx: &DalContext, parent_prop_id: PropId) -> Buil
         ctx,
         "ports",
         PropKind::Array,
+        None,
         Some(*container_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#ports",
@@ -149,6 +158,7 @@ async fn create_container_port_prop(
         ctx,
         "port",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#ports",
@@ -160,6 +170,7 @@ async fn create_container_port_prop(
         ctx,
         "containerPort",
         PropKind::Integer,
+        None,
         Some(*port_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#ports",
@@ -171,6 +182,7 @@ async fn create_container_port_prop(
         ctx,
         "protocol",
         PropKind::String,
+        None,
         Some(*port_prop.id()),
         Some(doc_url(
             "reference/kubernetes-api/workload-resources/pod-v1/#ports",

--- a/lib/dal/src/builtins/schema/kubernetes/kubernetes_metadata.rs
+++ b/lib/dal/src/builtins/schema/kubernetes/kubernetes_metadata.rs
@@ -12,6 +12,7 @@ pub async fn create_metadata_prop(
         ctx,
         "metadata",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta",
@@ -38,6 +39,7 @@ pub async fn create_metadata_prop(
             ctx,
             "name",
             PropKind::String,
+            None,
             Some(*metadata_prop.id()),
             Some(doc_url(
                 "reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta",
@@ -51,6 +53,7 @@ pub async fn create_metadata_prop(
             ctx,
             "generateName",
             PropKind::String,
+            None,
             Some(*metadata_prop.id()),
             Some(doc_url(
                 "reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta",
@@ -65,6 +68,7 @@ pub async fn create_metadata_prop(
             ctx,
             "namespace",
             PropKind::String,
+            None,
             Some(*metadata_prop.id()),
             Some(doc_url(
                 "concepts/overview/working-with-objects/namespaces/",
@@ -78,6 +82,7 @@ pub async fn create_metadata_prop(
             ctx,
             "labels",
             PropKind::Map,
+            None,
             Some(*metadata_prop.id()),
             Some(doc_url("concepts/overview/working-with-objects/labels/")),
         )
@@ -86,6 +91,7 @@ pub async fn create_metadata_prop(
             ctx,
             "labelValue",
             PropKind::String,
+            None,
             Some(*labels_prop.id()),
             Some(doc_url("concepts/overview/working-with-objects/labels/")),
         )
@@ -96,7 +102,8 @@ pub async fn create_metadata_prop(
         let annotations_prop = BuiltinSchemaHelpers::create_prop(
             ctx,
             "annotations",
-            PropKind::Map, // How to specify it as a map of string values?
+            PropKind::Map,
+            None, // How to specify it as a map of string values?
             Some(*metadata_prop.id()),
             Some(doc_url(
                 "concepts/overview/working-with-objects/annotations/",
@@ -107,6 +114,7 @@ pub async fn create_metadata_prop(
             ctx,
             "annotationValue",
             PropKind::String,
+            None,
             Some(*annotations_prop.id()),
             Some(doc_url(
                 "concepts/overview/working-with-objects/annotations/",

--- a/lib/dal/src/builtins/schema/kubernetes/kubernetes_selector.rs
+++ b/lib/dal/src/builtins/schema/kubernetes/kubernetes_selector.rs
@@ -11,6 +11,7 @@ pub async fn create_selector_prop(
         ctx,
         "selector",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         Some(doc_url(
             "reference/kubernetes-api/common-definitions/label-selector/#LabelSelector",
@@ -22,7 +23,8 @@ pub async fn create_selector_prop(
         let match_labels_prop = BuiltinSchemaHelpers::create_prop(
             ctx,
             "matchLabels",
-            PropKind::Map, // How to specify it as an array of strings?
+            PropKind::Map,
+            None,
             Some(*selector_prop.id()),
             Some(doc_url(
                 "reference/kubernetes-api/common-definitions/label-selector/#LabelSelector",
@@ -33,6 +35,7 @@ pub async fn create_selector_prop(
             ctx,
             "labelValue",
             PropKind::String,
+            None,
             Some(*match_labels_prop.id()),
             Some(doc_url(
                 "reference/kubernetes-api/common-definitions/label-selector/#LabelSelector",

--- a/lib/dal/src/builtins/schema/kubernetes/kubernetes_spec.rs
+++ b/lib/dal/src/builtins/schema/kubernetes/kubernetes_spec.rs
@@ -7,6 +7,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         ctx,
         "spec",
         PropKind::Object,
+        None,
         Some(parent_prop_id),
         None,
     )
@@ -16,7 +17,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         let containers_prop = BuiltinSchemaHelpers::create_prop(
             ctx,
             "containers",
-            PropKind::Array, // How to specify it as an array of objects?
+            PropKind::Array,
+            None,
             Some(*spec_prop.id()),
             None,
         )
@@ -28,6 +30,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "name",
                 PropKind::String,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -39,6 +42,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "image",
                 PropKind::String,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -50,7 +54,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
             let env_prop = BuiltinSchemaHelpers::create_prop(
                 ctx,
                 "env",
-                PropKind::Array, // How to specify it as an array of objects?
+                PropKind::Array,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -61,6 +66,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "name",
                     PropKind::String,
+                    None,
                     Some(*env_prop.id()),
                     None,
                 )
@@ -72,6 +78,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "value",
                     PropKind::String,
+                    None,
                     Some(*env_prop.id()),
                     None,
                 )
@@ -83,6 +90,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "valueFrom",
                     PropKind::Object,
+                    None,
                     Some(*env_prop.id()),
                     None,
                 )
@@ -93,6 +101,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                         ctx,
                         "secretKeyRef",
                         PropKind::Object,
+                        None,
                         Some(*_value_from_prop.id()),
                         None,
                     )
@@ -103,6 +112,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "name",
                             PropKind::String,
+                            None,
                             Some(*_secret_key_ref_prop.id()),
                             None,
                         )
@@ -114,6 +124,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "key",
                             PropKind::String,
+                            None,
                             Some(*_secret_key_ref_prop.id()),
                             None,
                         )
@@ -125,6 +136,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "optional",
                             PropKind::Boolean,
+                            None,
                             Some(*_secret_key_ref_prop.id()),
                             None,
                         )
@@ -137,6 +149,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                         ctx,
                         "configMapRef",
                         PropKind::Object,
+                        None,
                         Some(*_value_from_prop.id()),
                         None,
                     )
@@ -147,6 +160,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "name",
                             PropKind::String,
+                            None,
                             Some(*_config_map_ref_prop.id()),
                             None,
                         )
@@ -158,6 +172,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "key",
                             PropKind::String,
+                            None,
                             Some(*_config_map_ref_prop.id()),
                             None,
                         )
@@ -169,6 +184,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "optional",
                             PropKind::Boolean,
+                            None,
                             Some(*_config_map_ref_prop.id()),
                             None,
                         )
@@ -181,6 +197,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                         ctx,
                         "resourceFieldRef",
                         PropKind::Object,
+                        None,
                         Some(*_value_from_prop.id()),
                         None,
                     )
@@ -191,6 +208,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "containerName",
                             PropKind::String,
+                            None,
                             Some(*_resource_field_ref_prop.id()),
                             None,
                         )
@@ -202,6 +220,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "resource",
                             PropKind::String,
+                            None,
                             Some(*_resource_field_ref_prop.id()),
                             None,
                         )
@@ -213,6 +232,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "divisor",
                             PropKind::String,
+                            None,
                             Some(*_resource_field_ref_prop.id()),
                             None,
                         )
@@ -225,6 +245,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                         ctx,
                         "fieldRef",
                         PropKind::Object,
+                        None,
                         Some(*_value_from_prop.id()),
                         None,
                     )
@@ -236,6 +257,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "apiVersion",
                             PropKind::String,
+                            None,
                             Some(*_field_ref_prop.id()),
                             None,
                         )
@@ -247,6 +269,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                             ctx,
                             "fieldPath",
                             PropKind::String,
+                            None,
                             Some(*_field_ref_prop.id()),
                             None,
                         )
@@ -264,6 +287,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "imagePullPolicy",
                 PropKind::String,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -274,7 +298,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
             let ports_prop = BuiltinSchemaHelpers::create_prop(
                 ctx,
                 "ports",
-                PropKind::Array, // How to specify it as an array of objects?
+                PropKind::Array,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -285,6 +310,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "name",
                     PropKind::String,
+                    None,
                     Some(*ports_prop.id()),
                     None,
                 )
@@ -297,6 +323,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "containerPort",
                     PropKind::Integer,
+                    None,
                     Some(*ports_prop.id()),
                     None,
                 )
@@ -308,6 +335,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "hostIp",
                     PropKind::String,
+                    None,
                     Some(*ports_prop.id()),
                     None,
                 )
@@ -320,6 +348,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "hostPort",
                     PropKind::Integer,
+                    None,
                     Some(*ports_prop.id()),
                     None,
                 )
@@ -333,6 +362,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "protocol",
                     PropKind::String,
+                    None,
                     Some(*ports_prop.id()),
                     None,
                 )
@@ -344,7 +374,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
             let volume_mounts_prop = BuiltinSchemaHelpers::create_prop(
                 ctx,
                 "volumeMounts",
-                PropKind::Array, // How to specify it as an array of objects?
+                PropKind::Array,
+                None,
                 Some(*containers_prop.id()),
                 None,
             )
@@ -355,6 +386,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "name",
                     PropKind::String,
+                    None,
                     Some(*volume_mounts_prop.id()),
                     None,
                 )
@@ -366,6 +398,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "mountPath",
                     PropKind::String,
+                    None,
                     Some(*volume_mounts_prop.id()),
                     None,
                 )
@@ -378,7 +411,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         let volumes_prop = BuiltinSchemaHelpers::create_prop(
             ctx,
             "volumes",
-            PropKind::Array, // How to specify it as an array of objects?
+            PropKind::Array,
+            None,
             Some(*spec_prop.id()),
             None,
         )
@@ -389,6 +423,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "name",
                 PropKind::String,
+                None,
                 Some(*volumes_prop.id()),
                 None,
             )
@@ -400,6 +435,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "configMap",
                 PropKind::Object,
+                None,
                 Some(*volumes_prop.id()),
                 None,
             )
@@ -410,6 +446,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                     ctx,
                     "name",
                     PropKind::String,
+                    None,
                     Some(*config_map_prop.id()),
                     None,
                 )
@@ -422,7 +459,8 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
         let image_pull_secrets_prop = BuiltinSchemaHelpers::create_prop(
             ctx,
             "imagePullSecrets",
-            PropKind::Array, // How to specify it as an array of objects?
+            PropKind::Array,
+            None,
             Some(*spec_prop.id()),
             None,
         )
@@ -433,6 +471,7 @@ pub async fn create_spec_prop(ctx: &DalContext, parent_prop_id: PropId) -> Built
                 ctx,
                 "name",
                 PropKind::String,
+                None,
                 Some(*image_pull_secrets_prop.id()),
                 None,
             )

--- a/lib/dal/src/builtins/schema/kubernetes/kubernetes_template.rs
+++ b/lib/dal/src/builtins/schema/kubernetes/kubernetes_template.rs
@@ -9,9 +9,15 @@ pub async fn create_template_prop(
     ctx: &DalContext,
     parent_prop_id: Option<PropId>,
 ) -> BuiltinsResult<Prop> {
-    let template_prop =
-        BuiltinSchemaHelpers::create_prop(ctx, "template", PropKind::Object, parent_prop_id, None)
-            .await?;
+    let template_prop = BuiltinSchemaHelpers::create_prop(
+        ctx,
+        "template",
+        PropKind::Object,
+        None,
+        parent_prop_id,
+        None,
+    )
+    .await?;
 
     {
         let _optional_metadata_prop = create_metadata_prop(ctx, false, *template_prop.id()).await?;

--- a/lib/dal/src/edit_field/widget.rs
+++ b/lib/dal/src/edit_field/widget.rs
@@ -13,4 +13,7 @@ pub enum WidgetKind {
     Map,
     SecretSelect,
     Text,
+    /// Provides a select box for corresponding "primitive" (e.g. string, number, boolean)
+    /// [`PropKinds`](crate::PropKind).
+    Select,
 }

--- a/lib/dal/src/migrations/U0040__props.sql
+++ b/lib/dal/src/migrations/U0040__props.sql
@@ -13,6 +13,7 @@ CREATE TABLE props
     name                        text                     NOT NULL,
     kind                        text                     NOT NULL,
     widget_kind                 text                     NOT NULL,
+    widget_options              jsonb,
     doc_link                    text
 );
 SELECT standard_model_table_constraints_v1('props');
@@ -36,6 +37,7 @@ CREATE OR REPLACE FUNCTION prop_create_v1(
     this_name text,
     this_kind text,
     this_widget_kind text,
+    this_widget_options jsonb,
     OUT object json) AS
 $$
 DECLARE
@@ -49,11 +51,11 @@ BEGIN
     INSERT INTO props (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                        tenancy_workspace_ids,
                        visibility_change_set_pk, visibility_deleted_at,
-                       name, kind, widget_kind)
+                       name, kind, widget_kind, widget_options)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk,
-            this_visibility_record.visibility_deleted_at, this_name, this_kind, this_widget_kind)
+            this_visibility_record.visibility_deleted_at, this_name, this_kind, this_widget_kind, this_widget_options)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -26,22 +26,22 @@ impl RootProp {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<Self> {
-        let root_prop = Prop::new(ctx, "root", PropKind::Object).await?;
+        let root_prop = Prop::new(ctx, "root", PropKind::Object, None).await?;
         root_prop
             .add_schema_variant(ctx, &schema_variant_id)
             .await?;
 
-        let si_specific_prop = Prop::new(ctx, "si", PropKind::Object).await?;
+        let si_specific_prop = Prop::new(ctx, "si", PropKind::Object, None).await?;
         si_specific_prop
             .set_parent_prop(ctx, *root_prop.id())
             .await?;
 
-        let si_name_prop = Prop::new(ctx, "name", PropKind::String).await?;
+        let si_name_prop = Prop::new(ctx, "name", PropKind::String, None).await?;
         si_name_prop
             .set_parent_prop(ctx, *si_specific_prop.id())
             .await?;
 
-        let domain_specific_prop = Prop::new(ctx, "domain", PropKind::Object).await?;
+        let domain_specific_prop = Prop::new(ctx, "domain", PropKind::Object, None).await?;
         domain_specific_prop
             .set_parent_prop(ctx, *root_prop.id())
             .await?;

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -438,7 +438,7 @@ pub async fn create_system(ctx: &DalContext) -> System {
 
 pub async fn create_prop(ctx: &DalContext) -> Prop {
     let name = generate_fake_name();
-    Prop::new(ctx, name, PropKind::String)
+    Prop::new(ctx, name, PropKind::String, None)
         .await
         .expect("cannot create prop")
 }
@@ -446,7 +446,7 @@ pub async fn create_prop(ctx: &DalContext) -> Prop {
 #[allow(clippy::too_many_arguments)]
 pub async fn create_prop_of_kind(ctx: &DalContext, prop_kind: PropKind) -> Prop {
     let name = generate_fake_name();
-    Prop::new(ctx, name, prop_kind)
+    Prop::new(ctx, name, prop_kind, None)
         .await
         .expect("cannot create prop")
 }
@@ -458,7 +458,7 @@ pub async fn create_prop_of_kind_with_name(
     name: impl AsRef<str>,
 ) -> Prop {
     let name = name.as_ref();
-    Prop::new(ctx, name, prop_kind)
+    Prop::new(ctx, name, prop_kind, None)
         .await
         .expect("cannot create prop")
 }
@@ -471,7 +471,7 @@ pub async fn create_prop_of_kind_and_set_parent_with_name(
     parent_prop_id: PropId,
 ) -> Prop {
     let name = name.as_ref();
-    let new_prop = Prop::new(ctx, name, prop_kind)
+    let new_prop = Prop::new(ctx, name, prop_kind, None)
         .await
         .expect("cannot create prop");
     new_prop

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -8,6 +8,7 @@ use dal::{
 };
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 use serde_json::json;
+use std::option::Option::None;
 
 use crate::dal::test;
 
@@ -52,7 +53,7 @@ async fn qualification_view(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
 
-    let prop = Prop::new(ctx, "some_property", PropKind::String)
+    let prop = Prop::new(ctx, "some_property", PropKind::String, None)
         .await
         .expect("cannot create prop");
     prop.set_parent_prop(ctx, root.domain_prop_id)

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -3,6 +3,7 @@ use dal::{
     DalContext, HistoryActor, Prop, PropKind, SchemaKind, StandardModel, Visibility, WriteTenancy,
 };
 use pretty_assertions_sorted::assert_eq;
+use std::option::Option::None;
 
 use crate::dal::test;
 
@@ -11,7 +12,7 @@ async fn new(ctx: &DalContext) {
     let _write_tenancy = WriteTenancy::new_universal();
     let _visibility = Visibility::new_head(false);
     let _history_actor = HistoryActor::SystemInit;
-    let prop = Prop::new(ctx, "coolness", PropKind::String)
+    let prop = Prop::new(ctx, "coolness", PropKind::String, None)
         .await
         .expect("cannot create prop");
     assert_eq!(prop.name(), "coolness");

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -5,8 +5,8 @@ use dal::{
 };
 
 #[test]
-async fn schema_for_schema_variant(ctx: &DalContext) {
-    let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
+async fn property_editor_schema(ctx: &DalContext) {
+    let schema = Schema::find_by_attr(ctx, "name", &"aws_region".to_string())
         .await
         .expect("cannot find docker image schema")
         .pop()
@@ -21,7 +21,7 @@ async fn schema_for_schema_variant(ctx: &DalContext) {
 }
 
 #[test]
-async fn value_for_context(ctx: &DalContext) {
+async fn property_editor_value(ctx: &DalContext) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image schema")

--- a/lib/dal/tests/integration_test/qualification_prototype.rs
+++ b/lib/dal/tests/integration_test/qualification_prototype.rs
@@ -10,6 +10,7 @@ use dal::{
     QualificationPrototype, Schema, SchemaError, SchemaKind, SchemaVariant, StandardModel,
     SystemId,
 };
+use std::option::Option::None;
 
 #[test]
 async fn new(ctx: &DalContext) {
@@ -133,7 +134,9 @@ async fn associate_prototypes_with_func_and_objects(ctx: &DalContext) {
         let mut validation_prototype_ctx = ValidationPrototypeContext::default();
         validation_prototype_ctx.set_schema_id(*schema.id());
         validation_prototype_ctx.set_schema_variant_id(*variant.id());
-        let text_prop = Prop::new(ctx, "text", PropKind::String).await.unwrap();
+        let text_prop = Prop::new(ctx, "text", PropKind::String, None)
+            .await
+            .unwrap();
         text_prop
             .set_parent_prop(ctx, root_prop.domain_prop_id)
             .await


### PR DESCRIPTION
## Commit Description

- Add widget options (optional column for props)
- Add "Select" widget kind (pairs with widget options)
- Ensure AWS regions are loaded via a JSON file and are type-checked
  ("AwsRegion" struct)
- Add temporary "SelectWidgetOption" struct until select behavior and
  shape is solidified
  - Essentially, we throw serialized JSON "over the wall" rather than
    using a specific type for the time being

## GIF and Linear

<img src="https://media0.giphy.com/media/4XpPnxdp04A6aUAnTW/giphy.gif"/>

Fixes ENG-564