### PR TITLE
bug(dal) Fix intermittent test failures from unstable ordering

### DIFF
--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -244,13 +244,15 @@ async fn find_errors(ctx: &DalContext) {
         .sort_by(|a, b| i64::from(a.attribute_value_id).cmp(&i64::from(b.attribute_value_id)));
 
     let mut got_results = false;
-    for result in &validation_results {
+    for result in &mut validation_results {
         let av = AttributeValue::get_by_id(ctx, &result.attribute_value_id)
             .await
             .unwrap()
             .unwrap();
         if av.context.prop_id() == *prop.id() {
             assert_eq!(2, result.errors.len());
+            // Order of the individual error messages isn't stable, so we'll sort them lexicographically.
+            result.errors.sort_by(|a, b| a.message.cmp(&b.message));
             assert_eq!(
                 "value () does not match expected (amon amarth)",
                 &result.errors[0].message,


### PR DESCRIPTION
The errors array in an individual ValidationStatus isn't ordered in a stable way, so the test needs to account for this. It now does this by sorting the errors lexicographically by their message.

Not 100% sure how much of this being intermittent was already there vs. how much was because of something else I was working on, but it seemed appropriate to put this up as its own thing.