### PR TITLE
fix(web): fix selectmenu overflow bug in modals and FuncDetails

### DIFF
--- a/app/web/src/organisms/ChangeSetPanelDialog.vue
+++ b/app/web/src/organisms/ChangeSetPanelDialog.vue
@@ -29,7 +29,7 @@
             leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
             <DialogPanel
-              class="relative transform overflow-hidden rounded-md bg-shade-0 text-neutral-900 text-left shadow-xl transition-all dark:bg-neutral-800 dark:text-neutral-50 sm:w-full sm:max-w-sm"
+              class="relative transform rounded-md bg-shade-0 text-neutral-900 text-left shadow-xl transition-all dark:bg-neutral-800 dark:text-neutral-50 sm:w-full sm:max-w-sm"
             >
               <DialogTitle
                 as="h3"

--- a/app/web/src/organisms/FuncEditor/FuncDetails.vue
+++ b/app/web/src/organisms/FuncEditor/FuncDetails.vue
@@ -11,7 +11,7 @@
         </SiTabHeader>
       </template>
       <template #panels>
-        <TabPanel class="overflow-auto grow">
+        <TabPanel class="grow">
           <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
             <VButton
               :disabled="!isDevMode && editingFunc.isBuiltin"

--- a/app/web/src/organisms/FuncEditor/func_state.ts
+++ b/app/web/src/organisms/FuncEditor/func_state.ts
@@ -59,7 +59,7 @@ export const removeAttributePrototype = (
     return;
   }
 
-  // This is code duplicatey but we need to narrow the type heret
+  // This is code duplicatey but we need to narrow the type here
   const currentFunc = funcState.funcs[currentFuncIdx];
   if (currentFunc.associations?.type !== "attribute") {
     return;

--- a/app/web/src/ui-lib/Modal.vue
+++ b/app/web/src/ui-lib/Modal.vue
@@ -42,7 +42,7 @@
               </div>
 
               <div
-                class="py-1 px-2 border-t dark:border-black flex flex-col place-content-center overflow-hidden"
+                class="py-1 px-2 border-t dark:border-black flex flex-col place-content-center"
               >
                 <slot name="content" />
 
@@ -94,7 +94,7 @@ import {
   DialogTitle,
   TransitionChild,
   TransitionRoot,
-} from "@headlessui/vue";
+} from "@headlessui/vue"
 import { PropType, computed } from "vue";
 import VButton from "@/molecules/VButton.vue";
 
@@ -122,7 +122,7 @@ const dialogPanelClasses = computed(() => {
   if (props.size === "xl") size = "max-w-xl";
   if (props.size === "2xl") size = "max-w-2xl";
 
-  return `${size} w-full transform overflow-hidden rounded bg-white dark:bg-neutral-900 text-left align-middle shadow-xl transition-all text-black dark:text-white`;
+  return `${size} w-full transform rounded bg-white dark:bg-neutral-900 text-left align-middle shadow-xl transition-all text-black dark:text-white`;
 });
 
 const emit = defineEmits<{


### PR DESCRIPTION
![overflow](https://user-images.githubusercontent.com/1928978/193919518-b4d69870-718f-4e8f-8a1c-dc02be30f48d.gif)

Fixes SelectMenu being obscured by parent container in a few cases.