### PR TITLE
bug(dal) Use correct variable name in RAISE statement in PL/pgSQL function

### DIFF
--- a/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
+++ b/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
@@ -1063,7 +1063,7 @@ BEGIN
         ON avbtap.belongs_to_id = ap.id
             AND avbtap.object_id = given_attribute_value.id;
     IF NOT FOUND THEN
-        RAISE 'Unable to find AttributePrototype for AttributeValue(%), Tenancy(%), Visibility(%)', attribute_value.id,
+        RAISE 'Unable to find AttributePrototype for AttributeValue(%), Tenancy(%), Visibility(%)', given_attribute_value.id,
                                                                                                     this_read_tenancy,
                                                                                                     this_visibility;
     END IF;


### PR DESCRIPTION
This should have been using `given_attribute_value.id` or `this_attribute_value_id`. `attribute_value` is never a thing in `attribute_value_update_for_context_raw_v1`.