### PR TITLE
chore(dal): enable butane test and revive k8s end-to-end test 

### DIFF
--- a/lib/dal-test/src/helpers/builtins.rs
+++ b/lib/dal-test/src/helpers/builtins.rs
@@ -279,7 +279,7 @@ impl SchemaBuiltinsTestHarness {
             find_prop_and_parent_by_name(ctx, "name", "metadata", None, schema_variant_id)
                 .await
                 .expect("could not find prop and/or parent");
-        prop_map.insert("/root/si/metadata/name", metadata_name_prop_id);
+        prop_map.insert("/root/domain/metadata/name", metadata_name_prop_id);
         prop_map
     }
 }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -920,7 +920,6 @@ impl AttributeValue {
             let attr_val_id: AttributeValueId = row.try_get("attribute_value_id")?;
             let dependencies: Vec<AttributeValueId> =
                 row.try_get("dependent_attribute_value_ids")?;
-
             result.insert(attr_val_id, dependencies);
         }
 

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -131,10 +131,11 @@ async fn kubernetes_namespace(ctx: &DalContext, driver: &MigrationDriver) -> Bui
     };
     let metadata_name_prop =
         BuiltinSchemaHelpers::find_child_prop_by_name(ctx, *metadata_prop.id(), "name").await?;
+    let metadata_name_prop_id = *metadata_name_prop.id();
     let metadata_name_attribute_value = AttributeValue::find_for_context(
         ctx,
         AttributeReadContext {
-            prop_id: Some(*metadata_name_prop.id()),
+            prop_id: Some(metadata_name_prop_id),
             ..base_attribute_read_context
         },
     )
@@ -167,14 +168,12 @@ async fn kubernetes_namespace(ctx: &DalContext, driver: &MigrationDriver) -> Bui
         external_provider.attribute_prototype_id().ok_or_else(|| {
             BuiltinsError::MissingAttributePrototypeForExternalProvider(*external_provider.id())
         })?;
-    let metadata_name_prop =
-        BuiltinSchemaHelpers::find_child_prop_by_name(ctx, *metadata_prop.id(), "name").await?;
     let metadata_name_implicit_internal_provider =
-        InternalProvider::get_for_prop(ctx, *metadata_name_prop.id())
+        InternalProvider::get_for_prop(ctx, metadata_name_prop_id)
             .await?
-            .ok_or_else(|| {
-                BuiltinsError::ImplicitInternalProviderNotFoundForProp(*metadata_name_prop.id())
-            })?;
+            .ok_or(BuiltinsError::ImplicitInternalProviderNotFoundForProp(
+                metadata_name_prop_id,
+            ))?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,

--- a/lib/dal/tests/integration_test/builtins/coreos_butane.rs
+++ b/lib/dal/tests/integration_test/builtins/coreos_butane.rs
@@ -118,7 +118,6 @@ async fn butane_is_valid_ignition(ctx: &DalContext) {
     );
 }
 
-#[ignore]
 #[test]
 async fn connected_butane_is_valid_ignition(ctx: &DalContext) {
     let mut harness = SchemaBuiltinsTestHarness::new();


### PR DESCRIPTION
Enable Butane test since changes to AttributeValue updating have enabled
it work in a timely manner. Keep k8s test disabled as it currently
fails due to an unknown error.

Fixes ENG-731