### PR TITLE
bug(dal) Fix reference to table not specified in from clause SQL error

### DIFF
--- a/lib/dal/src/queries/attribute_prototype_attribute_values_in_context_or_greater.sql
+++ b/lib/dal/src/queries/attribute_prototype_attribute_values_in_context_or_greater.sql
@@ -4,12 +4,4 @@ INNER JOIN attribute_value_belongs_to_attribute_prototype_v1($1, $2) AS avbtap
     ON avbtap.object_id = av.id
 WHERE
     avbtap.belongs_to_id = $3
-    AND exact_or_more_attribute_read_context_v1(
-        $4, attribute_values.attribute_context_prop_id,
-        attribute_values.attribute_context_internal_provider_id,
-        attribute_values.attribute_context_external_provider_id,
-        attribute_values.attribute_context_schema_id,
-        attribute_values.attribute_context_schema_variant_id,
-        attribute_values.attribute_context_component_id,
-        attribute_values.attribute_context_system_id
-    );
+    AND exact_or_more_attribute_read_context_v1($4, av);


### PR DESCRIPTION
The query was changed to alias `attribute_values` as `av`, but the reference to it in the `WHERE` clause wasn't updated.