### PR TITLE
feat(dal): Add child internal provider values of objects to dep graph

### DIFF
--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1448,7 +1448,6 @@ async fn cyclone_crypto_e2e(ctx: &DalContext) {
 }
 
 #[test]
-#[ignore = "does not pass yet because of object vivification bugs"]
 async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     // Create and setup the schema and schema variant.
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
@@ -1534,7 +1533,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     .await
     .expect("could not create func");
     let code = "function getKratos(input) {
-        return input.ragnarok.kratos ?? '';
+        return input.ragnarok.kratos.toUpperCase() ?? '';
     }";
     transformation_func
         .set_code_plaintext(ctx, Some(code))
@@ -1657,7 +1656,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     );
 
     assert_eq!(
-        Some(serde_json::json!["canoe"]),
+        Some(serde_json::json!["POOP"]),
         dump_value(
             ctx,
             AttributeReadContext {
@@ -1666,7 +1665,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
             },
         )
         .await,
-        "ensure external provider gets value of atreus internal provider",
+        "ensure external provider gets value of kratos internal provider in upper case",
     );
 
     // Prop structure gets the expected values...

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -825,4 +825,31 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             .expect("cannot get destination component view")
             .properties,
     );
+
+    // confirm the presence of the correct internal provider value for a leaf of the base_object
+    // on the destination component
+    let destination_foo_ip = InternalProvider::find_for_prop(ctx, *destination_foo_prop.id())
+        .await
+        .expect("find ip for foo_string prop")
+        .expect("ip for foo string should exist");
+
+    let destination_foo_ip_av = AttributeValue::find_for_context(
+        ctx,
+        AttributeReadContext {
+            internal_provider_id: Some(*destination_foo_ip.id()),
+            component_id: Some(*destination_component.id()),
+            ..AttributeReadContext::default()
+        },
+    )
+    .await
+    .expect("find attribute value for foo_string internal provider")
+    .expect("attribute value for foo_string internal provider should exist");
+
+    assert_eq!(
+        Some(serde_json::json!["deep update"]),
+        destination_foo_ip_av
+            .get_value(ctx)
+            .await
+            .expect("able to get value")
+    );
 }


### PR DESCRIPTION
When we set the value of an object, we need to include the child props and internal providers in the dependency graph lookup, and we need to make sure
we do it at any stage in the update job process, without having to spawn multiple jobs. If we *don't* do this, the following scenario might occur:

An object prop is updated on component A. An explicit ExternalProvider is configured to take the value of that prop. An edge is connected to component B which takes the value of the ExternalProvider on A. The object on B is updated, but without this change, *the child values of the object on B* will not have their internal providers set, or added to the dependency graph, so any functions set to rely on them as arguments *will not be executed*. Adding those child internal providers to the dep graph ensures we don't stop our update chain at the root of the object when its value lands in component B.

![image](https://user-images.githubusercontent.com/1928978/206232833-6e10caa0-de75-4307-b615-af3419d8900f.png)

Relies on the changes in [zacharyhamm/remove-prop-object-check-in-vivify](https://github.com/systeminit/si/pull/1584)

Resolves ENG-820 and ENG-821