### PR TITLE
show region dropdown in attribute panel

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -37,7 +37,7 @@ export interface PropertyEditorPropWidgetKindInteger {
 }
 export interface PropertyEditorPropWidgetKindSelect {
   kind: "select";
-  options?: JSON;
+  options?: LabelList<string | number>;
 }
 export interface PropertyEditorPropWidgetKindSecretSelect {
   kind: "secretSelect";

--- a/app/web/src/organisms/AttributeViewer.vue
+++ b/app/web/src/organisms/AttributeViewer.vue
@@ -41,20 +41,12 @@
 
     <PropertyEditor
       v-if="editorContext"
-      class=""
       :editor-context="editorContext"
-      @updated-property="updateProperty($event)"
-      @add-to-array="addToArray($event)"
-      @add-to-map="addToMap($event)"
+      @updated-property="updateProperty"
+      @add-to-array="addToArray"
+      @add-to-map="addToMap"
       @create-attribute-func="onCreateAttributeFunc"
     />
-
-    <!--
-    <EditFormComponent
-      v-if="editFields"
-      :edit-fields="editFields"
-      :component-identification="componentIdentification"
-    /> -->
   </div>
 </template>
 

--- a/app/web/src/organisms/PropertyEditor.vue
+++ b/app/web/src/organisms/PropertyEditor.vue
@@ -1,12 +1,11 @@
 <template>
-  <div class="flex flex-col w-full h-full pb-5">
+  <div class="flex flex-col w-full h-full pb-5 text-left">
     <div
       v-for="(pv, index) in propertyValuesInOrder"
       :key="pv.id"
       class="flex flex-col w-full"
     >
       <PropertyWidget
-        class="text-left"
         :schema-prop="schemaForPropId(pv.propId)"
         :prop-value="pv"
         :path="paths[pv.id]"

--- a/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
@@ -42,10 +42,7 @@
     />
     <!-- TODO(nick): until we use the "options" for select, let's just ignore them for now and force a text box  -->
     <WidgetTextBox
-      v-else-if="
-        props.schemaProp.widgetKind.kind === 'text' ||
-        props.schemaProp.widgetKind.kind === 'select'
-      "
+      v-else-if="props.schemaProp.widgetKind.kind === 'text'"
       :name="props.schemaProp.name"
       :path="path"
       :collapsed-paths="props.collapsedPaths"
@@ -75,9 +72,12 @@
       @updated-property="updatedProperty($event)"
     />
     <WidgetSelectBox
-      v-else-if="props.schemaProp.widgetKind.kind === 'secretSelect'"
+      v-else-if="
+        props.schemaProp.widgetKind.kind === 'secretSelect' ||
+        props.schemaProp.widgetKind.kind === 'select'
+      "
       :name="props.schemaProp.name"
-      :options="props.schemaProp.widgetKind.options"
+      :options="props.schemaProp.widgetKind.options || []"
       :path="path"
       :collapsed-paths="props.collapsedPaths"
       :value="props.propValue.value"
@@ -89,6 +89,7 @@
       class="py-4 px-8"
       @updated-property="updatedProperty($event)"
     />
+
     <!-- restricting to text props for now -->
     <WidgetFuncButton
       v-if="!props.isFirstProp"

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -1,5 +1,4 @@
 use crate::attribute::context::AttributeContextBuilder;
-use crate::builtins::schema::aws::AwsRegion;
 use crate::edit_field::widget::WidgetKind;
 use crate::{
     component::ComponentKind,
@@ -39,15 +38,6 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
 pub struct SelectWidgetOption {
     label: String,
     value: String,
-}
-
-impl From<&AwsRegion> for SelectWidgetOption {
-    fn from(region: &AwsRegion) -> Self {
-        Self {
-            label: region.region_name.clone(),
-            value: region.region_value.clone(),
-        }
-    }
 }
 
 /// This unit struct (zero bytes) provides a singular place to index helpers for creating builtin

--- a/lib/dal/src/builtins/schema/data/aws_regions.json
+++ b/lib/dal/src/builtins/schema/data/aws_regions.json
@@ -1,94 +1,94 @@
 [
   {
-    "region_name": "US East (N. Virginia)",
-    "region_value": "us-east-1"
+    "name": "US East (N. Virginia)",
+    "code": "us-east-1"
   },
   {
-    "region_name": "US East (Ohio)",
-    "region_value": "us-east-2"
+    "name": "US East (Ohio)",
+    "code": "us-east-2"
   },
   {
-    "region_name": "US West (N. California)",
-    "region_value": "us-west-1"
+    "name": "US West (N. California)",
+    "code": "us-west-1"
   },
   {
-    "region_name": "US West (Oregon)",
-    "region_value": "us-west-2"
+    "name": "US West (Oregon)",
+    "code": "us-west-2"
   },
   {
-    "region_name": "Africa (Cape Town)",
-    "region_value": "af-south-1"
+    "name": "Africa (Cape Town)",
+    "code": "af-south-1"
   },
   {
-    "region_name": "Asia Pacific (Hong Kong)",
-    "region_value": "ap-east-1"
+    "name": "Asia Pacific (Hong Kong)",
+    "code": "ap-east-1"
   },
   {
-    "region_name": "Asia Pacific (Jakarta)",
-    "region_value": "ap-southeast-3"
+    "name": "Asia Pacific (Jakarta)",
+    "code": "ap-southeast-3"
   },
   {
-    "region_name": "Asia Pacific (Mumbai)",
-    "region_value": "ap-south-1"
+    "name": "Asia Pacific (Mumbai)",
+    "code": "ap-south-1"
   },
   {
-    "region_name": "Asia Pacific (Osaka)",
-    "region_value": "ap-northeast-3"
+    "name": "Asia Pacific (Osaka)",
+    "code": "ap-northeast-3"
   },
   {
-    "region_name": "Asia Pacific (Seoul)",
-    "region_value": "ap-northeast-2"
+    "name": "Asia Pacific (Seoul)",
+    "code": "ap-northeast-2"
   },
   {
-    "region_name": "Asia Pacific (Singapore)",
-    "region_value": "ap-southeast-1"
+    "name": "Asia Pacific (Singapore)",
+    "code": "ap-southeast-1"
   },
   {
-    "region_name": "Asia Pacific (Sydney)",
-    "region_value": "ap-southeast-2"
+    "name": "Asia Pacific (Sydney)",
+    "code": "ap-southeast-2"
   },
   {
-    "region_name": "Asia Pacific (Tokyo)",
-    "region_value": "ap-northeast-1"
+    "name": "Asia Pacific (Tokyo)",
+    "code": "ap-northeast-1"
   },
   {
-    "region_name": "Canada (Central)",
-    "region_value": "ca-central-1"
+    "name": "Canada (Central)",
+    "code": "ca-central-1"
   },
   {
-    "region_name": "Europe (Frankfurt)",
-    "region_value": "eu-central-1"
+    "name": "Europe (Frankfurt)",
+    "code": "eu-central-1"
   },
   {
-    "region_name": "Europe (Ireland)",
-    "region_value": "eu-west-1"
+    "name": "Europe (Ireland)",
+    "code": "eu-west-1"
   },
   {
-    "region_name": "Europe (London)",
-    "region_value": "eu-west-2"
+    "name": "Europe (London)",
+    "code": "eu-west-2"
   },
   {
-    "region_name": "Europe (Milan)",
-    "region_value": "eu-south-1"
+    "name": "Europe (Milan)",
+    "code": "eu-south-1"
   },
   {
-    "region_name": "Europe (Paris)",
-    "region_value": "eu-west-3"
+    "name": "Europe (Paris)",
+    "code": "eu-west-3"
   },
   {
-    "region_name": "Europe (Stockholm)",
-    "region_value": "eu-north-1"
+    "name": "Europe (Stockholm)",
+    "code": "eu-north-1"
   },
   {
-    "region_name": "Middle East (Bahrain)",
-    "region_value": "me-south-1"
+    "name": "Middle East (Bahrain)",
+    "code": "me-south-1"
   },
   {
-    "region_name": "Middle East (UAE)",
-    "region_value": "me-central-1"
+    "name": "Middle East (UAE)",
+    "code": "me-central-1"
   },
   {
-    "region_name": "South America (Sao Paulo)",
-    "region_value": "me-central-1"
+    "name": "South America (Sao Paulo)",
+    "code": "me-central-1"
   }
 ]


### PR DESCRIPTION
simply showing the region dropdown for the aws region component...

Ideally we’d add this dropdown on all the various region props and attach dropdowns (and validations) for a bunch of other props on all our schemas - but until we improve the authoring experience, the process is super awkward, so I’d suggest we only implement it on a few impactful places needed for upcoming user studies.

While the new authoring experience obviously will need to accommodate this kind of reuse, I think there may be a slight shift needed in the model itself for reusing these kinds of option lists - both in terms of reusing within prop/widget options and validations, but also in reusing across multiple props and components. For example AWS region will be present on many aws-related components, so it doesn’t really make sense to store that list on each prop. I’ve mentioned this as a sort of higher order “data type” which may have associated semantic meaning, validations, and impact on the inputs, but I know there are some other ideas too about how to accomplish this.

Also related - we’ll need to think a bit about how we want to handle dynamic options lists and when/how the frontend re-fetches it, both for short lists where we may want to fetch the entire list and longer lists where the input may be a typeahead that fetches results as the user types. This can also be thought about in connection to a larger question of how we want to handle dynamic schemas (or at least making the inputs dynamic even if the schema itself stays static). What I mean by that is when one attribute is changed, it may show/hide another set of attributes.