### PR TITLE
chore: docker directory typo & add busybox to veritech

### DIFF
--- a/bin/pinga/Dockerfile
+++ b/bin/pinga/Dockerfile
@@ -52,7 +52,7 @@ ARG BIN=pinga
 
 RUN set -eux; \
     useradd -ms /bin/bash app; \
-    for dir in /run /etc /usr/local/etc /home/app/.confg; do \
+    for dir in /run /etc /usr/local/etc /home/app/.config; do \
         mkdir -pv "$dir/$BIN"; \
     done;
 

--- a/bin/sdf/Dockerfile
+++ b/bin/sdf/Dockerfile
@@ -53,7 +53,7 @@ ARG BIN=sdf
 
 RUN set -eux; \
     useradd -ms /bin/bash app; \
-    for dir in /run /etc /usr/local/etc /home/app/.confg; do \
+    for dir in /run /etc /usr/local/etc /home/app/.config; do \
         mkdir -pv "$dir/$BIN"; \
     done;
 

--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -97,7 +97,7 @@ ARG BIN=veritech
 
 RUN set -eux; \
     useradd -ms /bin/bash app; \
-    for dir in /run /etc /usr/local/etc /home/app/.confg; do \
+    for dir in /run /etc /usr/local/etc /home/app/.config; do \
         mkdir -pv "$dir/$BIN"; \
     done;
 


### PR DESCRIPTION
A couple issues that came up as we're redeploying production