### PR TITLE
fix(veritech): install **x86_64** version of butane in Docker image

### DIFF
--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -126,7 +126,7 @@ RUN set -eux; \
     tar xvf /tmp/kubeval.tar.gz -C /usr/local/bin kubeval; \
     rm -v /tmp/kubeval.tar.gz; \
     wget -O /usr/local/bin/butane \
-        "https://github.com/coreos/butane/releases/download/v$BUTANE_VERSION/butane-ppc64le-unknown-linux-gnu"; \
+        "https://github.com/coreos/butane/releases/download/v$BUTANE_VERSION/butane-x86_64-unknown-linux-gnu"; \
     chmod +x /usr/local/bin/butane;
 
 WORKDIR /run/$BIN


### PR DESCRIPTION
Well...a prior refactoring accidentally selected the **ppc64le** version of Butane--that certainly won't run as expected!

<img src="https://media1.giphy.com/media/XKSPsk67cnCw0/giphy.gif"/>