### PR TITLE
chore(PG) Do not run pganalyze by default when running localy built PG container

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -26,7 +26,7 @@ partial-pganalyze: init
 		up -d nats pg otel faktory
 
 partial-local-pg: init
-	SI_ROOT="${MAKEPATH}/.." sh ${MAKEPATH}/scripts/push-pg-local.sh 
+	SI_ROOT="${MAKEPATH}/.." bash ${MAKEPATH}/scripts/push-pg-local.sh 
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \


### PR DESCRIPTION
The locally built PG container is meant to get an arm64 build of PG for performance improvements, and doesn't need to be booting pganalyze by default, as it should be specifically opted into.