### PR TITLE
bug(dal): fix list generated code

### DIFF
--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -110,12 +110,12 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
         match builtin_path.extension() {
             Some(extension) => {
                 if extension != std::ffi::OsStr::new("json") {
-                    debug!("Skipping {:?}: Not a json file", builtin_path);
+                    debug!("skipping {:?}: not a json file", builtin_path);
                     continue;
                 }
             }
             None => {
-                warn!("Skipping {:?}: No file extension", builtin_path);
+                warn!("skipping {:?}: no file extension", builtin_path);
                 continue;
             }
         };
@@ -137,7 +137,7 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
 
         let existing_func = Func::find_by_attr(ctx, "name", &func_name).await?;
         if !existing_func.is_empty() {
-            warn!("Skipping {:?}: Function already exists", func_metadata.name);
+            warn!("skipping {:?}: func already exists", &func_name);
             continue;
         }
 

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -53,19 +53,19 @@ impl BuiltinSchemaHelpers {
         node_color: Option<i64>,
     ) -> BuiltinsResult<Option<(Schema, SchemaVariant, RootProp)>> {
         let name = name.as_ref();
-        info!("migrating {name} schema");
 
         // NOTE(nick): There's one issue here. If the schema kind has changed, then this check will be
         // inaccurate. As a result, we will be unable to re-create the schema without manual intervention.
         // This should be fine since this code should likely only last as long as default schemas need to
         // be created... which is hopefully not long.... hopefully...
-
         let default_schema_exists = !Schema::find_by_attr(ctx, "name", &name.to_string())
             .await?
             .is_empty();
         if default_schema_exists {
+            info!("skipping {name} schema (already migrated)");
             return Ok(None);
         }
+        info!("migrating {name} schema");
 
         let mut schema = Schema::new(ctx, name, &kind, &component_kind).await?;
         let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;

--- a/lib/dal/src/component/code.rs
+++ b/lib/dal/src/component/code.rs
@@ -30,7 +30,6 @@ impl Component {
             .await?
             .ok_or(ComponentError::NoSchemaVariant(component_id))?;
         let base_read_context = AttributeReadContext {
-            prop_id: None,
             schema_id: Some(*schema.id()),
             schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(component_id),
@@ -43,7 +42,7 @@ impl Component {
         for code_generation_prototype in
             CodeGenerationPrototype::list_for_schema_variant(ctx, *schema_variant.id()).await?
         {
-            // Get the code and format.
+            // Get the raw value for the code generated object via the prop tree for the prototype.
             let tree_internal_provider =
                 InternalProvider::find_for_prop(ctx, code_generation_prototype.tree_prop_id())
                     .await?
@@ -67,6 +66,8 @@ impl Component {
             )
             .await?
             .ok_or(FuncBindingReturnValueError::Missing)?;
+
+            // Deserialize the value into the code generated object defined by the veritech client.
             let code_generated = match tree_func_binding_return_value.value() {
                 Some(value) => Some(CodeGenerated::deserialize(value)?),
                 None => None,


### PR DESCRIPTION
- Fix list generated code (code view assembly) by ensuring the base attribute read context has "prop_id" unset (i.e. "Some(PropId::NONE)")
  - Before, it was set to "any" (i.e. "None")
- Fix builtin func migration name logging
  - Before, it was printing an empty string for the func names
- Fix unclear "skip" vs. "migrate" logs for schemas
- Standardize builtin func migration logging

<img src="https://media0.giphy.com/media/R9AwTYcqDjZ4kbyq07/giphy.gif"/>