### PR TITLE
feat(dal,sdf): attribute prototype arguments refer to func_argument_id

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -24,6 +24,7 @@ mod schema;
 mod workflow;
 
 // Expose the "persist" function for creating and editing builtin funcs while in dev mode.
+use crate::func::argument::FuncArgumentError;
 pub use func::persist as func_persist;
 
 #[derive(Error, Debug)]
@@ -46,6 +47,8 @@ pub enum BuiltinsError {
     CodeGenerationPrototype(#[from] CodeGenerationPrototypeError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
+    #[error("func argument error: {0}")]
+    FuncArgument(#[from] FuncArgumentError),
     #[error("func binding error: {0}")]
     FuncBinding(#[from] FuncBindingError),
     #[error("func binding return value error: {0}")]
@@ -92,6 +95,8 @@ pub enum BuiltinsError {
     WorkflowPrototype(#[from] WorkflowPrototypeError),
     #[error("Func Metadata error: {0}")]
     FuncMetadata(String),
+    #[error("builtin {0} missing func argument {0}")]
+    BuiltinMissingFuncArgument(String, String),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/builtins/func/dockerImagesToButaneUnits.json
+++ b/lib/dal/src/builtins/func/dockerImagesToButaneUnits.json
@@ -2,5 +2,9 @@
   "kind": "Json",
   "response_type": "Array",
   "code_file": "dockerImagesToButaneUnits.js",
-  "code_entrypoint": "dockerImagesToButaneUnits"
+  "code_entrypoint": "dockerImagesToButaneUnits",
+  "arguments": [{
+    "name": "images",
+    "kind": "Array"
+  }]
 }

--- a/lib/dal/src/builtins/func/dockerImagesToK8sDeploymentContainerSpec.json
+++ b/lib/dal/src/builtins/func/dockerImagesToK8sDeploymentContainerSpec.json
@@ -2,5 +2,9 @@
   "kind": "Json",
   "response_type": "Array",
   "code_file": "dockerImagesToK8sDeploymentContainerSpec.js",
-  "code_entrypoint": "dockerImagesToK8sDeploymentContainerSpec"
+  "code_entrypoint": "dockerImagesToK8sDeploymentContainerSpec",
+  "arguments": [{
+    "name": "images",
+    "kind": "Array"
+  }]
 }

--- a/lib/dal/src/builtins/func/identity.json
+++ b/lib/dal/src/builtins/func/identity.json
@@ -1,4 +1,8 @@
 {
   "kind": "Identity",
-  "response_type": "Identity"
+  "response_type": "Identity",
+  "arguments": [{
+    "name": "identity" ,
+    "kind": "Any"
+  }]
 }

--- a/lib/dal/src/builtins/schema/aws.rs
+++ b/lib/dal/src/builtins/schema/aws.rs
@@ -138,8 +138,13 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+
     let (image_id_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
@@ -200,7 +205,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        "identity",
+        identity_func_identity_arg_id,
         *image_id_implicit_internal_provider.id(),
     )
     .await?;
@@ -230,7 +235,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -405,9 +410,14 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    // TODO(nick): add the ability to use butane as input.
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    // TODO(nick): add the ability to use butane and ami as an inputs.
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+
     let (_butane_explicit_internal_provider, mut input_socket) =
         InternalProvider::new_explicit_with_socket(
             ctx,
@@ -580,7 +590,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -605,7 +615,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *image_id_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *image_id_explicit_internal_provider.id(),
     )
     .await?;
@@ -631,7 +641,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *keyname_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *keyname_explicit_internal_provider.id(),
     )
     .await?;
@@ -719,8 +729,12 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
     // Output Socket
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
     let (region_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
@@ -753,7 +767,7 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        "identity",
+        identity_func_identity_arg_id,
         *region_implicit_internal_provider.id(),
     )
     .await?;
@@ -843,8 +857,12 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
     // Output Socket
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
     let (key_name_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
@@ -895,7 +913,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        "identity",
+        identity_func_identity_arg_id,
         *key_name_internal_provider.id(),
     )
     .await?;
@@ -926,7 +944,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -1016,7 +1034,7 @@ async fn ingress(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
+    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id, _) =
         BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
 
     // Input Socket
@@ -1123,7 +1141,7 @@ async fn egress(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
+    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id, _) =
         BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
 
     // Input Socket
@@ -1249,8 +1267,12 @@ async fn security_group(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
 
     // Socket Creation
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
 
     let system_socket = Socket::new(
         ctx,
@@ -1359,7 +1381,7 @@ async fn security_group(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *security_group_id_external_provider_attribute_prototype_id,
-        "identity",
+        identity_func_identity_arg_id,
         *security_group_id_internal_provider.id(),
     )
     .await?;
@@ -1385,7 +1407,7 @@ async fn security_group(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -1411,7 +1433,7 @@ async fn security_group(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *vpc_id_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *vpc_id_explicit_internal_provider.id(),
     )
     .await?;

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -62,7 +62,7 @@ async fn docker_hub_credential(ctx: &DalContext) -> BuiltinsResult<()> {
 
     let _ = QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
+    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id, _) =
         BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
 
     let system_socket = Socket::new(
@@ -149,8 +149,12 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut properties = HashMap::new();
     properties.insert("image".to_owned(), serde_json::json!(""));
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        identity_func_identity_arg_id,
+    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
 
     let (_docker_hub_credential_explicit_internal_provider, mut input_socket) =
         InternalProvider::new_explicit_with_socket(
@@ -239,7 +243,7 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *image_attribute_prototype.id(),
-        "identity",
+        identity_func_identity_arg_id,
         *si_name_internal_provider.id(),
     )
     .await?;
@@ -259,7 +263,7 @@ async fn docker_image(ctx: &DalContext) -> BuiltinsResult<()> {
                     *docker_image_external_provider.id(),
                 )
             })?,
-        "identity",
+        identity_func_identity_arg_id,
         *root_implicit_internal_provider.id(),
     )
     .await?;

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -25,7 +25,7 @@ async fn system(ctx: &DalContext) -> BuiltinsResult<()> {
 
     schema_variant.finalize(ctx).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
+    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id, _) =
         BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
     let (_component_output_provider, _component_output_socket) = ExternalProvider::new_with_socket(
         ctx,

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -50,6 +50,7 @@ pub enum FuncArgumentKind {
     Object,
     String,
     Map,
+    Any,
 }
 
 impl From<PropKind> for FuncArgumentKind {

--- a/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
+++ b/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
@@ -10,8 +10,8 @@ CREATE TABLE attribute_prototype_arguments
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
+    func_argument_id            bigint                   NOT NULL,
     attribute_prototype_id      bigint                   NOT NULL,
-    name                        text                     NOT NULL,
     internal_provider_id        bigint                   NOT NULL,
     external_provider_id        bigint                   NOT NULL,
     tail_component_id           bigint                   NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE attribute_prototype_arguments
 
 CREATE UNIQUE INDEX intra_component_argument
     ON attribute_prototype_arguments (attribute_prototype_id,
-                                      name,
+                                      func_argument_id,
                                       internal_provider_id,
                                       visibility_change_set_pk,
                                       (visibility_deleted_at IS NULL))
@@ -31,7 +31,7 @@ CREATE UNIQUE INDEX intra_component_argument
 
 CREATE UNIQUE INDEX inter_component_argument
     ON attribute_prototype_arguments (attribute_prototype_id,
-                                      name,
+                                      func_argument_id,
                                       external_provider_id,
                                       tail_component_id,
                                       head_component_id,
@@ -48,7 +48,7 @@ CREATE OR REPLACE FUNCTION attribute_prototype_argument_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
     this_attribute_prototype_argument_id bigint,
-    this_name text,
+    this_func_argument_id bigint,
     this_internal_provider_id bigint,
     this_external_provider_id bigint,
     this_tail_component_id bigint,
@@ -70,7 +70,7 @@ BEGIN
                                                visibility_change_set_pk,
                                                visibility_deleted_at,
                                                attribute_prototype_id,
-                                               name,
+                                               func_argument_id,
                                                internal_provider_id,
                                                external_provider_id,
                                                tail_component_id,
@@ -82,7 +82,7 @@ BEGIN
             this_visibility_record.visibility_change_set_pk,
             this_visibility_record.visibility_deleted_at,
             this_attribute_prototype_argument_id,
-            this_name,
+            this_func_argument_id,
             this_internal_provider_id,
             this_external_provider_id,
             this_tail_component_id,

--- a/lib/dal/src/test/helpers.rs
+++ b/lib/dal/src/test/helpers.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::attribute::context::AttributeContextBuilder;
+use crate::func::argument::{FuncArgument, FuncArgumentId};
 use crate::func::binding::FuncBindingId;
 use crate::func::binding_return_value::FuncBindingReturnValueId;
 use crate::node::NodeId;
@@ -195,12 +196,24 @@ pub async fn find_schema_and_default_variant_by_name(
 /// Get the "si:identity" [`Func`](crate::Func) and execute (if necessary).
 pub async fn setup_identity_func(
     ctx: &DalContext,
-) -> (FuncId, FuncBindingId, FuncBindingReturnValueId) {
+) -> (
+    FuncId,
+    FuncBindingId,
+    FuncBindingReturnValueId,
+    FuncArgumentId,
+) {
     let identity_func: Func = Func::find_by_attr(ctx, "name", &"si:identity".to_string())
         .await
         .expect("could not find identity func by name attr")
         .pop()
         .expect("identity func not found");
+
+    let identity_func_identity_arg = FuncArgument::list_for_func(ctx, *identity_func.id())
+        .await
+        .expect("cannot list identity func args")
+        .pop()
+        .expect("cannot find identity func identity arg");
+
     let (identity_func_binding, identity_func_binding_return_value, _) =
         FuncBinding::find_or_create_and_execute(
             ctx,
@@ -213,6 +226,7 @@ pub async fn setup_identity_func(
         *identity_func.id(),
         *identity_func_binding.id(),
         *identity_func_binding_return_value.id(),
+        *identity_func_identity_arg.id(),
     )
 }
 

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -15,7 +15,7 @@ use dal::{
 use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
 #[test]
-async fn new(ctx: &DalContext) {
+async fn new_attribute_prototype(ctx: &DalContext) {
     let schema = Schema::find_by_attr(ctx, "name", &"docker_image".to_string())
         .await
         .expect("cannot find docker image")

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -8,6 +8,7 @@ use dal::{
 };
 use dal::{AttributePrototypeArgument, DalContext, InternalProvider};
 
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::test_harness::create_prop_of_kind_and_set_parent_with_name;
 use pretty_assertions_sorted::assert_eq;
 
@@ -46,6 +47,9 @@ async fn create_and_list_for_attribute_prototype(ctx: &DalContext) {
     )
     .await
     .expect("cannot create func");
+    let func_arg = FuncArgument::new(ctx, "title", FuncArgumentKind::String, None, *func.id())
+        .await
+        .expect("cannot create func argument");
     let args = FuncBackendStringArgs::new("starfield".to_string());
     let func_binding = FuncBinding::new(
         ctx,
@@ -86,7 +90,7 @@ async fn create_and_list_for_attribute_prototype(ctx: &DalContext) {
     let argument = AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *attribute_prototype.id(),
-        "title",
+        *func_arg.id(),
         *internal_provider.id(),
     )
     .await
@@ -103,7 +107,10 @@ async fn create_and_list_for_attribute_prototype(ctx: &DalContext) {
         panic!("expected empty: found attribute prototype arguments returned more results than expected");
     }
 
-    assert_eq!(found_argument.name(), argument.name());
+    assert_eq!(
+        found_argument.func_argument_id(),
+        argument.func_argument_id()
+    );
     assert_eq!(
         found_argument.internal_provider_id(),
         argument.internal_provider_id()

--- a/lib/dal/tests/integration_test/builtins/aws_region.rs
+++ b/lib/dal/tests/integration_test/builtins/aws_region.rs
@@ -74,7 +74,6 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
     // Finally, create the inter component connection.
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *ec2_explicit_internal_provider.id(),
         ec2_payload.component_id,
         *region_external_provider.id(),

--- a/lib/dal/tests/integration_test/builtins/coreos_butane.rs
+++ b/lib/dal/tests/integration_test/builtins/coreos_butane.rs
@@ -159,7 +159,6 @@ async fn connected_butane_is_valid_ignition(ctx: &DalContext) {
     // Perform the two connections.
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *butane_provider.id(),
         butane_payload.component_id,
         *alpine_provider.id(),
@@ -169,7 +168,6 @@ async fn connected_butane_is_valid_ignition(ctx: &DalContext) {
     .expect("could not connect providers for components");
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *butane_provider.id(),
         butane_payload.component_id,
         *nginx_provider.id(),

--- a/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
@@ -67,7 +67,6 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
     // Finally, create the inter component connection.
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *head_explicit_internal_provider.id(),
         head_deployment_payload.component_id,
         *tail_external_provider.id(),

--- a/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
@@ -152,7 +152,6 @@ async fn kubernetes_deployment_intelligence(ctx: &DalContext) {
     .expect("external provider not found");
     Edge::connect_providers_for_components(
         ctx,
-        "identity".to_string(),
         *head_deployment_spongebob_docker_image_provider.id(),
         head_deployment_spongebob_payload.component_id,
         *tail_fedora_provider.id(),
@@ -259,7 +258,6 @@ async fn kubernetes_deployment_intelligence(ctx: &DalContext) {
     .expect("external provider not found");
     Edge::connect_providers_for_components(
         ctx,
-        "identity".to_string(),
         *head_deployment_spongebob_docker_image_provider.id(),
         head_deployment_spongebob_payload.component_id,
         *tail_alpine_provider.id(),
@@ -279,7 +277,6 @@ async fn kubernetes_deployment_intelligence(ctx: &DalContext) {
     .expect("external provider not found");
     Edge::connect_providers_for_components(
         ctx,
-        "identity".to_string(),
         *head_deployment_kubernetes_namespace_provider.id(),
         head_deployment_spongebob_payload.component_id,
         *tail_namespace_provider.id(),
@@ -291,7 +288,6 @@ async fn kubernetes_deployment_intelligence(ctx: &DalContext) {
     // Finally, connect fedora to the squidward deployment.
     Edge::connect_providers_for_components(
         ctx,
-        "identity".to_string(),
         *head_deployment_squidward_docker_image_provider.id(),
         head_deployment_squidward_payload.component_id,
         *tail_fedora_provider.id(),

--- a/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -67,7 +67,6 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
     // Finally, create the inter component connection.
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *head_explicit_internal_provider.id(),
         head_deployment_payload.component_id,
         *tail_external_provider.id(),

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -209,7 +209,7 @@ async fn func_argument_list_for_func(ctx: &DalContext) {
     let funcs = FuncArgument::list_for_func(ctx, 1.into())
         .await
         .expect("Could not list func arguments for func");
-    assert_eq!(6, funcs.len());
+    assert_eq!(7, funcs.len());
 }
 
 #[test]

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -18,7 +18,8 @@ async fn new_external(ctx: &DalContext) {
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
         .expect("cannot set default schema variant");
-    let (func_id, func_binding_id, func_binding_return_value_id) = setup_identity_func(ctx).await;
+    let (func_id, func_binding_id, func_binding_return_value_id, _) =
+        setup_identity_func(ctx).await;
 
     let (external_provider, output_socket) = ExternalProvider::new_with_socket(
         ctx,
@@ -54,7 +55,8 @@ async fn new_implicit_internal(ctx: &DalContext) {
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
         .expect("cannot set default schema variant");
-    let (func_id, func_binding_id, func_binding_return_value_id) = setup_identity_func(ctx).await;
+    let (func_id, func_binding_id, func_binding_return_value_id, _) =
+        setup_identity_func(ctx).await;
 
     let (explicit_internal_provider, input_socket) = InternalProvider::new_explicit_with_socket(
         ctx,

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -45,8 +45,12 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     );
 
     // Collect the identity func information we need.
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        setup_identity_func(ctx).await;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        id_func_arg_id,
+    ) = setup_identity_func(ctx).await;
 
     // Setup the "esp" intra component update functionality from "source" to "intermediate".
     let intermediate_attribute_value = AttributeValue::find_for_context(
@@ -73,7 +77,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *intermediate_attribute_prototype.id(),
-        "identity",
+        id_func_arg_id,
         *source_internal_provider.id(),
     )
     .await
@@ -140,7 +144,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
         *esp_external_provider
             .attribute_prototype_id()
             .expect("no attribute prototype id for external provider"),
-        "identity",
+        id_func_arg_id,
         *esp_intermediate_internal_provider.id(),
     )
     .await
@@ -179,7 +183,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *swings_destination_attribute_prototype.id(),
-        "identity",
+        id_func_arg_id,
         *swings_explicit_internal_provider.id(),
     )
     .await
@@ -215,7 +219,6 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // Connect the two components.
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *swings_explicit_internal_provider.id(),
         swings_payload.component_id,
         *esp_external_provider.id(),
@@ -426,8 +429,12 @@ async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
 
 #[test]
 async fn with_deep_data_structure(ctx: &DalContext) {
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id) =
-        setup_identity_func(ctx).await;
+    let (
+        identity_func_id,
+        identity_func_binding_id,
+        identity_func_binding_return_value_id,
+        id_func_arg_id,
+    ) = setup_identity_func(ctx).await;
 
     let mut source_schema = create_schema(ctx, &SchemaKind::Configuration).await;
     let (source_schema_variant, source_root) =
@@ -482,7 +489,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
         *source_external_provider
             .attribute_prototype_id()
             .expect("no attribute prototype id for external provider"),
-        "identity",
+        id_func_arg_id,
         *source_internal_provider.id(),
     )
     .await
@@ -563,7 +570,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *destination_object_prototype.id(),
-        "identity",
+        id_func_arg_id,
         *destination_internal_provider.id(),
     )
     .await
@@ -627,7 +634,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
 
     Edge::connect_providers_for_components(
         ctx,
-        "identity",
         *destination_internal_provider.id(),
         *destination_component.id(),
         *source_external_provider.id(),

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -1,5 +1,6 @@
 use crate::dal::test;
 use dal::attribute::context::AttributeContextBuilder;
+use dal::func::argument::FuncArgument;
 use dal::func::binding::FuncBinding;
 use dal::provider::internal::InternalProvider;
 use dal::test_harness::{
@@ -174,6 +175,11 @@ async fn intra_component_identity_update(ctx: &DalContext) {
         .expect("could not find func by name attr")
         .pop()
         .expect("identity func not found");
+    let identity_func_identity_arg = FuncArgument::list_for_func(ctx, *identity_func.id())
+        .await
+        .expect("cannot list identity func args")
+        .pop()
+        .expect("cannot find identity func identity arg");
     let (_identity_func_binding, _identity_func_binding_return_value, _) =
         FuncBinding::find_or_create_and_execute(
             ctx,
@@ -199,7 +205,7 @@ async fn intra_component_identity_update(ctx: &DalContext) {
     let _argument = AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *destination_attribute_prototype.id(),
-        "identity",
+        *identity_func_identity_arg.id(),
         *source_internal_provider.id(),
     )
     .await

--- a/lib/sdf/src/server/service/dev/create_builtin_func.rs
+++ b/lib/sdf/src/server/service/dev/create_builtin_func.rs
@@ -53,7 +53,7 @@ pub async fn create_builtin_func(
         _ => Err(FuncError::FuncNotSupported)?,
     };
 
-    dal::builtins::func_persist(&func).await?;
+    dal::builtins::func_persist(&ctx, &func).await?;
 
     // Update the ctx with the account details for proper WS signaling
     ctx.update_from_request_context(request_ctx.build(request.visibility));

--- a/lib/sdf/src/server/service/dev/save_builtin_func.rs
+++ b/lib/sdf/src/server/service/dev/save_builtin_func.rs
@@ -51,7 +51,7 @@ pub async fn save_builtin_func(
     func.set_code_plaintext(&ctx, request.code.as_deref())
         .await?;
 
-    dal::builtins::func_persist(&func).await?;
+    dal::builtins::func_persist(&ctx, &func).await?;
 
     // Update the ctx with the account details for proper WS signaling
     ctx.update_from_request_context(request_ctx.build(request.visibility));


### PR DESCRIPTION
In order to simplify the logic for modifying function argument names and connecting them to attribute prototypes, I've refactored AttributePrototypeArguments to take a function argument id instead of a name string. Function argument names are controlled by the name on the func_arguments table. This also adds the ability to persist new function arguments for the builtins (not yet fully supported in the frontend).