### PR TITLE
bug(web): fix size of select box in attribute panel

### DIFF
--- a/app/web/src/organisms/PropertyEditor/WidgetSelectBox.vue
+++ b/app/web/src/organisms/PropertyEditor/WidgetSelectBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="isShown" class="flex content-center">
+  <div v-show="isShown" class="flex content-center w-full">
     <div class="flex grow">
       <div class="w-full">
         <SiSelectBox


### PR DESCRIPTION
Fixes the width of the select box to fill the available space in the attribute panel.

<img src="https://media3.giphy.com/media/OjuxQYANA1l36DogQj/giphy.gif"/>

Signed-off-by: Adam Jacob <adam@systeminit.com>