### PR TITLE
add jq dependency to bootstrap script

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -68,6 +68,7 @@ function darwin-bootstrap {
         make
         protobuf
         skopeo
+        jq
     )
 
     brew update


### PR DESCRIPTION
was trying to get the new apple silicon postgres docker image running and ran into this missing dependency