### PR TITLE
feat(dal): confirmation/fix create aws security group

### DIFF
--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.js
@@ -1,0 +1,40 @@
+async function create(component) {
+    if (component.resource?.data) {
+        throw new Error("resource already exists");
+    }
+
+    // Initialize the input JSON.
+    const object = {
+        "Description": component.properties.domain.Description,
+        "GroupName": component.properties.domain.GroupName,
+        "VpcId": component.properties.domain.VpcId,
+    };
+
+    // Normalize tags to be in the weird Map-like structure AWS uses (array of { Key: string, Value: string } where Key is unique
+    const tags = [];
+    for (const [key, value] of Object.entries(component.properties.domain.tags)) {
+        tags.push({
+            "Key": key,
+            "Value": value,
+        });
+    }
+    if (tags.length > 0) {
+        object["TagSpecifications"] = [{ "Tags": tags }];
+    }
+
+    // Now, create the security group.
+    const child = await siExec.waitUntilEnd("aws", [
+        "ec2",
+        "create-security-group",
+        "--region",
+        component.properties.domain.region,
+        "--cli-input-json",
+        JSON.stringify(object),
+    ]);
+
+    if (child.exitCode !== 0) {
+        throw new Error(`Failure running aws ec2 create-security-group (${child.exitCode}): ${child.stderr}`);
+    }
+
+    return { value: JSON.parse(child.stdout) };
+}

--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.json
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsCommand",
+  "response_type": "Command",
+  "code_file": "awsSecurityGroupCreateCommand.js",
+  "code_entrypoint": "create"
+}

--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateWorkflow.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateWorkflow.js
@@ -1,0 +1,12 @@
+async function create(arg) {
+  return {
+    name: "si:awsSecurityGroupCreateWorkflow",
+    kind: "conditional",
+    steps: [
+      {
+        command: "si:awsSecurityGroupCreateCommand",
+        args: [arg],
+      },
+    ],
+  };
+}

--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateWorkflow.json
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateWorkflow.json
@@ -1,0 +1,6 @@
+{
+  "kind": "JsWorkflow",
+  "response_type": "Workflow",
+  "code_file": "awsSecurityGroupCreateWorkflow.js",
+  "code_entrypoint": "create"
+}


### PR DESCRIPTION
- SecurityGroupId prop is unused in the creation, do we want to infer it from the resource? (that's not currently possible)