### PR TITLE
chore(dal) Modify `set_belongs_to_v1` to also take a read Tenancy

### DIFF
--- a/lib/dal/src/migrations/U0004__standard_model.sql
+++ b/lib/dal/src/migrations/U0004__standard_model.sql
@@ -1025,19 +1025,21 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
-CREATE OR REPLACE FUNCTION set_belongs_to_v1(this_table_name text,
-                                             this_tenancy jsonb,
-                                             this_visibility jsonb,
-                                             this_object_id bigint,
-                                             this_belongs_to_id bigint
+CREATE OR REPLACE FUNCTION set_belongs_to_v1(
+    this_table_name text,
+    this_read_tenancy jsonb,
+    this_write_tenancy jsonb,
+    this_visibility jsonb,
+    this_object_id bigint,
+    this_belongs_to_id bigint
 ) RETURNS VOID AS
 $$
 DECLARE
     insert_query           text;
-    this_tenancy_record    tenancy_record_v1;
+    this_write_tenancy_record    tenancy_record_v1;
     this_visibility_record visibility_record_v1;
 BEGIN
-    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_write_tenancy_record := tenancy_json_to_columns_v1(this_write_tenancy);
     this_visibility_record := visibility_json_to_columns_v1(this_visibility);
 
     insert_query :=
@@ -1056,10 +1058,10 @@ BEGIN
                    this_table_name,
                    this_object_id,
                    this_belongs_to_id,
-                   this_tenancy_record.tenancy_universal,
-                   this_tenancy_record.tenancy_billing_account_ids,
-                   this_tenancy_record.tenancy_organization_ids,
-                   this_tenancy_record.tenancy_workspace_ids,
+                   this_write_tenancy_record.tenancy_universal,
+                   this_write_tenancy_record.tenancy_billing_account_ids,
+                   this_write_tenancy_record.tenancy_organization_ids,
+                   this_write_tenancy_record.tenancy_workspace_ids,
                    this_visibility_record.visibility_change_set_pk,
                    this_visibility_record.visibility_deleted_at
                 );

--- a/lib/dal/src/migrations/U0042__funcs.sql
+++ b/lib/dal/src/migrations/U0042__funcs.sql
@@ -196,11 +196,14 @@ BEGIN
         FROM func_binding_create_v1(this_write_tenancy, this_visibility, this_args, this_backend_kind, this_code_sha256)
         INTO object;
 
-        PERFORM set_belongs_to_v1('func_binding_belongs_to_func',
-                                  this_write_tenancy,
-                                  this_visibility,
-                                  (object ->> 'id')::bigint,
-                                  this_func_id);
+        PERFORM set_belongs_to_v1(
+            'func_binding_belongs_to_func',
+            this_read_tenancy,
+            this_write_tenancy,
+            this_visibility,
+            (object ->> 'id')::bigint,
+            this_func_id
+        );
     END IF;
 END;
 $$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
+++ b/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
@@ -260,11 +260,14 @@ BEGIN
         this_attribute_value_id
     );
 
-    PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                              this_write_tenancy,
-                              this_visibility,
-                              this_attribute_value_id,
-                              this_parent_attribute_value_id);
+    PERFORM set_belongs_to_v1(
+        'attribute_value_belongs_to_attribute_value',
+        this_read_tenancy,
+        this_write_tenancy,
+        this_visibility,
+        this_attribute_value_id,
+        this_parent_attribute_value_id
+    );
 END;
 $$ LANGUAGE PLPGSQL;
 
@@ -453,11 +456,14 @@ BEGIN
                 this_visibility,
                 proxy_attribute_value.id
             );
-            PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                                      this_write_tenancy,
-                                      this_visibility,
-                                      proxy_attribute_value.id,
-                                      this_prototype_id);
+            PERFORM set_belongs_to_v1(
+                'attribute_value_belongs_to_attribute_prototype',
+                this_read_tenancy,
+                this_write_tenancy,
+                this_visibility,
+                proxy_attribute_value.id,
+                this_prototype_id
+            );
         ELSE
             RAISE 'AttributeValue not found for AttributePrototype(%), parent AttributeValue(%) in Tenancy(%), Visibility(%)',
                   this_prototype_id,
