### PR TITLE
feat(dal): add aws key pair commands for "fixes"

### DIFF
--- a/docs/ops/CONFIGURING_AWS_CLI.md
+++ b/docs/ops/CONFIGURING_AWS_CLI.md
@@ -24,4 +24,6 @@ passing the following responses to each prompt:
 - Default region name: `us-east-2`
 - Default output format: Leave empty
 
+> The title of the **1password** item is "Amazon SI Production".
+
 

--- a/lib/dal/src/builtins/func/awsCreateKeyPairCommand.js
+++ b/lib/dal/src/builtins/func/awsCreateKeyPairCommand.js
@@ -1,0 +1,58 @@
+async function createKeyPair(component_view) {
+    console.log(component_view);
+
+    // TODO(nick): these checks should be removed once "all qualifications must pass before fixing" is implemented.
+    const region = component_view.data.properties.region;
+    if (region === undefined || region === null || region === "") {
+        throw new Error("region must be set");
+    }
+    const keyName = component_view.data.properties.keyName;
+    if (keyName === undefined || keyName === null || keyName === "") {
+        throw new Error("keyName must be set");
+    }
+    const keyType = component_view.data.properties.keyType;
+    if (keyType === undefined || keyType === null || keyType === "") {
+        throw new Error("keyType must be set");
+    }
+    const tags = component_view.data.properties.tags;
+
+    // Initialize the input JSON.
+    let jsonBuilder = {
+        "KeyName": `"${keyName}"`,
+        "KeyType": `"${keyType}"`
+    };
+
+    // Add tags to the input JSON if we find any.
+    let jsonTagsBuilder = [];
+    for (const key of tags) {
+        jsonTagsBuilder.push({
+            "Key": `"${key}"`,
+            "Value": `"${tags[key]}"`,
+        })
+    }
+    if (jsonTagsBuilder.length > 0) {
+        jsonBuilder["TagSpecifications"] = [
+            {
+                "Tags": jsonTagsBuilder
+            }
+        ];
+    }
+
+    // Now, create the key pair.
+    const cliInputJson = JSON.stringify(jsonBuilder);
+    const child = await siExec.waitUntilEnd("aws", [
+        "ec2",
+        "create-key-pair",
+        "--region",
+        region,
+        "--cli-input-json",
+        `'${cliInputJson}'`
+    ]);
+    if (child.exitCode !== 0) {
+        throw new Error(child.stderr);
+    }
+
+    // We will likely want the "KeyPairId" field off the output.
+    console.log(child.stdout);
+    return JSON.parse(child.stdout);
+}

--- a/lib/dal/src/builtins/func/awsCreateKeyPairCommand.json
+++ b/lib/dal/src/builtins/func/awsCreateKeyPairCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "awsCreateKeyPairCommand.js",
+  "code_entrypoint": "createKeyPair"
+}

--- a/lib/dal/src/builtins/func/awsCreateTagsForKeyPairCommand.js
+++ b/lib/dal/src/builtins/func/awsCreateTagsForKeyPairCommand.js
@@ -1,0 +1,53 @@
+async function createTagsForKeyPair(component_view) {
+    console.log(component_view);
+
+    // TODO(nick): these checks should be removed once "all qualifications must pass before fixing" is implemented.
+    const region = component_view.data.properties.region;
+    if (region === undefined || region === null || region === "") {
+        throw new Error("region must be set");
+    }
+    const tags = component_view.data.properties.tags;
+    if (tags === undefined || tags === null || tags.length < 1) {
+        throw new Error("at least one tag must exist");
+    }
+    const resources = component_view.data.resources;
+    if (resources === undefined || resources === null || resources.length < 1) {
+        // The "--resources" flag is required.
+        throw new Error("at least one resource must exist");
+    }
+
+    // Gather all AWS tags via the SI component properties.
+    let cliInputJsonTags = [];
+    for (const key of tags) {
+        cliInputJsonTags.push({
+            "Key": `${key}`,
+            "Value": `${tags[key]}`,
+        })
+    }
+    const cliInputJson = JSON.stringify(cliInputJsonTags);
+
+    // Gather all AWS resources via the SI resources.
+    let spaceSeperatedAwsResources = "";
+    for (const resource of resources) {
+        if (spaceSeperatedAwsResources === "") {
+            spaceSeperatedAwsResources = `"${resources.data["KeyPairId"]}"`;
+        } else {
+            spaceSeperatedAwsResources = `${spaceSeperatedAwsResources} "${resources.data["KeyPairId"]}"`;
+        }
+    }
+
+    // Now, create all tags for all resources.
+    const child = await siExec.waitUntilEnd("aws", [
+        "ec2",
+        "create-tags",
+        "--region",
+        region,
+        "--resources",
+        spaceSeperatedAwsResources,
+        "--cli-input-json",
+        cliInputJson
+    ]);
+    if (child.exitCode !== 0) {
+        throw new Error(child.stderr);
+    }
+}

