### PR TITLE
bug(dal): Ensure builtin funcs are available to production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,10 +751,12 @@ dependencies = [
  "dyn-clone",
  "faktory-async",
  "futures",
+ "iftree",
  "itertools",
  "jwt-simple",
  "lazy_static",
  "names",
+ "once_cell",
  "paste",
  "postgres-types",
  "pretty_assertions_sorted",
@@ -1360,6 +1371,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "group"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1617,39 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "iftree"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b367cab57a329f593a565be8d634cf060f21402786b801dd2de62d8351ce6551"
+dependencies = [
+ "ignore",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -17,10 +17,12 @@ diff = "0.1"
 dyn-clone = "1.0.6"
 faktory-async = { git = "https://github.com/systeminit/faktory-async", branch = "main" }
 futures = "0.3.13"
+iftree = "1.0.3"
 itertools = "0.10.3"
 jwt-simple = "0.11.0"
 lazy_static = "1.4.0"
 names = { version = "0.14.0", default-features = false }
+once_cell = "1.15.0"
 paste = "1.0"
 postgres-types = { version = "0.2.2", features = ["derive"] }
 rand = "0.8.3"


### PR DESCRIPTION
Previously, we were relying on the source tree being availble relative to the binary, but this assumption is false in production. Instead, we're now compiling the builtin func files into the SDF binary, and going over the in-memory version of them to see which ones need to be created during boot.

Co-authored-by: Fletcher Nichol <fletcher@systeminit.com>