### PR TITLE
feat(dal): order by id desc to prefer newer values in standard model

### DIFF
--- a/lib/dal/src/migrations/U0004__standard_model.sql
+++ b/lib/dal/src/migrations/U0004__standard_model.sql
@@ -668,7 +668,9 @@ BEGIN
                            '    SELECT DISTINCT ON (object_id) %1$I.* '
                            '    FROM %1$I '
                            '    WHERE in_tenancy_and_visible_v1(this_read_tenancy, this_visibility, %1$I) '
-                           '    ORDER BY object_id, visibility_change_set_pk DESC, visibility_deleted_at DESC NULLS FIRST '
+                           '    ORDER BY object_id DESC, '
+                           '             visibility_change_set_pk DESC, '
+                           '             visibility_deleted_at DESC NULLS FIRST '
                            '$table_view_fn$; ',
                            this_table_name,
                            this_object_table,
@@ -761,7 +763,9 @@ BEGIN
                           '    SELECT DISTINCT ON (id) %1$I.* '
                           '    FROM %1$I '
                           '    WHERE in_tenancy_and_visible_v1(this_read_tenancy, this_visibility, %1$I) '
-                          '    ORDER BY id, visibility_change_set_pk DESC, visibility_deleted_at DESC NULLS FIRST '
+                          '    ORDER BY id DESC, '
+                          '             visibility_change_set_pk DESC, '
+                          '             visibility_deleted_at DESC NULLS FIRST '
                           '$table_view_fn$; ',
                           this_table_name
         );
@@ -879,7 +883,9 @@ BEGIN
                            '    SELECT DISTINCT ON (id) %1$I.* '
                            '    FROM %1$I '
                            '    WHERE in_tenancy_and_visible_v1(this_read_tenancy, this_visibility, %1$I) '
-                           '    ORDER BY id, visibility_change_set_pk DESC, visibility_deleted_at DESC NULLS FIRST '
+                           '    ORDER BY id DESC, '
+                           '             visibility_change_set_pk DESC, '
+                           '             visibility_deleted_at DESC NULLS FIRST '
                            '$table_view_fn$;',
                            this_table_name,
                            this_left_object_table,


### PR DESCRIPTION
We should avoid surfacing universal tenancy versions of objects if one exists in a specific tenancy. We solve this naively by ensuring the newest ids show up first in the standard model table views.

This may cause issues in the future if we want to remove something from universal tenancy and make a new version of it, with an updated id. Adding a `CASE WHEN is_universal IS TRUE THEN 0 ELSE 1 END ASC` to the `ORDER BY` clause does not solve that problem, because `DISTINCT ON (x)` requires us to order by `x` *first*, which means the second ordering by `is_universal` is only relevant to us if there is an id match. But the `only_one_live` constraints we have in place mean that there cannot be two objects with the same id in the same visibility, so the visibility ordering will already take care of providing the correct object in those cases.