### PR TITLE
feat(web): make vite host configurable

### DIFF
--- a/app/web/.env
+++ b/app/web/.env
@@ -7,6 +7,7 @@ VITE_SI_ENV=local
 VITE_API_PROXY_PATH=/api
 
 # vars only used for local dev, but we keep them here anyway since they dont hurt anything
+DEV_HOST=127.0.0.1 # set this to 0.0.0.0 to serve vite to external clients
 DEV_PORT=8080
 DEV_API_PROXY_URL=http://127.0.0.1:5156
 

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -45,6 +45,7 @@ export default (opts: { mode: string }) => {
       },
     },
     server: {
+      host: config.DEV_HOST,
       port: parseInt(config.DEV_PORT),
       fs: {
         strict: true,


### PR DESCRIPTION
This allows you to bind your vite dev server to an external interface, to access it over a network (like say if you were running it on a giant 64 core threadripper but wanted to test it from your laptop)