### PR TITLE
chore(dal,sdf,web): drop schema and variant from attribute context

### DIFF
--- a/app/web/src/api/sdf/dal/attribute.ts
+++ b/app/web/src/api/sdf/dal/attribute.ts
@@ -2,7 +2,5 @@ export interface AttributeContext {
   attribute_context_prop_id: number;
   attribute_context_internal_provider_id: number;
   attribute_context_external_provider_id: number;
-  attribute_context_schema_id: number;
-  attribute_context_schema_variant_id: number;
   attribute_context_component_id: number;
 }

--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -160,8 +160,5 @@ export interface FuncWithPrototypeContext {
   backendKind: FuncBackendKind;
   isBuiltin: boolean;
   attributePrototypeId: number;
-  attributeContextSchemaId: number;
-  attributeContextSchemaVariantId: number;
   attributeContextComponentId: number;
-  attributeContextSystemId: number;
 }

--- a/app/web/src/organisms/AttributeViewer.vue
+++ b/app/web/src/organisms/AttributeViewer.vue
@@ -86,9 +86,6 @@ const getAttributeContext = (propId: number) => ({
   attribute_context_prop_id: propId,
   attribute_context_internal_provider_id: -1,
   attribute_context_external_provider_id: -1,
-  attribute_context_schema_id: lastSelectedComponent.value.schemaId,
-  attribute_context_schema_variant_id:
-    lastSelectedComponent.value.schemaVariantId,
   attribute_context_component_id: lastSelectedComponent.value.id,
 });
 

--- a/app/web/src/utils/attributeContext.ts
+++ b/app/web/src/utils/attributeContext.ts
@@ -14,8 +14,6 @@ export function buildAttributeContext(
       attribute_context_prop_id: baggage.prop_id,
       attribute_context_internal_provider_id: -1,
       attribute_context_external_provider_id: -1,
-      attribute_context_schema_id: -1,
-      attribute_context_schema_variant_id: -1,
       attribute_context_component_id: -1,
     };
   }
@@ -24,9 +22,6 @@ export function buildAttributeContext(
     attribute_context_prop_id: baggage.prop_id,
     attribute_context_internal_provider_id: -1,
     attribute_context_external_provider_id: -1,
-    attribute_context_schema_id: componentIdentification.schemaId,
-    attribute_context_schema_variant_id:
-      componentIdentification.schemaVariantId,
     attribute_context_component_id: componentIdentification.componentId,
   };
 }

--- a/lib/dal-test/src/helpers/builtins.rs
+++ b/lib/dal-test/src/helpers/builtins.rs
@@ -133,8 +133,6 @@ impl SchemaBuiltinsTestHarness {
             node_id: *node.id(),
             base_attribute_read_context: AttributeReadContext {
                 prop_id: None,
-                schema_id: Some(schema_id),
-                schema_variant_id: Some(schema_variant_id),
                 component_id: Some(*component.id()),
                 ..AttributeReadContext::default()
             },

--- a/lib/dal/src/attribute/context/read.rs
+++ b/lib/dal/src/attribute/context/read.rs
@@ -1,37 +1,29 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    AttributeContext, ComponentId, ExternalProviderId, InternalProviderId, PropId, SchemaId,
-    SchemaVariantId,
-};
-
-pub const UNSET_ID_VALUE: i64 = -1;
+use crate::{AttributeContext, ComponentId, ExternalProviderId, InternalProviderId, PropId};
 
 /// An `AttributeReadContext` allows for saying "do not use this field
 /// to filter results" by providing [`None`] for the field's value.
 /// It also allows for saying "explicitly filter out results for that
-/// have this field set" by providing [`UNSET_ID_VALUE`] for the field's
+/// have this field set" by providing the unset value for the field's
 /// value.
 ///
 /// For example:
 ///
 /// ```rust
 /// # use dal::attribute::context::read::AttributeReadContext;
-/// # const UNSET_ID_VALUE: i64 = -1;
+/// # use dal::{ExternalProviderId, InternalProviderId};
 /// let read_context = AttributeReadContext {
 ///     prop_id: None,
-///     internal_provider_id: Some(UNSET_ID_VALUE.into()),
-///     external_provider_id: Some(UNSET_ID_VALUE.into()),
-///     schema_id: Some(1.into()),
-///     schema_variant_id: Some(1.into()),
+///     internal_provider_id: Some(InternalProviderId::NONE),
+///     external_provider_id: Some(ExternalProviderId::NONE),
 ///     component_id: Some(1.into()),
 /// };
 /// ```
 ///
 /// The above `AttributeReadContext` would be used for finding all
 /// attributes, across all [`Props`](crate::Prop) that have been set
