### PR TITLE
feat(dal): create /root/resource prop and populate with Resource data

### DIFF
--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -42,8 +42,8 @@ async function main() {
 
   try {
     const requestJson = fs.readFileSync(STDIN_FD, "utf8");
+    debug({ request: requestJson });
     const request = JSON.parse(requestJson);
-    debug({ request, data: JSON.stringify(request?.data) });
     if (request.executionId) {
       executionId = request.executionId;
     } else {

--- a/lib/cyclone-server/src/result/resolver_function.rs
+++ b/lib/cyclone-server/src/result/resolver_function.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 #[serde(rename_all = "camelCase")]
 pub struct LangServerResolverFunctionResultSuccess {
     pub execution_id: String,
+    #[serde(default)]
     pub data: Value,
     pub unset: bool,
 }

--- a/lib/dal/src/builtins/func/awsKeyPairCreateCommand.js
+++ b/lib/dal/src/builtins/func/awsKeyPairCreateCommand.js
@@ -18,7 +18,10 @@ async function create(component) {
         });
     }
     if (tags.length > 0) {
-        object["TagSpecifications"] = [{ "Tags": tags }];
+        object["TagSpecifications"] = [{
+            "ResourceType": component.properties.domain.awsResourceType,
+            "Tags": tags
+        }];
     }
 
     // Now, create the key pair.

--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.js
@@ -19,7 +19,10 @@ async function create(component) {
         });
     }
     if (tags.length > 0) {
-        object["TagSpecifications"] = [{ "Tags": tags }];
+        object["TagSpecifications"] = [{
+            "ResourceType": component.properties.domain.awsResourceType,
+            "Tags": tags
+        }];
     }
 
     // Now, create the security group.

--- a/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.js
@@ -1,0 +1,5 @@
+function parse(properties) {
+    if (!properties.resource) return "";
+    const obj = JSON.parse(properties.resource);
+    return obj["GroupId"] ?? "";
+}

--- a/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.json
+++ b/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.json
@@ -1,0 +1,10 @@
+{
+  "kind": "Json",
+  "response_type": "String",
+  "code_file": "awsSecurityGroupIdFromResource.js",
+  "code_entrypoint": "parse",
+  "arguments": [{
+    "name": "resource",
+    "kind": "String"
+  }]
+}

--- a/lib/dal/src/func/backend/js_attribute.rs
+++ b/lib/dal/src/func/backend/js_attribute.rs
@@ -54,7 +54,6 @@ impl FuncDispatch for FuncBackendJsAttribute {
             }
             _ => {}
         };
-
         Ok(value)
     }
 }

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -121,6 +121,13 @@ impl From<&PropId> for PropertyEditorPropId {
     }
 }
 
+impl From<&PropertyEditorPropId> for PropId {
+    fn from(property_editor_prop_id: &PropertyEditorPropId) -> Self {
+        let number: i64 = (*property_editor_prop_id).into();
+        number.into()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyEditorProp {
@@ -193,6 +200,16 @@ impl PropertyEditorSchema {
             if let Some(child_prop_ids) = maybe_child_prop_ids {
                 child_props.insert(property_editor_prop.id, child_prop_ids);
             }
+
+            // Note: horrible hack to ignore resource in the frontend for now, I have no idea how to do it properly, let's leave it for after we test the concept
+            if child_props
+                .get(&root_prop.id().into())
+                .map_or(false, |p| p.contains(&property_editor_prop.id))
+                && property_editor_prop.name == "resource"
+            {
+                continue;
+            }
+
             props.insert(property_editor_prop.id, property_editor_prop);
         }
 

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -17,6 +17,7 @@ pub struct RootProp {
     pub prop_id: PropId,
     pub si_prop_id: PropId,
     pub domain_prop_id: PropId,
+    pub resource_prop_id: PropId,
 }
 
 impl RootProp {
@@ -43,6 +44,11 @@ impl RootProp {
 
         let domain_specific_prop = Prop::new(ctx, "domain", PropKind::Object, None).await?;
         domain_specific_prop
+            .set_parent_prop(ctx, *root_prop.id())
+            .await?;
+
+        let resource_specific_prop = Prop::new(ctx, "resource", PropKind::String, None).await?;
+        resource_specific_prop
             .set_parent_prop(ctx, *root_prop.id())
             .await?;
 
@@ -118,6 +124,7 @@ impl RootProp {
             prop_id: *root_prop.id(),
             si_prop_id: *si_specific_prop.id(),
             domain_prop_id: *domain_specific_prop.id(),
+            resource_prop_id: *resource_specific_prop.id(),
         })
     }
 }


### PR DESCRIPTION
- Remove SecurityGroupId prop from Security Group schema
- Populate internal provider from resource
- Parse SecurityGroupId from json blob in external provider

The external provider logic is not tested, I hope I don't break everything, but it's probably very close to it. I will test it on monday.