@@ -513,18 +519,24 @@ BEGIN
                                    this_func_binding_id,
                                    this_func_binding_return_value_id,
                                    this_key) AS av;
-    PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                              this_write_tenancy,
-                              this_visibility,
-                              attribute_value_id,
-                              new_attribute_prototype_id);
+    PERFORM set_belongs_to_v1(
+        'attribute_value_belongs_to_attribute_prototype',
+        this_read_tenancy,
+        this_write_tenancy,
+        this_visibility,
+        attribute_value_id,
+        new_attribute_prototype_id
+    );
 
     IF this_parent_attribute_value_id IS NOT NULL THEN
-        PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                  this_write_tenancy,
-                                  this_visibility,
-                                  attribute_value_id,
-                                  this_parent_attribute_value_id);
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_value',
+            this_read_tenancy,
+            this_write_tenancy,
+            this_visibility,
+            attribute_value_id,
+            this_parent_attribute_value_id
+        );
     END IF;
 
     IF NOT attribute_context_is_least_specific_v1(this_attribute_context) THEN
@@ -586,11 +598,14 @@ BEGIN
                                 this_visibility,
                                 this_attribute_value_id);
 
-    PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                              this_write_tenancy,
-                              this_visibility,
-                              this_attribute_value_id,
-                              new_attribute_prototype_id);
+    PERFORM set_belongs_to_v1(
+        'attribute_value_belongs_to_attribute_prototype',
+        this_read_tenancy,
+        this_write_tenancy,
+        this_visibility,
+        this_attribute_value_id,
+        new_attribute_prototype_id
+    );
 
     PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_value',
                                 this_write_tenancy,
@@ -598,11 +613,14 @@ BEGIN
                                 this_attribute_value_id);
 
     IF this_parent_attribute_value_id IS NOT NULL THEN
-        PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                  this_write_tenancy,
-                                  this_visibility,
-                                  this_attribute_value_id,
-                                  this_parent_attribute_value_id);
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_value',
+            this_read_tenancy,
+            this_write_tenancy,
+            this_visibility,
+            this_attribute_value_id,
+            this_parent_attribute_value_id
+        );
     END IF;
 END;
 $$ LANGUAGE PLPGSQL;
@@ -916,11 +934,14 @@ BEGIN
                                         this_write_tenancy,
                                         this_visibility,
                                         original_child_value.id);
-            PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                      this_write_tenancy,
-                                      this_visibility,
-                                      original_child_value.id,
-                                      this_attribute_value_id);
+            PERFORM set_belongs_to_v1(
+                'attribute_value_belongs_to_attribute_value',
+                this_read_tenancy,
+                this_write_tenancy,
+                this_visibility,
+                original_child_value.id,
+                this_attribute_value_id
+            );
         ELSE
             -- Since there isn't already an `AttributeValue` to represent the one from a less-specific
             -- `AttributeContext`, we need to create a proxy `AttributeValue` in the desired `AttributeContext`
@@ -945,16 +966,22 @@ BEGIN
                                         this_write_tenancy,
                                         this_visibility,
                                         new_child_value.id);
-            PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                                      this_write_tenancy,
-                                      this_visibility,
-                                      new_child_value.id,
-                                      child_attribute_value_prototype.id);
-            PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                      this_write_tenancy,
-                                      this_visibility,
-                                      new_child_value.id,
-                                      this_attribute_value_id);
+            PERFORM set_belongs_to_v1(
+                'attribute_value_belongs_to_attribute_prototype',
+                this_read_tenancy,
+                this_write_tenancy,
+                this_visibility,
+                new_child_value.id,
+                child_attribute_value_prototype.id
+            );
+            PERFORM set_belongs_to_v1(
+                'attribute_value_belongs_to_attribute_value',
+                this_read_tenancy,
+                this_write_tenancy,
+                this_visibility,
+                new_child_value.id,
+                this_attribute_value_id
+            );
             PERFORM update_by_id_v1('attribute_values',
                                     'proxy_for_attribute_value_id',
                                     this_read_tenancy,
@@ -1110,11 +1137,14 @@ BEGIN
             END IF;
 
             IF maybe_parent_attribute_value_id IS NOT NULL THEN
-               PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                         this_write_tenancy,
-                                         this_visibility,
-                                         attribute_value_id,
-                                         maybe_parent_attribute_value_id);
+                PERFORM set_belongs_to_v1(
+                    'attribute_value_belongs_to_attribute_value',
+                    this_read_tenancy,
+                    this_write_tenancy,
+                    this_visibility,
+                    attribute_value_id,
+                    maybe_parent_attribute_value_id
+                );
             END IF;
 
             IF this_create_child_proxies THEN