-/// for a given [`SchemaId`], [`SchemaVariantId`], [`ComponentId`]
-/// specificity.
+/// for a given [`ComponentId`].
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AttributeReadContext {
     #[serde(rename = "attribute_context_prop_id")]
@@ -40,10 +32,6 @@ pub struct AttributeReadContext {
     pub internal_provider_id: Option<InternalProviderId>,
     #[serde(rename = "attribute_context_external_provider_id")]
     pub external_provider_id: Option<ExternalProviderId>,
-    #[serde(rename = "attribute_context_schema_id")]
-    pub schema_id: Option<SchemaId>,
-    #[serde(rename = "attribute_context_schema_variant_id")]
-    pub schema_variant_id: Option<SchemaVariantId>,
     #[serde(rename = "attribute_context_component_id")]
     pub component_id: Option<ComponentId>,
 }
@@ -51,12 +39,10 @@ pub struct AttributeReadContext {
 impl Default for AttributeReadContext {
     fn default() -> Self {
         Self {
-            prop_id: Some(UNSET_ID_VALUE.into()),
-            internal_provider_id: Some(UNSET_ID_VALUE.into()),
-            external_provider_id: Some(UNSET_ID_VALUE.into()),
-            schema_id: Some(UNSET_ID_VALUE.into()),
-            schema_variant_id: Some(UNSET_ID_VALUE.into()),
-            component_id: Some(UNSET_ID_VALUE.into()),
+            prop_id: Some(PropId::NONE),
+            internal_provider_id: Some(InternalProviderId::NONE),
+            external_provider_id: Some(ExternalProviderId::NONE),
+            component_id: Some(ComponentId::NONE),
         }
     }
 }
@@ -67,14 +53,39 @@ impl From<AttributeContext> for AttributeReadContext {
             prop_id: Some(from_context.prop_id()),
             internal_provider_id: Some(from_context.internal_provider_id()),
             external_provider_id: Some(from_context.external_provider_id()),
-            schema_id: Some(from_context.schema_id()),
-            schema_variant_id: Some(from_context.schema_variant_id()),
             component_id: Some(from_context.component_id()),
         }
     }
 }
 
 impl AttributeReadContext {
+    /// Creates a [`read context`](Self) with a given [`PropId`](crate::Prop)
+    /// and all other fields set to their defaults.
+    pub fn default_with_prop(prop_id: PropId) -> Self {
+        Self {
+            prop_id: Some(prop_id),
+            ..Self::default()
+        }
+    }
+
+    /// Creates a [`read context`](Self) with a given [`InternalProviderId`](crate::InternalProvider)
+    /// and all other fields set to their defaults.
+    pub fn default_with_internal_provider(internal_provider_id: InternalProviderId) -> Self {
+        Self {
+            internal_provider_id: Some(internal_provider_id),
+            ..Self::default()
+        }
+    }
+
+    /// Creates a [`read context`](Self) with a given [`ExternalProviderId`](crate::ExternalProvider)
+    /// and all other fields set to their defaults.
+    pub fn default_with_external_provider(external_provider_id: ExternalProviderId) -> Self {
+        Self {
+            external_provider_id: Some(external_provider_id),
+            ..Self::default()
+        }
+    }
+
     pub fn prop_id(&self) -> Option<PropId> {
         self.prop_id
     }
@@ -85,7 +96,7 @@ impl AttributeReadContext {
 
     pub fn has_set_prop_id(&self) -> bool {
         if let Some(prop_id) = self.prop_id {
-            prop_id != UNSET_ID_VALUE.into()
+            prop_id != PropId::NONE
         } else {
             false
         }
@@ -93,7 +104,7 @@ impl AttributeReadContext {
 
     pub fn has_unset_prop_id(&self) -> bool {
         if let Some(prop_id) = self.prop_id {
-            prop_id == UNSET_ID_VALUE.into()
+            prop_id == PropId::NONE
         } else {
             false
         }
@@ -109,7 +120,7 @@ impl AttributeReadContext {
 
     pub fn has_set_internal_provider(&self) -> bool {
         if let Some(internal_provider) = self.internal_provider_id {
-            internal_provider != UNSET_ID_VALUE.into()
+            internal_provider != InternalProviderId::NONE
         } else {
             false
         }
@@ -117,7 +128,7 @@ impl AttributeReadContext {
 
     pub fn has_unset_internal_provider(&self) -> bool {
         if let Some(internal_provider) = self.internal_provider_id {
-            internal_provider == UNSET_ID_VALUE.into()
+            internal_provider == InternalProviderId::NONE
         } else {
             false
         }
@@ -133,7 +144,7 @@ impl AttributeReadContext {
 
     pub fn has_set_external_provider(&self) -> bool {
         if let Some(external_provider) = self.external_provider_id {
-            external_provider != UNSET_ID_VALUE.into()
+            external_provider != ExternalProviderId::NONE
         } else {
             false
         }
@@ -141,55 +152,7 @@ impl AttributeReadContext {
 
     pub fn has_unset_external_provider(&self) -> bool {
         if let Some(external_provider) = self.external_provider_id {
-            external_provider == UNSET_ID_VALUE.into()
-        } else {
-            false
-        }
-    }
-
-    pub fn schema_id(&self) -> Option<SchemaId> {
-        self.schema_id
-    }
-
-    pub fn has_schema_id(&self) -> bool {
-        self.schema_id.is_some()
-    }
-
-    pub fn has_set_schema_id(&self) -> bool {
-        if let Some(schema_id) = self.schema_id {
-            schema_id != UNSET_ID_VALUE.into()
-        } else {
-            false
-        }
-    }
-
-    pub fn has_unset_schema_id(&self) -> bool {
-        if let Some(schema_id) = self.schema_id {
-            schema_id == UNSET_ID_VALUE.into()
-        } else {
-            false
-        }
-    }
-
-    pub fn schema_variant_id(&self) -> Option<SchemaVariantId> {
-        self.schema_variant_id
-    }
-
-    pub fn has_schema_variant_id(&self) -> bool {
-        self.schema_variant_id.is_some()
-    }
-
-    pub fn has_set_schema_variant_id(&self) -> bool {
-        if let Some(schema_variant_id) = self.schema_variant_id {
-            schema_variant_id != UNSET_ID_VALUE.into()
-        } else {
-            false
-        }
-    }
-
-    pub fn has_unset_schema_variant_id(&self) -> bool {
-        if let Some(schema_variant_id) = self.schema_variant_id {
-            schema_variant_id == UNSET_ID_VALUE.into()
+            external_provider == ExternalProviderId::NONE
         } else {
             false
         }
@@ -205,7 +168,7 @@ impl AttributeReadContext {
 
     pub fn has_set_component_id(&self) -> bool {
         if let Some(component_id) = self.component_id {
-            component_id != UNSET_ID_VALUE.into()
+            component_id != ComponentId::NONE
         } else {
             false
         }
@@ -213,7 +176,7 @@ impl AttributeReadContext {
 
     pub fn has_unset_component_id(&self) -> bool {
         if let Some(component_id) = self.component_id {
-            component_id == UNSET_ID_VALUE.into()
+            component_id == ComponentId::NONE
         } else {
             false
         }
@@ -224,8 +187,6 @@ impl AttributeReadContext {
             prop_id: None,
             internal_provider_id: None,
             external_provider_id: None,
-            schema_id: None,
-            schema_variant_id: None,
             component_id: None,
         }
     }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -734,8 +734,6 @@ impl AttributePrototype {
                     &context.prop_id(),
                     &context.internal_provider_id(),
                     &context.external_provider_id(),
-                    &context.schema_id(),
-                    &context.schema_variant_id(),
                     &context.component_id(),
                 ],
             )

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -8,7 +8,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::{
-    attribute::context::UNSET_ID_VALUE, func::argument::FuncArgumentId, impl_standard_model, pk,
+    func::argument::FuncArgumentId, impl_standard_model, pk,
     provider::internal::InternalProviderId, standard_model, standard_model_accessor,
     AttributePrototypeId, ComponentId, DalContext, ExternalProviderId, HistoryEventError,
     StandardModel, StandardModelError, Timestamp, Visibility, WriteTenancy,
@@ -103,10 +103,10 @@ impl AttributePrototypeArgument {
         internal_provider_id: InternalProviderId,
     ) -> AttributePrototypeArgumentResult<Self> {
         // Ensure the value fields are what we expect.
-        let external_provider_id: ExternalProviderId = UNSET_ID_VALUE.into();
-        let tail_component_id: ComponentId = UNSET_ID_VALUE.into();
-        let head_component_id: ComponentId = UNSET_ID_VALUE.into();
-        if internal_provider_id == UNSET_ID_VALUE.into() {
+        let external_provider_id = ExternalProviderId::NONE;
+        let tail_component_id = ComponentId::NONE;
+        let head_component_id = ComponentId::NONE;
+        if internal_provider_id == InternalProviderId::NONE {
             return Err(AttributePrototypeArgumentError::RequiredValueFieldsUnset);
         }
 
@@ -141,15 +141,15 @@ impl AttributePrototypeArgument {
         external_provider_id: ExternalProviderId,
     ) -> AttributePrototypeArgumentResult<Self> {
         // Ensure the value fields are what we expect.
-        if external_provider_id == UNSET_ID_VALUE.into()
-            || tail_component_id == UNSET_ID_VALUE.into()
-            || head_component_id == UNSET_ID_VALUE.into()
+        if external_provider_id == ExternalProviderId::NONE
+            || tail_component_id == ComponentId::NONE
+            || head_component_id == ComponentId::NONE
         {
             return Err(AttributePrototypeArgumentError::RequiredValueFieldsUnset);
         }
 
         // For inter component connections, the internal provider id field must be unset.
-        let internal_provider_id: InternalProviderId = UNSET_ID_VALUE.into();
+        let internal_provider_id = InternalProviderId::NONE;
 
         let row = ctx
             .txns()
@@ -209,15 +209,15 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         internal_provider_id: InternalProviderId,
     ) -> AttributePrototypeArgumentResult<()> {
-        if self.internal_provider_id != UNSET_ID_VALUE.into()
-            && internal_provider_id == UNSET_ID_VALUE.into()
+        if self.internal_provider_id != InternalProviderId::NONE
+            && internal_provider_id == InternalProviderId::NONE
         {
             return Err(AttributePrototypeArgumentError::CannotFlipUnsetFieldToSet(
                 "InternalProviderId",
             ));
         };
-        if self.internal_provider_id == UNSET_ID_VALUE.into()
-            && internal_provider_id != UNSET_ID_VALUE.into()
+        if self.internal_provider_id == InternalProviderId::NONE
+            && internal_provider_id != InternalProviderId::NONE
         {
             return Err(AttributePrototypeArgumentError::CannotFlipSetFieldToUnset(
                 "InternalProviderId",
@@ -235,15 +235,15 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         external_provider_id: ExternalProviderId,
     ) -> AttributePrototypeArgumentResult<()> {
-        if self.external_provider_id != UNSET_ID_VALUE.into()
-            && external_provider_id == UNSET_ID_VALUE.into()
+        if self.external_provider_id != ExternalProviderId::NONE
+            && external_provider_id == ExternalProviderId::NONE
         {
             return Err(AttributePrototypeArgumentError::CannotFlipUnsetFieldToSet(
                 "ExternalProviderId",
             ));
         }
-        if self.external_provider_id == UNSET_ID_VALUE.into()
-            && external_provider_id != UNSET_ID_VALUE.into()
+        if self.external_provider_id == ExternalProviderId::NONE
+            && external_provider_id != ExternalProviderId::NONE
         {
             return Err(AttributePrototypeArgumentError::CannotFlipSetFieldToUnset(
                 "ExternalProviderId",
@@ -261,16 +261,12 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         tail_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<()> {
-        if self.tail_component_id != UNSET_ID_VALUE.into()
-            && tail_component_id == UNSET_ID_VALUE.into()
-        {
+        if self.tail_component_id != ComponentId::NONE && tail_component_id == ComponentId::NONE {
             return Err(AttributePrototypeArgumentError::CannotFlipUnsetFieldToSet(
                 "tail ComponentId",
             ));
         }
-        if self.tail_component_id == UNSET_ID_VALUE.into()
-            && tail_component_id != UNSET_ID_VALUE.into()
-        {
+        if self.tail_component_id == ComponentId::NONE && tail_component_id != ComponentId::NONE {
             return Err(AttributePrototypeArgumentError::CannotFlipSetFieldToUnset(
                 "tail ComponentId",
             ));
@@ -286,16 +282,12 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         head_component_id: ComponentId,
     ) -> AttributePrototypeArgumentResult<()> {
-        if self.head_component_id != UNSET_ID_VALUE.into()
-            && head_component_id == UNSET_ID_VALUE.into()
-        {
+        if self.head_component_id != ComponentId::NONE && head_component_id == ComponentId::NONE {
             return Err(AttributePrototypeArgumentError::CannotFlipUnsetFieldToSet(
                 "head ComponentId",
             ));
         }
-        if self.head_component_id == UNSET_ID_VALUE.into()
-            && head_component_id != UNSET_ID_VALUE.into()
-        {
+        if self.head_component_id == ComponentId::NONE && head_component_id != ComponentId::NONE {
             return Err(AttributePrototypeArgumentError::CannotFlipSetFieldToUnset(
                 "head ComponentId",
             ));
@@ -307,7 +299,7 @@ impl AttributePrototypeArgument {
     /// Determines if the [`InternalProviderId`](crate::InternalProvider) is unset. This function
     /// can be useful for determining how to build [`FuncBinding`](crate::FuncBinding) arguments.
     pub fn is_internal_provider_unset(&self) -> bool {
-        self.internal_provider_id == UNSET_ID_VALUE.into()
+        self.internal_provider_id == InternalProviderId::NONE
     }
 
     /// List all [`AttributePrototypeArguments`](Self) for a given

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -5,7 +5,7 @@ use crate::prototype_context::PrototypeContext;
 use crate::schema::variant::definition::SchemaVariantDefinition;
 use crate::socket::SocketArity;
 use crate::{
-    qualification_prototype::QualificationPrototypeContext, schema::SchemaUiMenu, AttributeContext,
+    qualification_prototype::QualificationPrototypeContext, schema::SchemaUiMenu,
     AttributePrototypeArgument, AttributeReadContext, AttributeValue, BuiltinsError,
     BuiltinsResult, CodeLanguage, DalContext, DiagramKind, ExternalProvider, Func, FuncError,
     InternalProvider, QualificationPrototype, SchemaError, SchemaKind, SchemaVariant,
@@ -42,11 +42,6 @@ impl MigrationDriver {
             Some(tuple) => tuple,
             None => return Ok(()),
         };
-
-        let mut attribute_context_builder = AttributeContext::builder();
-        attribute_context_builder
-            .set_schema_id(*schema.id())
-            .set_schema_variant_id(*schema_variant.id());
 
         // Diagram and UI Menu
         let diagram_kind = schema
@@ -136,37 +131,16 @@ impl MigrationDriver {
         let units_prop_id = prop_cache.get("units", systemd_prop_id)?;
 
         // Set default values after finalization.
-        self.set_default_value_for_prop(
-            ctx,
-            variant_prop_id,
-            *schema.id(),
-            *schema_variant.id(),
-            serde_json::json!["fcos"],
-        )
-        .await?;
-        self.set_default_value_for_prop(
-            ctx,
-            version_prop_id,
-            *schema.id(),
-            *schema_variant.id(),
-            serde_json::json!["1.4.0"],
-        )
-        .await?;
-
-        // Add the ability to use docker image as an input.
-        let base_attribute_read_context = AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
-            ..AttributeReadContext::default()
-        };
+        self.set_default_value_for_prop(ctx, variant_prop_id, serde_json::json!["fcos"])
+            .await?;
+        self.set_default_value_for_prop(ctx, version_prop_id, serde_json::json!["1.4.0"])
+            .await?;
 
         // Enable connections from the "Container Image" explicit internal provider to the
         // "/root/domain/systemd/units/" field. We need to use the appropriate function with and name
         // the argument "images".
-        let units_attribute_value_read_context = AttributeReadContext {
-            prop_id: Some(units_prop_id),
-            ..base_attribute_read_context
-        };
+        let units_attribute_value_read_context =
+            AttributeReadContext::default_with_prop(units_prop_id);
         let units_attribute_value =
             AttributeValue::find_for_context(ctx, units_attribute_value_read_context)
                 .await?

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -5,11 +5,11 @@ use crate::builtins::schema::MigrationDriver;
 use crate::{
     component::ComponentKind, edit_field::widget::*, prototype_context::PrototypeContext,
     qualification_prototype::QualificationPrototypeContext, schema::SchemaUiMenu,
-    socket::SocketArity, ActionPrototype, ActionPrototypeContext, AttributeContext,
-    AttributePrototypeArgument, AttributeReadContext, AttributeValue, AttributeValueError,
-    BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider, Func,
-    InternalProvider, Prop, PropKind, QualificationPrototype, SchemaError, SchemaKind,
-    StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
+    socket::SocketArity, ActionPrototype, ActionPrototypeContext, AttributePrototypeArgument,
+    AttributeReadContext, AttributeValue, AttributeValueError, BuiltinsError, BuiltinsResult,
+    DalContext, DiagramKind, ExternalProvider, Func, InternalProvider, Prop, PropKind,
+    QualificationPrototype, SchemaError, SchemaKind, StandardModel, WorkflowPrototype,
+    WorkflowPrototypeContext,
 };
 
 // Reference: https://www.docker.com/company/newsroom/media-resources/
@@ -104,11 +104,6 @@ impl MigrationDriver {
             None => return Ok(()),
         };
 
-        let mut attribute_context_builder = AttributeContext::builder();
-        attribute_context_builder
-            .set_schema_id(*schema.id())
-            .set_schema_variant_id(*schema_variant.id());
-
         let diagram_kind = schema
             .diagram_kind()
             .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
@@ -198,19 +193,10 @@ impl MigrationDriver {
 
         schema_variant.finalize(ctx).await?;
 
-        let base_attribute_read_context = AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
-            ..AttributeReadContext::default()
-        };
-
         // Connect the "/root/si/name" field to the "/root/domain/image" field.
         let image_attribute_value = AttributeValue::find_for_context(
             ctx,
-            AttributeReadContext {
-                prop_id: Some(*image_prop.id()),
-                ..base_attribute_read_context
-            },
+            AttributeReadContext::default_with_prop(*image_prop.id()),
         )
         .await?
         .ok_or(AttributeValueError::Missing)?;

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -2,8 +2,8 @@ use crate::builtins::schema::MigrationDriver;
 use crate::component::ComponentKind;
 use crate::validation::Validation;
 use crate::{
-    schema::SchemaUiMenu, AttributeContext, BuiltinsError, BuiltinsResult, DalContext, DiagramKind,
-    InternalProvider, PropKind, SchemaError, SchemaKind, SocketArity, StandardModel,
+    schema::SchemaUiMenu, BuiltinsError, BuiltinsResult, DalContext, DiagramKind, InternalProvider,
+    PropKind, SchemaError, SchemaKind, SocketArity, StandardModel,
 };
 
 const FRAME_NODE_COLOR: i64 = 0xFFFFFF;
@@ -29,11 +29,6 @@ impl MigrationDriver {
             Some(tuple) => tuple,
             None => return Ok(()),
         };
-
-        let mut attribute_context_builder = AttributeContext::builder();
-        attribute_context_builder
-            .set_schema_id(*schema.id())
-            .set_schema_variant_id(*schema_variant.id());
 
         // Diagram and UI Menu
         let diagram_kind = schema

--- a/lib/dal/src/component/code.rs
+++ b/lib/dal/src/component/code.rs
@@ -21,17 +21,11 @@ impl Component {
         let component = Self::get_by_id(ctx, &component_id)
             .await?
             .ok_or(ComponentError::NotFound(component_id))?;
-        let schema = component
-            .schema(ctx)
-            .await?
-            .ok_or(ComponentError::NoSchema(component_id))?;
         let schema_variant = component
             .schema_variant(ctx)
             .await?
             .ok_or(ComponentError::NoSchemaVariant(component_id))?;
         let base_read_context = AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(component_id),
             ..AttributeReadContext::default()
         };

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -52,18 +52,12 @@ impl ComponentDiff {
             .schema_variant(ctx)
             .await?
             .ok_or(ComponentError::NoSchemaVariant(component_id))?;
-        let schema = component
-            .schema(ctx)
-            .await?
-            .ok_or(ComponentError::NoSchema(component_id))?;
         let root_prop = Prop::find_root_for_schema_variant(ctx, *schema_variant.id())
             .await?
             .ok_or_else(|| ComponentError::RootPropNotFound(*schema_variant.id()))?;
 
         let component_view_context = AttributeReadContext {
             prop_id: Some(*root_prop.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(component_id),
             ..AttributeReadContext::default()
         };

--- a/lib/dal/src/migrations/U0056__attribute_prototypes.sql
+++ b/lib/dal/src/migrations/U0056__attribute_prototypes.sql
@@ -11,8 +11,6 @@ CREATE TABLE attribute_prototypes
     attribute_context_prop_id              bigint,
     attribute_context_internal_provider_id bigint,
     attribute_context_external_provider_id bigint,
-    attribute_context_schema_id            bigint,
-    attribute_context_schema_variant_id    bigint,
     attribute_context_component_id         bigint,
     created_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
@@ -51,8 +49,6 @@ BEGIN
                                       attribute_context_prop_id,
                                       attribute_context_internal_provider_id,
                                       attribute_context_external_provider_id,
-                                      attribute_context_schema_id,
-                                      attribute_context_schema_variant_id,
                                       attribute_context_component_id,
                                       func_id,
                                       key)
@@ -65,8 +61,6 @@ BEGIN
             this_attribute_context_record.attribute_context_prop_id,
             this_attribute_context_record.attribute_context_internal_provider_id,
             this_attribute_context_record.attribute_context_external_provider_id,
-            this_attribute_context_record.attribute_context_schema_id,
-            this_attribute_context_record.attribute_context_schema_variant_id,
             this_attribute_context_record.attribute_context_component_id,
             this_func_id,
             this_key)
@@ -80,22 +74,21 @@ $$ LANGUAGE PLPGSQL VOLATILE;
 -- take arguments of ROWTYPE, so we need to make a specific version
 -- of this function for every table we want to use it with.
 CREATE OR REPLACE FUNCTION in_attribute_context_v1(
-    check_context   jsonb,
+    check_context jsonb,
     record_to_check attribute_prototypes
 )
-RETURNS bool
-LANGUAGE sql
-IMMUTABLE
-PARALLEL SAFE
-CALLED ON NULL INPUT
-AS $$
-    SELECT in_attribute_context_v1(
-        check_context,
-        record_to_check.attribute_context_prop_id,
-        record_to_check.attribute_context_internal_provider_id,
-        record_to_check.attribute_context_external_provider_id,
-        record_to_check.attribute_context_schema_id,
-        record_to_check.attribute_context_schema_variant_id,
-        record_to_check.attribute_context_component_id
-    )
+    RETURNS bool
+    LANGUAGE sql
+    IMMUTABLE
+    PARALLEL SAFE
+    CALLED ON NULL INPUT
+AS
+$$
+SELECT in_attribute_context_v1(
+               check_context,
+               record_to_check.attribute_context_prop_id,
+               record_to_check.attribute_context_internal_provider_id,
+               record_to_check.attribute_context_external_provider_id,
+               record_to_check.attribute_context_component_id
+           )
 $$;

--- a/lib/dal/src/migrations/U0057__attribute_values.sql
+++ b/lib/dal/src/migrations/U0057__attribute_values.sql
@@ -11,8 +11,6 @@ CREATE TABLE attribute_values
     attribute_context_prop_id              bigint                   NOT NULL,
     attribute_context_internal_provider_id bigint                   NOT NULL,
     attribute_context_external_provider_id bigint                   NOT NULL,
-    attribute_context_schema_id            bigint                   NOT NULL,
-    attribute_context_schema_variant_id    bigint                   NOT NULL,
     attribute_context_component_id         bigint                   NOT NULL,
     created_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
     updated_at                             timestamp with time zone NOT NULL DEFAULT NOW(),
@@ -39,8 +37,6 @@ CREATE INDEX ON public.attribute_values USING btree (func_binding_return_value_i
 CREATE INDEX ON attribute_values (attribute_context_prop_id);
 CREATE INDEX ON attribute_values (attribute_context_internal_provider_id);
 CREATE INDEX ON attribute_values (attribute_context_external_provider_id);
-CREATE INDEX ON attribute_values (attribute_context_schema_id);
-CREATE INDEX ON attribute_values (attribute_context_schema_variant_id);
 CREATE INDEX ON attribute_values (attribute_context_component_id);
 CREATE INDEX ON attribute_values (proxy_for_attribute_value_id);
 
@@ -72,8 +68,6 @@ BEGIN
                                   attribute_context_prop_id,
                                   attribute_context_internal_provider_id,
                                   attribute_context_external_provider_id,
-                                  attribute_context_schema_id,
-                                  attribute_context_schema_variant_id,
                                   attribute_context_component_id,
                                   func_binding_id,
                                   func_binding_return_value_id,
@@ -87,8 +81,6 @@ BEGIN
             this_attribute_context_record.attribute_context_prop_id,
             this_attribute_context_record.attribute_context_internal_provider_id,
             this_attribute_context_record.attribute_context_external_provider_id,
-            this_attribute_context_record.attribute_context_schema_id,
-            this_attribute_context_record.attribute_context_schema_variant_id,
             this_attribute_context_record.attribute_context_component_id,
             this_func_binding_id,
             this_func_binding_return_value_id,
@@ -103,22 +95,21 @@ $$ LANGUAGE PLPGSQL VOLATILE;
 -- take arguments of ROWTYPE, so we need to make a specific version
 -- of this function for every table we want to use it with.
 CREATE OR REPLACE FUNCTION in_attribute_context_v1(
-    check_context   jsonb,
+    check_context jsonb,
     record_to_check attribute_values
 )
-RETURNS bool
-LANGUAGE sql
-IMMUTABLE
-PARALLEL SAFE
-CALLED ON NULL INPUT
-AS $$
-    SELECT in_attribute_context_v1(
-        check_context,
-        record_to_check.attribute_context_prop_id,
-        record_to_check.attribute_context_internal_provider_id,
-        record_to_check.attribute_context_external_provider_id,
-        record_to_check.attribute_context_schema_id,
-        record_to_check.attribute_context_schema_variant_id,
-        record_to_check.attribute_context_component_id
-    )
+    RETURNS bool
+    LANGUAGE sql
+    IMMUTABLE
+    PARALLEL SAFE
+    CALLED ON NULL INPUT
+AS
+$$
+SELECT in_attribute_context_v1(
+               check_context,
+               record_to_check.attribute_context_prop_id,
+               record_to_check.attribute_context_internal_provider_id,
+               record_to_check.attribute_context_external_provider_id,
+               record_to_check.attribute_context_component_id
+           )
 $$;

--- a/lib/dal/src/migrations/U0062__attribute_value_payload_for_root_stored_procedure.sql
+++ b/lib/dal/src/migrations/U0062__attribute_value_payload_for_root_stored_procedure.sql
@@ -1,13 +1,12 @@
-CREATE TYPE func_with_attribute_prototype_context AS (
-    id bigint,
-    NAME text,
-    display_name text,
-    backend_kind text,
-    backend_response_type text,
-    is_builtin bool,
-    attribute_prototype_id bigint,
-    attribute_context_schema_id bigint,
-    attribute_context_schema_variant_id bigint,
+CREATE TYPE func_with_attribute_prototype_context AS
+(
+    id                             bigint,
+    NAME                           text,
+    display_name                   text,
+    backend_kind                   text,
+    backend_response_type          text,
+    is_builtin                     bool,
+    attribute_prototype_id         bigint,
     attribute_context_component_id bigint
 );
 CREATE OR REPLACE FUNCTION attribute_value_list_payload_for_read_context_and_root_v1(
@@ -15,58 +14,59 @@ CREATE OR REPLACE FUNCTION attribute_value_list_payload_for_read_context_and_roo
     this_visibility jsonb,
     this_context jsonb,
     this_attribute_value_id bigint
-) RETURNS TABLE (
-    parent_attribute_value_id bigint,
-    attribute_value_object json,
-    prop_object json,
-    func_binding_return_value_object json,
-    func_with_prototype_context json
-) AS $$
+)
+    RETURNS TABLE
+            (
+                parent_attribute_value_id        bigint,
+                attribute_value_object           json,
+                prop_object                      json,
+                func_binding_return_value_object json,
+                func_with_prototype_context      json
+            )
+AS
+$$
 DECLARE
     new_child_attribute_value_ids bigint[];
-    parent_attribute_value_ids bigint[];
+    parent_attribute_value_ids    bigint[];
 BEGIN
     -- Make sure we return the result for the base AttributeValue before looping through
     -- to return all of its children.
     RETURN QUERY
-    SELECT 
-        avbtav.belongs_to_id AS parent_attribute_value_id,
-        row_to_json(av. *) AS attribute_value_object,
-        row_to_json(prop. *) AS prop_object,
-        row_to_json(fbrv. *) AS func_binding_return_value_object,
-        row_to_json(cast(
-            ROW(
-                func.id,
-                func.name,
-                func.display_name,
-                func.backend_kind,
-                func.backend_response_type,
-                CASE
-                    WHEN func.tenancy_universal IS TRUE
-                    AND func.visibility_change_set_pk = -1 THEN TRUE
-                    ELSE FALSE
-                END,
-                ap.id,
-                ap.attribute_context_schema_id,
-                ap.attribute_context_schema_variant_id,
-                ap.attribute_context_component_id
-            ) AS func_with_attribute_prototype_context
-        )) AS func_with_prototype_context
-    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-    LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
-        ON av.id = avbtav.object_id
-    INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
-        ON avbtap.object_id = av.id
-    INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
-        ON avbtap.belongs_to_id = ap.id
-    INNER JOIN funcs_v1(this_tenancy, this_visibility) AS func
-        ON ap.func_id = func.id
-    INNER JOIN props_v1(this_tenancy, this_visibility) AS prop
-        ON av.attribute_context_prop_id = prop.id
-    INNER JOIN func_binding_return_values_v1(this_tenancy, this_visibility) AS fbrv
-        ON fbrv.id = av.func_binding_return_value_id
-    WHERE av.id = this_attribute_value_id
-    ORDER BY av.id;
+        SELECT avbtav.belongs_to_id AS parent_attribute_value_id,
+               row_to_json(av.*)    AS attribute_value_object,
+               row_to_json(prop.*)  AS prop_object,
+               row_to_json(fbrv.*)  AS func_binding_return_value_object,
+               row_to_json(cast(
+                       ROW (
+                           func.id,
+                           func.name,
+                           func.display_name,
+                           func.backend_kind,
+                           func.backend_response_type,
+                           CASE
+                               WHEN func.tenancy_universal IS TRUE
+                                   AND func.visibility_change_set_pk = -1 THEN TRUE
+                               ELSE FALSE
+                               END,
+                           ap.id,
+                           ap.attribute_context_component_id
+                           ) AS func_with_attribute_prototype_context
+                   ))               AS func_with_prototype_context
+        FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                 LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
+                           ON av.id = avbtav.object_id
+                 INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
+                            ON avbtap.object_id = av.id
+                 INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+                            ON avbtap.belongs_to_id = ap.id
+                 INNER JOIN funcs_v1(this_tenancy, this_visibility) AS func
+                            ON ap.func_id = func.id
+                 INNER JOIN props_v1(this_tenancy, this_visibility) AS prop
+                            ON av.attribute_context_prop_id = prop.id
+                 INNER JOIN func_binding_return_values_v1(this_tenancy, this_visibility) AS fbrv
+                            ON fbrv.id = av.func_binding_return_value_id
+        WHERE av.id = this_attribute_value_id
+        ORDER BY av.id;
 
     parent_attribute_value_ids := ARRAY [ this_attribute_value_id ];
 
@@ -74,68 +74,62 @@ BEGIN
         SELECT array_agg(attribute_value_id) AS attribute_value_ids
         INTO STRICT new_child_attribute_value_ids
         FROM (
-                SELECT DISTINCT ON (
-                        COALESCE(avbtav.belongs_to_id, -1),
-                        av.attribute_context_prop_id,
-                        COALESCE(av.key, '')
-                )
-                    av.id AS attribute_value_id
-                FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-                LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
-                    ON av.id = avbtav.object_id
-                WHERE
-                    in_attribute_context_v1(this_context, av)
-                    AND avbtav.belongs_to_id = ANY (parent_attribute_value_ids)
-                ORDER BY
-                    COALESCE(avbtav.belongs_to_id, -1) DESC,
-                    av.attribute_context_prop_id DESC,
-                    COALESCE(av.key, ''),
-                    av.attribute_context_schema_id DESC,
-                    av.attribute_context_schema_variant_id DESC,
-                    av.attribute_context_component_id DESC,
-                    av.tenancy_universal -- bools sort false first ascending.
-            ) AS av_ids;
+                 SELECT DISTINCT ON (
+                     COALESCE(avbtav.belongs_to_id, -1),
+                     av.attribute_context_prop_id,
+                     COALESCE(av.key, '')
+                     ) av.id AS attribute_value_id
+                 FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                          LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy,
+                                                                                  this_visibility) AS avbtav
+                                    ON av.id = avbtav.object_id
+                 WHERE in_attribute_context_v1(this_context, av)
+                   AND avbtav.belongs_to_id = ANY (parent_attribute_value_ids)
+                 ORDER BY COALESCE(avbtav.belongs_to_id, -1) DESC,
+                          av.attribute_context_prop_id DESC,
+                          COALESCE(av.key, ''),
+                          av.attribute_context_component_id DESC,
+                          av.tenancy_universal -- bools sort false first ascending.
+             ) AS av_ids;
         -- Exit the loop, since we haven't found any new child AttributeValues to return.
         EXIT WHEN new_child_attribute_value_ids IS NULL;
 
         -- This returns a partial result for the AttributeValues that we've found so far.
         RETURN QUERY
-            SELECT
-                avbtav.belongs_to_id AS parent_attribute_value_id,
-                row_to_json(av. *) AS attribute_value_object,
-                row_to_json(prop. *) AS prop_object,
-                row_to_json(fbrv. *) AS func_binding_return_value_object,
-                row_to_json(cast(
-                    ROW (
-                        func.id,
-                        func.name,
-                        func.display_name,
-                        func.backend_kind,
-                        func.backend_response_type,
-                        CASE
-                            WHEN func.tenancy_universal IS TRUE
-                            AND func.visibility_change_set_pk = -1 THEN TRUE
-                            ELSE FALSE
-                        END,
-                        ap.id,
-                        ap.attribute_context_schema_id,
-                        ap.attribute_context_schema_variant_id,
-                        ap.attribute_context_component_id
-                    ) AS func_with_attribute_prototype_context
-                )) AS func_with_prototype_context
+            SELECT avbtav.belongs_to_id AS parent_attribute_value_id,
+                   row_to_json(av.*)    AS attribute_value_object,
+                   row_to_json(prop.*)  AS prop_object,
+                   row_to_json(fbrv.*)  AS func_binding_return_value_object,
+                   row_to_json(cast(
+                           ROW (
+                               func.id,
+                               func.name,
+                               func.display_name,
+                               func.backend_kind,
+                               func.backend_response_type,
+                               CASE
+                                   WHEN func.tenancy_universal IS TRUE
+                                       AND func.visibility_change_set_pk = -1 THEN TRUE
+                                   ELSE FALSE
+                                   END,
+                               ap.id,
+                               ap.attribute_context_component_id
+                               ) AS func_with_attribute_prototype_context
+                       ))               AS func_with_prototype_context
             FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-            LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
-                ON av.id = avbtav.object_id
-            INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
-                ON avbtap.object_id = av.id
-            INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
-                ON avbtap.belongs_to_id = ap.id
-            INNER JOIN funcs_v1(this_tenancy, this_visibility) AS func
-                ON ap.func_id = func.id
-            INNER JOIN props_v1(this_tenancy, this_visibility) AS prop
-                ON av.attribute_context_prop_id = prop.id
-            INNER JOIN func_binding_return_values_v1(this_tenancy, this_visibility) AS fbrv
-                ON fbrv.id = av.func_binding_return_value_id
+                     LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
+                               ON av.id = avbtav.object_id
+                     INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy,
+                                                                                  this_visibility) AS avbtap
+                                ON avbtap.object_id = av.id
+                     INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+                                ON avbtap.belongs_to_id = ap.id
+                     INNER JOIN funcs_v1(this_tenancy, this_visibility) AS func
+                                ON ap.func_id = func.id
+                     INNER JOIN props_v1(this_tenancy, this_visibility) AS prop
+                                ON av.attribute_context_prop_id = prop.id
+                     INNER JOIN func_binding_return_values_v1(this_tenancy, this_visibility) AS fbrv
+                                ON fbrv.id = av.func_binding_return_value_id
             WHERE av.id = ANY (new_child_attribute_value_ids)
             ORDER BY av.id;
 
@@ -155,36 +149,33 @@ CREATE OR REPLACE FUNCTION attribute_value_id_for_prop_and_context_v1(
     this_context jsonb,
     this_prop_id bigint
 )
-RETURNS bigint
-LANGUAGE SQL
-STABLE
-PARALLEL SAFE
-AS $$
-    SELECT DISTINCT ON (
-        av.attribute_context_prop_id,
-        COALESCE(avbtav.belongs_to_id, -1),
-        COALESCE(av.key, '')
-    )
-        av.id
-    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-    LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
-        ON av.id = avbtav.object_id
-    INNER JOIN prop_many_to_many_schema_variants_v1(this_tenancy, this_visibility) AS pmtmsv
-        ON av.attribute_context_prop_id = pmtmsv.left_object_id
-    WHERE in_attribute_context_v1(this_context, av)
-        AND pmtmsv.right_object_id = this_prop_id
-    ORDER BY
-        av.attribute_context_prop_id,
-        COALESCE(avbtav.belongs_to_id, -1),
-        COALESCE(av.key, ''),
-        av.visibility_change_set_pk DESC,
-        av.visibility_deleted_at DESC NULLS FIRST,
-        av.attribute_context_internal_provider_id DESC,
-        av.attribute_context_external_provider_id DESC,
-        av.attribute_context_schema_id DESC,
-        av.attribute_context_schema_variant_id DESC,
-        av.attribute_context_component_id DESC,
-        av.tenancy_universal -- bools sort false first ascending.
+    RETURNS bigint
+    LANGUAGE SQL
+    STABLE
+    PARALLEL SAFE
+AS
+$$
+SELECT DISTINCT ON (
+    av.attribute_context_prop_id,
+    COALESCE(avbtav.belongs_to_id, -1),
+    COALESCE(av.key, '')
+    ) av.id
+FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+         LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
+                   ON av.id = avbtav.object_id
+         INNER JOIN prop_many_to_many_schema_variants_v1(this_tenancy, this_visibility) AS pmtmsv
+                    ON av.attribute_context_prop_id = pmtmsv.left_object_id
+WHERE in_attribute_context_v1(this_context, av)
+  AND pmtmsv.right_object_id = this_prop_id
+ORDER BY av.attribute_context_prop_id,
+         COALESCE(avbtav.belongs_to_id, -1),
+         COALESCE(av.key, ''),
+         av.visibility_change_set_pk DESC,
+         av.visibility_deleted_at DESC NULLS FIRST,
+         av.attribute_context_internal_provider_id DESC,
+         av.attribute_context_external_provider_id DESC,
+         av.attribute_context_component_id DESC,
+         av.tenancy_universal -- bools sort false first ascending.
 $$;
 
 CREATE OR REPLACE FUNCTION attribute_value_list_payload_for_read_context_v1(
@@ -193,27 +184,29 @@ CREATE OR REPLACE FUNCTION attribute_value_list_payload_for_read_context_v1(
     this_context jsonb,
     this_prop_id bigint
 )
-RETURNS TABLE (
-    parent_attribute_value_id bigint,
-    attribute_value_object json,
-    prop_object json,
-    func_binding_return_value_object json,
-    func_with_prototype_context json
-)
-LANGUAGE SQL
-STABLE
-PARALLEL SAFE
-AS $$
-    SELECT *
-    FROM attribute_value_list_payload_for_read_context_and_root_v1(
-            this_tenancy,
-            this_visibility,
-            this_context,
-            attribute_value_id_for_prop_and_context_v1(
+    RETURNS TABLE
+            (
+                parent_attribute_value_id        bigint,
+                attribute_value_object           json,
+                prop_object                      json,
+                func_binding_return_value_object json,
+                func_with_prototype_context      json
+            )
+    LANGUAGE SQL
+    STABLE
+    PARALLEL SAFE
+AS
+$$
+SELECT *
+FROM attribute_value_list_payload_for_read_context_and_root_v1(
+        this_tenancy,
+        this_visibility,
+        this_context,
+        attribute_value_id_for_prop_and_context_v1(
                 this_tenancy,
                 this_visibility,
                 this_context,
                 this_prop_id
             )
-        )
+    )
 $$;

--- a/lib/dal/src/migrations/U0067__attribute_value_update_graph.sql
+++ b/lib/dal/src/migrations/U0067__attribute_value_update_graph.sql
@@ -3,10 +3,11 @@ CREATE OR REPLACE FUNCTION attribute_value_affected_graph_v1(
     this_visibility jsonb,
     this_attribute_value_id bigint
 )
-RETURNS TABLE(
-    attribute_value_id           bigint,
-    dependent_attribute_value_id bigint
-)
+    RETURNS TABLE
+            (
+                attribute_value_id           bigint,
+                dependent_attribute_value_id bigint
+            )
 AS
 $$
 DECLARE
@@ -26,7 +27,7 @@ DECLARE
     tmp_prop                    props%ROWTYPE;
 BEGIN
     RAISE DEBUG 'attribute_value_affected_graph_v1: Finding graph of AttributeValues affected by AttributeValue(%)', this_attribute_value_id;
-    current_attribute_value_ids := ARRAY[this_attribute_value_id];
+    current_attribute_value_ids := ARRAY [this_attribute_value_id];
 
     LOOP
         RAISE DEBUG 'attribute_value_affected_graph_v1: Current set of AttributeValueIds: %', current_attribute_value_ids;
@@ -37,252 +38,241 @@ BEGIN
         -- don't end up in any future batches of "current" AttributeValueIds.
         seen_attribute_value_ids := array_cat(seen_attribute_value_ids, current_attribute_value_ids);
 
-        FOREACH attribute_value_id IN ARRAY current_attribute_value_ids LOOP
-            RAISE DEBUG 'attribute_value_affected_graph_v1: Looking at AttributeValue(%)', attribute_value_id;
+        FOREACH attribute_value_id IN ARRAY current_attribute_value_ids
+            LOOP
+                RAISE DEBUG 'attribute_value_affected_graph_v1: Looking at AttributeValue(%)', attribute_value_id;
 
-            SELECT *
-            INTO STRICT attribute_value
-            FROM attribute_values_v1(this_tenancy, this_visibility)
-            WHERE id = attribute_value_id;
-
-            -- If the attribute_context_prop_id != -1 then that means that this AttributeValue
-            -- represents a value that is "directly" part of a Component's schema, either
-            -- because it is a value set for an attribute, or because it is for an implicit
-            -- InternalProvider that is the "summary" of the schema from that Prop down to the
-            -- leaf nodes.
-            IF attribute_value.attribute_context_prop_id != -1 THEN
                 SELECT *
-                INTO STRICT tmp_prop
-                FROM props_v1(this_tenancy, this_visibility)
-                WHERE id = attribute_value.attribute_context_prop_id;
-                RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is for Prop(%)', attribute_value.id, tmp_prop;
-
-                current_prop_id := attribute_value.attribute_context_prop_id;
-
-                -- If there are any "unsealed" proxies to the current AttributeValue, then we
-                -- need to consider them as needing an update.
-                SELECT array_agg(id)
-                INTO tmp_record_ids
+                INTO STRICT attribute_value
                 FROM attribute_values_v1(this_tenancy, this_visibility)
-                WHERE sealed_proxy = FALSE
-                    AND proxy_for_attribute_value_id = attribute_value.id;
+                WHERE id = attribute_value_id;
 
-                IF FOUND THEN
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: Found unsealed proxies: %', tmp_record_ids;
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depend on AttributeValue(%)', tmp_record_ids, attribute_value.id;
+                -- If the attribute_context_prop_id != -1 then that means that this AttributeValue
+                -- represents a value that is "directly" part of a Component's schema, either
+                -- because it is a value set for an attribute, or because it is for an implicit
+                -- InternalProvider that is the "summary" of the schema from that Prop down to the
+                -- leaf nodes.
+                IF attribute_value.attribute_context_prop_id != -1 THEN
+                    SELECT *
+                    INTO STRICT tmp_prop
+                    FROM props_v1(this_tenancy, this_visibility)
+                    WHERE id = attribute_value.attribute_context_prop_id;
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is for Prop(%)', attribute_value.id, tmp_prop;
 
-                    RETURN QUERY
-                        SELECT
-                            target_id AS attribute_value_id,
-                            attribute_value_id AS dependent_attribute_value_id
-                        FROM unnest(tmp_record_ids) AS target_id;
-                    -- Add these new AttributeValues to the ones we'll use in the next loop iteration.
-                    next_attribute_value_ids := array_cat(next_attribute_value_ids, tmp_record_ids);
-                END IF;
+                    current_prop_id := attribute_value.attribute_context_prop_id;
 
-                internal_provider_id := closest_internal_provider_to_prop_v1(this_tenancy, this_visibility, current_prop_id);
-                If internal_provider_id IS NULL THEN
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: Could not find InternalProvider for Prop(%)', current_prop_id;
-                    CONTINUE;
-                END IF;
-
-                -- Find the AttributeValue for the InternalProvider that we just found that is
-                -- for the exact same AttributeContext as the AttributeValue that caused us to
-                -- find it. This AttributeValue directly depends on the AttributeValue we are
-                -- currently looking at.
-                tmp_attribute_context := jsonb_build_object('attribute_context_prop_id',              -1,
-                                                            'attribute_context_external_provider_id', -1,
-                                                            'attribute_context_internal_provider_id', internal_provider_id,
-                                                            'attribute_context_schema_id',            attribute_value.attribute_context_schema_id,
-                                                            'attribute_context_schema_variant_id',    attribute_value.attribute_context_schema_variant_id,
-                                                            'attribute_context_component_id',         attribute_value.attribute_context_component_id);
-
-                SELECT id
-                INTO tmp_record_id
-                FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-                WHERE
-                    exact_attribute_context_v1(tmp_attribute_context, av)
-                    AND attribute_context_internal_provider_id = internal_provider_id;
-                IF NOT FOUND THEN
-                    RAISE 'attribute_value_affected_graph_v1: Unable to find AttributeValue for InternalProvider(%) at AttributeContext(%)',
-                        internal_provider_id,
-                        tmp_attribute_context;
-                    CONTINUE;
-                END IF;
-
-                RAISE DEBUG 'attribute_value_affected_graph_v1: Found InternalProvider value(s): %', tmp_record_id;
-                RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depends on AttributeValue(%)', tmp_record_id, attribute_value.id;
-
-                RETURN QUERY SELECT
-                    tmp_record_id AS attribute_value_id,
-                    attribute_value.id AS dependency_attribute_value_id;
-
-                next_attribute_value_ids := array_append(next_attribute_value_ids, tmp_record_id);
-            ELSIF attribute_value.attribute_context_internal_provider_id != -1 THEN
-                -- We found an AttributeValue for an InternalProvider
-                RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is InternalProvider(%)', attribute_value.id, attribute_value.attribute_context_internal_provider_id;
-
-                -- Is there a parent Prop (and therefore an InternalProvider) that needs to be updated?
-                SELECT ip.*
-                INTO tmp_internal_provider
-                FROM internal_providers_v1(this_tenancy, this_visibility) AS ip
-                INNER JOIN prop_belongs_to_prop_v1(this_tenancy, this_visibility) AS pbtp
-                    ON pbtp.belongs_to_id = ip.prop_id
-                INNER JOIN internal_providers_v1(this_tenancy, this_visibility) AS child_internal_providers
-                    ON child_internal_providers.prop_id = pbtp.object_id
-                WHERE child_internal_providers.id = attribute_value.attribute_context_internal_provider_id;
-
-                IF FOUND THEN
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: Found a parent InternalProvider(%) for InternalProvider(%)', tmp_internal_provider.id, attribute_value.attribute_context_internal_provider_id;
-                    tmp_attribute_context := jsonb_build_object(
-                        'attribute_context_prop_id',              -1,
-                        'attribute_context_internal_provider_id', tmp_internal_provider.id,
-                        'attribute_context_external_provider_id', -1,
-                        'attribute_context_schema_id',            attribute_value.attribute_context_schema_id,
-                        'attribute_context_schema_variant_id',    attribute_value.attribute_context_schema_variant_id,
-                        'attribute_context_component_id',         attribute_value.attribute_context_component_id
-                    );
-                    -- TODO(jhelwig): This can, strictly speaking, find more AttributeValues that it considers
-                    --                depending on this specific AttributeValue than there really are. The
-                    --                problem is that we're not checking to see if there is a more appropriate
-                    --                AttributeValue that this InternalProvider should be using, instead of
-                    --                this (possibly less specific) AttributeValue.
+                    -- If there are any "unsealed" proxies to the current AttributeValue, then we
+                    -- need to consider them as needing an update.
                     SELECT array_agg(id)
                     INTO tmp_record_ids
-                    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-                    WHERE 
-                        attribute_context_internal_provider_id = tmp_internal_provider.id
-                        AND exact_or_more_attribute_read_context_v1(tmp_attribute_context, av);
+                    FROM attribute_values_v1(this_tenancy, this_visibility)
+                    WHERE sealed_proxy = FALSE
+                      AND proxy_for_attribute_value_id = attribute_value.id;
 
-                    IF tmp_record_ids IS NOT NULL THEN
-                        RAISE DEBUG 'attribute_value_affected_graph_v1: Found AttributeValues for parent InternalProvider';
+                    IF FOUND THEN
+                        RAISE DEBUG 'attribute_value_affected_graph_v1: Found unsealed proxies: %', tmp_record_ids;
                         RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depend on AttributeValue(%)', tmp_record_ids, attribute_value.id;
 
                         RETURN QUERY
-                            SELECT
-                                target_id AS attribute_value_id,
-                                attribute_value.id AS dependency_attribute_value_id
+                            SELECT target_id          AS attribute_value_id,
+                                   attribute_value_id AS dependent_attribute_value_id
+                            FROM unnest(tmp_record_ids) AS target_id;
+                        -- Add these new AttributeValues to the ones we'll use in the next loop iteration.
+                        next_attribute_value_ids := array_cat(next_attribute_value_ids, tmp_record_ids);
+                    END IF;
+
+                    internal_provider_id := closest_internal_provider_to_prop_v1(this_tenancy, this_visibility,
+                                                                                 current_prop_id);
+                    If internal_provider_id IS NULL THEN
+                        RAISE DEBUG 'attribute_value_affected_graph_v1: Could not find InternalProvider for Prop(%)', current_prop_id;
+                        CONTINUE;
+                    END IF;
+
+                    -- Find the AttributeValue for the InternalProvider that we just found that is
+                    -- for the exact same AttributeContext as the AttributeValue that caused us to
+                    -- find it. This AttributeValue directly depends on the AttributeValue we are
+                    -- currently looking at.
+                    tmp_attribute_context := jsonb_build_object('attribute_context_prop_id', -1,
+                                                                'attribute_context_external_provider_id', -1,
+                                                                'attribute_context_internal_provider_id',
+                                                                internal_provider_id,
+                                                                'attribute_context_component_id',
+                                                                attribute_value.attribute_context_component_id);
+
+                    SELECT id
+                    INTO tmp_record_id
+                    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                    WHERE exact_attribute_context_v1(tmp_attribute_context, av)
+                      AND attribute_context_internal_provider_id = internal_provider_id;
+                    IF NOT FOUND THEN
+                        RAISE 'attribute_value_affected_graph_v1: Unable to find AttributeValue for InternalProvider(%) at AttributeContext(%)',
+                            internal_provider_id,
+                            tmp_attribute_context;
+                        CONTINUE;
+                    END IF;
+
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: Found InternalProvider value(s): %', tmp_record_id;
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depends on AttributeValue(%)', tmp_record_id, attribute_value.id;
+
+                    RETURN QUERY SELECT tmp_record_id      AS attribute_value_id,
+                                        attribute_value.id AS dependency_attribute_value_id;
+
+                    next_attribute_value_ids := array_append(next_attribute_value_ids, tmp_record_id);
+                ELSIF attribute_value.attribute_context_internal_provider_id != -1 THEN
+                    -- We found an AttributeValue for an InternalProvider
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is InternalProvider(%)', attribute_value.id, attribute_value.attribute_context_internal_provider_id;
+
+                    -- Is there a parent Prop (and therefore an InternalProvider) that needs to be updated?
+                    SELECT ip.*
+                    INTO tmp_internal_provider
+                    FROM internal_providers_v1(this_tenancy, this_visibility) AS ip
+                             INNER JOIN prop_belongs_to_prop_v1(this_tenancy, this_visibility) AS pbtp
+                                        ON pbtp.belongs_to_id = ip.prop_id
+                             INNER JOIN internal_providers_v1(this_tenancy, this_visibility) AS child_internal_providers
+                                        ON child_internal_providers.prop_id = pbtp.object_id
+                    WHERE child_internal_providers.id = attribute_value.attribute_context_internal_provider_id;
+
+                    IF FOUND THEN
+                        RAISE DEBUG 'attribute_value_affected_graph_v1: Found a parent InternalProvider(%) for InternalProvider(%)', tmp_internal_provider.id, attribute_value.attribute_context_internal_provider_id;
+                        tmp_attribute_context := jsonb_build_object(
+                                'attribute_context_prop_id', -1,
+                                'attribute_context_internal_provider_id', tmp_internal_provider.id,
+                                'attribute_context_external_provider_id', -1,
+                                'attribute_context_component_id', attribute_value.attribute_context_component_id
+                            );
+                        -- TODO(jhelwig): This can, strictly speaking, find more AttributeValues that it considers
+                        --                depending on this specific AttributeValue than there really are. The
+                        --                problem is that we're not checking to see if there is a more appropriate
+                        --                AttributeValue that this InternalProvider should be using, instead of
+                        --                this (possibly less specific) AttributeValue.
+                        SELECT array_agg(id)
+                        INTO tmp_record_ids
+                        FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                        WHERE attribute_context_internal_provider_id = tmp_internal_provider.id
+                          AND exact_or_more_attribute_read_context_v1(tmp_attribute_context, av);
+
+                        IF tmp_record_ids IS NOT NULL THEN
+                            RAISE DEBUG 'attribute_value_affected_graph_v1: Found AttributeValues for parent InternalProvider';
+                            RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depend on AttributeValue(%)', tmp_record_ids, attribute_value.id;
+
+                            RETURN QUERY
+                                SELECT target_id          AS attribute_value_id,
+                                       attribute_value.id AS dependency_attribute_value_id
+                                FROM unnest(tmp_record_ids) AS target_id;
+                            next_attribute_value_ids := array_cat(next_attribute_value_ids, tmp_record_ids);
+                        END IF;
+                    END IF;
+
+                    -- Which AttributePrototypes reference this InternalProvider, and therefore have AttributeValues
+                    -- that need to be updated.
+
+                    -- The AttributePrototypes could be associated with any of a Prop, an InternalProvider, or an,
+                    -- ExternalProvider, but they will always need to be within the same Component to be able to
+                    -- pull data from _this_ InternalProvider. (Which is why they're called _Internal_ Providers.)
+                    tmp_attribute_context := jsonb_build_object(
+                            'attribute_context_prop_id', NULL,
+                            'attribute_context_internal_provider_id', NULL,
+                            'attribute_context_external_provider_id', NULL,
+                            'attribute_context_component_id', attribute_value.attribute_context_component_id
+                        );
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: Looking for AttributeValues with AttributePrototypes that use InternalProvider(%) in at least AttributeContext(%)',
+                        attribute_value.attribute_context_internal_provider_id,
+                        tmp_attribute_context;
+
+                    -- AttributeValues for AttributePrototypes that use this AttributeValue's InternalProvider as an argument.
+                    FOR attribute_value_id IN
+                        SELECT av.id
+                        FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                                 INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy,
+                                                                                              this_visibility) AS avbtap
+                                            ON avbtap.object_id = av.id
+                                 INNER JOIN attribute_prototype_arguments_v1(this_tenancy, this_visibility) AS apa
+                                            ON apa.attribute_prototype_id = avbtap.belongs_to_id
+                                                AND apa.internal_provider_id =
+                                                    attribute_value.attribute_context_internal_provider_id
+                        WHERE exact_or_more_attribute_read_context_v1(tmp_attribute_context, av)
+                        LOOP
+                            RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depends on AttributeValue(%)', attribute_value_id, attribute_value.id;
+
+                            RETURN QUERY SELECT attribute_value_id AS attribute_value_id,
+                                                attribute_value.id AS dependency_attribute_value_id;
+
+                            next_attribute_value_ids := array_append(next_attribute_value_ids, attribute_value_id);
+                        END LOOP;
+                ELSIF attribute_value.attribute_context_external_provider_id != -1 THEN
+                    -- We found an AttributeValue for an ExternalProvider
+                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is ExternalProvider(%)', attribute_value.id, attribute_value.attribute_context_external_provider_id;
+
+                    -- TODO(jhelwig): This combined with `exact_or_more_attribute_read_context_v1` isn't quite what we want.
+                    --                We need a function that can tell us:
+                    --                  * Is AttributeContext A set to the same level of specificity as AttributeContext B.
+                    --                  * Are any parts of the AttributeContext more specific than Component, that are set
+                    --                    in BOTH A & B identical.
+                    --                  * If any parts of the AttributeContext more specific than Component that are in B,
+                    --                    that are NOT in A, they count as being "or more".
+                    --
+                    -- Build up an AttributeReadContext appropriate for finding InternalProviders
+                    -- that are using this ExternalProvider as one of their arguments.
+                    tmp_attribute_context := jsonb_build_object(
+                            'attribute_context_prop_id', -1,
+                        -- The InternalProvider is likely to be for some other SchemaVariant, and is
+                        -- pretty much guaranteed to be for a different Component, so we need to be
+                        -- looking at any possible values there.
+                            'attribute_context_internal_provider_id', NULL,
+                            'attribute_context_external_provider_id', -1,
+                            'attribute_context_component_id', NULL
+                        );
+
+                    -- TODO(jhelwig): This can, strictly speaking, find more AttributeValues that it considers
+                    --                depending on this specific AttributeValue for the ExternalProvider than
+                    --                there really are. The problem is that we're not checking to see if there
+                    --                is a more appropriate AttributeValue for this ExternalProvider that the
+                    --                InternalProvider on the other end of the connection should be using,
+                    --                instead of this (possibly less specific) AttributeValue.
+                    --
+                    -- Which InternalProviders reference this ExternalProvider in their arguments (and specifically
+                    -- the Component) that the AttributeValue is for.
+                    SELECT array_agg(av.id)
+                    INTO tmp_record_ids
+                    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+                             INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy,
+                                                                                          this_visibility) AS avbtap
+                                        ON avbtap.object_id = av.id
+                             INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+                                        ON ap.id = avbtap.belongs_to_id
+                             INNER JOIN attribute_prototype_arguments_v1(this_tenancy, this_visibility) AS apa
+                                        ON apa.attribute_prototype_id = ap.id
+                                            AND apa.external_provider_id =
+                                                attribute_value.attribute_context_external_provider_id
+                                            AND apa.tail_component_id = attribute_value.attribute_context_component_id
+                         -- For an AttributeValue to actually be using an ExternalProvider, it _must_ be (at least) for a Component.
+                    WHERE av.attribute_context_component_id != -1;
+                    -- See the TODO above tmp_attribute_context for why this is commented out.
+                    --
+                    -- WHERE exact_or_more_attribute_read_context_v1(tmp_attribute_context, av)
+
+                    IF tmp_record_ids IS NOT NULL THEN
+                        RAISE DEBUG 'attribute_value_affected_graph_v1: Found InternalProviders that use this ExternalProvider';
+                        RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depend on AttributeValue(%)', tmp_record_ids, attribute_value.id;
+
+                        RETURN QUERY
+                            SELECT target_id          AS attribute_value_id,
+                                   attribute_value.id AS dependency_attribute_value_id
                             FROM unnest(tmp_record_ids) AS target_id;
                         next_attribute_value_ids := array_cat(next_attribute_value_ids, tmp_record_ids);
                     END IF;
+                ELSE
+                    -- No idea what we just found, but it can't be good.
+                    RAISE EXCEPTION 'attribute_value_affected_graph_v1: Found an AttributeValue that we can''t determine the type of: %', attribute_value.id;
                 END IF;
-
-                -- Which AttributePrototypes reference this InternalProvider, and therefore have AttributeValues
-                -- that need to be updated.
-
-                -- The AttributePrototypes could be associated with any of a Prop, an InternalProvider, or an,
-                -- ExternalProvider, but they will always need to be within the same Component to be able to
-                -- pull data from _this_ InternalProvider. (Which is why they're called _Internal_ Providers.)
-                tmp_attribute_context := jsonb_build_object(
-                    'attribute_context_prop_id',              NULL,
-                    'attribute_context_internal_provider_id', NULL,
-                    'attribute_context_external_provider_id', NULL,
-                    'attribute_context_schema_id',            attribute_value.attribute_context_schema_id,
-                    'attribute_context_schema_variant_id',    attribute_value.attribute_context_schema_variant_id,
-                    'attribute_context_component_id',         attribute_value.attribute_context_component_id
-                );
-                RAISE DEBUG 'attribute_value_affected_graph_v1: Looking for AttributeValues with AttributePrototypes that use InternalProvider(%) in at least AttributeContext(%)',
-                    attribute_value.attribute_context_internal_provider_id,
-                    tmp_attribute_context;
-
-                -- AttributeValues for AttributePrototypes that use this AttributeValue's InternalProvider as an argument.
-                FOR attribute_value_id IN
-                    SELECT av.id
-                    FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-                    INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
-                        ON avbtap.object_id = av.id
-                    INNER JOIN attribute_prototype_arguments_v1(this_tenancy, this_visibility) AS apa
-                        ON apa.attribute_prototype_id = avbtap.belongs_to_id
-                            AND apa.internal_provider_id = attribute_value.attribute_context_internal_provider_id
-                    WHERE exact_or_more_attribute_read_context_v1(tmp_attribute_context, av)
-                LOOP
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depends on AttributeValue(%)', attribute_value_id, attribute_value.id;
-
-                    RETURN QUERY SELECT
-                        attribute_value_id AS attribute_value_id,
-                        attribute_value.id AS dependency_attribute_value_id;
-
-                    next_attribute_value_ids := array_append(next_attribute_value_ids, attribute_value_id);
-                END LOOP;
-            ELSIF attribute_value.attribute_context_external_provider_id != -1 THEN
-                -- We found an AttributeValue for an ExternalProvider
-                RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) is ExternalProvider(%)', attribute_value.id, attribute_value.attribute_context_external_provider_id;
-
-                -- TODO(jhelwig): This combined with `exact_or_more_attribute_read_context_v1` isn't quite what we want.
-                --                We need a function that can tell us:
-                --                  * Is AttributeContext A set to the same level of specificity as AttributeContext B.
-                --                  * Are any parts of the AttributeContext more specific than Component, that are set
-                --                    in BOTH A & B identical.
-                --                  * If any parts of the AttributeContext more specific than Component that are in B,
-                --                    that are NOT in A, they count as being "or more".
-                --
-                -- Build up an AttributeReadContext appropriate for finding InternalProviders
-                -- that are using this ExternalProvider as one of their arguments.
-                tmp_attribute_context := jsonb_build_object(
-                    'attribute_context_prop_id',              -1,
-                    -- The InternalProvider is likely to be for some other Schema/Variant, and is
-                    -- pretty much guaranteed to be for a different Component, so we need to be
-                    -- looking at any possible values there. If this value for the ExternalProvider
-                    -- is specific to a SystemId, then we need to make sure that we're only
-                    -- considering AttributeValues that are also specific to that SystemId, but if
-                    -- the AttributeValue for the ExternalProvider isn't specific to a SystemId,
-                    -- then it doesn't matter whether or not the InternalProvider-side AttributeValue
-                    -- is specific to a SystemId.
-                    'attribute_context_internal_provider_id', NULL,
-                    'attribute_context_external_provider_id', -1,
-                    'attribute_context_schema_id',            NULL,
-                    'attribute_context_schema_variant_id',    NULL,
-                    'attribute_context_component_id',         NULL
-                );
-
-                -- TODO(jhelwig): This can, strictly speaking, find more AttributeValues that it considers
-                --                depending on this specific AttributeValue for the ExternalProvider than
-                --                there really are. The problem is that we're not checking to see if there
-                --                is a more appropriate AttributeValue for this ExternalProvider that the
-                --                InternalProvider on the other end of the connection should be using,
-                --                instead of this (possibly less specific) AttributeValue.
-                --
-                -- Which InternalProviders reference this ExternalProvider in their arguments (and specifically
-                -- the Component) that the AttributeValue is for.
-                SELECT array_agg(av.id)
-                INTO tmp_record_ids
-                FROM attribute_values_v1(this_tenancy, this_visibility) AS av
-                INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
-                    ON avbtap.object_id = av.id
-                INNER JOIN attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
-                    ON ap.id = avbtap.belongs_to_id
-                INNER JOIN attribute_prototype_arguments_v1(this_tenancy, this_visibility) AS apa
-                    ON apa.attribute_prototype_id = ap.id
-                        AND apa.external_provider_id = attribute_value.attribute_context_external_provider_id
-                        AND apa.tail_component_id = attribute_value.attribute_context_component_id
-                -- For an AttributeValue to actually be using an ExternalProvider, it _must_ be (at least) for a Component.
-                WHERE av.attribute_context_component_id != -1;
-                -- See the TODO above tmp_attribute_context for why this is commented out.
-                --
-                -- WHERE exact_or_more_attribute_read_context_v1(tmp_attribute_context, av)
-
-                IF tmp_record_ids IS NOT NULL THEN
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: Found InternalProviders that use this ExternalProvider';
-                    RAISE DEBUG 'attribute_value_affected_graph_v1: AttributeValue(%) depend on AttributeValue(%)', tmp_record_ids, attribute_value.id;
-
-                    RETURN QUERY
-                        SELECT
-                            target_id AS attribute_value_id,
-                            attribute_value.id AS dependency_attribute_value_id
-                        FROM unnest(tmp_record_ids) AS target_id;
-                    next_attribute_value_ids := array_cat(next_attribute_value_ids, tmp_record_ids);
-                END IF;
-            ELSE
-                -- No idea what we just found, but it can't be good.
-                RAISE EXCEPTION 'attribute_value_affected_graph_v1: Found an AttributeValue that we can''t determine the type of: %', attribute_value.id;
-            END IF;
-        END LOOP;
+            END LOOP;
 
         -- Set up current_attribute_value_ids to be the ones we found on this pass through
         -- the loop, that we haven't already seen, so we can start looking at them.
         RAISE DEBUG 'attribute_value_affected_graph_v1: Next AttributeValues to look at: %', next_attribute_value_ids;
-        current_attribute_value_ids := array_agg(x) FROM unnest(next_attribute_value_ids) AS x
-                                                    WHERE x != all(seen_attribute_value_ids);
+        current_attribute_value_ids := array_agg(x)
+                                       FROM unnest(next_attribute_value_ids) AS x
+                                       WHERE x != all (seen_attribute_value_ids);
         -- Clear out the "next" accumulator, so we don't add the new AttributeValues to the
         -- end of the list of ones we're looking through "currently" in the next iteration
         -- through the loop.

--- a/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
+++ b/lib/dal/src/migrations/U0609__create_new_affected_attribute_values.sql
@@ -3,9 +3,10 @@ CREATE OR REPLACE FUNCTION attribute_value_create_appropriate_for_prototype_and_
     this_read_tenancy jsonb,
     this_visibility jsonb,
     this_attribute_prototype_id bigint,
-    this_attribute_context      jsonb,
+    this_attribute_context jsonb,
     OUT new_attribute_value_ids bigint[]
-) AS $$
+) AS
+$$
 DECLARE
     attribute_value        attribute_values%ROWTYPE;
     tmp_attribute_value    attribute_values%ROWTYPE;
@@ -19,81 +20,83 @@ BEGIN
     FOR attribute_value IN
         SELECT *
         FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-        INNER JOIN (
+                 INNER JOIN (
             SELECT object_id AS attribute_value_id
             FROM attribute_value_belongs_to_attribute_prototype_v1(this_read_tenancy, this_visibility)
             WHERE belongs_to_id = this_attribute_prototype_id
         ) AS avbtap ON avbtap.attribute_value_id = av.id
         WHERE in_attribute_context_v1(this_attribute_context, av)
         ORDER BY id
-    LOOP
-        -- Check if the AttributeValue is of the _exact_ AttributeContext that we're looking for.
-        IF exact_attribute_context_v1(this_attribute_context, attribute_value) THEN
-            RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Found appropriate AttributeValue(%)', attribute_value;
-
-            -- Nothing to do, since we found an AttributeValue that we would have tried to create.
-            new_attribute_value_ids := array_append(new_attribute_value_ids, attribute_value.id);
-            CONTINUE attribute_value_is_appropriate_check;
-        END IF;
-
-        -- If the AttributeValue that we found has any proxies (even indirectly) that are of the
-        -- appropriate AttributeContext then there's nothing to do here, as the AttributeValue
-        -- we'd like to create already exists.
-        FOR tmp_attribute_value IN
-            SELECT *
-            FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-            WHERE id IN (
-                WITH RECURSIVE recursive_attribute_values
-                AS (
-                    SELECT attribute_value.id AS attribute_value_id
-                    UNION ALL
-                    SELECT av.id AS attribute_value_id
-                    FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-                    JOIN recursive_attribute_values ON av.proxy_for_attribute_value_id = recursive_attribute_values.attribute_value_id
-                    WHERE in_attribute_context_v1(this_attribute_context, av)
-                )
-                SELECT attribute_value_id
-                FROM recursive_attribute_values
-            )
-            ORDER BY id
         LOOP
-            IF exact_attribute_context_v1(this_attribute_context, attribute_context_from_record_v1(tmp_attribute_value)) THEN
-                -- One of the proxies for the AttributeValue we're looking at is of the correct
-                -- AttributeContext, so we don't need to create anything as it already exists.
-                RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Found appropriate proxy AttributeValue(%)', tmp_attribute_value;
+            -- Check if the AttributeValue is of the _exact_ AttributeContext that we're looking for.
+            IF exact_attribute_context_v1(this_attribute_context, attribute_value) THEN
+                RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Found appropriate AttributeValue(%)', attribute_value;
 
-                new_attribute_value_ids := array_append(new_attribute_value_ids, tmp_attribute_value.id);
+                -- Nothing to do, since we found an AttributeValue that we would have tried to create.
+                new_attribute_value_ids := array_append(new_attribute_value_ids, attribute_value.id);
                 CONTINUE attribute_value_is_appropriate_check;
             END IF;
-        END LOOP;
 
-        -- We need to create an AttributeValue that is of the specific AttributeContext that is a proxy
-        -- back to this AttributeValue, since it now "exists" in the more specific context (even though,
-        -- it might have a different value due to the function that generates its value having different
-        --- inputs).
-        new_attribute_value_id := attribute_value_vivify_value_and_parent_values_raw_v1(
-            this_write_tenancy,
-            this_read_tenancy,
-            this_visibility,
-            this_attribute_context,
-            attribute_value.id,
-            false
-        );
-        PERFORM set_belongs_to_v1(
-            'attribute_value_belongs_to_attribute_prototype',
-            this_read_tenancy,
-            this_write_tenancy,
-            this_visibility,
-            new_attribute_value_id,
-            this_attribute_prototype_id
-        );
-        RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Using AttributeValue(%) for AttributeValue(%) in AttributeContext(%)',
-            new_attribute_value_id,
-            attribute_value,
-            this_attribute_context;
+            -- If the AttributeValue that we found has any proxies (even indirectly) that are of the
+            -- appropriate AttributeContext then there's nothing to do here, as the AttributeValue
+            -- we'd like to create already exists.
+            FOR tmp_attribute_value IN
+                SELECT *
+                FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
+                WHERE id IN (
+                    WITH RECURSIVE recursive_attribute_values
+                                       AS (
+                            SELECT attribute_value.id AS attribute_value_id
+                            UNION ALL
+                            SELECT av.id AS attribute_value_id
+                            FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
+                                     JOIN recursive_attribute_values ON av.proxy_for_attribute_value_id =
+                                                                        recursive_attribute_values.attribute_value_id
+                            WHERE in_attribute_context_v1(this_attribute_context, av)
+                        )
+                    SELECT attribute_value_id
+                    FROM recursive_attribute_values
+                )
+                ORDER BY id
+                LOOP
+                    IF exact_attribute_context_v1(this_attribute_context,
+                                                  attribute_context_from_record_v1(tmp_attribute_value)) THEN
+                        -- One of the proxies for the AttributeValue we're looking at is of the correct
+                        -- AttributeContext, so we don't need to create anything as it already exists.
+                        RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Found appropriate proxy AttributeValue(%)', tmp_attribute_value;
 
-        new_attribute_value_ids := array_append(new_attribute_value_ids, new_attribute_value_id);
-    END LOOP attribute_value_is_appropriate_check;
+                        new_attribute_value_ids := array_append(new_attribute_value_ids, tmp_attribute_value.id);
+                        CONTINUE attribute_value_is_appropriate_check;
+                    END IF;
+                END LOOP;
+
+            -- We need to create an AttributeValue that is of the specific AttributeContext that is a proxy
+            -- back to this AttributeValue, since it now "exists" in the more specific context (even though,
+            -- it might have a different value due to the function that generates its value having different
+            --- inputs).
+            new_attribute_value_id := attribute_value_vivify_value_and_parent_values_raw_v1(
+                    this_write_tenancy,
+                    this_read_tenancy,
+                    this_visibility,
+                    this_attribute_context,
+                    attribute_value.id,
+                    false
+                );
+            PERFORM set_belongs_to_v1(
+                    'attribute_value_belongs_to_attribute_prototype',
+                    this_read_tenancy,
+                    this_write_tenancy,
+                    this_visibility,
+                    new_attribute_value_id,
+                    this_attribute_prototype_id
+                );
+            RAISE DEBUG 'attribute_value_create_appropriate_for_prototype_and_context_v1: Using AttributeValue(%) for AttributeValue(%) in AttributeContext(%)',
+                new_attribute_value_id,
+                attribute_value,
+                this_attribute_context;
+
+            new_attribute_value_ids := array_append(new_attribute_value_ids, new_attribute_value_id);
+        END LOOP attribute_value_is_appropriate_check;
 END;
 $$ LANGUAGE PLPGSQL;
 
@@ -143,11 +146,12 @@ $$ LANGUAGE PLPGSQL;
 --   * AttributePrototype is the _most specific_ where above is true
 --   * AttributePrototype.context <= InternalProvider AttributeValue.context
 CREATE OR REPLACE FUNCTION attribute_value_create_new_affected_values_v1(
-    this_write_tenancy      jsonb,
-    this_read_tenancy       jsonb,
-    this_visibility         jsonb,
+    this_write_tenancy jsonb,
+    this_read_tenancy jsonb,
+    this_visibility jsonb,
     this_attribute_value_id bigint
-) RETURNS void AS $$
+) RETURNS void AS
+$$
 DECLARE
     attribute_prototype           attribute_prototypes%ROWTYPE;
     attribute_prototype_context   jsonb;
@@ -182,7 +186,7 @@ BEGIN
         this_visibility,
         this_attribute_value_id;
 
-    current_attribute_value_ids := ARRAY[this_attribute_value_id];
+    current_attribute_value_ids := ARRAY [this_attribute_value_id];
     -- Grab the AttributeContext that we're starting with, since there should be an
     -- AttributeValue for every dependent AttributeValue that is _at least_ as specific as
     -- this starting AttributeContext.
@@ -193,18 +197,13 @@ BEGIN
     -- `ExternalProvider -> InternalProvider` link, but we need to dynamically figure out
     -- what the appropriate ComponentId is to use as we go along.
     base_attribute_context := jsonb_build_object(
-        'attribute_context_schema_id',          attribute_context_schema_id,
-        'attribute_context_schema_variant_id',  attribute_context_schema_variant_id,
-        'attribute_context_component_id',       attribute_context_component_id
-    )
-    FROM (
-        SELECT
-            attribute_context_schema_id,
-            attribute_context_schema_variant_id,
-            attribute_context_component_id
-        FROM attribute_values_v1(this_read_tenancy, this_visibility)
-        WHERE id = this_attribute_value_id
-    ) AS av;
+                                      'attribute_context_component_id', attribute_context_component_id
+                                  )
+                              FROM (
+                                       SELECT attribute_context_component_id
+                                       FROM attribute_values_v1(this_read_tenancy, this_visibility)
+                                       WHERE id = this_attribute_value_id
+                                   ) AS av;
     RAISE DEBUG 'attribute_value_create_new_affected_values_v1: base_attribute_context: %', base_attribute_context;
 
     LOOP
@@ -213,332 +212,336 @@ BEGIN
         EXIT WHEN current_attribute_value_ids IS NULL;
         seen_attribute_value_ids := array_cat(seen_attribute_value_ids, current_attribute_value_ids);
 
-        FOREACH current_attribute_value_id IN ARRAY current_attribute_value_ids LOOP
-            SELECT *
-            INTO STRICT source_attribute_value
-            FROM attribute_values_v1(this_read_tenancy, this_visibility)
-            WHERE id = current_attribute_value_id;
-            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: source_attribute_value: %', source_attribute_value;
+        FOREACH current_attribute_value_id IN ARRAY current_attribute_value_ids
+            LOOP
+                SELECT *
+                INTO STRICT source_attribute_value
+                FROM attribute_values_v1(this_read_tenancy, this_visibility)
+                WHERE id = current_attribute_value_id;
+                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: source_attribute_value: %', source_attribute_value;
 
-            -- The base_attribute_context should take precedence for everything in the AttributeContext
-            -- _except_ for the ComponentId, which we should get from the current AttributeValue since
-            -- the current AttributeValue may have crossed an ExternalProvider -> InternalProvider
-            -- boundary into a new Component.
-            current_attribute_context := attribute_context_from_record_v1(source_attribute_value)
-                || base_attribute_context
-                || jsonb_build_object(
-                    'attribute_context_schema_id', source_attribute_value.attribute_context_schema_id,
-                    'attribute_context_schema_variant_id', source_attribute_value.attribute_context_schema_variant_id,
-                    'attribute_context_component_id', source_attribute_value.attribute_context_component_id
-                );
-            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: current_attribute_context: %', current_attribute_context;
-
-            IF source_attribute_value.attribute_context_prop_id != -1 THEN
-                -- AttributeValues that are directly for a Prop can only be used by implicit InternalProviders.
-                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for Prop';
-                -- Need to make sure the direct (and parent) InternalProviders have AttributeValues for the exact context.
-                FOR
-                    current_internal_provider_id,
-                    attribute_prototype_id,
-                    tmp_attribute_context
-                IN
-                    WITH RECURSIVE parent_prop_tree AS (
-                        SELECT source_attribute_value.attribute_context_prop_id AS prop_id
-                        UNION ALL
-                        SELECT p.parent_prop_id AS prop_id
-                        FROM (
-                            SELECT
-                                object_id AS child_prop_id,
-                                belongs_to_id AS parent_prop_id
-                            FROM prop_belongs_to_prop_v1(this_read_tenancy, this_visibility)
-                        ) AS p
-                        JOIN parent_prop_tree ON p.child_prop_id = parent_prop_tree.prop_id
-                    )
-                    SELECT
-                        ip.id AS current_internal_provider_id,
-                        ip.attribute_prototype_id,
-                        current_attribute_context ||
-                            jsonb_build_object(
-                                'attribute_context_prop_id', -1,
-                                'attribute_context_internal_provider_id', ip.id,
-                                'attribute_context_external_provider_id', -1
-                            ) AS tmp_attribute_context
-                    FROM internal_providers_v1(this_read_tenancy, this_visibility) AS ip
-                    INNER JOIN parent_prop_tree ON parent_prop_tree.prop_id = ip.prop_id
-                LOOP
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: current_attribute_context(%)', current_attribute_context;
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: tmp_attribute_context(%)', tmp_attribute_context;
-
-                    -- TODO Looks like we've got a mismatch between some Prop setup, and some InternalProvider setup, where we're setting some things specific to Prop only, and the InternalProvider value only existing starting at the SchemaVariant level is causing an issue.
-                    -- Grab the most specific AttributeValue that we already have for this InternalProvider
-                    SELECT DISTINCT ON (attribute_context_internal_provider_id) av.*
-                    INTO STRICT tmp_attribute_value
-                    FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-                    WHERE in_attribute_context_v1(tmp_attribute_context, av)
-                    ORDER BY
-                        attribute_context_internal_provider_id DESC,
-                        attribute_context_prop_id DESC,
-                        attribute_context_external_provider_id DESC,
-                        attribute_context_schema_id DESC,
-                        attribute_context_schema_variant_id DESC,
-                        attribute_context_component_id DESC,
-                        -- bools sort false first ascending.
-                        av.tenancy_universal;
-                    IF exact_attribute_context_v1(tmp_attribute_context, attribute_context_from_record_v1(tmp_attribute_value)) THEN
-                        -- There's already an appropriate AttributeValue for the InternalProvider. Nothing to do.
-                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found appropriate pre-existing AttributeValue(%) for InternalProvider(%)',
-                            tmp_attribute_value,
-                            current_internal_provider_id;
-                        next_attribute_value_ids := array_append(next_attribute_value_ids, tmp_attribute_value.id);
-                        CONTINUE;
-                    END IF;
-
-                    -- We don't need to worry about giving the newly created AttributeValue an appropriate AttributePrototype as
-                    -- implicit InternalProviders operate based off of their prop_id.
-                    next_attribute_value_ids := array_append(
-                        next_attribute_value_ids,
-                        attribute_value_update_for_context_without_child_proxies_v1(
-                            this_write_tenancy,
-                            this_read_tenancy,
-                            this_visibility,
-                            tmp_attribute_value.id,
-                            NULL, -- No parent
-                            tmp_attribute_context,
-                            NULL, -- 'Unset' value
-                            NULL -- No key
-                        )
-                    );
-                END LOOP;
-            ELSIF source_attribute_value.attribute_context_internal_provider_id != -1 THEN
-                -- AttributeValues that are for an InternalProvider can be used by either of:
-                --   * An ExternalProvider
-                --   * An AttributeValue that is directly for a Prop.
-
-                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for InternalProvider';
-                current_internal_provider_id := source_attribute_value.attribute_context_internal_provider_id;
-                tmp_attribute_context := base_attribute_context
+                -- The base_attribute_context should take precedence for everything in the AttributeContext
+                -- _except_ for the ComponentId, which we should get from the current AttributeValue since
+                -- the current AttributeValue may have crossed an ExternalProvider -> InternalProvider
+                -- boundary into a new Component.
+                current_attribute_context := attribute_context_from_record_v1(source_attribute_value)
+                                                 || base_attribute_context
                     || jsonb_build_object(
-                        'attribute_context_schema_id', source_attribute_value.attribute_context_schema_id,
-                        'attribute_context_schema_variant_id', source_attribute_value.attribute_context_schema_variant_id,
-                        'attribute_context_component_id', source_attribute_value.attribute_context_component_id
-                    );
-                -- AttributePrototypes that refer to this InternalProvider (through AttributePrototypeArguments)
-                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Looking for AttributePrototype that use InternalProvider(%) in AttributeContext(%), Tenancy(%), Visibility(%)',
-                    current_internal_provider_id,
-                    tmp_attribute_context,
-                    this_read_tenancy,
-                    this_visibility;
-                FOR attribute_prototype IN
-                    SELECT ap.*
-                    FROM attribute_prototypes_v1(this_read_tenancy, this_visibility) AS ap
-                    INNER JOIN attribute_prototype_arguments_v1(this_read_tenancy, this_visibility) AS apa
-                        ON ap.id = apa.attribute_prototype_id
-                            AND apa.internal_provider_id = current_internal_provider_id
-                LOOP
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributePrototype(%)', attribute_prototype;
-                    IF NOT in_attribute_context_v1(tmp_attribute_context, attribute_prototype) THEN
-                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Does not have appropriate AttributeContext';
-                        CONTINUE;
-                    END IF;
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) uses InternalProvider(%)', attribute_prototype, current_internal_provider_id;
-                    desired_attribute_context := attribute_context_from_record_v1(attribute_prototype) || tmp_attribute_context;
+                                                     'attribute_context_component_id',
+                                                     source_attribute_value.attribute_context_component_id
+                                                 );
+                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: current_attribute_context: %', current_attribute_context;
 
-                    IF attribute_prototype.attribute_context_prop_id != -1 THEN
-                        -- This AttributePrototype is directly associated with a Prop
-                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) is for Prop(%)',
-                            attribute_prototype.id,
-                            attribute_prototype.attribute_context_prop_id;
-
-                        -- For each AttributeValue for this AttributePrototype, check if it is the level of specificity that we want,
-                        -- if not, check the AttributeValue that is a proxy for the AttributeValue that we just looked at. Repeat
-                        -- checking proxy AttributeValues until we either find an AttributeValue of the appropriate AttributeContext
-                        -- (at which point, we're done, and can move on to the next "starting" AttributeValue), or we've run out of
-                        -- proxy AttributeValues (at which point we need to create a new one with
-                        -- attribute_value_update_for_context_raw_v1(...)).
-                        <<attribute_values_for_prototype>>
-                        FOR tmp_attribute_value IN
-                            SELECT av.*
-                            FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-                            INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_read_tenancy, this_visibility) AS avbtap
-                                ON avbtap.object_id = av.id
-                                    AND avbtap.belongs_to_id = attribute_prototype.id
-                            WHERE in_attribute_context_v1(desired_attribute_context, av)
-                            ORDER BY av.id
+                IF source_attribute_value.attribute_context_prop_id != -1 THEN
+                    -- AttributeValues that are directly for a Prop can only be used by implicit InternalProviders.
+                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for Prop';
+                    -- Need to make sure the direct (and parent) InternalProviders have AttributeValues for the exact context.
+                    FOR current_internal_provider_id,
+                        attribute_prototype_id,
+                        tmp_attribute_context
+                        IN
+                        WITH RECURSIVE parent_prop_tree AS (
+                            SELECT source_attribute_value.attribute_context_prop_id AS prop_id
+                            UNION ALL
+                            SELECT p.parent_prop_id AS prop_id
+                            FROM (
+                                     SELECT object_id     AS child_prop_id,
+                                            belongs_to_id AS parent_prop_id
+                                     FROM prop_belongs_to_prop_v1(this_read_tenancy, this_visibility)
+                                 ) AS p
+                                     JOIN parent_prop_tree ON p.child_prop_id = parent_prop_tree.prop_id
+                        )
+                        SELECT ip.id AS current_internal_provider_id,
+                               ip.attribute_prototype_id,
+                               current_attribute_context ||
+                               jsonb_build_object(
+                                       'attribute_context_prop_id', -1,
+                                       'attribute_context_internal_provider_id', ip.id,
+                                       'attribute_context_external_provider_id', -1
+                                   ) AS tmp_attribute_context
+                        FROM internal_providers_v1(this_read_tenancy, this_visibility) AS ip
+                                 INNER JOIN parent_prop_tree ON parent_prop_tree.prop_id = ip.prop_id
                         LOOP
-                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Checking if AttributeValue(%) is of desired AttributeContext(%)',
-                                tmp_attribute_value,
-                                desired_attribute_context;
-                            -- Check if this AttributeValue is of the AttributeContext that we want.
-                            IF exact_attribute_context_v1(desired_attribute_context, attribute_context_from_record_v1(tmp_attribute_value)) THEN
-                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributeValue(%) is appropriate', tmp_attribute_value;
-                                next_attribute_value_ids := array_append(next_attribute_value_ids, tmp_attribute_value.id);
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: current_attribute_context(%)', current_attribute_context;
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: tmp_attribute_context(%)', tmp_attribute_context;
+
+                            -- TODO Looks like we've got a mismatch between some Prop setup, and some InternalProvider setup, where we're setting some things specific to Prop only, and the InternalProvider value only existing starting at the SchemaVariant level is causing an issue.
+                            -- Grab the most specific AttributeValue that we already have for this InternalProvider
+                            SELECT DISTINCT ON (attribute_context_internal_provider_id) av.*
+                            INTO STRICT tmp_attribute_value
+                            FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
+                            WHERE in_attribute_context_v1(tmp_attribute_context, av)
+                            ORDER BY attribute_context_internal_provider_id DESC,
+                                     attribute_context_prop_id DESC,
+                                     attribute_context_external_provider_id DESC,
+                                     attribute_context_component_id DESC,
+                                     -- bools sort false first ascending.
+                                     av.tenancy_universal;
+                            IF exact_attribute_context_v1(tmp_attribute_context,
+                                                          attribute_context_from_record_v1(tmp_attribute_value)) THEN
+                                -- There's already an appropriate AttributeValue for the InternalProvider. Nothing to do.
+                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found appropriate pre-existing AttributeValue(%) for InternalProvider(%)',
+                                    tmp_attribute_value,
+                                    current_internal_provider_id;
+                                next_attribute_value_ids :=
+                                        array_append(next_attribute_value_ids, tmp_attribute_value.id);
                                 CONTINUE;
                             END IF;
 
-                            -- It wasn't, but there might be an AttributeValue that is a proxy for it that could be of the
-                            -- AttributeContext that we need one to exist for. We need to follow the proxy chain here,
-                            -- because the proxy might be overridden to have a different AttributePrototype. If that's the
-                            -- case, we still want to consider it as existing for the purposes of _this_
-                            -- AttributePrototype, and not create a new AttributeValue in the specific AttributeContext.
-                            FOR proxy_attribute_value IN
-                                WITH RECURSIVE proxy_attribute_values AS (
-                                    SELECT *
-                                    FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-                                    WHERE av.proxy_for_attribute_value_id = tmp_attribute_value.id
-                                    UNION ALL
+                            -- We don't need to worry about giving the newly created AttributeValue an appropriate AttributePrototype as
+                            -- implicit InternalProviders operate based off of their prop_id.
+                            next_attribute_value_ids := array_append(
+                                    next_attribute_value_ids,
+                                    attribute_value_update_for_context_without_child_proxies_v1(
+                                            this_write_tenancy,
+                                            this_read_tenancy,
+                                            this_visibility,
+                                            tmp_attribute_value.id,
+                                            NULL, -- No parent
+                                            tmp_attribute_context,
+                                            NULL, -- 'Unset' value
+                                            NULL -- No key
+                                        )
+                                );
+                        END LOOP;
+                ELSIF source_attribute_value.attribute_context_internal_provider_id != -1 THEN
+                    -- AttributeValues that are for an InternalProvider can be used by either of:
+                    --   * An ExternalProvider
+                    --   * An AttributeValue that is directly for a Prop.
+
+                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for InternalProvider';
+                    current_internal_provider_id := source_attribute_value.attribute_context_internal_provider_id;
+                    tmp_attribute_context := base_attribute_context
+                        || jsonb_build_object(
+                                                     'attribute_context_component_id',
+                                                     source_attribute_value.attribute_context_component_id
+                                                 );
+                    -- AttributePrototypes that refer to this InternalProvider (through AttributePrototypeArguments)
+                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Looking for AttributePrototype that use InternalProvider(%) in AttributeContext(%), Tenancy(%), Visibility(%)',
+                        current_internal_provider_id,
+                        tmp_attribute_context,
+                        this_read_tenancy,
+                        this_visibility;
+                    FOR attribute_prototype IN
+                        SELECT ap.*
+                        FROM attribute_prototypes_v1(this_read_tenancy, this_visibility) AS ap
+                                 INNER JOIN attribute_prototype_arguments_v1(this_read_tenancy, this_visibility) AS apa
+                                            ON ap.id = apa.attribute_prototype_id
+                                                AND apa.internal_provider_id = current_internal_provider_id
+                        LOOP
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributePrototype(%)', attribute_prototype;
+                            IF NOT in_attribute_context_v1(tmp_attribute_context, attribute_prototype) THEN
+                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Does not have appropriate AttributeContext';
+                                CONTINUE;
+                            END IF;
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) uses InternalProvider(%)', attribute_prototype, current_internal_provider_id;
+                            desired_attribute_context := attribute_context_from_record_v1(attribute_prototype) ||
+                                                         tmp_attribute_context;
+
+                            IF attribute_prototype.attribute_context_prop_id != -1 THEN
+                                -- This AttributePrototype is directly associated with a Prop
+                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) is for Prop(%)',
+                                    attribute_prototype.id,
+                                    attribute_prototype.attribute_context_prop_id;
+
+                                -- For each AttributeValue for this AttributePrototype, check if it is the level of specificity that we want,
+                                -- if not, check the AttributeValue that is a proxy for the AttributeValue that we just looked at. Repeat
+                                -- checking proxy AttributeValues until we either find an AttributeValue of the appropriate AttributeContext
+                                -- (at which point, we're done, and can move on to the next "starting" AttributeValue), or we've run out of
+                                -- proxy AttributeValues (at which point we need to create a new one with
+                                -- attribute_value_update_for_context_raw_v1(...)).
+                                <<attribute_values_for_prototype>>
+                                FOR tmp_attribute_value IN
                                     SELECT av.*
                                     FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
-                                    JOIN proxy_attribute_values ON av.proxy_for_attribute_value_id = proxy_attribute_values.id
-                                )
-                                SELECT * FROM proxy_attribute_values
-                            LOOP
-                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Checking if proxy AttributeValue(%) is of desired AttributeContext(%)',
-                                    proxy_attribute_value,
-                                    desired_attribute_context;
-                                IF exact_attribute_context_v1(desired_attribute_context, attribute_context_from_record_v1(proxy_attribute_value)) THEN
-                                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Proxy AttributeValue(%) is appropriate', proxy_attribute_value;
-                                    next_attribute_value_ids := array_append(next_attribute_value_ids, proxy_attribute_value.id);
-                                    CONTINUE attribute_values_for_prototype;
-                                END IF;
-                            END LOOP;
+                                             INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(
+                                            this_read_tenancy, this_visibility) AS avbtap
+                                                        ON avbtap.object_id = av.id
+                                                            AND avbtap.belongs_to_id = attribute_prototype.id
+                                    WHERE in_attribute_context_v1(desired_attribute_context, av)
+                                    ORDER BY av.id
+                                    LOOP
+                                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Checking if AttributeValue(%) is of desired AttributeContext(%)',
+                                            tmp_attribute_value,
+                                            desired_attribute_context;
+                                        -- Check if this AttributeValue is of the AttributeContext that we want.
+                                        IF exact_attribute_context_v1(desired_attribute_context,
+                                                                      attribute_context_from_record_v1(tmp_attribute_value)) THEN
+                                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributeValue(%) is appropriate', tmp_attribute_value;
+                                            next_attribute_value_ids :=
+                                                    array_append(next_attribute_value_ids, tmp_attribute_value.id);
+                                            CONTINUE;
+                                        END IF;
 
-                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: No appropriate AttributeValue found, creating new one.';
-                            -- The AttributeValue for an affected AttributePrototype, but there isn't a version of it that
-                            -- is of the AttributeContext that we're interested in, so we should make one.
-                            new_attribute_value_id := attribute_value_vivify_value_and_parent_no_child_proxies_v1(
-                                this_write_tenancy,
-                                this_read_tenancy,
-                                this_visibility,
-                                desired_attribute_context,
-                                tmp_attribute_value.id
-                            );
-                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Setting prototype of AttributeValue(%) to AttributePrototype(%)',
-                                new_attribute_value_id,
-                                attribute_prototype.id;
-                            -- We need to make sure the new AttributeValue is associated with the correct AttributePrototype
-                            -- so that we can find it when we go through to update affected AttributeValues.
-                            PERFORM set_belongs_to_v1(
-                                'attribute_value_belongs_to_attribute_prototype',
-                                this_read_tenancy,
-                                this_write_tenancy,
-                                this_visibility,
-                                new_attribute_value_id,
-                                attribute_prototype.id
-                            );
+                                        -- It wasn't, but there might be an AttributeValue that is a proxy for it that could be of the
+                                        -- AttributeContext that we need one to exist for. We need to follow the proxy chain here,
+                                        -- because the proxy might be overridden to have a different AttributePrototype. If that's the
+                                        -- case, we still want to consider it as existing for the purposes of _this_
+                                        -- AttributePrototype, and not create a new AttributeValue in the specific AttributeContext.
+                                        FOR proxy_attribute_value IN
+                                            WITH RECURSIVE proxy_attribute_values AS (
+                                                SELECT *
+                                                FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
+                                                WHERE av.proxy_for_attribute_value_id = tmp_attribute_value.id
+                                                UNION ALL
+                                                SELECT av.*
+                                                FROM attribute_values_v1(this_read_tenancy, this_visibility) AS av
+                                                         JOIN proxy_attribute_values
+                                                              ON av.proxy_for_attribute_value_id = proxy_attribute_values.id
+                                            )
+                                            SELECT *
+                                            FROM proxy_attribute_values
+                                            LOOP
+                                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Checking if proxy AttributeValue(%) is of desired AttributeContext(%)',
+                                                    proxy_attribute_value,
+                                                    desired_attribute_context;
+                                                IF exact_attribute_context_v1(desired_attribute_context,
+                                                                              attribute_context_from_record_v1(proxy_attribute_value)) THEN
+                                                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Proxy AttributeValue(%) is appropriate', proxy_attribute_value;
+                                                    next_attribute_value_ids :=
+                                                            array_append(next_attribute_value_ids, proxy_attribute_value.id);
+                                                    CONTINUE attribute_values_for_prototype;
+                                                END IF;
+                                            END LOOP;
 
-                            next_attribute_value_ids := array_append(
-                                next_attribute_value_ids,
-                                new_attribute_value_id
-                            );
-                        END LOOP attribute_values_for_prototype;
-                    ELSIF attribute_prototype.attribute_context_external_provider_id != -1 THEN
-                        insertion_attribute_context := attribute_context_from_record_v1(attribute_prototype)
-                            || base_attribute_context
-                            || jsonb_build_object(
-                                'attribute_context_schema_id', source_attribute_value.attribute_context_schema_id,
-                                'attribute_context_schema_variant_id', source_attribute_value.attribute_context_schema_variant_id,
-                                'attribute_context_component_id', source_attribute_value.attribute_context_component_id
-                            );
-                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Ensuring AttributeValue exists for ExternalProvider at AttributeContext(%)', insertion_attribute_context;
-                        -- This AttributePrototype is directly associated with an ExternalProvider
-                        next_attribute_value_ids := array_cat(
-                            next_attribute_value_ids,
-                            attribute_value_create_appropriate_for_prototype_and_context_v1(
-                                this_write_tenancy,
-                                this_read_tenancy,
-                                this_visibility,
-                                attribute_prototype.id,
-                                insertion_attribute_context
-                            )
-                        );
-                    ELSE
-                        RAISE 'attribute_value_create_new_affected_values_v1: Don''t know how to handle an AttributePrototype(%) that isn''t for a Prop, or an ExternalProvider, and gets it''s data from an InternalProvider.', attribute_prototype;
-                    END IF;
+                                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: No appropriate AttributeValue found, creating new one.';
+                                        -- The AttributeValue for an affected AttributePrototype, but there isn't a version of it that
+                                        -- is of the AttributeContext that we're interested in, so we should make one.
+                                        new_attribute_value_id :=
+                                                attribute_value_vivify_value_and_parent_no_child_proxies_v1(
+                                                        this_write_tenancy,
+                                                        this_read_tenancy,
+                                                        this_visibility,
+                                                        desired_attribute_context,
+                                                        tmp_attribute_value.id
+                                                    );
+                                        RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Setting prototype of AttributeValue(%) to AttributePrototype(%)',
+                                            new_attribute_value_id,
+                                            attribute_prototype.id;
+                                        -- We need to make sure the new AttributeValue is associated with the correct AttributePrototype
+                                        -- so that we can find it when we go through to update affected AttributeValues.
+                                        PERFORM set_belongs_to_v1(
+                                                'attribute_value_belongs_to_attribute_prototype',
+                                                this_read_tenancy,
+                                                this_write_tenancy,
+                                                this_visibility,
+                                                new_attribute_value_id,
+                                                attribute_prototype.id
+                                            );
 
-                END LOOP;
-            ELSIF source_attribute_value.attribute_context_external_provider_id != -1 THEN
-                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for ExternalProvider(%)',
-                    source_attribute_value.attribute_context_external_provider_id;
-                -- This AttributeValue is directly for an ExternalProvider.
+                                        next_attribute_value_ids := array_append(
+                                                next_attribute_value_ids,
+                                                new_attribute_value_id
+                                            );
+                                    END LOOP attribute_values_for_prototype;
+                            ELSIF attribute_prototype.attribute_context_external_provider_id != -1 THEN
+                                insertion_attribute_context := attribute_context_from_record_v1(attribute_prototype)
+                                                                   || base_attribute_context
+                                    || jsonb_build_object(
+                                                                       'attribute_context_component_id',
+                                                                       source_attribute_value.attribute_context_component_id
+                                                                   );
+                                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Ensuring AttributeValue exists for ExternalProvider at AttributeContext(%)', insertion_attribute_context;
+                                -- This AttributePrototype is directly associated with an ExternalProvider
+                                next_attribute_value_ids := array_cat(
+                                        next_attribute_value_ids,
+                                        attribute_value_create_appropriate_for_prototype_and_context_v1(
+                                                this_write_tenancy,
+                                                this_read_tenancy,
+                                                this_visibility,
+                                                attribute_prototype.id,
+                                                insertion_attribute_context
+                                            )
+                                    );
+                            ELSE
+                                RAISE 'attribute_value_create_new_affected_values_v1: Don''t know how to handle an AttributePrototype(%) that isn''t for a Prop, or an ExternalProvider, and gets it''s data from an InternalProvider.', attribute_prototype;
+                            END IF;
 
-                -- Only InternalProviders can use ExternalProviders, so those are what we need to be looking for
-                -- on what will be using this AttributeValue.
-                tmp_attribute_context := attribute_context_from_record_v1(source_attribute_value)
-                    || jsonb_build_object(
-                        'attribute_context_prop_id', -1,
-                        'attribute_context_internal_provider_id', NULL,
-                        'attribute_context_external_provider_id', -1,
-                        -- The InternalProviders that use this Attribute value can be for any Component,
-                        -- and will not likely have the same ComponentId as the source AttributeValue
-                        'attribute_context_schema_id', NULL,
-                        'attribute_context_schema_variant_id', NULL,
-                        'attribute_context_component_id', NULL
-                    );
-                RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Looking in AttributeContext(%)', tmp_attribute_context;
-                -- AttributePrototypes that "use" this ExternalProvider will have the ExternalProviderId set AND have the
-                -- same tail_component_id as source_attribute_value.attribute_context_component_id.
-                FOR
-                    head_schema_id,
-                    head_schema_variant_id,
-                    head_component_id,
-                    internal_provider_id,
-                    attribute_prototype_id
-                IN
-                    SELECT
-                        cbts.belongs_to_id AS head_schema_id,
-                        cbtsv.belongs_to_id AS head_schema_variant_id,
-                        apa.head_component_id,
-                        attribute_context_internal_provider_id AS internal_provider_id,
-                        ap.id AS attribute_prototype_id
-                    FROM attribute_prototypes_v1(this_read_tenancy, this_visibility) AS ap
-                    INNER JOIN attribute_prototype_arguments_v1(this_read_tenancy, this_visibility) AS apa
-                        ON apa.attribute_prototype_id = ap.id
-                            AND external_provider_id = source_attribute_value.attribute_context_external_provider_id
-                            AND tail_component_id = source_attribute_value.attribute_context_component_id
-                    INNER JOIN component_belongs_to_schema_v1(this_read_tenancy, this_visibility) AS cbts ON cbts.object_id = apa.head_component_id
-                    INNER JOIN component_belongs_to_schema_variant_v1(this_read_tenancy, this_visibility) cbtsv ON cbtsv.object_id = apa.head_component_id
-                    WHERE in_attribute_context_v1(tmp_attribute_context, ap)
-                LOOP
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) uses ExternalProvider(%)', attribute_prototype, source_attribute_value.attribute_context_external_provider_id;
-                    -- The AttributeContext that we want to ensure an AttributeValue exists for will be identical to the
-                    -- source AttributeValue, except that it will be for an InternalProvider, instead of an ExternalProvider,
-                    -- and that it will be associated with a different Component.
-                    insertion_attribute_context := tmp_attribute_context
+                        END LOOP;
+                ELSIF source_attribute_value.attribute_context_external_provider_id != -1 THEN
+                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Found AttributeValue for ExternalProvider(%)',
+                        source_attribute_value.attribute_context_external_provider_id;
+                    -- This AttributeValue is directly for an ExternalProvider.
+
+                    -- Only InternalProviders can use ExternalProviders, so those are what we need to be looking for
+                    -- on what will be using this AttributeValue.
+                    tmp_attribute_context := attribute_context_from_record_v1(source_attribute_value)
                         || jsonb_build_object(
-                            'attribute_context_external_provider_id', -1,
-                            'attribute_context_internal_provider_id', internal_provider_id,
-                            'attribute_context_schema_id', head_schema_id,
-                            'attribute_context_schema_variant_id', head_schema_variant_id,
-                            'attribute_context_component_id', head_component_id
-                        );
+                                                     'attribute_context_prop_id', -1,
+                                                     'attribute_context_internal_provider_id', NULL,
+                                                     'attribute_context_external_provider_id', -1,
+                                                 -- The InternalProviders that use this Attribute value can be for any Component,
+                                                 -- and will not likely have the same ComponentId as the source AttributeValue
+                                                     'attribute_context_component_id', NULL
+                                                 );
+                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Looking in AttributeContext(%)', tmp_attribute_context;
+                    -- AttributePrototypes that "use" this ExternalProvider will have the ExternalProviderId set AND have the
+                    -- same tail_component_id as source_attribute_value.attribute_context_component_id.
+                    FOR head_schema_id,
+                        head_schema_variant_id,
+                        head_component_id,
+                        internal_provider_id,
+                        attribute_prototype_id
+                        IN
+                        SELECT cbts.belongs_to_id                     AS head_schema_id,
+                               cbtsv.belongs_to_id                    AS head_schema_variant_id,
+                               apa.head_component_id,
+                               attribute_context_internal_provider_id AS internal_provider_id,
+                               ap.id                                  AS attribute_prototype_id
+                        FROM attribute_prototypes_v1(this_read_tenancy, this_visibility) AS ap
+                                 INNER JOIN attribute_prototype_arguments_v1(this_read_tenancy, this_visibility) AS apa
+                                            ON apa.attribute_prototype_id = ap.id
+                                                AND external_provider_id =
+                                                    source_attribute_value.attribute_context_external_provider_id
+                                                AND
+                                               tail_component_id = source_attribute_value.attribute_context_component_id
+                                 INNER JOIN component_belongs_to_schema_v1(this_read_tenancy, this_visibility) AS cbts
+                                            ON cbts.object_id = apa.head_component_id
+                                 INNER JOIN component_belongs_to_schema_variant_v1(this_read_tenancy,
+                                                                                   this_visibility) cbtsv
+                                            ON cbtsv.object_id = apa.head_component_id
+                        WHERE in_attribute_context_v1(tmp_attribute_context, ap)
+                        LOOP
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: AttributePrototype(%) uses ExternalProvider(%)', attribute_prototype, source_attribute_value.attribute_context_external_provider_id;
+                            -- The AttributeContext that we want to ensure an AttributeValue exists for will be identical to the
+                            -- source AttributeValue, except that it will be for an InternalProvider, instead of an ExternalProvider,
+                            -- and that it will be associated with a different Component.
+                            insertion_attribute_context := tmp_attribute_context
+                                || jsonb_build_object(
+                                                                   'attribute_context_external_provider_id', -1,
+                                                                   'attribute_context_internal_provider_id',
+                                                                   internal_provider_id,
+                                                                   'attribute_context_component_id', head_component_id
+                                                               );
 
-                    RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Source AttributeValue(%) destination AttributeContext(%)',
-                        source_attribute_value,
-                        insertion_attribute_context;
-                    next_attribute_value_ids := array_cat(
-                        next_attribute_value_ids,
-                        attribute_value_create_appropriate_for_prototype_and_context_v1(
-                            this_write_tenancy,
-                            this_read_tenancy,
-                            this_visibility,
-                            attribute_prototype_id,
-                            insertion_attribute_context
-                        )
-                    );
-                END LOOP;
-            ELSE
-                -- No idea what kind of AttributeValue this is, but it can't be good.
-                RAISE 'attribute_value_create_new_affected_values_v1: Found an AttributeValue(%) of unknown type. Tenancy(%), Visibility(%)',
-                    source_attribute_value.id,
-                    this_read_tenancy,
-                    this_visibility;
-            END IF;
-        END LOOP;
+                            RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Source AttributeValue(%) destination AttributeContext(%)',
+                                source_attribute_value,
+                                insertion_attribute_context;
+                            next_attribute_value_ids := array_cat(
+                                    next_attribute_value_ids,
+                                    attribute_value_create_appropriate_for_prototype_and_context_v1(
+                                            this_write_tenancy,
+                                            this_read_tenancy,
+                                            this_visibility,
+                                            attribute_prototype_id,
+                                            insertion_attribute_context
+                                        )
+                                );
+                        END LOOP;
+                ELSE
+                    -- No idea what kind of AttributeValue this is, but it can't be good.
+                    RAISE 'attribute_value_create_new_affected_values_v1: Found an AttributeValue(%) of unknown type. Tenancy(%), Visibility(%)',
+                        source_attribute_value.id,
+                        this_read_tenancy,
+                        this_visibility;
+                END IF;
+            END LOOP;
 
         -- Set up current_attribute_value_ids to be the ones we found on this pass through the loop,
         -- that we haven't already seen, so we can start looking at them.
-        current_attribute_value_ids := array_agg(x) FROM unnest(next_attribute_value_ids) AS x
-                                                    WHERE x != all(seen_attribute_value_ids);
+        current_attribute_value_ids := array_agg(x)
+                                       FROM unnest(next_attribute_value_ids) AS x
+                                       WHERE x != all (seen_attribute_value_ids);
         RAISE DEBUG 'attribute_value_create_new_affected_values_v1: Checking AttributeValueIds on next loop: %', current_attribute_value_ids;
         next_attribute_value_ids := NULL;
     END LOOP;

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -134,12 +134,15 @@ impl ExternalProvider {
         let mut external_provider: ExternalProvider =
             standard_model::finish_create_from_row(ctx, row).await?;
 
+        let attribute_context = AttributeContext::builder()
+            .set_external_provider_id(external_provider.id)
+            .to_context()?;
         let attribute_prototype = AttributePrototype::new(
             ctx,
             func_id,
             func_binding_id,
             func_binding_return_value_id,
-            external_provider.attribute_context()?,
+            attribute_context,
             None,
             None,
         )
@@ -289,15 +292,5 @@ impl ExternalProvider {
             )
             .await?;
         Ok(standard_model::objects_from_rows(rows)?)
-    }
-
-    /// Returns an [`AttributeContext`](crate::AttributeContext) corresponding to our id, our
-    /// [`SchemaId`](crate::SchemaId) and our [`SchemaVariantId`](crate::SchemaVariantId).
-    pub fn attribute_context(&self) -> ExternalProviderResult<AttributeContext> {
-        Ok(AttributeContext::builder()
-            .set_external_provider_id(self.id)
-            .set_schema_id(self.schema_id)
-            .set_schema_variant_id(self.schema_variant_id)
-            .to_context()?)
     }
 }

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -72,7 +72,7 @@ use si_data_pg::PgError;
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::attribute::context::{AttributeContextBuilder, UNSET_ID_VALUE};
+use crate::attribute::context::AttributeContextBuilder;
 use crate::func::backend::identity::FuncBackendIdentityArgs;
 use crate::func::binding::{FuncBindingError, FuncBindingId};
 use crate::func::binding_return_value::FuncBindingReturnValueId;
@@ -198,8 +198,7 @@ pub struct InternalProvider {
     timestamp: Timestamp,
 
     /// Indicates which [`Prop`](crate::Prop) this provider belongs to. This will be
-    /// [`UNSET_ID_VALUE`](crate::attribute::context::UNSET_ID_VALUE) if [`Self`] is "explicit". If
-    /// [`Self`] is "implicit", this will always be a "set" id.
+    /// unset if [`Self`] is "explicit". If [`Self`] is "implicit", this will always be a "set" id.
     prop_id: PropId,
     /// Indicates which [`SchemaVariant`](crate::SchemaVariant) this provider belongs to.
     schema_variant_id: SchemaVariantId,
@@ -300,7 +299,8 @@ impl InternalProvider {
         diagram_kind: DiagramKind,
     ) -> InternalProviderResult<(Self, Socket)> {
         let name = name.as_ref();
-        let prop_id: PropId = UNSET_ID_VALUE.into();
+        let prop_id = PropId::NONE;
+
         let row = ctx
             .txns()
             .pg()
@@ -394,7 +394,7 @@ impl InternalProvider {
 
     /// If the [`PropId`](crate::Prop) field is not unset, then [`Self`] is an internal consumer.
     pub fn is_internal_consumer(&self) -> bool {
-        self.prop_id != UNSET_ID_VALUE.into()
+        self.prop_id != PropId::NONE
     }
 
     /// Consume with a provided [`AttributeContext`](crate::AttributeContext) and return the

--- a/lib/dal/src/queries/attribute_prototype/argument_values_by_name_for_head_component_id.sql
+++ b/lib/dal/src/queries/attribute_prototype/argument_values_by_name_for_head_component_id.sql
@@ -7,94 +7,86 @@
  */
 SELECT row_to_json(prototype_args) AS object
 FROM (
-    SELECT
-        attribute_prototype_id,
-        name AS argument_name,
-        array_agg(CASE WHEN internal_provider_data.internal_provider_id IS NOT NULL THEN internal_provider_data.value ELSE external_provider_data.value END) AS values
-    FROM (
-        SELECT
-            apa.attribute_prototype_id,
-            fa.name,
-            apa.internal_provider_id,
-            apa.external_provider_id,
-            apa.tail_component_id
-        FROM attribute_prototype_arguments_v1($1, $2) AS apa
-        INNER JOIN func_arguments_v1($1, $2) AS fa
-            ON apa.func_argument_id = fa.id
-        WHERE
-            apa.attribute_prototype_id = $3
-            AND CASE WHEN apa.external_provider_id != -1
-                THEN
-                    apa.head_component_id = $4
-                ELSE
-                    TRUE
-            END
-    ) AS prototype_argument_data
-    -- Get the values for InternalProviders
-    LEFT JOIN LATERAL (
-        SELECT DISTINCT ON (attribute_context_internal_provider_id)
-            attribute_context_internal_provider_id AS internal_provider_id,
-            fbrv.value
-        FROM attribute_values_v1($1, $2) AS av
-        INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
-            ON av.func_binding_return_value_id = fbrv.id
-        WHERE
-            -- We want to override the Prop/ExternalProvider/InternalProvider information on the AttributeContext
-            -- that we're provided to make sure that we're looking for AttributeValues for the particular
-            -- InternalProvider that we're interested in at this point. `jsonb || jsonb` is the union of the two,
-            -- taking values from the second where there are conflicts.
-            --
-            -- # SELECT '{"a": "b", "c": "d"}'::jsonb || '{"a": "foo", "e": "f"}'::jsonb;
-            --              ?column?
-            -- ----------------------------------
-            --  {"a": "foo", "c": "d", "e": "f"}
-            -- (1 row)
-            in_attribute_context_v1(
-                $5 || jsonb_build_object(
-                    'attribute_context_prop_id',              -1,
-                    'attribute_context_external_provider_id', -1,
-                    -- The reference to `prototype_argument_data` is why this needs to be a `LATERAL` join.
-                    'attribute_context_internal_provider_id', prototype_argument_data.internal_provider_id
-                ),
-                av
-            )
-        ORDER BY
-            attribute_context_internal_provider_id,
-            attribute_context_schema_id DESC,
-            attribute_context_schema_variant_id DESC,
-            attribute_context_component_id DESC,
-            av.tenancy_universal -- bools sort false first ascending.
-    ) AS internal_provider_data ON prototype_argument_data.internal_provider_id = internal_provider_data.internal_provider_id
-    LEFT JOIN LATERAL (
-        SELECT DISTINCT ON (attribute_context_external_provider_id)
-            attribute_context_external_provider_id AS external_provider_id,
-            value
-        FROM attribute_values_v1($1, $2) AS av
-        INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
-            ON av.func_binding_return_value_id = fbrv.id
-        WHERE
-            -- We're also overriding the AttributeContext's ComponentId, SchemaId, and SchemaVariantId here,
-            -- because the source data is coming from a different Component (and potentially
-            -- Schema & SchemaVaiant) from where we're trying to set the final value.
-            in_attribute_context_v1(
-                $5 || jsonb_build_object(
-                    'attribute_context_prop_id',              -1,
-                    'attribute_context_external_provider_id', prototype_argument_data.external_provider_id,
-                    'attribute_context_internal_provider_id', -1,
-                    'attribute_context_component_id',         prototype_argument_data.tail_component_id,
-                    'attribute_context_schema_id', NULL,
-                    'attribute_context_schema_variant_id', NULL
-                ),
-                av
-            )
-        ORDER BY
-            attribute_context_external_provider_id,
-            attribute_context_schema_id DESC,
-            attribute_context_schema_variant_id DESC,
-            attribute_context_component_id DESC,
-            av.tenancy_universal -- bools sort false first ascending.
-    ) AS external_provider_data ON prototype_argument_data.external_provider_id = external_provider_data.external_provider_id
-    GROUP BY
-        attribute_prototype_id,
-        name
-) AS prototype_args
+         SELECT attribute_prototype_id,
+                name                                                 AS argument_name,
+                array_agg(CASE
+                              WHEN internal_provider_data.internal_provider_id IS NOT NULL
+                                  THEN internal_provider_data.value
+                              ELSE external_provider_data.value END) AS values
+         FROM (
+                  SELECT apa.attribute_prototype_id,
+                         fa.name,
+                         apa.internal_provider_id,
+                         apa.external_provider_id,
+                         apa.tail_component_id
+                  FROM attribute_prototype_arguments_v1($1, $2) AS apa
+                           INNER JOIN func_arguments_v1($1, $2) AS fa
+                                      ON apa.func_argument_id = fa.id
+                  WHERE apa.attribute_prototype_id = $3
+                    AND CASE
+                            WHEN apa.external_provider_id != -1
+                                THEN
+                                apa.head_component_id = $4
+                            ELSE
+                                TRUE
+                      END
+              ) AS prototype_argument_data
+                  -- Get the values for InternalProviders
+                  LEFT JOIN LATERAL (
+             SELECT DISTINCT ON (attribute_context_internal_provider_id) attribute_context_internal_provider_id AS internal_provider_id,
+                                                                         fbrv.value
+             FROM attribute_values_v1($1, $2) AS av
+                      INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
+                                 ON av.func_binding_return_value_id = fbrv.id
+             WHERE
+                 -- We want to override the Prop/ExternalProvider/InternalProvider information on the AttributeContext
+                 -- that we're provided to make sure that we're looking for AttributeValues for the particular
+                 -- InternalProvider that we're interested in at this point. `jsonb || jsonb` is the union of the two,
+                 -- taking values from the second where there are conflicts.
+                 --
+                 -- # SELECT '{"a": "b", "c": "d"}'::jsonb || '{"a": "foo", "e": "f"}'::jsonb;
+                 --              ?column?
+                 -- ----------------------------------
+                 --  {"a": "foo", "c": "d", "e": "f"}
+                 -- (1 row)
+                 in_attribute_context_v1(
+                             $5 || jsonb_build_object(
+                                 'attribute_context_prop_id', -1,
+                                 'attribute_context_external_provider_id', -1,
+                             -- The reference to `prototype_argument_data` is why this needs to be a `LATERAL` join.
+                                 'attribute_context_internal_provider_id', prototype_argument_data.internal_provider_id
+                             ),
+                             av
+                     )
+             ORDER BY attribute_context_internal_provider_id,
+                      attribute_context_component_id DESC,
+                      av.tenancy_universal -- bools sort false first ascending.
+             ) AS internal_provider_data ON prototype_argument_data.internal_provider_id =
+                                            internal_provider_data.internal_provider_id
+                  LEFT JOIN LATERAL (
+             SELECT DISTINCT ON (attribute_context_external_provider_id) attribute_context_external_provider_id AS external_provider_id,
+                                                                         value
+             FROM attribute_values_v1($1, $2) AS av
+                      INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
+                                 ON av.func_binding_return_value_id = fbrv.id
+             WHERE
+                 -- We're also overriding the AttributeContext's ComponentId here,
+                 -- because the source data is coming from a different Component from
+                 -- where we're trying to set the final value.
+                 in_attribute_context_v1(
+                             $5 || jsonb_build_object(
+                                 'attribute_context_prop_id', -1,
+                                 'attribute_context_external_provider_id', prototype_argument_data.external_provider_id,
+                                 'attribute_context_internal_provider_id', -1,
+                                 'attribute_context_component_id', prototype_argument_data.tail_component_id
+                             ),
+                             av
+                     )
+             ORDER BY attribute_context_external_provider_id,
+                      attribute_context_component_id DESC,
+                      av.tenancy_universal -- bools sort false first ascending.
+             ) AS external_provider_data ON prototype_argument_data.external_provider_id =
+                                            external_provider_data.external_provider_id
+         GROUP BY attribute_prototype_id,
+                  name
+     ) AS prototype_args

--- a/lib/dal/src/queries/attribute_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_for_context.sql
@@ -2,20 +2,13 @@ SELECT DISTINCT ON (
     attribute_prototypes.attribute_context_prop_id,
     attribute_prototypes.attribute_context_internal_provider_id,
     attribute_prototypes.attribute_context_external_provider_id
-)
-    row_to_json(attribute_prototypes.*) AS object
+    ) row_to_json(attribute_prototypes.*) AS object
 FROM attribute_prototypes_v1($1, $2) AS attribute_prototypes
-WHERE
-    attribute_prototypes.attribute_context_prop_id = $3
-    AND attribute_prototypes.attribute_context_internal_provider_id = $4
-    AND attribute_prototypes.attribute_context_external_provider_id = $5
-    AND attribute_prototypes.attribute_context_schema_id = $6
-    AND attribute_prototypes.attribute_context_schema_variant_id = $7
-    AND attribute_prototypes.attribute_context_component_id = $8
-ORDER BY
-    attribute_context_prop_id DESC,
-    attribute_context_internal_provider_id DESC,
-    attribute_context_external_provider_id DESC,
-    attribute_context_schema_id DESC,
-    attribute_context_schema_variant_id DESC,
-    attribute_context_component_id DESC;
+WHERE attribute_prototypes.attribute_context_prop_id = $3
+  AND attribute_prototypes.attribute_context_internal_provider_id = $4
+  AND attribute_prototypes.attribute_context_external_provider_id = $5
+  AND attribute_prototypes.attribute_context_component_id = $6
+ORDER BY attribute_context_prop_id DESC,
+         attribute_context_internal_provider_id DESC,
+         attribute_context_external_provider_id DESC,
+         attribute_context_component_id DESC;

--- a/lib/dal/src/queries/attribute_prototype_find_with_parent_value_and_key_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_with_parent_value_and_key_for_context.sql
@@ -28,7 +28,5 @@ ORDER BY
     visibility_change_set_pk DESC,
     attribute_context_internal_provider_id DESC,
     attribute_context_external_provider_id DESC,
-    attribute_context_schema_id DESC,
-    attribute_context_schema_variant_id DESC,
     attribute_context_component_id DESC,
     av.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_prototype_list_for_context.sql
+++ b/lib/dal/src/queries/attribute_prototype_list_for_context.sql
@@ -1,18 +1,13 @@
 SELECT DISTINCT ON (
     attribute_context_prop_id,
     COALESCE(key, '')
-)
-    row_to_json(ap.*) AS object
+    ) row_to_json(ap.*) AS object
 FROM attribute_prototypes_v1($1, $2) AS ap
-WHERE
-    in_attribute_context_v1($3, ap)
-    AND attribute_context_prop_id = $4
-ORDER BY
-    attribute_context_prop_id,
-    COALESCE(key, ''),
-    attribute_context_internal_provider_id DESC,
-    attribute_context_external_provider_id DESC,
-    attribute_context_schema_id DESC,
-    attribute_context_schema_variant_id DESC,
-    attribute_context_component_id DESC,
-    ap.tenancy_universal -- bools sort false first ascending.
+WHERE in_attribute_context_v1($3, ap)
+  AND attribute_context_prop_id = $4
+ORDER BY attribute_context_prop_id,
+         COALESCE(key, ''),
+         attribute_context_internal_provider_id DESC,
+         attribute_context_external_provider_id DESC,
+         attribute_context_component_id DESC,
+         ap.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_value_child_attribute_values_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_child_attribute_values_for_context.sql
@@ -1,17 +1,12 @@
-SELECT DISTINCT ON (av.attribute_context_prop_id, COALESCE(av.key, ''))
-    row_to_json(av.*) AS object
+SELECT DISTINCT ON (av.attribute_context_prop_id, COALESCE(av.key, '')) row_to_json(av.*) AS object
 FROM attribute_values_v1($1, $2) AS av
-INNER JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
-    ON avbtav.object_id = av.id
-WHERE
-    in_attribute_context_v1($4, av)
-    AND avbtav.belongs_to_id = $3
-ORDER BY
-    attribute_context_prop_id,
-    COALESCE(key, ''),
-    attribute_context_internal_provider_id DESC,
-    attribute_context_external_provider_id DESC,
-    attribute_context_schema_id DESC,
-    attribute_context_schema_variant_id DESC,
-    attribute_context_component_id DESC,
-    av.tenancy_universal -- bools sort false first ascending.
+         INNER JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
+                    ON avbtav.object_id = av.id
+WHERE in_attribute_context_v1($4, av)
+  AND avbtav.belongs_to_id = $3
+ORDER BY attribute_context_prop_id,
+         COALESCE(key, ''),
+         attribute_context_internal_provider_id DESC,
+         attribute_context_external_provider_id DESC,
+         attribute_context_component_id DESC,
+         av.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_value_find_with_parent_and_key_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_find_with_parent_and_key_for_context.sql
@@ -1,22 +1,18 @@
-SELECT DISTINCT ON (av.attribute_context_prop_id)
-      row_to_json(av.*) AS object
+SELECT DISTINCT ON (av.attribute_context_prop_id) row_to_json(av.*) AS object
 FROM attribute_values_v1($1, $2) AS av
-LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
-      ON avbtav.object_id = av.id
-WHERE
-      in_attribute_context_v1($3, av)
-      AND CASE
-            WHEN $4::bigint IS NULL THEN avbtav.belongs_to_id IS NULL
-            ELSE avbtav.belongs_to_id = $4::bigint
-      END
-      AND CASE
-            WHEN $5::text IS NULL THEN av.key IS NULL
-            ELSE av.key = $5::text
-      END
+         LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
+                   ON avbtav.object_id = av.id
+WHERE in_attribute_context_v1($3, av)
+  AND CASE
+          WHEN $4::bigint IS NULL THEN avbtav.belongs_to_id IS NULL
+          ELSE avbtav.belongs_to_id = $4::bigint
+    END
+  AND CASE
+          WHEN $5::text IS NULL THEN av.key IS NULL
+          ELSE av.key = $5::text
+    END
 ORDER BY attribute_context_prop_id,
          attribute_context_internal_provider_id DESC,
          attribute_context_external_provider_id DESC,
-         attribute_context_schema_id DESC,
-         attribute_context_schema_variant_id DESC,
          attribute_context_component_id DESC,
          av.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_value_find_with_parent_and_prototype_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_find_with_parent_and_prototype_for_context.sql
@@ -1,30 +1,26 @@
-SELECT DISTINCT ON (av.attribute_context_prop_id)
-    row_to_json(av.*) AS object
+SELECT DISTINCT ON (av.attribute_context_prop_id) row_to_json(av.*) AS object
 FROM attribute_values_v1($1, $2) AS av
 
 -- Scope by attribute prototype. We need these for handling elements in arrays and values in maps.
-INNER JOIN attribute_value_belongs_to_attribute_prototype_v1($1, $2) AS avbtap
-    ON avbtap.object_id = av.id
-INNER JOIN attribute_prototypes_v1($1, $2) AS ap
-    ON ap.id = avbtap.belongs_to_id
+         INNER JOIN attribute_value_belongs_to_attribute_prototype_v1($1, $2) AS avbtap
+                    ON avbtap.object_id = av.id
+         INNER JOIN attribute_prototypes_v1($1, $2) AS ap
+                    ON ap.id = avbtap.belongs_to_id
 
 -- Handle parentage. We need to use LEFT JOINs here to not wipe out attribute values that do not have relevant parents.
-LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
-    ON avbtav.object_id = av.id
-LEFT JOIN attribute_values_v1($1, $2) AS parent_attribute_values
-    ON parent_attribute_values.id = avbtav.belongs_to_id
+         LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
+                   ON avbtav.object_id = av.id
+         LEFT JOIN attribute_values_v1($1, $2) AS parent_attribute_values
+                   ON parent_attribute_values.id = avbtav.belongs_to_id
 
-WHERE
-    exact_attribute_context_v1($3, av)
-    AND ap.id = $4
-    AND CASE
-        WHEN $5::bigint IS NULL THEN parent_attribute_values.id IS NULL
-        ELSE parent_attribute_values.id = $5::bigint
+WHERE exact_attribute_context_v1($3, av)
+  AND ap.id = $4
+  AND CASE
+          WHEN $5::bigint IS NULL THEN parent_attribute_values.id IS NULL
+          ELSE parent_attribute_values.id = $5::bigint
     END
 ORDER BY attribute_context_prop_id,
          attribute_context_internal_provider_id DESC,
          attribute_context_external_provider_id DESC,
-         attribute_context_schema_id DESC,
-         attribute_context_schema_variant_id DESC,
          attribute_context_component_id DESC,
          av.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/attribute_value_list_for_context.sql
+++ b/lib/dal/src/queries/attribute_value_list_for_context.sql
@@ -4,19 +4,15 @@ SELECT DISTINCT ON (
     attribute_context_internal_provider_id,
     attribute_context_external_provider_id,
     COALESCE(key, '')
-)
-    row_to_json(av.*) AS object
+    ) row_to_json(av.*) AS object
 FROM attribute_values_v1($1, $2) AS av
-LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
-    ON avbtav.object_id = av.id
+         LEFT JOIN attribute_value_belongs_to_attribute_value_v1($1, $2) AS avbtav
+                   ON avbtav.object_id = av.id
 WHERE in_attribute_context_v1($3, av)
-ORDER BY
-    belongs_to_id,
-    attribute_context_prop_id DESC,
-    attribute_context_internal_provider_id DESC,
-    attribute_context_external_provider_id DESC,
-    COALESCE(key, ''),
-    attribute_context_schema_id DESC,
-    attribute_context_schema_variant_id DESC,
-    attribute_context_component_id DESC,
-    av.tenancy_universal -- bools sort false first ascending.
+ORDER BY belongs_to_id,
+         attribute_context_prop_id DESC,
+         attribute_context_internal_provider_id DESC,
+         attribute_context_external_provider_id DESC,
+         COALESCE(key, ''),
+         attribute_context_component_id DESC,
+         av.tenancy_universal -- bools sort false first ascending.

--- a/lib/dal/src/queries/component/name_from_context.sql
+++ b/lib/dal/src/queries/component/name_from_context.sql
@@ -1,48 +1,42 @@
 SELECT fbrv.value AS component_name
 FROM func_binding_return_values_v1($1, $2) AS fbrv
 WHERE id IN (
-    SELECT DISTINCT ON (av.attribute_context_prop_id)
-        av.func_binding_return_value_id
+    SELECT DISTINCT ON (av.attribute_context_prop_id) av.func_binding_return_value_id
     FROM attribute_values_v1($1, $2) AS av
-    JOIN (
+             JOIN (
         SELECT name_prop.id
         FROM props_v1($1, $2) AS name_prop
-        JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
-            ON name_prop.name = 'name'
-                AND pbtp.object_id = name_prop.id
-                AND pbtp.belongs_to_id IN (
-                    SELECT si_prop.id
-                    FROM props_v1($1, $2) AS si_prop
-                    JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
-                        ON si_prop.name = 'si'
-                            AND pbtp.object_id = si_prop.id
-                            AND pbtp.belongs_to_id IN (
-                                SELECT pmtmsv.left_object_id AS root_prop_id
-                                FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
-                                JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
-                                    ON cbtsv.belongs_to_id = pmtmsv.right_object_id
-                                        AND cbtsv.object_id = $3
-                            )
-                )
+                 JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
+                      ON name_prop.name = 'name'
+                          AND pbtp.object_id = name_prop.id
+                          AND pbtp.belongs_to_id IN (
+                              SELECT si_prop.id
+                              FROM props_v1($1, $2) AS si_prop
+                                       JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
+                                            ON si_prop.name = 'si'
+                                                AND pbtp.object_id = si_prop.id
+                                                AND pbtp.belongs_to_id IN (
+                                                    SELECT pmtmsv.left_object_id AS root_prop_id
+                                                    FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
+                                                             JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
+                                                                  ON cbtsv.belongs_to_id = pmtmsv.right_object_id
+                                                                      AND cbtsv.object_id = $3
+                                                )
+                          )
     ) AS name_prop
-        ON av.attribute_context_prop_id = name_prop.id
+                  ON av.attribute_context_prop_id = name_prop.id
     WHERE in_attribute_context_v1(
-        attribute_context_build_from_parts_v1(
-            name_prop.id, -- PropId
-            -1, -- InternalProviderId
-            -1, -- ExternalProviderId
-            NULL, -- SchemaId (handled by ComponentId)
-            NULL, -- SchemaVariantId (handled by ComponentId)
-            $3 -- ComponentId
-        ),
-        av
-    )
-    ORDER BY
-        av.attribute_context_prop_id,
-        av.attribute_context_schema_id DESC,
-        av.attribute_context_schema_variant_id DESC,
-        av.attribute_context_component_id DESC,
-        av.tenancy_universal -- bools sort false first ascending.
+                  attribute_context_build_from_parts_v1(
+                          name_prop.id, -- PropId
+                          -1, -- InternalProviderId
+                          -1, -- ExternalProviderId
+                          $3 -- ComponentId
+                      ),
+                  av
+              )
+    ORDER BY av.attribute_context_prop_id,
+             av.attribute_context_component_id DESC,
+             av.tenancy_universal -- bools sort false first ascending.
 )
 
 -- This ends up with an extremely bad query plan to the point where it
@@ -80,8 +74,6 @@ WHERE id IN (
 --         attribute_context_prop_id,
 --         attribute_context_internal_provider_id,
 --         attribute_context_external_provider_id,
---         attribute_context_schema_id,
---         attribute_context_schema_variant_id,
 --         attribute_context_component_id,
 --         attribute_context_system_id
 --     FROM attribute_values_v1($1, $2) AS av
@@ -95,8 +87,6 @@ WHERE id IN (
 --                 name_prop.id, -- PropId
 --                 -1, -- InternalProviderId
 --                 -1, -- ExternalProviderId
---                 NULL, -- SchemaId (handled by ComponentId)
---                 NULL, -- SchemaVariantId (handled by ComponentId)
 --                 $3, -- ComponentId
 --                 $4 -- SystemId
 --             ),
@@ -105,8 +95,6 @@ WHERE id IN (
 --         AND attribute_context_prop_id = name_prop.id
 --     ORDER BY
 --         attribute_context_prop_id,
---         attribute_context_schema_id DESC,
---         attribute_context_schema_variant_id DESC,
 --         attribute_context_component_id DESC,
 --         attribute_context_system_id DESC,
 --         av.tenancy_universal

--- a/lib/dal/src/queries/component/root_child_attribute_value_for_component.sql
+++ b/lib/dal/src/queries/component/root_child_attribute_value_for_component.sql
@@ -22,15 +22,11 @@ WHERE in_attribute_context_v1(
                       root_child_prop.id, -- PropId
                       -1, -- InternalProviderId
                       -1, -- ExternalProviderId
-                      NULL, -- SchemaId (handled by ComponentId)
-                      NULL, -- SchemaVariantId (handled by ComponentId)
                       $4 -- ComponentId
                   ),
               av
           )
 ORDER BY av.attribute_context_prop_id,
-         av.attribute_context_schema_id DESC,
-         av.attribute_context_schema_variant_id DESC,
          av.attribute_context_component_id DESC,
          av.tenancy_universal
 -- bools sort false first ascending.

--- a/lib/dal/src/validation/resolver.rs
+++ b/lib/dal/src/validation/resolver.rs
@@ -172,14 +172,8 @@ impl ValidationResolver {
             .await
             .map_err(|err| ValidationResolverError::Component(err.to_string()))?
             .ok_or(ValidationResolverError::SchemaVariantNotFound)?;
-        let schema = schema_variant
-            .schema(ctx)
-            .await?
-            .ok_or(ValidationResolverError::SchemaNotFound)?;
         let context = AttributeReadContext {
             prop_id: None,
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(component_id),
             ..AttributeReadContext::default()
         };

--- a/lib/dal/src/workflow_prototype.rs
+++ b/lib/dal/src/workflow_prototype.rs
@@ -212,8 +212,6 @@ impl WorkflowPrototype {
 
             let context = AttributeReadContext {
                 prop_id: None,
-                schema_id: Some(*schema.id()),
-                schema_variant_id: Some(*schema_variant.id()),
                 component_id: Some(*component.id()),
                 ..AttributeReadContext::default()
             };

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -62,8 +62,6 @@ async fn new_attribute_prototype(ctx: &DalContext) {
 
     let context = AttributeContext::builder()
         .set_prop_id(*first_prop.id())
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*default_variant.id())
         .set_component_id(*component.id())
         .to_context()
         .expect("cannot create context");
@@ -83,17 +81,12 @@ async fn new_attribute_prototype(ctx: &DalContext) {
 #[test]
 async fn list_for_context_with_a_hash(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
         .expect("cannot set default schema variant");
-
-    let mut base_prototype_context = AttributeContext::builder();
-    base_prototype_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id());
+    let base_prototype_context = AttributeContext::builder();
 
     // {
     //   albums: [
@@ -392,8 +385,6 @@ async fn remove_component_specific(ctx: &DalContext) {
 
     let read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -416,8 +407,6 @@ async fn remove_component_specific(ctx: &DalContext) {
 
     let context = AttributeContextBuilder::new()
         .set_prop_id(*prop.id())
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
         .set_component_id(*component.id())
         .to_context()
         .expect("could not build context");

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -70,8 +70,6 @@ async fn create_and_list_for_attribute_prototype(ctx: &DalContext) {
         .expect("failed to execute func binding");
     let context = AttributeContext::builder()
         .set_prop_id(*name_prop.id())
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
         .to_context()
         .expect("cannot create context");
 

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -36,8 +36,6 @@ async fn update_for_context_simple(ctx: &DalContext) {
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -177,8 +175,6 @@ async fn insert_for_context_simple(ctx: &DalContext) {
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -293,8 +289,6 @@ async fn update_for_context_object(ctx: &DalContext) {
 
     let read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -320,8 +314,6 @@ async fn update_for_context_object(ctx: &DalContext) {
         AttributeReadContext {
             prop_id: Some(root.prop_id),
             component_id: Some(*component.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             ..AttributeReadContext::any()
         },
     )
@@ -337,8 +329,6 @@ async fn update_for_context_object(ctx: &DalContext) {
         AttributeReadContext {
             prop_id: Some(root.domain_prop_id),
             component_id: Some(*component.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             ..AttributeReadContext::any()
         },
     )
@@ -351,8 +341,6 @@ async fn update_for_context_object(ctx: &DalContext) {
 
     let update_context = AttributeContext::builder()
         .set_prop_id(root.domain_prop_id)
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
         .set_component_id(*component.id())
         .to_context()
         .expect("cannot build write AttributeContext");
@@ -492,8 +480,6 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -586,10 +572,8 @@ async fn list_payload(ctx: &DalContext) {
     let payloads = AttributeValue::list_payload_for_read_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant_id),
-            component_id: Some(*component.id()),
             prop_id: None,
+            component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },
     )

--- a/lib/dal/tests/integration_test/attribute/view.rs
+++ b/lib/dal/tests/integration_test/attribute/view.rs
@@ -18,12 +18,6 @@ async fn schema_variant_specific(ctx: &DalContext) {
         .await
         .expect("cannot set default schema variant");
 
-    let base_context = AttributeReadContext {
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
-        ..AttributeReadContext::default()
-    };
-
     let name_prop = create_prop_of_kind_with_name(ctx, PropKind::String, "name").await;
     name_prop
         .set_parent_prop(ctx, root_prop.domain_prop_id)
@@ -40,7 +34,7 @@ async fn schema_variant_specific(ctx: &DalContext) {
         None,
         AttributeReadContext {
             prop_id: Some(root_prop.prop_id),
-            ..base_context
+            ..AttributeReadContext::default()
         },
     )
     .await
@@ -51,7 +45,7 @@ async fn schema_variant_specific(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            ..base_context
+            ..AttributeReadContext::default()
         },
         Some(*root_attribute_value.id()),
     )
@@ -73,7 +67,7 @@ async fn schema_variant_specific(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: Some(root_prop.domain_prop_id),
-            ..base_context
+            ..AttributeReadContext::default()
         },
     )
     .await
@@ -84,14 +78,14 @@ async fn schema_variant_specific(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: Some(*name_prop.id()),
-            ..base_context
+            ..AttributeReadContext::default()
         },
     )
     .await
     .expect("cannot find attribute value")
     .expect("attribute value not found");
 
-    let update_context = AttributeContextBuilder::from(base_context)
+    let update_context = AttributeContextBuilder::from(AttributeReadContext::default())
         .set_prop_id(*name_prop.id())
         .to_context()
         .expect("could not convert builder to attribute context");
@@ -111,7 +105,7 @@ async fn schema_variant_specific(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            ..base_context
+            ..AttributeReadContext::default()
         },
         Some(*root_attribute_value.id()),
     )
@@ -136,7 +130,7 @@ async fn schema_variant_specific(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            ..base_context
+            ..AttributeReadContext::default()
         },
         Some(updated_name_attribute_value_id),
     )

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -248,12 +248,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
     .expect("could not create explicit internal provider");
     let u12a_attribute_value = AttributeValue::find_for_context(
         ctx,
-        AttributeReadContext {
-            prop_id: Some(*u12a_prop.id()),
-            schema_id: Some(*noctua_schema.id()),
-            schema_variant_id: Some(*noctua_schema_variant.id()),
-            ..AttributeReadContext::default()
-        },
+        AttributeReadContext::default_with_prop(*u12a_prop.id()),
     )
     .await
     .expect("could not perform attribute value find for context")
@@ -308,15 +303,11 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
     // Cache the read contexts for generating views for our components.
     let ekwb_component_view_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*ekwb_schema.id()),
-        schema_variant_id: Some(*ekwb_schema_variant.id()),
         component_id: Some(*ekwb_component.id()),
         ..AttributeReadContext::default()
     };
     let noctua_component_view_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*noctua_schema.id()),
-        schema_variant_id: Some(*noctua_schema_variant.id()),
         component_id: Some(*noctua_component.id()),
         ..AttributeReadContext::default()
     };

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -67,8 +67,6 @@ async fn set_code_prop_for_component(ctx: &DalContext) {
     // Set a value on the prop to check if our code generation works as intended.
     let read_context = AttributeReadContext {
         prop_id: Some(*poop_prop.id()),
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -100,8 +98,6 @@ async fn set_code_prop_for_component(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -99,8 +99,6 @@ async fn check_validations_for_component(ctx: &DalContext) {
             .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -341,8 +339,6 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
             .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -425,13 +421,7 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
         .expect("Update validation func code");
     let mut cache: HashMap<PropId, (Option<Value>, AttributeValue)> = HashMap::new();
     component
-        .check_single_validation(
-            ctx,
-            &validation_prototype,
-            &mut cache,
-            *schema_variant.id(),
-            *schema.id(),
-        )
+        .check_single_validation(ctx, &validation_prototype, &mut cache)
         .await
         .expect("check single validation");
 
@@ -559,14 +549,6 @@ async fn ensure_validations_are_sourced_correctly(ctx: &DalContext) {
             .await
             .expect("could not get attribute value by id")
             .expect("attribute value not found by id");
-        assert_eq!(
-            attribute_value.context.schema_id(),
-            component_payload.schema_id
-        );
-        assert_eq!(
-            attribute_value.context.schema_variant_id(),
-            component_payload.schema_variant_id
-        );
         assert_eq!(
             attribute_value.context.component_id(),
             component_payload.component_id

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -420,7 +420,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 
 #[test]
 async fn only_string_props(ctx: &DalContext) {
-    let (schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
+    let (_schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
     let (component, _) =
         Component::new_for_schema_variant_with_node(ctx, "capoeira", schema_variant.id())
@@ -428,10 +428,7 @@ async fn only_string_props(ctx: &DalContext) {
             .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -486,8 +483,6 @@ async fn only_string_props(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -513,7 +508,7 @@ async fn only_string_props(ctx: &DalContext) {
 
 #[test]
 async fn one_object_prop(ctx: &DalContext) {
-    let (schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
+    let (_schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
     let (component, _) =
         Component::new_for_schema_variant_with_node(ctx, "santos dumont", schema_variant.id())
@@ -521,10 +516,7 @@ async fn one_object_prop(ctx: &DalContext) {
             .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -599,8 +591,6 @@ async fn one_object_prop(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -626,7 +616,7 @@ async fn one_object_prop(ctx: &DalContext) {
 #[test]
 async fn nested_object_prop(ctx: &DalContext) {
     let (
-        schema,
+        _schema,
         schema_variant,
         queen_prop,
         bohemian_prop,
@@ -641,10 +631,7 @@ async fn nested_object_prop(ctx: &DalContext) {
             .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -759,8 +746,6 @@ async fn nested_object_prop(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -792,7 +777,7 @@ async fn nested_object_prop(ctx: &DalContext) {
 
 #[test]
 async fn simple_array_of_strings(ctx: &DalContext) {
-    let (schema, schema_variant, sammy_prop, album_prop, root_prop) =
+    let (_schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
     let (component, _) =
@@ -801,10 +786,7 @@ async fn simple_array_of_strings(ctx: &DalContext) {
             .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -864,8 +846,6 @@ async fn simple_array_of_strings(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -892,7 +872,7 @@ async fn simple_array_of_strings(ctx: &DalContext) {
 #[test]
 async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
     let (
-        schema,
+        _schema,
         schema_variant,
         sammy_prop,
         album_object_prop,
@@ -909,10 +889,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
     .await
     .expect("Unable to create component");
 
-    let mut unset_attribute_context = AttributeContext::builder();
-    unset_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id());
+    let unset_attribute_context = AttributeContext::builder();
     let mut base_attribute_context = unset_attribute_context;
     base_attribute_context.set_component_id(*component.id());
 
@@ -1114,8 +1091,6 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -1152,7 +1127,7 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
 
 #[test]
 async fn simple_map(ctx: &DalContext) {
-    let (schema, schema_variant, album_prop, album_item_prop, root_prop) =
+    let (_schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
     let (component, _) = Component::new_for_schema_variant_with_node(
         ctx,
@@ -1163,10 +1138,7 @@ async fn simple_map(ctx: &DalContext) {
     .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -1226,8 +1198,6 @@ async fn simple_map(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::any()
         },
@@ -1253,7 +1223,7 @@ async fn simple_map(ctx: &DalContext) {
 #[test]
 async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
     let (
-        schema,
+        _schema,
         schema_variant,
         sammy_prop,
         album_object_prop,
@@ -1272,10 +1242,7 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
     .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -1406,10 +1373,8 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
     let component_view = ComponentView::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
-            component_id: Some(*component.id()),
             prop_id: None,
+            component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },
     )
@@ -1548,12 +1513,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
 
     let external_provider_attribute_value = AttributeValue::find_for_context(
         ctx,
-        AttributeReadContext {
-            external_provider_id: Some(*external_provider.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
-            ..AttributeReadContext::default()
-        },
+        AttributeReadContext::default_with_external_provider(*external_provider.id()),
     )
     .await
     .unwrap()
@@ -1631,12 +1591,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     // Assign the func for the object prop.
     let ragnarok_attribute_value = AttributeValue::find_for_context(
         ctx,
-        AttributeReadContext {
-            prop_id: Some(*ragnarok_prop.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
-            ..AttributeReadContext::default()
-        },
+        AttributeReadContext::default_with_prop(*ragnarok_prop.id()),
     )
     .await
     .expect("could not perform find for context")
@@ -1675,8 +1630,6 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
             .await
             .expect("unable to create component");
     let base_attribute_read_context = AttributeReadContext {
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -31,8 +31,6 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant_id),
             component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },
@@ -82,8 +80,6 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: None,
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant_id),
             component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -40,10 +40,8 @@ async fn property_editor_value(ctx: &DalContext) {
     let property_editor_values = PropertyEditorValues::for_context(
         ctx,
         AttributeReadContext {
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant_id),
-            component_id: Some(*component.id()),
             prop_id: None,
+            component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },
     )

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -358,8 +358,6 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
         node_id: *node.id(),
         base_attribute_read_context: AttributeReadContext {
             prop_id: None,
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             component_id: Some(*component.id()),
             ..AttributeReadContext::default()
         },
@@ -422,8 +420,6 @@ async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -549,8 +545,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
         ctx,
         AttributeReadContext {
             prop_id: Some(*destination_object_prop.id()),
-            schema_id: Some(*destination_schema.id()),
-            schema_variant_id: Some(*destination_schema_variant.id()),
             ..AttributeReadContext::default()
         },
     )
@@ -594,8 +588,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
 
     let source_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*source_schema.id()),
-        schema_variant_id: Some(*source_schema_variant.id()),
         component_id: Some(*source_component.id()),
         ..AttributeReadContext::default()
     };
@@ -623,8 +615,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
 
     let destination_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*destination_schema.id()),
-        schema_variant_id: Some(*destination_schema_variant.id()),
         component_id: Some(*destination_component.id()),
         ..AttributeReadContext::default()
     };
@@ -693,8 +683,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
 
     let source_foo_update_context = AttributeContext::builder()
         .set_prop_id(*source_foo_prop.id())
-        .set_schema_id(*source_schema.id())
-        .set_schema_variant_id(*source_schema_variant.id())
         .set_component_id(*source_component.id())
         .to_context()
         .expect("could not create source foo update context");
@@ -777,8 +765,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
 
     let source_bar_update_context = AttributeContext::builder()
         .set_prop_id(*source_bar_prop.id())
-        .set_schema_id(*source_schema.id())
-        .set_schema_variant_id(*source_schema_variant.id())
         .set_component_id(*source_component.id())
         .to_context()
         .expect("could not create source foo update context");

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -67,8 +67,6 @@ async fn intra_component_identity_update(ctx: &DalContext) {
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };
@@ -357,8 +355,6 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
         ctx,
         AttributeReadContext {
             external_provider_id: Some(*external_provider.id()),
-            schema_id: Some(*schema.id()),
-            schema_variant_id: Some(*schema_variant.id()),
             ..AttributeReadContext::default()
         },
     )
@@ -420,10 +416,7 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
             .expect("unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
-    base_attribute_context
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
-        .set_component_id(*component.id());
+    base_attribute_context.set_component_id(*component.id());
 
     let domain_context = base_attribute_context
         .clone()
@@ -459,8 +452,6 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
     .expect("run update for context");
 
     let base_attribute_read_context = AttributeReadContext {
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -80,8 +80,6 @@ async fn new(ctx: &DalContext) {
     let context = AttributeContext::builder()
         .set_prop_id(*prop.id())
         .set_component_id(*component.id())
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
         .to_context()
         .expect("unable to build attribute context");
     let attribute_value = AttributeValue::new(
@@ -188,8 +186,6 @@ async fn find_errors(ctx: &DalContext) {
     let context = AttributeContext::builder()
         .set_prop_id(*prop.id())
         .set_component_id(*component.id())
-        .set_schema_id(*schema.id())
-        .set_schema_variant_id(*schema_variant.id())
         .to_context()
         .expect("unable to build attribute context");
     let attribute_value = AttributeValue::new(

--- a/lib/dal/tests/integration_test/workflow_prototype.rs
+++ b/lib/dal/tests/integration_test/workflow_prototype.rs
@@ -104,16 +104,10 @@ async fn resolve(ctx: &DalContext) {
         .expect("unable to find docker image schema")
         .pop()
         .expect("unable to find docker image");
-    let schema_variant = schema
-        .default_variant(ctx)
-        .await
-        .expect("unable to find default schema variant");
     let component = create_component_for_schema(ctx, schema.id()).await;
 
     let context = AttributeReadContext {
         prop_id: None,
-        schema_id: Some(*schema.id()),
-        schema_variant_id: Some(*schema_variant.id()),
         component_id: Some(*component.id()),
         ..AttributeReadContext::default()
     };

--- a/lib/sdf/src/server/service/component/get_property_editor_values.rs
+++ b/lib/sdf/src/server/service/component/get_property_editor_values.rs
@@ -32,24 +32,9 @@ pub async fn get_property_editor_values(
         return Err(ComponentError::InvalidVisibility);
     }
 
-    let component = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .ok_or(ComponentError::ComponentNotFound)?;
-    let schema_id = *component
-        .schema(&ctx)
-        .await?
-        .ok_or(ComponentError::SchemaNotFound)?
-        .id();
-    let schema_variant_id = *component
-        .schema_variant(&ctx)
-        .await?
-        .ok_or(ComponentError::SchemaVariantNotFound)?
-        .id();
     let context = AttributeReadContext {
-        schema_id: Some(schema_id),
-        schema_variant_id: Some(schema_variant_id),
-        component_id: Some(request.component_id),
         prop_id: None,
+        component_id: Some(request.component_id),
         ..AttributeReadContext::default()
     };
     let prop_edit_values = PropertyEditorValues::for_context(&ctx, context).await?;

--- a/lib/sdf/src/server/service/diagram/create_connection.rs
+++ b/lib/sdf/src/server/service/diagram/create_connection.rs
@@ -59,7 +59,7 @@ pub async fn create_connection(
         .await?
         .ok_or(DiagramError::SchemaVariantNotFound)?;
 
-    let schema = schema_variant
+    let _schema = schema_variant
         .schema(&ctx)
         .await?
         .ok_or(DiagramError::SchemaNotFound)?;
@@ -72,10 +72,8 @@ pub async fn create_connection(
             ))?;
 
     let attribute_value_context = AttributeReadContext {
-        component_id: Some(*component.id()),
-        schema_variant_id: Some(*schema_variant.id()),
-        schema_id: Some(*schema.id()),
         external_provider_id: Some(*from_socket_external_provider.id()),
+        component_id: Some(*component.id()),
         ..Default::default()
     };
     let attribute_value = AttributeValue::find_for_context(&ctx, attribute_value_context)

--- a/lib/sdf/src/server/service/func/exec_func.rs
+++ b/lib/sdf/src/server/service/func/exec_func.rs
@@ -5,7 +5,7 @@ use dal::{
     job::definition::{DependentValuesUpdate, Qualification},
     AttributePrototype, AttributeValue, Component, DalContext, Func, FuncBackendKind, FuncId,
     PropId, PrototypeListForFunc, QualificationPrototype, QualificationPrototypeError,
-    SchemaVariant, StandardModel, ValidationPrototype, Visibility, WsEvent,
+    StandardModel, ValidationPrototype, Visibility, WsEvent,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -80,18 +80,9 @@ async fn run_validations(ctx: &DalContext, func: &Func) -> FuncResult<()> {
         }
         let components = Component::list_for_schema_variant(ctx, schema_variant_id).await?;
         for component in components {
-            let schema_variant = SchemaVariant::get_by_id(ctx, &schema_variant_id)
-                .await?
-                .ok_or_else(|| FuncError::ComponentMissingSchemaVariant(*component.id()))?;
-
-            let schema = schema_variant
-                .schema(ctx)
-                .await?
-                .ok_or(FuncError::SchemaVariantMissingSchema(schema_variant_id))?;
-
             let mut cache: HashMap<PropId, (Option<Value>, AttributeValue)> = HashMap::new();
             component
-                .check_single_validation(ctx, &proto, &mut cache, schema_variant_id, *schema.id())
+                .check_single_validation(ctx, &proto, &mut cache)
                 .await?;
         }
     }

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -132,7 +132,7 @@ async fn save_attr_func_prototypes(
 ) -> FuncResult<()> {
     let mut id_set = HashSet::new();
     for proto_view in prototypes {
-        let context = proto_view.into_context(ctx).await?;
+        let context = proto_view.to_attribute_context()?;
 
         let (mut existing_value_proto, need_to_create) =
             match AttributePrototype::find_for_context(ctx, context)


### PR DESCRIPTION
Drop `schema_id` and `schema_variant_id` from `AttributeContext` and all relevant locations. `Props` and providers are unique for a given `Schema` and `SchemaVariant`, so the distinction is unimportant.

The one location this change may affect the most is builtins. Generally, intelligence functions and setup operations were being done in `SchemaVariant`-specific contexts.

<img src="https://media3.giphy.com/media/1xu1qTIEadfwAJXaiY/giphy.gif"/>

Fixes ENG-829