### PR TITLE
single vue root

### DIFF
--- a/app/web/.eslintrc.js
+++ b/app/web/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     "vue/padding-line-between-blocks": "error",
     "vue/prefer-true-attribute-shorthand": "error",
     "vue/eqeqeq": "error",
+    "vue/no-multiple-template-root": "error",
 
     // some strict rules from TS / airbnb presets to relax -----------
     camelcase: "off",

--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -73,7 +73,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-no-autofix": "^1.2.3",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-vue": "^9.4.0",
+        "eslint-plugin-vue": "^9.8.0",
         "faker": "^6.6.6",
         "postcss": "^8.4.16",
         "postcss-comment": "^2.0.0",
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.4.0.tgz",
-      "integrity": "sha512-Nzz2QIJ8FG+rtJaqT/7/ru5ie2XgT9KCudkbN0y3uFYhQ41nuHEaboLAiqwMcK006hZPQv/rVMRhUIwEGhIvfQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
@@ -9298,9 +9298,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.4.0.tgz",
-      "integrity": "sha512-Nzz2QIJ8FG+rtJaqT/7/ru5ie2XgT9KCudkbN0y3uFYhQ41nuHEaboLAiqwMcK006hZPQv/rVMRhUIwEGhIvfQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-no-autofix": "^1.2.3",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-vue": "^9.4.0",
+    "eslint-plugin-vue": "^9.8.0",
     "faker": "^6.6.6",
     "postcss": "^8.4.16",
     "postcss-comment": "^2.0.0",

--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
 <template>
   <RealtimeConnectionStatus />
   <router-view :key="selectedWorkspace?.id" />

--- a/app/web/src/atoms/SiCheckBox.vue
+++ b/app/web/src/atoms/SiCheckBox.vue
@@ -1,59 +1,61 @@
 <template>
-  <label
-    :for="props.id"
-    class="block text-sm font-medium text-neutral-800 dark:text-neutral-50"
-  >
-    {{ props.title }} <span v-if="required">(required)</span>
-  </label>
-
-  <div class="mt-1 w-full relative">
-    <input
-      :id="props.id"
-      v-model="inputValue"
-      :data-test="props.id"
-      type="checkbox"
-      :name="props.id"
-      :autocomplete="props.id"
-      :aria-invalid="inError"
-      :disabled="props.disabled"
-      :indeterminate.prop="isIndeterminate"
-      required
-      :class="
-        clsx(
-          'appearance-none block px-5 py-4 border border-neutral-300 dark:border-neutral-500 rounded-sm shadow-xs focus:outline-none sm:text-sm dark:bg-shade-100 bg-neutral-50 indeterminate:bg-neutral-500 indeterminate:dark:bg-neutral-500',
-          inError
-            ? 'border-destructive-400 focus:ring-destructive-400 focus:border-destructive-400 checked:border-destructive-400 indeterminate:border-destructive-400'
-            : 'border-neutral-600 checked:dark:border-neutral-600 checked:border-neutral-200 indeterminate:dark:border-neutral-500 indeterminate:border-neutral-500',
-        )
-      "
-      @blur="setDirty"
-    />
-    <div
-      v-if="inError"
-      class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none text-destructive-400"
+  <div>
+    <label
+      :for="props.id"
+      class="block text-sm font-medium text-neutral-800 dark:text-neutral-50"
     >
-      <Icon name="exclamation-circle" size="sm" />
+      {{ props.title }} <span v-if="required">(required)</span>
+    </label>
+
+    <div class="mt-1 w-full relative">
+      <input
+        :id="props.id"
+        v-model="inputValue"
+        :data-test="props.id"
+        type="checkbox"
+        :name="props.id"
+        :autocomplete="props.id"
+        :aria-invalid="inError"
+        :disabled="props.disabled"
+        :indeterminate.prop="isIndeterminate"
+        required
+        :class="
+          clsx(
+            'appearance-none block px-5 py-4 border border-neutral-300 dark:border-neutral-500 rounded-sm shadow-xs focus:outline-none sm:text-sm dark:bg-shade-100 bg-neutral-50 indeterminate:bg-neutral-500 indeterminate:dark:bg-neutral-500',
+            inError
+              ? 'border-destructive-400 focus:ring-destructive-400 focus:border-destructive-400 checked:border-destructive-400 indeterminate:border-destructive-400'
+              : 'border-neutral-600 checked:dark:border-neutral-600 checked:border-neutral-200 indeterminate:dark:border-neutral-500 indeterminate:border-neutral-500',
+          )
+        "
+        @blur="setDirty"
+      />
+      <div
+        v-if="inError"
+        class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none text-destructive-400"
+      >
+        <Icon name="exclamation-circle" size="sm" />
+      </div>
     </div>
+
+    <p v-if="props.docLink" class="mt-2 text-xs text-action-500">
+      <a :href="props.docLink" target="_blank" class="hover:underline">
+        Documentation
+      </a>
+    </p>
+
+    <p v-if="props.description" class="mt-2 text-xs text-neutral-300">
+      {{ props.description }}
+    </p>
+
+    <SiValidation
+      :value="String(inputValue)"
+      :validations="validations"
+      :required="required"
+      :dirty="reallyDirty"
+      class="mt-2"
+      @errors="setInError($event)"
+    />
   </div>
-
-  <p v-if="props.docLink" class="mt-2 text-xs text-action-500">
-    <a :href="props.docLink" target="_blank" class="hover:underline">
-      Documentation
-    </a>
-  </p>
-
-  <p v-if="props.description" class="mt-2 text-xs text-neutral-300">
-    {{ props.description }}
-  </p>
-
-  <SiValidation
-    :value="String(inputValue)"
-    :validations="validations"
-    :required="required"
-    :dirty="reallyDirty"
-    class="mt-2"
-    @errors="setInError($event)"
-  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/atoms/SiComboBox.vue
+++ b/app/web/src/atoms/SiComboBox.vue
@@ -1,98 +1,100 @@
 <template>
