### PR TITLE
bug(prepare) Fix newline output suppression in wait-for-pg.sh on macOS

### DIFF
--- a/scripts/wait-for-pg.sh
+++ b/scripts/wait-for-pg.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 echo -n "Trying PG"
 while :; do


### PR DESCRIPTION
On Ubuntu, `sh` and `bash` are, more or less, functionally equivalent. This means that `echo -n foo` will suppress the newline output, regardless of which is used to run the script. On macOS, `sh` and `bash` behave differently, and `echo -n foo` will output `-n foo\n` with `sh`. Using `bash` gives us the desired newline suppression in the output on both Ubuntu and macOS.