### PR TITLE
fix(web): skip updates if value id is out of date

### DIFF
--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -7,6 +7,7 @@ import { addStoreHooks } from "@/utils/pinia_hooks_plugin";
 import {
   PropertyEditorSchema,
   PropertyEditorValidation,
+  PropertyEditorValue,
   PropertyEditorValues,
 } from "@/api/sdf/dal/property_editor";
 import { AttributeContext } from "@/api/sdf/dal/attribute";
@@ -49,6 +50,10 @@ export const useComponentAttributesStore = () => {
         values: null as PropertyEditorValues | null,
       }),
       getters: {
+        currentValueForValueId:
+          (state) =>
+          (valueId: number): PropertyEditorValue | undefined =>
+            state.values?.values[valueId],
         // puts the schema, validations, values all together in a format used by the property editor
         editorContext: (state) => {
           const { schema, validations, values } = state;
@@ -163,6 +168,17 @@ export const useComponentAttributesStore = () => {
             | { insert: InsertPropertyEditorValueArgs },
         ) {
           const isInsert = "insert" in updatePayload;
+          // If the valueid for this update does not exist in the values tree,
+          // we shouldn't perform the update!
+          if (
+            this.currentValueForValueId(
+              isInsert
+                ? updatePayload.insert.parentAttributeValueId
+                : updatePayload.update.attributeValueId,
+            ) === undefined
+          ) {
+            return;
+          }
           return new ApiRequest<{ success: true }>({
             method: "post",
             url: isInsert


### PR DESCRIPTION
This is a stop gap before implementing better update synchronization.

When updating a value that does not yet exist in the component context, we only have the value id for the schema variant default value. If blur is triggered fast enough, the update can fire before the vue reactive tree has been able to update the value id from the get_property_editor_values request. This can be the case *even if* the request has completed and is not currently in flight.

We should just not execute the update in this case. We should also debounce the blur, probably. It would also be ideal if the update operation was idempotent, or close to it, when updating the value for a schema variant level attribute but passing in a component level context.

There are some other validation bugs I'm tinkering on as a follow up.