-  <label
-    :for="props.id"
-    class="block text-sm font-medium text-neutral-900 dark:text-neutral-50"
-  >
-    {{ title }} <span v-if="required">(required)</span>
-  </label>
+  <div>
+    <label
+      :for="props.id"
+      class="block text-sm font-medium text-neutral-900 dark:text-neutral-50"
+    >
+      {{ title }} <span v-if="required">(required)</span>
+    </label>
 
-  <div class="mt-1 w-full relative">
-    <Combobox v-model="inputValue">
-      <div class="relative">
-        <ComboboxButton as="div">
-          <ComboboxInput
-            class="placeholder-neutral-400 border border-neutral-200 dark:border-neutral-600 text-sm rounded-sm shadow-sm w-full focus:border-action-300 pr-7"
-            :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
-            @change="query = $event.target.value"
-          />
-          <Icon
-            name="selector"
-            class="absolute right-1.5 top-1.5 text-neutral-400"
-          />
-          <div
-            v-if="inError"
-            class="absolute right-8 top-1.5 flex items-center text-destructive-400"
-          >
-            <Icon name="exclamation-circle" />
-          </div>
-        </ComboboxButton>
-        <ComboboxOptions
-          class="absolute z-20 w-full mt-1 text-sm border dark:border-neutral-600 rounded-sm"
-          :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
-          as="div"
-        >
-          <li
-            class="flex flex-col gap-0.5 px-2.5 py-2.5 gap-1 border-b dark:border-neutral-600"
-          >
-            <div>
-              <b>{{ filteredOptions.length }}</b> Result{{
-                filteredOptions.length === 1 ? "" : "s"
-              }}
-            </div>
-            <div class="text-neutral-500 italic text-smt">
-              Type in the field above to filter the list below.
-            </div>
-          </li>
-          <ul class="max-h-60 overflow-y-auto overflow-x-hidden">
-            <ComboboxOption
-              v-for="{ label, value } in filteredOptions"
-              :key="value"
-              v-slot="{ active, selected }"
-              as="template"
-              :value="value"
+    <div class="mt-1 w-full relative">
+      <Combobox v-model="inputValue">
+        <div class="relative">
+          <ComboboxButton as="div">
+            <ComboboxInput
+              class="placeholder-neutral-400 border border-neutral-200 dark:border-neutral-600 text-sm rounded-sm shadow-sm w-full focus:border-action-300 pr-7"
+              :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
+              @change="query = $event.target.value"
+            />
+            <Icon
+              name="selector"
+              class="absolute right-1.5 top-1.5 text-neutral-400"
+            />
+            <div
+              v-if="inError"
+              class="absolute right-8 top-1.5 flex items-center text-destructive-400"
             >
-              <li
-                class="relative cursor-default select-none py-1.5 mx-2 dark:text-white rounded m-0.5 pl flex flex-row items-center"
-                :class="{
-                  'bg-action-400 text-white': active,
-                  'text-gray-900': !active,
-                }"
+              <Icon name="exclamation-circle" />
+            </div>
+          </ComboboxButton>
+          <ComboboxOptions
+            class="absolute z-20 w-full mt-1 text-sm border dark:border-neutral-600 rounded-sm"
+            :class="clsx(themeClasses('bg-neutral-50', 'bg-neutral-900'))"
+            as="div"
+          >
+            <li
+              class="flex flex-col gap-0.5 px-2.5 py-2.5 gap-1 border-b dark:border-neutral-600"
+            >
+              <div>
+                <b>{{ filteredOptions.length }}</b> Result{{
+                  filteredOptions.length === 1 ? "" : "s"
+                }}
+              </div>
+              <div class="text-neutral-500 italic text-smt">
+                Type in the field above to filter the list below.
+              </div>
+            </li>
+            <ul class="max-h-60 overflow-y-auto overflow-x-hidden">
+              <ComboboxOption
+                v-for="{ label, value } in filteredOptions"
+                :key="value"
+                v-slot="{ active, selected }"
+                as="template"
+                :value="value"
               >
-                <Icon v-if="selected" name="check" class="mx-2" size="sm" />
-                <span
-                  class="block truncate"
-                  :class="
-                    clsx(selected ? 'font-extrabold' : 'font-normal pl-9')
-                  "
+                <li
+                  class="relative cursor-default select-none py-1.5 mx-2 dark:text-white rounded m-0.5 pl flex flex-row items-center"
+                  :class="{
+                    'bg-action-400 text-white': active,
+                    'text-gray-900': !active,
+                  }"
                 >
-                  {{ label }}
-                </span>
-              </li>
-            </ComboboxOption>
-          </ul>
-        </ComboboxOptions>
-      </div>
-    </Combobox>
+                  <Icon v-if="selected" name="check" class="mx-2" size="sm" />
+                  <span
+                    class="block truncate"
+                    :class="
+                      clsx(selected ? 'font-extrabold' : 'font-normal pl-9')
+                    "
+                  >
+                    {{ label }}
+                  </span>
+                </li>
+              </ComboboxOption>
+            </ul>
+          </ComboboxOptions>
+        </div>
+      </Combobox>
+    </div>
+
+    <p v-if="docLink" class="mt-2 text-xs text-action-500">
+      <a :href="docLink" target="_blank" class="hover:underline">
+        Documentation
+      </a>
+    </p>
+
+    <p v-if="description" class="mt-2 text-xs text-neutral-300">
+      {{ description }}
+    </p>
+
+    <SiValidation
+      :value="String(inputValue)"
+      :validations="validations"
+      :required="required"
+      :dirty="reallyDirty"
+      class="mt-2"
+      @errors="setInError($event)"
+    />
   </div>
