### PR TITLE
chore(bootstrap): add pop os to environments

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -17,11 +17,12 @@ information.
 
 | Environment | `x84_64 (amd64)` | `aarch64 (arm64)` |
 |-------------|------------------|-------------------|
-| Arch Linux  | ✅                | 🚫                |
-| Fedora      | ✅                | 🚫                |
-| macOS       | ✅                | ✅                 |
-| Ubuntu      | ✅                | 🚫                |
-| WSL2        | ✅                | 🚫                |
+| Arch Linux  | ✅               | 🚫                |
+| Fedora      | ✅               | 🚫                |
+| macOS       | ✅               | ✅                |
+| Pop!_OS     | ✅               | 🚫                |
+| Ubuntu      | ✅               | 🚫                |
+| WSL2        | ✅               | 🚫                |
 
 We recommend using the latest stable Rust toolchain and latest LTS Node toolchain for your environment.
 If unsure, the following tools are recommended to help manage your toolchains:


### PR DESCRIPTION
Upgraded my Thelio Major R2 to Pop!_OS 22.04 LTS (from Fedora 36).