### PR TITLE
fix(web): fix validation reactivity in PropertyEditor

### DIFF
--- a/app/web/src/atoms/SiTextBox.vue
+++ b/app/web/src/atoms/SiTextBox.vue
@@ -83,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref } from "vue";
+import { computed, PropType, ref, toRefs } from "vue";
 import _ from "lodash";
 import { useFormSettings } from "@/composables/formSettings";
 import SiValidation, {
@@ -113,6 +113,8 @@ const props = defineProps({
   disabled: Boolean,
   loginMode: Boolean,
 });
+
+const { validations } = toRefs(props);
 
 const formSettings = useFormSettings();
 

--- a/app/web/src/atoms/SiValidation.vue
+++ b/app/web/src/atoms/SiValidation.vue
@@ -32,7 +32,9 @@ const emit = defineEmits<{ (e: "errors", errors: ErrorsArray): void }>();
 
 const errors = ref<ErrorsArray>([]);
 
-const evaluateErrors = (newValue: string) => {
+const { value, validations, required, showRequired, dirty } = toRefs(props);
+
+const evaluateErrors = (newValue: string, validations?: ValidatorArray) => {
   const currentErrors: ErrorsArray = [];
 
   if (required?.value && value.value.length === 0) {
@@ -42,8 +44,8 @@ const evaluateErrors = (newValue: string) => {
     });
   }
 
-  if (validations?.value) {
-    for (const v of validations.value) {
+  if (validations) {
+    for (const v of validations) {
       if (v.check(newValue) === false) {
         if (dirty.value) {
           currentErrors.push({ id: v.id, message: v.message });
@@ -56,19 +58,11 @@ const evaluateErrors = (newValue: string) => {
   emit("errors", errors.value);
 };
 
-const { value, validations, required, showRequired, dirty } = toRefs(props);
 watch(
-  value,
-  (newValue, _oldValue) => {
-    evaluateErrors(newValue);
-  },
-  { immediate: true },
-);
-watch(
-  dirty,
-  (newValue) => {
+  [() => value.value, () => dirty.value, () => validations?.value],
+  ([newValue, _newDirty, newValidations]) => {
     if (newValue) {
-      evaluateErrors(value.value);
+      evaluateErrors(newValue, newValidations);
     }
   },
   { immediate: true },

--- a/app/web/src/organisms/PropertyEditor.vue
+++ b/app/web/src/organisms/PropertyEditor.vue
@@ -71,15 +71,18 @@ const values = ref<PropertyEditorValues>(props.editorContext.values);
 const validations = ref<PropertyEditorValidation[]>(
   props.editorContext.validations,
 );
-watch(editorContext, (newValue) => {
-  schema.value = newValue.schema;
-  values.value = newValue.values;
-  validations.value = newValue.validations;
-});
+watch(
+  editorContext,
+  (newValue) => {
+    schema.value = newValue.schema;
+    values.value = newValue.values;
+    validations.value = newValue.validations;
+  },
+  { immediate: true },
+);
 
-const validationForValueId = (valueId: number) => {
-  return validations.value.find((validation) => validation.valueId === valueId);
-};
+const validationForValueId = (valueId: number) =>
+  validations.value.find((validation) => validation.valueId === valueId);
 
 const schemaForPropId = (propId: number) => {
   const schemaForProp = schema.value.props[propId];

--- a/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
@@ -52,7 +52,7 @@
       :value-id="props.propValue.id"
       :prop-kind="props.schemaProp.kind"
       :doc-link="props.schemaProp.docLink"
-      :validation="props.validation"
+      :validation="validation"
       :disabled="disabled"
       :func="props.propValue.func"
       :class="INPUT_CLASSES"
@@ -67,7 +67,7 @@
       :prop-id="props.propValue.propId"
       :value-id="props.propValue.id"
       :doc-link="props.schemaProp.docLink"
-      :validation="props.validation"
+      :validation="validation"
       :disabled="disabled"
       :class="INPUT_CLASSES"
       @updated-property="updatedProperty($event)"
@@ -85,7 +85,7 @@
       :prop-id="props.propValue.propId"
       :value-id="props.propValue.id"
       :doc-link="props.schemaProp.docLink"
-      :validation="props.validation"
+      :validation="validation"
       :disabled="disabled"
       :class="INPUT_CLASSES"
       @updated-property="updatedProperty($event)"
@@ -167,6 +167,8 @@ const props = defineProps<{
   arrayLength?: number;
   isFirstProp?: boolean;
 }>();
+
+const { validation } = toRefs(props);
 
 const emits = defineEmits<{
   (e: "toggleCollapsed", path: Array<string>): void;


### PR DESCRIPTION
The ref chain did not go all the way up to SiValidation, and the watcher in SiValidation needed to react on validation changes as well as value changes.