-
-  <p v-if="docLink" class="mt-2 text-xs text-action-500">
-    <a :href="docLink" target="_blank" class="hover:underline">
-      Documentation
-    </a>
-  </p>
-
-  <p v-if="description" class="mt-2 text-xs text-neutral-300">
-    {{ description }}
-  </p>
-
-  <SiValidation
-    :value="String(inputValue)"
-    :validations="validations"
-    :required="required"
-    :dirty="reallyDirty"
-    class="mt-2"
-    @errors="setInError($event)"
-  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/atoms/SiSelectBox.vue
+++ b/app/web/src/atoms/SiSelectBox.vue
@@ -1,49 +1,51 @@
 <template>
-  <label
-    :for="props.id"
-    class="block text-sm font-medium text-neutral-900 dark:text-neutral-50"
-  >
-    {{ props.title }} <span v-if="required">(required)</span>
-  </label>
-
-  <div class="mt-1 w-full relative">
-    <SiSelect
-      :id="props.id"
-      v-model="inputValue"
-      :options="props.options"
-      :data-test="props.id"
-      :disabled="props.disabled"
-      required
-      class="appearance-none block px-3 py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm bg-neutral-50 dark:bg-neutral-700 border-neutral-600"
-      :class="boxClasses"
-      @change="setDirty"
-    />
-    <div
-      v-if="inError"
-      class="absolute inset-y-0 right-0 pr-3 flex items-center text-destructive-400"
+  <div>
+    <label
+      :for="props.id"
+      class="block text-sm font-medium text-neutral-900 dark:text-neutral-50"
     >
-      <Icon name="exclamation-circle" />
+      {{ props.title }} <span v-if="required">(required)</span>
+    </label>
+
+    <div class="mt-1 w-full relative">
+      <SiSelect
+        :id="props.id"
+        v-model="inputValue"
+        :options="props.options"
+        :data-test="props.id"
+        :disabled="props.disabled"
+        required
+        class="appearance-none block px-3 py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm bg-neutral-50 dark:bg-neutral-700 border-neutral-600"
+        :class="boxClasses"
+        @change="setDirty"
+      />
+      <div
+        v-if="inError"
+        class="absolute inset-y-0 right-0 pr-3 flex items-center text-destructive-400"
+      >
+        <Icon name="exclamation-circle" />
+      </div>
     </div>
+
+    <p v-if="props.docLink" class="mt-2 text-xs text-action-500">
+      <a :href="props.docLink" target="_blank" class="hover:underline">
+        Documentation
+      </a>
+    </p>
+
+    <p v-if="props.description" class="mt-2 text-xs text-neutral-300">
+      {{ props.description }}
+    </p>
+
+    <SiValidation
+      :value="String(inputValue)"
+      :validations="validations"
+      :required="required"
+      :dirty="reallyDirty"
+      class="mt-2"
+      @errors="setInError($event)"
+    />
   </div>
-
-  <p v-if="props.docLink" class="mt-2 text-xs text-action-500">
-    <a :href="props.docLink" target="_blank" class="hover:underline">
-      Documentation
-    </a>
-  </p>
-
-  <p v-if="props.description" class="mt-2 text-xs text-neutral-300">
-    {{ props.description }}
-  </p>
-
-  <SiValidation
-    :value="String(inputValue)"
-    :validations="validations"
-    :required="required"
-    :dirty="reallyDirty"
-    class="mt-2"
-    @errors="setInError($event)"
-  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/atoms/SiValidation.vue
+++ b/app/web/src/atoms/SiValidation.vue
@@ -1,11 +1,13 @@
 <template>
-  <div
-    v-for="error in displayErrors"
-    :key="error.id"
-    :class="errorClasses(error.id)"
-    v-bind="$attrs"
-  >
-    {{ error.message }}
+  <div>
+    <div
+      v-for="error in displayErrors"
+      :key="error.id"
+      :class="errorClasses(error.id)"
+      v-bind="$attrs"
+    >
+      {{ error.message }}
+    </div>
   </div>
 </template>
 

--- a/app/web/src/molecules/SiTabHeader.vue
+++ b/app/web/src/molecules/SiTabHeader.vue
@@ -1,5 +1,5 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
 <template>
-  <!-- selectedToFront ? (selected ? 'order-1' : 'order-2') : '' -->
   <Tab
     v-slot="{ selected }"
     class="focus:outline-none whitespace-nowrap"
@@ -43,7 +43,7 @@
     v-if="noAfterMargin === false"
     class="border-b border-neutral-300 dark:border-neutral-600 w-2"
     :class="selectedToFront ? 'order-2' : ''"
-  ></div>
+  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/organisms/AssetPalette.vue
+++ b/app/web/src/organisms/AssetPalette.vue
@@ -1,60 +1,63 @@
 <template>
-  <template v-if="schemasReqStatus.isPending || addMenuReqStatus.isPending">
-    <div class="w-full p-lg flex flex-col gap-2 items-center">
-      <Icon name="loader" size="2xl" />
-      <h2>Loading Asset Palette...</h2>
-    </div>
-  </template>
-  <template v-else-if="schemasReqStatus.isSuccess">
-    <!-- <SiSearch /> -->
-
-    <p
-      class="border-b-2 dark:border-neutral-600 text-sm leading-tight p-2.5 text-neutral-500"
-    >
-      Drag the assets that you wish to include in your application into the
-      canvas to the right.
-    </p>
-
-    <ul class="overflow-y-auto">
-      <SiCollapsible
-        v-for="(category, categoryIndex) in addMenuData"
-        :key="categoryIndex"
-        :label="category.displayName"
-        as="li"
-        content-as="ul"
-        default-open
-        class="select-none"
-      >
-        <li
-          v-for="(schema, schemaIndex) in category.schemas"
-          :key="schemaIndex"
-          class="select-none border-b-2 dark:border-neutral-600"
-        >
-          <SiNodeSprite
-            :class="
-              componentsStore.selectedInsertSchemaId === schema.id
-                ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
-                : ''
-            "
-            :color="schema.color"
-            :name="schema.displayName"
-            class="border border-transparent hover:border-action-500 dark:hover:border-action-300 dark:text-white hover:text-action-500 dark:hover:text-action-500 hover:cursor-pointer"
-            @mousedown.left="onSelect(schema.id)"
-          />
-        </li>
-      </SiCollapsible>
-    </ul>
-  </template>
-  <template v-if="selectedSchema">
-    <Teleport to="body">
-      <div
-        ref="mouseNode"
-        class="fixed top-0 pointer-events-none translate-x-[-50%] translate-y-[-50%] z-100"
-      >
-        <NodeSkeleton :color="selectedSchema.color" />
+  <div>
+    <template v-if="schemasReqStatus.isPending || addMenuReqStatus.isPending">
+      <div class="w-full p-lg flex flex-col gap-2 items-center">
+        <Icon name="loader" size="2xl" />
+        <h2>Loading Asset Palette...</h2>
       </div>
