### PR TITLE
chore(dal): extend cyclone bin canonicalization error message

### DIFF
--- a/lib/dal/src/test.rs
+++ b/lib/dal/src/test.rs
@@ -23,6 +23,13 @@ use crate::check_runtime_dependencies;
 
 pub mod helpers;
 
+#[cfg(debug_assertions)]
+pub const CANONICALIZE_CYCLONE_BIN_PATH_ERROR_MESSAGE: &str =
+    "failed to canonicalize cyclone bin path (you likely need to build cyclone: cargo build --bin cyclone)";
+#[cfg(not(debug_assertions))]
+pub const CANONICALIZE_CYCLONE_BIN_PATH_ERROR_MESSAGE: &str =
+    "failed to canonicalize cyclone bin path";
+
 const DEFAULT_PG_DBNAME: &str = "si_test";
 
 const ENV_VAR_NATS_URL: &str = "SI_TEST_NATS_URL";
@@ -290,7 +297,7 @@ pub async fn veritech_server_for_uds_cyclone(
             .try_cyclone_cmd_path(
                 dir.join("../../target/debug/cyclone")
                     .canonicalize()
-                    .expect("failed to canonicalize cyclone bin path")
+                    .expect(CANONICALIZE_CYCLONE_BIN_PATH_ERROR_MESSAGE)
                     .to_string_lossy()
                     .to_string(),
             )

--- a/lib/dal/src/test_harness.rs
+++ b/lib/dal/src/test_harness.rs
@@ -8,6 +8,7 @@ use si_data::{NatsClient, NatsConfig, PgPool, PgPoolConfig};
 use uuid::Uuid;
 use veritech::{EncryptionKey, Instance, StandardConfig};
 
+use crate::test::CANONICALIZE_CYCLONE_BIN_PATH_ERROR_MESSAGE;
 use crate::{
     billing_account::BillingAccountSignup,
     component::ComponentKind,
@@ -154,7 +155,7 @@ async fn veritech_server_for_uds_cyclone(
             .try_cyclone_cmd_path(
                 dir.join("../../target/debug/cyclone")
                     .canonicalize()
-                    .expect("failed to canonicalize cyclone bin path")
+                    .expect(CANONICALIZE_CYCLONE_BIN_PATH_ERROR_MESSAGE)
                     .to_string_lossy()
                     .to_string(),
             )


### PR DESCRIPTION
Extend cyclone bin canonicalization error message to provide more context on the user likely needs to do. The message has only been extended in "dev" mode since the error is sufficient and succinct for production.