### PR TITLE
feat(dal,web): Stop frame resizing below minimum dimensions

### DIFF
--- a/app/web/src/organisms/GenericDiagram/diagram_constants.ts
+++ b/app/web/src/organisms/GenericDiagram/diagram_constants.ts
@@ -27,6 +27,7 @@ export const SOCKET_SIZE = 15;
 
 export const GROUP_HEADER_BOTTOM_MARGIN = 14;
 export const GROUP_TITLE_FONT_SIZE = 14;
+export const GROUP_INTERNAL_PADDING = 20;
 
 // corner radius used on nodes (maybe other things later?)
 export const CORNER_RADIUS = 3;

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use std::num::ParseIntError;
+use std::num::{ParseFloatError, ParseIntError};
 use strum_macros::{AsRefStr, Display, EnumString};
 use thiserror::Error;
 
@@ -34,6 +34,8 @@ pub enum DiagramError {
     InternalProvider(#[from] InternalProviderError),
     #[error(transparent)]
     ParseInt(#[from] ParseIntError),
+    #[error(transparent)]
+    ParseFloat(#[from] ParseFloatError),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("position not found")]

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -179,6 +179,9 @@ impl DiagramNodeView {
             None
         };
 
+        let x = position.x().parse::<f64>()?;
+        let y = position.y().parse::<f64>()?;
+
         Ok(Self {
             id: node.id().to_string(),
             ty: None,
@@ -188,8 +191,8 @@ impl DiagramNodeView {
             content: None,
             sockets: Some(SocketView::list(ctx, schema_variant).await?),
             position: GridPoint {
-                x: position.x().parse()?,
-                y: position.y().parse()?,
+                x: x.round() as isize,
+                y: y.round() as isize,
             },
             size,
             color: component


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6564471/204899570-b9100107-a1e5-4206-b615-139110af5faf.png)


Bonus:
- get_diagram does not break on float coordinates anymore

Co-authored-by: @stack72 