### PR TITLE
chore(dal) Simplify InternalProvider::implicit_emit

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -962,17 +962,11 @@ impl AttributeValue {
                         )
                     })?;
             if internal_provider.is_internal_consumer() {
-                let prop_attribute_context = AttributeContextBuilder::from(self.context)
-                    .set_prop_id(*internal_provider.prop_id())
-                    .unset_internal_provider_id()
-                    .unset_external_provider_id()
-                    .to_context()?;
-
                 // We don't care about the AttributeValue that comes back from implicit_emit, since we should already be
                 // operating on an AttributeValue that has the correct AttributeContext, which means that a new one should
                 // not need to be created.
                 internal_provider
-                    .implicit_emit(ctx, prop_attribute_context)
+                    .implicit_emit(ctx, self)
                     .await
                     .map_err(|e| AttributeValueError::InternalProvider(e.to_string()))?;
 


### PR DESCRIPTION
Previously, `implicit_emit` needed to be concerned with potentially creating an AttributeValue that is appropriate for the desired context. This is no longer necessary, as this is handled by the `attribute_value_create_new_affected_values_v1` database function, before `InternalProvider::implicit_emit` is ever called.