### PR TITLE
fix(web): don't  open -1 func ids, load last selected func

### DIFF
--- a/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
@@ -53,22 +53,28 @@ const props = defineProps<{
 
 const funcIdParam = toRef(props, "funcId", -1);
 
+const routeToFunc = useRouteToFunc();
+const selectFunc = (func: ListedFuncView) => {
+  routeToFunc(func.id);
+};
+
 watch(
   () => funcIdParam.value,
   (funcIdParam) => {
     let funcId = funcIdParam ?? -1;
-    if (Number.isNaN(funcIdParam)) {
-      funcId = -1;
+    if (Number.isNaN(funcIdParam) || funcId === -1) {
+      if (selectedFuncId.value !== -1) {
+        routeToFunc(selectedFuncId.value);
+        return;
+      } else {
+        funcId = -1;
+      }
     }
     funcStore.SELECT_FUNC(funcId);
   },
   { immediate: true },
 );
 
-const routeToFunc = useRouteToFunc();
-const selectFunc = (func: ListedFuncView) => {
-  routeToFunc(func.id);
-};
 
 const createFunc = async ({
   isBuiltin,

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -104,6 +104,10 @@ export const useFuncStore = () => {
     },
     actions: {
       async SELECT_FUNC(funcId: FuncId) {
+        if (funcId === -1) {
+          return;
+        }
+
         const existing = this.openFuncsById[funcId];
         if (existing) {
           this.selectedFuncId = funcId;


### PR DESCRIPTION
Switching from the Customize Screen to the Model Screen and back to the Customize screen should reload the last selected function instead of reset to -1. Also, don't fetch funcId = -1;