### PR TITLE
Remove SchemaKind

### DIFF
--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     AttributeReadContext, AttributeValue, BuiltinsError, BuiltinsResult, DalContext,
     ExternalProvider, Func, FuncError, FuncId, InternalProvider, Prop, PropError, PropId, PropKind,
-    Schema, SchemaError, SchemaId, SchemaKind, SchemaVariant, SchemaVariantId, StandardModel,
+    Schema, SchemaError, SchemaId, SchemaVariant, SchemaVariantId, StandardModel,
     ValidationPrototype, ValidationPrototypeContext,
 };
 
@@ -163,14 +163,11 @@ impl MigrationDriver {
         self.func_id_cache.get(name.as_ref()).copied()
     }
 
-    /// Create a [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant). In addition, set the node
-    /// color for the given [`SchemaKind`](crate::SchemaKind) (which may correspond to a
-    /// [`DiagramKind`](crate::DiagramKind)).
+    /// Create a [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant).
     pub async fn create_schema_and_variant(
         &self,
         ctx: &DalContext,
         name: impl AsRef<str>,
-        kind: SchemaKind,
         component_kind: ComponentKind,
         node_color: Option<i64>,
         definition: Option<SchemaVariantDefinition>,
@@ -200,7 +197,7 @@ impl MigrationDriver {
         info!("migrating {name} schema");
 
         // NOTE(nick): D.R.Y. not desired, but feel free to do so.
-        let mut schema = Schema::new(ctx, name, &kind, &component_kind).await?;
+        let mut schema = Schema::new(ctx, name, &component_kind).await?;
         if let Some(definition) = definition {
             let (
                 mut schema_variant,

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -18,7 +18,7 @@ use crate::{
     schema::SchemaUiMenu, ActionPrototype, ActionPrototypeContext, AttributePrototypeArgument,
     AttributeReadContext, AttributeValue, BuiltinsResult, ConfirmationPrototype,
     ConfirmationPrototypeContext, DalContext, DiagramKind, ExternalProvider, Func,
-    InternalProvider, PropKind, SchemaError, SchemaKind, StandardModel, WorkflowPrototype,
+    InternalProvider, PropKind, SchemaError, StandardModel, WorkflowPrototype,
     WorkflowPrototypeContext,
 };
 use crate::{AttributeValueError, SchemaVariant};
@@ -70,7 +70,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "AMI",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -82,10 +81,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "AMI", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "AMI", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop and validation creation
@@ -284,7 +281,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "EC2 Instance",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -296,10 +292,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "EC2 Instance", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "EC2 Instance", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop: /root/domain/ImageId
@@ -889,7 +883,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Region",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -901,10 +894,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Region", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Region", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop Creation
@@ -1098,7 +1089,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Elastic IP",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -1110,10 +1100,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Elastic IP", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Elastic IP", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop: /root/domain/tags
@@ -1457,7 +1445,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Key Pair",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -1469,10 +1456,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Key Pair", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Key Pair", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop: /root/domain/KeyName

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -10,8 +10,8 @@ use crate::{
     schema::SchemaUiMenu, ActionPrototype, ActionPrototypeContext, AttributePrototypeArgument,
     AttributeReadContext, AttributeValue, AttributeValueError, BuiltinsResult,
     ConfirmationPrototype, ConfirmationPrototypeContext, DalContext, DiagramKind, ExternalProvider,
-    Func, FuncBinding, InternalProvider, PropKind, SchemaError, SchemaKind, SchemaVariant,
-    StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
+    Func, FuncBinding, InternalProvider, PropKind, SchemaError, SchemaVariant, StandardModel,
+    WorkflowPrototype, WorkflowPrototypeContext,
 };
 use crate::{
     builtins::schema::aws::{AWS_NODE_COLOR, EC2_TAG_DOCS_URL},
@@ -45,7 +45,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Ingress",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -57,10 +56,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Ingress", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Ingress", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop Creation
@@ -630,7 +627,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Egress",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -642,10 +638,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Egress", "AWS", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Egress", "AWS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop Creation
@@ -1117,7 +1111,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Security Group",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(AWS_NODE_COLOR),
                 None,
@@ -1129,10 +1122,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        SchemaUiMenu::new(ctx, "Security Group", "AWS", &diagram_kind)
+
+        SchemaUiMenu::new(ctx, "Security Group", "AWS")
             .await?
             .set_schema(ctx, schema.id())
             .await?;

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -9,7 +9,7 @@ use crate::{
 use crate::{
     schema::SchemaUiMenu, AttributePrototype, AttributePrototypeArgument, AttributePrototypeError,
     AttributeReadContext, AttributeValue, BuiltinsError, BuiltinsResult, DalContext,
-    InternalProvider, SchemaError, SchemaKind, SchemaVariant, StandardModel,
+    InternalProvider, SchemaVariant, StandardModel,
 };
 
 // Definitions
@@ -39,7 +39,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Butane",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(COREOS_NODE_COLOR),
                 Some(definition),
@@ -51,10 +50,7 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Butane", "CoreOS", &diagram_kind).await?;
+        let ui_menu = SchemaUiMenu::new(ctx, "Butane", "CoreOS").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Code generation

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -7,8 +7,8 @@ use crate::{
     component::ComponentKind, edit_field::widget::*, schema::SchemaUiMenu, socket::SocketArity,
     ActionPrototype, ActionPrototypeContext, AttributePrototypeArgument, AttributeReadContext,
     AttributeValue, AttributeValueError, BuiltinsError, BuiltinsResult, DalContext, DiagramKind,
-    ExternalProvider, Func, InternalProvider, Prop, PropKind, SchemaError, SchemaKind,
-    SchemaVariant, StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
+    ExternalProvider, Func, InternalProvider, Prop, PropKind, SchemaError, SchemaVariant,
+    StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
 };
 
 // Reference: https://www.docker.com/company/newsroom/media-resources/
@@ -26,7 +26,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Docker Hub Credential",
-                SchemaKind::Configuration,
                 ComponentKind::Credential,
                 Some(DOCKER_NODE_COLOR),
                 None,
@@ -85,10 +84,8 @@ impl MigrationDriver {
             .await?;
 
         // Note: I wasn't able to create a ui menu with two layers
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Credential", "Docker", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Credential", "Docker").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         Ok(())
@@ -99,7 +96,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Docker Image",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(DOCKER_NODE_COLOR),
                 None,
@@ -110,10 +106,7 @@ impl MigrationDriver {
             None => return Ok(()),
         };
 
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Image", "Docker", &diagram_kind).await?;
+        let ui_menu = SchemaUiMenu::new(ctx, "Image", "Docker").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         let image_prop = Prop::new(ctx, "image", PropKind::String, None).await?;

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -5,7 +5,7 @@ use crate::{
     func::argument::FuncArgument, schema::SchemaUiMenu, socket::SocketArity,
     AttributePrototypeArgument, AttributeReadContext, AttributeValue, AttributeValueError,
     BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider, InternalProvider,
-    PropKind, SchemaError, SchemaKind, SchemaVariant, StandardModel,
+    PropKind, SchemaVariant, StandardModel,
 };
 
 mod kubernetes_deployment_spec;
@@ -42,7 +42,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Kubernetes Namespace",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(KUBERNETES_NODE_COLOR),
                 None,
@@ -55,10 +54,7 @@ impl MigrationDriver {
 
         schema_variant.set_link(ctx, Some("https://v1-22.docs.kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/".to_owned())).await?;
 
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Namespace", "Kubernetes", &diagram_kind).await?;
+        let ui_menu = SchemaUiMenu::new(ctx, "Namespace", "Kubernetes").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         let metadata_prop = self
@@ -175,7 +171,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Kubernetes Deployment",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(KUBERNETES_NODE_COLOR),
                 None,
@@ -307,10 +302,7 @@ impl MigrationDriver {
             .await?;
         input_socket.set_color(ctx, Some(0x85c9a3)).await?;
 
-        let diagram_kind = schema
-            .diagram_kind()
-            .expect("no diagram kind for schema kind");
-        let ui_menu = SchemaUiMenu::new(ctx, "Deployment", "Kubernetes", &diagram_kind).await?;
+        let ui_menu = SchemaUiMenu::new(ctx, "Deployment", "Kubernetes").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         self.finalize_schema_variant(ctx, &schema_variant, &root_prop)

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -1,10 +1,7 @@
 use crate::builtins::schema::MigrationDriver;
 use crate::component::ComponentKind;
 use crate::validation::Validation;
-use crate::{
-    schema::SchemaUiMenu, BuiltinsResult, DalContext, PropKind, SchemaError, SchemaKind,
-    StandardModel,
-};
+use crate::{schema::SchemaUiMenu, BuiltinsResult, DalContext, PropKind, StandardModel};
 
 const FRAME_NODE_COLOR: i64 = 0xFFFFFF;
 
@@ -19,7 +16,6 @@ impl MigrationDriver {
             .create_schema_and_variant(
                 ctx,
                 "Generic Frame",
-                SchemaKind::Configuration,
                 ComponentKind::Standard,
                 Some(FRAME_NODE_COLOR),
                 None,
@@ -31,10 +27,8 @@ impl MigrationDriver {
         };
 
         // Diagram and UI Menu
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let ui_menu = SchemaUiMenu::new(ctx, "Generic Frame", "Frames", &diagram_kind).await?;
+
+        let ui_menu = SchemaUiMenu::new(ctx, "Generic Frame", "Frames").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
         // Prop and validation creation

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -30,7 +30,6 @@ use crate::standard_model::object_from_row;
 use crate::standard_model::TypeHint;
 use crate::validation::ValidationConstructorError;
 use crate::ws_event::WsEventError;
-use crate::UserId;
 use crate::{
     func::FuncId, impl_standard_model, node::NodeId, pk, provider::internal::InternalProviderError,
     standard_model, standard_model_accessor, standard_model_belongs_to, standard_model_has_many,
@@ -44,6 +43,7 @@ use crate::{
     WriteTenancy,
 };
 use crate::{AttributeValueId, QualificationError};
+use crate::{NodeKind, UserId};
 
 pub use view::{ComponentView, ComponentViewError};
 
@@ -300,7 +300,7 @@ impl Component {
 
         // Need to flesh out node so that the template data is also included in the node we
         // persist. But it isn't, - our node is anemic.
-        let node = Node::new(ctx, &(*schema.kind()).into()).await?;
+        let node = Node::new(ctx, &NodeKind::Configuration).await?;
         node.set_component(ctx, component.id()).await?;
         component.set_name(ctx, Some(name.as_ref())).await?;
 

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -4,9 +4,7 @@ use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use crate::diagram::DiagramResult;
 use crate::schema::SchemaUiMenu;
 use crate::socket::{SocketArity, SocketEdgeKind};
-use crate::{
-    DalContext, DiagramError, Node, NodePosition, SchemaError, SchemaVariant, StandardModel,
-};
+use crate::{DalContext, DiagramError, Node, NodePosition, SchemaVariant, StandardModel};
 
 #[derive(
     AsRefStr,
@@ -162,13 +160,10 @@ impl DiagramNodeView {
             .schema(ctx)
             .await?
             .ok_or(DiagramError::SchemaNotFound)?;
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
-        let category =
-            SchemaUiMenu::get_by_schema_and_diagram_kind(ctx, *schema.id(), diagram_kind)
-                .await?
-                .map(|um| um.category().to_string());
+
+        let category = SchemaUiMenu::find_for_schema(ctx, *schema.id())
+            .await?
+            .map(|um| um.category().to_string());
 
         let size = if let (Some(w), Some(h)) = (position.width(), position.height()) {
             Some(Size2D {

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -159,9 +159,7 @@ pub use qualification::{QualificationError, QualificationView};
 pub use read_tenancy::{ReadTenancy, ReadTenancyError};
 pub use resource_scheduler::{ResourceScheduler, ResourceSchedulerError};
 pub use schema::variant::root_prop::RootProp;
-pub use schema::{
-    Schema, SchemaError, SchemaId, SchemaKind, SchemaPk, SchemaVariant, SchemaVariantId,
-};
+pub use schema::{Schema, SchemaError, SchemaId, SchemaPk, SchemaVariant, SchemaVariantId};
 pub use secret::{
     DecryptedSecret, EncryptedSecret, Secret, SecretAlgorithm, SecretError, SecretId, SecretKind,
     SecretObjectType, SecretPk, SecretResult, SecretVersion,

--- a/lib/dal/src/migrations/U0031__schema.sql
+++ b/lib/dal/src/migrations/U0031__schema.sql
@@ -1,17 +1,16 @@
 CREATE TABLE schemas
 (
-    pk                          ident primary key default ident_create_v1(),
-    id                          ident not null default ident_create_v1(),
+    pk                          ident primary key                 default ident_create_v1(),
+    id                          ident                    not null default ident_create_v1(),
     tenancy_universal           bool                     NOT NULL,
     tenancy_billing_account_ids ident[],
     tenancy_organization_ids    ident[],
     tenancy_workspace_ids       ident[],
-    visibility_change_set_pk    ident                   NOT NULL DEFAULT ident_nil_v1(),
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     name                        text                     NOT NULL,
-    kind                        text                     NOT NULL,
     ui_menu_name                text,
     ui_menu_category            ltree,
     ui_hidden                   boolean                  NOT NULL DEFAULT false,
@@ -38,7 +37,6 @@ CREATE OR REPLACE FUNCTION schema_create_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
     this_name text,
-    this_kind text,
     this_component_kind text,
     OUT object json) AS
 $$
@@ -52,11 +50,11 @@ BEGIN
 
     INSERT INTO schemas (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                          tenancy_workspace_ids,
-                         visibility_change_set_pk, visibility_deleted_at, name, kind, component_kind)
+                         visibility_change_set_pk, visibility_deleted_at, name, component_kind)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_deleted_at,
-            this_name, this_kind, this_component_kind)
+            this_name, this_component_kind)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/migrations/U0032__schema_ui_menus.sql
+++ b/lib/dal/src/migrations/U0032__schema_ui_menus.sql
@@ -1,24 +1,22 @@
 CREATE TABLE schema_ui_menus
 (
-    pk                          ident primary key default ident_create_v1(),
-    id                          ident not null default ident_create_v1(),
+    pk                          ident primary key                 default ident_create_v1(),
+    id                          ident                    not null default ident_create_v1(),
     tenancy_universal           bool                     NOT NULL,
     tenancy_billing_account_ids ident[],
     tenancy_organization_ids    ident[],
     tenancy_workspace_ids       ident[],
-    visibility_change_set_pk    ident                   NOT NULL DEFAULT ident_nil_v1(),
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     name                        text                     NOT NULL,
-    category                    text                     NOT NULL,
-    diagram_kind                text                     NOT NULL
+    category                    text                     NOT NULL
 );
 
 CREATE UNIQUE INDEX unique_schema_ui_menus
     ON schema_ui_menus (name,
                         category,
-                        diagram_kind,
                         tenancy_universal,
                         tenancy_billing_account_ids,
                         tenancy_organization_ids,
@@ -40,7 +38,6 @@ CREATE OR REPLACE FUNCTION schema_ui_menu_create_v1(
     this_visibility jsonb,
     this_name text,
     this_category text,
-    this_diagram_kind text,
     OUT object json) AS
 $$
 DECLARE
@@ -54,11 +51,11 @@ BEGIN
     INSERT INTO schema_ui_menus (tenancy_universal, tenancy_billing_account_ids, tenancy_organization_ids,
                                  tenancy_workspace_ids,
                                  visibility_change_set_pk, visibility_deleted_at,
-                                 name, category, diagram_kind)
+                                 name, category)
     VALUES (this_tenancy_record.tenancy_universal, this_tenancy_record.tenancy_billing_account_ids,
             this_tenancy_record.tenancy_organization_ids, this_tenancy_record.tenancy_workspace_ids,
             this_visibility_record.visibility_change_set_pk, this_visibility_record.visibility_deleted_at,
-            this_name, this_category, this_diagram_kind)
+            this_name, this_category)
     RETURNING * INTO this_new_row;
 
     object := row_to_json(this_new_row);

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::schema::SchemaUiMenu;
-use crate::{DalContext, DiagramKind};
+use crate::DalContext;
 use crate::{SchemaError, SchemaId, StandardModel, StandardModelError};
 
 #[allow(clippy::large_enum_variant)]
@@ -209,9 +209,11 @@ pub struct GenerateMenuItem {
 
 impl GenerateMenuItem {
     /// Generates raw items and initializes menu items as an empty vec.
-    pub async fn new(ctx: &DalContext, diagram_kind: DiagramKind) -> NodeMenuResult<Self> {
+    pub async fn new(ctx: &DalContext) -> NodeMenuResult<Self> {
         let mut item_list = Vec::new();
-        let mut ui_menus = SchemaUiMenu::list_for_diagram_kind(ctx, diagram_kind).await?;
+
+        // NOTE(nick): currently, we only generate ui menus for schemas.
+        let mut ui_menus = SchemaUiMenu::list(ctx).await?;
 
         // Ensure the names and categories are alphabetically sorted.
         ui_menus.sort_by(|a, b| a.name().cmp(b.name()));

--- a/lib/dal/src/queries/ui_menus_find_for_schema.sql
+++ b/lib/dal/src/queries/ui_menus_find_for_schema.sql
@@ -1,0 +1,7 @@
+SELECT row_to_json(schema_ui_menus.*) AS object
+FROM schema_ui_menus_v1($1, $2) AS schema_ui_menus
+         INNER JOIN schema_ui_menu_belongs_to_schema_v1($1, $2) AS schema_ui_menu_belongs_to_schema
+                    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
+         INNER JOIN schemas_v1($1, $2) AS schemas
+                    ON schema_ui_menu_belongs_to_schema.belongs_to_id = schemas.id
+                        AND schemas.id = $3

--- a/lib/dal/src/queries/ui_menus_get_by_schema_and_diagram_kind.sql
+++ b/lib/dal/src/queries/ui_menus_get_by_schema_and_diagram_kind.sql
@@ -1,8 +1,0 @@
-SELECT row_to_json(schema_ui_menus.*) AS object
-FROM schema_ui_menus_v1($1, $2) AS schema_ui_menus
-INNER JOIN schema_ui_menu_belongs_to_schema_v1($1, $2) AS schema_ui_menu_belongs_to_schema
-    ON schema_ui_menus.id = schema_ui_menu_belongs_to_schema.object_id
-INNER JOIN schemas_v1($1, $2) AS schemas
-    ON schema_ui_menu_belongs_to_schema.belongs_to_id = schemas.id
-        AND schemas.id = $3
-WHERE schema_ui_menus.diagram_kind = $4

--- a/lib/dal/src/queries/ui_menus_list_for_diagram_kind.sql
+++ b/lib/dal/src/queries/ui_menus_list_for_diagram_kind.sql
@@ -1,6 +1,0 @@
-SELECT
-    schema_ui_menus.id                       AS id,
-    schema_ui_menus.visibility_change_set_pk AS visibility_change_set_pk,
-    row_to_json(schema_ui_menus.*)           AS object
-FROM schema_ui_menus_v1($1, $2) AS schema_ui_menus
-WHERE schema_ui_menus.diagram_kind = $3

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -3,8 +3,7 @@ use dal::{
     attribute::prototype::AttributePrototype,
     func::{backend::string::FuncBackendStringArgs, binding::FuncBinding},
     AttributePrototypeError, AttributeValue, Component, ComponentView, DalContext, Func,
-    FuncBackendKind, FuncBackendResponseType, Prop, PropKind, Schema, SchemaKind, SchemaVariant,
-    StandardModel,
+    FuncBackendKind, FuncBackendResponseType, Prop, PropKind, Schema, SchemaVariant, StandardModel,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
@@ -78,7 +77,7 @@ async fn new_attribute_prototype(ctx: &DalContext) {
 
 #[test]
 async fn list_for_context_with_a_hash(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -350,7 +349,7 @@ async fn remove_least_specific(ctx: &DalContext) {
 /// Test attribute prototype removal corresponding to a component-specific context.
 #[test]
 async fn remove_component_specific(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/attribute/prototype_argument.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype_argument.rs
@@ -6,7 +6,7 @@ use dal::{
         binding::FuncBinding,
     },
     AttributePrototypeArgument, DalContext, Func, FuncBackendKind, FuncBackendResponseType,
-    InternalProvider, PropKind, SchemaKind, StandardModel,
+    InternalProvider, PropKind, StandardModel,
 };
 use dal_test::{
     test,
@@ -16,7 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn create_and_list_for_attribute_prototype(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -1,7 +1,7 @@
 use dal::{
     attribute::context::AttributeContextBuilder, component::view::ComponentView, generate_name,
     AttributeContext, AttributeReadContext, AttributeValue, Component, DalContext, PropKind,
-    Schema, SchemaKind, StandardModel,
+    Schema, StandardModel,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
@@ -13,7 +13,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn update_for_context_simple(ctx: &DalContext) {
     // "name": String
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -141,7 +141,7 @@ async fn update_for_context_simple(ctx: &DalContext) {
 
 #[test]
 async fn insert_for_context_simple(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -220,7 +220,7 @@ async fn insert_for_context_simple(ctx: &DalContext) {
 
 #[test]
 async fn update_for_context_object(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -409,7 +409,7 @@ async fn update_for_context_object(ctx: &DalContext) {
 
 #[test]
 async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/attribute/view.rs
+++ b/lib/dal/tests/integration_test/attribute/view.rs
@@ -1,6 +1,6 @@
 use dal::{
     attribute::context::AttributeContextBuilder, AttributeReadContext, AttributeValue,
-    AttributeView, DalContext, PropKind, SchemaKind, SchemaVariant, StandardModel,
+    AttributeView, DalContext, PropKind, SchemaVariant, StandardModel,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
@@ -12,7 +12,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn schema_variant_specific(ctx: &DalContext) {
     // "name": String
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -1,8 +1,8 @@
 use dal::{
     func::backend::js_command::CommandRunResult, generate_name, AttributePrototypeArgument,
     AttributeReadContext, AttributeValue, ChangeSet, ChangeSetStatus, Component, ComponentView,
-    DalContext, DiagramKind, Edge, ExternalProvider, InternalProvider, PropKind, SchemaKind,
-    SocketArity, StandardModel, Visibility, WorkspaceId,
+    DalContext, DiagramKind, Edge, ExternalProvider, InternalProvider, PropKind, SocketArity,
+    StandardModel, Visibility, WorkspaceId,
 };
 use dal_test::{
     helpers::setup_identity_func,
@@ -28,7 +28,7 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn new_for_schema_variant_with_node(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
 
     let (component, node) =
@@ -49,14 +49,14 @@ async fn new_for_schema_variant_with_node(ctx: &DalContext) {
 
 #[test]
 async fn schema_relationships(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     let _component = create_component_for_schema_variant(ctx, schema_variant.id()).await;
 }
 
 #[test]
 async fn name_from_context(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
 
     let (component, _) =
@@ -83,7 +83,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
     ctx.update_to_universal_head();
 
     // Create "ekwb" schema.
-    let ekwb_schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let ekwb_schema = create_schema(ctx).await;
     let (ekwb_schema_variant, ekwb_root_prop) =
         create_schema_variant_with_root(ctx, *ekwb_schema.id()).await;
     ekwb_schema_variant
@@ -92,7 +92,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
         .expect("unable to finalize schema variant");
 
     // Create "noctua" schema.
-    let noctua_schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let noctua_schema = create_schema(ctx).await;
     let (noctua_schema_variant, noctua_root_prop) =
         create_schema_variant_with_root(ctx, *noctua_schema.id()).await;
     let u12a_prop = create_prop_and_set_parent(

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -6,7 +6,7 @@ use dal::{
 };
 use dal::{
     AttributeReadContext, AttributeValue, CodeLanguage, Component, ComponentView, DalContext, Func,
-    PropKind, SchemaKind, SchemaVariant, StandardModel,
+    PropKind, SchemaVariant, StandardModel,
 };
 use dal_test::test;
 use dal_test::test_harness::{
@@ -16,7 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/component/qualification.rs
+++ b/lib/dal/tests/integration_test/component/qualification.rs
@@ -5,7 +5,7 @@ use dal::{
     qualification::QualificationSubCheckStatus,
     schema::variant::leaves::{LeafInput, LeafInputLocation},
     AttributeReadContext, AttributeValue, Component, ComponentView, DalContext, Func,
-    FuncBackendKind, FuncBackendResponseType, PropKind, SchemaKind, SchemaVariant, StandardModel,
+    FuncBackendKind, FuncBackendResponseType, PropKind, SchemaVariant, StandardModel,
 };
 use dal_test::test;
 use dal_test::test_harness::{
@@ -15,7 +15,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn add_and_list_qualifications(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -3,7 +3,7 @@ use dal::{
     func::backend::validation::FuncBackendValidationArgs,
     validation::{Validation, ValidationError, ValidationErrorKind},
     AttributeReadContext, AttributeValue, AttributeValueId, Component, ComponentView, DalContext,
-    Func, FuncBackendKind, FuncBackendResponseType, PropId, PropKind, SchemaKind, StandardModel,
+    Func, FuncBackendKind, FuncBackendResponseType, PropId, PropKind, StandardModel,
     ValidationPrototype, ValidationPrototypeContext, ValidationResolver, ValidationStatus,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 #[test]
 async fn check_validations_for_component(ctx: &DalContext) {
     // Setup the schema and schema variant and create a validation for a string field.
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -283,7 +283,7 @@ async fn check_validations_for_component(ctx: &DalContext) {
 
 #[test]
 async fn check_js_validation_for_component(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -1,6 +1,6 @@
 use dal::{
     schema::RootProp, AttributeContext, AttributeValue, Component, ComponentView, DalContext, Prop,
-    PropKind, Schema, SchemaKind, SchemaVariant, StandardModel,
+    PropKind, Schema, SchemaVariant, StandardModel,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
@@ -22,7 +22,7 @@ pub async fn create_schema_with_object_and_string_prop(
 ) -> (Schema, SchemaVariant, Prop, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -69,7 +69,7 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
 ) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -118,7 +118,7 @@ pub async fn create_schema_with_string_props(
 ) -> (Schema, SchemaVariant, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -153,7 +153,7 @@ pub async fn create_schema_with_array_of_string_props(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
 
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -195,7 +195,7 @@ pub async fn create_schema_with_nested_array_objects(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
 
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -244,7 +244,7 @@ pub async fn create_schema_with_nested_array_objects(
 pub async fn create_simple_map(ctx: &DalContext) -> (Schema, SchemaVariant, Prop, Prop, RootProp) {
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -286,7 +286,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
 
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -3,8 +3,7 @@ use dal::job::definition::DependentValuesUpdate;
 use dal::{
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue, Component,
     ComponentView, DalContext, DiagramKind, ExternalProvider, Func, FuncBackendKind,
-    FuncBackendResponseType, FuncBinding, InternalProvider, PropKind, SchemaKind, SocketArity,
-    StandardModel,
+    FuncBackendResponseType, FuncBinding, InternalProvider, PropKind, SocketArity, StandardModel,
 };
 use dal_test::helpers::setup_identity_func;
 use dal_test::test_harness::create_prop_and_set_parent;
@@ -17,7 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     // Create and setup the schema and schema variant.
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -285,7 +284,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
 
 #[test]
 async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -7,7 +7,7 @@ use dal::{
 
 use dal::{
     AttributeReadContext, AttributeValue, Component, ComponentView, DalContext, Func,
-    FuncBackendKind, FuncBackendResponseType, PropKind, SchemaKind, SchemaVariant, StandardModel,
+    FuncBackendKind, FuncBackendResponseType, PropKind, SchemaVariant, StandardModel,
 };
 
 use dal_test::helpers::component_view::ComponentViewProperties;
@@ -21,7 +21,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema

--- a/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
+++ b/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
@@ -4,20 +4,14 @@ use dal::{
     edge::EdgeKind, edge::EdgeObjectId, edge::VertexObjectKind, socket::SocketArity,
     ActionPrototype, ActionPrototypeContext, BuiltinsResult, ConfirmationPrototype,
     ConfirmationPrototypeContext, ConfirmationResolverTree, DalContext, DiagramKind, Edge,
-    ExternalProvider, Func, HasPrototypeContext, InternalProvider, Schema, SchemaError, SchemaKind,
+    ExternalProvider, Func, HasPrototypeContext, InternalProvider, Schema, SchemaError,
     SchemaVariant, Socket, StandardModel, WorkflowPrototypeId,
 };
 use dal_test::helpers::setup_identity_func;
 use dal_test::{helpers::create_component_and_node_for_schema, test};
 
 async fn create_dummy_schema(ctx: &DalContext) -> BuiltinsResult<(Schema, Socket, Socket)> {
-    let mut schema = Schema::new(
-        ctx,
-        "Dummy Schema",
-        &SchemaKind::Configuration,
-        &ComponentKind::Standard,
-    )
-    .await?;
+    let mut schema = Schema::new(ctx, "Dummy Schema", &ComponentKind::Standard).await?;
     let (schema_variant, _root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -47,16 +47,14 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
         component_view_properties.drop_qualification().to_value() // actual
     );
 
-    let node_template = NodeTemplate::new_from_schema_id(ctx, *schema.id())
+    let node_template = NodeTemplate::new_for_schema(ctx, *schema.id())
         .await
         .expect("could not create node template");
-    let diagram_kind = schema.diagram_kind().expect("no diagram kind for schema");
-    assert_eq!(diagram_kind, DiagramKind::Configuration);
 
     let position = NodePosition::new(
         ctx,
         *node.id(),
-        diagram_kind,
+        DiagramKind::Configuration,
         "0",
         "0",
         Some("500"),

--- a/lib/dal/tests/integration_test/node.rs
+++ b/lib/dal/tests/integration_test/node.rs
@@ -1,6 +1,6 @@
 use dal::{
     node::{NodeKind, NodeTemplate},
-    DalContext, HistoryActor, Node, SchemaKind, StandardModel, Visibility, WriteTenancy,
+    DalContext, HistoryActor, Node, StandardModel, Visibility, WriteTenancy,
 };
 use dal_test::{
     test,
@@ -36,14 +36,14 @@ async fn component_relationships(ctx: &DalContext) {
 
 #[test]
 async fn new_node_template(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
         .expect("cannot set default schema variant");
 
-    let node_template = NodeTemplate::new_from_schema_id(ctx, *schema.id())
+    let node_template = NodeTemplate::new_for_schema(ctx, *schema.id())
         .await
         .expect("cannot create node template");
     assert_eq!(node_template.title, schema.name());

--- a/lib/dal/tests/integration_test/node_menu.rs
+++ b/lib/dal/tests/integration_test/node_menu.rs
@@ -1,4 +1,4 @@
-use dal::{node_menu::GenerateMenuItem, DalContext, DiagramKind};
+use dal::{node_menu::GenerateMenuItem, DalContext};
 use dal_test::{
     helpers::builtins::{Builtin, SchemaBuiltinsTestHarness},
     test,
@@ -11,9 +11,7 @@ async fn get_node_menu(ctx: &DalContext) {
         .create_component(ctx, "valorant", Builtin::DockerImage)
         .await;
 
-    let gmi = GenerateMenuItem::new(ctx, DiagramKind::Configuration)
-        .await
-        .expect("cannot get items");
+    let gmi = GenerateMenuItem::new(ctx).await.expect("cannot get items");
     let items = gmi.raw_items;
 
     let docker_image_item = items.iter().find(|(path, item)| {

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -1,6 +1,4 @@
-use dal::{
-    DalContext, HistoryActor, Prop, PropKind, SchemaKind, StandardModel, Visibility, WriteTenancy,
-};
+use dal::{DalContext, HistoryActor, Prop, PropKind, StandardModel, Visibility, WriteTenancy};
 use dal_test::helpers::generate_fake_name;
 use dal_test::{
     test,
@@ -22,7 +20,7 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn schema_variants(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
     let prop = Prop::new(ctx, generate_fake_name(), PropKind::String, None)
         .await

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -1,6 +1,5 @@
 use dal::{
-    socket::SocketArity, DalContext, DiagramKind, ExternalProvider, InternalProvider, SchemaKind,
-    StandardModel,
+    socket::SocketArity, DalContext, DiagramKind, ExternalProvider, InternalProvider, StandardModel,
 };
 use dal_test::{
     helpers::setup_identity_func,
@@ -13,7 +12,7 @@ mod intra_component;
 
 #[test]
 async fn new_external(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, _root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -50,7 +49,7 @@ async fn new_external(ctx: &DalContext) {
 
 #[test]
 async fn new_implicit_internal(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, _root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use dal::{
     socket::SocketArity, AttributeContext, AttributePrototypeArgument, AttributeReadContext,
     AttributeValue, Component, ComponentView, DalContext, DiagramKind, Edge, ExternalProvider,
-    InternalProvider, PropKind, SchemaKind, StandardModel,
+    InternalProvider, PropKind, StandardModel,
 };
 use dal_test::{
     helpers::{component_payload::ComponentPayload, setup_identity_func},
@@ -299,7 +299,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
 
 // 38.805354552534816, -77.05091482877533
 async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -369,7 +369,7 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
 
 // 38.82091849697006, -77.05236860190759
 async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -426,7 +426,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
         id_func_arg_id,
     ) = setup_identity_func(ctx).await;
 
-    let mut source_schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut source_schema = create_schema(ctx).await;
     let (source_schema_variant, source_root) =
         create_schema_variant_with_root(ctx, *source_schema.id()).await;
     source_schema
@@ -489,7 +489,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     .await
     .expect("cannot create source external provider attribute prototype argument");
 
-    let mut destination_schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut destination_schema = create_schema(ctx).await;
     let (destination_schema_variant, destination_root) =
         create_schema_variant_with_root(ctx, *destination_schema.id()).await;
     destination_schema

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -5,7 +5,7 @@ use dal::{
     provider::internal::InternalProvider,
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue, Component,
     ComponentView, DalContext, DiagramKind, ExternalProvider, Func, FuncBackendKind,
-    FuncBackendResponseType, PropKind, SchemaKind, SocketArity, StandardModel,
+    FuncBackendResponseType, PropKind, SocketArity, StandardModel,
 };
 use dal_test::{
     helpers::setup_identity_func,
@@ -16,7 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn intra_component_identity_update(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -283,7 +283,7 @@ async fn intra_component_identity_update(ctx: &DalContext) {
 
 #[test]
 async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/dal/tests/integration_test/schema.rs
+++ b/lib/dal/tests/integration_test/schema.rs
@@ -1,7 +1,6 @@
 use dal::{
-    component::ComponentKind,
-    schema::{SchemaKind, SchemaUiMenu},
-    BillingAccountSignup, DalContext, DiagramKind, JwtSecretKey, Schema, StandardModel,
+    component::ComponentKind, schema::SchemaUiMenu, BillingAccountSignup, DalContext, JwtSecretKey,
+    Schema, StandardModel,
 };
 
 use dal_test::{
@@ -14,27 +13,17 @@ pub mod variant;
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let _schema = Schema::new(
-        ctx,
-        "mastodon",
-        &SchemaKind::Configuration,
-        &ComponentKind::Standard,
-    )
-    .await
-    .expect("cannot create schema");
+    let _schema = Schema::new(ctx, "mastodon", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
 }
 
 #[test]
 async fn billing_accounts(ctx: &DalContext, jwt_secret_key: &JwtSecretKey) {
     let (nba, _token) = billing_account_signup(ctx, jwt_secret_key).await;
-    let schema = Schema::new(
-        ctx,
-        "mastodon",
-        &SchemaKind::Configuration,
-        &ComponentKind::Standard,
-    )
-    .await
-    .expect("cannot create schema");
+    let schema = Schema::new(ctx, "mastodon", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
     schema
         .add_billing_account(ctx, nba.billing_account.id())
         .await
@@ -59,14 +48,9 @@ async fn billing_accounts(ctx: &DalContext, jwt_secret_key: &JwtSecretKey) {
 
 #[test]
 async fn organizations(ctx: &DalContext, nba: &BillingAccountSignup) {
-    let schema = Schema::new(
-        ctx,
-        "mastodon",
-        &SchemaKind::Configuration,
-        &ComponentKind::Standard,
-    )
-    .await
-    .expect("cannot create schema");
+    let schema = Schema::new(ctx, "mastodon", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
     schema
         .add_organization(ctx, nba.organization.id())
         .await
@@ -91,14 +75,9 @@ async fn organizations(ctx: &DalContext, nba: &BillingAccountSignup) {
 
 #[test]
 async fn workspaces(ctx: &DalContext, nba: &BillingAccountSignup) {
-    let schema = Schema::new(
-        ctx,
-        "mastodon",
-        &SchemaKind::Configuration,
-        &ComponentKind::Standard,
-    )
-    .await
-    .expect("cannot create schema");
+    let schema = Schema::new(ctx, "mastodon", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
     schema
         .add_workspace(ctx, nba.workspace.id())
         .await
@@ -117,8 +96,8 @@ async fn workspaces(ctx: &DalContext, nba: &BillingAccountSignup) {
 
 #[test]
 async fn ui_menus(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_ui_menu = SchemaUiMenu::new(ctx, "visa", "m.i.a.", &DiagramKind::Configuration)
+    let schema = create_schema(ctx).await;
+    let schema_ui_menu = SchemaUiMenu::new(ctx, "visa", "m.i.a.")
         .await
         .expect("cannot create schema ui menu");
     schema_ui_menu

--- a/lib/dal/tests/integration_test/schema/ui_menu.rs
+++ b/lib/dal/tests/integration_test/schema/ui_menu.rs
@@ -1,19 +1,14 @@
-use dal::{
-    schema::{SchemaKind, SchemaUiMenu},
-    DalContext, DiagramKind, StandardModel,
-};
+use dal::{schema::SchemaUiMenu, DalContext, StandardModel};
 use dal_test::{test, test_harness::create_schema};
 
 #[test]
 async fn new_and_set_schema(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
-    let schema_ui_menu =
-        SchemaUiMenu::new(ctx, "riot", "awaken, my love!", &DiagramKind::Configuration)
-            .await
-            .expect("cannot create schema ui menu");
+    let schema = create_schema(ctx).await;
+    let schema_ui_menu = SchemaUiMenu::new(ctx, "riot", "awaken, my love!")
+        .await
+        .expect("cannot create schema ui menu");
     assert_eq!(schema_ui_menu.name(), "riot");
     assert_eq!(schema_ui_menu.category(), "awaken, my love!");
-    assert_eq!(schema_ui_menu.diagram_kind(), DiagramKind::Configuration);
 
     schema_ui_menu
         .set_schema(ctx, schema.id())

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -1,13 +1,13 @@
 use dal::{
     schema::{variant::leaves::LeafKind, SchemaVariant},
-    DalContext, InternalProvider, SchemaKind, StandardModel,
+    DalContext, InternalProvider, StandardModel,
 };
 use dal_test::{test, test_harness::create_schema};
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
 
     let (variant, _) = SchemaVariant::new(ctx, *schema.id(), "ringo")
         .await
@@ -17,7 +17,7 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn set_schema(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let (variant, _) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await
         .expect("cannot create schema variant");
@@ -39,7 +39,7 @@ async fn set_schema(ctx: &DalContext) {
 
 #[test]
 async fn find_code_item_prop(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await
         .expect("cannot create schema variant");
@@ -62,7 +62,7 @@ async fn find_code_item_prop(ctx: &DalContext) {
 
 #[test]
 async fn find_implicit_internal_providers_for_root_children(ctx: &DalContext) {
-    let schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await
         .expect("cannot create schema variant");

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -1,7 +1,7 @@
 use dal::{
     component::ComponentKind, standard_model, BillingAccount, BillingAccountPk,
     BillingAccountSignup, ChangeSet, ChangeSetPk, DalContext, Func, FuncBackendKind, Group,
-    GroupId, KeyPair, Schema, SchemaKind, StandardModel, User, UserId, WriteTenancy,
+    GroupId, KeyPair, Schema, StandardModel, User, UserId, WriteTenancy,
 };
 use dal_test::{
     test,
@@ -643,7 +643,7 @@ async fn find_by_attr(ctx: &mut DalContext) {
     let _billing_account = create_billing_account(ctx).await;
     ctx.update_to_universal_head();
 
-    let schema_one = create_schema(ctx, &SchemaKind::Configuration).await;
+    let schema_one = create_schema(ctx).await;
 
     let result: Vec<Schema> =
         standard_model::find_by_attr(ctx, "schemas", "name", &schema_one.name().to_string())
@@ -652,14 +652,9 @@ async fn find_by_attr(ctx: &mut DalContext) {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], schema_one);
 
-    let schema_two = Schema::new(
-        ctx,
-        schema_one.name(),
-        schema_one.kind(),
-        &ComponentKind::Standard,
-    )
-    .await
-    .expect("cannot create another schema with the same name");
+    let schema_two = Schema::new(ctx, schema_one.name(), &ComponentKind::Standard)
+        .await
+        .expect("cannot create another schema with the same name");
 
     let result: Vec<Schema> =
         standard_model::find_by_attr(ctx, "schemas", "name", &schema_one.name().to_string())

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -2,8 +2,7 @@ use dal::{
     func::{backend::validation::FuncBackendValidationArgs, binding::FuncBinding},
     validation::Validation,
     AttributeContext, AttributeValue, DalContext, Func, FuncBackendKind, FuncBackendResponseType,
-    PropKind, SchemaKind, StandardModel, ValidationPrototype, ValidationPrototypeContext,
-    ValidationResolver,
+    PropKind, StandardModel, ValidationPrototype, ValidationPrototypeContext, ValidationResolver,
 };
 use dal_test::test_harness::create_prop_and_set_parent;
 use dal_test::{
@@ -13,7 +12,7 @@ use dal_test::{
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
@@ -100,7 +99,7 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn find_errors(ctx: &DalContext) {
-    let mut schema = create_schema(ctx, &SchemaKind::Configuration).await;
+    let mut schema = create_schema(ctx).await;
     let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))

--- a/lib/sdf/src/server/service/component/list_components_identification.rs
+++ b/lib/sdf/src/server/service/component/list_components_identification.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{ComponentError, ComponentResult};
 use crate::server::extract::{AccessBuilder, HandlerContext};
-use crate::service::schema::SchemaError;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -89,9 +88,6 @@ pub async fn list_components_identification(
             .schema(&ctx)
             .await?
             .ok_or(ComponentError::SchemaNotFound)?;
-        let diagram_kind = schema
-            .diagram_kind()
-            .ok_or_else(|| SchemaError::NoDiagramKindForSchemaKind(*schema.kind()))?;
 
         let created_at = ListComponentsIdentificationItemTimestamp::from_history_actor_timestamp(
             &ctx,
@@ -110,7 +106,7 @@ pub async fn list_components_identification(
             schema_variant_name: schema_variant.name().to_owned(),
             schema_id: *schema.id(),
             schema_name: schema.name().to_owned(),
-            diagram_kind,
+            diagram_kind: DiagramKind::Configuration,
             resource,
             created_at,
             updated_at,

--- a/lib/sdf/src/server/service/diagram.rs
+++ b/lib/sdf/src/server/service/diagram.rs
@@ -7,9 +7,9 @@ use dal::provider::external::ExternalProviderError as DalExternalProviderError;
 use dal::socket::{SocketError, SocketId};
 use dal::{
     node::NodeId, schema::variant::SchemaVariantError, AttributeValueError, ComponentError,
-    DiagramError as DalDiagramError, DiagramKind, InternalProviderError, NodeError, NodeKind,
-    NodeMenuError, NodePositionError, ReadTenancyError, SchemaError as DalSchemaError,
-    SchemaVariantId, StandardModelError, TransactionsError,
+    DiagramError as DalDiagramError, InternalProviderError, NodeError, NodeKind, NodeMenuError,
+    NodePositionError, ReadTenancyError, SchemaError as DalSchemaError, SchemaVariantId,
+    StandardModelError, TransactionsError,
 };
 use dal::{AttributeReadContext, WsEventError};
 use thiserror::Error;
@@ -88,8 +88,6 @@ pub enum DiagramError {
     NotAuthorized,
     #[error("invalid system")]
     InvalidSystem,
-    #[error("invalid diagram kind {0}")]
-    InvalidDiagramKind(DiagramKind),
     #[error("parent node not found {0}")]
     ParentNodeNotFound(NodeId),
     #[error("invalid parent node kind {0:?}")]

--- a/lib/sdf/src/server/service/diagram/get_node_add_menu.rs
+++ b/lib/sdf/src/server/service/diagram/get_node_add_menu.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use dal::node_menu::GenerateMenuItem;
-use dal::{DiagramKind, Visibility, WorkspaceId};
+use dal::{Visibility, WorkspaceId};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;
@@ -23,8 +23,8 @@ pub async fn get_node_add_menu(
 ) -> DiagramResult<Json<GetNodeAddMenuResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    // NOTE(nick): return only components at the moment.
-    let gmi = GenerateMenuItem::new(&ctx, DiagramKind::Configuration).await?;
+    // NOTE(nick): return only configuration-related content at the moment.
+    let gmi = GenerateMenuItem::new(&ctx).await?;
     let response = gmi.create_menu_json()?;
 
     Ok(Json(response))

--- a/lib/sdf/src/server/service/diagram/get_node_template.rs
+++ b/lib/sdf/src/server/service/diagram/get_node_template.rs
@@ -25,7 +25,7 @@ pub async fn get_node_template(
 ) -> DiagramResult<Json<GetNodeTemplateResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let response = NodeTemplate::new_from_schema_id(&ctx, request.schema_id).await?;
+    let response = NodeTemplate::new_for_schema(&ctx, request.schema_id).await?;
 
     Ok(Json(response))
 }

--- a/lib/sdf/src/server/service/schema.rs
+++ b/lib/sdf/src/server/service/schema.rs
@@ -3,9 +3,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use dal::{
-    SchemaError as DalSchemaError, SchemaKind, StandardModelError, TransactionsError, WsEventError,
-};
+use dal::{SchemaError as DalSchemaError, StandardModelError, TransactionsError, WsEventError};
 use thiserror::Error;
 
 pub mod create_schema;
@@ -20,8 +18,6 @@ pub enum SchemaError {
     Pg(#[from] si_data_pg::PgError),
     #[error(transparent)]
     ContextTransaction(#[from] TransactionsError),
-    #[error("no diagram kind for schema kind {0}")]
-    NoDiagramKindForSchemaKind(SchemaKind),
     #[error(transparent)]
     StandardModel(#[from] StandardModelError),
     #[error("schema error: {0}")]

--- a/lib/sdf/src/server/service/schema/create_schema.rs
+++ b/lib/sdf/src/server/service/schema/create_schema.rs
@@ -1,14 +1,13 @@
 use super::SchemaResult;
 use crate::server::extract::{Authorization, HandlerContext, HistoryActor, Tenancy};
 use axum::Json;
-use dal::{component::ComponentKind, Schema, SchemaKind, Visibility, WriteTenancy, WsEvent};
+use dal::{component::ComponentKind, Schema, Visibility, WriteTenancy, WsEvent};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSchemaRequest {
     pub name: String,
-    pub kind: SchemaKind,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -37,7 +36,7 @@ pub async fn create_schema(
         )
         .await?;
 
-    let schema = Schema::new(&ctx, &request.name, &request.kind, &ComponentKind::Standard).await?;
+    let schema = Schema::new(&ctx, &request.name, &ComponentKind::Standard).await?;
     let response = CreateSchemaResponse { schema };
 
     WsEvent::change_set_written(&ctx)

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use dal::{Component, SchemaKind, StandardModel, Visibility};
+use dal::{Component, StandardModel, Visibility};
 use dal_test::{
     test,
     test_harness::{create_component_for_schema_variant, create_schema, create_schema_variant},
@@ -33,7 +33,7 @@ async fn list_components_identification() {
         _faktory,
     );
 
-    let schema = create_schema(&dal_ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(&dal_ctx).await;
     let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
         .finalize(&dal_ctx)
@@ -145,7 +145,7 @@ async fn get_components_metadata() {
     );
     let visibility = Visibility::new_head(false);
 
-    let schema = create_schema(&dal_ctx, &SchemaKind::Configuration).await;
+    let schema = create_schema(&dal_ctx).await;
 
     let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant

--- a/lib/sdf/tests/service_tests/schema.rs
+++ b/lib/sdf/tests/service_tests/schema.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use axum::http::Method;
-use dal::{SchemaKind, StandardModel, Visibility};
+use dal::{StandardModel, Visibility};
 use dal_test::{test, test_harness::create_schema as dal_create_schema};
 use sdf::service::schema::{
     create_schema::{CreateSchemaRequest, CreateSchemaResponse},
@@ -35,7 +35,6 @@ async fn create_schema() {
     let visibility = Visibility::new_head(false);
     let request = CreateSchemaRequest {
         name: "fancyPants".to_string(),
-        kind: SchemaKind::Configuration,
         visibility,
     };
     let response: CreateSchemaResponse = api_request_auth_json_body(
@@ -47,7 +46,6 @@ async fn create_schema() {
     )
     .await;
     assert_eq!(response.schema.name(), "fancyPants");
-    assert_eq!(response.schema.kind(), &SchemaKind::Configuration);
 }
 
 #[test]
@@ -70,9 +68,9 @@ async fn list_schemas() {
     );
     dal_ctx.update_to_universal_head();
 
-    let rand_schema1 = dal_create_schema(&dal_ctx, &SchemaKind::Configuration).await;
+    let rand_schema1 = dal_create_schema(&dal_ctx).await;
     let rand_schema1_name = rand_schema1.name();
-    let rand_schema2 = dal_create_schema(&dal_ctx, &SchemaKind::Configuration).await;
+    let rand_schema2 = dal_create_schema(&dal_ctx).await;
     let rand_schema2_name = rand_schema2.name();
 
     dal_ctx.commit().await.expect("cannot commit txn");
@@ -120,7 +118,7 @@ async fn get_schemas() {
     );
     dal_ctx.update_to_universal_head();
 
-    let schema_one = dal_create_schema(&dal_ctx, &SchemaKind::Configuration).await;
+    let schema_one = dal_create_schema(&dal_ctx).await;
 
     dal_ctx.commit().await.expect("cannot commit txn");
 


### PR DESCRIPTION
## Preface

This is a soft continuation of #1230 and other subsequent PRs. As we move towards Schema authoring, removing outdated concepts and papercuts in affected areas should help it shine.

## Description

- Remove SchemaKind
- Ensure NodeKind relies on DiagramKind instead of SchemaKind
- Remove "kind" from SchemaUiMenu
- Remove DiagramKind from Schema (since they are only for configuration diagrams)

## Linear

Fixes ENG-893



