### PR TITLE
Convert definition prop cache to struct

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -107,8 +107,6 @@ pub enum BuiltinsError {
     BuiltinMissingFuncArgument(String, String),
     #[error("prop cache not found: {0}")]
     PropCacheNotFound(SchemaVariantId),
-    #[error("prop not found in cache for name ({0}) and parent prop id ({1})")]
-    PropNotFoundInCache(&'static str, PropId),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -130,27 +130,10 @@ impl MigrationDriver {
         // Collect the props we need.
         let prop_cache = maybe_prop_cache
             .ok_or_else(|| BuiltinsError::PropCacheNotFound(*schema_variant.id()))?;
-        let variant_prop_id = *prop_cache
-            .get(&("variant".to_string(), root_prop.domain_prop_id))
-            .ok_or(BuiltinsError::PropNotFoundInCache(
-                "variant",
-                root_prop.domain_prop_id,
-            ))?;
-        let version_prop_id = *prop_cache
-            .get(&("version".to_string(), root_prop.domain_prop_id))
-            .ok_or(BuiltinsError::PropNotFoundInCache(
-                "version",
-                root_prop.domain_prop_id,
-            ))?;
-        let systemd_prop_id = *prop_cache
-            .get(&("systemd".to_string(), root_prop.domain_prop_id))
-            .ok_or(BuiltinsError::PropNotFoundInCache(
-                "systemd",
-                root_prop.domain_prop_id,
-            ))?;
-        let units_prop_id = *prop_cache
-            .get(&("units".to_string(), systemd_prop_id))
-            .ok_or(BuiltinsError::PropNotFoundInCache("units", systemd_prop_id))?;
+        let variant_prop_id = prop_cache.get("variant", root_prop.domain_prop_id)?;
+        let version_prop_id = prop_cache.get("version", root_prop.domain_prop_id)?;
+        let systemd_prop_id = prop_cache.get("systemd", root_prop.domain_prop_id)?;
+        let units_prop_id = prop_cache.get("units", systemd_prop_id)?;
 
         // Set default values after finalization.
         self.set_default_value_for_prop(

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -76,6 +76,8 @@ pub enum SchemaVariantError {
     Std(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 
     // Errors related to definitions.
+    #[error("prop not found in cache for name ({0}) and parent prop id ({1})")]
+    PropNotFoundInCache(String, PropId),
     #[error("cannot use doc link and doc link ref for prop definition name: ({0})")]
     MultipleDocLinksProvided(String),
     #[error("link not found in doc links map for doc link ref: {0}")]


### PR DESCRIPTION
This is a quick follow up to #1561.

- Convert definition prop cache from type alias to struct for easier helper methods
- Add new, insert, and get helper methods to make the experience more ergonomic in builtins
- Fix typo in todo macro for maps in definition module