### PR TITLE
fix(web): rework combobox to fix unset positioning

### DIFF
--- a/app/web/src/atoms/SiComboBox.vue
+++ b/app/web/src/atoms/SiComboBox.vue
@@ -1,77 +1,98 @@
 <template>
+  <label
+    :for="props.id"
+    class="block text-sm font-medium text-neutral-900 dark:text-neutral-50"
+  >
+    {{ title }} <span v-if="required">(required)</span>
+  </label>
+
   <div class="mt-1 w-full relative">
     <Combobox v-model="inputValue">
-      <ComboboxButton as="div">
-        <ComboboxInput
-          class="placeholder-neutral-400 border border-neutral-200 dark:border-neutral-600 text-sm rounded-sm shadow-sm w-full focus:border-action-300 pr-7"
-          :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
-          @change="query = $event.target.value"
-        />
-        <Icon
-          name="selector"
-          class="absolute right-1.5 top-1.5 text-neutral-400"
-        />
-        <div
-          v-if="inError"
-          class="absolute right-8 top-1.5 flex items-center text-destructive-400"
-        >
-          <Icon name="exclamation-circle" />
-        </div>
-      </ComboboxButton>
-      <ComboboxOptions
-        class="absolute z-20 w-full mt-1 text-sm border dark:border-neutral-600 rounded-sm"
-        :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
-        as="div"
-      >
-        <li
-          class="flex flex-col gap-0.5 px-2.5 py-2.5 gap-1 border-b dark:border-neutral-600"
-        >
-          <div>
-            <b>{{ filteredOptions.length }}</b> Result{{
-              filteredOptions.length === 1 ? "" : "s"
-            }}
-          </div>
-          <div class="text-neutral-500 italic text-smt">
-            Type in the field above to filter the list below.
-          </div>
-        </li>
-        <ul class="max-h-60 overflow-y-auto overflow-x-hidden">
-          <ComboboxOption
-            v-for="{ label, value } in filteredOptions"
-            :key="value"
-            v-slot="{ active, selected }"
-            as="template"
-            :value="value"
+      <div class="relative">
+        <ComboboxButton as="div">
+          <ComboboxInput
+            class="placeholder-neutral-400 border border-neutral-200 dark:border-neutral-600 text-sm rounded-sm shadow-sm w-full focus:border-action-300 pr-7"
+            :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
+            @change="query = $event.target.value"
+          />
+          <Icon
+            name="selector"
+            class="absolute right-1.5 top-1.5 text-neutral-400"
+          />
+          <div
+            v-if="inError"
+            class="absolute right-8 top-1.5 flex items-center text-destructive-400"
           >
-            <li
-              class="relative cursor-default select-none py-1.5 mx-2 dark:text-white rounded m-0.5 pl flex flex-row items-center"
-              :class="{
-                'bg-action-400 text-white': active,
-                'text-gray-900': !active,
-              }"
+            <Icon name="exclamation-circle" />
+          </div>
+        </ComboboxButton>
+        <ComboboxOptions
+          class="absolute z-20 w-full mt-1 text-sm border dark:border-neutral-600 rounded-sm"
+          :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
+          as="div"
+        >
+          <li
+            class="flex flex-col gap-0.5 px-2.5 py-2.5 gap-1 border-b dark:border-neutral-600"
+          >
+            <div>
+              <b>{{ filteredOptions.length }}</b> Result{{
+                filteredOptions.length === 1 ? "" : "s"
+              }}
+            </div>
+            <div class="text-neutral-500 italic text-smt">
+              Type in the field above to filter the list below.
+            </div>
+          </li>
+          <ul class="max-h-60 overflow-y-auto overflow-x-hidden">
+            <ComboboxOption
+              v-for="{ label, value } in filteredOptions"
+              :key="value"
+              v-slot="{ active, selected }"
+              as="template"
+              :value="value"
             >
-              <Icon v-if="selected" name="check" class="mx-2" size="sm" />
-              <span
-                class="block truncate"
-                :class="clsx(selected ? 'font-extrabold' : 'font-normal pl-9')"
+              <li
+                class="relative cursor-default select-none py-1.5 mx-2 dark:text-white rounded m-0.5 pl flex flex-row items-center"
+                :class="{
+                  'bg-action-400 text-white': active,
+                  'text-gray-900': !active,
+                }"
               >
