### PR TITLE
bug(web,cyclone): fix small regressions

### DIFF
--- a/app/web/src/observable/visibility.ts
+++ b/app/web/src/observable/visibility.ts
@@ -10,7 +10,7 @@ import { tag } from "rxjs-spy/operators/tag";
 
 import { switchMap } from "rxjs/operators";
 import { NO_CHANGE_SET_PK, Visibility } from "@/api/sdf/dal/visibility";
-import { changeSet$ } from "@/service/change_set";
+import { changeSet$, eventChangeSetWritten$ } from "@/service/change_set";
 
 export const visibility$: Observable<Visibility> = combineLatest([
   changeSet$,
@@ -28,5 +28,5 @@ export const visibility$: Observable<Visibility> = combineLatest([
 
 export const standardVisibilityTriggers$ = combineLatest([
   visibility$,
-  changeSet$,
+  eventChangeSetWritten$,
 ]).pipe(tag("standard-visibility"), shareReplay(1));

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
@@ -400,9 +400,10 @@ impl LocalHttpInstanceSpec {
         if self.qualification {
             cmd.arg("--enable-qualification");
         }
-        if self.confirmation {
-            cmd.arg("--enable-confirmation");
-        }
+        // NOTE: Not yet implemented on the other side.
+        // if self.confirmation {
+        //     cmd.arg("--enable-confirmation");
+        // }
         if self.resolver {
             cmd.arg("--enable-resolver");
         }

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -412,9 +412,10 @@ impl LocalUdsInstanceSpec {
         if self.qualification {
             cmd.arg("--enable-qualification");
         }
-        if self.confirmation {
-            cmd.arg("--enable-confirmation");
-        }
+        // NOTE: Not implemented yet on the other side.
+        //if self.confirmation {
+        //    cmd.arg("--enable-confirmation");
+        //}
         if self.resolver {
             cmd.arg("--enable-resolver");
         }


### PR DESCRIPTION
The work to switch to Pinia stores rather than RxJS missed sending the eventChangeSetWritten$ to standardVisibility$ - the result was that the UI was not refreshing appropriately in many cases when work was done on the server side. There were previously a few other events that were also included in standard visibility; I believe they are not being used in the current version of the UI, but it's hard to say for certain without a deeper analysis than time warrants.

There is also a small fix to disable sending the `--enable-confirmations` flag to cyclone, as it appears to not be enabled in cyclone itself. This makes qualifications run to completion again, rather than generate an error.

<img src="https://media4.giphy.com/media/XHcw3cqlZrWO5ke2CV/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>