### PR TITLE
fix(sdf): update_property_editor_value should lookup value by context first

### DIFF
--- a/lib/sdf/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/update_property_editor_value.rs
@@ -1,5 +1,8 @@
 use axum::Json;
-use dal::{AttributeContext, AttributeValue, AttributeValueId, Visibility, WsEvent};
+use dal::{
+    AttributeContext, AttributeReadContext, AttributeValue, AttributeValueId, ExternalProviderId,
+    InternalProviderId, StandardModel, SystemId, Visibility, WsEvent,
+};
 use serde::{Deserialize, Serialize};
 
 use super::ComponentResult;
@@ -30,10 +33,44 @@ pub async fn update_property_editor_value(
 ) -> ComponentResult<Json<UpdatePropertyEditorValueResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
+    let read_context = AttributeReadContext {
+        prop_id: Some(request.attribute_context.prop_id()),
+        internal_provider_id: Some(InternalProviderId::NONE),
+        external_provider_id: Some(ExternalProviderId::NONE),
+        schema_id: Some(request.attribute_context.schema_id()),
+        schema_variant_id: Some(request.attribute_context.schema_variant_id()),
+        component_id: Some(request.attribute_context.component_id()),
+        system_id: Some(SystemId::NONE),
+    };
+
+    // When we set the value for the first time, we might only have the schema variant specific
+    // value id since there may not yet be a value for the component context. Let's make sure a
+    // value does not already exist for this context first. And if it does, set *that* value
+    // instead.
+    let (av_id, maybe_pav_id) =
+        if let Some(av) = AttributeValue::find_for_context(&ctx, read_context).await? {
+            if *av.id() != request.attribute_value_id {
+                (
+                    *av.id(),
+                    av.parent_attribute_value(&ctx).await?.map(|pav| *pav.id()),
+                )
+            } else {
+                (
+                    request.attribute_value_id,
+                    request.parent_attribute_value_id,
+                )
+            }
+        } else {
+            (
+                request.attribute_value_id,
+                request.parent_attribute_value_id,
+            )
+        };
+
     let (_, _) = AttributeValue::update_for_context(
         &ctx,
-        request.attribute_value_id,
-        request.parent_attribute_value_id,
+        av_id,
+        maybe_pav_id,
         request.attribute_context,
         request.value,
         request.key,


### PR DESCRIPTION
When making the first update to a value, the blur event might be triggered twice quickly in a row. We should look into synchronizing those blur updates so that we don't have overlapping ones going on at once, but in this case, the updates did not actually overlap. Instead, the update_for_context method was being called twice in a row with the attribute value of the "base" prop, since a value did not yet exist for the prop + component context. This caused two attribute values to be created. The validation would be run for the second one, but the property editor would get the attribute value id of the first one, and so we wouldn't display validations for the value. This ensures we lookup the existing attribute value by the provided context, and update *that* attribute value if it is a different one than the one sent in the request.