@@ -1243,11 +1273,14 @@ BEGIN
                                 this_write_tenancy,
                                 this_visibility,
                                 attribute_value_id);
-    PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                              this_write_tenancy,
-                              this_visibility,
-                              attribute_value_id,
-                              attribute_prototype_id);
+    PERFORM set_belongs_to_v1(
+        'attribute_value_belongs_to_attribute_prototype',
+        this_read_tenancy,
+        this_write_tenancy,
+        this_visibility,
+        attribute_value_id,
+        attribute_prototype_id
+    );
 
     PERFORM update_by_id_v1('attribute_values',
                             'func_binding_return_value_id',
@@ -1537,11 +1570,14 @@ BEGIN
                                                                                 unset_func_binding_return_value_id,
                                                                                 field_context,
                                                                                 NULL));
-                PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                          this_write_tenancy,
-                                          this_visibility,
-                                          attribute_value.id,
-                                          this_parent_attribute_value_id);
+                PERFORM set_belongs_to_v1(
+                    'attribute_value_belongs_to_attribute_value',
+                    this_read_tenancy,
+                    this_write_tenancy,
+                    this_visibility,
+                    attribute_value.id,
+                    this_parent_attribute_value_id
+                );
                 PERFORM attribute_prototype_new_with_attribute_value_v1(this_write_tenancy,
                                                                         this_read_tenancy,
                                                                         this_visibility,
@@ -2554,11 +2590,14 @@ BEGIN
                                                                                      unset_func_binding_return_value_id,
                                                                                      unset_child_attribute_context,
                                                                                      NULL));
-                PERFORM set_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                          this_write_tenancy,
-                                          this_visibility,
-                                          prop_attribute_value.id,
-                                          (child_prop_info ->> 'parent_attribute_value_id')::bigint);
+                PERFORM set_belongs_to_v1(
+                    'attribute_value_belongs_to_attribute_value',
+                    this_read_tenancy,
+                    this_write_tenancy,
+                    this_visibility,
+                    prop_attribute_value.id,
+                    (child_prop_info ->> 'parent_attribute_value_id')::bigint
+                );
                 -- XXX: The Rust code was originally using `child_prop_info.parent_attribute_value_id` as BOTH
                 -- OF the last two arguments here, then setting prop_attribute_value's AttributePrototype to be
                 -- the newly created AttributePrototype. This seems wrong, so instead we're passing in

--- a/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
+++ b/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
@@ -87,6 +87,7 @@ BEGIN
         );
         PERFORM set_belongs_to_v1(
             'attribute_value_belongs_to_attribute_prototype',
+            this_read_tenancy,
             this_write_tenancy,
             this_visibility,
             new_attribute_value_id,
@@ -430,6 +431,7 @@ BEGIN
                             );
                             PERFORM set_belongs_to_v1(
                                 'attribute_value_belongs_to_attribute_prototype',
+                                this_read_tenancy,
                                 this_write_tenancy,
                                 this_visibility,
                                 new_attribute_value_id,

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -196,9 +196,10 @@ pub async fn set_belongs_to<ObjectId: Send + Sync + ToSql, BelongsToId: Send + S
     ctx.txns()
         .pg()
         .query_one(
-            "SELECT set_belongs_to_v1($1, $2, $3, $4, $5)",
+            "SELECT set_belongs_to_v1($1, $2, $3, $4, $5, $6)",
             &[
                 &table,
+                ctx.read_tenancy(),
                 ctx.write_tenancy(),
                 ctx.visibility(),
                 &object_id,


### PR DESCRIPTION
We're going to be changing `set_belongs_to_v1` to do a find & modify, or insert, and to do that it'll need to take a read Tenancy to be able to find an existing record.