### PR TITLE
chore(dal) Audit queries for <table_name>_v1 function use

### DIFF
--- a/lib/dal/src/queries/attribute_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_for_context.sql
@@ -1,27 +1,22 @@
-SELECT DISTINCT
-    ON (attribute_prototypes.id) attribute_prototypes.id,
-                                 attribute_prototypes.attribute_context_prop_id,
-                                 attribute_prototypes.visibility_change_set_pk,
-                                 attribute_prototypes.visibility_deleted_at,
-                                 attribute_prototypes.attribute_context_internal_provider_id,
-                                 attribute_prototypes.attribute_context_external_provider_id,
-                                 attribute_prototypes.attribute_context_schema_id,
-                                 attribute_prototypes.attribute_context_schema_variant_id,
-                                 attribute_prototypes.attribute_context_component_id,
-                                 row_to_json(attribute_prototypes.*) AS object
+SELECT DISTINCT ON (
+    attribute_prototypes.attribute_context_prop_id,
+    attribute_prototypes.attribute_context_internal_provider_id,
+    attribute_prototypes.attribute_context_external_provider_id
+)
+    row_to_json(attribute_prototypes.*) AS object
 FROM attribute_prototypes_v1($1, $2) AS attribute_prototypes
-WHERE attribute_prototypes.attribute_context_prop_id = $3
-  AND attribute_prototypes.attribute_context_internal_provider_id = $4
-  AND attribute_prototypes.attribute_context_external_provider_id = $5
-  AND attribute_prototypes.attribute_context_schema_id = $6
-  AND attribute_prototypes.attribute_context_schema_variant_id = $7
-  AND attribute_prototypes.attribute_context_component_id = $8
-ORDER BY attribute_prototypes.id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST,
-         tenancy_universal,
-         attribute_context_internal_provider_id DESC,
-         attribute_context_external_provider_id DESC,
-         attribute_context_schema_id DESC,
-         attribute_context_schema_variant_id DESC,
-         attribute_context_component_id DESC;
+WHERE
+    attribute_prototypes.attribute_context_prop_id = $3
+    AND attribute_prototypes.attribute_context_internal_provider_id = $4
+    AND attribute_prototypes.attribute_context_external_provider_id = $5
+    AND attribute_prototypes.attribute_context_schema_id = $6
+    AND attribute_prototypes.attribute_context_schema_variant_id = $7
+    AND attribute_prototypes.attribute_context_component_id = $8
+ORDER BY
+    attribute_context_prop_id DESC,
+    attribute_context_internal_provider_id DESC,
+    attribute_context_external_provider_id DESC,
+    attribute_context_schema_id DESC,
+    attribute_context_schema_variant_id DESC,
+    attribute_context_component_id DESC,
+    attribute_context_system_id DESC;

--- a/lib/dal/src/queries/attribute_prototype_find_with_parent_value_and_key_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_with_parent_value_and_key_for_context.sql
@@ -1,5 +1,8 @@
-SELECT DISTINCT ON (attribute_prototypes.attribute_context_prop_id, attribute_prototypes.key)
-    row_to_json(attribute_prototypes.*) AS object
+SELECT DISTINCT ON (
+    ap.attribute_context_prop_id,
+    COALESCE(ap.key, '')
+)
+    row_to_json(ap.*) AS object
 FROM attribute_prototypes_v1($1, $2) AS ap
 INNER JOIN attribute_value_belongs_to_attribute_prototype_v1($1, $2) AS avbtap
     ON avbtap.belongs_to_id = ap.id
@@ -10,26 +13,18 @@ LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
 LEFT JOIN attribute_values_v1($1, $2) AS parent_attribute_values
     ON parent_attribute_values.id = avbtav.belongs_to_id
 WHERE
-    exact_attribute_context_v1(
-        $3,
-        attribute_prototypes.attribute_context_prop_id,
-        attribute_prototypes.attribute_context_internal_provider_id,
-        attribute_prototypes.attribute_context_external_provider_id,
-        attribute_prototypes.attribute_context_schema_id,
-        attribute_prototypes.attribute_context_schema_variant_id,
-        attribute_prototypes.attribute_context_component_id
-    )
+    exact_attribute_context_v1($3, ap)
     AND CASE
             WHEN $4::bigint IS NULL THEN parent_attribute_values.id IS NULL
             ELSE parent_attribute_values.id = $4::bigint
         END
     AND CASE
-            WHEN $5::text IS NULL THEN attribute_prototypes.key IS NULL
-            ELSE attribute_prototypes.key = $5::text
+            WHEN $5::text IS NULL THEN ap.key IS NULL
+            ELSE ap.key = $5::text
         END
 ORDER BY
     attribute_context_prop_id,
-    key,
+    COALESCE(key, ''),
     visibility_change_set_pk DESC,
     attribute_context_internal_provider_id DESC,
     attribute_context_external_provider_id DESC,

--- a/lib/dal/src/queries/attribute_prototype_list_by_head_from_external_provider_use_with_tail.sql
+++ b/lib/dal/src/queries/attribute_prototype_list_by_head_from_external_provider_use_with_tail.sql
@@ -1,11 +1,14 @@
-SELECT DISTINCT ON (attribute_prototypes.id, attribute_prototype_arguments.head_component_id)
+SELECT DISTINCT ON (
+    ap.id,
+    apa.head_component_id
+)
     row_to_json(attribute_prototypes.*)             AS object
 FROM attribute_prototypes_v1($1, $2) AS ap
 INNER JOIN attribute_prototype_arguments_v1($1, $2) AS apa
     ON apa.attribute_prototype_id = ap.id
 WHERE
-    attribute_prototype_arguments.external_provider_id = $3
-    AND attribute_prototype_arguments.tail_component_id = $4
+    apa.external_provider_id = $3
+    AND apa.tail_component_id = $4
 ORDER BY
-    attribute_prototypes.id,
-    attribute_prototype_arguments.head_component_id DESC;
+    ap.id,
+    apa.head_component_id DESC;

--- a/lib/dal/src/queries/attribute_prototype_list_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_list_for_context.sql
@@ -1,14 +1,18 @@
-SELECT DISTINCT ON (attribute_context_prop_id, COALESCE(key, ''))
+SELECT DISTINCT ON (
+    attribute_context_prop_id,
+    COALESCE(key, '')
+)
     row_to_json(ap.*) AS object
 FROM attribute_prototypes_v1($1, $2) AS ap
 WHERE
     in_attribute_context_v1($3, ap)
     AND attribute_context_prop_id = $4
-ORDER BY attribute_context_prop_id,
-         COALESCE(key, ''),
-         attribute_context_internal_provider_id DESC,
-         attribute_context_external_provider_id DESC,
-         attribute_context_schema_id DESC,
-         attribute_context_schema_variant_id DESC,
-         attribute_context_component_id DESC,
-         ap.tenancy_universal -- bools sort false first ascending.
+ORDER BY
+    attribute_context_prop_id,
+    COALESCE(key, ''),
+    attribute_context_internal_provider_id DESC,
+    attribute_context_external_provider_id DESC,
+    attribute_context_schema_id DESC,
+    attribute_context_schema_variant_id DESC,
+    attribute_context_component_id DESC,
+    ap.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_value_find_with_parent_and_prototype_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_find_with_parent_and_prototype_for_context.sql
@@ -15,15 +15,7 @@ LEFT JOIN attribute_values_v1($1, $2) AS parent_attribute_values
     ON parent_attribute_values.id = avbtav.belongs_to_id
 
 WHERE
-    exact_attribute_context_v1(
-        $3,
-        av.attribute_context_prop_id,
-        av.attribute_context_internal_provider_id,
-        av.attribute_context_external_provider_id,
-        av.attribute_context_schema_id,
-        av.attribute_context_schema_variant_id,
-        av.attribute_context_component_id
-    )
+    exact_attribute_context_v1($3, av)
     AND ap.id = $4
     AND CASE
         WHEN $5::bigint IS NULL THEN parent_attribute_values.id IS NULL

--- a/lib/dal/src/queries/attribute_value_list_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_list_for_context.sql
@@ -1,10 +1,11 @@
 SELECT DISTINCT ON (
-        belongs_to_id,
-        attribute_context_prop_id,
-        attribute_context_internal_provider_id,
-        attribute_context_external_provider_id,
-        COALESCE(key, '')
-    ) row_to_json(av.*) AS object
+    belongs_to_id,
+    attribute_context_prop_id,
+    attribute_context_internal_provider_id,
+    attribute_context_external_provider_id,
+    COALESCE(key, '')
+)
+    row_to_json(av.*) AS object
 FROM attribute_values_v1($1, $2) AS av
 LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
     ON avbtav.object_id = av.id

