### PR TITLE
feat(dal) Make set_belongs_to_v1 update pre-existing relation records

### DIFF
--- a/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
+++ b/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
@@ -253,13 +253,6 @@ BEGIN
               this_visibility;
     END IF;
 
-    PERFORM unset_belongs_to_v1(
-        'attribute_value_belongs_to_attribute_value',
-        this_write_tenancy,
-        this_visibility,
-        this_attribute_value_id
-    );
-
     PERFORM set_belongs_to_v1(
         'attribute_value_belongs_to_attribute_value',
         this_read_tenancy,
@@ -450,12 +443,6 @@ BEGIN
                                     this_visibility,
                                     proxy_attribute_value.id,
                                     proxy_target.id);
-            PERFORM unset_belongs_to_v1(
-                'attribute_value_belongs_to_attribute_prototype',
-                this_write_tenancy,
-                this_visibility,
-                proxy_attribute_value.id
-            );
             PERFORM set_belongs_to_v1(
                 'attribute_value_belongs_to_attribute_prototype',
                 this_read_tenancy,
@@ -593,11 +580,6 @@ BEGIN
                                        this_func_id,
                                        this_key) AS ap;
 
-    PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                                this_write_tenancy,
-                                this_visibility,
-                                this_attribute_value_id);
-
     PERFORM set_belongs_to_v1(
         'attribute_value_belongs_to_attribute_prototype',
         this_read_tenancy,
@@ -607,11 +589,6 @@ BEGIN
         new_attribute_prototype_id
     );
 
-    PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                this_write_tenancy,
-                                this_visibility,
-                                this_attribute_value_id);
-
     IF this_parent_attribute_value_id IS NOT NULL THEN
         PERFORM set_belongs_to_v1(
             'attribute_value_belongs_to_attribute_value',
@@ -620,6 +597,13 @@ BEGIN
             this_visibility,
             this_attribute_value_id,
             this_parent_attribute_value_id
+        );
+    ELSE
+        PERFORM unset_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_value',
+            this_write_tenancy,
+            this_visibility,
+            this_attribute_value_id
         );
     END IF;
 END;
@@ -930,10 +914,6 @@ BEGIN
             -- `AttributeContext`, but its parent was from a less-specific `AttributeContext`. Since it now has
             -- an appropriate parent `AttributeValue` within the desired `AttributeContext`, we need to have it
             -- under that parent instead of the old one.
-            PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_value',
-                                        this_write_tenancy,
-                                        this_visibility,
-                                        original_child_value.id);
             PERFORM set_belongs_to_v1(
                 'attribute_value_belongs_to_attribute_value',
                 this_read_tenancy,
@@ -962,10 +942,6 @@ BEGIN
                 ON avbtap.belongs_to_id = ap.id
                     AND avbtap.object_id = original_child_value.id;
 
-            PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                                        this_write_tenancy,
-                                        this_visibility,
-                                        new_child_value.id);
             PERFORM set_belongs_to_v1(
                 'attribute_value_belongs_to_attribute_prototype',
                 this_read_tenancy,
@@ -1269,10 +1245,6 @@ BEGIN
               attribute_value_id;
     END IF;
 
-    PERFORM unset_belongs_to_v1('attribute_value_belongs_to_attribute_prototype',
-                                this_write_tenancy,
-                                this_visibility,
-                                attribute_value_id);
     PERFORM set_belongs_to_v1(
         'attribute_value_belongs_to_attribute_prototype',
         this_read_tenancy,

--- a/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
+++ b/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
@@ -79,12 +79,6 @@ BEGIN
             attribute_value.id,
             false
         );
-        PERFORM unset_belongs_to_v1(
-            'attribute_value_belongs_to_attribute_prototype',
-            this_write_tenancy,
-            this_visibility,
-            new_attribute_value_id
-        );
         PERFORM set_belongs_to_v1(
             'attribute_value_belongs_to_attribute_prototype',
             this_read_tenancy,
@@ -423,12 +417,6 @@ BEGIN
                                 attribute_prototype.id;
                             -- We need to make sure the new AttributeValue is associated with the correct AttributePrototype
                             -- so that we can find it when we go through to update affected AttributeValues.
-                            PERFORM unset_belongs_to_v1(
-                                'attribute_value_belongs_to_attribute_prototype',
-                                this_write_tenancy,
-                                this_visibility,
-                                new_attribute_value_id
-                            );
                             PERFORM set_belongs_to_v1(
                                 'attribute_value_belongs_to_attribute_prototype',
                                 this_read_tenancy,


### PR DESCRIPTION
Previously, you had to manually `unset_belongs_to_v1` before you could change the `belongs_to_id` of an object, which caused issues with merging changesets, and was generally unintuitive. Now we use the existing `find_by_attr_v1` logic to see if there is already a relation record for the `object_id` we're interested in and, if there is, use `update_by_id_v1` to update that record according to our "normal" changeset logic, instead of always inserting a new record into the changeset.