### PR TITLE
feat(dal,sdf): exec_func endpoint supports validation funcs

### DIFF
--- a/lib/dal/src/migrations/U0044__validation_resolvers.sql
+++ b/lib/dal/src/migrations/U0044__validation_resolvers.sql
@@ -1,20 +1,24 @@
 CREATE TABLE validation_resolvers
 (
-    pk                           bigserial PRIMARY KEY,
-    id                           bigserial                NOT NULL,
-    tenancy_universal            bool                     NOT NULL,
-    tenancy_billing_account_ids  bigint[],
-    tenancy_organization_ids     bigint[],
-    tenancy_workspace_ids        bigint[],
-    visibility_change_set_pk     bigint                   NOT NULL DEFAULT -1,
-    visibility_deleted_at        timestamp with time zone,
-    created_at                   timestamp with time zone NOT NULL DEFAULT NOW(),
-    updated_at                   timestamp with time zone NOT NULL DEFAULT NOW(),
-    validation_prototype_id      bigint                   NOT NULL,
-    attribute_value_id           bigint                   NOT NULL,
-    func_id                      bigint                   NOT NULL,
-    func_binding_id              bigint                   NOT NULL,
-    func_binding_return_value_id bigint                   NOT NULL
+    pk                                           bigserial PRIMARY KEY,
+    id                                           bigserial                NOT NULL,
+    tenancy_universal                            bool                     NOT NULL,
+    tenancy_billing_account_ids                  bigint[],
+    tenancy_organization_ids                     bigint[],
+    tenancy_workspace_ids                        bigint[],
+    visibility_change_set_pk                     bigint                   NOT NULL DEFAULT -1,
+    visibility_deleted_at                        timestamp with time zone,
+    created_at                                   timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at                                   timestamp with time zone NOT NULL DEFAULT NOW(),
+    validation_prototype_id                      bigint                   NOT NULL,
+    attribute_value_id                           bigint                   NOT NULL,
+    validation_func_id                           bigint                   NOT NULL,
+    validation_func_binding_id                   bigint                   NOT NULL,
+    attribute_value_func_binding_return_value_id bigint                   NOT NULL,
+    CONSTRAINT one_resolver_per_func_and_value unique (tenancy_universal, tenancy_billing_account_ids,
+                                                       tenancy_organization_ids, tenancy_workspace_ids,
+                                                       visibility_change_set_pk, visibility_deleted_at,
+                                                       validation_func_id, attribute_value_id)
 );
 SELECT standard_model_table_constraints_v1('validation_resolvers');
 
@@ -31,17 +35,17 @@ CREATE OR REPLACE FUNCTION validation_resolver_create_v1(
     OUT object json) AS
 $$
 DECLARE
-    this_write_tenancy_record         tenancy_record_v1;
-    this_visibility_record            visibility_record_v1;
-    this_new_row                      validation_resolvers%ROWTYPE;
-    this_func_id                      bigint;
-    this_func_binding_return_value_id bigint;
+    this_write_tenancy_record                  tenancy_record_v1;
+    this_visibility_record                     visibility_record_v1;
+    this_new_row                               validation_resolvers%ROWTYPE;
+    this_func_id                               bigint;
+    this_attr_val_func_binding_return_value_id bigint;
 BEGIN
     this_write_tenancy_record := tenancy_json_to_columns_v1(this_write_tenancy);
     this_visibility_record := visibility_json_to_columns_v1(this_visibility);
 
     SELECT DISTINCT ON (id) func_binding_return_value_id
-    INTO STRICT this_func_binding_return_value_id
+    INTO STRICT this_attr_val_func_binding_return_value_id
     FROM attribute_values
     WHERE in_tenancy_and_visible_v1(this_read_tenancy, this_visibility, attribute_values)
       AND id = this_attribute_value_id
@@ -67,9 +71,9 @@ BEGIN
                                       visibility_deleted_at,
                                       validation_prototype_id,
                                       attribute_value_id,
