### PR TITLE
fix(dal): remove stray system_id reference

### DIFF
--- a/lib/dal/src/queries/attribute_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_for_context.sql
@@ -18,5 +18,4 @@ ORDER BY
     attribute_context_external_provider_id DESC,
     attribute_context_schema_id DESC,
     attribute_context_schema_variant_id DESC,
-    attribute_context_component_id DESC,
-    attribute_context_system_id DESC;
+    attribute_context_component_id DESC;


### PR DESCRIPTION
A system_id reference snuck back in, I think during merge conflict resolution, breaking attribute function authoring. This removes it.