### PR TITLE
chore(dal): add driver to schema builtins

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -6,6 +6,7 @@
 use telemetry::prelude::*;
 use thiserror::Error;
 
+use crate::func::argument::FuncArgumentError;
 use crate::func::binding::FuncBindingError;
 use crate::func::binding_return_value::FuncBindingReturnValueError;
 use crate::provider::external::ExternalProviderError;
@@ -20,13 +21,12 @@ use crate::{
     StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
 };
 
+// Private builtins modules.
 mod func;
 mod schema;
 mod workflow;
 
 // Expose the "persist" function for creating and editing builtin funcs while in dev mode.
-pub use self::schema::BuiltinSchemaHelpers;
-use crate::func::argument::FuncArgumentError;
 pub use func::persist as func_persist;
 
 #[derive(Error, Debug)]
@@ -55,6 +55,8 @@ pub enum BuiltinsError {
     FuncBinding(#[from] FuncBindingError),
     #[error("func binding return value error: {0}")]
     FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
+    #[error("func not found in migration cache {0}")]
+    FuncNotFoundInMigrationCache(&'static str),
     #[error("external provider error: {0}")]
     ExternalProvider(#[from] ExternalProviderError),
     #[error("implicit internal provider not found for prop: {0}")]
@@ -119,5 +121,6 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     workflow::migrate(ctx).await?;
     info!("migrating schemas");
     schema::migrate(ctx).await?;
+    info!("completed migrating functions, workflows and schemas");
     Ok(())
 }

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
+use std::collections::HashMap;
 use telemetry::prelude::*;
 
 use crate::attribute::context::AttributeContextBuilder;
@@ -27,25 +26,19 @@ mod kubernetes;
 mod systeminit;
 
 pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
-    systeminit::migrate(ctx).await?;
-    docker::migrate(ctx).await?;
-    kubernetes::migrate(ctx).await?;
-    coreos::migrate(ctx).await?;
-    aws::migrate(ctx).await?;
+    let driver = MigrationDriver::new(ctx).await?;
+
+    systeminit::migrate(ctx, &driver).await?;
+    docker::migrate(ctx, &driver).await?;
+    kubernetes::migrate(ctx, &driver).await?;
+    coreos::migrate(ctx, &driver).await?;
+    aws::migrate(ctx, &driver).await?;
     Ok(())
 }
 
-// TODO(nick): once shape is finalized and we stop serializing this within builtins, please
-// move to a more formal type in the property editor module.
-#[derive(Deserialize, Serialize, Debug)]
-pub struct SelectWidgetOption {
-    label: String,
-    value: String,
-}
-
-/// This unit struct (zero bytes) provides a singular place to index helpers for creating builtin
-/// [`Schemas`](crate::Schema).
-pub struct BuiltinSchemaHelpers;
+/// This private unit struct (zero bytes) provides a singular place to index helpers for creating
+/// builtin [`Schemas`](crate::Schema).
+struct BuiltinSchemaHelpers;
 
 impl BuiltinSchemaHelpers {
     /// Create a [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant). In addition, set the node
@@ -103,47 +96,6 @@ impl BuiltinSchemaHelpers {
             prop.set_doc_link(ctx, doc_link).await?;
         }
         Ok(prop)
-    }
-
-    /// Get the "si:identity" [`Func`](crate::Func) and execute (if necessary).
-    pub async fn setup_identity_func(
-        ctx: &DalContext,
-    ) -> BuiltinsResult<(
-        FuncId,
-        FuncBindingId,
-        FuncBindingReturnValueId,
-        FuncArgumentId,
-    )> {
-        let identity_func_name = "si:identity".to_string();
-        let identity_func: Func = Func::find_by_attr(ctx, "name", &identity_func_name)
-            .await?
-            .pop()
-            .ok_or_else(|| FuncError::NotFoundByName(identity_func_name.clone()))?;
-
-        let identity_func_identity_arg = FuncArgument::list_for_func(ctx, *identity_func.id())
-            .await?
-            .pop()
-            .ok_or_else(|| {
-                BuiltinsError::BuiltinMissingFuncArgument(
-                    identity_func_name.clone(),
-                    "identity".to_string(),
-                )
-            })?;
-
-        let (identity_func_binding, identity_func_binding_return_value, _) =
-            FuncBinding::find_or_create_and_execute(
-                ctx,
-                serde_json::json![{ "identity": null }],
-                *identity_func.id(),
-            )
-            .await?;
-
-        Ok((
-            *identity_func.id(),
-            *identity_func_binding.id(),
-            *identity_func_binding_return_value.id(),
-            *identity_func_identity_arg.id(),
-        ))
     }
 
     /// Find the child of a [`Prop`](crate::Prop) by name.
@@ -240,21 +192,64 @@ impl BuiltinSchemaHelpers {
             _ => Err(BuiltinsError::NonPrimitivePropKind(*prop.kind())),
         }
     }
+}
+
+/// An item containing useful metadata alongside a [`FuncId`](crate::Func). This is used by
+/// the [`MigrationDriver`].
+#[derive(Copy, Clone)]
+pub struct FuncCacheItem {
+    func_id: FuncId,
+    func_binding_id: FuncBindingId,
+    func_binding_return_value_id: FuncBindingReturnValueId,
+    func_argument_id: FuncArgumentId,
+}
+
+/// A driver providing caches and helper methods for efficiently creating builtin
+/// [`Schemas`](crate::Schema).
+#[derive(Default)]
+pub struct MigrationDriver {
+    pub func_item_cache: HashMap<String, FuncCacheItem>,
+    pub func_id_cache: HashMap<String, FuncId>,
+}
+
+impl MigrationDriver {
+    /// Create a [`driver`](Self) with commonly used, cached data.
+    pub async fn new(ctx: &DalContext) -> BuiltinsResult<Self> {
+        let mut driver = Self::default();
+
+        driver
+            .add_func_item(
+                ctx,
+                "si:identity".to_string(),
+                serde_json::json![{ "identity": null }],
+                "identity".to_string(),
+            )
+            .await?;
+
+        for builtin_func_name in ["si:validation", "si:generateAwsJSON", "si:generateYAML"] {
+            driver
+                .add_func_id(ctx, builtin_func_name.to_string())
+                .await?;
+        }
+
+        Ok(driver)
+    }
 
     /// Create a [`validation`](crate::validation) for a [`Prop`](crate::Prop) within a
     /// [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant).
     ///
     /// Users of this helper should provide a [`None`] value to the "value" (or similar) field.
     pub async fn create_validation(
+        &self,
         ctx: &DalContext,
         validation: Validation,
         prop_id: PropId,
         schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
     ) -> BuiltinsResult<()> {
-        let func_name = "si:validation".to_string();
-        let mut funcs = Func::find_by_attr(ctx, "name", &func_name).await?;
-        let func = funcs.pop().ok_or(FuncError::NotFoundByName(func_name))?;
+        let validation_func_id = self
+            .get_func_id("si:validation")
+            .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:validation"))?;
 
         let mut builder = ValidationPrototypeContext::builder();
         builder
@@ -264,11 +259,64 @@ impl BuiltinSchemaHelpers {
 
         ValidationPrototype::new(
             ctx,
-            *func.id(),
+            validation_func_id,
             serde_json::to_value(FuncBackendValidationArgs::new(validation))?,
             builder.to_context(ctx).await?,
         )
         .await?;
         Ok(())
+    }
+
+    /// Add a [`FuncCacheItem`] for a given [`Func`](crate::Func) name.
+    pub async fn add_func_item(
+        &mut self,
+        ctx: &DalContext,
+        func_name: String,
+        func_binding_args: Value,
+        func_argument_name: String,
+    ) -> BuiltinsResult<()> {
+        let func: Func = Func::find_by_attr(ctx, "name", &func_name)
+            .await?
+            .pop()
+            .ok_or_else(|| FuncError::NotFoundByName(func_name.clone()))?;
+        let func_id = *func.id();
+        let (func_binding, func_binding_return_value, _) =
+            FuncBinding::find_or_create_and_execute(ctx, func_binding_args, func_id).await?;
+        let func_argument = FuncArgument::find_by_name_for_func(ctx, &func_argument_name, func_id)
+            .await?
+            .ok_or_else(|| {
+                BuiltinsError::BuiltinMissingFuncArgument(func_name.clone(), func_argument_name)
+            })?;
+        self.func_item_cache.insert(
+            func_name,
+            FuncCacheItem {
+                func_id,
+                func_binding_id: *func_binding.id(),
+                func_binding_return_value_id: *func_binding_return_value.id(),
+                func_argument_id: *func_argument.id(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Add a [`FuncId`](crate::Func) for a given [`Func`](crate::Func) name.
+    pub async fn add_func_id(&mut self, ctx: &DalContext, func_name: String) -> BuiltinsResult<()> {
+        let func: Func = Func::find_by_attr(ctx, "name", &func_name)
+            .await?
+            .pop()
+            .ok_or_else(|| FuncError::NotFoundByName(func_name.clone()))?;
+        self.func_id_cache.insert(func_name, *func.id());
+        Ok(())
+    }
+
+    /// Get a [`FuncCacheItem`] (from the cache) for a given [`Func`](crate::Func) name.
+    pub fn get_func_item(&self, name: impl AsRef<str>) -> Option<FuncCacheItem> {
+        self.func_item_cache.get(name.as_ref()).copied()
+    }
+
+    /// Get a [`FuncId`](crate::Func) (from the cache) for a given [`Func`](crate::Func) name.
+    pub fn get_func_id(&self, name: impl AsRef<str>) -> Option<FuncId> {
+        self.func_id_cache.get(name.as_ref()).copied()
     }
 }

--- a/lib/dal/src/builtins/schema/aws.rs
+++ b/lib/dal/src/builtins/schema/aws.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::builtins::schema::{BuiltinSchemaHelpers, SelectWidgetOption};
+use crate::builtins::schema::{BuiltinSchemaHelpers, MigrationDriver};
 use crate::builtins::BuiltinsError;
 use crate::code_generation_prototype::CodeGenerationPrototypeContext;
 use crate::component::ComponentKind;
 use crate::edit_field::widget::WidgetKind;
 use crate::func::backend::js_code_generation::FuncBackendJsCodeGenerationArgs;
+use crate::property_editor::SelectWidgetOption;
 use crate::prototype_context::PrototypeContext;
 use crate::qualification_prototype::QualificationPrototypeContext;
 use crate::socket::{SocketArity, SocketEdgeKind, SocketKind};
@@ -41,19 +42,19 @@ const KEY_PAIR_DOCS_URL: &str =
 const REGIONS_JSON_STR: &str = include_str!("data/aws_regions.json");
 const INSTANCE_TYPES_JSON_STR: &str = include_str!("data/aws_instance_types.json");
 
-pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
-    ami(ctx).await?;
-    ec2(ctx).await?;
-    region(ctx).await?;
-    keypair(ctx).await?;
-    vpc::migrate(ctx).await?;
+pub async fn migrate(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
+    ami(ctx, driver).await?;
+    ec2(ctx, driver).await?;
+    region(ctx, driver).await?;
+    keypair(ctx, driver).await?;
+    vpc::migrate(ctx, driver).await?;
     Ok(())
 }
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct AwsRegion {
-    pub(crate) name: String,
-    pub(crate) code: String,
+struct AwsRegion {
+    name: String,
+    code: String,
 }
 
 impl From<&AwsRegion> for SelectWidgetOption {
@@ -66,7 +67,7 @@ impl From<&AwsRegion> for SelectWidgetOption {
 }
 
 /// A [`Schema`](crate::Schema) migration for [`AWS AMI`](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Ami.html).
-async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
+async fn ami(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
     let (schema, schema_variant, root_prop) = match BuiltinSchemaHelpers::create_schema_and_variant(
         ctx,
         "AMI",
@@ -103,17 +104,18 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
-    BuiltinSchemaHelpers::create_validation(
-        ctx,
-        Validation::StringHasPrefix {
-            value: None,
-            expected: "ami-".to_string(),
-        },
-        *image_id_prop.id(),
-        *schema.id(),
-        *schema_variant.id(),
-    )
-    .await?;
+    driver
+        .create_validation(
+            ctx,
+            Validation::StringHasPrefix {
+                value: None,
+                expected: "ami-".to_string(),
+            },
+            *image_id_prop.id(),
+            *schema.id(),
+            *schema_variant.id(),
+        )
+        .await?;
 
     let region_prop = BuiltinSchemaHelpers::create_prop(
         ctx,
@@ -126,13 +128,9 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
 
     // Code Generation
-    let code_generation_func_name = "si:generateAwsJSON".to_owned();
-    let code_generation_func =
-        Func::find_by_attr(ctx, "name", &code_generation_func_name.to_owned())
-            .await?
-            .pop()
-            .ok_or(SchemaError::FuncNotFound(code_generation_func_name))?;
-
+    let code_generation_func_id = driver.get_func_id("si:generateAwsJSON").ok_or(
+        BuiltinsError::FuncNotFoundInMigrationCache("si:generateAwsJSON"),
+    )?;
     let code_generation_args = FuncBackendJsCodeGenerationArgs::default();
     let code_generation_args_json = serde_json::to_value(&code_generation_args)?;
     let mut code_generation_prototype_context = CodeGenerationPrototypeContext::new();
@@ -140,7 +138,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
 
     let _prototype = CodeGenerationPrototype::new(
         ctx,
-        *code_generation_func.id(),
+        code_generation_func_id,
         code_generation_args_json,
         CodeLanguage::Json,
         code_generation_prototype_context,
@@ -159,12 +157,9 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    let (
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
-        identity_func_identity_arg_id,
-    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let identity_func_item = driver
+        .get_func_item("si:identity")
+        .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
 
     let (image_id_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
@@ -172,9 +167,9 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
         *schema_variant.id(),
         "Image ID",
         None,
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
+        identity_func_item.func_id,
+        identity_func_item.func_binding_id,
+        identity_func_item.func_binding_return_value_id,
         SocketArity::Many,
         DiagramKind::Configuration,
     )
@@ -187,9 +182,9 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Region",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -229,7 +224,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *image_id_implicit_internal_provider.id(),
     )
     .await?;
@@ -254,12 +249,12 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     region_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -268,7 +263,7 @@ async fn ami(ctx: &DalContext) -> BuiltinsResult<()> {
 }
 
 /// A [`Schema`](crate::Schema) migration for [`AWS EC2`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html).
-async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
+async fn ec2(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
     let (schema, schema_variant, root_prop) = match BuiltinSchemaHelpers::create_schema_and_variant(
         ctx,
         "EC2 Instance",
@@ -305,17 +300,18 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
-    BuiltinSchemaHelpers::create_validation(
-        ctx,
-        Validation::StringHasPrefix {
-            value: None,
-            expected: "ami-".to_string(),
-        },
-        *image_id_prop.id(),
-        *schema.id(),
-        *schema_variant.id(),
-    )
-    .await?;
+    driver
+        .create_validation(
+            ctx,
+            Validation::StringHasPrefix {
+                value: None,
+                expected: "ami-".to_string(),
+            },
+            *image_id_prop.id(),
+            *schema.id(),
+            *schema_variant.id(),
+        )
+        .await?;
 
     let expected_instance_types: Vec<String> = serde_json::from_str(INSTANCE_TYPES_JSON_STR)?;
     let instance_types_option_list: Vec<SelectWidgetOption> = expected_instance_types
@@ -338,18 +334,19 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     )
     .await?;
 
-    BuiltinSchemaHelpers::create_validation(
-        ctx,
-        Validation::StringInStringArray {
-            value: None,
-            expected: expected_instance_types,
-            display_expected: false,
-        },
-        *instance_type_prop.id(),
-        *schema.id(),
-        *schema_variant.id(),
-    )
-    .await?;
+    driver
+        .create_validation(
+            ctx,
+            Validation::StringInStringArray {
+                value: None,
+                expected: expected_instance_types,
+                display_expected: false,
+            },
+            *instance_type_prop.id(),
+            *schema.id(),
+            *schema_variant.id(),
+        )
+        .await?;
 
     // Prop: /root/domain/KeyName
     let key_name_prop = BuiltinSchemaHelpers::create_prop(
@@ -441,13 +438,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
 
     // Code Generation Prototype
-    let code_generation_func_name = "si:generateAwsJSON".to_owned();
-    let code_generation_func =
-        Func::find_by_attr(ctx, "name", &code_generation_func_name.to_owned())
-            .await?
-            .pop()
-            .ok_or(SchemaError::FuncNotFound(code_generation_func_name))?;
-
+    let code_generation_func_id = driver.get_func_id("si:generateAwsJSON").ok_or(
+        BuiltinsError::FuncNotFoundInMigrationCache("si:generateAwsJSON"),
+    )?;
     let code_generation_args = FuncBackendJsCodeGenerationArgs::default();
     let code_generation_args_json = serde_json::to_value(&code_generation_args)?;
     let mut code_generation_prototype_context = CodeGenerationPrototypeContext::new();
@@ -455,7 +448,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
 
     let _prototype = CodeGenerationPrototype::new(
         ctx,
-        *code_generation_func.id(),
+        code_generation_func_id,
         code_generation_args_json,
         CodeLanguage::Json,
         code_generation_prototype_context,
@@ -474,12 +467,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
-    let (
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
-        identity_func_identity_arg_id,
-    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let identity_func_item = driver
+        .get_func_item("si:identity")
+        .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
 
     let (image_id_explicit_internal_provider, mut input_socket) =
         InternalProvider::new_explicit_with_socket(
@@ -487,9 +477,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Image ID",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -502,9 +492,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Security Group ID",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -517,9 +507,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Key Name",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -532,9 +522,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Region",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -547,9 +537,9 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "User Data",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -636,16 +626,17 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     name_tags_item_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
-    let identity_arg = FuncArgument::find_by_name_for_func(ctx, "identity", identity_func_id)
-        .await?
-        .ok_or_else(|| {
-            BuiltinsError::BuiltinMissingFuncArgument(
-                "identity".to_string(),
-                "identity".to_string(),
-            )
-        })?;
+    let identity_arg =
+        FuncArgument::find_by_name_for_func(ctx, "identity", identity_func_item.func_id)
+            .await?
+            .ok_or_else(|| {
+                BuiltinsError::BuiltinMissingFuncArgument(
+                    "identity".to_string(),
+                    "identity".to_string(),
+                )
+            })?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *name_tags_item_attribute_prototype.id(),
@@ -670,12 +661,12 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     region_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -695,12 +686,12 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     image_id_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *image_id_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *image_id_explicit_internal_provider.id(),
     )
     .await?;
@@ -721,12 +712,12 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
             .await?
             .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     keyname_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *keyname_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *keyname_explicit_internal_provider.id(),
     )
     .await?;
@@ -746,12 +737,12 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     security_group_id_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *security_group_id_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *security_group_ids_explicit_internal_provider.id(),
     )
     .await?;
@@ -771,12 +762,12 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     user_data_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *user_data_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *user_data_explicit_internal_provider.id(),
     )
     .await?;
@@ -785,7 +776,7 @@ async fn ec2(ctx: &DalContext) -> BuiltinsResult<()> {
 }
 
 /// A [`Schema`](crate::Schema) migration for [`AWS Region`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
-async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
+async fn region(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
     let (schema, schema_variant, root_prop) = match BuiltinSchemaHelpers::create_schema_and_variant(
         ctx,
         "Region",
@@ -834,18 +825,19 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
         .iter()
         .map(|r| r.code.clone())
         .collect::<Vec<String>>();
-    BuiltinSchemaHelpers::create_validation(
-        ctx,
-        Validation::StringInStringArray {
-            value: None,
-            expected,
-            display_expected: true,
-        },
-        *region_prop.id(),
-        *schema.id(),
-        *schema_variant.id(),
-    )
-    .await?;
+    driver
+        .create_validation(
+            ctx,
+            Validation::StringInStringArray {
+                value: None,
+                expected,
+                display_expected: true,
+            },
+            *region_prop.id(),
+            *schema.id(),
+            *schema_variant.id(),
+        )
+        .await?;
 
     // System Socket
     let system_socket = Socket::new(
@@ -860,21 +852,18 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
     // Output Socket
-    let (
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
-        identity_func_identity_arg_id,
-    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let identity_func_item = driver
+        .get_func_item("si:identity")
+        .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
     let (region_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
         *schema_variant.id(),
         "Region",
         None,
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
+        identity_func_item.func_id,
+        identity_func_item.func_binding_id,
+        identity_func_item.func_binding_return_value_id,
         SocketArity::Many,
         DiagramKind::Configuration,
     )
@@ -898,7 +887,7 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *region_implicit_internal_provider.id(),
     )
     .await?;
@@ -907,7 +896,7 @@ async fn region(ctx: &DalContext) -> BuiltinsResult<()> {
 }
 
 /// A [`Schema`](crate::Schema) migration for [`AWS Key Pair`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html).
-async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
+async fn keypair(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
     let (schema, schema_variant, root_prop) = match BuiltinSchemaHelpers::create_schema_and_variant(
         ctx,
         "Key Pair",
@@ -1012,13 +1001,9 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     .await?;
 
     // Code Generation Prototype
-    let code_generation_func_name = "si:generateAwsJSON".to_owned();
-    let code_generation_func =
-        Func::find_by_attr(ctx, "name", &code_generation_func_name.to_owned())
-            .await?
-            .pop()
-            .ok_or(SchemaError::FuncNotFound(code_generation_func_name))?;
-
+    let code_generation_func_id = driver.get_func_id("si:generateAwsJSON").ok_or(
+        BuiltinsError::FuncNotFoundInMigrationCache("si:generateAwsJSON"),
+    )?;
     let code_generation_args = FuncBackendJsCodeGenerationArgs::default();
     let code_generation_args_json = serde_json::to_value(&code_generation_args)?;
     let mut code_generation_prototype_context = CodeGenerationPrototypeContext::new();
@@ -1026,7 +1011,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
 
     let _prototype = CodeGenerationPrototype::new(
         ctx,
-        *code_generation_func.id(),
+        code_generation_func_id,
         code_generation_args_json,
         CodeLanguage::Json,
         code_generation_prototype_context,
@@ -1046,21 +1031,18 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     schema_variant.add_socket(ctx, system_socket.id()).await?;
 
     // Output Socket
-    let (
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
-        identity_func_identity_arg_id,
-    ) = BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let identity_func_item = driver
+        .get_func_item("si:identity")
+        .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
     let (key_name_external_provider, mut output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
         *schema_variant.id(),
         "Key Name",
         None,
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
+        identity_func_item.func_id,
+        identity_func_item.func_binding_id,
+        identity_func_item.func_binding_return_value_id,
         SocketArity::Many,
         DiagramKind::Configuration,
     )
@@ -1074,9 +1056,9 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
             *schema.id(),
             *schema_variant.id(),
             "Region",
-            identity_func_id,
-            identity_func_binding_id,
-            identity_func_binding_return_value_id,
+            identity_func_item.func_id,
+            identity_func_item.func_binding_id,
+            identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
             DiagramKind::Configuration,
         )
@@ -1112,7 +1094,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *external_provider_attribute_prototype_id,
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *key_name_internal_provider.id(),
     )
     .await?;
@@ -1166,16 +1148,17 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     name_tags_item_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
-    let identity_arg = FuncArgument::find_by_name_for_func(ctx, "identity", identity_func_id)
-        .await?
-        .ok_or_else(|| {
-            BuiltinsError::BuiltinMissingFuncArgument(
-                "identity".to_string(),
-                "identity".to_string(),
-            )
-        })?;
+    let identity_arg =
+        FuncArgument::find_by_name_for_func(ctx, "identity", identity_func_item.func_id)
+            .await?
+            .ok_or_else(|| {
+                BuiltinsError::BuiltinMissingFuncArgument(
+                    "identity".to_string(),
+                    "identity".to_string(),
+                )
+            })?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *name_tags_item_attribute_prototype.id(),
@@ -1205,12 +1188,12 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
     region_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *region_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *region_explicit_internal_provider.id(),
     )
     .await?;
@@ -1230,7 +1213,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .ok_or(AttributeValueError::MissingAttributePrototype)?;
     key_name_attribute_prototype
-        .set_func_id(ctx, identity_func_id)
+        .set_func_id(ctx, identity_func_item.func_id)
         .await?;
     let si_name_prop =
         BuiltinSchemaHelpers::find_child_prop_by_name(ctx, root_prop.si_prop_id, "name").await?;
@@ -1242,7 +1225,7 @@ async fn keypair(ctx: &DalContext) -> BuiltinsResult<()> {
     AttributePrototypeArgument::new_for_intra_component(
         ctx,
         *key_name_attribute_prototype.id(),
-        identity_func_identity_arg_id,
+        identity_func_item.func_argument_id,
         *si_name_internal_provider.id(),
     )
     .await?;

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -1,16 +1,16 @@
-use crate::builtins::schema::BuiltinSchemaHelpers;
+use crate::builtins::schema::{BuiltinSchemaHelpers, MigrationDriver};
 use crate::component::ComponentKind;
 use crate::{
-    socket::SocketArity, BuiltinsResult, DalContext, DiagramKind, ExternalProvider, SchemaKind,
-    StandardModel,
+    socket::SocketArity, BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider,
+    SchemaKind, StandardModel,
 };
 
-pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
-    system(ctx).await?;
+pub async fn migrate(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
+    system(ctx, driver).await?;
     Ok(())
 }
 
-async fn system(ctx: &DalContext) -> BuiltinsResult<()> {
+async fn system(ctx: &DalContext, driver: &MigrationDriver) -> BuiltinsResult<()> {
     let (mut schema, schema_variant, _) = match BuiltinSchemaHelpers::create_schema_and_variant(
         ctx,
         "system",
@@ -27,17 +27,19 @@ async fn system(ctx: &DalContext) -> BuiltinsResult<()> {
     schema.set_ui_hidden(ctx, true).await?;
     schema_variant.finalize(ctx).await?;
 
-    let (identity_func_id, identity_func_binding_id, identity_func_binding_return_value_id, _) =
-        BuiltinSchemaHelpers::setup_identity_func(ctx).await?;
+    let identity_func_item = driver
+        .get_func_item("si:identity")
+        .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
+
     let (_component_output_provider, _component_output_socket) = ExternalProvider::new_with_socket(
         ctx,
         *schema.id(),
         *schema_variant.id(),
         "component_output",
         None,
-        identity_func_id,
-        identity_func_binding_id,
-        identity_func_binding_return_value_id,
+        identity_func_item.func_id,
+        identity_func_item.func_binding_id,
+        identity_func_item.func_binding_return_value_id,
         SocketArity::Many,
         DiagramKind::Configuration,
     )

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -2,11 +2,10 @@
 //pub enum PropertyEditorError {
 //}
 
-use std::{cmp::Ordering, collections::HashMap};
-
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_data::PgError;
+use std::{cmp::Ordering, collections::HashMap};
 use thiserror::Error;
 
 use crate::attribute::value::FuncWithPrototypeContext;
@@ -350,4 +349,12 @@ impl PropertyEditorValidations {
         }
         Ok(Self { validations })
     }
+}
+
+// TODO(nick): once shape is finalized and we stop serializing this within builtins, please
+// convert to a more formal type.
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SelectWidgetOption {
+    pub(crate) label: String,
+    pub(crate) value: String,
 }


### PR DESCRIPTION
## Description

This PR adds `MigrationDriver` to the schema builtins module. This PR is intended as a "first pass" at improving schema builtin migration times. I suspect it will make an imperceptible difference in many cases, but we can start moving towards caching builtin items as we get closer to "create JSON/TOML file and then turn into builtin schema" logic.

On a Thelio Major R2 (`Pop!_OS 22.04` / `Threadripper 3970X`), migrating builtin schemas takes ~11 seconds when running a debug build of `sdf`. I suspect the majority of the time is related to attribute values and providers.

```
2022-10-20T22:33:31.538698Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins: migrating schemas
2022-10-20T22:33:31.577249Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating system schema
2022-10-20T22:33:31.861135Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Docker Hub Credential schema
2022-10-20T22:33:32.164089Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Docker Image schema
2022-10-20T22:33:32.592368Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Kubernetes Namespace schema
2022-10-20T22:33:33.188846Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Kubernetes Deployment schema
2022-10-20T22:33:34.839369Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Butane schema
2022-10-20T22:33:35.612604Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating AMI schema
2022-10-20T22:33:36.208041Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating EC2 Instance schema
2022-10-20T22:33:37.553387Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Region schema
2022-10-20T22:33:38.075827Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Key Pair schema
2022-10-20T22:33:39.039347Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Ingress schema
2022-10-20T22:33:40.188875Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Egress schema
2022-10-20T22:33:41.552136Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins::schema: migrating Security Group schema
2022-10-20T22:33:42.806802Z  INFO ThreadId(02) sdf.init.migrate_database:migrate_all:migrate_builtins: dal::builtins: completed migrating functions, workflows and schemas
```

## Commit Description

- Add driver to schema builtins for the purpose of caching information
  to speed up schema builtins migration time (this is the first pass)
- Replace "setup_identity_func" and cache common functions
- Move select widget to the property editor module
- Ensure the builtins helpers, structs, etc. are private (unless exposed
  via "pub use")

## Linear

Fixes ENG-664