### PR TITLE
bug(PG): Fix typos in logging settings

### DIFF
--- a/component/postgres/postgresql-additions.conf
+++ b/component/postgres/postgresql-additions.conf
@@ -11,9 +11,9 @@ log_directory = '/var/log/postgresql'
 log_file_mode = 0644
 log_line_prefix = '%m [%p] %q[user=%u,db=%d,app=%a] '
 log_min_duration_statement = 250
-log_log_waits = on
+log_lock_waits = on
 log_temp_files = 0
-log_checkpoints = 0
+log_checkpoints = on
 log_connections = on
 log_disconnections = on
 log_autovacuum_min_duration = 0


### PR DESCRIPTION
Caught these before opening up the previous PR, but apparently forgot to actually amend the commit.

<img src="https://media1.giphy.com/media/3xz2BLBOt13X9AgjEA/giphy.gif"/>