--- a/lib/dal/src/queries/attribute_value_list_payload_for_read_context.sql
+++ b/lib/dal/src/queries/attribute_value_list_payload_for_read_context.sql
@@ -1,12 +1,14 @@
-SELECT parent_attribute_value_id,
-       attribute_value_object,
-       prop_object,
-       func_binding_return_value_object AS object,
-       func_with_prototype_context
-FROM attribute_value_list_payload_for_read_context_v1($1, $2, $3, $4) AS payload (
-                                                                                  parent_attribute_value_id,
-                                                                                  attribute_value_object,
-                                                                                  prop_object,
-                                                                                  func_binding_return_value_object,
-                                                                                  func_with_prototype_context
+SELECT
+    parent_attribute_value_id,
+    attribute_value_object,
+    prop_object,
+    func_binding_return_value_object AS object,
+    func_with_prototype_context
+FROM attribute_value_list_payload_for_read_context_v1($1, $2, $3, $4)
+    AS payload (
+        parent_attribute_value_id,
+        attribute_value_object,
+        prop_object,
+        func_binding_return_value_object,
+        func_with_prototype_context
     );

--- a/lib/dal/src/queries/attribute_value_list_payload_for_read_context_and_root.sql
+++ b/lib/dal/src/queries/attribute_value_list_payload_for_read_context_and_root.sql
@@ -1,12 +1,14 @@
-SELECT parent_attribute_value_id,
-       attribute_value_object,
-       prop_object,
-       func_binding_return_value_object AS object,
-       func_with_prototype_context
-FROM attribute_value_list_payload_for_read_context_and_root_v1($1, $2, $3, $4) AS payload (
-                                                                                           parent_attribute_value_id,
-                                                                                           attribute_value_object,
-                                                                                           prop_object,
-                                                                                           func_binding_return_value_object,
-                                                                                           func_with_prototype_context
+SELECT
+    parent_attribute_value_id,
+    attribute_value_object,
+    prop_object,
+    func_binding_return_value_object AS object,
+    func_with_prototype_context
+FROM attribute_value_list_payload_for_read_context_and_root_v1($1, $2, $3, $4)
+    AS payload(
+        parent_attribute_value_id,
+        attribute_value_object,
+        prop_object,
+        func_binding_return_value_object,
+        func_with_prototype_context
     );

--- a/lib/dal/src/queries/authorize_user.sql
+++ b/lib/dal/src/queries/authorize_user.sql
@@ -1,23 +1,18 @@
--- TODO: Not quite sure what's going on here with the pk = pk matching. Older understanding of how visibility querying works?
-SELECT true AS authorized, users.id, users.visibility_change_set_pk
-FROM users
-         INNER JOIN group_many_to_many_users
-                    ON users.id = group_many_to_many_users.right_object_id
-                        AND users.visibility_change_set_pk = group_many_to_many_users.visibility_change_set_pk
-                        AND group_many_to_many_users.visibility_deleted_at IS NULL
-         INNER JOIN capability_belongs_to_group
-                    ON capability_belongs_to_group.belongs_to_id = group_many_to_many_users.left_object_id
-                        AND users.visibility_change_set_pk = capability_belongs_to_group.visibility_change_set_pk
-                        AND capability_belongs_to_group.visibility_deleted_at IS NULL
-         INNER JOIN capabilities
-                    ON capabilities.id = capability_belongs_to_group.object_id
-                        AND users.visibility_change_set_pk = capabilities.visibility_change_set_pk
-                        AND capabilities.visibility_deleted_at IS NULL
-                        AND capabilities.subject = 'any'
-                        AND capabilities.action = 'any'
+SELECT
+    true AS authorized,
+    users.id,
+    users.visibility_change_set_pk
+FROM users_v1($1, $2) AS users
+INNER JOIN group_many_to_many_users_v1($1, $2) AS group_many_to_many_users
+    ON users.id = group_many_to_many_users.right_object_id
+        AND group_many_to_many_users.visibility_deleted_at IS NULL
+INNER JOIN capability_belongs_to_group_v1($1, $2) AS capability_belongs_to_group
+    ON capability_belongs_to_group.belongs_to_id = group_many_to_many_users.left_object_id
+        AND capability_belongs_to_group.visibility_deleted_at IS NULL
+INNER JOIN capabilities_v1($1, $2) AS capabilities
+    ON capabilities.id = capability_belongs_to_group.object_id
+        AND capabilities.visibility_deleted_at IS NULL
+        AND capabilities.subject = 'any'
+        AND capabilities.action = 'any'
 WHERE users.id = $3
-  AND in_tenancy_v1($1, users.tenancy_universal, users.tenancy_billing_account_ids, users.tenancy_organization_ids,
-                    users.tenancy_workspace_ids)
-  AND is_visible_v1($2, users.visibility_change_set_pk, users.visibility_deleted_at)
-ORDER BY id, visibility_change_set_pk DESC
 LIMIT 1;

--- a/lib/dal/src/queries/change_set_get_by_pk.sql
+++ b/lib/dal/src/queries/change_set_get_by_pk.sql
@@ -1,6 +1,11 @@
 SELECT row_to_json(change_sets) AS object
 FROM change_sets
-WHERE change_sets.pk = $2
-  AND in_tenancy_v1($1, change_sets.tenancy_universal, change_sets.tenancy_billing_account_ids,
-                    change_sets.tenancy_organization_ids,
-                    change_sets.tenancy_workspace_ids);
+WHERE
+    change_sets.pk = $2
+    AND in_tenancy_v1(
+        $1,
+        change_sets.tenancy_universal,
+        change_sets.tenancy_billing_account_ids,
+        change_sets.tenancy_organization_ids,
+        change_sets.tenancy_workspace_ids
+    )

--- a/lib/dal/src/queries/change_set_open_list.sql
+++ b/lib/dal/src/queries/change_set_open_list.sql
@@ -1,6 +1,13 @@
-SELECT change_sets.name AS name, change_sets.pk AS value
+SELECT
+    change_sets.name AS name,
+    change_sets.pk AS value
 FROM change_sets
-WHERE status = 'Open'
-  AND in_tenancy_v1($1, change_sets.tenancy_universal, change_sets.tenancy_billing_account_ids,
-                    change_sets.tenancy_organization_ids,
-                    change_sets.tenancy_workspace_ids);
+WHERE
+    status = 'Open'
+    AND in_tenancy_v1(
+        $1,
+        change_sets.tenancy_universal,
+        change_sets.tenancy_billing_account_ids,
+        change_sets.tenancy_organization_ids,
+        change_sets.tenancy_workspace_ids
+    )

--- a/lib/dal/src/queries/code_generation_prototype_find_for_prop.sql
+++ b/lib/dal/src/queries/code_generation_prototype_find_for_prop.sql
@@ -1,10 +1,5 @@
-SELECT DISTINCT ON (id) id,
-                        row_to_json(code_generation_prototypes.*) AS object
-
+SELECT
+    id,
+    row_to_json(code_generation_prototypes.*) AS object
 FROM code_generation_prototypes_v1($1, $2) AS code_generation_prototypes
 WHERE prop_id = $3
-
-ORDER BY id,
-         prop_id DESC,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;

--- a/lib/dal/src/queries/code_generation_prototype_list_for_schema_variant.sql
+++ b/lib/dal/src/queries/code_generation_prototype_list_for_schema_variant.sql
@@ -1,10 +1,6 @@
-SELECT DISTINCT ON (id) row_to_json(cgp.*) AS object
-
+SELECT row_to_json(cgp.*) AS object
 FROM code_generation_prototypes_v1($1, $2) AS cgp
 WHERE schema_variant_id = $3
-
-ORDER BY id,
-         prop_id DESC,
-         schema_variant_id DESC,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
+ORDER BY
+    prop_id DESC,
+    schema_variant_id DESC

--- a/lib/dal/src/queries/component_find_for_node.sql
+++ b/lib/dal/src/queries/component_find_for_node.sql
@@ -1,5 +1,5 @@
 SELECT row_to_json(c.*) AS object
 FROM components_v1($1, $2) AS c
 INNER JOIN node_belongs_to_component_v1($1, $2) AS nbtc
-        ON c.id = nbtc.belongs_to_id
-            AND nbtc.object_id = $3
+    ON c.id = nbtc.belongs_to_id
+        AND nbtc.object_id = $3

--- a/lib/dal/src/queries/component_get_resource.sql
+++ b/lib/dal/src/queries/component_get_resource.sql
@@ -1,5 +1,4 @@
-SELECT DISTINCT ON (rr.id)
-    row_to_json(fbrv.*) AS object
+SELECT row_to_json(fbrv.*) AS object
 FROM resource_resolvers_v1($1, $2) AS rr
 INNER JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) AS fbrvbtfb
     ON fbrvbtfb.belongs_to_id = rr.func_binding_id
@@ -7,5 +6,3 @@ INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
     ON fbrv.id = fbrvbtfb.object_id
 WHERE
     rr.component_id = $3
-ORDER BY rr.id DESC,
-         fbrv.id DESC

--- a/lib/dal/src/queries/confirmation_prototype_list_for_context.sql
+++ b/lib/dal/src/queries/confirmation_prototype_list_for_context.sql
@@ -1,23 +1,13 @@
-SELECT DISTINCT ON (confirmation_prototypes.func_id) confirmation_prototypes.id,
-                                                 confirmation_prototypes.component_id,
-                                                 confirmation_prototypes.schema_id,
-                                                 confirmation_prototypes.schema_variant_id,
-                                                 confirmation_prototypes.visibility_change_set_pk,
-
-                                                 row_to_json(confirmation_prototypes.*) AS object
-FROM confirmation_prototypes
-WHERE in_tenancy_v1($1, confirmation_prototypes.tenancy_universal,
-                    confirmation_prototypes.tenancy_billing_account_ids,
-                    confirmation_prototypes.tenancy_organization_ids,
-                    confirmation_prototypes.tenancy_workspace_ids)
-  AND is_visible_v1($2, confirmation_prototypes.visibility_change_set_pk,
-                    confirmation_prototypes.visibility_deleted_at)
-  AND (confirmation_prototypes.schema_id = $5
+SELECT DISTINCT ON (confirmation_prototypes.func_id)
+    row_to_json(confirmation_prototypes.*) AS object
+FROM confirmation_prototypes_v1($1, $2) AS confirmation_prototypes
+WHERE
+    confirmation_prototypes.schema_id = $5
     OR confirmation_prototypes.schema_variant_id = $4
-    OR confirmation_prototypes.component_id = $3)
-ORDER BY confirmation_prototypes.func_id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         func_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
+    OR confirmation_prototypes.component_id = $3
+ORDER BY
+    confirmation_prototypes.func_id,
+    component_id DESC,
+    func_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;

--- a/lib/dal/src/queries/confirmation_resolver_find_for_prototype.sql
+++ b/lib/dal/src/queries/confirmation_resolver_find_for_prototype.sql
@@ -1,18 +1,7 @@
-SELECT DISTINCT ON (confirmation_resolvers.id) confirmation_resolvers.id,
-                                                confirmation_resolvers.visibility_change_set_pk,
-
-                                                confirmation_resolvers.component_id,
-                                                confirmation_resolvers.schema_id,
-                                                confirmation_resolvers.schema_variant_id,
-                                                row_to_json(confirmation_resolvers.*) as object
-FROM confirmation_resolvers_v1($1, $2) as confirmation_resolvers
-WHERE confirmation_resolvers.confirmation_prototype_id = $3
-  AND confirmation_resolvers.component_id = $4
-  AND confirmation_resolvers.schema_id = $5
-  AND confirmation_resolvers.schema_variant_id = $6
-ORDER BY confirmation_resolvers.id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
-
+SELECT row_to_json(confirmation_resolvers.*) as object
+FROM confirmation_resolvers_v1($1, $2) AS confirmation_resolvers
+WHERE
+    confirmation_resolvers.confirmation_prototype_id = $3
+    AND confirmation_resolvers.component_id = $4
+    AND confirmation_resolvers.schema_id = $5
+    AND confirmation_resolvers.schema_variant_id = $6

--- a/lib/dal/src/queries/edge_list_parents_for_component.sql
+++ b/lib/dal/src/queries/edge_list_parents_for_component.sql
@@ -1,21 +1,17 @@
-SELECT DISTINCT ON (tail_object_id) tail_object_id,
-                                    visibility_change_set_pk,
-                                    visibility_deleted_at
-
-FROM edges
-WHERE in_tenancy_and_visible_v1($1, $2, edges)
-  AND kind = 'configuration'
-  AND head_object_kind = 'configuration'
-  AND head_object_id = $3
-
-ORDER BY tail_object_id DESC,
-         id DESC,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST,
-         head_node_id DESC,
-         head_object_kind DESC,
-         head_object_id DESC,
-         head_socket_id DESC,
-         tail_node_id DESC,
-         tail_object_kind DESC,
-         tail_socket_id DESC;
+SELECT DISTINCT ON (tail_object_id)
+    tail_object_id
+FROM edges_v1($1, $2) AS edges
+WHERE
+    kind = 'configuration'
+    AND head_object_kind = 'configuration'
+    AND head_object_id = $3
+ORDER BY
+    tail_object_id DESC,
+    id DESC,
+    head_node_id DESC,
+    head_object_kind DESC,
+    head_object_id DESC,
+    head_socket_id DESC,
+    tail_node_id DESC,
+    tail_object_kind DESC,
+    tail_socket_id DESC;

--- a/lib/dal/src/queries/external_provider_find_for_schema_variant_and_name.sql
+++ b/lib/dal/src/queries/external_provider_find_for_schema_variant_and_name.sql
@@ -1,15 +1,5 @@
-SELECT DISTINCT ON (id) id,
-                        visibility_change_set_pk,
-                        visibility_deleted_at,
-                        row_to_json(external_providers.*) AS object
-FROM external_providers
-WHERE in_tenancy_v1($1, tenancy_universal, tenancy_billing_account_ids,
-                    tenancy_organization_ids, tenancy_workspace_ids)
-  AND is_visible_v1($2, visibility_change_set_pk,
-                    visibility_deleted_at)
-  AND schema_variant_id = $3
-  AND name = $4
-
-ORDER BY id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(external_providers.*) AS object
+FROM external_providers_v1($1, $2) AS external_providers
+WHERE
+    schema_variant_id = $3
+    AND name = $4

--- a/lib/dal/src/queries/external_provider_find_for_socket.sql
+++ b/lib/dal/src/queries/external_provider_find_for_socket.sql
@@ -1,29 +1,5 @@
-SELECT DISTINCT ON (external_providers.id) external_providers.id,
-                                           external_providers.visibility_change_set_pk,
-                                           external_providers.visibility_deleted_at,
-                                           row_to_json(external_providers.*) AS object
-
-FROM external_providers
-         INNER JOIN socket_belongs_to_external_provider
-                    ON external_providers.id = socket_belongs_to_external_provider.belongs_to_id
-                        AND in_tenancy_v1($1,
-                                          socket_belongs_to_external_provider.tenancy_universal,
-                                          socket_belongs_to_external_provider.tenancy_billing_account_ids,
-                                          socket_belongs_to_external_provider.tenancy_organization_ids,
-                                          socket_belongs_to_external_provider.tenancy_workspace_ids)
-                        AND is_visible_v1($2,
-                                          socket_belongs_to_external_provider.visibility_change_set_pk,
-                                          socket_belongs_to_external_provider.visibility_deleted_at)
-                        AND socket_belongs_to_external_provider.object_id = $3
-WHERE in_tenancy_v1($1,
-                    external_providers.tenancy_universal,
-                    external_providers.tenancy_billing_account_ids,
-                    external_providers.tenancy_organization_ids,
-                    external_providers.tenancy_workspace_ids)
-  AND is_visible_v1($2,
-                    external_providers.visibility_change_set_pk,
-                    external_providers.visibility_deleted_at)
-
-ORDER BY external_providers.id,
-         external_providers.visibility_change_set_pk DESC,
-         external_providers.visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(external_providers.*) AS object
+FROM external_providers_v1($1, $2) AS external_providers
+INNER JOIN socket_belongs_to_external_provider_v1($1, $2) AS socket_belongs_to_external_provider
+    ON external_providers.id = socket_belongs_to_external_provider.belongs_to_id
+        AND socket_belongs_to_external_provider.object_id = $3

--- a/lib/dal/src/queries/external_provider_list_for_attribute_prototype_with_tail_component_id.sql
+++ b/lib/dal/src/queries/external_provider_list_for_attribute_prototype_with_tail_component_id.sql
@@ -1,21 +1,7 @@
-SELECT DISTINCT ON (external_providers.id) external_providers.id,
-                                           external_providers.visibility_change_set_pk,
-
-                                           external_providers.visibility_deleted_at,
-                                           row_to_json(external_providers.*) AS object
-FROM external_providers
-         INNER JOIN attribute_prototype_arguments ON
-            attribute_prototype_arguments.external_provider_id = external_providers.id
-        AND is_visible_v1($2, attribute_prototype_arguments.visibility_change_set_pk,
-                          attribute_prototype_arguments.visibility_deleted_at)
-
-WHERE in_tenancy_v1($1, external_providers.tenancy_universal, external_providers.tenancy_billing_account_ids,
-                    external_providers.tenancy_organization_ids, external_providers.tenancy_workspace_ids)
-  AND is_visible_v1($2, external_providers.visibility_change_set_pk,
-                    external_providers.visibility_deleted_at)
-  AND external_providers.attribute_prototype_id = $3
-  AND attribute_prototype_arguments.tail_component_id = $4
-
-ORDER BY external_providers.id,
-         external_providers.visibility_change_set_pk DESC,
-         external_providers.visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(external_providers.*) AS object
+FROM external_providers_v1($1, $2) AS external_providers
+    INNER JOIN attribute_prototype_arguments_v1($1, $2)
+        ON attribute_prototype_arguments.external_provider_id = external_providers.id
+WHERE
+    external_providers.attribute_prototype_id = $3
+    AND attribute_prototype_arguments.tail_component_id = $4

--- a/lib/dal/src/queries/external_provider_list_for_schema_variant.sql
+++ b/lib/dal/src/queries/external_provider_list_for_schema_variant.sql
@@ -1,13 +1,3 @@
-SELECT DISTINCT ON (id) id,
-                        visibility_change_set_pk,
-                        visibility_deleted_at,
-                        row_to_json(external_providers.*) AS object
-FROM external_providers
-WHERE in_tenancy_v1($1, tenancy_universal, tenancy_billing_account_ids,
-                    tenancy_organization_ids, tenancy_workspace_ids)
-  AND is_visible_v1($2, visibility_change_set_pk, visibility_deleted_at)
-  AND schema_variant_id = $3
-
-ORDER BY id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(external_providers.*) AS object
+FROM external_providers_v1($1, $2) AS external_providers
+WHERE schema_variant_id = $3

--- a/lib/dal/src/queries/external_provider_list_from_internal_provider_use.sql
+++ b/lib/dal/src/queries/external_provider_list_from_internal_provider_use.sql
@@ -1,24 +1,7 @@
-SELECT DISTINCT ON (external_providers.id) external_providers.id,
-                                           external_providers.visibility_change_set_pk,
-
-                                           external_providers.visibility_deleted_at,
-                                           row_to_json(external_providers.*) AS object
-FROM external_proivders
-         INNER JOIN attribute_prototypes
-                    ON attribute_prototypes.id = external_prototypes.attribute_prototype_id
-                        AND is_visible_v1($2, attribute_prototypes.visibility_change_set_pk,
-                                          attribute_prototypes.visibility_deleted_at)
-         INNER JOIN attribute_prototype_arguments
-                    ON attribute_prototype_arguments.attribute_prototype_id = attribute_prototypes.id
-                        AND is_visible_v1($2, attribute_prototype_arguments.visibility_change_set_pk,
-                                          attribute_prototype_arguments.visibility_deleted_at)
-
-WHERE in_tenancy_v1($1, external_providers.tenancy_universal, external_providers.tenancy_billing_account_ids,
-                    external_providers.tenancy_organization_ids, external_providers.tenancy_workspace_ids)
-  AND is_visible_v1($2, external_providers.visibility_change_set_pk,
-                    external_providers.visibility_deleted_at)
-  AND attribute_prototype_arguments.internal_provider_id = $3
-
-ORDER BY external_providers.id,
-         external_providers.visibility_change_set_pk DESC,
-         external_providers.visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(external_providers.*) AS object
+FROM external_providers_v1($1, $2) AS external_providers
+INNER JOIN attribute_prototypes_v1($1, $2) AS attribute_prototypes
+    ON attribute_prototypes.id = external_prototypes.attribute_prototype_id
+INNER JOIN attribute_prototype_arguments_v1($1, $2) AS attribute_prototype_arguments
+    ON attribute_prototype_arguments.attribute_prototype_id = attribute_prototypes.id
+WHERE attribute_prototype_arguments.internal_provider_id = $3

--- a/lib/dal/src/queries/fix_batch_list_finished.sql
+++ b/lib/dal/src/queries/fix_batch_list_finished.sql
@@ -1,12 +1,3 @@
-SELECT DISTINCT ON (fix_batches.id) fix_batches.id,
-                                    fix_batches.visibility_change_set_pk,
-                                    fix_batches.visibility_deleted_at,
-                                    row_to_json(fix_batches.*) AS object
-
-FROM fix_batches
+SELECT row_to_json(fix_batches.*) AS object
+FROM fix_batches_v1($1, $2) AS fix_batches
 WHERE fix_batches.completion_status IS NOT NULL
-  AND in_tenancy_and_visible_v1($1, $2, fix_batches)
-
-ORDER BY fix_batches.id,
-         fix_batches.visibility_change_set_pk DESC,
-         fix_batches.visibility_deleted_at DESC NULLS FIRST

--- a/lib/dal/src/queries/fix_resolver_find_for_confirmation.sql
+++ b/lib/dal/src/queries/fix_resolver_find_for_confirmation.sql
@@ -1,10 +1,7 @@
 SELECT row_to_json(fix_resolvers.*) as object
-FROM fix_resolvers_v1($1, $2) as fix_resolvers
-WHERE fix_resolvers.confirmation_resolver_id = $3
-  AND fix_resolvers.component_id = $4
-  AND fix_resolvers.schema_id = $5
-  AND fix_resolvers.schema_variant_id = $6
-ORDER BY fix_resolvers.id,
-         component_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
+FROM fix_resolvers_v1($1, $2) AS fix_resolvers
+WHERE
+    fix_resolvers.confirmation_resolver_id = $3
+    AND fix_resolvers.component_id = $4
+    AND fix_resolvers.schema_id = $5
+    AND fix_resolvers.schema_variant_id = $6

--- a/lib/dal/src/queries/func_argument_find_by_name_for_func.sql
+++ b/lib/dal/src/queries/func_argument_find_by_name_for_func.sql
@@ -1,13 +1,5 @@
-SELECT DISTINCT
-ON (func_arguments.id) func_arguments.id,
-    func_arguments.visibility_change_set_pk,
-    func_arguments.visibility_deleted_at,
-    row_to_json(func_arguments.*) AS object
-FROM func_arguments
-WHERE in_tenancy_and_visible_v1($1, $2, func_arguments)
-    AND func_arguments.name = $3
+SELECT row_to_json(func_arguments.*) AS object
+FROM func_arguments_v1($1, $2) AS func_arguments
+WHERE
+    func_arguments.name = $3
     AND func_arguments.func_id = $4
-ORDER BY func_arguments.id,
-    visibility_change_set_pk DESC,
-    visibility_deleted_at DESC NULLS FIRST
-LIMIT 1

--- a/lib/dal/src/queries/func_argument_list_for_func.sql
+++ b/lib/dal/src/queries/func_argument_list_for_func.sql
@@ -1,11 +1,3 @@
-SELECT DISTINCT
-ON (func_arguments.id) func_arguments.id,
-    func_arguments.visibility_change_set_pk,
-    func_arguments.visibility_deleted_at,
-    row_to_json(func_arguments.*) AS object
-FROM func_arguments
-WHERE in_tenancy_and_visible_v1($1, $2, func_arguments)
-  AND func_arguments.func_id = $3
-ORDER BY func_arguments.id,
-    visibility_change_set_pk DESC,
-    visibility_deleted_at DESC NULLS FIRST
+SELECT row_to_json(func_arguments.*) AS object
+FROM func_arguments_v1($1, $2) AS func_arguments
+WHERE func_arguments.func_id = $3

--- a/lib/dal/src/queries/func_argument_list_for_func_with_prototype_arguments.sql
+++ b/lib/dal/src/queries/func_argument_list_for_func_with_prototype_arguments.sql
@@ -1,14 +1,10 @@
-SELECT DISTINCT
-    ON (func_arguments.name) func_arguments.name,
-                             row_to_json(func_arguments.*) as func_argument_object,
-                             row_to_json(apa.*)            AS prototype_argument_object
-FROM func_arguments
-         LEFT JOIN attribute_prototype_arguments apa
-                   ON func_arguments.id = apa.func_argument_id
-                       AND apa.attribute_prototype_id = $4
-                       AND in_tenancy_and_visible_v1($1, $2, apa)
-WHERE in_tenancy_and_visible_v1($1, $2, func_arguments)
-  AND func_arguments.func_id = $3
-ORDER BY func_arguments.name,
-         func_arguments.visibility_change_set_pk DESC,
-         func_arguments.visibility_deleted_at DESC NULLS FIRST;
+SELECT DISTINCT ON (func_arguments.name)
+    func_arguments.name,
+    row_to_json(func_arguments.*) as func_argument_object,
+    row_to_json(apa.*)            AS prototype_argument_object
+FROM func_arguments_v1($1, $2) AS func_arguments
+LEFT JOIN attribute_prototype_arguments_v1($1, $2) AS apa
+    ON func_arguments.id = apa.func_argument_id
+        AND apa.attribute_prototype_id = $4
+WHERE func_arguments.func_id = $3
+ORDER BY func_arguments.name

--- a/lib/dal/src/queries/func_binding_return_value_get_for_attribute_value.sql
+++ b/lib/dal/src/queries/func_binding_return_value_get_for_attribute_value.sql
@@ -1,22 +1,5 @@
-SELECT DISTINCT ON (func_binding_return_values.id) func_binding_return_values.id,
-                                                   func_binding_return_values.visibility_change_set_pk,
-                                                   func_binding_return_values.visibility_deleted_at,
-                                                   row_to_json(func_binding_return_values.*) as object
-FROM func_binding_return_values
-         INNER JOIN attribute_values ON
-            func_binding_return_values.id = attribute_values.func_binding_return_value_id
-        AND in_tenancy_v1($1, attribute_values.tenancy_universal,
-                          attribute_values.tenancy_billing_account_ids,
-                          attribute_values.tenancy_organization_ids,
-                          attribute_values.tenancy_workspace_ids)
-        AND is_visible_v1($2, attribute_values.visibility_change_set_pk,
-                          attribute_values.visibility_deleted_at)
-WHERE in_tenancy_v1($1, func_binding_return_values.tenancy_universal,
-                    func_binding_return_values.tenancy_billing_account_ids,
-                    func_binding_return_values.tenancy_organization_ids,
-                    func_binding_return_values.tenancy_workspace_ids)
-  AND is_visible_v1($2, func_binding_return_values.visibility_change_set_pk,
-                    func_binding_return_values.visibility_deleted_at)
-  AND attribute_values.id = $3
-ORDER BY func_binding_return_values.id func_binding_return_values.visibility_change_set_pk DESC,
-         func_binding_return_values.visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(fbrv.*) as object
+FROM func_binding_return_values_v1($1, $2) AS fbrv
+INNER JOIN attribute_values_v1($1, $2) AS av
+    ON fbrv.id = av.func_binding_return_value_id
+WHERE av.id = $3;

--- a/lib/dal/src/queries/func_binding_return_value_get_for_func_binding.sql
+++ b/lib/dal/src/queries/func_binding_return_value_get_for_func_binding.sql
@@ -1,24 +1,5 @@
-SELECT DISTINCT ON (func_binding_return_values.id) func_binding_return_values.id,
-                                                   func_binding_return_values.visibility_change_set_pk,
-
-                                                   func_binding_return_values.unprocessed_value,
-                                                   func_binding_return_values.value,
-                                                   row_to_json(func_binding_return_values.*) as object
-FROM func_binding_return_values
-         INNER JOIN func_binding_return_value_belongs_to_func_binding ON
-        func_binding_return_value_belongs_to_func_binding.object_id = func_binding_return_values.id
-WHERE in_tenancy_v1($1, func_binding_return_values.tenancy_universal,
-                    func_binding_return_values.tenancy_billing_account_ids,
-                    func_binding_return_values.tenancy_organization_ids,
-                    func_binding_return_values.tenancy_workspace_ids)
-  AND is_visible_v1($2, func_binding_return_values.visibility_change_set_pk,
-                    func_binding_return_values.visibility_deleted_at)
-  AND is_visible_v1($2,
-                    func_binding_return_value_belongs_to_func_binding.visibility_change_set_pk,
-                    func_binding_return_value_belongs_to_func_binding.visibility_deleted_at)
-  AND func_binding_return_value_belongs_to_func_binding.belongs_to_id = $3
-ORDER BY func_binding_return_values.id,
-         visibility_change_set_pk DESC,
-         func_binding_return_value_belongs_to_func_binding.belongs_to_id DESC,
-         func_binding_return_value_belongs_to_func_binding.object_id DESC
-LIMIT 1;
+SELECT row_to_json(func_binding_return_values.*) as object
+FROM func_binding_return_values_v1($1, $2) AS func_binding_return_values
+INNER JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) AS func_binding_return_value_belongs_to_func_binding
+    ON func_binding_return_value_belongs_to_func_binding.object_id = func_binding_return_values.id
+WHERE func_binding_return_value_belongs_to_func_binding.belongs_to_id = $3

