### PR TITLE
chore: manually deploy prod & speed up dev pulls

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -10,29 +10,29 @@ boostrap:
 
 # Run this target alongside local developer builds of web, sdf, etc.
 # This target does not compose down beforehand.
-partial: init
+partial: init-partial
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
-		up -d nats pg otel faktory
+			up --detach
 
-partial-pganalyze: init
+partial-pganalyze: init-partial
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.pganalyze.yml \
-		up -d nats pg otel faktory
+			up --detach
 
-partial-local-pg: init
+partial-local-pg: init-partial
 	SI_ROOT="${MAKEPATH}/.." bash ${MAKEPATH}/scripts/push-pg-local.sh 
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.local-postgres.yml \
-		up -d nats pg otel faktory
+			up --detach
 
 # Run interactively and compose down beforehand. This target is meant to be run iteratively for
 # local development and testing.
@@ -41,18 +41,21 @@ dev: down init
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
-		up
+			-f $(MAKEPATH)/docker-compose.ci.yml \
+			--profile si \
+			up
 
 # Run in a detached state and do not compose down beforehand.
 # This is the target to run in production.
-prod: init
+prod:
 	GATEWAY=$(shell $(MAKEPATH)/scripts/gateway.sh) \
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.pganalyze.yml \
 			-f $(MAKEPATH)/docker-compose.prod.yml \
-		up -d
+			--profile si \
+			up --detach
 
 web: init
 	# REPOPATH=$(REPOPATH) $(MAKEPATH)/scripts/check-for-artifacts-before-mounting.sh
@@ -62,7 +65,7 @@ web: init
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.ci.yml \
-		up -d
+			up --detach
 
 ci: init
 	REPOPATH=$(REPOPATH) $(MAKEPATH)/scripts/check-for-artifacts-before-mounting.sh
@@ -71,14 +74,27 @@ ci: init
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
 			-f $(MAKEPATH)/docker-compose.ci.yml \
-		up -d
+			up --detach
 
 down:
-	-docker compose -f $(MAKEPATH)/docker-compose.yml \
+	-docker compose \
+		-f $(MAKEPATH)/docker-compose.yml \
+		--profile si \
 		down
+
+init-partial:
+	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
+		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
+	fi
+	docker compose \
+		-f $(MAKEPATH)/docker-compose.yml \
+		pull
 
 init:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
-	docker compose -f $(MAKEPATH)/docker-compose.yml pull
+	docker compose \
+		-f $(MAKEPATH)/docker-compose.yml \
+		--profile si \
+		pull

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,21 +1,27 @@
 version: "3"
 
-# NOTE(nick): "depends_on" will start parent containers when using `docker compose` run, so we should
-# try to only use it when necessary.
+# NOTE(nick): "depends_on" will start parent containers when using `docker
+# compose` run, so we should try to only use it when necessary.
 
 services:
   web:
     image: "index.docker.io/systeminit/web:stable"
+    profiles:
+      - si
+      - si-watchtower
+      - web
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "443:443"
-    depends_on:
-      - watchtower
     restart: "unless-stopped"
 
   sdf:
     image: "index.docker.io/systeminit/sdf:stable"
+    profiles:
+      - si
+      - si-watchtower
+      - sdf
     ports:
       - "5156:5156"
     environment:
@@ -31,7 +37,6 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:
-      - watchtower
       - pg
       - faktory
       - otel
@@ -40,6 +45,10 @@ services:
 
   veritech:
     image: "index.docker.io/systeminit/veritech:stable"
+    profiles:
+      - si
+      - si-watchtower
+      - veritech
     environment:
       - "SI_VERITECH__NATS__URL=nats"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
@@ -49,13 +58,16 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:
-      - watchtower
       - otel
       - nats
     restart: "unless-stopped"
 
   pinga:
     image: "index.docker.io/systeminit/pinga:stable"
+    profiles:
+      - si
+      - si-watchtower
+      - pinga
     environment:
       - "SI_PINGA__PG__HOSTNAME=postgres"
       - "SI_PINGA__NATS__URL=nats"
@@ -69,7 +81,6 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:
-      - watchtower
       - pg
       - faktory
       - otel
@@ -88,8 +99,6 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "5432:5432"
-    depends_on:
-      - watchtower
 
   faktory:
     image: "index.docker.io/contribsys/faktory:latest"
@@ -103,8 +112,6 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - "4222:4222"
-    depends_on:
-      - watchtower
 
   otel:
     image: "index.docker.io/systeminit/otelcol:stable"
@@ -113,12 +120,14 @@ services:
     ports:
       - "4317:4317"
       - "55679:55679"
-    depends_on:
-      - watchtower
 
-  # NOTE(nick): watchtower requires full image names for private registries, which include prefixes like "index.docker.io".
+  # NOTE(nick): watchtower requires full image names for private registries,
+  # which include prefixes like "index.docker.io".
   watchtower:
     image: "containrrr/watchtower"
+    profiles:
+      - watchtower
+      - si-watchtower
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "${DOCKER_CONFIG:-~/.docker/config}:/config.json:ro"


### PR DESCRIPTION
This change, while adding some more Docker Compose complexity accomplishes 2 things:

- Disable the watchtower behavior in `make prod` by default by introducing Docker Compose [profiles][] which are explicitly opt-in groupings of services. This required adding another `docker-compose.watchtower.yml` overlay which tracks the `depends_on` dependencies for all services are all `depends_on` services are required and since watchtower is not occasionally required, these relationships need to be conditionally added (oi).
- Speed up Docker image pulls in CI and development by introducing an `si` profile which groups our own authored services (i.e. web, sdf, veritech, pinga) into an optional group, leaving the remaining required services (i.e. pg, nats, otel) as "always deploying" services. In the proudction deploys, `--profile si` is used which runs all of our services and the `partial*` targets don't use the `si` profile, thus only running our required supporting services (oi oi).

[profiles]: https://docs.docker.com/compose/profiles/

Signed-off-by: Fletcher Nichol <fletcher@systeminit.com>