### PR TITLE
chore(ci): add optional `SI_SKIP_PULL` to skip image pull with `prepare`

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -126,6 +126,12 @@ In one terminal pane (e.g. using a terminal multiplexer, such as `tmux`, or tabs
 make prepare
 ```
 
+If you would like to skip pulling potentially newers Docker images before running the supporting services, then set `SI_SKIP_PULL` to a non-empty value, for example:
+
+```bash
+make prepare SI_SKIP_PULL=true
+```
+
 > #### Running Postgres on macOS `aarch64` (i.e. `arm64` or "Apple Silicon")
 >
 > As of October 2022, Docker Desktop runs Linux `x86_64` (i.e. `amd64`) images in a `qemu`, Linux `x86_64` VM.

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -86,15 +86,24 @@ init-partial:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
-	docker compose \
-		-f $(MAKEPATH)/docker-compose.yml \
-		pull
+	if [ -n "$(SI_SKIP_PULL)" ]; then \
+		echo "--- SI_SKIP_PULL set, skipping docker compose pull"; \
+	else \
+		docker compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			pull; \
+	fi
 
 init:
 	if [ ! -f $(MAKEPATH)/docker-compose.env.yml ]; then \
 		echo "version: \"3\"" > $(MAKEPATH)/docker-compose.env.yml; \
 	fi
-	docker compose \
-		-f $(MAKEPATH)/docker-compose.yml \
-		--profile si \
-		pull
+	if [ -n "$(SI_SKIP_PULL)" ]; then \
+		echo "--- SI_SKIP_PULL set, skipping docker compose pull"; \
+	else \
+		docker compose \
+			-f $(MAKEPATH)/docker-compose.yml \
+			--profile si \
+			pull; \
+	fi
+


### PR DESCRIPTION
This change adds an optional `SI_SKIP_PULL` environment variable which can be used or passed when calling `make prepare`. If the value is non-empty, then the `docker compose ... pull` step will be skipped over, potentially saving time, freezing specific Docker images for bug reproductions, etc.

To skip the step where new images are pulled before starting up our supporting services (i.e. pg, nats, faktory, otel), you can call the `prepare` task like so:

```bash
make prepare SI_SKIP_PULL=true
```

or:

```bash
export SI_SKIP_PULL=true
make prepare
```

or:

```bash
SI_SKIP_PULL=true make prepare
```

<img src="https://media3.giphy.com/media/MXM5QQ3jY7WmcmPwTI/giphy.gif"/>