### PR TITLE
feat(dal,sdf): add schema variant finalized once field

### DIFF
--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -7,7 +7,7 @@ use dal::{
     },
     BillingAccount, BillingAccountId, BillingAccountSignup, ChangeSet, Component, DalContext,
     DalContextBuilder, Func, FuncBinding, FuncId, Group, HistoryActor, JwtSecretKey, Node, Prop,
-    PropId, RequestContext, Schema, SchemaId, SchemaVariant, SchemaVariantId, StandardModel, User,
+    PropId, RequestContext, Schema, SchemaVariant, SchemaVariantId, StandardModel, User,
     Visibility,
 };
 use names::{Generator, Name};
@@ -154,23 +154,15 @@ pub async fn new_ctx_for_new_change_set(
     ctx.clone_with_new_visibility(visibility)
 }
 
-pub async fn create_component_and_node_for_schema(
+pub async fn create_component_and_node_for_schema_variant(
     ctx: &DalContext,
-    schema_id: &SchemaId,
+    schema_variant_id: SchemaVariantId,
 ) -> (Component, Node) {
     let name = generate_fake_name();
-    let (component, node) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, node) = Component::new(ctx, &name, schema_variant_id)
         .await
         .expect("cannot create component");
     (component, node)
-}
-
-pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
-    let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
-        .await
-        .expect("cannot create component");
-    component
 }
 
 pub async fn find_schema_by_name(ctx: &DalContext, schema_name: impl AsRef<str>) -> Schema {

--- a/lib/dal-test/src/helpers/builtins.rs
+++ b/lib/dal-test/src/helpers/builtins.rs
@@ -121,7 +121,7 @@ impl SchemaBuiltinsTestHarness {
         prop_map: HashMap<&'static str, PropId>,
         name: impl AsRef<str>,
     ) -> ComponentPayload {
-        let (component, node) = Component::new_for_schema_with_node(ctx, name, &schema_id)
+        let (component, node) = Component::new(ctx, name, schema_variant_id)
             .await
             .expect("unable to create component");
 

--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -360,36 +360,26 @@ pub async fn create_schema_variant_with_root(
     (variant, root)
 }
 
-pub async fn create_component_and_schema(ctx: &DalContext) -> Component {
+pub async fn create_component_and_schema_with_variant(ctx: &DalContext) -> Component {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema_variant
         .finalize(ctx)
         .await
         .expect("unable to finalize schema variant");
     let name = generate_fake_name();
-    let (entity, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant.id())
-        .await
-        .expect("cannot create component");
-    entity
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn create_component_for_schema_variant(
-    ctx: &DalContext,
-    schema_variant_id: &SchemaVariantId,
-) -> Component {
-    let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
+    let (component, _) = Component::new(ctx, &name, *schema_variant.id())
         .await
         .expect("cannot create component");
     component
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
+pub async fn create_component_for_schema_variant(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, _) = Component::new(ctx, &name, schema_variant_id)
         .await
         .expect("cannot create component");
     component

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -262,7 +262,7 @@ impl MigrationDriver {
     pub async fn finalize_schema_variant(
         &self,
         ctx: &DalContext,
-        schema_variant: &SchemaVariant,
+        schema_variant: &mut SchemaVariant,
         root_prop: &RootProp,
     ) -> BuiltinsResult<()> {
         schema_variant.finalize(ctx).await?;

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -61,7 +61,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS AMI`](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Ami.html).
     async fn migrate_ami(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "AMI",
@@ -179,7 +179,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the props to providers.
@@ -267,7 +267,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EC2`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html).
     async fn migrate_ec2(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "EC2 Instance",
@@ -546,7 +546,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -848,7 +848,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Region`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
     async fn migrate_region(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Region",
@@ -927,7 +927,7 @@ impl MigrationDriver {
         output_socket.set_color(ctx, Some(0xd61e8c)).await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // set the component as a configuration frame
@@ -1057,7 +1057,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EIP`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-eip.html).
     async fn migrate_eip(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Elastic IP",
@@ -1191,7 +1191,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -1392,7 +1392,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Key Pair`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html).
     async fn migrate_keypair(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Key Pair",
@@ -1563,7 +1563,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -36,7 +36,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Ingress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_ingress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Ingress",
@@ -315,7 +315,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -601,7 +601,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Egress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_egress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Egress",
@@ -839,7 +839,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -1068,7 +1068,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Security Group`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_security_group(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Security Group",
@@ -1248,7 +1248,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up!
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -25,7 +25,7 @@ impl MigrationDriver {
     async fn migrate_butane(&self, ctx: &DalContext) -> BuiltinsResult<()> {
         let definition: SchemaVariantDefinition = serde_json::from_str(BUTANE_DEFINITION)?;
 
-        let (schema, schema_variant, root_prop, maybe_prop_cache) = match self
+        let (schema, mut schema_variant, root_prop, maybe_prop_cache) = match self
             .create_schema_and_variant(
                 ctx,
                 "Butane",
@@ -112,7 +112,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Collect the props we need.

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -22,7 +22,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_hub_credential(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Hub Credential",
@@ -77,7 +77,7 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x1e88d6)).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Note: I wasn't able to create a ui menu with two layers
@@ -91,7 +91,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_image(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Image",
@@ -199,7 +199,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/image" field.

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -107,7 +107,7 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x85c9a3)).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/metadata/name" field.
@@ -301,7 +301,7 @@ impl MigrationDriver {
         let ui_menu = SchemaUiMenu::new(ctx, "Deployment", "Kubernetes", &diagram_kind).await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set default values after finalization.

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -15,7 +15,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_generic_frame(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _) = match self
+        let (schema, mut schema_variant, root_prop, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Generic Frame",
@@ -58,7 +58,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // set the component as a configuration frame

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -168,6 +168,8 @@ pub enum ComponentError {
     BadAttributeReadContext(String),
     #[error("found child attribute value of a map without a key: {0}")]
     FoundMapEntryWithoutKey(AttributeValueId),
+    #[error("schema variant has not been finalized at least once: {0}")]
+    SchemaVariantNotFinalized(SchemaVariantId),
 }
 
 pub type ComponentResult<T> = Result<T, ComponentError>;
@@ -237,35 +239,25 @@ impl_standard_model! {
 
 impl Component {
     #[instrument(skip_all)]
-    pub async fn new_for_schema_with_node(
+    pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,
-        schema_id: &SchemaId,
+        schema_variant_id: SchemaVariantId,
     ) -> ComponentResult<(Self, Node)> {
-        let schema = Schema::get_by_id(ctx, schema_id)
+        let schema_variant = SchemaVariant::get_by_id(ctx, &schema_variant_id)
             .await?
-            .ok_or(SchemaError::NotFound(*schema_id))?;
+            .ok_or(SchemaVariantError::NotFound(schema_variant_id))?;
 
-        let schema_variant_id = schema
-            .default_schema_variant_id()
-            .ok_or(SchemaError::NoDefaultVariant(*schema_id))?;
+        // NOTE(nick): we may want to replace this with a better solution. We use this temporarily to
+        // ensure components are not created unless the variant has been finalized at least once.
+        if !schema_variant.finalized_once() {
+            return Err(ComponentError::SchemaVariantNotFinalized(schema_variant_id));
+        }
 
-        Self::new_for_schema_variant_with_node(ctx, name, schema_variant_id).await
-    }
-
-    #[instrument(skip_all)]
-    pub async fn new_for_schema_variant_with_node(
-        ctx: &DalContext,
-        name: impl AsRef<str>,
-        schema_variant_id: &SchemaVariantId,
-    ) -> ComponentResult<(Self, Node)> {
-        let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id)
-            .await?
-            .ok_or(SchemaVariantError::NotFound(*schema_variant_id))?;
         let schema = schema_variant
             .schema(ctx)
             .await?
-            .ok_or(SchemaVariantError::MissingSchema(*schema_variant_id))?;
+            .ok_or(SchemaVariantError::MissingSchema(schema_variant_id))?;
 
         let row = ctx
             .txns()
@@ -283,7 +275,7 @@ impl Component {
         let component: Component = standard_model::finish_create_from_row(ctx, row).await?;
         component.set_schema(ctx, schema.id()).await?;
         component
-            .set_schema_variant(ctx, schema_variant.id())
+            .set_schema_variant(ctx, &schema_variant_id)
             .await?;
 
         // Need to flesh out node so that the template data is also included in the node we

--- a/lib/dal/src/migrations/U0033__schema_variants.sql
+++ b/lib/dal/src/migrations/U0033__schema_variants.sql
@@ -1,18 +1,19 @@
 CREATE TABLE schema_variants
 (
-    pk                          ident primary key default ident_create_v1(),
-    id                          ident not null default ident_create_v1(),
+    pk                          ident primary key                 DEFAULT ident_create_v1(),
+    id                          ident                    NOT NULL DEFAULT ident_create_v1(),
     tenancy_universal           bool                     NOT NULL,
     tenancy_billing_account_ids ident[],
     tenancy_organization_ids    ident[],
     tenancy_workspace_ids       ident[],
-    visibility_change_set_pk    ident                   NOT NULL DEFAULT ident_nil_v1(),
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     name                        text                     NOT NULL,
     link                        text,
-    color                       bigint
+    color                       bigint,
+    finalized_once              bool                     NOT NULL DEFAULT FALSE
 );
 SELECT standard_model_table_constraints_v1('schema_variants');
 SELECT belongs_to_table_create_v1('schema_variant_belongs_to_schema', 'schema_variants', 'schemas');

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -184,23 +184,23 @@ impl SchemaVariant {
                 }
             },
             PropKind::Map => todo!("maps not yet implemented simply because nick didn't need them yet and didn't want an untested solution"),
-            _ => match (definition.entry.is_some(), definition.children.is_empty()) {
-                (true, false) => {
+            _ => match (definition.entry.is_none(), definition.children.is_empty()) {
+                (false, false) => {
                     return Err(SchemaVariantError::FoundChildrenAndEntryForPrimitive(
                         definition.name.clone(),
                     ));
                 }
-                (true, true) => {
+                (false, true) => {
                     return Err(SchemaVariantError::FoundEntryForPrimitive(
                         definition.name.clone(),
                     ));
                 }
-                (false, false) => {
+                (true, false) => {
                     return Err(SchemaVariantError::FoundChildrenForPrimitive(
                         definition.name.clone(),
                     ));
                 }
-                (false, true) => {}
+                (true, true) => {}
             },
         }
 

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -14,7 +14,7 @@ use pretty_assertions_sorted::assert_eq;
 async fn update_for_context_simple(ctx: &DalContext) {
     // "name": String
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -26,7 +26,7 @@ async fn update_for_context_simple(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
+    let (component, _) = Component::new(ctx, "Basic component", *schema_variant.id())
         .await
         .expect("Unable to create component");
 
@@ -142,7 +142,7 @@ async fn update_for_context_simple(ctx: &DalContext) {
 #[test]
 async fn insert_for_context_simple(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -157,7 +157,7 @@ async fn insert_for_context_simple(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
+    let (component, _) = Component::new(ctx, "Array Component", *schema_variant.id())
         .await
         .expect("Unable to create component");
 
@@ -221,7 +221,7 @@ async fn insert_for_context_simple(ctx: &DalContext) {
 #[test]
 async fn update_for_context_object(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -247,7 +247,7 @@ async fn update_for_context_object(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
+    let (component, _) = Component::new(ctx, "Basic component", *schema_variant.id())
         .await
         .expect("Unable to create component");
 
@@ -410,7 +410,7 @@ async fn update_for_context_object(ctx: &DalContext) {
 #[test]
 async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -425,7 +425,7 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
+    let (component, _) = Component::new(ctx, "Array Component", *schema_variant.id())
         .await
         .expect("Unable to create component");
 
@@ -515,10 +515,9 @@ async fn list_payload(ctx: &DalContext) {
         .default_schema_variant_id()
         .expect("missing default schema variant id");
     let name = generate_name();
-    let (component, _node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, _node) = Component::new(ctx, &name, *schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let payloads = AttributeValue::list_payload_for_read_context(
         ctx,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -8,7 +8,7 @@ use dal_test::{
     helpers::setup_identity_func,
     test,
     test_harness::{
-        create_component_and_schema, create_component_for_schema_variant,
+        create_component_and_schema_with_variant, create_component_for_schema_variant,
         create_prop_and_set_parent, create_schema, create_schema_variant,
         create_schema_variant_with_root,
     },
@@ -23,18 +23,21 @@ mod view;
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let _component = create_component_and_schema(ctx).await;
+    let _component = create_component_and_schema_with_variant(ctx).await;
 }
 
 #[test]
 async fn new_for_schema_variant_with_node(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("could not finalize schema variant");
 
-    let (component, node) =
-        Component::new_for_schema_variant_with_node(ctx, "mastodon", schema_variant.id())
-            .await
-            .expect("cannot create component");
+    let (component, node) = Component::new(ctx, "mastodon", *schema_variant.id())
+        .await
+        .expect("cannot create component");
 
     // Test the find for node query.
     let found_component = Component::find_for_node(ctx, *node.id())
@@ -50,20 +53,27 @@ async fn new_for_schema_variant_with_node(ctx: &DalContext) {
 #[test]
 async fn schema_relationships(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
-    let _component = create_component_for_schema_variant(ctx, schema_variant.id()).await;
+    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("could not finalize schema variant");
+    let _component = create_component_for_schema_variant(ctx, *schema_variant.id()).await;
 }
 
 #[test]
 async fn name_from_context(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("could not finalize schema variant");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "mastodon", schema_variant.id())
-            .await
-            .expect("cannot create component");
-    let _ = Component::new_for_schema_variant_with_node(ctx, "wooly mammoth", schema_variant.id())
+    let (component, _) = Component::new(ctx, "mastodon", *schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let _ = Component::new(ctx, "wooly mammoth", *schema_variant.id())
         .await
         .expect("cannot create second component");
 
@@ -84,7 +94,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
 
     // Create "ekwb" schema.
     let ekwb_schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (ekwb_schema_variant, ekwb_root_prop) =
+    let (mut ekwb_schema_variant, ekwb_root_prop) =
         create_schema_variant_with_root(ctx, *ekwb_schema.id()).await;
     ekwb_schema_variant
         .finalize(ctx)
@@ -93,7 +103,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
 
     // Create "noctua" schema.
     let noctua_schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (noctua_schema_variant, noctua_root_prop) =
+    let (mut noctua_schema_variant, noctua_root_prop) =
         create_schema_variant_with_root(ctx, *noctua_schema.id()).await;
     let u12a_prop = create_prop_and_set_parent(
         ctx,
@@ -193,14 +203,12 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
         .expect("could not create new change set");
     ctx.update_visibility(Visibility::new(new_change_set.pk, None));
 
-    let (ekwb_component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "ekwb", ekwb_schema_variant.id())
-            .await
-            .expect("cannot create component");
-    let (noctua_component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "noctua", noctua_schema_variant.id())
-            .await
-            .expect("cannot create component");
+    let (ekwb_component, _) = Component::new(ctx, "ekwb", *ekwb_schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let (noctua_component, _) = Component::new(ctx, "noctua", *noctua_schema_variant.id())
+        .await
+        .expect("cannot create component");
     let ekwb_component_id = *ekwb_component.id();
     let noctua_component_id = *noctua_component.id();
 

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -14,7 +14,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -55,10 +55,9 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         .await
         .expect("unable to finalize schema variant");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", schema_variant.id())
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", *schema_variant.id())
+        .await
+        .expect("cannot create component");
 
     // Set a value on the prop to check if our code generation works as intended.
     let read_context = AttributeReadContext {

--- a/lib/dal/tests/integration_test/component/qualification.rs
+++ b/lib/dal/tests/integration_test/component/qualification.rs
@@ -14,7 +14,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn add_and_list_qualifications(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema
         .set_default_schema_variant_id(ctx, Some(schema_variant_id))
@@ -74,10 +74,9 @@ async fn add_and_list_qualifications(ctx: &DalContext) {
         .await
         .expect("unable to finalize schema variant");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", &schema_variant_id)
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", schema_variant_id)
+        .await
+        .expect("cannot create component");
 
     // Set a value on the prop to check if our qualification works as intended.
     let read_context = AttributeReadContext {

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 async fn check_validations_for_component(ctx: &DalContext) {
     // Setup the schema and schema variant and create a validation for a string field.
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -97,10 +97,9 @@ async fn check_validations_for_component(ctx: &DalContext) {
         .expect("cannot finalize SchemaVariant");
 
     // Once setup is complete, create a component and update the target field to an "invalid" value.
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "hundo_gecs", schema_variant.id())
-            .await
-            .expect("could not create component");
+    let (component, _) = Component::new(ctx, "hundo_gecs", *schema_variant.id())
+        .await
+        .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
         component_id: Some(*component.id()),
@@ -284,7 +283,7 @@ async fn check_validations_for_component(ctx: &DalContext) {
 #[test]
 async fn check_js_validation_for_component(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -336,10 +335,9 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
         .await
         .expect("could not finalize");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "Danoth", schema_variant.id())
-            .await
-            .expect("could not create component");
+    let (component, _) = Component::new(ctx, "Danoth", *schema_variant.id())
+        .await
+        .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
         component_id: Some(*component.id()),

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -23,7 +23,7 @@ pub async fn create_schema_with_object_and_string_prop(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -70,7 +70,7 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -119,7 +119,7 @@ pub async fn create_schema_with_string_props(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -154,7 +154,7 @@ pub async fn create_schema_with_array_of_string_props(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -196,7 +196,7 @@ pub async fn create_schema_with_nested_array_objects(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -245,7 +245,7 @@ pub async fn create_simple_map(ctx: &DalContext) -> (Schema, SchemaVariant, Prop
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -287,7 +287,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -337,10 +337,9 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 async fn only_string_props(ctx: &DalContext) {
     let (_schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "capoeira", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "capoeira", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -419,10 +418,9 @@ async fn only_string_props(ctx: &DalContext) {
 async fn one_object_prop(ctx: &DalContext) {
     let (_schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "santos dumont", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "santos dumont", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -528,10 +526,9 @@ async fn nested_object_prop(ctx: &DalContext) {
         dust_prop,
         root_prop,
     ) = create_schema_with_nested_objects_and_string_prop(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "free ronaldinho", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "free ronaldinho", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -677,10 +674,9 @@ async fn simple_array_of_strings(ctx: &DalContext) {
     let (_schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "tim maia", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "tim maia", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -772,10 +768,10 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
         song_name_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
+    let (component, _) = Component::new(
         ctx,
         "An Integralist Doesn't Run, It Flies",
-        schema_variant.id(),
+        *schema_variant.id(),
     )
     .await
     .expect("Unable to create component");
@@ -1014,13 +1010,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
 async fn simple_map(ctx: &DalContext) {
     let (_schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "E como isso afeta o Grêmio?",
-        schema_variant.id(),
-    )
-    .await
-    .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "E como isso afeta o Grêmio?", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -1112,13 +1104,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
         song_map_item_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects_and_a_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "E como isso afeta o Grêmio?",
-        schema_variant.id(),
-    )
-    .await
-    .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "E como isso afeta o Grêmio?", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -18,7 +18,7 @@ use pretty_assertions_sorted::assert_eq;
 async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     // Create and setup the schema and schema variant.
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -182,10 +182,9 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     .await;
 
     // Now that everything is set up, create the component.
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "god-of-war", schema_variant.id())
-            .await
-            .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "god-of-war", *schema_variant.id())
+        .await
+        .expect("unable to create component");
 
     // Confirm the component view renders what we expect
     let component_view = ComponentView::new(ctx, *component.id())
@@ -286,7 +285,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
 #[test]
 async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -451,13 +450,9 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
 
     // Create the component and cache what we need to insert into the map.
     // prototype argument for each item.
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "the-game-awards-2022",
-        schema_variant.id(),
-    )
-    .await
-    .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "the-game-awards-2022", *schema_variant.id())
+        .await
+        .expect("unable to create component");
     let component_id = *component.id();
     let insert_context = AttributeContext::builder()
         .set_prop_id(map_prop_id)

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -19,7 +19,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema
         .set_default_schema_variant_id(ctx, Some(schema_variant_id))
@@ -78,10 +78,9 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
         .finalize(ctx)
         .await
         .expect("unable to finalize schema variant");
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", &schema_variant_id)
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", schema_variant_id)
+        .await
+        .expect("cannot create component");
 
     // Check the view and properties before updating the poop field.
     let component_view = ComponentView::new(ctx, *component.id())

--- a/lib/dal/tests/integration_test/confirmation_prototype.rs
+++ b/lib/dal/tests/integration_test/confirmation_prototype.rs
@@ -2,7 +2,7 @@ use dal::{
     confirmation_prototype::ConfirmationPrototypeContext, ConfirmationPrototype, DalContext, Func,
     Schema, StandardModel,
 };
-use dal_test::{test, test_harness::create_component_for_schema};
+use dal_test::{test, test_harness::create_component_for_schema_variant};
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
@@ -30,7 +30,7 @@ async fn find_for_component(ctx: &DalContext) {
         .default_variant(ctx)
         .await
         .expect("unable to find default schema variant");
-    let component = create_component_for_schema(ctx, schema.id()).await;
+    let component = create_component_for_schema_variant(ctx, *schema_variant.id()).await;
 
     let func_name = "si:resourceExistsConfirmation";
     let func = Func::find_by_attr(ctx, "name", &func_name)
@@ -62,7 +62,11 @@ async fn run(ctx: &DalContext) {
         .expect("unable to find schema")
         .pop()
         .expect("unable to find schema");
-    let component = create_component_for_schema(ctx, schema.id()).await;
+    let default_variant = schema
+        .default_variant(ctx)
+        .await
+        .expect("could not find default variant");
+    let component = create_component_for_schema_variant(ctx, *default_variant.id()).await;
 
     let prototype = ConfirmationPrototype::list_for_component(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/confirmation_resolver.rs
+++ b/lib/dal/tests/integration_test/confirmation_resolver.rs
@@ -2,7 +2,7 @@ use dal::{
     confirmation_resolver::ConfirmationResolverContext, ActionPrototype, ConfirmationPrototype,
     ConfirmationResolver, DalContext, FuncBindingId, FuncId, Schema, StandardModel,
 };
-use dal_test::{test, test_harness::create_component_for_schema};
+use dal_test::{test, test_harness::create_component_for_schema_variant};
 
 #[test]
 async fn new(ctx: &DalContext) {
@@ -11,7 +11,11 @@ async fn new(ctx: &DalContext) {
         .expect("unable to find schema")
         .pop()
         .expect("unable to find schema");
-    let component = create_component_for_schema(ctx, schema.id()).await;
+    let default_variant = schema
+        .default_variant(ctx)
+        .await
+        .expect("could not find default variant");
+    let component = create_component_for_schema_variant(ctx, *default_variant.id()).await;
 
     let prototype = ConfirmationPrototype::list_for_component(ctx, *component.id())
         .await
@@ -63,7 +67,11 @@ async fn find_for_prototype(ctx: &DalContext) {
         .expect("unable to find schema")
         .pop()
         .expect("unable to find schema");
-    let component = create_component_for_schema(ctx, schema.id()).await;
+    let default_variant = schema
+        .default_variant(ctx)
+        .await
+        .expect("could not find default variant");
+    let component = create_component_for_schema_variant(ctx, *default_variant.id()).await;
 
     let prototype = ConfirmationPrototype::list_for_component(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
+++ b/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
@@ -8,7 +8,7 @@ use dal::{
     SchemaVariant, Socket, StandardModel, WorkflowPrototypeId,
 };
 use dal_test::helpers::setup_identity_func;
-use dal_test::{helpers::create_component_and_node_for_schema, test};
+use dal_test::{helpers::create_component_and_node_for_schema_variant, test};
 
 async fn create_dummy_schema(ctx: &DalContext) -> BuiltinsResult<(Schema, Socket, Socket)> {
     let mut schema = Schema::new(
@@ -18,7 +18,7 @@ async fn create_dummy_schema(ctx: &DalContext) -> BuiltinsResult<(Schema, Socket
         &ComponentKind::Standard,
     )
     .await?;
-    let (schema_variant, _root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
+    let (mut schema_variant, _root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;
@@ -94,13 +94,22 @@ async fn new(ctx: &DalContext) {
     let (schema, input_socket, output_socket) = create_dummy_schema(ctx)
         .await
         .expect("unable to create dummy schema");
+    let schema_variant_id = *schema
+        .default_schema_variant_id()
+        .expect("no default variant");
 
-    let (first, first_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
-    let (first2, _first2_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
-    let (second, second_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
-    let (second2, second2_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
-    let (third, third_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
-    let (third2, third2_node) = create_component_and_node_for_schema(ctx, schema.id()).await;
+    let (first, first_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
+    let (first2, _first2_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
+    let (second, second_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
+    let (second2, second2_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
+    let (third, third_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
+    let (third2, third2_node) =
+        create_component_and_node_for_schema_variant(ctx, schema_variant_id).await;
 
     Edge::new(
         ctx,

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -18,15 +18,14 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
         .expect("could not perform schema find by attr")
         .pop()
         .expect("docker image schema not found");
-    let schema_variant_id = schema
+    let schema_variant_id = *schema
         .default_schema_variant_id()
         .expect("could not find default schema variant id");
     let name = "13700KF".to_string();
 
-    let (component, node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, node) = Component::new(ctx, &name, schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let component_view = ComponentView::new(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -5,7 +5,7 @@ use dal::{
 use dal_test::{
     test,
     test_harness::{
-        create_component_and_schema, create_node, create_schema, create_schema_variant,
+        create_component_and_schema_with_variant, create_node, create_schema, create_schema_variant,
     },
 };
 
@@ -21,7 +21,7 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn component_relationships(ctx: &DalContext) {
-    let component = create_component_and_schema(ctx).await;
+    let component = create_component_and_schema_with_variant(ctx).await;
     let node = create_node(ctx, &NodeKind::Configuration).await;
     node.set_component(ctx, component.id())
         .await

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -32,10 +32,9 @@ async fn property_editor_value(ctx: &DalContext) {
         .default_schema_variant_id()
         .expect("missing default schema variant id");
     let name = generate_name();
-    let (component, _node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, _node) = Component::new(ctx, &name, *schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let property_editor_values = PropertyEditorValues::for_component(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -300,7 +300,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
 // 38.805354552534816, -77.05091482877533
 async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -327,7 +327,7 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
     prop_map.insert("/root/domain/object/source", *source_prop.id());
     prop_map.insert("/root/domain/object/intermediate", *intermediate_prop.id());
 
-    let (component, node) = Component::new_for_schema_with_node(ctx, "esp", schema.id())
+    let (component, node) = Component::new(ctx, "esp", *schema_variant.id())
         .await
         .expect("unable to create component");
 
@@ -370,7 +370,7 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
 // 38.82091849697006, -77.05236860190759
 async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -395,7 +395,7 @@ async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     let mut prop_map = HashMap::new();
     prop_map.insert("/root/domain/destination", *destination_prop.id());
 
-    let (component, node) = Component::new_for_schema_with_node(ctx, "swings", schema.id())
+    let (component, node) = Component::new(ctx, "swings", *schema_variant.id())
         .await
         .expect("unable to create component");
 
@@ -427,7 +427,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     ) = setup_identity_func(ctx).await;
 
     let mut source_schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (source_schema_variant, source_root) =
+    let (mut source_schema_variant, source_root) =
         create_schema_variant_with_root(ctx, *source_schema.id()).await;
     source_schema
         .set_default_schema_variant_id(ctx, Some(*source_schema_variant.id()))
@@ -490,7 +490,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     .expect("cannot create source external provider attribute prototype argument");
 
     let mut destination_schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (destination_schema_variant, destination_root) =
+    let (mut destination_schema_variant, destination_root) =
         create_schema_variant_with_root(ctx, *destination_schema.id()).await;
     destination_schema
         .set_default_schema_variant_id(ctx, Some(*destination_schema_variant.id()))
@@ -571,7 +571,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     .expect("cannot create prototype argument for destination");
 
     let (source_component, _) =
-        Component::new_for_schema_with_node(ctx, "Source Component", source_schema.id())
+        Component::new(ctx, "Source Component", *source_schema_variant.id())
             .await
             .expect("Unable to create source component");
 
@@ -598,7 +598,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     );
 
     let (destination_component, _) =
-        Component::new_for_schema_with_node(ctx, "Destination Component", destination_schema.id())
+        Component::new(ctx, "Destination Component", *source_schema_variant.id())
             .await
             .expect("Unable to create destination component");
 
@@ -707,7 +707,6 @@ async fn with_deep_data_structure(ctx: &DalContext) {
                 "si": {
                     "name": "Destination Component",
                 },
-
                 "domain": {
                     "parent_object": {
                         "base_object": {

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -17,7 +17,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn intra_component_identity_update(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -39,7 +39,7 @@ async fn intra_component_identity_update(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "starfield", schema.id())
+    let (component, _) = Component::new(ctx, "starfield", *schema_variant.id())
         .await
         .expect("unable to create component");
 
@@ -284,7 +284,7 @@ async fn intra_component_identity_update(ctx: &DalContext) {
 #[test]
 async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContext) {
     let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -376,10 +376,9 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
     .await
     .expect("could not create attribute prototype argument");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "valkyrie-queen", schema_variant.id())
-            .await
-            .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "valkyrie-queen", *schema_variant.id())
+        .await
+        .expect("unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -63,7 +63,7 @@ async fn find_code_item_prop(ctx: &DalContext) {
 #[test]
 async fn find_implicit_internal_providers_for_root_children(ctx: &DalContext) {
     let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let (schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
+    let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await
         .expect("cannot create schema variant");
     schema_variant

--- a/lib/sdf/src/server/service/diagram/create_node.rs
+++ b/lib/sdf/src/server/service/diagram/create_node.rs
@@ -55,8 +55,7 @@ pub async fn create_node(
         return Err(DiagramError::InvalidDiagramKind(diagram_kind));
     }
 
-    let (component, node) =
-        Component::new_for_schema_variant_with_node(&ctx, &name, schema_variant_id).await?;
+    let (component, node) = Component::new(&ctx, &name, *schema_variant_id).await?;
 
     let component_id = *component.id();
 

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -34,7 +34,7 @@ async fn list_components_identification() {
     );
 
     let schema = create_schema(&dal_ctx, &SchemaKind::Configuration).await;
-    let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
         .finalize(&dal_ctx)
         .await
@@ -43,19 +43,17 @@ async fn list_components_identification() {
     let component_name1 = "poop";
     let component_name2 = "ilikemybutt";
     for name in &[component_name1, component_name2] {
-        let _component =
-            Component::new_for_schema_variant_with_node(&dal_ctx, &name, schema_variant.id())
-                .await
-                .expect("cannot create new component");
+        let _component = Component::new(&dal_ctx, &name, *schema_variant.id())
+            .await
+            .expect("cannot create new component");
     }
 
     let component_name3 = "bobão";
     let component_name4 = "comédia";
     for name in &[component_name3, component_name4] {
-        let _component =
-            Component::new_for_schema_variant_with_node(&dal_ctx, &name, schema_variant.id())
-                .await
-                .expect("cannot create new component");
+        let _component = Component::new(&dal_ctx, &name, *schema_variant.id())
+            .await
+            .expect("cannot create new component");
     }
 
     let visibility = *dal_ctx.visibility();
@@ -147,13 +145,13 @@ async fn get_components_metadata() {
 
     let schema = create_schema(&dal_ctx, &SchemaKind::Configuration).await;
 
-    let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
         .finalize(&dal_ctx)
         .await
         .expect("could not finalize schema variant");
 
-    let _component = create_component_for_schema_variant(&dal_ctx, schema_variant.id()).await;
+    let _component = create_component_for_schema_variant(&dal_ctx, *schema_variant.id()).await;
 
     dal_ctx.commit().await.expect("cannot commit transaction");
 


### PR DESCRIPTION
Primary:
- Add "finalized_once" field for schema variants to ensure that we do
  not create components unless the variants have been finalized once
- Remove "finalize_by_id" as we need to modify a schema variant column
  when finalizing
- Only finalize once when adding a leaf for a schema variant
  (performance benefit!)

Secondary:
- Reduce two component creation methods down to one and rename it to
  "new" (we no longer have the method that looks for the default
  variant as the user should decide that)
  - Remove helper functions that relied on the removed creation method
 
<img src="https://media2.giphy.com/media/IhP6NP2rOTGYvQOjkq/giphy.gif"/>

Fixes ENG-855