-                                      func_id,
-                                      func_binding_id,
-                                      func_binding_return_value_id)
+                                      validation_func_id,
+                                      validation_func_binding_id,
+                                      attribute_value_func_binding_return_value_id)
     VALUES (this_write_tenancy_record.tenancy_universal,
             this_write_tenancy_record.tenancy_billing_account_ids,
             this_write_tenancy_record.tenancy_organization_ids,
@@ -80,7 +84,7 @@ BEGIN
             this_attribute_value_id,
             this_func_id,
             this_func_binding_id,
-            this_func_binding_return_value_id)
+            this_attr_val_func_binding_return_value_id)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/queries/validation_resolver_find_for_attribute_value_and_func_binding.sql
+++ b/lib/dal/src/queries/validation_resolver_find_for_attribute_value_and_func_binding.sql
@@ -1,5 +1,5 @@
 select row_to_json(validation_resolvers.*) as object
 from validation_resolvers_v1($1, $2) as validation_resolvers
 where attribute_value_id = $3
-  and func_binding_id = $4
+  and validation_func_id = $4
 order by validation_resolvers.id desc

--- a/lib/dal/src/queries/validation_resolver_find_status.sql
+++ b/lib/dal/src/queries/validation_resolver_find_status.sql
@@ -5,36 +5,31 @@ SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
                                              row_to_json(validation_prototypes.*)      as validation_prototype_json,
                                              row_to_json(func_binding_return_values.*) as object
 
-FROM attribute_values
-         LEFT JOIN validation_resolvers
+FROM attribute_values_v1($1, $2) as attribute_values
+         LEFT JOIN validation_resolvers_v1($1, $2) as validation_resolvers
                    ON validation_resolvers.attribute_value_id = attribute_values.id
                        AND
-                      validation_resolvers.func_binding_return_value_id = attribute_values.func_binding_return_value_id
-                       AND in_tenancy_and_visible_v1($1, $2, validation_resolvers)
-         LEFT JOIN validation_prototypes
+                      validation_resolvers.attribute_value_func_binding_return_value_id =
+                      attribute_values.func_binding_return_value_id
+         LEFT JOIN validation_prototypes_v1($1, $2) as validation_prototypes
                    ON validation_prototypes.id = validation_resolvers.validation_prototype_id
