### PR TITLE
feat(lang-js,dal): ENG-637 async code gen fns, add si:generateButaneIgnition

### DIFF
--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -52,7 +52,7 @@ async function main() {
 
     switch (kind) {
       case FunctionKind.CodeGeneration:
-        executeCodeGeneration(request);
+        await executeCodeGeneration(request);
         break;
       case FunctionKind.QualificationCheck:
         await executeQualificationCheck(request);

--- a/bin/lang-js/src/sandbox.ts
+++ b/bin/lang-js/src/sandbox.ts
@@ -31,9 +31,13 @@ const resolverFunctionSandbox = {};
 
 const resourceSyncSandbox = {};
 
-const codeGenerationSandbox = {
-  // Is there any risk leaking this function plainly here? It smells like a risk for RCE outside of the sandbox
-  YAML: { stringify: yaml.dump },
+function codeGenerationSandbox(executionId: string) {
+  return {
+    // Is there any risk leaking this function plainly here? It smells like a risk for RCE outside of the sandbox
+    YAML: {stringify: yaml.dump},
+    // definitely a risk
+    siExec: makeExec(executionId),
+  };
 };
 
 const confirmationSandbox = {};
@@ -64,7 +68,7 @@ export function createSandbox(
     case FunctionKind.CodeGeneration:
       return {
         ...commonSandbox(executionId),
-        ...codeGenerationSandbox,
+        ...codeGenerationSandbox(executionId),
       };
     case FunctionKind.QualificationCheck:
       return {

--- a/lib/dal/src/builtins/func/generateButaneIgnition.js
+++ b/lib/dal/src/builtins/func/generateButaneIgnition.js
@@ -1,0 +1,10 @@
+async function generateButaneIgnition(component) {
+    const domainJson = JSON.stringify(component.properties.domain);
+    domainJson.replace("\n", "\\\\n");
+    const options = {input: `${domainJson}`};
+    const { stdout } = await siExec.waitUntilEnd("butane", ["--pretty", "--strict"], options);
+    return {
+        format: "json",
+        code: stdout.toString(),
+    };
+}

--- a/lib/dal/src/builtins/func/generateButaneIgnition.json
+++ b/lib/dal/src/builtins/func/generateButaneIgnition.json
@@ -1,0 +1,10 @@
+{
+  "kind": "JsCodeGeneration",
+  "arguments": [],
+  "response_type": "CodeGeneration",
+  "display_name": "si:generateButaneIgnition",
+  "description": "Produce an Ignition JSON from a Butane component",
+  "link": "https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/",
+  "code_file": "generateButaneIgnition.js",
+  "code_entrypoint": "generateButaneIgnition"
+}


### PR DESCRIPTION
Add async support to code generation functions, and add siExec to the sandbox. Call `butane` to generate an `ignition` json.

![ignite](https://user-images.githubusercontent.com/1928978/196267356-4ba2d44b-06ad-400d-a2c6-1e2976de15a8.gif)

<img width="292" alt="image" src="https://user-images.githubusercontent.com/1928978/196267506-5527ab50-ebbc-4c78-b857-96f69e0824b2.png">