-                {{ label }}
-              </span>
-            </li>
-          </ComboboxOption>
-        </ul>
-      </ComboboxOptions>
+                <Icon v-if="selected" name="check" class="mx-2" size="sm" />
+                <span
+                  class="block truncate"
+                  :class="
+                    clsx(selected ? 'font-extrabold' : 'font-normal pl-9')
+                  "
+                >
+                  {{ label }}
+                </span>
+              </li>
+            </ComboboxOption>
+          </ul>
+        </ComboboxOptions>
+      </div>
     </Combobox>
-
-    <SiValidation
-      :value="String(inputValue)"
-      :validations="validations"
-      :required="required"
-      :dirty="reallyDirty"
-      class="mt-2"
-      @errors="setInError($event)"
-    />
   </div>
+
+  <p v-if="docLink" class="mt-2 text-xs text-action-500">
+    <a :href="docLink" target="_blank" class="hover:underline">
+      Documentation
+    </a>
+  </p>
+
+  <p v-if="description" class="mt-2 text-xs text-neutral-300">
+    {{ description }}
+  </p>
+
+  <SiValidation
+    :value="String(inputValue)"
+    :validations="validations"
+    :required="required"
+    :dirty="reallyDirty"
+    class="mt-2"
+    @errors="setInError($event)"
+  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/organisms/FuncEditor/FuncDetails.vue
+++ b/app/web/src/organisms/FuncEditor/FuncDetails.vue
@@ -57,14 +57,14 @@
                 v-model="editingFunc.handler"
                 title="Entrypoint"
                 required
-                placeholder="The name of the function that will be executed first..."
+                placeholder="The name of the function that will be executed..."
                 :disabled="!isDevMode && editingFunc.isBuiltin"
                 @blur="updateFunc"
               />
               <SiTextBox
                 id="description"
                 v-model="editingFunc.description"
-                placeholder="Provide a brief description of what this qualification validates here..."
+                placeholder="Provide a brief description of this function here..."
                 title="Description"
                 text-area
                 :disabled="!isDevMode && editingFunc.isBuiltin"

--- a/app/web/src/organisms/PropertyEditor/WidgetComboBox.vue
+++ b/app/web/src/organisms/PropertyEditor/WidgetComboBox.vue
@@ -1,42 +1,27 @@
 <template>
-  <div v-show="isShown" class="flex flex-col content-center w-full">
-    <label
-      :for="fieldId"
-      class="block text-sm font-medium text-neutral-900 dark:text-neutral-50 whitespace-nowrap"
-    >
-      {{ props.name }} <span v-if="required">(required)</span>
-    </label>
-
-    <div class="flex items-center">
-      <SiComboBox
-        :id="fieldId"
-        v-model="currentValue"
-        class="flex-grow"
-        :options="props.options"
-        :title="props.name"
-        :doc-link="docLink"
-        :disabled="disabled"
-        :validations="validations"
-        always-validate
-        @change="setField"
-      />
-      <UnsetButton
-        v-if="!disabled"
-        class="mt-0"
-        :disabled="disableUnset"
-        @click="unsetField"
-      />
+  <div v-show="isShown" class="flex content-center w-full">
+    <div class="flex grow">
+      <div class="w-full">
+        <SiComboBox
+          :id="fieldId"
+          v-model="currentValue"
+          class="flex-grow"
+          :options="options"
+          :title="name"
+          :doc-link="docLink"
+          :disabled="disabled"
+          :validations="validations"
+          always-validate
+          @change="setField"
+        />
+      </div>
     </div>
 
-    <p v-if="docLink" class="mt-2 text-xs text-action-500">
-      <a :href="docLink" target="_blank" class="hover:underline">
-        Documentation
-      </a>
-    </p>
-
-    <p v-if="description" class="mt-2 text-xs text-neutral-300">
-      {{ description }}
-    </p>
+    <UnsetButton
+      v-if="!disabled"
+      :disabled="disableUnset"
+      @click="unsetField"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
Syncs combobox up with the structure of our other widgets so that the unset button will appear in the correct place when validation errors are rendered.

After: 
<img width="540" alt="Screenshot 2022-11-16 at 12 48 19 PM" src="https://user-images.githubusercontent.com/1928978/202267256-3f34cd9e-990d-45f7-9d02-065920ca7dd7.png">

Before: 
<img width="590" alt="image" src="https://user-images.githubusercontent.com/1928978/202267277-29354893-0c0b-46d1-ba67-5634c806d8b3.png">
