### PR TITLE
few small bugs and improvements for the user study

### DIFF
--- a/app/web/src/organisms/StatusBarTabs/Qualification/QualificationViewerMultiple.vue
+++ b/app/web/src/organisms/StatusBarTabs/Qualification/QualificationViewerMultiple.vue
@@ -23,10 +23,13 @@
 import { computed, watch } from "vue";
 import QualificationViewerSingle from "@/organisms/StatusBarTabs/Qualification/QualificationViewerSingle.vue";
 import { useQualificationsStore } from "@/store/qualifications.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 
 const props = defineProps<{
   componentId: number;
 }>();
+
+const changeSetsStore = useChangeSetsStore();
 
 const qualificationsStore = useQualificationsStore();
 const qualificationsReqStatus = qualificationsStore.getRequestStatus(
@@ -35,7 +38,7 @@ const qualificationsReqStatus = qualificationsStore.getRequestStatus(
 );
 
 watch(
-  () => props.componentId,
+  [() => props.componentId, changeSetsStore.selectedChangeSetWritten],
   () => {
     qualificationsStore.FETCH_COMPONENT_QUALIFICATIONS(props.componentId);
   },

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -22,6 +22,7 @@ export function useChangeSetsStore() {
       state: () => ({
         changeSetsById: {} as Record<ChangeSetId, ChangeSet>,
         selectedChangeSetId: null as ChangeSetId | null,
+        changeSetsWrittenAtById: {} as Record<ChangeSetId, Date>,
       }),
       getters: {
         allChangeSets: (state) => _.values(state.changeSetsById),
@@ -34,6 +35,11 @@ export function useChangeSetsStore() {
         selectedChangeSet: (state) =>
           state.selectedChangeSetId
             ? state.changeSetsById[state.selectedChangeSetId] || null
+            : null,
+
+        selectedChangeSetWritten: (state) =>
+          state.selectedChangeSetId
+            ? state.changeSetsById[state.selectedChangeSetId]
             : null,
 
         // expose here so other stores can get it without needing to call useWorkspaceStore directly
@@ -154,8 +160,12 @@ export function useChangeSetsStore() {
           },
           {
             eventType: "ChangeSetWritten",
-            callback: () => {
-              // could refetch the change sets here, but not useful right now...
+            callback: (cs) => {
+              // we'll update a timestamp here so individual components can watch this to trigger something if necessary
+              // hopefully with more targeted realtime updates we won't need this, but could be useful for now
+              this.changeSetsWrittenAtById[cs] = new Date();
+
+              // could refetch the change sets here, but not useful right now since no interesting metadata exists on the changeset itself
             },
           },
         ]);


### PR DESCRIPTION
(apparently I need to "improv" my spelling...)

fixes ENG-639
fixes ENG-640

I'm now exposing a "currentChangeSetWritten" timestamp which can be watched by components if they need to react to the websocket event. In many cases things can just get reloaded and it lives directly within the store, but in a few cases, a component may want to re-trigger something when the event happens. Longterm I dont think that will be necessary if we are pushing more targeted updates with more data, but it may be useful for now.

will continue to push more changes to this branch, but we can merge along the way.