### PR TITLE
chore(web): use lint:strict in CI, make lint:strict error on formatting lints

### DIFF
--- a/app/web/.eslintrc.js
+++ b/app/web/.eslintrc.js
@@ -139,6 +139,8 @@ module.exports = {
     "no-autofix/no-unreachable": 1,
     // useful while debugging and commenting things out, otherwise gets automatically changed from let to const
     "no-autofix/prefer-const": process.env.STRICT_LINT ? "error" : "warn",
+
+    "prettier/prettier": process.env.STRICT_LINT ? "error" : "warn",
   },
 
   overrides: [

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -11,7 +11,7 @@
     "watch": "npm run build:watch",
     "lint": "eslint src --ext .ts,.js,.vue",
     "lint:fix": "npm run lint -- --fix",
-    "lint:strict": "STRICT_LINT=1 npm run lint -- --max-warnings 0",
+    "lint:strict": "STRICT_LINT=1 npm run lint",
     "lint:summary": "npm run lint -- --format summary-chart",
     "fmt": "npm run lint:fix",
     "fmt:check": "npm run lint",

--- a/app/web/src/organisms/FuncEditor/utils.ts
+++ b/app/web/src/organisms/FuncEditor/utils.ts
@@ -1,1 +1,9 @@
-export const toOptionValues = < T extends { value: string | number; label: string }, >( options: T[], ids: number[],): T[] => options.filter((opt) => typeof opt.value === "number" ? ids.includes(opt.value) : false,);
+export const toOptionValues = <
+  T extends { value: string | number; label: string },
+>(
+  options: T[],
+  ids: number[],
+): T[] =>
+  options.filter((opt) =>
+    typeof opt.value === "number" ? ids.includes(opt.value) : false,
+  );


### PR DESCRIPTION
`npm run check` now runs `lint:strict`, and the prettier rules have now been set to error if `LINT_STRICT` is truthy.