### PR TITLE
chore(dal,dal-test): add component view properties helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "sodiumoxide",
  "telemetry",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing-subscriber",
  "uuid",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -472,6 +472,18 @@ variable.
 SI_TEST_LOG=info
 ```
 
+#### Migrations Running Too Slow? Try Disabling Builtin Schema Migrations!
+
+If your integration test does not rely on builtin `Schema(s)` and `SchemaVariant(s)` (e.g. "Docker Image" and
+"AWS EC2"), you can disable their migration with an environment variable.
+
+```shell
+SI_TEST_SKIP_MIGRATING_SCHEMAS=true cargo test -p dal --test integration <your-test>
+```
+
+You will likely notice a dramatic difference in end-to-end wall clock time since the database will skip migrating
+builtin `Schema(s)` and `SchemaVariant(s)` entirely.
+
 ### Debugging Integration Tests with Database Contents
 
 Integration tests in the `lib/dal` crate typically perform their work without

--- a/lib/dal-test/Cargo.toml
+++ b/lib/dal-test/Cargo.toml
@@ -17,9 +17,10 @@ si-data-pg = { path = "../../lib/si-data-pg" }
 si-std = { path = "../../lib/si-std" }
 si-test-macros = { path = "../../lib/si-test-macros" }
 sodiumoxide = "0.2.6"
-tempfile = "3.2.0"
-tokio = { version = "1.2.0", features = ["full", "tracing"] }
 telemetry = { path = "../../lib/telemetry-rs" }
+tempfile = "3.2.0"
+thiserror = "1.0.24"
+tokio = { version = "1.2.0", features = ["full", "tracing"] }
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 uuid = { version = "1.0.0", features = ["v4"] }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -14,6 +14,7 @@ use names::{Generator, Name};
 
 pub mod builtins;
 pub mod component_payload;
+pub mod component_view;
 
 /// Commits the transactions in the given [`DalContext`] and returns a new context which reuses the
 /// underlying [`dal::Connections`] and with identical state.

--- a/lib/dal-test/src/helpers/component_view.rs
+++ b/lib/dal-test/src/helpers/component_view.rs
@@ -1,0 +1,48 @@
+use dal::ComponentView;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+/// This struct provides the ability to drop fields from a [`ComponentView`](dal::ComponentView)
+/// properties tree and then re-render the view using [`Self::to_value()`].
+///
+/// - It is not recommended to use [`self`] "as-is" in assertions.
+/// - It is recommended to use [`Self::to_value()`] in assertions.
+///
+/// The fields on this struct are **intentionally private**.
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ComponentViewProperties {
+    si: serde_json::Value,
+    domain: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    qualification: Option<serde_json::Value>,
+}
+
+#[derive(Error, Debug)]
+pub enum ComponentViewPropertiesError {
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+}
+
+impl ComponentViewProperties {
+    pub fn drop_code(&mut self) -> &mut Self {
+        self.code = None;
+        self
+    }
+
+    pub fn to_value(&self) -> Result<serde_json::Value, ComponentViewPropertiesError> {
+        Ok(serde_json::to_value(self)?)
+    }
+}
+
+impl TryFrom<ComponentView> for ComponentViewProperties {
+    type Error = ComponentViewPropertiesError;
+
+    fn try_from(value: ComponentView) -> Result<Self, Self::Error> {
+        Ok(serde_json::from_value(value.properties)?)
+    }
+}

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -46,6 +46,7 @@ const DEFAULT_PG_DBNAME: &str = "si_test";
 const ENV_VAR_NATS_URL: &str = "SI_TEST_NATS_URL";
 const ENV_VAR_PG_HOSTNAME: &str = "SI_TEST_PG_HOSTNAME";
 const ENV_VAR_PG_DBNAME: &str = "SI_TEST_PG_DBNAME";
+const ENV_VAR_SKIP_MIGRATING_SCHEMAS: &str = "SI_TEST_SKIP_MIGRATING_SCHEMAS";
 
 const JWT_PUBLIC_FILENAME: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/", "config/public.pem");
 const JWT_PRIVATE_FILENAME: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/", "config/private.pem");
@@ -449,6 +450,13 @@ async fn global_setup(test_context_builer: TestContextBuilder) -> Result<()> {
             .wrap_err("failed to commit jwt key insertion txn")?;
     }
 
+    // Check if the user would like to skip migrating schemas. This is helpful for boosting
+    // performance when running integration tests that do not rely on builtin schemas.
+    let skip_migrating_schemas = match env::var(ENV_VAR_SKIP_MIGRATING_SCHEMAS) {
+        Ok(skip_migrating_schemas_variable) => !skip_migrating_schemas_variable.is_empty(),
+        Err(_) => false,
+    };
+
     info!("creating builtins");
     dal::migrate_builtins(
         services_ctx.pg_pool(),
@@ -456,6 +464,7 @@ async fn global_setup(test_context_builer: TestContextBuilder) -> Result<()> {
         services_ctx.job_processor(),
         services_ctx.veritech().clone(),
         services_ctx.encryption_key(),
+        skip_migrating_schemas,
     )
     .await
     .wrap_err("failed to run builtin migrations")?;

--- a/lib/dal/clippy.toml
+++ b/lib/dal/clippy.toml
@@ -1,4 +1,10 @@
 disallowed-methods = [
     { path = "dal_test::helpers::commit_and_continue", reason = "should not be left in tests as this could infect other tests" },
-    { path = "dal::job::definition::dependent_values_update::dependency_graph_to_dot", reason = "graphviz functions should only be used for local debugging" }
+    { path = "dal::job::definition::dependent_values_update::dependency_graph_to_dot", reason = "graphviz functions should only be used for local debugging" },
+    { path = "env::var", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
+    { path = "env::vars", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
+    { path = "env::var_os", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
+    { path = "env::vars_os", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
+    { path = "env::args", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
+    { path = "env::args_os", reason = "dal should not directly access environment variables (barring ones from CARGO)" },
 ]

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -114,13 +114,20 @@ pub type BuiltinsResult<T> = Result<T, BuiltinsError>;
 /// 1. [`Funcs`](crate::Func)
 /// 1. [`WorkflowPrototypes`](crate::workflow_prototype::WorkflowPrototype)
 /// 1. [`Schemas`](crate::Schema)
-pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext, skip_migrating_schemas: bool) -> BuiltinsResult<()> {
     info!("migrating functions");
     func::migrate(ctx).await?;
+
     info!("migrating workflows");
     workflow::migrate(ctx).await?;
-    info!("migrating schemas");
-    schema::migrate(ctx).await?;
+
+    if skip_migrating_schemas {
+        info!("skipping migrating schemas (this should only be possible when running integration tests)");
+    } else {
+        info!("migrating schemas");
+        schema::migrate(ctx).await?;
+    }
+
     info!("completed migrating functions, workflows and schemas");
     Ok(())
 }

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -2,15 +2,16 @@ use dal::{
     schema::RootProp, AttributeContext, AttributeValue, Component, ComponentView, DalContext, Prop,
     PropKind, Schema, SchemaKind, SchemaVariant, StandardModel,
 };
-
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
     test,
     test_harness::{create_schema, create_schema_variant_with_root},
 };
 use pretty_assertions_sorted::assert_eq;
+
 mod complex_func;
 mod cyclone_crypto;
+mod properties;
 
 /// Create a schema that looks like this:
 /// ```json

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -1,0 +1,182 @@
+use dal::attribute::context::AttributeContextBuilder;
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
+use dal::schema::variant::leaves::LeafKind;
+use dal::{
+    AttributeReadContext, AttributeValue, Component, ComponentView, DalContext, Func,
+    FuncBackendKind, FuncBackendResponseType, PropKind, SchemaKind, SchemaVariant, StandardModel,
+};
+use dal_test::helpers::component_view::ComponentViewProperties;
+use dal_test::test_harness::create_prop_and_set_parent;
+use dal_test::{
+    test,
+    test_harness::{create_schema, create_schema_variant_with_root},
+};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
+    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let schema_variant_id = *schema_variant.id();
+    schema
+        .set_default_schema_variant_id(ctx, Some(schema_variant_id))
+        .await
+        .expect("cannot set default schema variant");
+    let poop_prop =
+        create_prop_and_set_parent(ctx, PropKind::String, "poop", root_prop.domain_prop_id).await;
+
+    // Create a fake code gen func.
+    let mut code_generation_func = Func::new(
+        ctx,
+        "test:codeGeneration",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    let code_generation_func_id = *code_generation_func.id();
+    let code = "function generate(input) {
+        return {
+            code: input.domain?.poop ?? \"\",
+            format: \"json\"
+        };
+    }";
+    code_generation_func
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    code_generation_func
+        .set_handler(ctx, Some("generate"))
+        .await
+        .expect("set handler");
+    let code_generation_func_argument = FuncArgument::new(
+        ctx,
+        "domain",
+        FuncArgumentKind::Object,
+        None,
+        code_generation_func_id,
+    )
+    .await
+    .expect("could not create func argument");
+
+    // Add a code generation leaf.
+    SchemaVariant::add_leaf(
+        ctx,
+        code_generation_func_id,
+        *code_generation_func_argument.id(),
+        schema_variant_id,
+        LeafKind::CodeGeneration,
+    )
+    .await
+    .expect("could not add code generation");
+
+    // Finalize the variant and create a component.
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("unable to finalize schema variant");
+    let (component, _) =
+        Component::new_for_schema_variant_with_node(ctx, "component", &schema_variant_id)
+            .await
+            .expect("cannot create component");
+
+    // Check the view and properties before updating the poop field.
+    let component_view = ComponentView::new(ctx, *component.id())
+        .await
+        .expect("could not create component view");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": { },
+            "code": {
+                "test:codeGeneration": {}
+            }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    let mut component_view_properties = ComponentViewProperties::try_from(component_view)
+        .expect("could not convert component view to component view properties");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {}
+        }], // expected
+        component_view_properties
+            .drop_code()
+            .to_value()
+            .expect("could not convert component view properties to value") // actual
+    );
+
+    // Update the poop field, which will cause the code generation entry to be updated.
+    let poop_attribute_read_context = AttributeReadContext {
+        prop_id: Some(*poop_prop.id()),
+        component_id: Some(*component.id()),
+        ..AttributeReadContext::default()
+    };
+    let poop_attribute_context = AttributeContextBuilder::from(poop_attribute_read_context)
+        .to_context()
+        .expect("could not convert builder to context");
+    let poop_attribute_value = AttributeValue::find_for_context(ctx, poop_attribute_read_context)
+        .await
+        .expect("could not perform find for context")
+        .expect("attribute value not found");
+    let domain_attribute_value = poop_attribute_value
+        .parent_attribute_value(ctx)
+        .await
+        .expect("could not perform parent attribute value")
+        .expect("parent attribute value not found");
+    AttributeValue::update_for_context(
+        ctx,
+        *poop_attribute_value.id(),
+        Some(*domain_attribute_value.id()),
+        poop_attribute_context,
+        Some(serde_json::json!["canoe"]),
+        None,
+    )
+    .await
+    .expect("could not update for context");
+
+    // Check the value with and without the code subtree.
+    let component_view = ComponentView::new(ctx, *component.id())
+        .await
+        .expect("could not create component view");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {
+                "poop": "canoe"
+            },
+            "code": {
+                "test:codeGeneration": {
+                    "code": "canoe",
+                    "format": "json",
+                }
+            }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    let mut component_view_properties = ComponentViewProperties::try_from(component_view)
+        .expect("could not convert component view to component view properties");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {
+                "poop": "canoe"
+            }
+        }], // expected
+        component_view_properties
+            .drop_code()
+            .to_value()
+            .expect("could not convert component view properties to value") // actual
+    );
+}


### PR DESCRIPTION
- Add "ComponentViewProperties" helper for dropping subtrees after rendering "ComponentViews" in dal integration tests
  - Since qualifications are moving to the "Prop" tree, having the ability to drop the subtree is important for test assertions to remain deterministic (example issue: qualification messages containing timestamps)
- Add "SI_TEST_SKIP_MIGRATING_SCHEMAS" to help speed up local development cycles of integration tests that do not rely on builtin schemas
  - In local testing, using this environment variable reduced an arbitrary test total wall clock time from ~1m38s to ~11s

<img src="https://media2.giphy.com/media/4cm8oDGzx6chCOA4Cc/giphy.gif"/>

Fixes ENG-848
Fixes ENG-849