--- a/lib/dal/src/builtins/func/awsCreateTagsForKeyPairCommand.json
+++ b/lib/dal/src/builtins/func/awsCreateTagsForKeyPairCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "awsCreateTagsForKeyPairCommand.js",
+  "code_entrypoint": "createTagsForKeyPair"
+}

--- a/lib/dal/src/builtins/func/awsDeleteKeyPairCommand.js
+++ b/lib/dal/src/builtins/func/awsDeleteKeyPairCommand.js
@@ -1,0 +1,30 @@
+async function deleteKeyPair(component_view) {
+    console.log(component_view);
+
+    // TODO(nick): these checks should be removed once "all qualifications must pass before fixing" is implemented.
+    const region = component_view.data.properties.region;
+    if (region === undefined || region === null || region === "") {
+        throw new Error("region must be set");
+    }
+    const resources = component_view.data.resources;
+
+    // Delete each key pair (should only be one since we are bound by region).
+    // If there are no resources, we do nothing.
+    let child_errors = [];
+    for (const resource of resources) {
+        const child = await siExec.waitUntilEnd("aws", [
+            "ec2",
+            "delete-key-pair",
+            "--region",
+            region,
+            "--key-pair-id",
+            `${resources.data["KeyPairId"]}`,
+        ]);
+        if (child.exitCode !== 0) {
+            child_errors.push(child.stderr);
+        }
+    }
+    if (child_errors.length > 0) {
+        throw new Error(JSON.stringify(child_errors));
+    }
+}

--- a/lib/dal/src/builtins/func/awsDeleteKeyPairCommand.json
+++ b/lib/dal/src/builtins/func/awsDeleteKeyPairCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "awsDeleteKeyPairCommand.js",
+  "code_entrypoint": "deleteKeyPair"
+}

--- a/lib/dal/src/builtins/func/awsDeleteTagsForKeyPairCommand.js
+++ b/lib/dal/src/builtins/func/awsDeleteTagsForKeyPairCommand.js
@@ -1,0 +1,76 @@
+async function deleteTagsForKeyPair(component_view) {
+    console.log(component_view);
+
+    // TODO(nick): these checks should be removed once "all qualifications must pass before fixing" is implemented.
+    const region = component_view.data.properties.region;
+    if (region === undefined || region === null || region === "") {
+        throw new Error("region must be set");
+    }
+    const resources = component_view.data.resources;
+    if (resources === undefined || resources === null || resources.length < 1) {
+        // The "--resources" flag is required and the tag will not exist for resources
+        // corresponding to this component if the resources do not exist. It's like a
+        // reference counter: no resources, no tags for that resource. Thus, we fail
+        // here instead of returning early or proceeding with intent to "do nothing".
+        throw new Error("at least one resource must exist");
+    }
+
+    const componentTags = component_view.data.properties.tags;
+    if (componentTags !== undefined && componentTags !== null && componentTags.length > 0) {
+        // If there are tags, let's delete tags on a "per resource" basis. We do this because not all resources will
+        // necessarily match the model.
+        for (const resource of resources) {
+            const resourceTags = resources.data["Tags"];
+
+            // Only delete tags that do not exist in the "componentTags", but _do_ exist on the resource.
+            const tagsToDelete = resourceTags.filter(resourceTag => !componentTags.some(componentTag => componentTag["Key"] === resourceTag["Key"]));
+
+            let jsonTagsBuilder = [];
+            for (const key of tagsToDelete) {
+                jsonTagsBuilder.push({
+                    "Key": `${key}`,
+                    "Value": `${resourceTags[key]}`,
+                })
+            }
+            const cliInputJson = JSON.stringify({
+                "Tags": jsonTagsBuilder
+            });
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "ec2",
+                "delete-tags",
+                "--region",
+                region,
+                "--resources",
+                `${resources.data["KeyPairId"]}`,
+                "--cli-input-json",
+                cliInputJson
+            ]);
+            if (child.exitCode !== 0) {
+                throw new Error(child.stderr);
+            }
+        }
+    } else {
+        // Otherwise, the component tags are empty, and we can delete them all.
+        let spaceSeperatedAwsResources = "";
+        for (const resource of resources) {
+            if (spaceSeperatedAwsResources === "") {
+                spaceSeperatedAwsResources = `"${resources.data["KeyPairId"]}"`;
+            } else {
+                spaceSeperatedAwsResources = `${spaceSeperatedAwsResources} "${resources.data["KeyPairId"]}"`;
+            }
+        }
+
+        const child = await siExec.waitUntilEnd("aws", [
+            "ec2",
+            "delete-tags",
+            "--region",
+            region,
+            "--resources",
+            spaceSeperatedAwsResources,
+        ]);
+        if (child.exitCode !== 0) {
+            throw new Error(child.stderr);
+        }
+    }
+}

