### PR TITLE
chore(web): remove the open address link

### DIFF
--- a/app/web/src/organisms/FixProgressOverlay.vue
+++ b/app/web/src/organisms/FixProgressOverlay.vue
@@ -15,25 +15,6 @@
           {{ fixState.highlightedSummary }}
         </span>
       </span>
-
-      <Transition
-        enter-active-class="duration-300 ease-out"
-        enter-from-class="transform opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="delay-1000 duration-200 ease-in"
-        leave-from-class="opacity-100 "
-        leave-to-class="transform opacity-0"
-      >
-        <a
-          v-if="diagramLink"
-          :href="diagramLink"
-          target="_blank"
-          class="text-action-400 flex items-center gap-1.5"
-        >
-          Open Address
-          <Icon name="external-link" class="inline-block" />
-        </a>
-      </Transition>
     </div>
 
     <Transition
@@ -78,15 +59,6 @@ const loadFixesReqStatus = fixesStore.getRequestStatus("LOAD_FIXES");
 const execFixesReqStatus = fixesStore.getRequestStatus("EXECUTE_FIXES");
 
 const totalResources = computed(() => resourcesStore.allResources.length);
-
-const diagramLink = computed(() => {
-  for (const resource of resourcesStore.allResources) {
-    if (resource.link) {
-      return resource.link;
-    }
-  }
-  return undefined;
-});
 
 const fixState = computed(() => {
   if (fixesStore.runningFixBatch) {


### PR DESCRIPTION
It feels too magical - where it's placed makes it seem like a side effect of the fix, which it isn't. And what happens when there is more than one?

The fake fix screen feels *really* legit, so I'm removing this while we figure out exactly how we would want to dress up the UI to expose things like "links" to the user from a fix/resource.

Signed-off-by: Adam Jacob <adam@systeminit.com>