### PR TITLE
fix(web): avoid crash when merging a change-set

### DIFF
--- a/app/web/src/organisms/ChangeSetPanel.vue
+++ b/app/web/src/organisms/ChangeSetPanel.vue
@@ -283,7 +283,7 @@ const applyChangeSet = async () => {
   // when the change set is done done, check if the change set apply was successful
   if (changeSetMergeStatus.value.isSuccess) {
     await jsConfetti.addConfetti(_.sample(confettis));
-    wipeRef.value.close();
+    wipeRef.value?.close();
     await navigateToFixMode();
   }
 };


### PR DESCRIPTION
The await above means another line of code could be executed, setting wipeRef.value to null. This was causing a crash.