### PR TITLE
feat(web,dal): Add the ability to change node types for a schema

### DIFF
--- a/app/web/src/organisms/GenericDiagram/DiagramDemoPage.vue
+++ b/app/web/src/organisms/GenericDiagram/DiagramDemoPage.vue
@@ -124,6 +124,7 @@ const nodes = reactive<DiagramNodeDef[]>([
     color: colors.action[500],
     typeIcon: "logo-docker",
     isLoading: false,
+    nodeType: "component",
   },
   {
     id: "n2",
@@ -135,6 +136,7 @@ const nodes = reactive<DiagramNodeDef[]>([
     color: "#A752DE",
     typeIcon: "logo-docker",
     isLoading: false,
+    nodeType: "component",
   },
   {
     id: "n3",
@@ -153,6 +155,7 @@ const nodes = reactive<DiagramNodeDef[]>([
       // { icon: "logo-docker", tone: "neutral" },
     ],
     isLoading: false,
+    nodeType: "component",
   },
   {
     id: "n4",
@@ -164,6 +167,7 @@ const nodes = reactive<DiagramNodeDef[]>([
     color: "#5AACAD",
     typeIcon: "logo-k8s",
     isLoading: false,
+    nodeType: "component",
   },
   {
     id: "n5",
@@ -175,6 +179,7 @@ const nodes = reactive<DiagramNodeDef[]>([
     color: "#FF9900",
     typeIcon: "logo-k8s",
     isLoading: true,
+    nodeType: "component",
   },
 ]);
 
@@ -237,6 +242,7 @@ function onInsert(e: InsertElementEvent) {
         sockets: getSockets(`n${newNodeId}`),
         typeIcon: "logo-docker",
         isLoading: false,
+        nodeType: "component",
       });
 
       // parent needs to call this when insert is complete

--- a/app/web/src/organisms/GenericDiagram/DiagramNode.vue
+++ b/app/web/src/organisms/GenericDiagram/DiagramNode.vue
@@ -270,7 +270,10 @@ const subtitleTextRef = ref();
 const groupRef = ref();
 
 const leftSockets = computed(() =>
-  _.filter(props.node.sockets, (s) => s.def.nodeSide === "left"),
+  _.filter(
+    props.node.sockets,
+    (s) => s.def.nodeSide === "left" && s.def.label !== "Frame",
+  ),
 );
 const rightSockets = computed(() =>
   _.filter(props.node.sockets, (s) => s.def.nodeSide === "right"),

--- a/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
+++ b/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
@@ -1605,13 +1605,13 @@ function onNodeLayoutOrLocationChange(el: DiagramNodeData | DiagramGroupData) {
 
 const nodes = computed(() =>
   _.map(
-    _.filter(props.nodes, (n) => n.childIds === undefined),
+    _.filter(props.nodes, (n) => n.nodeType === "component"),
     (nodeDef) => new DiagramNodeData(nodeDef),
   ),
 );
 const groups = computed(() =>
   _.map(
-    _.filter(props.nodes, (n) => n.childIds !== undefined),
+    _.filter(props.nodes, (n) => n.nodeType !== "component"),
     (groupDef) => new DiagramGroupData(groupDef),
   ),
 );

--- a/app/web/src/organisms/GenericDiagram/diagram_types.ts
+++ b/app/web/src/organisms/GenericDiagram/diagram_types.ts
@@ -145,6 +145,8 @@ export type DiagramNodeDef = {
   color?: string | null;
   /** icon (name/slug) used to help convey node type */
   typeIcon?: string | null;
+  /** type of node - possible options are component, configurationFrame or aggregationFrame */
+  nodeType: "component" | "configurationFrame" | "aggregationFrame";
   /** array of icons (slug and colors) to show statuses */
   statusIcons?: DiagramStatusIcon[];
   /** if true, node shows the `loading` overlay */

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -52,6 +52,7 @@ type Component = {
   schemaVariantName: string;
   icon: IconNames;
   color: string;
+  nodeType: "component" | "configurationFrame" | "aggregationFrame";
   changeStatus?: ComponentChangeStatus;
   // TODO: probably want to move this to a different store and not load it all the time
   resource: Resource;
@@ -189,7 +190,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             return {
               id: ci.componentId,
               // TODO: return this info from the backend (and not in category)
-              isGroup: socketFromChildren !== undefined,
               parentId: frameEdge?.toNodeId,
               childIds: socketFromChildren ? frameChildIds : undefined,
               displayName: diagramNode?.subtitle,
@@ -202,6 +202,8 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               icon: typeIcon,
               color: diagramNode?.color,
               changeStatus: this.componentChangeStatusById[ci.componentId],
+              nodeType: diagramNode?.nodeType,
+              isGroup: diagramNode?.nodeType !== "component",
             } as Component;
           });
         },
@@ -245,6 +247,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               ...node,
               parentId: component.parentId,
               childIds: component.childIds,
+              nodeType: component.nodeType,
               isLoading:
                 !!statusStore.componentStatusById[componentId]?.isUpdating,
               typeIcon: component?.icon || "logo-si",

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -255,6 +255,25 @@ impl MigrationDriver {
         Err(PropError::ExpectedChildNotFound(child_prop_name.to_string()).into())
     }
 
+    pub async fn finalize_schema_variant(
+        &self,
+        ctx: &DalContext,
+        schema_variant: &SchemaVariant,
+        root_prop: &RootProp,
+    ) -> BuiltinsResult<()> {
+        schema_variant.finalize(ctx).await?;
+
+        // set the default type for the node to be a component
+        // individual schemas can override this value where appropriate
+        let type_prop = self
+            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "type")
+            .await?;
+        self.set_default_value_for_prop(ctx, *type_prop.id(), serde_json::json!["component"])
+            .await?;
+
+        Ok(())
+    }
+
     /// Set a default [`Value`](serde_json::Value) for a given [`Prop`](crate::Prop) in a
     /// [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant).
     ///

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -191,7 +191,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Connect the props to providers.
         let external_provider_attribute_prototype_id = image_id_external_provider
@@ -563,7 +564,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -916,24 +918,6 @@ impl MigrationDriver {
         )
         .await?;
 
-        // Sockets
-        let identity_func_item = self
-            .get_func_item("si:identity")
-            .ok_or(BuiltinsError::FuncNotFoundInMigrationCache("si:identity"))?;
-
-        // Input Socket
-        let (_frame_internal_provider, _input_socket) = InternalProvider::new_explicit_with_socket(
-            ctx,
-            *schema_variant.id(),
-            "Frame",
-            identity_func_item.func_id,
-            identity_func_item.func_binding_id,
-            identity_func_item.func_binding_return_value_id,
-            SocketArity::Many,
-            DiagramKind::Configuration,
-        )
-        .await?;
-
         // Output Socket
         let identity_func_item = self
             .get_func_item("si:identity")
@@ -954,7 +938,20 @@ impl MigrationDriver {
         output_socket.set_color(ctx, Some(0xd61e8c)).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
+
+        // set the component as a configuration frame
+        let si_type_prop = self
+            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "type")
+            .await?;
+
+        self.set_default_value_for_prop(
+            ctx,
+            *si_type_prop.id(),
+            serde_json::json!["configurationFrame"],
+        )
+        .await?;
 
         let region_implicit_internal_provider =
             InternalProvider::find_for_prop(ctx, *region_prop.id())
@@ -1224,7 +1221,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -1587,7 +1585,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -322,7 +322,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -846,7 +847,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -1244,7 +1246,8 @@ impl MigrationDriver {
         QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up!
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set Defaults
         self.set_default_value_for_prop(

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -120,7 +120,8 @@ impl MigrationDriver {
         let _ = QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
         // Wrap it up.
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Collect the props we need.
         let prop_cache = maybe_prop_cache

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -76,7 +76,8 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x1e88d6)).await?;
 
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Note: I wasn't able to create a ui menu with two layers
         let diagram_kind = schema
@@ -191,7 +192,8 @@ impl MigrationDriver {
 
         let _ = QualificationPrototype::new(ctx, *qual_func.id(), qual_prototype_context).await?;
 
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/image" field.
         let image_attribute_value = AttributeValue::find_for_context(

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -109,7 +109,8 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x85c9a3)).await?;
 
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/metadata/name" field.
         let metadata_name_prop = self
@@ -306,7 +307,8 @@ impl MigrationDriver {
         let ui_menu = SchemaUiMenu::new(ctx, "Deployment", "Kubernetes", &diagram_kind).await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
-        schema_variant.finalize(ctx).await?;
+        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+            .await?;
 
         // Set default values after finalization.
         self.set_default_value_for_prop(ctx, *api_version_prop.id(), serde_json::json!["apps/v1"])

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -145,6 +145,7 @@ pub struct DiagramNodeView {
     position: GridPoint,
     size: Option<Size2D>,
     color: Option<String>,
+    node_type: String,
 }
 
 impl DiagramNodeView {
@@ -203,6 +204,10 @@ impl DiagramNodeView {
                         .color()
                         .map(|color_int| format!("#{color_int:x}"))
                 }),
+            node_type: component
+                .find_value_by_json_pointer::<String>(ctx, "/root/si/type")
+                .await?
+                .unwrap_or_else(|| "component".to_string()),
         })
     }
 

--- a/lib/dal/tests/integration_test/builtins/aws_region.rs
+++ b/lib/dal/tests/integration_test/builtins/aws_region.rs
@@ -35,7 +35,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             },
             "code": {},
             "si": {
-                "name": "us-east-2"
+                "name": "us-east-2",
+                "type": "configurationFrame"
             }
         }], // expected
         region_payload.component_view_properties(ctx).await // actual
@@ -55,7 +56,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
                 },
             },
             "si": {
-                "name": "server"
+                "name": "server",
+                "type": "component"
             }
         }], // expected
         ec2_payload.component_view_properties(ctx).await // actual