--- a/lib/dal/src/queries/node_position_list_for_node.sql
+++ b/lib/dal/src/queries/node_position_list_for_node.sql
@@ -1,11 +1,5 @@
-SELECT DISTINCT ON (node_positions.id) node_positions.id,
-                                       node_positions.visibility_change_set_pk,
-                                       node_positions.visibility_deleted_at,
-                                       row_to_json(node_positions.*) AS object
-FROM node_positions_v1($1, $2) as node_positions
-         INNER JOIN node_position_belongs_to_node_v1($1, $2) as node_position_belongs_to_node
-                    ON node_position_belongs_to_node.object_id = node_positions.id
-                        AND node_position_belongs_to_node.belongs_to_id = $3
-ORDER BY node_positions.id,
-         node_positions.visibility_change_set_pk DESC,
-         node_positions.visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(node_positions.*) AS object
+FROM node_positions_v1($1, $2) AS node_positions
+INNER JOIN node_position_belongs_to_node_v1($1, $2) AS node_position_belongs_to_node
+    ON node_position_belongs_to_node.object_id = node_positions.id
+WHERE node_position_belongs_to_node.belongs_to_id = $3

--- a/lib/dal/src/queries/prop_all_ancestor_props.sql
+++ b/lib/dal/src/queries/prop_all_ancestor_props.sql
@@ -1,12 +1,17 @@
-WITH RECURSIVE recursive_props AS
-                   (SELECT $3::bigint AS prop_id,
-                           0::bigint  AS depth
-                    UNION ALL
-                    SELECT pbp.belongs_to_id         AS prop_id,
-                           recursive_props.depth + 1 AS depth
-                    FROM prop_belongs_to_prop_v1($1, $2) AS pbp
-                             JOIN recursive_props ON pbp.object_id = recursive_props.prop_id)
+WITH RECURSIVE recursive_props AS (
+    SELECT
+        $3::bigint AS prop_id,
+        0::bigint  AS depth
+    UNION ALL
+    SELECT
+        pbp.belongs_to_id         AS prop_id,
+        recursive_props.depth + 1 AS depth
+    FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+    JOIN recursive_props
+        ON pbp.object_id = recursive_props.prop_id
+)
 SELECT row_to_json(props.*) AS object
 FROM props_v1($1, $2) as props