-    </Teleport>
-  </template>
+    </template>
+    <template v-else-if="schemasReqStatus.isSuccess">
+      <!-- <SiSearch /> -->
+
+      <p
+        class="border-b-2 dark:border-neutral-600 text-sm leading-tight p-2.5 text-neutral-500"
+      >
+        Drag the assets that you wish to include in your application into the
+        canvas to the right.
+      </p>
+
+      <ul class="overflow-y-auto">
+        <SiCollapsible
+          v-for="(category, categoryIndex) in addMenuData"
+          :key="categoryIndex"
+          :label="category.displayName"
+          as="li"
+          content-as="ul"
+          default-open
+          class="select-none"
+        >
+          <li
+            v-for="(schema, schemaIndex) in category.schemas"
+            :key="schemaIndex"
+            class="select-none border-b-2 dark:border-neutral-600"
+          >
+            <SiNodeSprite
+              :class="
+                componentsStore.selectedInsertSchemaId === schema.id
+                  ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
+                  : ''
+              "
+              :color="schema.color"
+              :name="schema.displayName"
+              class="border border-transparent hover:border-action-500 dark:hover:border-action-300 dark:text-white hover:text-action-500 dark:hover:text-action-500 hover:cursor-pointer"
+              @mousedown.left="onSelect(schema.id)"
+            />
+          </li>
+        </SiCollapsible>
+      </ul>
+    </template>
+
+    <template v-if="selectedSchema">
+      <Teleport to="body">
+        <div
+          ref="mouseNode"
+          class="fixed top-0 pointer-events-none translate-x-[-50%] translate-y-[-50%] z-100"
+        >
+          <NodeSkeleton :color="selectedSchema.color" />
+        </div>
+      </Teleport>
+    </template>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/ChangeSetPanel.vue
+++ b/app/web/src/organisms/ChangeSetPanel.vue
@@ -31,6 +31,7 @@
         </VormInput>
       </div>
     </section>
+
     <Modal
       :open="showDialog === 'create'"
       size="sm"
@@ -118,40 +119,41 @@
         </Stack>
       </template>
     </Modal>
+
+    <Wipe ref="wipeRef">
+      <template #duringWipe>
+        <VButton2
+          icon="git-merge"
+          size="md"
+          loading-text="Merging"
+          label="Merge"
+          loading
+        />
+      </template>
+      <template #afterWipe>
+        <div
+          v-if="changeSetMergeStatus.isPending"
+          class="gap-2 items-center flex flex-row p-xl min-w-0 w-full justify-center"
+        >
+          <Icon name="loader" size="2xl" />
+          <span class="text-3xl italic truncate">
+            Merging Change Set<template v-if="selectedChangeSetName">
+              "{{ selectedChangeSetName }}"
+            </template>
+          </span>
+        </div>
+        <div
+          v-else-if="changeSetMergeStatus.isSuccess"
+          class="gap-2 items-center flex flex-col"
+        >
+          <span class="text-3xl">Change Set Merged!</span>
+          <span class="text-md italic pt-sm">
+            Preparing your recommendations...
+          </span>
+        </div>
+      </template>
+    </Wipe>
   </div>
-  <Wipe ref="wipeRef">
-    <template #duringWipe>
-      <VButton2
-        icon="git-merge"
-        size="md"
-        loading-text="Merging"
-        label="Merge"
-        loading
-      />
-    </template>
-    <template #afterWipe>
-      <div
-        v-if="changeSetMergeStatus.isPending"
-        class="gap-2 items-center flex flex-row p-xl min-w-0 w-full justify-center"
-      >
-        <Icon name="loader" size="2xl" />
-        <span class="text-3xl italic truncate">
-          Merging Change Set<template v-if="selectedChangeSetName">
-            "{{ selectedChangeSetName }}"
-          </template>
-        </span>
-      </div>
-      <div
-        v-else-if="changeSetMergeStatus.isSuccess"
-        class="gap-2 items-center flex flex-col"
-      >
-        <span class="text-3xl">Change Set Merged!</span>
-        <span class="text-md italic pt-sm">
-          Preparing your recommendations...
-        </span>
-      </div>
-    </template>
-  </Wipe>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/DiagramOutline.vue
+++ b/app/web/src/organisms/DiagramOutline.vue
@@ -1,48 +1,50 @@
 <template>