@@ -99,7 +101,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             },
             "code": {},
             "si": {
-                "name": "us-east-2"
+                "name": "us-east-2",
+                "type": "configurationFrame"
             }
         }], // expected
         region_payload.component_view_properties(ctx).await // actual
@@ -119,7 +122,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
                 },
             },
             "si": {
-                "name": "server"
+                "name": "server",
+                "type": "component"
             }
         }], // expected
         ec2_payload.component_view_properties(ctx).await // actual
@@ -142,7 +146,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             },
             "code": {},
             "si": {
-                "name": "us-west-2"
+                "name": "us-west-2",
+                "type": "configurationFrame"
             }
         }], // expected
         region_payload.component_view_properties(ctx).await // actual
@@ -163,7 +168,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
                 },
             },
             "si": {
-                "name": "server"
+                "name": "server",
+                "type": "component"
             }
         }], // expected
         ec2_payload.component_view_properties(ctx).await // actual
@@ -188,11 +194,12 @@ async fn aws_region_field_validation(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "us-poop-1"
+                "name": "us-poop-1",
+                "type": "configurationFrame"
             },
             "code": {},
             "domain": {
-                "region": "us-poop-1"
+                "region": "us-poop-1",
             }
         }], // actual
         region_payload.component_view_properties(ctx).await // expected
