### PR TITLE
feat(PG): Auto-explain nested statements

### DIFF
--- a/component/postgres/postgresql-additions.conf
+++ b/component/postgres/postgresql-additions.conf
@@ -19,5 +19,6 @@ auto_explain.log_timing = off
 auto_explain.log_triggers = on
 auto_explain.log_verbose = on
 auto_explain.sample_rate = 1
+auto_explain.log_nested_statements = on
 
 track_io_timing = on


### PR DESCRIPTION
`auto_explain.log_nested_statements` causes nested statements (statements executed inside a function) to be considered for logging. When it is off, only top-level query plans are logged. Given that we have a *lot* of functions defined that execute multiple queries, it would be very handy to get query plans for any of those queries that are slow.