### PR TITLE
feat(sdf,web): command func crud

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -4,6 +4,7 @@ export enum FuncBackendKind {
   Identity = "Identity",
   Integer = "Integer",
   JsQualification = "JsQualification",
+  JsCommand = "JsCommand",
   JsConfirmation = "JsConfirmation",
   JsCodeGeneration = "JsCodeGeneration",
   JsAttribute = "JsAttribute",

--- a/app/web/src/organisms/FuncEditor/FuncPicker.vue
+++ b/app/web/src/organisms/FuncEditor/FuncPicker.vue
@@ -171,8 +171,9 @@ const onSearch = (search: string) => {
 const funcTypes = {
   [FuncBackendKind.JsQualification]: "Qualifications",
   [FuncBackendKind.JsAttribute]: "Attributes",
-  [FuncBackendKind.JsCodeGeneration]: "Code Generation",
-  [FuncBackendKind.JsConfirmation]: "Confirmation",
+  [FuncBackendKind.JsCodeGeneration]: "Code Generators",
+  [FuncBackendKind.JsConfirmation]: "Confirmations",
+  [FuncBackendKind.JsCommand]: "Commands",
 };
 
 const funcCreateTypes = {
@@ -180,6 +181,7 @@ const funcCreateTypes = {
   [FuncBackendKind.JsAttribute]: "Attribute",
   [FuncBackendKind.JsCodeGeneration]: "Code Generation",
   [FuncBackendKind.JsConfirmation]: "Confirmation",
+  [FuncBackendKind.JsCommand]: "Command",
 };
 
 const filteredList = computed(() =>

--- a/lib/sdf/src/server/service/func/defaults/command.ts
+++ b/lib/sdf/src/server/service/func/defaults/command.ts
@@ -1,0 +1,3 @@
+async function command() {
+    throw new Error("unimplemented!");
+}

--- a/lib/sdf/src/server/service/func/list_funcs.rs
+++ b/lib/sdf/src/server/service/func/list_funcs.rs
@@ -41,6 +41,7 @@ pub async fn list_funcs(
             &FuncBackendKind::JsQualification.as_ref().to_string(),
             &FuncBackendKind::JsAttribute.as_ref().to_string(),
             &FuncBackendKind::JsCodeGeneration.as_ref().to_string(),
+            &FuncBackendKind::JsCommand.as_ref().to_string(),
             &FuncBackendKind::JsConfirmation.as_ref().to_string(),
         ],
     )


### PR DESCRIPTION
Command funcs do not have prototypes (it appears they are just referenced by name in workflows?). So this just allows you to create and edit them as bare funcs with no associations yet.