-                       AND in_tenancy_and_visible_v1($1, $2, validation_prototypes)
-         LEFT JOIN func_bindings
-                   ON func_bindings.id = validation_resolvers.func_binding_id
-                       AND in_tenancy_and_visible_v1($1, $2, func_bindings)
-         LEFT JOIN func_binding_return_value_belongs_to_func_binding
-                   ON func_binding_return_value_belongs_to_func_binding.belongs_to_id = func_bindings.id
-                       AND in_tenancy_and_visible_v1($1, $2, func_binding_return_value_belongs_to_func_binding)
-         LEFT JOIN func_binding_return_values
-                   ON func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
-                       AND in_tenancy_and_visible_v1($1, $2, func_binding_return_values)
-
-WHERE in_tenancy_and_visible_v1($1, $2, attribute_values)
-  AND attribute_values.attribute_context_prop_id IN (WITH RECURSIVE recursive_props AS
-                                                                        (SELECT left_object_id AS prop_id
-                                                                         FROM prop_many_to_many_schema_variants
-                                                                         WHERE right_object_id = $4
-                                                                         UNION ALL
-                                                                         SELECT pbp.object_id AS prop_id
-                                                                         FROM prop_belongs_to_prop AS pbp
-                                                                                  JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
-                                                     SELECT prop_id
-                                                     FROM recursive_props)
+         LEFT JOIN func_bindings_v1($1, $2) as func_bindings
+                   ON func_bindings.id = validation_resolvers.validation_func_binding_id
+         LEFT JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) as fbrvbtfb
+                   ON fbrvbtfb.belongs_to_id = func_bindings.id
+         LEFT JOIN func_binding_return_values_v1($1, $2) as func_binding_return_values
+                   ON func_binding_return_values.id = fbrvbtfb.object_id
+WHERE attribute_values.attribute_context_prop_id IN
+      (WITH RECURSIVE recursive_props AS
+                          (SELECT left_object_id AS prop_id
+                           FROM prop_many_to_many_schema_variants
+                           WHERE right_object_id = $4
+                           UNION ALL
+                           SELECT pbp.object_id AS prop_id
+                           FROM prop_belongs_to_prop AS pbp
+                                    JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
+       SELECT prop_id
+       FROM recursive_props)
   AND exact_attribute_read_context_v1($3, attribute_values.attribute_context_prop_id,
                                       attribute_values.attribute_context_internal_provider_id,
                                       attribute_values.attribute_context_external_provider_id,

--- a/lib/dal/src/standard_pk.rs
+++ b/lib/dal/src/standard_pk.rs
@@ -36,6 +36,12 @@ macro_rules! pk {
             }
         }
 
+        impl<'a> From<&'a $name> for $name {
+            fn from(pk: &'a $name) -> Self {
+                *pk
+            }
+        }
+
         impl std::str::FromStr for $name {
             type Err = std::num::ParseIntError;
 

--- a/lib/dal/src/validation/resolver.rs
+++ b/lib/dal/src/validation/resolver.rs
@@ -69,10 +69,12 @@ pub struct ValidationResolver {
     id: ValidationResolverId,
     validation_prototype_id: ValidationPrototypeId,
     attribute_value_id: AttributeValueId,
-    func_id: FuncId,
-    func_binding_id: FuncBindingId,
+    /// The [`FuncId`] of the validation func that we're the resolver for.
+    validation_func_id: FuncId,
+    /// The [`FuncBindingId`] for the validation func itself.
+    validation_func_binding_id: FuncBindingId,
     /// The [`FuncBindingReturnValueId`] that represents the value at this specific position & context.
-    func_binding_return_value_id: FuncBindingReturnValueId,
+    attribute_value_func_binding_return_value_id: FuncBindingReturnValueId,
     #[serde(flatten)]
     tenancy: WriteTenancy,
     #[serde(flatten)]
@@ -123,18 +125,22 @@ impl ValidationResolver {
         Pk(ValidationPrototypeId),
         ValidationResolverResult
     );
-    standard_model_accessor!(func_id, Pk(FuncId), ValidationResolverResult);
-    standard_model_accessor!(func_binding_id, Pk(FuncBindingId), ValidationResolverResult);
+    standard_model_accessor!(validation_func_id, Pk(FuncId), ValidationResolverResult);
     standard_model_accessor!(
-        func_binding_return_value_id,
+        validation_func_binding_id,
+        Pk(FuncBindingId),
+        ValidationResolverResult
+    );
+    standard_model_accessor!(
+        attribute_value_func_binding_return_value_id,
         Pk(FuncBindingReturnValueId),
         ValidationResolverResult
     );
 
-    pub async fn find_for_attribute_value_and_validation_func_binding(
+    pub async fn find_for_attribute_value_and_validation_func(
         ctx: &DalContext,
-        attribute_value_id: &AttributeValueId,
-        func_binding_id: &FuncBindingId,
+        attribute_value_id: AttributeValueId,
+        func_id: FuncId,
     ) -> ValidationResolverResult<Vec<Self>> {
         let rows = ctx
             .txns()
@@ -144,8 +150,8 @@ impl ValidationResolver {
                 &[
                     ctx.read_tenancy(),
                     ctx.visibility(),
-                    attribute_value_id,
-                    func_binding_id,
+                    &attribute_value_id,
+                    &func_id,
                 ],
             )
             .await?;

--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -138,6 +138,10 @@ pub enum FuncError {
     ValidationPrototypeMissingSchemaVariant(SchemaVariantId),
     #[error("validation prototype schema is missing")]
     ValidationPrototypeMissingSchema,
+    #[error("component missing schema variant")]
+    ComponentMissingSchemaVariant(ComponentId),
+    #[error("schema variant missing schema")]
+    SchemaVariantMissingSchema(SchemaVariantId),
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;


### PR DESCRIPTION
Makes it possible to just execute one validation func on a component (a single validation for a single prop).

Reworks the validation_resolvers table slightly for clarity. Adds a uniqueness constraint to the table so that there can only ever be one validation resolver per attribute_value_id and func_id. The func_binding/return_value caching mechanisms ensure we don't have to re-execute identical functions, but we need to be able to modify a function for the same value and same validation result but return a different message without creating another resolver.

Also fixes a bug in the list components for schema variant method where tenancy and visibility were swapped