### PR TITLE
chore(dal): add Clippy lint to catch `commit_and_continue` usage

### DIFF
--- a/lib/dal/clippy.toml
+++ b/lib/dal/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "dal::test::helpers::commit_and_continue", reason = "should not be left in tests as this could infect other tests" }
+]


### PR DESCRIPTION
This change adds a specific Clippy lint warning when, as a developer, I forget to remove a call to `commit_and_continue()` in an integration test.

Ideally we shouldn't be committing tests with this call as a database commit could infect the correctness of other tests. A warning will be shown with these calls and in CI all warnings are flipped to errors.

<img src="https://media1.giphy.com/media/nR4L10XlJcSeQ/giphy.gif"/>