-  <SiSearch auto-search @search="onSearchUpdated" />
-  <template v-if="!allComponents.length">
-    <div class="p-2 text-neutral-500">No components</div>
-  </template>
-  <template v-else-if="!filteredComponenets.length">
-    <div class="p-2 text-neutral-500">No components matching your search</div>
-  </template>
-  <template v-else>
-    <ul>
-      <li
-        v-for="component in filteredComponenets"
-        :key="component.id"
-        class="border-b-2 dark:border-neutral-600 cursor-pointer"
-        @click="emit('select', component.id)"
-      >
-        <span
-          :class="
-            selectedComponentId === component.id
-              ? ['bg-action-500 text-white']
-              : ['hover:bg-action-400 hover:text-white']
-          "
-          :style="{
-            'border-color': component.color || colors.neutral[400],
-          }"
-          class="w-full px-2 py-2 border-l-8 group flex flex-row items-baseline"
+  <div>
+    <SiSearch auto-search @search="onSearchUpdated" />
+    <template v-if="!allComponents.length">
+      <div class="p-2 text-neutral-500">No components</div>
+    </template>
+    <template v-else-if="!filteredComponenets.length">
+      <div class="p-2 text-neutral-500">No components matching your search</div>
+    </template>
+    <template v-else>
+      <ul>
+        <li
+          v-for="component in filteredComponenets"
+          :key="component.id"
+          class="border-b-2 dark:border-neutral-600 cursor-pointer"
+          @click="emit('select', component.id)"
         >
           <span
-            class="whitespace-nowrap text-ellipsis overflow-hidden shrink leading-tight"
-            >{{ component.displayName || "si-123" }}</span
-          >
-          <i
             :class="
               selectedComponentId === component.id
                 ? ['bg-action-500 text-white']
-                : ['text-neutral-500 group-hover:text-white']
+                : ['hover:bg-action-400 hover:text-white']
             "
-            class="text-sm pl-1 flex-none"
+            :style="{
+              'border-color': component.color || colors.neutral[400],
+            }"
+            class="w-full px-2 py-2 border-l-8 group flex flex-row items-baseline"
           >
-            {{ component.schemaName }}
-          </i>
-        </span>
-      </li>
-    </ul>
-  </template>
+            <span
+              class="whitespace-nowrap text-ellipsis overflow-hidden shrink leading-tight"
+              >{{ component.displayName || "si-123" }}</span
+            >
+            <i
+              :class="
+                selectedComponentId === component.id
+                  ? ['bg-action-500 text-white']
+                  : ['text-neutral-500 group-hover:text-white']
+              "
+              class="text-sm pl-1 flex-none"
+            >
+              {{ component.schemaName }}
+            </i>
+          </span>
+        </li>
+      </ul>
+    </template>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/organisms/FuncEditor/AttributeBindings.vue
@@ -1,76 +1,79 @@
 <template>
-  <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
-    <VButton
-      :disabled="disabled"
-      button-rank="primary"
-      button-type="success"
-      icon="plus"
-      label="Add binding"
-      size="md"
-      @click="openModal()"
-    />
+  <div>
+    <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
+      <VButton
+        :disabled="disabled"
+        button-rank="primary"
+        button-type="success"
+        icon="plus"
+        label="Add binding"
+        size="md"
+        @click="openModal()"
+      />
+    </div>
+    <ul class="flex flex-col p-3 gap-1">
+      <li v-for="proto in prototypeView" :key="proto.id">
+        <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+          Schema Variant:
+        </h1>
+        <h2 class="pb-2 text-sm">{{ proto.schemaVariant }}</h2>
+
+        <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+          Component:
+        </h1>
+        <h2 class="pb-2 text-sm">{{ proto.component }}</h2>
+
+        <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+          Output location:
+        </h1>
+        <h2 class="pb-2 text-sm">{{ proto.prop }}</h2>
+
+        <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+          Expected Function Arguments:
+        </h1>
+        <h2 class="pb-2 text-sm">
+          Below is the source of the data for each function argument listed.
+        </h2>
+        <ul>
+          <li v-for="arg in proto.args" :key="arg.name">
+            <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+              {{ arg.name }}
+            </h1>
+            <h2 class="pb-2 text-sm">{{ arg.prop }}</h2>
+          </li>
+        </ul>
+        <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
+          <VButton
+            :disabled="disabled"
+            button-rank="primary"
+            button-type="neutral"
+            label="Edit binding "
+            size="md"
+            @click="openModal(proto.id)"
+          />
+          <VButton
+            :disabled="disabled"
+            button-rank="tertiary"
+            button-type="destructive"
+            icon="x"
+            label="Remove Binding"
+            size="sm"
+            @click="removeBinding(proto.id)"
+          />
+        </div>
+      </li>
+
+      <AttributeBindingsModal
+        :func-id="funcId"
+        :open="isModalOpen"
+        :prototype="editingPrototype"
+        :edit="editingPrototype !== undefined"
+        type="save"
+        @close="closeModal()"
+        @save="saveModal"
+      />
+    </ul>
   </div>
-  <ul class="flex flex-col p-3 gap-1">
-    <li v-for="proto in prototypeView" :key="proto.id">
-      <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-        Schema Variant:
-      </h1>
-      <h2 class="pb-2 text-sm">{{ proto.schemaVariant }}</h2>
-
-      <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-        Component:
-      </h1>
-      <h2 class="pb-2 text-sm">{{ proto.component }}</h2>
-
-      <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-        Output location:
-      </h1>
-      <h2 class="pb-2 text-sm">{{ proto.prop }}</h2>
-
-      <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-        Expected Function Arguments:
-      </h1>
-      <h2 class="pb-2 text-sm">
-        Below is the source of the data for each function argument listed.
-      </h2>
-      <ul>
-        <li v-for="arg in proto.args" :key="arg.name">
-          <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-            {{ arg.name }}
-          </h1>
-          <h2 class="pb-2 text-sm">{{ arg.prop }}</h2>
-        </li>
-      </ul>
-      <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
-        <VButton
-          :disabled="disabled"
-          button-rank="primary"
-          button-type="neutral"
-          label="Edit binding "
-          size="md"
-          @click="openModal(proto.id)"
-        />
-        <VButton
-          :disabled="disabled"
-          button-rank="tertiary"
-          button-type="destructive"
-          icon="x"
-          label="Remove Binding"
-          size="sm"
-          @click="removeBinding(proto.id)"
-        />
-      </div>
-    </li>
-  </ul>
-  <AttributeBindingsModal
-    :func-id="funcId"
-    :open="isModalOpen"
-    :prototype="editingPrototype"
-    :edit="editingPrototype !== undefined"
-    type="save"
-    @close="closeModal()"
-    @save="saveModal"
-  />
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/FuncEditor/FuncPicker.vue
+++ b/app/web/src/organisms/FuncEditor/FuncPicker.vue
@@ -66,37 +66,37 @@
         </ul>
       </TabPanel>
     </template>