@@ -242,7 +249,8 @@ async fn aws_region_field_validation(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "us-east-1"
+                "name": "us-east-1",
+                "type": "configurationFrame",
             },
             "code": {},
             "domain": {

--- a/lib/dal/tests/integration_test/builtins/coreos_butane.rs
+++ b/lib/dal/tests/integration_test/builtins/coreos_butane.rs
@@ -104,6 +104,7 @@ async fn butane_to_ec2_user_data_is_valid_ignition(ctx: &DalContext) {
         serde_json::json![{
             "si": {
                 "name": "Mimic Tear",
+                "type": "component"
             },
             "code": {
                 "si:generateButaneIgnition": {

--- a/lib/dal/tests/integration_test/builtins/docker_image_intelligence.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_intelligence.rs
@@ -24,6 +24,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "soulrender",
+                "type": "component"
             },
         }], // expected
         soulrender_payload.component_view_properties(ctx).await // actual
@@ -36,6 +37,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "bloodscythe",
+                "type": "component"
             },
         }], // expected
         bloodscythe_payload.component_view_properties(ctx).await // actual
@@ -59,6 +61,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "soulrender",
+                "type": "component"
             },
         }], // expected
         soulrender_payload.component_view_properties(ctx).await // actual
@@ -72,6 +75,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "bloodscythe-updated",
+                "type": "component"
             },
         }], // expected
         bloodscythe_payload.component_view_properties(ctx).await // actual
@@ -95,6 +99,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "soulrender-updated",
+                "type": "component"
             },
         }], // expected
         soulrender_payload.component_view_properties(ctx).await // actual
@@ -107,6 +112,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "bloodscythe-updated",
+                "type": "component"
             },
         }], // expected
         bloodscythe_payload.component_view_properties(ctx).await // actual

--- a/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
@@ -28,7 +28,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
             },
             "code": {},
             "si": {
-                "name": "tail"
+                "name": "tail",
+                "type": "component"
             }
         }], // expected
         tail_docker_image_payload
