### PR TITLE
fix(web): WorkspaceCustomize expects funcId param to be prop

### DIFF
--- a/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
@@ -67,10 +67,10 @@ import { clearFuncs, updateFuncFromSave } from "../FuncEditor/func_state";
 
 const isDevMode = import.meta.env.DEV;
 
-const props = defineProps<{ funcId?: string }>();
+const props = defineProps<{ funcId?: number }>();
 
 const selectedFuncId = computed(() => {
-  const funcId = parseInt(props.funcId ?? "");
+  const funcId = props.funcId ?? -1;
   if (Number.isNaN(funcId)) {
     return -1;
   }

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -68,6 +68,7 @@ const routes: RouteRecordRaw[] = [
         path: ":changeSetId/l/:funcId?",
         name: "workspace-lab",
         component: () => import("@/organisms/Workspace/WorkspaceCustomize.vue"),
+        props: castNumberProps,
       },
       {
         path: "v",


### PR DESCRIPTION
WorkspaceCustomize is built to expect the params to be turned into props on the component. This feels right to me, but I'm open to using `useRoute` to get the params instead. However, we can make that a future improvement if it seems called for. For now, let's get the FuncEditor working again by restoring the `props: true` flag.