--- a/lib/dal/src/builtins/func/awsDeleteTagsForKeyPairCommand.json
+++ b/lib/dal/src/builtins/func/awsDeleteTagsForKeyPairCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "awsDeleteTagsForKeyPairCommand.js",
+  "code_entrypoint": "deleteTagsForKeyPair"
+}

--- a/lib/dal/src/builtins/schema/aws.rs
+++ b/lib/dal/src/builtins/schema/aws.rs
@@ -282,7 +282,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     let ui_menu = SchemaUiMenu::new(ctx, "EC2 Instance", "AWS", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
-    // Prop and validation creation
+    // Prop: /root/domain/ImageId
     let image_id_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "ImageId",
@@ -305,6 +305,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/InstanceType
     let instance_type_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "InstanceType",
@@ -329,6 +330,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/KeyName
     let key_name_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "KeyName",
@@ -339,6 +341,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/SecurityGroupIds
     let security_groups_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "SecurityGroupIds",
@@ -349,6 +352,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/SecurityGroupIds/SecurityGroupId
     let _security_group_id_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "SecurityGroupId",
@@ -359,6 +363,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/tags
     let tags_map_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "tags",
@@ -370,6 +375,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
 
     // TODO(victor): Make one item of the list have key `Name` and value equal to /root/si/name
+    // Prop: /root/domain/tags/tag
     let _tags_map_item_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "tag",
@@ -380,6 +386,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/UserData
     let _user_data_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "UserData",
@@ -390,6 +397,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/awsResourceType
     let aws_resource_type_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "awsResourceType",
@@ -400,6 +408,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/region
     let region_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "region",
@@ -832,7 +841,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     let ui_menu = SchemaUiMenu::new(ctx, "Key Pair", "AWS", &diagram_kind).await?;
     ui_menu.set_schema(ctx, schema.id()).await?;
 
-    // Prop Creation
+    // Prop: /root/domain/KeyName
     let key_name_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "KeyName",
@@ -843,6 +852,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/KeyType
     let _key_type_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "KeyType",
@@ -853,6 +863,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/tags
     let tags_map_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "tags",
@@ -863,6 +874,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/tags/tag
     let _tags_map_item_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "tag",
@@ -873,6 +885,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/awsResourceType
     let aws_resource_type_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "awsResourceType",
@@ -883,6 +896,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
+    // Prop: /root/domain/region
     let region_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
         "region",


### PR DESCRIPTION
This PR adds AWS Key Pair commands for the upcoming "fix" functionality. This PR doesn't not affect SI other than loading in unused builtins. In essences, these functions are entirely unused at the moment.

Normally, I'd avoid checking in "dead code", but this was part of a minor research spike / acclimation-to-"fixing"-resources and this is a good stopping point. We'll be using these functions soon.

Fixes ENG-598