### PR TITLE
feat(web,dal): update and create js validations

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -8,6 +8,7 @@ export enum FuncBackendKind {
   JsConfirmation = "JsConfirmation",
   JsCodeGeneration = "JsCodeGeneration",
   JsAttribute = "JsAttribute",
+  JsValidation = "JsValidation",
   Map = "Map",
   PropObject = "PropObject",
   String = "String",
@@ -37,6 +38,10 @@ export const CUSTOMIZABLE_FUNC_TYPES = {
   [FuncBackendKind.JsCommand]: {
     pluralLabel: "Commands",
     singularLabel: "Command",
+  },
+  [FuncBackendKind.JsValidation]: {
+    pluralLabel: "Validations",
+    singularLabel: "Validation",
   },
 };
 

--- a/app/web/src/organisms/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/organisms/FuncEditor/AttributeBindings.vue
@@ -153,8 +153,6 @@ const prototypeView = computed(() => {
         (sv) => sv.value === proto.schemaVariantId,
       )?.label ?? "none";
 
-    console.log(componentOptions.value);
-
     const component =
       componentOptions.value.find((c) => c.value === proto.componentId)
         ?.label ?? "all";

--- a/app/web/src/organisms/FuncEditor/AttributeBindingsModal.vue
+++ b/app/web/src/organisms/FuncEditor/AttributeBindingsModal.vue
@@ -76,7 +76,8 @@ const componentsStore = useComponentsStore();
 const { allComponents } = storeToRefs(componentsStore);
 
 const funcStore = useFuncStore();
-const { schemaVariantOptions, inputSources } = storeToRefs(funcStore);
+const { schemaVariantOptions, inputSources, propsAsOptionsForSchemaVariant } =
+  storeToRefs(funcStore);
 
 const props = withDefaults(
   defineProps<{
@@ -147,18 +148,12 @@ const filteredComponentOptions = computed<Option[]>(() =>
   ),
 );
 
-const outputLocationOptions = computed<Option[]>(
-  () =>
-    inputSources?.value.props
-      .filter(
-        (prop) =>
-          selectedVariant.value.value === -1 ||
-          selectedVariant.value.value === prop.schemaVariantId,
-      )
-      .map((prop) => ({
-        label: `${prop.path}${prop.name}`,
-        value: prop.propId,
-      })) ?? [],
+const outputLocationOptions = computed<Option[]>(() =>
+  propsAsOptionsForSchemaVariant.value(
+    typeof selectedVariant.value.value === "number"
+      ? selectedVariant.value.value
+      : -1,
+  ),
 );
 
 const inputSourceOptions = computed<Option[]>(() => {

--- a/app/web/src/organisms/FuncEditor/FuncDetails.vue
+++ b/app/web/src/organisms/FuncEditor/FuncDetails.vue
@@ -76,26 +76,45 @@
             v-if="
               editingFunc.kind === FuncBackendKind.JsQualification ||
               editingFunc.kind === FuncBackendKind.JsCodeGeneration ||
-              editingFunc.kind === FuncBackendKind.JsConfirmation
+              editingFunc.kind === FuncBackendKind.JsConfirmation ||
+              editingFunc.kind === FuncBackendKind.JsValidation
             "
             label="Run On"
             default-open
           >
             <QualificationDetails
-              v-if="associations && associations.type === 'qualification'"
-              v-model="associations"
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'qualification'
+              "
+              v-model="editingFunc.associations"
               :disabled="editingFunc.isBuiltin"
               @change="updateFunc"
             />
             <CodeGenerationDetails
-              v-if="associations && associations.type === 'codeGeneration'"
-              v-model="associations"
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'codeGeneration'
+              "
+              v-model="editingFunc.associations"
               :disabled="editingFunc.isBuiltin"
               @change="updateFunc"
             />
             <ConfirmationDetails
-              v-if="associations && associations.type === 'confirmation'"
-              v-model="associations"
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'confirmation'
+              "
+              v-model="editingFunc.associations"
+              :disabled="editingFunc.isBuiltin"
+              @change="updateFunc"
+            />
+            <ValidationDetails
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'validation'
+              "
+              v-model="editingFunc.associations"
               :disabled="editingFunc.isBuiltin"
               @change="updateFunc"
             />
@@ -106,9 +125,12 @@
             default-open
           >
             <FuncArguments
-              v-if="associations && associations.type === 'attribute'"
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'attribute'
+              "
               :func-id="selectedFuncId"
-              :arguments="associations.arguments"
+              :arguments="editingFunc.associations.arguments"
               :disabled="editingFunc.isBuiltin"
             />
           </SiCollapsible>
@@ -116,9 +138,12 @@
 
         <TabPanel v-if="editingFunc.kind === FuncBackendKind.JsAttribute">
           <AttributeBindings
-            v-if="associations && associations.type === 'attribute'"
+            v-if="
+              editingFunc.associations &&
+              editingFunc.associations.type === 'attribute'
+            "
             :func-id="selectedFuncId"
-            :associations="associations"
+            :associations="editingFunc.associations"
           />
         </TabPanel>
       </template>
@@ -145,14 +170,15 @@ import FuncArguments from "./FuncArguments.vue";
 import AttributeBindings from "./AttributeBindings.vue";
 import CodeGenerationDetails from "./CodeGenerationDetails.vue";
 import ConfirmationDetails from "./ConfirmationDetails.vue";
+import ValidationDetails from "./ValidationDetails.vue";
 
 const funcStore = useFuncStore();
 const { getFuncById, selectedFuncId } = storeToRefs(funcStore);
 
 const isDevMode = import.meta.env.DEV;
 const funcArgumentsIdMap = computed(() =>
-  associations.value?.type === "attribute"
-    ? associations.value.arguments.reduce((idMap, arg) => {
+  editingFunc?.value?.associations?.type === "attribute"
+    ? editingFunc?.value?.associations.arguments.reduce((idMap, arg) => {
         idMap[arg.id] = arg;
         return idMap;
       }, {} as { [key: number]: FuncArgument })
@@ -164,10 +190,12 @@ provide("funcArgumentsIdMap", funcArgumentsIdMap);
 const editingFunc = computed(
   () => getFuncById.value(selectedFuncId.value) ?? nullEditingFunc,
 );
-const associations = computed(() => editingFunc.value.associations);
 
 const updateFunc = () => {
-  funcStore.updateFuncAssociations(editingFunc.value.id, associations.value);
+  funcStore.updateFuncAssociations(
+    editingFunc.value.id,
+    editingFunc.value.associations,
+  );
 };
 
 const revertFunc = async () => {

--- a/app/web/src/organisms/FuncEditor/FuncPicker.vue
+++ b/app/web/src/organisms/FuncEditor/FuncPicker.vue
@@ -38,7 +38,7 @@
             as="li"
             class="w-full"
             content-as="ul"
-            :default-open="selectedFuncId > -1 && selectedFunc?.kind === kind"
+            default-open
           >
             <template #label>
               <div class="flex items-center gap-2">
@@ -121,7 +121,7 @@ import { useRouteToFunc } from "@/utils/useRouteToFunc";
 
 const routeToFunc = useRouteToFunc();
 const funcStore = useFuncStore();
-const { funcList, selectedFuncId, selectedFunc } = storeToRefs(funcStore);
+const { funcList, selectedFuncId } = storeToRefs(funcStore);
 
 const isDevMode = import.meta.env.DEV;
 

--- a/app/web/src/organisms/FuncEditor/ValidationDetails.vue
+++ b/app/web/src/organisms/FuncEditor/ValidationDetails.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="p-3 flex flex-col gap-2">
+    <h1 class="text-neutral-400 dark:text-neutral-300 text-sm">
+      Run this validation on the selected schema variant attributes below.
+    </h1>
+
+    <h2 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+      Run on Schema Variant and Attribute:
+    </h2>
+    <SelectMenu
+      v-model="selectedVariant"
+      class="flex-auto"
+      :options="schemaVariantOptions ?? []"
+    />
+    <SelectMenu
+      v-model="selectedProp"
+      class="flex-auto"
+      :options="propOptions"
+    />
+    <VButton
+      label="Add"
+      button-rank="primary"
+      icon="plus"
+      :disabled="disabled"
+      @click="addValidation"
+    />
+  </div>
+  <h2 class="p-3 pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+    Currently Validating:
+  </h2>
+  <ul class="flex flex-col p-3 gap-1 list-disc list-inside">
+    <li
+      v-for="protoView in prototypeViews"
+      :key="protoView.key"
+      class="flex flex-row gap-1 items-center text-sm pb-2 pl-4"
+    >
+      <div class="pr-2" role="decoration">•</div>
+      {{ protoView.schemaVariantName }}: {{ protoView.propName }}
+      <VButton
+        class="flex-none"
+        label=""
+        icon="trash"
+        button-rank="tertiary"
+        :disabled="disabled"
+        @click="deleteValidation(protoView.proto)"
+      />
+    </li>
+  </ul>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { storeToRefs } from "pinia";
+import isEqual from "lodash/isEqual";
+import SelectMenu, { Option } from "@/molecules/SelectMenu.vue";
+import { useFuncStore } from "@/store/func/funcs.store";
+import {
+  ValidationAssociations,
+  ValidationPrototypeView,
+} from "@/store/func/types";
+import VButton from "@/molecules/VButton.vue";
+
+const funcStore = useFuncStore();
+const {
+  schemaVariantOptions,
+  propsAsOptionsForSchemaVariant,
+  propIdToSourceName,
+} = storeToRefs(funcStore);
+
+const props = defineProps<{
+  modelValue: ValidationAssociations;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: ValidationAssociations): void;
+  (e: "change", v: ValidationAssociations): void;
+}>();
+
+const noneVariant = { label: "select schema variant", value: -1 };
+const noneProp = { label: "select attribute to validate", value: -1 };
+
+const selectedVariant = ref<Option>(noneVariant);
+const selectedProp = ref<Option>(noneProp);
+
+const propOptions = computed<Option[]>(() =>
+  propsAsOptionsForSchemaVariant.value(
+    typeof selectedVariant.value.value === "number"
+      ? selectedVariant.value.value
+      : -1,
+  ),
+);
+
+const prototypeViews = computed(() => {
+  return props.modelValue.prototypes.map((proto) => {
+    const schemaVariantName =
+      schemaVariantOptions.value.find(
+        (sv) => sv.value === proto.schemaVariantId,
+      )?.label ?? "none";
+    const propName = propIdToSourceName.value[proto.propId] ?? "none";
+
+    return {
+      schemaVariantName,
+      propName,
+      key: `${proto.id}-${proto.schemaVariantId}`,
+      proto: { ...proto },
+    };
+  });
+});
+
+const addValidation = () => {
+  const prototypes = Array.from(
+    new Set(
+      props.modelValue.prototypes.concat({
+        id: -1,
+        schemaVariantId: selectedVariant.value.value as number,
+        propId: selectedProp.value.value as number,
+      }),
+    ),
+  );
+
+  emit("update:modelValue", { type: "validation", prototypes });
+  emit("change", { type: "validation", prototypes });
+  selectedVariant.value = noneVariant;
+  selectedProp.value = noneProp;
+};
+
+const deleteValidation = (protoToDelete: ValidationPrototypeView) => {
+  const prototypes = props.modelValue.prototypes.filter(
+    (proto) => !isEqual(proto, protoToDelete),
+  );
+  emit("update:modelValue", { type: "validation", prototypes });
+  emit("change", { type: "validation", prototypes });
+};
+</script>

--- a/app/web/src/organisms/SiCollapsible.vue
+++ b/app/web/src/organisms/SiCollapsible.vue
@@ -62,7 +62,7 @@ const props = defineProps({
 });
 
 // why on earth are vue props not reactive by default
-const defaultOpen = toRef(props, 'defaultOpen', true);
+const defaultOpen = toRef(props, "defaultOpen", true);
 
 const slots = useSlots();
 const labelSlot = computed(() => slots.label?.());

--- a/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
@@ -75,7 +75,6 @@ watch(
   { immediate: true },
 );
 
-
 const createFunc = async ({
   isBuiltin,
   kind,

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -53,7 +53,6 @@ export const useFuncStore = () => {
       openFuncsList: [] as ListedFuncView[],
       selectedFuncId: -1 as FuncId,
       inputSources: { sockets: [], props: [] } as ListInputSourcesResponse,
-
       saveQueue: {} as Record<FuncId, (...args: unknown[]) => unknown>,
     }),
     getters: {
@@ -66,6 +65,18 @@ export const useFuncStore = () => {
       getFuncByIndex: (state) => (index: number) => state.openFuncsList[index],
       getIndexForFunc: (state) => (funcId: FuncId) =>
         state.openFuncsList.findIndex((f) => f.id === funcId),
+      // Filter props by schema variant
+      propsAsOptionsForSchemaVariant: (state) => (schemaVariantId: number) =>
+        state.inputSources.props
+          .filter(
+            (prop) =>
+              schemaVariantId === -1 ||
+              schemaVariantId === prop.schemaVariantId,
+          )
+          .map((prop) => ({
+            label: `${prop.path}${prop.name}`,
+            value: prop.propId,
+          })),
       selectedFunc: (state) => state.openFuncsById[state.selectedFuncId],
       schemaVariantOptions() {
         return componentsStore.schemaVariants.map((sv) => ({

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -23,6 +23,17 @@ export interface QualificationAssocations {
   componentIds: number[];
 }
 
+export interface ValidationAssociations {
+  type: "validation";
+  prototypes: ValidationPrototypeView[];
+}
+
+export interface ValidationPrototypeView {
+  id: number;
+  schemaVariantId: number;
+  propId: number;
+}
+
 export interface AttributePrototypeArgumentView {
   funcArgumentId: number;
   id?: number;
@@ -47,4 +58,5 @@ export type FuncAssociations =
   | AttributeAssocations
   | CodeGenerationAssociations
   | ConfirmationAssociations
-  | QualificationAssocations;
+  | QualificationAssocations
+  | ValidationAssociations;

--- a/lib/dal/src/queries/validation_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/validation_prototype_find_for_context.sql
@@ -1,0 +1,7 @@
+select 
+    validation_prototypes.id,
+    row_to_json(validation_prototypes.*) as object 
+from validation_prototypes_v1($1, $2) as validation_prototypes 
+    where validation_prototypes.prop_id = $3
+    and validation_prototypes.schema_variant_id = $4
+    and validation_prototypes.schema_id = $5

--- a/lib/dal/src/queries/validation_prototype_list_for_func.sql
+++ b/lib/dal/src/queries/validation_prototype_list_for_func.sql
@@ -1,0 +1,4 @@
+select validation_prototypes.id,
+    row_to_json(validation_prototypes.*) as object
+from validation_prototypes_v1($1, $2) as validation_prototypes
+where validation_prototypes.func_id = $3;

--- a/lib/sdf/src/server/service/func/create_func.rs
+++ b/lib/sdf/src/server/service/func/create_func.rs
@@ -59,6 +59,8 @@ pub static DEFAULT_CONFIRMATION_HANDLER: &str = "confirm";
 pub static DEFAULT_CONFIRMATION_CODE: &str = include_str!("./defaults/confirmation.ts");
 pub static DEFAULT_COMMAND_HANDLER: &str = "command";
 pub static DEFAULT_COMMAND_CODE: &str = include_str!("./defaults/command.ts");
+pub static DEFAULT_VALIDATION_HANDLER: &str = "validate";
+pub static DEFAULT_VALIDATION_CODE: &str = include_str!("./defaults/validation.ts");
 
 async fn create_qualification_func(ctx: &DalContext) -> FuncResult<Func> {
     let mut func = Func::new(
@@ -76,6 +78,23 @@ async fn create_qualification_func(ctx: &DalContext) -> FuncResult<Func> {
 
     let _ =
         QualificationPrototype::new(ctx, *func.id(), QualificationPrototypeContext::new()).await?;
+
+    Ok(func)
+}
+
+async fn create_validation_func(ctx: &DalContext) -> FuncResult<Func> {
+    let mut func = Func::new(
+        ctx,
+        generate_name(None),
+        FuncBackendKind::JsValidation,
+        FuncBackendResponseType::Validation,
+    )
+    .await?;
+
+    func.set_code_plaintext(ctx, Some(DEFAULT_VALIDATION_CODE))
+        .await?;
+    func.set_handler(ctx, Some(DEFAULT_VALIDATION_HANDLER))
+        .await?;
 
     Ok(func)
 }
@@ -285,6 +304,7 @@ pub async fn create_func(
         FuncBackendKind::JsCodeGeneration => create_code_gen_func(&ctx).await?,
         FuncBackendKind::JsConfirmation => create_confirmation_func(&ctx).await?,
         FuncBackendKind::JsCommand => create_command_func(&ctx).await?,
+        FuncBackendKind::JsValidation => create_validation_func(&ctx).await?,
         _ => Err(FuncError::FuncNotSupported)?,
     };
 

--- a/lib/sdf/src/server/service/func/defaults/validation.ts
+++ b/lib/sdf/src/server/service/func/defaults/validation.ts
@@ -1,0 +1,6 @@
+function validate(value) {
+    return {
+        valid: true,
+        message: "validation error message",
+    };
+}

--- a/lib/sdf/src/server/service/func/list_funcs.rs
+++ b/lib/sdf/src/server/service/func/list_funcs.rs
@@ -43,6 +43,7 @@ pub async fn list_funcs(
             &FuncBackendKind::JsCodeGeneration.as_ref().to_string(),
             &FuncBackendKind::JsCommand.as_ref().to_string(),
             &FuncBackendKind::JsConfirmation.as_ref().to_string(),
+            &FuncBackendKind::JsValidation.as_ref().to_string(),
         ],
     )
     .await?


### PR DESCRIPTION
Create save and update js validation functions. Also fixes some model-value bugs I introduced on accident for updating the associations for qualifications and functions other than attributes.