### PR TITLE
feat(deploy,bootstrap): switch from docker compose v1 to v2

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -104,7 +104,7 @@ passing the following responses to each prompt:
 ### Checking for Potential Service Conflicts (3/5)
 
 SI uses external services in conjunction with its native components.
-These external services are deployed via `docker-compose` and are configured to stick to their default settings as
+These external services are deployed via [`docker compose`](https://docs.docker.com/compose/) and are configured to stick to their default settings as
 closely as possible, including port settings.
 Thus, it is worth checking if you are running these services to avoid conflicts when running SI.
 Potentially conflicting services include, but are not limited to, the following:

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -12,7 +12,7 @@ boostrap:
 # This target does not compose down beforehand.
 partial: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose \
+		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 		up -d nats pg otel faktory
@@ -21,7 +21,7 @@ partial: init
 # local development and testing.
 dev: down init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose \
+		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 		up
@@ -30,7 +30,7 @@ dev: down init
 # This is the target to run in production.
 prod: init
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
-		docker-compose \
+		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 		up -d
@@ -39,7 +39,7 @@ web: init
 	# REPOPATH=$(REPOPATH) $(MAKEPATH)/scripts/check-for-artifacts-before-mounting.sh
 	$(MAKEPATH)/scripts/generate-ci-yml.sh $(CI_FROM_REF) $(CI_TO_REF)
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) REPOPATH=$(REPOPATH) \
-		docker-compose \
+		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.ci.yml \
@@ -48,18 +48,18 @@ web: init
 ci: init
 	REPOPATH=$(REPOPATH) $(MAKEPATH)/scripts/check-for-artifacts-before-mounting.sh
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) REPOPATH=$(REPOPATH) \
-		docker-compose \
+		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.ci.yml \
 		up -d
 
 down:
-	-docker-compose -f $(MAKEPATH)/docker-compose.yml \
+	-docker compose -f $(MAKEPATH)/docker-compose.yml \
 		down
 
 init:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
