### PR TITLE
fix(dal): ensure validation statuses contexts are valid

### DIFF
--- a/lib/dal/src/queries/validation_resolver_find_status.sql
+++ b/lib/dal/src/queries/validation_resolver_find_status.sql
@@ -1,44 +1,48 @@
 SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
                                              validation_resolvers.visibility_change_set_pk,
-
+                                             validation_resolvers.visibility_deleted_at,
                                              attribute_values.id                       as attribute_value_id,
                                              row_to_json(validation_prototypes.*)      as validation_prototype_json,
                                              row_to_json(func_binding_return_values.*) as object
+
 FROM attribute_values
          LEFT JOIN validation_resolvers
                    ON validation_resolvers.attribute_value_id = attribute_values.id
                        AND
                       validation_resolvers.func_binding_return_value_id = attribute_values.func_binding_return_value_id
-                       AND in_tenancy_v1($1, validation_resolvers.tenancy_universal,
-                                         validation_resolvers.tenancy_billing_account_ids,
-                                         validation_resolvers.tenancy_organization_ids,
-                                         validation_resolvers.tenancy_workspace_ids)
-                       AND is_visible_v1($2, validation_resolvers.visibility_change_set_pk,
-                                         validation_resolvers.visibility_deleted_at)
-         LEFT JOIN validation_prototypes ON validation_prototypes.id = validation_resolvers.validation_prototype_id
-         LEFT JOIN func_bindings ON func_bindings.id = validation_resolvers.func_binding_id
+                       AND in_tenancy_and_visible_v1($1, $2, validation_resolvers)
+         LEFT JOIN validation_prototypes
+                   ON validation_prototypes.id = validation_resolvers.validation_prototype_id
+                       AND in_tenancy_and_visible_v1($1, $2, validation_prototypes)
+         LEFT JOIN func_bindings
+                   ON func_bindings.id = validation_resolvers.func_binding_id
+                       AND in_tenancy_and_visible_v1($1, $2, func_bindings)
          LEFT JOIN func_binding_return_value_belongs_to_func_binding
                    ON func_binding_return_value_belongs_to_func_binding.belongs_to_id = func_bindings.id
+                       AND in_tenancy_and_visible_v1($1, $2, func_binding_return_value_belongs_to_func_binding)
          LEFT JOIN func_binding_return_values
                    ON func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
-WHERE in_tenancy_v1($1, attribute_values.tenancy_universal, attribute_values.tenancy_billing_account_ids,
-                    attribute_values.tenancy_organization_ids, attribute_values.tenancy_workspace_ids)
-  AND is_visible_v1($2, attribute_values.visibility_change_set_pk, attribute_values.visibility_deleted_at)
-  AND in_attribute_context_v1($3, attribute_values.attribute_context_prop_id,
-                              attribute_values.attribute_context_internal_provider_id,
-                              attribute_values.attribute_context_external_provider_id,
-                              attribute_values.attribute_context_schema_id,
-                              attribute_values.attribute_context_schema_variant_id,
-                              attribute_values.attribute_context_component_id,
-                              attribute_values.attribute_context_system_id)
-  AND attribute_values.attribute_context_prop_id IN (WITH RECURSIVE recursive_props AS (SELECT left_object_id AS prop_id
-                                                                                        FROM prop_many_to_many_schema_variants
-                                                                                        WHERE right_object_id = $4
-                                                                                        UNION ALL
-                                                                                        SELECT pbp.object_id AS prop_id
-                                                                                        FROM prop_belongs_to_prop AS pbp
-                                                                                                 JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
+                       AND in_tenancy_and_visible_v1($1, $2, func_binding_return_values)
+
+WHERE in_tenancy_and_visible_v1($1, $2, attribute_values)
+  AND attribute_values.attribute_context_prop_id IN (WITH RECURSIVE recursive_props AS
+                                                                        (SELECT left_object_id AS prop_id
+                                                                         FROM prop_many_to_many_schema_variants
+                                                                         WHERE right_object_id = $4
+                                                                         UNION ALL
+                                                                         SELECT pbp.object_id AS prop_id
+                                                                         FROM prop_belongs_to_prop AS pbp
+                                                                                  JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
                                                      SELECT prop_id
                                                      FROM recursive_props)
+  AND exact_attribute_read_context_v1($3, attribute_values.attribute_context_prop_id,
+                                      attribute_values.attribute_context_internal_provider_id,
+                                      attribute_values.attribute_context_external_provider_id,
+                                      attribute_values.attribute_context_schema_id,
+                                      attribute_values.attribute_context_schema_variant_id,
+                                      attribute_values.attribute_context_component_id,
+                                      attribute_values.attribute_context_system_id)
+
 ORDER BY validation_resolvers.id,
-         visibility_change_set_pk DESC;
+         visibility_change_set_pk DESC,
+         visibility_deleted_at DESC NULLS FIRST;

--- a/lib/dal/src/validation_resolver.rs
+++ b/lib/dal/src/validation_resolver.rs
@@ -140,11 +140,11 @@ impl ValidationResolver {
             .await?
             .ok_or(ValidationResolverError::SchemaNotFound)?;
         let context = AttributeReadContext {
+            prop_id: None,
+            schema_id: Some(*schema.id()),
+            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(component_id),
             system_id: Some(system_id),
-            schema_variant_id: Some(*schema_variant.id()),
-            schema_id: Some(*schema.id()),
-            prop_id: None,
             ..AttributeReadContext::default()
         };
         let rows = ctx


### PR DESCRIPTION
## Commit Description

- Ensure validation statuses correspond to attribute values whose attribute contexts are valid (i.e. the context is of the same specificity)
  - This fixes the observed failure in the frontend where "All Fields Valid" was reported as failing because validation statuses from a less specific context were being returned (e.g. the prop-specific value was unset, but the component-specific value was correctly set)
- Add integration test to track if this regresses

## Known Issue

Specifically for @theoephraim @wendybujalski @vbustamante, the validations array prop for the `SiTextBox` Vue Component properly updates, but the state of the validation's appearance in the UI does not. You need to deselect and reselect the component in order to "reset" whether or not the validation error message and colors should appear. We tried to fix this, but was ultimately out of scope for this PR due to a rabbit hole.

## GIF and Linear

<img src="https://media4.giphy.com/media/GxmqepIBKZEa25dkpP/giphy.gif"/>

Fixes ENG-578