-  </SiTabGroup>
 
-  <Modal
-    size="sm"
-    :open="funcNameModalOpen"
-    type="save"
-    @close="closeFuncNameModal"
-    @save="createBuiltinFunc"
-  >
-    <template #title>Name your Builtin Function</template>
-    <template #content>
-      <SiTextBox
-        id="name"
-        v-model="newBuiltinFuncName"
-        class="pb-2"
-        autofocus
-        title=""
-        required
-        placeholder="Type the name of this function here..."
-        :validations="[
-          {
-            id: 'name',
-            message: 'Alphanumeric characters only.',
-            check: validator.isAlphanumeric,
-          },
-        ]"
-        @keyup.enter="createBuiltinFunc"
-        @error="updateFuncNameError"
-      />
-    </template>
-  </Modal>
+    <Modal
+      size="sm"
+      :open="funcNameModalOpen"
+      type="save"
+      @close="closeFuncNameModal"
+      @save="createBuiltinFunc"
+    >
+      <template #title>Name your Builtin Function</template>
+      <template #content>
+        <SiTextBox
+          id="name"
+          v-model="newBuiltinFuncName"
+          class="pb-2"
+          autofocus
+          title=""
+          required
+          placeholder="Type the name of this function here..."
+          :validations="[
+            {
+              id: 'name',
+              message: 'Alphanumeric characters only.',
+              check: validator.isAlphanumeric,
+            },
+          ]"
+          @keyup.enter="createBuiltinFunc"
+          @error="updateFuncNameError"
+        />
+      </template>
+    </Modal>
+  </SiTabGroup>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/FuncEditor/RunOnSelector.vue
+++ b/app/web/src/organisms/FuncEditor/RunOnSelector.vue
@@ -1,44 +1,46 @@
 <template>
-  <div class="flex items-center">
-    <SelectMenu
-      v-model="optionsState"
-      class="w-4/5"
-      :none-selected-label="`select ${props.thingLabel}...`"
-      :options="options"
-      :disabled="disabled"
-    />
-    <VButton
-      label="Add"
-      button-rank="tertiary"
-      icon="plus"
-      :disabled="disabled"
-      @click="addOptions"
-    />
-  </div>
   <div>
-    <h2 class="pb-2 text-sm">Selected {{ props.thingLabel }}</h2>
-    <p v-if="props.modelValue.length === 0" class="pl-4 text-sm">
-      None selected. Select {{ props.thingLabel }} above...
-    </p>
-    <ul v-else class="list-disc list-inside flex flex-col">
-      <li
-        v-for="option in modelValue"
-        :key="option.value"
-        class="flex items-center text-sm pb-2 pl-4"
-      >
-        <div class="pr-2" role="decoration">•</div>
-        {{ option.label }}
-        <div class="ml-auto">
-          <VButton
-            label=""
-            icon="trash"
-            button-rank="tertiary"
-            :disabled="disabled"
-            @click="removeOption(option)"
-          />
-        </div>
-      </li>
-    </ul>
+    <div class="flex items-center">
+      <SelectMenu
+        v-model="optionsState"
+        class="w-4/5"
+        :none-selected-label="`select ${props.thingLabel}...`"
+        :options="options"
+        :disabled="disabled"
+      />
+      <VButton
+        label="Add"
+        button-rank="tertiary"
+        icon="plus"
+        :disabled="disabled"
+        @click="addOptions"
+      />
+    </div>
+    <div>
+      <h2 class="pb-2 text-sm">Selected {{ props.thingLabel }}</h2>
+      <p v-if="props.modelValue.length === 0" class="pl-4 text-sm">
+        None selected. Select {{ props.thingLabel }} above...
+      </p>
+      <ul v-else class="list-disc list-inside flex flex-col">
+        <li
+          v-for="option in modelValue"
+          :key="option.value"
+          class="flex items-center text-sm pb-2 pl-4"
+        >
+          <div class="pr-2" role="decoration">•</div>
+          {{ option.label }}
+          <div class="ml-auto">
+            <VButton
+              label=""
+              icon="trash"
+              button-rank="tertiary"
+              :disabled="disabled"
+              @click="removeOption(option)"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 

--- a/app/web/src/organisms/FuncEditor/ValidationDetails.vue
+++ b/app/web/src/organisms/FuncEditor/ValidationDetails.vue
@@ -1,51 +1,53 @@
 <template>
-  <div class="p-3 flex flex-col gap-2">
-    <h1 class="text-neutral-400 dark:text-neutral-300 text-sm">
-      Run this validation on the selected schema variant attributes below.
-    </h1>
+  <div>
+    <div class="p-3 flex flex-col gap-2">
+      <h1 class="text-neutral-400 dark:text-neutral-300 text-sm">
+        Run this validation on the selected schema variant attributes below.
+      </h1>
 
