### PR TITLE
feat(PG): Tune logging for use with pganalyze

### DIFF
--- a/component/postgres/postgresql-additions.conf
+++ b/component/postgres/postgresql-additions.conf
@@ -10,6 +10,13 @@ log_destination = 'syslog,stderr'
 log_directory = '/var/log/postgresql'
 log_file_mode = 0644
 log_line_prefix = '%m [%p] %q[user=%u,db=%d,app=%a] '
+log_min_duration_statement = 250
+log_log_waits = on
+log_temp_files = 0
+log_checkpoints = 0
+log_connections = on
+log_disconnections = on
+log_autovacuum_min_duration = 0
 
 auto_explain.log_format = 'json'
 auto_explain.log_min_duration = 250


### PR DESCRIPTION
`log_min_duration_statement = 250` lets us get the full query run, including the values of the bind params for any statement that takes at least 250ms, without slowing things down by logging _every_ query that is run.

`log_lock_waits = on` enables logging of "Process acquired lock", and "Process still waiting for lock" events to help us see if there is any lock contention going on with slower queries.

`log_temp_files = 0` lets us know if there is excessive temp file creation, by logging any temp files above the threshold. Excessive temp file creation means that `work_mem` might be set too low.

`log_checkpoints = on` let us know when checkpoints happen, which can be very I/O intensive. We may need to tune the checkpoint interval, based on what this reveals.

`log_connections = on` and `log_disconnections = on` lets us know how frequent, and how long-lived the connections are.

`log_autovacuum_min_duration = 0` can let us know if there are tables that get vacuumed a lot, even if it is very fast.