-         INNER JOIN recursive_props rp ON rp.prop_id = props.id
+INNER JOIN recursive_props rp
+    ON rp.prop_id = props.id
 ORDER BY depth DESC;

--- a/lib/dal/src/queries/prop_find_root_for_schema_variant.sql
+++ b/lib/dal/src/queries/prop_find_root_for_schema_variant.sql
@@ -1,21 +1,5 @@
-SELECT DISTINCT ON (props.id) props.id,
-                              props.visibility_change_set_pk,
-
-                              props.visibility_deleted_at,
-                              row_to_json(props.*) as object
-
-FROM props
-         INNER JOIN prop_many_to_many_schema_variants
-                    ON prop_many_to_many_schema_variants.left_object_id = props.id
-
-WHERE in_tenancy_v1($1, props.tenancy_universal,
-                    props.tenancy_billing_account_ids,
-                    props.tenancy_organization_ids,
-                    props.tenancy_workspace_ids)
-  AND is_visible_v1($2, props.visibility_change_set_pk,
-                    props.visibility_deleted_at)
-  AND prop_many_to_many_schema_variants.right_object_id = $3
-
-ORDER BY props.id,
-         props.visibility_change_set_pk DESC,
-         props.visibility_deleted_at DESC NULLS FIRST
+SELECT row_to_json(props.*) as object
+FROM props_v1($1, $2) AS props
+INNER JOIN prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+    ON prop_many_to_many_schema_variants.left_object_id = props.id
+WHERE prop_many_to_many_schema_variants.right_object_id = $3