-    <h2 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-      Run on Schema Variant and Attribute:
-    </h2>
-    <SelectMenu
-      v-model="selectedVariant"
-      class="flex-auto"
-      :options="schemaVariantOptions ?? []"
-    />
-    <SelectMenu
-      v-model="selectedProp"
-      class="flex-auto"
-      :options="propOptions"
-    />
-    <VButton
-      label="Add"
-      button-rank="primary"
-      icon="plus"
-      :disabled="disabled"
-      @click="addValidation"
-    />
-  </div>
-  <h2 class="p-3 pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-    Currently Validating:
-  </h2>
-  <ul class="flex flex-col p-3 gap-1 list-disc list-inside">
-    <li
-      v-for="protoView in prototypeViews"
-      :key="protoView.key"
-      class="flex flex-row gap-1 items-center text-sm pb-2 pl-4"
-    >
-      <div class="pr-2" role="decoration">•</div>
-      {{ protoView.schemaVariantName }}: {{ protoView.propName }}
-      <VButton
-        class="flex-none"
-        label=""
-        icon="trash"
-        button-rank="tertiary"
-        :disabled="disabled"
-        @click="deleteValidation(protoView.proto)"
+      <h2 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+        Run on Schema Variant and Attribute:
+      </h2>
+      <SelectMenu
+        v-model="selectedVariant"
+        class="flex-auto"
+        :options="schemaVariantOptions ?? []"
       />
-    </li>
-  </ul>
+      <SelectMenu
+        v-model="selectedProp"
+        class="flex-auto"
+        :options="propOptions"
+      />
+      <VButton
+        label="Add"
+        button-rank="primary"
+        icon="plus"
+        :disabled="disabled"
+        @click="addValidation"
+      />
+    </div>
+    <h2 class="p-3 pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
+      Currently Validating:
+    </h2>
+    <ul class="flex flex-col p-3 gap-1 list-disc list-inside">
+      <li
+        v-for="protoView in prototypeViews"
+        :key="protoView.key"
+        class="flex flex-row gap-1 items-center text-sm pb-2 pl-4"
+      >
+        <div class="pr-2" role="decoration">•</div>
+        {{ protoView.schemaVariantName }}: {{ protoView.propName }}
+        <VButton
+          class="flex-none"
+          label=""
+          icon="trash"
+          button-rank="tertiary"
+          :disabled="disabled"
+          @click="deleteValidation(protoView.proto)"
+        />
+      </li>
+    </ul>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/GenericDiagram/DiagramEdge.vue
+++ b/app/web/src/organisms/GenericDiagram/DiagramEdge.vue
@@ -1,27 +1,27 @@
 <template>
-  <v-line
-    v-if="points"
-    :config="{
-      visible: isSelected,
-      points,
-      stroke: SELECTION_COLOR,
-      strokeWidth: 7,
-      listening: false,
-    }"
-  />
-  <v-line
-    v-if="points"
-    :config="{
-      id: edge.uniqueKey,
-      points,
-      stroke: strokeColor,
-      strokeWidth: isHovered ? 3 : 2,
-      hitStrokeWidth: 8,
-    }"
-    @mouseover="onMouseOver"
-    @mouseout="onMouseOut"
-    @mousedown="onMouseDown"
-  />
+  <v-group v-if="points">
+    <v-line
+      :config="{
+        visible: isSelected,
+        points,
+        stroke: SELECTION_COLOR,
+        strokeWidth: 7,
+        listening: false,
+      }"
+    />
+    <v-line
+      :config="{
+        id: edge.uniqueKey,
+        points,
+        stroke: strokeColor,
+        strokeWidth: isHovered ? 3 : 2,
+        hitStrokeWidth: 8,
+      }"
+      @mouseover="onMouseOver"
+      @mouseout="onMouseOut"
+      @mousedown="onMouseDown"
+    />
+  </v-group>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/GenericDiagram/DiagramNodeSocket.vue
+++ b/app/web/src/organisms/GenericDiagram/DiagramNodeSocket.vue
@@ -1,38 +1,40 @@
 <template>
-  <v-circle
-    :config="{
-      id: socket.uniqueKey,
-      x,
-      y,
-      width: socketSize,
-      height: socketSize,
-      stroke: colors.stroke,
-      strokeWidth: isHovered ? 2 : 1,
-      fill: colors.fill,
-    }"
-    @mouseover="onMouseOver"
-    @mouseout="onMouseOut"
-  />
-  <v-text
-    ref="socketLabelRef"
-    :config="{
-      x: socket.def.nodeSide === 'left' ? 15 : -nodeWidth + 15,
-      y: y - SOCKET_SIZE / 2,
-      verticalAlign: 'middle',
-      align: socket.def.nodeSide === 'left' ? 'left' : 'right',
-      height: SOCKET_SIZE,
-      width: nodeWidth - 30,
-      text: socket.def.label,
-      padding: 0,
-      fill: colors.labelText,
-      wrap: 'none',
-      ellipsis: true,
-      listening: false,
-      fontFamily: DIAGRAM_FONT_FAMILY,
-      fontSize: 11,
-      opacity: state === 'draw_edge_disabled' ? 0.5 : 1,
-    }"
-  />
+  <v-group>
+    <v-circle
+      :config="{
+        id: socket.uniqueKey,
+        x,
+        y,
+        width: socketSize,
+        height: socketSize,
+        stroke: colors.stroke,
+        strokeWidth: isHovered ? 2 : 1,
+        fill: colors.fill,
+      }"
+      @mouseover="onMouseOver"
+      @mouseout="onMouseOut"
+    />
+    <v-text
+      ref="socketLabelRef"
+      :config="{
+        x: socket.def.nodeSide === 'left' ? 15 : -nodeWidth + 15,
+        y: y - SOCKET_SIZE / 2,
+        verticalAlign: 'middle',
+        align: socket.def.nodeSide === 'left' ? 'left' : 'right',
+        height: SOCKET_SIZE,
+        width: nodeWidth - 30,
+        text: socket.def.label,
+        padding: 0,
+        fill: colors.labelText,
+        wrap: 'none',
+        ellipsis: true,
+        listening: false,
+        fontFamily: DIAGRAM_FONT_FAMILY,
+        fontSize: 11,
+        opacity: state === 'draw_edge_disabled' ? 0.5 : 1,
+      }"
+    />
+  </v-group>
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
+++ b/app/web/src/organisms/GenericDiagram/GenericDiagram.vue
@@ -135,8 +135,8 @@ overflow hidden */
         />
       </v-layer>
     </v-stage>
