### PR TITLE
cleaning up console logs in the frontend

### DIFF
--- a/app/web/.eslintrc.js
+++ b/app/web/.eslintrc.js
@@ -26,6 +26,8 @@ module.exports = {
     },
   },
   rules: {
+    "prettier/prettier": process.env.STRICT_LINT ? "error" : "warn",
+
     // some customizations of vue rules ------------------
     // standard order of sections in vue SFCs
     "vue/component-tags-order": [
@@ -120,27 +122,24 @@ module.exports = {
     "@typescript-eslint/naming-convention": 0,
     "@typescript-eslint/no-shadow": 0,
     "guard-for-in": 0,
-    "no-console": 0,
 
     // some rules to downgrade to warning while developing --------------------
     // useful so things dont crash when code is temporarily commented out
+    "no-console": process.env.STRICT_LINT ? "error" : "warn",
     "@typescript-eslint/no-empty-function": process.env.STRICT_LINT
       ? "error"
       : "warn",
     "no-debugger": process.env.STRICT_LINT ? "error" : "warn",
     "no-alert": process.env.STRICT_LINT ? "error" : "warn",
     "no-empty": process.env.STRICT_LINT ? "error" : "warn",
-    // "no-console": process.env.STRICT_LINT ? "error" : "warn",
 
-    // rules that we want to warn, but disable agressive auto-fixing
+    // rules that we want to warn, but disable agressive auto-fixing -----------
     "prefer-const": 0,
     "no-unreachable": 0, // handy when you return early or throw an error while debugging
     // unreachable code will be removed by default, so we disable autofix, but leave a warning
     "no-autofix/no-unreachable": 1,
     // useful while debugging and commenting things out, otherwise gets automatically changed from let to const
     "no-autofix/prefer-const": process.env.STRICT_LINT ? "error" : "warn",
-
-    "prettier/prettier": process.env.STRICT_LINT ? "error" : "warn",
   },
 
   overrides: [

--- a/app/web/src/molecules/HealthIcon.vue
+++ b/app/web/src/molecules/HealthIcon.vue
@@ -10,11 +10,11 @@
 
     <span
       class="flex flex-col w-full h-full break-words"
-      :title="props.message.join('\n')"
+      :title="message.join('\n')"
     >
       <strong
-        v-for="(message, index) in props.message"
-        :key="message"
+        v-for="(singleMessage, index) in message"
+        :key="singleMessage"
         class="mt-1 ml-1"
       >
         {{ message }}
@@ -26,9 +26,7 @@
           View Details
         </button>
       </strong>
-      <strong v-if="props.message.length === 0"
-        >Health {{ props.health }}</strong
-      >
+      <strong v-if="message.length === 0">Health {{ health }}</strong>
     </span>
 
     <Modal size="2xl" :open="modalOpen" @close="closeModal">
@@ -44,14 +42,14 @@
 
           <span class="flex flex-col">
             <p
-              v-for="message in props.message"
-              :key="message"
+              v-for="singleMessage in message"
+              :key="singleMessage"
               class="mt-1 ml-1"
             >
               {{ message }}
             </p>
           </span>
-          <p v-if="props.message.length === 0">Health {{ props.health }}</p>
+          <p v-if="message.length === 0">Health {{ health }}</p>
         </span>
       </template>
       <template #content>

--- a/app/web/src/organisms/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/organisms/FuncEditor/AttributeBindings.vue
@@ -146,7 +146,6 @@ const associations = toRef(props, "associations", {
 });
 
 const prototypeView = computed(() => {
-  console.log("prototypeView");
   return associations.value.prototypes.map((proto) => {
     const schemaVariant =
       schemaVariantOptions.value.find(

--- a/app/web/src/organisms/FuncEditor/FuncPicker.vue
+++ b/app/web/src/organisms/FuncEditor/FuncPicker.vue
@@ -163,7 +163,6 @@ const emits = defineEmits<{
 }>();
 
 const createFunc = (kind: FuncBackendKind) => {
-  console.log(kind);
   emits("createFunc", { kind, isBuiltin: false });
 };
 

--- a/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
+++ b/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
@@ -574,6 +574,7 @@ function checkIfDragStarted(_e: MouseEvent) {
     beginDrawEdge(lastMouseDownElement.value);
   } else if (lastMouseDownElement.value instanceof DiagramEdgeData) {
     // not sure what dragging an edge means... maybe nothing?
+    /* eslint-disable-next-line no-console */
     console.log("dragging edge ?");
   } else if (
     lastMouseDownElement.value instanceof DiagramNodeData ||
@@ -957,7 +958,7 @@ function onDragElementsMove() {
     else delta.x = 0;
   }
 
-  _.each(currentSelectionMovableElements.value, (el, i) => {
+  _.each(currentSelectionMovableElements.value, (el) => {
     if (!draggedElementsPositionsPreDrag.value?.[el.uniqueKey]) return;
     const newPosition = vectorAdd(
       draggedElementsPositionsPreDrag.value?.[el.uniqueKey],

--- a/app/web/src/organisms/PropertyEditor.vue
+++ b/app/web/src/organisms/PropertyEditor.vue
@@ -88,7 +88,6 @@ const toggleCollapsed = (path: string[]) => {
     }
   }
   collapsed.value.push(path);
-  console.log("new collapsed", { collapsed: JSON.stringify(collapsed.value) });
 };
 
 const findParentProp = (propId: number) => {

--- a/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/organisms/PropertyEditor/PropertyWidget.vue
@@ -212,10 +212,6 @@ const showArrayElementHeader = computed(() => {
   if (_.isUndefined(arrayIndex?.value) && _.isNull(props.propValue.key)) {
     return false;
   } else {
-    console.log("showing array element header", {
-      ai: JSON.stringify(arrayIndex?.value),
-      key: JSON.stringify(props.propValue.key),
-    });
     return true;
   }
   // if (props.schemaProp.kind === "array") {

--- a/app/web/src/organisms/PropertyEditor/WidgetHeader.vue
+++ b/app/web/src/organisms/PropertyEditor/WidgetHeader.vue
@@ -79,7 +79,6 @@ const nestingLevel = computed(() =>
 
 const setCollapsed = () => {
   if (props.path) {
-    console.log("collapsing", { triggerPath: props.path.triggerPath });
     emits("toggle-collapsed", props.path.triggerPath);
   }
 };

--- a/app/web/src/store/auth.store.ts
+++ b/app/web/src/store/auth.store.ts
@@ -49,7 +49,6 @@ export const useAuthStore = defineStore("auth", {
         url: "/session/login",
         params: payload,
         onSuccess: (response) => {
-          console.log("login success!", response);
           // finish login is split out because we'll likely add other login methods or trigger login after signup
           // (ex: oauth, magic link)
           this.finishUserLogin(response);
@@ -65,6 +64,7 @@ export const useAuthStore = defineStore("auth", {
           this.billingAccount = response.billingAccount;
         },
         onFail(e) {
+          /* eslint-disable-next-line no-console */
           console.log("RESTORE AUTH FAILED!", e);
           // trigger logout?
         },

--- a/app/web/src/store/counter.store.ts
+++ b/app/web/src/store/counter.store.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { defineStore } from "pinia";
 import { watch } from "vue";
 import { addStoreHooks } from "@/utils/pinia_hooks_plugin";

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -161,6 +161,7 @@ export const useRealtimeStore = defineStore("realtime", () => {
     eventData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     eventMetadata: RealtimeEventMetadata,
   ) {
+    /* eslint-disable-next-line no-console */
     console.log("WS message", eventKind, eventData);
 
     _.each(subscriptions, (sub) => {
@@ -182,6 +183,7 @@ export const useRealtimeStore = defineStore("realtime", () => {
     );
   });
   socket.addEventListener("error", (errorEvent) => {
+    /* eslint-disable-next-line no-console */
     console.log("ws error", errorEvent.error, errorEvent.message);
   });
 

--- a/app/web/src/ui-lib/menus/DropdownMenu.vue
+++ b/app/web/src/ui-lib/menus/DropdownMenu.vue
@@ -102,7 +102,6 @@ function refreshSortedItemIds() {
     if (domNode1.$el) domNode1 = domNode1.$el;
     if (domNode2.$el) domNode2 = domNode2.$el;
     if (!domNode1 || !domNode2) return 0;
-    console.log(domNode1, domNode2);
     const position = domNode1.compareDocumentPosition(domNode2);
     /* eslint-disable no-bitwise */
     if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
@@ -204,7 +203,6 @@ const posX = ref(0);
 const posY = ref(0);
 
 function readjustMenuPosition() {
-  // console.log("readjustMenuPosition");
   if (!internalRef.value) return;
 
   isRepositioning.value = false;

--- a/app/web/src/utils/pinia_api_tools.ts
+++ b/app/web/src/utils/pinia_api_tools.ts
@@ -271,6 +271,7 @@ export const initPiniaApiToolkitPlugin = (config: { api: AxiosInstance }) => {
         // but there are cases where its useful to be able to get it from the return value
         // like redirecting to a newly created ID, so we return the api response
       } catch (err: any) {
+        /* eslint-disable-next-line no-console */
         console.log(err);
         // TODO: trigger global error hook that can be added on plugin init (or split by api)
 
@@ -323,7 +324,7 @@ export const initPiniaApiToolkitPlugin = (config: { api: AxiosInstance }) => {
             request.requestSpec,
           );
           if (!triggerResult) {
-            console.log(`no trigger result for ${actionName}`);
+            throw new Error(`No trigger result for ${actionName}`);
           }
 
           // attach the result back to the api request object so caller can use it if necessary

--- a/app/web/src/utils/pinia_hooks_plugin.ts
+++ b/app/web/src/utils/pinia_hooks_plugin.ts
@@ -66,7 +66,7 @@ export const piniaHooksPlugin: PiniaPlugin = ({
     // console.log(store.$id, "+");
     // store._trackedStoreUsersCount++;
     if (store._trackedStoreUsersCount === 1 && storeOptions.onActivated) {
-      console.log(`${store.$id} - ACTIVATE`);
+      // console.log(`${store.$id} - ACTIVATE`);
       // activation fn can return a deactivate / cleanup fn
       store.onDeactivated = storeOptions.onActivated.call(store);
 
@@ -97,7 +97,7 @@ export const piniaHooksPlugin: PiniaPlugin = ({
         store.onDeactivated &&
         _.isFunction(store.onDeactivated)
       ) {
-        console.log(`${store.$id} - DEACTIVATE`);
+        // console.log(`${store.$id} - DEACTIVATE`);
         store.onDeactivated.call(store);
       }
     });


### PR DESCRIPTION
- linter now treats console.log as warning in dev and error on strict mode (CI)
- removed some unnecessary logs
- commented some that may be useful again later
- added some lint ignores to a few that we may want to stick around for now
- small cleanup on eslint config
- few other small linting related fixes

<img src="https://media2.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif?cid=ecf05e47drg247vrlku39mzthetrxx3se6djxkwdq890hzg3&rid=giphy.gif&ct=g" />

