### PR TITLE
bug(dal): partially fix intelligence across visibilities

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -143,6 +143,8 @@ pub enum AttributeValueError {
         "parent must be for an array, map, or object prop: attribute resolver id {0} is for a {1}"
     )]
     ParentNotAllowed(AttributeValueId, PropKind),
+    #[error("parent not found or does not exist for value: {0}")]
+    ParentNotFound(AttributeValueId),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("prop error: {0}")]

--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -342,9 +342,10 @@ impl Edge {
                 *head_explicit_internal_provider.id(),
             ));
         }
-        let head_explicit_internal_provider_attribute_prototype = head_explicit_internal_provider
-            .attribute_prototype_id()
-            .ok_or(InternalProviderError::EmptyAttributePrototype)?;
+        let head_explicit_internal_provider_attribute_prototype_id =
+            head_explicit_internal_provider
+                .attribute_prototype_id()
+                .ok_or(InternalProviderError::EmptyAttributePrototype)?;
 
         let identity_func = Func::find_by_attr(ctx, "name", &"si:identity")
             .await?
@@ -358,7 +359,7 @@ impl Edge {
         // Now, we can create the inter component attribute prototype argument.
         AttributePrototypeArgument::new_for_inter_component(
             ctx,
-            *head_explicit_internal_provider_attribute_prototype,
+            *head_explicit_internal_provider_attribute_prototype_id,
             *identity_func_arg.id(),
             head_component_id,
             tail_component_id,

--- a/lib/dal/src/migrations/U0058__internal_providers.sql
+++ b/lib/dal/src/migrations/U0058__internal_providers.sql
@@ -6,7 +6,7 @@ CREATE TABLE internal_providers
     tenancy_billing_account_ids bigint[],
     tenancy_organization_ids    bigint[],
     tenancy_workspace_ids       bigint[],
-    visibility_change_set_pk    bigint,
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),

--- a/lib/dal/src/migrations/U0059__external_providers.sql
+++ b/lib/dal/src/migrations/U0059__external_providers.sql
@@ -6,7 +6,7 @@ CREATE TABLE external_providers
     tenancy_billing_account_ids bigint[],
     tenancy_organization_ids    bigint[],
     tenancy_workspace_ids       bigint[],
-    visibility_change_set_pk    bigint,
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),

--- a/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
+++ b/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
@@ -6,7 +6,7 @@ CREATE TABLE attribute_prototype_arguments
     tenancy_billing_account_ids bigint[],
     tenancy_organization_ids    bigint[],
     tenancy_workspace_ids       bigint[],
-    visibility_change_set_pk    bigint,
+    visibility_change_set_pk    bigint                   NOT NULL DEFAULT -1,
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT NOW(),

--- a/lib/dal/src/queries/component/resource_attribute_value_for_component.sql
+++ b/lib/dal/src/queries/component/resource_attribute_value_for_component.sql
@@ -1,0 +1,38 @@
+SELECT DISTINCT ON (av.attribute_context_prop_id) row_to_json(av.*) AS object
+
+FROM attribute_values_v1($1, $2) AS av
+         JOIN (
+    SELECT resource_prop.id
+    FROM props_v1($1, $2) AS resource_prop
+             JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
+                  ON resource_prop.name = 'resource'
+                      AND pbtp.object_id = resource_prop.id
+                      AND pbtp.belongs_to_id IN (
+                          SELECT pmtmsv.left_object_id AS root_prop_id
+                          FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
+                                   JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
+                                        ON cbtsv.belongs_to_id = pmtmsv.right_object_id
+                                            AND cbtsv.object_id = $3
+                      )
+) AS resource_prop
+              ON av.attribute_context_prop_id = resource_prop.id
+
+WHERE in_attribute_context_v1(
+              attribute_context_build_from_parts_v1(
+                      resource_prop.id, -- PropId
+                      -1, -- InternalProviderId
+                      -1, -- ExternalProviderId
+                      NULL, -- SchemaId (handled by ComponentId)
+                      NULL, -- SchemaVariantId (handled by ComponentId)
+                      $3, -- ComponentId
+                      -1 -- SystemId (NOTE(nick,jacob): system is going away, we never set it)
+                  ),
+              av
+          )
+ORDER BY av.attribute_context_prop_id,
+         av.attribute_context_schema_id DESC,
+         av.attribute_context_schema_variant_id DESC,
+         av.attribute_context_component_id DESC,
+         av.attribute_context_system_id DESC,
+         av.tenancy_universal
+-- bools sort false first ascending.

--- a/lib/dal/src/resource.rs
+++ b/lib/dal/src/resource.rs
@@ -126,7 +126,7 @@ impl Resource {
         let component = Component::get_by_id(ctx, &component_id)
             .await?
             .ok_or(ResourceError::ComponentNotFound(component_id))?;
-        component.set_resource(ctx, &data).await.map_err(Box::new)?;
+        component.set_resource(ctx, data).await.map_err(Box::new)?;
 
         Ok(standard_model::finish_create_from_row(ctx, row).await?)
     }
@@ -144,7 +144,10 @@ impl Resource {
             let component = Component::get_by_id(ctx, &component_id)
                 .await?
                 .ok_or(ResourceError::ComponentNotFound(component_id))?;
-            component.set_resource(ctx, &data).await.map_err(Box::new)?;
+            component
+                .set_resource(ctx, data.clone())
+                .await
+                .map_err(Box::new)?;
 
             if resource.data != data {
                 resource.set_data(ctx, data.clone()).await?;


### PR DESCRIPTION
## Commit Description

- Partially fix intelligence across visibilities by ensuring the
  "change_set_pk" for providers and attribute prototype arguments
  defaults to "-1" and cannot be null (every other table does this)
  - This may fix other strange behavior observed in the UI
- Refactor the ability to set resources for a component to be more
  robust
- Refactor the integration tracking the bug outlined in the following
  PR: #1479
  - Since the bug has not been fully solved and likely exists in
    "attribute_value_affected_graph_v1", the test still retains the
    "ignore" macro

## What was the bug this PR fixed?

Short version: the `change_set_pk` was `null` on HEAD for both providers and `AttributePrototypeArguments`. Yes, this bug has existed since the three affected were originally added. The fix may affect more than the `/root/resource` intelligence bug tracked in the primary test of this PR, so after this is merged, we should monitor behavioral changes in the frontend (likely good ones, if any!).

## How can we prevent this in the future?

@jhelwig brought up a good idea to alter tables with the tenancy and visibility columns in the future rather than copy/pasting the columns per table.

## What about the bug where setting `/root/resource` doesn't update pre-existing relationships?

That is still a bug and will likely be tracked in a new Linear issue. Fixing the visibility bug seen here can be considered a partial fix for that and may even improve/alter behavior observed in the frontend generally (untested).

## GIF and Linear

<img src="https://media2.giphy.com/media/26xBtkkKAbDwkkU9i/giphy.gif"/>

Fixes ENG-732