### PR TITLE
feat(dal,sdf): set return types for funcs based on destination prop

### DIFF
--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -23,7 +23,7 @@ use crate::{
     HistoryEventError, ReadTenancyError, SchemaVariant, SchemaVariantId, StandardModel,
     StandardModelError, Timestamp, Visibility, WriteTenancy,
 };
-use crate::{AttributeValueError, AttributeValueId};
+use crate::{AttributeValueError, AttributeValueId, FuncBackendResponseType};
 
 const ALL_ANCESTOR_PROPS: &str = include_str!("./queries/prop_all_ancestor_props.sql");
 const FIND_ROOT_FOR_SCHEMA_VARIANT: &str =
@@ -101,6 +101,19 @@ impl From<PropKind> for WidgetKind {
             PropKind::String | PropKind::Integer => Self::Text,
             PropKind::Object => Self::Header,
             PropKind::Map => Self::Map,
+        }
+    }
+}
+
+impl From<PropKind> for FuncBackendResponseType {
+    fn from(prop: PropKind) -> Self {
+        match prop {
+            PropKind::Array => Self::Array,
+            PropKind::Boolean => Self::Boolean,
+            PropKind::Integer => Self::Integer,
+            PropKind::Object => Self::PropObject,
+            PropKind::Map => Self::Map,
+            PropKind::String => Self::String,
         }
     }
 }

--- a/lib/dal/src/queries/attribute_prototype_find_for_context_null_key.sql
+++ b/lib/dal/src/queries/attribute_prototype_find_for_context_null_key.sql
@@ -1,0 +1,16 @@
+SELECT DISTINCT ON (
+    attribute_prototypes.attribute_context_prop_id,
+    attribute_prototypes.attribute_context_internal_provider_id,
+    attribute_prototypes.attribute_context_external_provider_id,
+    attribute_prototypes.attribute_context_component_id
+    ) row_to_json(attribute_prototypes.*) AS object
+FROM attribute_prototypes_v1($1, $2) AS attribute_prototypes
+WHERE attribute_prototypes.attribute_context_prop_id = $3
+  AND attribute_prototypes.attribute_context_internal_provider_id = $4
+  AND attribute_prototypes.attribute_context_external_provider_id = $5
+  AND attribute_prototypes.attribute_context_component_id = $6
+  AND attribute_prototypes.key IS NULL 
+ORDER BY attribute_context_prop_id DESC,
+         attribute_context_internal_provider_id DESC,
+         attribute_context_external_provider_id DESC,
+         attribute_context_component_id DESC;

--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -140,6 +140,8 @@ pub enum FuncError {
     FuncCannotBeTurnedIntoVariant(FuncId),
     #[error("unexpected func variant ({0:?}) creating attribute func")]
     UnexpectedFuncVariantCreatingAttributeFunc(FuncVariant),
+    #[error("cannot bind func to different prop kinds")]
+    FuncDestinationPropKindMismatch,
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;


### PR DESCRIPTION
Use the `prop_id` on the `AttributePrototype` context to get the`PropKind` and set the return type automatically for `JsAttribute` functions.