+    <DiagramHelpModal :open="helpModalOpen" @close="helpModalClose" />
   </div>
-  <DiagramHelpModal :open="helpModalOpen" @close="helpModalClose" />
 </template>
 
 <script lang="ts" setup>

--- a/app/web/src/organisms/NewFuncDropdown.vue
+++ b/app/web/src/organisms/NewFuncDropdown.vue
@@ -8,17 +8,17 @@
     @click="menuRef?.open"
   >
     {{ label }}
+    <DropdownMenu ref="menuRef">
+      <DropdownMenuItem
+        v-for="(fnLabel, fnKind) in fnTypes"
+        :key="fnKind"
+        @select="emit('selectedFuncKind', fnKind)"
+      >
+        <template #icon><FuncSkeleton /></template>
+        {{ fnLabel }}
+      </DropdownMenuItem>
+    </DropdownMenu>
   </VButton2>
-  <DropdownMenu ref="menuRef">
-    <DropdownMenuItem
-      v-for="(fnLabel, fnKind) in fnTypes"
-      :key="fnKind"
-      @select="emit('selectedFuncKind', fnKind)"
-    >
-      <template #icon><FuncSkeleton /></template>
-      {{ fnLabel }}
-    </DropdownMenuItem>
-  </DropdownMenu>
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/organisms/PropertyEditor/WidgetHeader.vue
+++ b/app/web/src/organisms/PropertyEditor/WidgetHeader.vue
@@ -86,12 +86,8 @@ const setCollapsed = () => {
 const { name, path, collapsedPaths } = toRefs(props);
 
 const displayPath = computed(() => {
-  if (path && path.value) {
-    // Always chop off the root path
-    return path.value.displayPath.slice(0, -1).reverse();
-  } else {
-    return [];
-  }
+  // Always chop off the root path
+  return path?.value?.displayPath.slice(0, -1).reverse() || [];
 });
 
 const pathParents = computed(() => displayPath.value.slice(undefined, -1));

--- a/app/web/src/organisms/Workspace/WorkspaceApply.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceApply.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
 <template>
   <SiPanel remember-size-key="workflow-left" side="left" :min-size="315">
     <RecommendationPicker />

--- a/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceCustomize.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
 <template>
   <SiPanel remember-size-key="func-picker" side="left" :min-size="300">
     <div class="flex flex-col h-full">

--- a/app/web/src/organisms/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/organisms/Workspace/WorkspaceModelAndView.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
 <template>
   <SiPanel remember-size-key="changeset-and-asset" side="left" :min-size="250">
     <div class="flex flex-col h-full">

--- a/app/web/src/ui-lib/forms/VormInputOption.vue
+++ b/app/web/src/ui-lib/forms/VormInputOption.vue
@@ -2,48 +2,46 @@
 meant to be used within it specifically it's only for VormInputs with type =
 dropdown | radio | multi-checkbox */
 <template>
-  <template v-if="parentInputType === 'dropdown'">
-    <option
-      class="vorm-input-option"
+  <option
+    v-if="parentInputType === 'dropdown'"
+    class="vorm-input-option"
+    :value="safeOptionValue"
+    :selected="dropdownOptionSelected"
+    :disabled="disabledBySelfOrParent"
+  >
+    <slot>{{ value }}</slot>
+  </option>
+  <label v-else-if="parentInputType === 'radio'" class="vorm-input-option">
+    <input
+      class="vorm-input-option__input"
+      type="radio"
       :value="safeOptionValue"
-      :selected="dropdownOptionSelected"
+      :name="radioName"
       :disabled="disabledBySelfOrParent"
-    >
-      <slot>{{ value }}</slot>
-    </option>
-  </template>
-  <template v-else-if="parentInputType === 'radio'">
-    <label class="vorm-input-option">
-      <input
-        class="vorm-input-option__input"
-        type="radio"
-        :value="safeOptionValue"
-        :name="radioName"
-        :disabled="disabledBySelfOrParent"
-        :checked="value === parentValue"
-        @focus="onFocus"
-        @blur="onBlur"
-        @change="onChange"
-      />
-      <slot>{{ value }}</slot>
-    </label>
-  </template>
+      :checked="value === parentValue"
+      @focus="onFocus"
+      @blur="onBlur"
+      @change="onChange"
+    />
+    <slot>{{ value }}</slot>
+  </label>
 
-  <template v-else-if="parentInputType === 'multi-checkbox'">
-    <label class="vorm-input-option">
-      <input
-        class="vorm-input-option__input"
-        type="checkbox"
-        :value="safeOptionValue"
-        :disabled="disabledBySelfOrParent"
-        :checked="parentValue?.indexOf(value) > -1"
-        @focus="onFocus"
-        @blur="onBlur"
-        @change="onMultiCheckboxChange"
-      />
-      <slot>{{ value }}</slot>
-    </label>
-  </template>
+  <label
+    v-else-if="parentInputType === 'multi-checkbox'"
+    class="vorm-input-option"
+  >
+    <input
+      class="vorm-input-option__input"
+      type="checkbox"
+      :value="safeOptionValue"
+      :disabled="disabledBySelfOrParent"
+      :checked="parentValue?.indexOf(value) > -1"
+      @focus="onFocus"
+      @blur="onBlur"
+      @change="onMultiCheckboxChange"
+    />
+    <slot>{{ value }}</slot>
+  </label>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
Enabled a linting rule that yells at us if we have more than one root element in a vue component.

This should be the case 99% of the time, and only violated when you really know what you're doing and are doing it on purpose.

It was a bit harder than it should be to fix this in the tab header component :(
We should probably build a new tab component anyway not based on headless UI, which will likely make it much easier to do what we want.

<img src="https://media0.giphy.com/media/3oKIPrwk5SCKWexkLS/200w.webp?cid=ecf05e47pdfe367c61dst1t0awsznt7noh5qwe2wo7zcdkie&rid=200w.webp&ct=g">