### PR TITLE
fix(dal): fix prototype override for region.name

### DIFF
--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -968,6 +968,9 @@ impl MigrationDriver {
             .find_child_prop_by_name(ctx, root_prop.si_prop_id, "name")
             .await?;
 
+        self.set_default_value_for_prop(ctx, *si_name_prop.id(), serde_json::json!["region"])
+            .await?;
+
         let si_name_attribute_value = AttributeValue::find_for_context(
             ctx,
             AttributeReadContext::default_with_prop(*si_name_prop.id()),


### PR DESCRIPTION
Additionally, set_value_by_json_pointer has been rename to set_name and will not override the name prop if it has a custom function set on it.

Co-Authored-By: Victor Bustamante <victor@systeminit.com>
Co-Authored-By: Paul Stack <paul@systeminit.com>
Co-Authored-By: Nick Gerace <nick@systeminit.com>
Co-Authored-By: Paulo Cabral <paulo@systeminit.com>