### PR TITLE
Add schema variant definitions (starting with coreos butane)

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -18,7 +18,7 @@ use crate::{
     AttributePrototypeError, AttributeReadContext, AttributeValueError, AttributeValueId,
     CodeGenerationPrototypeError, ConfirmationPrototypeError, DalContext, ExternalProviderId,
     FuncError, PropError, PropId, PropKind, QualificationPrototypeError, SchemaError,
-    StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
+    SchemaVariantId, StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
 };
 
 // Private builtins modules.
@@ -105,6 +105,10 @@ pub enum BuiltinsError {
     FuncMetadata(String),
     #[error("builtin {0} missing func argument {0}")]
     BuiltinMissingFuncArgument(String, String),
+    #[error("prop cache not found: {0}")]
+    PropCacheNotFound(SchemaVariantId),
+    #[error("prop not found in cache for name ({0}) and parent prop id ({1})")]
+    PropNotFoundInCache(&'static str, PropId),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -63,13 +63,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS AMI`](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Ami.html).
     async fn migrate_ami(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "AMI",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -285,13 +286,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EC2`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html).
     async fn migrate_ec2(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "EC2 Instance",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -897,13 +899,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Region`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
     async fn migrate_region(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Region",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -1039,13 +1042,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EIP`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-eip.html).
     async fn migrate_eip(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Elastic IP",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -1391,13 +1395,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Key Pair`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html).
     async fn migrate_keypair(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Key Pair",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -37,13 +37,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Ingress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_ingress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Ingress",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -632,13 +633,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Egress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_egress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Egress",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -1122,13 +1124,14 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Security Group`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_security_group(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Security Group",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
+                None,
             )
             .await?
         {

--- a/lib/dal/src/builtins/schema/definitions/coreos/butane.json
+++ b/lib/dal/src/builtins/schema/definitions/coreos/butane.json
@@ -1,0 +1,51 @@
+{
+  "docLinks": {
+    "default": "https://coreos.github.io/butane/config-fcos-v1_4/"
+  },
+  "props": [
+    {
+      "name": "variant",
+      "kind": "string",
+      "docLinkRef": "default"
+    },
+    {
+      "name": "version",
+      "kind": "string",
+      "docLinkRef": "default"
+    },
+    {
+      "name": "systemd",
+      "kind": "object",
+      "docLinkRef": "default",
+      "children": [
+        {
+          "name": "units",
+          "kind": "array",
+          "docLinkRef": "default",
+          "entry": {
+            "name": "unit",
+            "kind": "object",
+            "docLinkRef": "default",
+            "children": [
+              {
+                "name": "name",
+                "kind": "string",
+                "docLinkRef": "default"
+              },
+              {
+                "name": "enabled",
+                "kind": "boolean",
+                "docLinkRef": "default"
+              },
+              {
+                "name": "contents",
+                "kind": "string",
+                "docLinkRef": "default"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -23,13 +23,14 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_hub_credential(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Hub Credential",
                 SchemaKind::Configuration,
                 ComponentKind::Credential,
                 Some(DOCKER_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -88,13 +89,14 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_image(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Image",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(DOCKER_NODE_COLOR),
+                None,
             )
             .await?
         {

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -40,13 +40,14 @@ impl MigrationDriver {
     }
 
     async fn migrate_kubernetes_namespace(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, mut schema_variant, root_prop) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Kubernetes Namespace",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(KUBERNETES_NODE_COLOR),
+                None,
             )
             .await?
         {
@@ -180,13 +181,14 @@ impl MigrationDriver {
     }
 
     async fn migrate_kubernetes_deployment(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, mut schema_variant, root_prop) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Kubernetes Deployment",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(KUBERNETES_NODE_COLOR),
+                None,
             )
             .await?
         {

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -15,13 +15,14 @@ impl MigrationDriver {
     }
 
     async fn migrate_generic_frame(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop) = match self
+        let (schema, schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Generic Frame",
                 SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(FRAME_NODE_COLOR),
+                None,
             )
             .await?
         {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -21,6 +21,7 @@ use crate::{
     WsEventError,
 };
 
+pub mod definition;
 pub mod root_prop;
 
 #[derive(Error, Debug)]
@@ -73,6 +74,26 @@ pub enum SchemaVariantError {
     WsEvent(#[from] WsEventError),
     #[error("std error: {0}")]
     Std(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+
+    // Errors related to definitions.
+    #[error("cannot use doc link and doc link ref for prop definition name: ({0})")]
+    MultipleDocLinksProvided(String),
+    #[error("link not found in doc links map for doc link ref: {0}")]
+    LinkNotFoundForDocLinkRef(String),
+    #[error("cannot provide entry for object with name: ({0})")]
+    FoundEntryForObject(String),
+    #[error("must provide children for object with name: ({0})")]
+    MissingChildrenForObject(String),
+    #[error("cannot provide children for array with name: ({0})")]
+    FoundChildrenForArray(String),
+    #[error("must provide entry for array with name: ({0})")]
+    MissingEntryForArray(String),
+    #[error("cannot provide children for primitive with name: ({0})")]
+    FoundChildrenForPrimitive(String),
+    #[error("cannot provide entry for primitive with name: ({0})")]
+    FoundEntryForPrimitive(String),
+    #[error("can neither provide children nor entry for primitive with name: ({0})")]
+    FoundChildrenAndEntryForPrimitive(String),
 }
 
 pub type SchemaVariantResult<T> = Result<T, SchemaVariantError>;

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -1,0 +1,175 @@
+//! Create a [`SchemaVariant`](crate::SchemaVariant) with a [`Prop`](crate::Prop) tree via a
+//! "definition" struct, usually provided via a "definition" file.
+
+use async_recursion::async_recursion;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};
+use crate::{DalContext, Prop, PropId, PropKind, RootProp, SchemaId, SchemaVariant, StandardModel};
+
+/// A cache of [`PropIds`](crate::Prop) where the _key_ is a tuple corresponding to the
+/// [`Prop`](crate::Prop) name and the _parent_ [`PropId`](crate::Prop) who's child is the
+/// [`PropId`](crate::Prop) in the _value_ of the entry.
+///
+/// It is recommended to start with the [`RootProp`](crate::RootProp) in order to descend into the
+/// cache.
+pub type PropCache = HashMap<(String, PropId), PropId>;
+
+/// The definition for a [`SchemaVariant`](crate::SchemaVariant)'s [`Prop`](crate::Prop) tree (and
+/// more in the future).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantDefinition {
+    /// The name of the [`SchemaVariant`](crate::SchemaVariant). This is _not_ the name of the
+    /// [`Schema`](crate::Schema) and will default to "v0" if empty.
+    name: Option<String>,
+    /// A map of documentation links to reference. To reference links (values) specify the key via
+    /// the "doc_link_ref" field for a [`PropDefinition`].
+    doc_links: HashMap<String, String>,
+    /// The immediate child [`Props`](crate::Prop) underneath "/root/domain".
+    #[serde(default)]
+    props: Vec<PropDefinition>,
+}
+
+/// The definition for a [`Prop`](crate::Prop) in a [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropDefinition {
+    /// The name of the [`Prop`](crate::Prop) to be created.
+    name: String,
+    /// The [`kind`](crate::PropKind) of the [`Prop`](crate::Prop) to be created.
+    kind: PropKind,
+    /// An optional reference to a documentation link in the "doc_links" field for the
+    /// [`SchemaVariantDefinition`] for the [`Prop`](crate::Prop) to be created.
+    doc_link_ref: Option<String>,
+    /// An optional documentation link for the [`Prop`](crate::Prop) to be created.
+    doc_link: Option<String>,
+    /// If our [`kind`](crate::PropKind) is [`Object`](crate::PropKind::Object), specify the
+    /// child definition(s).
+    #[serde(default)]
+    children: Vec<PropDefinition>,
+    /// If our [`kind`](crate::PropKind) is [`Array`](crate::PropKind::Array), specify the entry
+    /// definition.
+    entry: Option<Box<PropDefinition>>,
+}
+
+impl SchemaVariant {
+    /// Create a [`SchemaVariant`] like [`usual`](Self::new()), but use the
+    /// [`SchemaVariantDefinition`] to create a [`Prop`](crate::Prop) tree as well with a
+    /// [`cache`](PropCache).
+    pub async fn new_with_definition(
+        ctx: &DalContext,
+        schema_id: SchemaId,
+        schema_variant_definition: SchemaVariantDefinition,
+    ) -> SchemaVariantResult<(Self, RootProp, PropCache)> {
+        let name = match schema_variant_definition.name {
+            Some(name) => name,
+            None => "v0".to_string(),
+        };
+        let (schema_variant, root_prop) = Self::new(ctx, schema_id, name).await?;
+
+        // NOTE(nick): allow users to use a definition without props... just in case, I guess.
+        let mut prop_cache = PropCache::new();
+        for prop_definition in schema_variant_definition.props {
+            Self::walk_definition(
+                ctx,
+                &mut prop_cache,
+                prop_definition,
+                root_prop.domain_prop_id,
+                &schema_variant_definition.doc_links,
+            )
+            .await?;
+        }
+        Ok((schema_variant, root_prop, prop_cache))
+    }
+
+    /// A recursive walk of [`PropDefinition`] that populates the [`cache`](PropCache) as each
+    /// [`Prop`](crate::Prop) is created.
+    #[async_recursion]
+    async fn walk_definition(
+        ctx: &DalContext,
+        prop_cache: &mut PropCache,
+        definition: PropDefinition,
+        parent_prop_id: PropId,
+        doc_links: &HashMap<String, String>,
+    ) -> SchemaVariantResult<()> {
+        // Start by creating the prop and setting the parent. We cache the id for later.
+        let mut prop = Prop::new(ctx, definition.name.clone(), definition.kind, None).await?;
+        prop.set_parent_prop(ctx, parent_prop_id).await?;
+        let prop_id = *prop.id();
+
+        // Always cache the prop that was created.
+        prop_cache.insert((prop.name().to_string(), parent_prop_id), prop_id);
+
+        // Either use the doc link or the doc link ref. Do not use both.
+        match (definition.doc_link.is_some(), definition.doc_link_ref) {
+            (true, Some(_)) => {
+                return Err(SchemaVariantError::MultipleDocLinksProvided(
+                    definition.name.clone(),
+                ));
+            }
+            (true, None) => prop.set_doc_link(ctx, definition.doc_link).await?,
+            (false, Some(doc_link_ref)) => match doc_links.get(&doc_link_ref) {
+                Some(link) => prop.set_doc_link(ctx, Some(link)).await?,
+                None => return Err(SchemaVariantError::LinkNotFoundForDocLinkRef(doc_link_ref)),
+            },
+            (false, None) => {}
+        }
+
+        // Determine if we need to descend and check the "entry" and "children" fields accordingly.
+        match definition.kind {
+            PropKind::Object => {
+                if definition.entry.is_some() {
+                    return Err(SchemaVariantError::FoundEntryForObject(
+                        definition.name.clone(),
+                    ));
+                }
+                if definition.children.is_empty() {
+                    return Err(SchemaVariantError::MissingChildrenForObject(
+                        definition.name.clone(),
+                    ));
+                }
+                for child in definition.children {
+                    Self::walk_definition(ctx, prop_cache, child, prop_id, doc_links).await?;
+                }
+            }
+            PropKind::Array => match definition.entry {
+                Some(entry) => {
+                    if !definition.children.is_empty() {
+                        return Err(SchemaVariantError::FoundChildrenForArray(
+                            definition.name.clone(),
+                        ));
+                    }
+                    Self::walk_definition(ctx, prop_cache, *entry, prop_id, doc_links).await?;
+                }
+                None => {
+                    return Err(SchemaVariantError::MissingEntryForArray(
+                        definition.name.clone(),
+                    ));
+                }
+            },
+            PropKind::Map => todo!("maps not yet implemented simply because nick didn't need them yet and didn't want an untested solutionz"),
+            _ => match (definition.entry.is_some(), definition.children.is_empty()) {
+                (true, false) => {
+                    return Err(SchemaVariantError::FoundChildrenAndEntryForPrimitive(
+                        definition.name.clone(),
+                    ));
+                }
+                (true, true) => {
+                    return Err(SchemaVariantError::FoundEntryForPrimitive(
+                        definition.name.clone(),
+                    ));
+                }
+                (false, false) => {
+                    return Err(SchemaVariantError::FoundChildrenForPrimitive(
+                        definition.name.clone(),
+                    ));
+                }
+                (false, true) => {}
+            },
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit plants a flagpole for authoring schema variants (possibly
schemas later) with a configuration file rather than pure copy/paste
Rust. If the language, style, method, etc. are undesired in the near
future, that is fine! As mentioned, this is purely meant to be a start.

- Start with CoreOS Butane only and use the new definition file for it
- Add definition submodule with prop cache, schema variant definition and prop definition

<img src="https://media2.giphy.com/media/0dWC0LbJQBKzl34eu4/giphy.gif"/>

Fixes ENG-799