### PR TITLE
fix(dal): add tenancy_universal to belongs-to uniqueness constraint

### DIFF
--- a/lib/dal/src/migrations/U0004__standard_model.sql
+++ b/lib/dal/src/migrations/U0004__standard_model.sql
@@ -621,6 +621,7 @@ BEGIN
                            '                    WHERE visibility_deleted_at IS NULL; '
                            'CREATE UNIQUE INDEX %1$s_single_association ON %1$I (object_id, '
                            '                                        visibility_change_set_pk, '
+                           '                                        tenancy_universal, '
                            '                                        (visibility_deleted_at IS NULL)) '
                            '                    WHERE visibility_deleted_at IS NULL; '
                            'CREATE INDEX ON %1$I (object_id); '


### PR DESCRIPTION
Less sure that we need it for the only_one_live constraint since that is keyed on `id` and we should not, I think, be writing duplicate ids for objects in universal tenancy? Not sure. If we run into a problem we should add it.

I *believe* the recent changes that use the order by in DISTINCT ON queries to prefer non-universal tenancy to universal tenancy should ensure that we don't break things by adding this. 