### PR TITLE
chore(dal,bootstrap): add required runtime dep check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "url",
  "uuid",
  "veritech",
+ "which",
 ]
 
 [[package]]

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -42,6 +42,7 @@ tokio-stream = "0.1.3"
 url = "2.2.2"
 uuid = { version = "1.0.0", features = ["v4"] }
 veritech = { path = "../../lib/veritech", features = ["client"] }
+which = "4.3.0"
 
 [dev-dependencies]
 pretty_assertions_sorted = "1.1.2"

--- a/lib/dal/src/test.rs
+++ b/lib/dal/src/test.rs
@@ -18,6 +18,9 @@ use crate::{
     DalContext, JwtSecretKey, ServicesContext,
 };
 
+#[cfg(debug_assertions)]
+use crate::check_runtime_dependencies;
+
 pub mod helpers;
 
 const DEFAULT_PG_DBNAME: &str = "si_test";
@@ -332,6 +335,11 @@ async fn global_setup(test_context_builer: TestContextBuilder) {
 
     debug!("initializing crypto");
     sodiumoxide::init().expect("failed to init sodiumoxide crypto");
+
+    #[cfg(debug_assertions)]
+    debug!("checking for required runtime dependencies");
+    #[cfg(debug_assertions)]
+    check_runtime_dependencies().unwrap();
 
     let nats_subject_prefix = nats_subject_prefix();
 

--- a/lib/dal/tests/database.rs
+++ b/lib/dal/tests/database.rs
@@ -1,17 +1,16 @@
-use dal::{test::DalContextUniversalHeadRef, StandardModel, System};
+//! This module is useful for local usage (executing "cargo test database") after making extensive
+//! changes to queries and migrations. In addition, it alphabetically comes before
+//! "integration_test" so it’ll fail fast in CI, but please note: tests should never be reliant on
+//! order, this is more of a side benefit. Even if that benefit did not exist, tests from this
+//! module could still be good to look for in CI failures to reduce "developer WTF time"... but that
+//! also might not be too useful since you'll likely see a bunch of integration tests failing
+//! anyway.
+
+use dal::{test::DalContextUniversalHeadRef, StandardModel, System, SystemId};
 use si_test_macros::dal_test as test;
-
-// This module is useful for local usage (executing "cargo test database") after making extensive
-// changes to queries and migrations. In addition, it alphabetically comes before "integration_test"
-// so it’ll fail fast in CI, but please note: tests should never be reliant on order, this is more
-// of a side benefit. Even if that benefit did not exist, tests from this module could still be
-// good to look for in CI failures to reduce "developer WTF time"... but that also might not be
-// too useful since you'll likely see a bunch of integration tests failing anyway.
-
-const UNSET_ID_VALUE: i64 = -1;
 
 /// Smoke test to ensure the database is running and setup worked (migrations, etc.).
 #[test]
 async fn database_smoke(DalContextUniversalHeadRef(ctx): DalContextUniversalHeadRef<'_>) {
-    assert!(System::get_by_id(ctx, &UNSET_ID_VALUE.into()).await.is_ok())
+    assert!(System::get_by_id(ctx, &SystemId::NONE).await.is_ok())
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -61,6 +61,7 @@ function darwin-bootstrap {
         awscli
         bash
         butane
+        coreutils
         git
         kubeval
         libtool
@@ -202,19 +203,21 @@ function install-butane-linux-amd64 {
 }
 
 function check-binaries {
-    local binaries=(
-        butane
-        cargo
-        docker
-        docker-compose
-        kubeval
-        node
-        npm
-        protoc
-        skopeo
-    )
+    # Ensure we can get the absolute path of the required binaries file.
+    REALPATH=realpath
+    if [ ! "$(command -v realpath)" ]; then
+        REALPATH=grealpath
+        if [ ! "$(command -v grealpath)" ]; then
+            die "realpath or grealpath must be installed and in PATH (from GNU coreutils)"
+        fi
+    fi
 
-    for binary in "${binaries[@]}"; do
+    # Get the binaries from the file.
+    SCRIPT_DIR=$(dirname $(${REALPATH} -s "$0"));
+    BINARIES=$(cat $SCRIPT_DIR/data/required-binaries.txt)
+
+    # Check if each required binary in PATH.
+    for binary in $BINARIES; do
         if ! [ "$(command -v ${binary})" ]; then
             die "\"$binary\" must be installed and in PATH"
         fi

--- a/scripts/data/required-binaries.txt
+++ b/scripts/data/required-binaries.txt
@@ -1,0 +1,9 @@
+butane
+cargo
+docker
+docker-compose
+kubeval
+node
+npm
+protoc
+skopeo


### PR DESCRIPTION
## Description

Tests failing because you haven't ran the bootstrapper in a few months? _Worry no more._

With ~1ms runtime, the new dependency check function is here to the rescue.

## Disclaimer

This PR also adds the [which](https://crates.io/crates/which) crate. Yes, `Command::new()` logic works too with an `io::ErrorKind::NotFound` check, but this library checks for edge cases and is preferable as a result.

Relevant: https://github.com/rust-lang-nursery/rust-cookbook/issues/117#issuecomment-302301165

## Commit Description

Primary:
- Add required runtime dependency check (in dev mode only)
- Split out required dependencies from bootstrapper into its own file
- Ensure the check is ran in dev mode in two places: dal initalization
  and global test setup

Misc:
- Tidy up database smoke module

## Linear

Fixes ENG-590