@@ -48,7 +49,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                 "kind": "Deployment",
             },
             "si": {
-                "name": "deployment"
+                "name": "deployment",
+                "type": "component"
             }
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual
@@ -92,7 +94,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                 "image": "tail"
             },
             "si": {
-                "name": "tail"
+                "name": "tail",
+                "type": "component"
             }
         }], // expected
         tail_docker_image_payload
@@ -112,7 +115,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                 "kind": "Deployment",
             },
             "si": {
-                "name": "deployment"
+                "name": "deployment",
+                "type": "component"
             }
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual
@@ -135,7 +139,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                 "image": "ironsides"
             },
             "si": {
-                "name": "ironsides"
+                "name": "ironsides",
+                "type": "component"
             }
         }], // expected
         tail_docker_image_payload
@@ -169,7 +174,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalC
                 },
             },
             "si": {
-                "name": "deployment"
+                "name": "deployment",
+                "type": "component"
             },
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual

--- a/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
@@ -108,7 +108,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "fedora"
+                "name": "fedora",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -122,7 +123,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "alpine"
+                "name": "alpine",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -136,7 +138,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "namespace"
+                "name": "namespace",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -155,7 +158,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "spongebob"
+                "name": "spongebob",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -175,7 +179,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "patrick"
+                "name": "patrick",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -217,7 +222,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "fedora-updated"
+                "name": "fedora-updated",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -231,7 +237,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "alpine"
+                "name": "alpine",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -245,7 +252,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "namespace"
+                "name": "namespace",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -264,7 +272,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "spongebob"
+                "name": "spongebob",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -297,7 +306,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "patrick"
+                "name": "patrick",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -376,7 +386,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "fedora-updated-twice"
+                "name": "fedora-updated-twice",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -390,7 +401,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "alpine-updated"
+                "name": "alpine-updated",
+                "type": "component"
             },
             "code": {},
             "domain": {
@@ -404,7 +416,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "namespace"
+                "name": "namespace",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -423,7 +436,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "spongebob"
+                "name": "spongebob",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {
@@ -467,7 +481,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "patrick"
+                "name": "patrick",
+                "type": "component"
             },
             "code": {
                 "si:generateYAML": {

--- a/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -35,7 +35,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "tail"
+                "name": "tail",
+                "type": "component"
             }
         }], // expected
         tail_namespace_payload.component_view_properties(ctx).await // actual
@@ -53,7 +54,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "head"
+                "name": "head",
+                "type": "component"
             }
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual
@@ -104,7 +106,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "tail"
+                "name": "tail",
+                "type": "component"
             }
         }], // expected
         tail_namespace_payload.component_view_properties(ctx).await // actual
@@ -122,7 +125,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "head"
+                "name": "head",
+                "type": "component"
             }
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual
@@ -152,7 +156,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "look-at-me-mom-i-updated"
+                "name": "look-at-me-mom-i-updated",
+                "type": "component"
             }
         }], // expected
         tail_namespace_payload.component_view_properties(ctx).await // actual
@@ -181,7 +186,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
                 },
             },
             "si": {
-                "name": "head"
+                "name": "head",
+                "type": "component"
             }
         }], // expected
         head_deployment_payload.component_view_properties(ctx).await // actual

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -526,11 +526,12 @@ async fn ensure_validations_are_sourced_correctly(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "us-east-1"
+                "name": "us-east-1",
+                "type": "configurationFrame",
             },
             "code": {},
             "domain": {
-                "region": "us-east-1"
+                "region": "us-east-1",
             }
         }], // actual
         component_payload.component_view_properties(ctx).await // expected

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -45,6 +45,7 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "13700KF",
+                "type": "component"
             },
         }], // expected
         component_view.properties // actual
@@ -94,6 +95,7 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
             "code": {},
             "si": {
                 "name": "13700KF",
+                "type": "component"
             },
         }], // expected
         component_view.properties // actual


### PR DESCRIPTION
![frame changes](https://i.imgflip.com/73nnix.jpg)

Originally we were determining a frame due to presence of childIds,
now we have a nodeType prop that can be a frame but defaults to
a component

The user can change this type in the property editor panel on the UI
to promote a component to be a frame

All nodes have an input and output frame socket by default not but we
hide input Frame sockets when the node type is a component

Co-authored-by: Victor Bustamente<victor@systeminit.com>