-	docker-compose -f $(MAKEPATH)/docker-compose.yml pull
+	docker compose -f $(MAKEPATH)/docker-compose.yml pull

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 
-# NOTE(nick): "depends_on" will start parent containers when using docker-compose run, so we should
+# NOTE(nick): "depends_on" will start parent containers when using `docker compose` run, so we should
 # try to only use it when necessary.
 
 services:

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -28,13 +28,16 @@ function verify-fedora {
 function install-docker {
     dnf -y install dnf-plugins-core
     dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-    dnf install -y docker-ce docker-ce-cli containerd.io docker-compose
+    dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     systemctl start docker
     systemctl enable docker
     docker run hello-world
 }
 
 verify-fedora
-if [ ! "$(command -v docker)" ] || [ ! "$(command -v docker-compose)" ]; then
+if [ ! "$(command -v docker)" ]; then
+    install-docker
+fi
+if ! eval "docker compose version" > /dev/null; then
     install-docker
 fi

--- a/docs/ci/GITHUB_ACTIONS_CUSTOM_RUNNER.md
+++ b/docs/ci/GITHUB_ACTIONS_CUSTOM_RUNNER.md
@@ -15,7 +15,7 @@ sudo hostnamectl set-hostname ci-2
 sudo dnf -y upgrade
 sudo dnf -y install @development-tools nvme-cli lld clang cmake openssl libev libevent jq dnf-plugins-core make git lld skopeo wget butane golang-github-instrumenta-kubeval
 sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-compose
+sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 sudo systemctl start docker
 sudo systemctl enable docker
 ```

--- a/docs/ops/PRODUCTION.md
+++ b/docs/ops/PRODUCTION.md
@@ -14,7 +14,7 @@ You can log in interactively with:
 ssh fedora@prod-1
 ```
 
-The environment is running via [docker-compose](https://docs.docker.com/compose/) out of the `deploy` directory.
+The environment is running via [`docker compose`](https://docs.docker.com/compose/) out of the `deploy` directory.
 
 ## Updates
 

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -1,5 +1,8 @@
 //! The Data Access Layer (DAL) for System Initiative.
 
+use std::collections::VecDeque;
+use std::io;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 use rand::Rng;
@@ -198,11 +201,17 @@ pub use ws_event::{WsEvent, WsEventError, WsPayload};
 
 #[cfg(debug_assertions)]
 const REQUIRED_BINARIES: &str = include_str!("../../../scripts/data/required-binaries.txt");
+#[cfg(debug_assertions)]
+const REQUIRED_COMMANDS: &str = include_str!("../../../scripts/data/required-commands.txt");
 
 #[derive(Error, Debug)]
 pub enum InitializationError {
-    #[error("missing required runtime dependencies: {0:?}")]
-    MissingRequiredRuntimeDependencies(Vec<&'static str>),
+    #[error("command not found from parts: {0:?}")]
+    CommandNotFoundFromParts(Vec<&'static str>),
+    #[error(
+        "missing required runtime dependencies ({0:?}) and/or required commands failed ({1:?})"
+    )]
+    MissingRequiredRuntimeDependencies(Vec<&'static str>, Vec<(&'static str, io::Error)>),
     #[error("failed to initialize sodium oxide")]
     SodiumOxide,
 }
@@ -224,14 +233,31 @@ pub fn init() -> InitializationResult<()> {
 #[cfg(debug_assertions)]
 pub fn check_runtime_dependencies() -> InitializationResult<()> {
     let mut missing_binaries = Vec::new();
+    let mut failed_commands = Vec::new();
+
     for binary in REQUIRED_BINARIES.lines() {
         if which::which(binary).is_err() {
             missing_binaries.push(binary);
         }
     }
+    for command in REQUIRED_COMMANDS.lines() {
+        let mut parts = command.split(' ').collect::<VecDeque<&str>>();
+        let command = parts.pop_front().ok_or_else(|| {
+            InitializationError::CommandNotFoundFromParts(Vec::from(parts.clone()))
+        })?;
+        if let Err(e) = Command::new(command)
+            .args(parts)
+            .stdout(Stdio::null())
+            .spawn()
+        {
+            failed_commands.push((command, e))
+        }
+    }
+
     if !missing_binaries.is_empty() {
         return Err(InitializationError::MissingRequiredRuntimeDependencies(
             missing_binaries,
+            failed_commands,
         ));
     }
     Ok(())

--- a/scripts/data/required-binaries.txt
+++ b/scripts/data/required-binaries.txt
@@ -1,7 +1,6 @@
 butane
 cargo
 docker
-docker-compose
 kubeval
 node
 npm

--- a/scripts/data/required-commands.txt
+++ b/scripts/data/required-commands.txt
@@ -1,0 +1,1 @@
+docker compose version

--- a/support/dev/demo-build.sh
+++ b/support/dev/demo-build.sh
@@ -6,6 +6,7 @@ main() {
   if [ -n "${DEBUG:-}" ]; then set -v; fi
   if [ -n "${TRACE:-}" ]; then set -xv; fi
 
+  # NOTE(nick): we are now using "docker compose v2", so I am unsure if this works.
   set -x
   env \
     DOCKER_BUILDKIT=1 \


### PR DESCRIPTION
## Commit Description

Primary:
- Switch from docker compose v1 ("docker-compose" separate Python script) to docker compose v2 ("docker compose" subcommand delivered as a plugin)
- Ensure "commands" are validated before running SI and in the bootstrapper

Secondary:
- Add node installation to pop-os in bootstrapper
- Ensure node LTS check is generic

## What do I need to do to ensure I have `docker compose` v2?

Two answers...

### Short Version

Run `./scripts/bootstrap.sh` or `docker compose version` once this PR has been merged to see if your system has `docker compose` v2.

### Long Version

Once this is available on `main` , you should run the following command:

```bash
docker compose version
```

Note how the hyphen has been removed. If this command returns something like "Docker Compose version v2.x.x", then you are good.

If that did not happen, see the following for your environment(s):

- **macOS:** you don't need to do anything. Docker Desktop comes with docker compose v2. However, you may want to uninstall v1 since you will not need it anymore (`brew uninstall docker-compose`).
- **WSL2 with Docker Desktop:** I believe this is generic for most distros (GNU userspace, etc.), so I also believe you will have docker compose v2 already, just like macOS.
- **Linux distros with Docker Desktop:** same as WSL2 with Docker Desktop, but, again, I'm unsure since I only use Docker Desktop on Windows and macOS.
- **Ubuntu/Pop with Docker Engine:** you will likely need to install the plugin. Assuming you have installed Docker Engine via the official Docker docs, you can run the following: `sudo apt install -y docker-compose-plugin`.
- **Fedora with Docker Engine:** same as Ubuntu/Pop: `sudo dnf install -y docker-compose-plugin`.
I did this for our CI and production instances.
- **Arch with Docker Engine:** there are a ton of variables, including if you did an AUR install. I assume if you are on Arch, you'll know how to install the plugin for your environment better than me.

Essentially, you want to ensure `docker compose version` works and `docker-compose` is uninstalled. Please let me know if you have any questions!

## GIF and Linear

<img src="https://media0.giphy.com/media/gp3tvIHTheXPW/giphy.gif"/>

Fixes ENG-623