### PR TITLE
feat(dal): split confirmations into single jobs and publish events

### DIFF
--- a/app/web/src/store/fixes/fixes.store.ts
+++ b/app/web/src/store/fixes/fixes.store.ts
@@ -226,9 +226,9 @@ export const useFixesStore = () => {
         const realtimeStore = useRealtimeStore();
         realtimeStore.subscribe(this.$id, `workspace/${workspaceId}/head`, [
           {
-            eventType: "ChangeSetWritten",
-            callback: (writtenChangeSetId) => {
-              if (writtenChangeSetId === -1) this.LOAD_FIXES();
+            eventType: "ConfirmationStatusUpdate",
+            callback: (update) => {
+              if (update.status === "success" || update.status === "failure") this.LOAD_FIXES();
             },
           },
         ]);

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -22,6 +22,11 @@ export type WsEventPayloadMap = {
     systemId: number;
   };
 
+  ConfirmationStatusUpdate: {
+    confirmationPrototypeId: number;
+    status: "success" | "running" | "pending" | "failure"
+  };
+
   // NOT CURRENTLY USED - but leaving here so we remember these events exist
   // SecretCreated: number;
   // ResourceRefreshed: {

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -12,8 +12,8 @@ use tokio::{
 use dal::{
     job::consumer::{JobConsumer, JobConsumerError},
     job::definition::{
-        CodeGeneration, Confirmations, DependentValuesUpdate, Fixes, Qualification, Qualifications,
-        WorkflowRun,
+        CodeGeneration, Confirmation, Confirmations, DependentValuesUpdate, Fixes, Qualification,
+        Qualifications, WorkflowRun,
     },
     CycloneKeyPair, DalContext, DalContextBuilder, JobFailure, JobFailureError, ServicesContext,
     TransactionsError,
@@ -289,6 +289,7 @@ async fn execute_job_fallible(
 
     let job = match job_match!(
         job,
+        Confirmation,
         Confirmations,
         Qualification,
         Qualifications,

--- a/lib/dal/src/confirmation_prototype.rs
+++ b/lib/dal/src/confirmation_prototype.rs
@@ -34,6 +34,9 @@ pub enum ConfirmationPrototypeError {
     ConfirmationResolver(#[from] ConfirmationResolverError),
     #[error(transparent)]
     ActionPrototype(#[from] ActionPrototypeError),
+
+    #[error("not found by id: {0}")]
+    NotFound(ConfirmationPrototypeId),
 }
 
 pub type ConfirmationPrototypeResult<T> = Result<T, ConfirmationPrototypeError>;

--- a/lib/dal/src/confirmation_resolver.rs
+++ b/lib/dal/src/confirmation_resolver.rs
@@ -134,19 +134,19 @@ impl ConfirmationResolver {
         context: ConfirmationResolverContext,
     ) -> ConfirmationResolverResult<Self> {
         let row = ctx.txns().pg().query_one(
-                "SELECT object FROM confirmation_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
-                &[ctx.write_tenancy(), ctx.visibility(),
-                    &confirmation_prototype_id,
-                    &success,
-                    &message,
-                    &func_id,
-                    &func_binding_id,
-                    &context.component_id(),
-                    &context.schema_id(),
-                    &context.schema_variant_id(),
-                    &context.system_id(),
-                ],
-            )
+            "SELECT object FROM confirmation_resolver_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            &[ctx.write_tenancy(), ctx.visibility(),
+                &confirmation_prototype_id,
+                &success,
+                &message,
+                &func_id,
+                &func_binding_id,
+                &context.component_id(),
+                &context.schema_id(),
+                &context.schema_variant_id(),
+                &context.system_id(),
+            ],
+        )
             .await?;
 
         let object: Self = standard_model::finish_create_from_row(ctx, row).await?;

--- a/lib/dal/src/confirmation_status.rs
+++ b/lib/dal/src/confirmation_status.rs
@@ -1,0 +1,38 @@
+
+
+use crate::{
+    ConfirmationPrototypeId, DalContext, WsEvent, WsPayload,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfirmationStatus {
+    Running,
+    Success,
+    Failure,
+    Pending,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmationStatusUpdate {
+    confirmation_prototype_id: ConfirmationPrototypeId,
+    status: ConfirmationStatus,
+}
+
+impl WsEvent {
+    pub fn confirmation_status_update(
+        ctx: &DalContext,
+        confirmation_prototype_id: ConfirmationPrototypeId,
+        status: ConfirmationStatus,
+    ) -> Self {
+        WsEvent::new(
+            ctx,
+            WsPayload::ConfirmationStatusUpdate(ConfirmationStatusUpdate {
+                confirmation_prototype_id,
+                status,
+            }),
+        )
+    }
+}

--- a/lib/dal/src/job/definition.rs
+++ b/lib/dal/src/job/definition.rs
@@ -1,4 +1,5 @@
 mod code_generation;
+mod confirmation;
 mod confirmations;
 mod dependent_values_update;
 pub mod fix;
@@ -7,6 +8,7 @@ mod qualifications;
 mod workflow_run;
 
 pub use code_generation::CodeGeneration;
+pub use confirmation::Confirmation;
 pub use confirmations::Confirmations;
 pub use dependent_values_update::DependentValuesUpdate;
 pub use fix::Fixes;

--- a/lib/dal/src/job/definition/confirmation.rs
+++ b/lib/dal/src/job/definition/confirmation.rs
@@ -1,0 +1,152 @@
+use std::{collections::HashMap, convert::TryFrom};
+
+use async_trait::async_trait;
+use jwt_simple::prelude::Deserialize;
+use serde::Serialize;
+
+use crate::confirmation_status::ConfirmationStatus;
+
+
+use crate::{
+    job::{
+        consumer::{FaktoryJobInfo, JobConsumer, JobConsumerError, JobConsumerResult},
+        producer::{JobMeta, JobProducer, JobProducerResult},
+    },
+    AccessBuilder, ComponentId, ConfirmationPrototype, ConfirmationPrototypeError,
+    ConfirmationPrototypeId, DalContext, StandardModel, SystemId, Visibility, WsEvent,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ConfirmationArgs {
+    component_id: ComponentId,
+    system_id: SystemId,
+    confirmation_prototype_id: ConfirmationPrototypeId,
+}
+
+impl From<Confirmation> for ConfirmationArgs {
+    fn from(value: Confirmation) -> Self {
+        Self {
+            component_id: value.component_id,
+            system_id: value.system_id,
+            confirmation_prototype_id: value.confirmation_prototype_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Confirmation {
+    access_builder: AccessBuilder,
+    visibility: Visibility,
+    faktory_job: Option<FaktoryJobInfo>,
+    component_id: ComponentId,
+    system_id: SystemId,
+    confirmation_prototype_id: ConfirmationPrototypeId,
+}
+
+impl Confirmation {
+    pub fn new(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        system_id: SystemId,
+        confirmation_prototype_id: ConfirmationPrototypeId,
+    ) -> Box<Self> {
+        let access_builder = AccessBuilder::from(ctx.clone());
+        let visibility = *ctx.visibility();
+
+        Box::new(Self {
+            access_builder,
+            visibility,
+            faktory_job: None,
+            component_id,
+            system_id,
+            confirmation_prototype_id,
+        })
+    }
+}
+
+impl JobProducer for Confirmation {
+    fn args(&self) -> JobProducerResult<serde_json::Value> {
+        Ok(serde_json::to_value(ConfirmationArgs::from(self.clone()))?)
+    }
+
+    fn meta(&self) -> JobProducerResult<JobMeta> {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "access_builder".to_string(),
+            serde_json::to_value(self.access_builder.clone())?,
+        );
+        custom.insert(
+            "visibility".to_string(),
+            serde_json::to_value(self.visibility)?,
+        );
+
+        Ok(JobMeta {
+            retry: Some(0),
+            custom,
+            ..JobMeta::default()
+        })
+    }
+
+    fn identity(&self) -> String {
+        serde_json::to_string(self).expect("Cannot serialize Confirmations")
+    }
+}
+
+#[async_trait]
+impl JobConsumer for Confirmation {
+    fn type_name(&self) -> String {
+        "Confirmation".to_string()
+    }
+
+    fn access_builder(&self) -> AccessBuilder {
+        self.access_builder.clone()
+    }
+
+    fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
+    async fn run(&self, ctx: &DalContext) -> JobConsumerResult<()> {
+        let prototype = ConfirmationPrototype::get_by_id(ctx, &self.confirmation_prototype_id)
+            .await?
+            .ok_or_else(|| ConfirmationPrototypeError::NotFound(self.confirmation_prototype_id))?;
+        let resolver = prototype
+            .run(ctx, self.component_id, self.system_id)
+            .await?;
+        let status = match resolver.success() {
+            true => ConfirmationStatus::Success,
+            false => ConfirmationStatus::Failure,
+        };
+        WsEvent::confirmation_status_update(ctx, *prototype.id(), status)
+            .publish(ctx)
+            .await?;
+        Ok(())
+    }
+}
+
+impl TryFrom<faktory_async::Job> for Confirmation {
+    type Error = JobConsumerError;
+
+    fn try_from(job: faktory_async::Job) -> Result<Self, Self::Error> {
+        if job.args().len() != 3 {
+            return Err(JobConsumerError::InvalidArguments(
+                r#"[{ component_id: ComponentId, system_id: SystemId, confirmation_prototype_id: ConfirmationPrototypeId }, <AccessBuilder>, <Visibility>]"#.to_string(),
+                job.args().to_vec(),
+            ));
+        }
+        let args: ConfirmationArgs = serde_json::from_value(job.args()[0].clone())?;
+        let access_builder: AccessBuilder = serde_json::from_value(job.args()[1].clone())?;
+        let visibility: Visibility = serde_json::from_value(job.args()[2].clone())?;
+
+        let faktory_job_info = FaktoryJobInfo::try_from(job)?;
+
+        Ok(Self {
+            access_builder,
+            visibility,
+            faktory_job: Some(faktory_job_info),
+            component_id: args.component_id,
+            system_id: args.system_id,
+            confirmation_prototype_id: args.confirmation_prototype_id,
+        })
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -25,6 +25,7 @@ pub mod component;
 pub mod confirmation_prototype;
 pub mod confirmation_resolver;
 pub mod confirmation_resolver_tree;
+pub mod confirmation_status;
 pub mod context;
 pub mod cyclone_key_pair;
 pub mod diagram;

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use si_data::NatsError;
 
 use crate::code_generation_resolver::CodeGenerationId;
+use crate::confirmation_status::ConfirmationStatusUpdate;
 use crate::qualification::QualificationCheckId;
 use crate::resource::ResourceRefreshId;
 use crate::workflow::{CommandOutput, CommandReturn, FixReturn};
@@ -33,6 +34,7 @@ pub enum WsPayload {
     CommandOutput(CommandOutput),
     CommandReturn(CommandReturn),
     FixReturn(FixReturn),
+    ConfirmationStatusUpdate(ConfirmationStatusUpdate),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
## Description

Publish "running", "success" and "failure" events of individual confirmations to the frontend. In addition, split confirmations into individual jobs for performance reasons.

## Screenshot

![image](https://user-images.githubusercontent.com/39320683/197253765-9b069c5d-4c24-4ddc-8499-b9082e0499b2.png)

## GIF and Linear

<img src="https://media3.giphy.com/media/rENopoYGHYif6cc6mC/giphy.gif"/>

Fixes ENG-675