--- a/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
+++ b/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
@@ -1,33 +1,27 @@
-SELECT DISTINCT ON (props.id, child_prop_ids.belongs_to_id) props.id,
-                                                            props.visibility_change_set_pk,
-                                                            child_prop_ids.child_prop_ids as child_prop_ids,
-                                                            row_to_json(props.*)          AS object
-FROM props
-         LEFT JOIN (SELECT prop_belongs_to_prop.belongs_to_id        AS belongs_to_id,
-                           array_agg(prop_belongs_to_prop.object_id) AS child_prop_ids
-                    FROM prop_belongs_to_prop
-                    GROUP BY prop_belongs_to_prop.belongs_to_id) AS child_prop_ids
-                   ON child_prop_ids.belongs_to_id = props.id
-WHERE in_tenancy_v1(
-        $1,
-        props.tenancy_universal,
-        props.tenancy_billing_account_ids,
-        props.tenancy_organization_ids,
-        props.tenancy_workspace_ids
+SELECT
+    child_prop_ids.child_prop_ids as child_prop_ids,
+    row_to_json(props.*)          AS object
+FROM props_v1($1, $2) AS props
+LEFT JOIN (
+    SELECT
+        prop_belongs_to_prop.belongs_to_id        AS belongs_to_id,
+        array_agg(prop_belongs_to_prop.object_id) AS child_prop_ids
+    FROM prop_belongs_to_prop_v1($1, $2) AS prop_belongs_to_prop
+    GROUP BY prop_belongs_to_prop.belongs_to_id
+) AS child_prop_ids
+    ON child_prop_ids.belongs_to_id = props.id
+WHERE
+    props.hidden = FALSE
+    AND props.id IN (
+        WITH RECURSIVE recursive_props AS (
+            SELECT left_object_id AS prop_id
+            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+            WHERE right_object_id = $3
+            UNION ALL
+            SELECT pbp.object_id AS prop_id
+            FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+            JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+        )
+        SELECT prop_id
+        FROM recursive_props
     )
-  AND is_visible_v1(
-        $2,
-        props.visibility_change_set_pk,
-        props.visibility_deleted_at
-    )
-  AND props.hidden = FALSE
-  AND props.id IN (WITH RECURSIVE recursive_props AS (SELECT left_object_id AS prop_id
-                                                      FROM prop_many_to_many_schema_variants
-                                                      WHERE right_object_id = $3
-                                                      UNION ALL
-                                                      SELECT pbp.object_id AS prop_id
-                                                      FROM prop_belongs_to_prop AS pbp
-                                                               JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
-                   SELECT prop_id
-                   FROM recursive_props)
-ORDER BY props.id, child_prop_ids.belongs_to_id, props.visibility_change_set_pk DESC;

--- a/lib/dal/src/queries/qualification_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/qualification_prototype_find_for_context.sql
@@ -1,22 +1,11 @@
-SELECT DISTINCT ON (qualification_prototypes.func_id) qualification_prototypes.id,
-                                                 qualification_prototypes.component_id,
-                                                 qualification_prototypes.schema_id,
-                                                 qualification_prototypes.schema_variant_id,
-                                                 qualification_prototypes.visibility_change_set_pk,
-
-                                                 row_to_json(qualification_prototypes.*) AS object
-FROM qualification_prototypes
-WHERE in_tenancy_v1($1, qualification_prototypes.tenancy_universal,
-                    qualification_prototypes.tenancy_billing_account_ids,
-                    qualification_prototypes.tenancy_organization_ids,
-                    qualification_prototypes.tenancy_workspace_ids)
-  AND is_visible_v1($2, qualification_prototypes.visibility_change_set_pk,
-                    qualification_prototypes.visibility_deleted_at)
-  AND (qualification_prototypes.schema_id = $5
+SELECT DISTINCT ON (qualification_prototypes.func_id)
+    row_to_json(qualification_prototypes.*) AS object
+FROM qualification_prototypes_v1($1, $2) AS qualification_prototypes
+WHERE
+    qualification_prototypes.schema_id = $5
     OR qualification_prototypes.schema_variant_id = $4
-    OR qualification_prototypes.component_id = $3)
+    OR qualification_prototypes.component_id = $3
 ORDER BY qualification_prototypes.func_id,
-         visibility_change_set_pk DESC,
          component_id DESC,
          func_id DESC,
          schema_variant_id DESC,

--- a/lib/dal/src/queries/qualification_resolver_find_for_prototype.sql
+++ b/lib/dal/src/queries/qualification_resolver_find_for_prototype.sql
@@ -1,15 +1,10 @@
-SELECT DISTINCT ON (qualification_resolvers.id) qualification_resolvers.id,
-                                                qualification_resolvers.visibility_change_set_pk,
-                                                qualification_resolvers.component_id,
-                                                qualification_resolvers.schema_id,
-                                                qualification_resolvers.schema_variant_id,
-                                                row_to_json(qualification_resolvers.*) as object
-FROM qualification_resolvers_v1($1, $2) as qualification_resolvers
-WHERE qualification_resolvers.qualification_prototype_id = $3
-  AND qualification_resolvers.component_id = $4
-ORDER BY qualification_resolvers.id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
+SELECT row_to_json(qualification_resolvers.*) as object
+FROM qualification_resolvers_v1($1, $2) AS qualification_resolvers
+WHERE
+    qualification_resolvers.qualification_prototype_id = $3
+    AND qualification_resolvers.component_id = $4
+ORDER BY
+    component_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;
 

--- a/lib/dal/src/queries/qualifications_summary_for_tenancy.sql
+++ b/lib/dal/src/queries/qualifications_summary_for_tenancy.sql
@@ -1,35 +1,39 @@
-SELECT component_id,
-       component_name,
-       count(qualification_id)                                         as total_qualifications,
-       sum(case when qualification_status = 'true' then 1 else 0 end)  as succeeded,
-       sum(case when qualification_status = 'false' then 1 else 0 end) as failed
-FROM (SELECT DISTINCT ON (components.component_id, qualification_prototypes.id, qualification_resolvers.id) components.component_id,
-                                                                                                            components.prop_values -> 'si' ->> 'name'      as component_name,
-                                                                                                            qualification_prototypes.id                    as qualification_id,
-                                                                                                            func_binding_return_values.value ->> 'success' as qualification_status
-      FROM components_with_attributes components
-               LEFT JOIN qualification_prototypes
-                         ON components.schema_variant_id = qualification_prototypes.schema_variant_id
-                             AND in_tenancy_and_visible_v1($1, $2, qualification_prototypes)
-               LEFT JOIN qualification_resolvers
-                         ON components.component_id = qualification_resolvers.component_id
-                             AND in_tenancy_and_visible_v1($1, $2, qualification_resolvers)
-               LEFT JOIN func_binding_return_value_belongs_to_func_binding
-                         ON func_binding_return_value_belongs_to_func_binding.belongs_to_id =
-                            qualification_resolvers.func_binding_id
-                             AND in_tenancy_and_visible_v1($1, $2, func_binding_return_value_belongs_to_func_binding)
-               LEFT JOIN func_binding_return_values
-                         ON func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
-                             AND in_tenancy_and_visible_v1($1, $2, func_binding_return_values)
-               LEFT JOIN component_belongs_to_schema
-                         ON components.component_id = component_belongs_to_schema.object_id
-                             AND in_tenancy_and_visible_v1($1, $2, component_belongs_to_schema)
-               LEFT JOIN schemas
-                         ON component_belongs_to_schema.belongs_to_id = schemas.id
-                             AND in_tenancy_and_visible_v1($1, $2, schemas)
-      WHERE in_tenancy_and_visible_v1($1, $2, components)
+SELECT
+    component_id,
+    component_name,
+    count(qualification_id)                                         as total_qualifications,
+    sum(case when qualification_status = 'true' then 1 else 0 end)  as succeeded,
+    sum(case when qualification_status = 'false' then 1 else 0 end) as failed
+FROM (
+    SELECT DISTINCT ON (
+        components.component_id,
+        qualification_prototypes.id,
+        qualification_resolvers.id
+    )
+        components.component_id,
+        components.prop_values -> 'si' ->> 'name'      as component_name,
+        qualification_prototypes.id                    as qualification_id,
+        func_binding_return_values.value ->> 'success' as qualification_status
+    FROM components_with_attributes components
+    LEFT JOIN qualification_prototypes_v1($1, $2) AS qualification_prototypes
+        ON components.schema_variant_id = qualification_prototypes.schema_variant_id
+    LEFT JOIN qualification_resolvers_v1($1, $2) AS qualification_resolvers
+        ON components.component_id = qualification_resolvers.component_id
+    LEFT JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) AS func_binding_return_value_belongs_to_func_binding
+        ON func_binding_return_value_belongs_to_func_binding.belongs_to_id =  qualification_resolvers.func_binding_id
+    LEFT JOIN func_binding_return_values_v1($1, $2) AS func_binding_return_values
+        ON func_binding_return_values.id = func_binding_return_value_belongs_to_func_binding.object_id
+    LEFT JOIN component_belongs_to_schema_v1($1, $2) AS component_belongs_to_schema
+        ON components.component_id = component_belongs_to_schema.object_id
+    LEFT JOIN schemas_v1($1, $2) AS schemas
+        ON component_belongs_to_schema.belongs_to_id = schemas.id
+    WHERE in_tenancy_and_visible_v1($1, $2, components)
         AND schemas.kind != 'concept'
-      ORDER BY components.component_id, qualification_prototypes.id, qualification_resolvers.id,
-               qualification_prototypes.visibility_change_set_pk DESC,
-               qualification_resolvers.visibility_change_set_pk DESC) as qualification_data
+    ORDER BY
+        components.component_id,
+        qualification_prototypes.id,
+        qualification_resolvers.id,
+        qualification_prototypes.visibility_change_set_pk DESC,
+        qualification_resolvers.visibility_change_set_pk DESC
+) as qualification_data
 GROUP BY component_id, component_name

--- a/lib/dal/src/queries/schema_variant_all_props.sql
+++ b/lib/dal/src/queries/schema_variant_all_props.sql
@@ -1,32 +1,15 @@
-SELECT DISTINCT ON (props.id) props.id,
-                              props.visibility_change_set_pk,
-
-                              props.visibility_deleted_at,
-                              row_to_json(props.*) AS object
-FROM props
-WHERE in_tenancy_v1(
-        $1,
-        props.tenancy_universal,
-        props.tenancy_billing_account_ids,
-        props.tenancy_organization_ids,
-        props.tenancy_workspace_ids
+SELECT row_to_json(props.*) AS object
+FROM props_v1($1, $2) AS props
+WHERE props.id IN (
+    WITH RECURSIVE recursive_props AS (
+        SELECT left_object_id AS prop_id
+        FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+        WHERE right_object_id = $3
+        UNION ALL
+        SELECT pbp.object_id AS prop_id
+        FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+        JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
     )
-  AND is_visible_v1(
-        $2,
-        props.visibility_change_set_pk,
-        props.visibility_deleted_at
-    )
-  AND props.id IN (WITH RECURSIVE recursive_props AS (SELECT left_object_id AS prop_id
-                                                      FROM prop_many_to_many_schema_variants
-                                                      WHERE right_object_id = $3
-                                                      UNION ALL
-                                                      SELECT pbp.object_id AS prop_id
-                                                      FROM prop_belongs_to_prop AS pbp
-                                                               JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
-                   SELECT prop_id
-                   FROM recursive_props)
-ORDER BY id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
-
-
+    SELECT prop_id
+    FROM recursive_props
+)

--- a/lib/dal/src/queries/ui_menus_get_by_schema_and_diagram_kind.sql
+++ b/lib/dal/src/queries/ui_menus_get_by_schema_and_diagram_kind.sql
@@ -1,20 +1,8 @@
-SELECT DISTINCT ON (schema_ui_menus.id) schema_ui_menus.id,
-                                        schema_ui_menus.visibility_change_set_pk,
-                                        schema_ui_menus.visibility_deleted_at,
-                                        row_to_json(schema_ui_menus.*) AS object
-
-FROM schema_ui_menus
-         INNER JOIN schema_ui_menu_belongs_to_schema
-                    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
-                        AND in_tenancy_and_visible_v1($1, $2, schema_ui_menu_belongs_to_schema)
-         INNER JOIN schemas
-                    ON schema_ui_menu_belongs_to_schema.belongs_to_id = schemas.id
-                        AND in_tenancy_and_visible_v1($1, $2, schemas)
-                        AND schemas.id = $3
-
+SELECT row_to_json(schema_ui_menus.*) AS object
+FROM schema_ui_menus_v1($1, $2) AS schema_ui_menus
+INNER JOIN schema_ui_menu_belongs_to_schema_v1($1, $2) AS schema_ui_menu_belongs_to_schema
+    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
+INNER JOIN schemas_v1($1, $2) AS schemas
+    ON schema_ui_menu_belongs_to_schema.belongs_to_id = schemas.id
+        AND schemas.id = $3
 WHERE schema_ui_menus.diagram_kind = $4
-  AND in_tenancy_and_visible_v1($1, $2, schema_ui_menus)
-
-ORDER BY schema_ui_menus.id DESC,
-         schema_ui_menus.visibility_change_set_pk DESC,
-         schema_ui_menus.visibility_deleted_at DESC NULLS FIRST;

--- a/lib/dal/src/queries/ui_menus_list_for_diagram_kind.sql
+++ b/lib/dal/src/queries/ui_menus_list_for_diagram_kind.sql
@@ -1,7 +1,6 @@
-SELECT schema_ui_menus.id                       AS id,
-       schema_ui_menus.visibility_change_set_pk AS visibility_change_set_pk,
-       row_to_json(schema_ui_menus.*)           AS object
-
-FROM schema_ui_menus
+SELECT
+    schema_ui_menus.id                       AS id,
+    schema_ui_menus.visibility_change_set_pk AS visibility_change_set_pk,
+    row_to_json(schema_ui_menus.*)           AS object
+FROM schema_ui_menus_v1($1, $2) AS schema_ui_menus
 WHERE schema_ui_menus.diagram_kind = $3
-  AND in_tenancy_and_visible_v1($1, $2, schema_ui_menus);

--- a/lib/dal/src/queries/user_find_by_email.sql
+++ b/lib/dal/src/queries/user_find_by_email.sql
@@ -1,11 +1,3 @@
-SELECT DISTINCT ON (users.id) users.id,
-                              users.visibility_change_set_pk,
-
-                              row_to_json(users.*) AS object
-FROM users
+SELECT row_to_json(users.*) AS object
+FROM users_v1($2, $3) AS users
 WHERE users.email = $1
-  AND in_tenancy_v1($2, users.tenancy_universal, users.tenancy_billing_account_ids, users.tenancy_organization_ids,
-                    users.tenancy_workspace_ids)
-  AND is_visible_v1($3, users.visibility_change_set_pk, users.visibility_deleted_at)
-ORDER BY id, visibility_change_set_pk DESC
-LIMIT 1;

--- a/lib/dal/src/queries/validation_prototype_list_for_schema_variant.sql
+++ b/lib/dal/src/queries/validation_prototype_list_for_schema_variant.sql
@@ -1,24 +1,17 @@
-SELECT DISTINCT ON (validation_prototypes.id) validation_prototypes.id,
-                                              validation_prototypes.visibility_change_set_pk,
-                                              validation_prototypes.visibility_deleted_at,
-                                              row_to_json(validation_prototypes.*) AS object
-
+SELECT row_to_json(validation_prototypes.*) AS object
 FROM validation_prototypes_v1($1, $2) as validation_prototypes
-         INNER JOIN props_v1($1, $2) as props
-                    ON props.id = validation_prototypes.prop_id
-                        AND in_tenancy_and_visible_v1($1, $2, props)
-                        AND props.id IN (
-                            WITH RECURSIVE recursive_props AS (
-                                SELECT left_object_id AS prop_id
-                                FROM prop_many_to_many_schema_variants
-                                WHERE right_object_id = $3
-                                UNION ALL
-                                SELECT pbp.object_id AS prop_id
-                                FROM prop_belongs_to_prop AS pbp
-                                         JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
-                            )
-                            SELECT prop_id
-                            FROM recursive_props)
-ORDER BY validation_prototypes.id,
-         validation_prototypes.visibility_change_set_pk DESC,
-         validation_prototypes.visibility_deleted_at DESC NULLS FIRST;
+INNER JOIN props_v1($1, $2) as props
+    ON props.id = validation_prototypes.prop_id
+    AND props.id IN (
+        WITH RECURSIVE recursive_props AS (
+            SELECT left_object_id AS prop_id
+            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+            WHERE right_object_id = $3
+            UNION ALL
+            SELECT pbp.object_id AS prop_id
+            FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+            JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+        )
+    SELECT prop_id
+    FROM recursive_props
+)

--- a/lib/dal/src/queries/validation_resolver_find_status.sql
+++ b/lib/dal/src/queries/validation_resolver_find_status.sql
@@ -1,41 +1,34 @@
-SELECT DISTINCT ON (validation_resolvers.id) validation_resolvers.id,
-                                             validation_resolvers.visibility_change_set_pk,
-                                             validation_resolvers.visibility_deleted_at,
-                                             attribute_values.id                       as attribute_value_id,
-                                             row_to_json(validation_prototypes.*)      as validation_prototype_json,
-                                             row_to_json(func_binding_return_values.*) as object
-
+SELECT
+    validation_resolvers.id,
+    validation_resolvers.visibility_change_set_pk,
+    validation_resolvers.visibility_deleted_at,
+    attribute_values.id                            as attribute_value_id,
+    row_to_json(validation_prototypes.*)           as validation_prototype_json,
+    row_to_json(func_binding_return_values.*)      as object
 FROM attribute_values_v1($1, $2) as attribute_values
-         LEFT JOIN validation_resolvers_v1($1, $2) as validation_resolvers
-                   ON validation_resolvers.attribute_value_id = attribute_values.id
-                       AND
-                      validation_resolvers.attribute_value_func_binding_return_value_id =
-                      attribute_values.func_binding_return_value_id
-         LEFT JOIN validation_prototypes_v1($1, $2) as validation_prototypes
-                   ON validation_prototypes.id = validation_resolvers.validation_prototype_id
-         LEFT JOIN func_bindings_v1($1, $2) as func_bindings
-                   ON func_bindings.id = validation_resolvers.validation_func_binding_id
-         LEFT JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) as fbrvbtfb
-                   ON fbrvbtfb.belongs_to_id = func_bindings.id
-         LEFT JOIN func_binding_return_values_v1($1, $2) as func_binding_return_values
-                   ON func_binding_return_values.id = fbrvbtfb.object_id
-WHERE attribute_values.attribute_context_prop_id IN
-      (WITH RECURSIVE recursive_props AS
-                          (SELECT left_object_id AS prop_id
-                           FROM prop_many_to_many_schema_variants
-                           WHERE right_object_id = $4
-                           UNION ALL
-                           SELECT pbp.object_id AS prop_id
-                           FROM prop_belongs_to_prop AS pbp
-                                    JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id)
-       SELECT prop_id
-       FROM recursive_props)
-  AND exact_attribute_read_context_v1($3, attribute_values.attribute_context_prop_id,
-                                      attribute_values.attribute_context_internal_provider_id,
-                                      attribute_values.attribute_context_external_provider_id,
-                                      attribute_values.attribute_context_schema_id,
-                                      attribute_values.attribute_context_schema_variant_id,
-                                      attribute_values.attribute_context_component_id)
-ORDER BY validation_resolvers.id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
+LEFT JOIN validation_resolvers_v1($1, $2) as validation_resolvers
+    ON validation_resolvers.attribute_value_id = attribute_values.id
+        AND validation_resolvers.attribute_value_func_binding_return_value_id = attribute_values.func_binding_return_value_id
+LEFT JOIN validation_prototypes_v1($1, $2) as validation_prototypes
+        ON validation_prototypes.id = validation_resolvers.validation_prototype_id
+LEFT JOIN func_bindings_v1($1, $2) as func_bindings
+        ON func_bindings.id = validation_resolvers.validation_func_binding_id
+LEFT JOIN func_binding_return_value_belongs_to_func_binding_v1($1, $2) as fbrvbtfb
+        ON fbrvbtfb.belongs_to_id = func_bindings.id
+LEFT JOIN func_binding_return_values_v1($1, $2) as func_binding_return_values
+        ON func_binding_return_values.id = fbrvbtfb.object_id
+WHERE
+    attribute_values.attribute_context_prop_id IN (
+        WITH RECURSIVE recursive_props AS (
+            SELECT left_object_id AS prop_id
+            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+            WHERE right_object_id = $4
+            UNION ALL
+            SELECT pbp.object_id AS prop_id
+            FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+            JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
+        )
+        SELECT prop_id
+        FROM recursive_props
+    )
+    AND exact_attribute_read_context_v1($3, attribute_values)

--- a/lib/dal/src/queries/workflow_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/workflow_prototype_find_for_context.sql
@@ -1,23 +1,11 @@
-SELECT DISTINCT ON (workflow_prototypes.id) workflow_prototypes.id,
-                                                 workflow_prototypes.component_id,
-                                                 workflow_prototypes.schema_id,
-                                                 workflow_prototypes.schema_variant_id,
-                                                 workflow_prototypes.visibility_change_set_pk,
-
-                                                 row_to_json(workflow_prototypes.*) AS object
-FROM workflow_prototypes
-WHERE in_tenancy_v1($1, workflow_prototypes.tenancy_universal,
-                    workflow_prototypes.tenancy_billing_account_ids,
-                    workflow_prototypes.tenancy_organization_ids,
-                    workflow_prototypes.tenancy_workspace_ids)
-  AND is_visible_v1($2, workflow_prototypes.visibility_change_set_pk,
-                    workflow_prototypes.visibility_deleted_at)
-  AND workflow_prototypes.schema_id = $5
-  AND workflow_prototypes.schema_variant_id = $4
-  AND workflow_prototypes.component_id = $3
-ORDER BY workflow_prototypes.id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         func_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
+SELECT row_to_json(workflow_prototypes.*) AS object
+FROM workflow_prototypes_v1($1, $2) AS workflow_prototypes
+WHERE
+    workflow_prototypes.schema_id = $5
+    AND workflow_prototypes.schema_variant_id = $4
+    AND workflow_prototypes.component_id = $3
+ORDER BY
+    component_id DESC,
+    func_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;

--- a/lib/dal/src/queries/workflow_resolver_find_for_prototype.sql
+++ b/lib/dal/src/queries/workflow_resolver_find_for_prototype.sql
@@ -1,18 +1,13 @@
-SELECT DISTINCT ON (workflow_resolvers.id) workflow_resolvers.id,
-                                                workflow_resolvers.visibility_change_set_pk,
-
-                                                workflow_resolvers.component_id,
-                                                workflow_resolvers.schema_id,
-                                                workflow_resolvers.schema_variant_id,
-                                                row_to_json(workflow_resolvers.*) as object
+SELECT row_to_json(workflow_resolvers.*) as object
 FROM workflow_resolvers_v1($1, $2) as workflow_resolvers
-WHERE workflow_resolvers.workflow_prototype_id = $3
-  AND (workflow_resolvers.component_id = $4
-       OR workflow_resolvers.schema_id = $5
-       OR workflow_resolvers.schema_variant_id = $6)
-ORDER BY workflow_resolvers.id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
-
+WHERE
+    workflow_resolvers.workflow_prototype_id = $3
+    AND (
+        workflow_resolvers.component_id = $4
+        OR workflow_resolvers.schema_id = $5
+        OR workflow_resolvers.schema_variant_id = $6
+    )
+ORDER BY
+    component_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;

--- a/lib/dal/src/queries/workflow_runner_find_for_prototype.sql
+++ b/lib/dal/src/queries/workflow_runner_find_for_prototype.sql
@@ -1,17 +1,13 @@
-SELECT DISTINCT ON (workflow_runners.id) workflow_runners.id,
-                                                workflow_runners.visibility_change_set_pk,
-
-                                                workflow_runners.component_id,
-                                                workflow_runners.schema_id,
-                                                workflow_runners.schema_variant_id,
-                                                row_to_json(workflow_runners.*) as object
+SELECT row_to_json(workflow_runners.*) as object
 FROM workflow_runners_v1($1, $2) as workflow_runners
-WHERE workflow_runners.workflow_prototype_id = $3
-  AND (workflow_runners.component_id = $4
-       OR workflow_runners.schema_id = $5
-       OR workflow_runners.schema_variant_id = $6)
-ORDER BY workflow_runners.id,
-         visibility_change_set_pk DESC,
-         component_id DESC,
-         schema_variant_id DESC,
-         schema_id DESC;
+WHERE
+    workflow_runners.workflow_prototype_id = $3
+    AND (
+        workflow_runners.component_id = $4
+        OR workflow_runners.schema_id = $5
+        OR workflow_runners.schema_variant_id = $6
+    )
+ORDER BY
+    component_id DESC,
+    schema_variant_id DESC,
+    schema_id DESC;

--- a/lib/dal/src/queries/workflow_runner_state_find_for_workflow_runner.sql
+++ b/lib/dal/src/queries/workflow_runner_state_find_for_workflow_runner.sql
@@ -1,15 +1,3 @@
-SELECT DISTINCT ON (id) id,
-                        visibility_change_set_pk,
-                        visibility_deleted_at,
-                        row_to_json(workflow_runner_states.*) AS object
-
-FROM workflow_runner_states
-WHERE in_tenancy_v1($1, tenancy_universal, tenancy_billing_account_ids,
-                    tenancy_organization_ids, tenancy_workspace_ids)
-  AND is_visible_v1($2, visibility_change_set_pk,
-                    visibility_deleted_at)
-  AND workflow_runner_id = $3
-
-ORDER BY id,
-         visibility_change_set_pk DESC,
-         visibility_deleted_at DESC NULLS FIRST;
+SELECT row_to_json(workflow_runner_states.*) AS object
+FROM workflow_runner_states_v1($1, $2) AS workflow_runner_states
+WHERE workflow_runner_id = $3


### PR DESCRIPTION
Since we've created the `<table_name>_v1`, this makes sure that most of our existing queries use them to handle making sure that we are properly obeying the tenancy, and visibility.