### PR TITLE
Finalize variants before creating components (ENG-855)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -472,10 +472,25 @@ variable.
 SI_TEST_LOG=info
 ```
 
+#### Want To See The Live Log Stream?
+
+If you'd like to see a live log stream during test execution, use the `SI_TEST_LOG` variable in conjunction with
+the `--nocapture` flag for `cargo test`.
+
+```shell
+SI_TEST_LOG=info cargo test -p dal --test integration <your-test> -- --nocapture
+```
+
+You can combine this with the `DEBUG` environment variable for `lang-js` for even more information.
+
+```shell
+DEBUG=* SI_TEST_LOG=info cargo test -p dal --test integration <your-test> -- --nocapture
+```
+
 #### Migrations Running Too Slow? Try Disabling Builtin Schema Migrations!
 
 If your integration test does not rely on builtin `Schema(s)` and `SchemaVariant(s)` (e.g. "Docker Image" and
-"AWS EC2"), you can disable their migration with an environment variable.
+"AWS EC2"), you can disable migrating them  with an environment variable.
 
 ```shell
 SI_TEST_SKIP_MIGRATING_SCHEMAS=true cargo test -p dal --test integration <your-test>

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -159,7 +159,7 @@ pub async fn create_component_and_node_for_schema(
     schema_id: &SchemaId,
 ) -> (Component, Node) {
     let name = generate_fake_name();
-    let (component, node) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, node) = Component::new_for_default_variant_from_schema(ctx, &name, *schema_id)
         .await
         .expect("cannot create component");
     (component, node)
@@ -167,7 +167,7 @@ pub async fn create_component_and_node_for_schema(
 
 pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, _) = Component::new_for_default_variant_from_schema(ctx, &name, *schema_id)
         .await
         .expect("cannot create component");
     component

--- a/lib/dal-test/src/helpers/builtins.rs
+++ b/lib/dal-test/src/helpers/builtins.rs
@@ -121,9 +121,10 @@ impl SchemaBuiltinsTestHarness {
         prop_map: HashMap<&'static str, PropId>,
         name: impl AsRef<str>,
     ) -> ComponentPayload {
-        let (component, node) = Component::new_for_schema_with_node(ctx, name, &schema_id)
-            .await
-            .expect("unable to create component");
+        let (component, node) =
+            Component::new_for_default_variant_from_schema(ctx, name, schema_id)
+                .await
+                .expect("unable to create component");
 
         ComponentPayload {
             schema_id,

--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -353,16 +353,16 @@ pub async fn create_schema_variant_with_root(
 
 pub async fn create_component_and_schema(ctx: &DalContext) -> Component {
     let schema = create_schema(ctx).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema_variant
         .finalize(ctx)
         .await
         .expect("unable to finalize schema variant");
     let name = generate_fake_name();
-    let (entity, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant.id())
+    let (component, _) = Component::new(ctx, &name, *schema_variant.id())
         .await
         .expect("cannot create component");
-    entity
+    component
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -371,7 +371,7 @@ pub async fn create_component_for_schema_variant(
     schema_variant_id: &SchemaVariantId,
 ) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
+    let (component, _) = Component::new(ctx, &name, *schema_variant_id)
         .await
         .expect("cannot create component");
     component
@@ -380,7 +380,7 @@ pub async fn create_component_for_schema_variant(
 #[allow(clippy::too_many_arguments)]
 pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
     let name = generate_fake_name();
-    let (component, _) = Component::new_for_schema_with_node(ctx, &name, schema_id)
+    let (component, _) = Component::new_for_default_variant_from_schema(ctx, &name, *schema_id)
         .await
         .expect("cannot create component");
     component

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -287,7 +287,7 @@ impl MigrationDriver {
     pub async fn finalize_schema_variant(
         &self,
         ctx: &DalContext,
-        schema_variant: &SchemaVariant,
+        schema_variant: &mut SchemaVariant,
         root_prop: &RootProp,
     ) -> BuiltinsResult<()> {
         schema_variant.finalize(ctx).await?;

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -66,7 +66,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS AMI`](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Ami.html).
     async fn migrate_ami(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "AMI",
@@ -189,7 +189,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the props to providers.
@@ -277,7 +277,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EC2`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html).
     async fn migrate_ec2(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "EC2 Instance",
@@ -577,7 +577,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -879,7 +879,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Region`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
     async fn migrate_region(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Region",
@@ -955,7 +955,7 @@ impl MigrationDriver {
         output_socket.set_color(ctx, Some(0xd61e8c)).await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // set the component as a configuration frame
@@ -1085,7 +1085,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS EIP`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-eip.html).
     async fn migrate_eip(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Elastic IP",
@@ -1240,7 +1240,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -1441,7 +1441,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Key Pair`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html).
     async fn migrate_keypair(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Key Pair",
@@ -1629,7 +1629,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -41,7 +41,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Ingress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_ingress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Ingress",
@@ -337,7 +337,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -623,7 +623,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Egress`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_egress(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Egress",
@@ -878,7 +878,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults
@@ -1107,7 +1107,7 @@ impl MigrationDriver {
 
     /// A [`Schema`](crate::Schema) migration for [`AWS Security Group`](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).
     async fn migrate_security_group(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Security Group",
@@ -1314,7 +1314,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up!
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set Defaults

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -30,7 +30,7 @@ impl MigrationDriver {
 
         let (
             schema,
-            schema_variant,
+            mut schema_variant,
             root_prop,
             maybe_prop_cache,
             explicit_internal_providers,
@@ -92,7 +92,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Collect the props we need.

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -22,7 +22,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_hub_credential(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Hub Credential",
@@ -80,7 +80,7 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x1e88d6)).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Note: I wasn't able to create a ui menu with two layers
@@ -92,7 +92,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_docker_image(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Docker Image",
@@ -200,7 +200,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/image" field.

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -107,7 +107,7 @@ impl MigrationDriver {
         .await?;
         output_socket.set_color(ctx, Some(0x85c9a3)).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/metadata/name" field.
@@ -305,7 +305,7 @@ impl MigrationDriver {
         let ui_menu = SchemaUiMenu::new(ctx, "Deployment", "Kubernetes").await?;
         ui_menu.set_schema(ctx, schema.id()).await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // Set default values after finalization.

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -12,7 +12,7 @@ impl MigrationDriver {
     }
 
     async fn migrate_generic_frame(&self, ctx: &DalContext) -> BuiltinsResult<()> {
-        let (schema, schema_variant, root_prop, _, _, _) = match self
+        let (schema, mut schema_variant, root_prop, _, _, _) = match self
             .create_schema_and_variant(
                 ctx,
                 "Generic Frame",
@@ -52,7 +52,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &schema_variant, &root_prop)
+        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
             .await?;
 
         // set the component as a configuration frame

--- a/lib/dal/src/migrations/U0033__schema_variants.sql
+++ b/lib/dal/src/migrations/U0033__schema_variants.sql
@@ -1,18 +1,19 @@
 CREATE TABLE schema_variants
 (
-    pk                          ident primary key default ident_create_v1(),
-    id                          ident not null default ident_create_v1(),
+    pk                          ident primary key                 default ident_create_v1(),
+    id                          ident                    not null default ident_create_v1(),
     tenancy_universal           bool                     NOT NULL,
     tenancy_billing_account_ids ident[],
     tenancy_organization_ids    ident[],
     tenancy_workspace_ids       ident[],
-    visibility_change_set_pk    ident                   NOT NULL DEFAULT ident_nil_v1(),
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
     visibility_deleted_at       timestamp with time zone,
     created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
     name                        text                     NOT NULL,
     link                        text,
-    color                       bigint
+    color                       bigint,
+    finalized_once              bool                     NOT NULL DEFAULT FALSE
 );
 SELECT standard_model_table_constraints_v1('schema_variants');
 SELECT belongs_to_table_create_v1('schema_variant_belongs_to_schema', 'schema_variants', 'schemas');

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -126,16 +126,20 @@ pk!(SchemaVariantId);
 pub struct SchemaVariant {
     pk: SchemaVariantPk,
     id: SchemaVariantId,
-    name: String,
-    link: Option<String>,
-    // NOTE(nick): we should consider whether or not we want to keep the color.
-    color: Option<i64>,
     #[serde(flatten)]
     tenancy: WriteTenancy,
     #[serde(flatten)]
     timestamp: Timestamp,
     #[serde(flatten)]
     visibility: Visibility,
+
+    name: String,
+    link: Option<String>,
+    // NOTE(nick): we should consider whether or not we want to keep the color.
+    color: Option<i64>,
+    // NOTE(nick): we may want to replace this with a better solution. We use this to ensure
+    // components are not created unless the variant has been finalized at least once.
+    finalized_once: bool,
 }
 
 impl_standard_model! {
@@ -243,11 +247,6 @@ impl SchemaVariant {
         Ok((object, root_prop))
     }
 
-    /// Calls [`Self::finalize_for_id()`]. Refer to the aforementioned method for more information.
-    pub async fn finalize(&self, ctx: &DalContext) -> SchemaVariantResult<()> {
-        Self::finalize_for_id(ctx, self.id).await
-    }
-
     /// This _idempotent_ function "finalizes" a [`SchemaVariant`].
     ///
     /// Once a [`SchemaVariant`] has had all of its [`Props`](crate::Prop) created, there are a few
@@ -262,12 +261,16 @@ impl SchemaVariant {
     /// This method **MUST** be called once all the [`Props`](Prop) have been created for the
     /// [`SchemaVariant`]. It can be called multiple times while [`Props`](Prop) are being created,
     /// but it must be called once after all [`Props`](Prop) have been created.
-    pub async fn finalize_for_id(
-        ctx: &DalContext,
-        schema_variant_id: SchemaVariantId,
-    ) -> SchemaVariantResult<()> {
-        Self::create_default_prototypes_and_values(ctx, schema_variant_id).await?;
-        Self::create_implicit_internal_providers(ctx, schema_variant_id).await?;
+    pub async fn finalize(&mut self, ctx: &DalContext) -> SchemaVariantResult<()> {
+        let total_start = std::time::Instant::now();
+
+        Self::create_default_prototypes_and_values(ctx, self.id).await?;
+        Self::create_implicit_internal_providers(ctx, self.id).await?;
+        if !self.finalized_once() {
+            self.set_finalized_once(ctx, true).await?;
+        }
+
+        debug!("finalizing {:?} took {:?}", self.id, total_start.elapsed());
         Ok(())
     }
 
@@ -327,6 +330,7 @@ impl SchemaVariant {
     standard_model_accessor!(name, String, SchemaVariantResult);
     standard_model_accessor!(link, Option<String>, SchemaVariantResult);
     standard_model_accessor!(color, OptionBigInt<i64>, SchemaVariantResult);
+    standard_model_accessor!(finalized_once, bool, SchemaVariantResult);
 
     standard_model_belongs_to!(
         lookup_fn: schema,
@@ -410,8 +414,7 @@ impl SchemaVariant {
     /// "/root/domain", which is of kind [`object`](crate::PropKind::Object).
     ///
     /// _Note: the [`SchemaVariant`](crate::SchemaVariant) must be
-    /// [`finalized`](crate::SchemaVariant::finalize()) (or
-    /// [`finalized for id`](crate::SchemaVariant::finalize_for_id())) before running this query.
+    /// [`finalized`](crate::SchemaVariant::finalize()) before running this query._
     pub async fn find_domain_implicit_internal_provider(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -423,8 +426,7 @@ impl SchemaVariant {
     /// "/root/code", which is of kind [`map`](crate::PropKind::Map).
     ///
     /// _Note: the [`SchemaVariant`](crate::SchemaVariant) must be
-    /// [`finalized`](crate::SchemaVariant::finalize()) (or
-    /// [`finalized for id`](crate::SchemaVariant::finalize_for_id())) before running this query.
+    /// [`finalized`](crate::SchemaVariant::finalize()) before running this query._
     pub async fn find_code_implicit_internal_provider(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -436,8 +438,7 @@ impl SchemaVariant {
     /// "/root/qualification", which is of kind [`map`](crate::PropKind::Map).
     ///
     /// _Note: the [`SchemaVariant`](crate::SchemaVariant) must be
-    /// [`finalized`](crate::SchemaVariant::finalize()) (or
-    /// [`finalized for id`](crate::SchemaVariant::finalize_for_id())) before running this query.
+    /// [`finalized`](crate::SchemaVariant::finalize()) before running this query._
     pub async fn find_qualification_implicit_internal_provider(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -93,9 +93,14 @@ impl SchemaVariant {
             ));
         }
 
-        // NOTE(nick): perhaps, considering only finalizing once and outside of this method. We only
-        // need to finalize once if multiple leaves are added.
-        SchemaVariant::finalize_for_id(ctx, schema_variant_id).await?;
+        // We only need to finalize once since we are adding a leaf to a known descendant of the
+        // root prop.
+        let mut schema_variant = SchemaVariant::get_by_id(ctx, &schema_variant_id)
+            .await?
+            .ok_or(SchemaVariantError::NotFound(schema_variant_id))?;
+        if !schema_variant.finalized_once() {
+            schema_variant.finalize(ctx).await?;
+        }
 
         // Assemble the values we need to insert an object into the map.
         let item_prop =

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -14,7 +14,7 @@ use pretty_assertions_sorted::assert_eq;
 async fn update_for_context_simple(ctx: &DalContext) {
     // "name": String
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -26,9 +26,10 @@ async fn update_for_context_simple(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
-        .await
-        .expect("Unable to create component");
+    let (component, _) =
+        Component::new_for_default_variant_from_schema(ctx, "Basic component", *schema.id())
+            .await
+            .expect("Unable to create component");
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
@@ -142,7 +143,7 @@ async fn update_for_context_simple(ctx: &DalContext) {
 #[test]
 async fn insert_for_context_simple(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -157,9 +158,10 @@ async fn insert_for_context_simple(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
-        .await
-        .expect("Unable to create component");
+    let (component, _) =
+        Component::new_for_default_variant_from_schema(ctx, "Array Component", *schema.id())
+            .await
+            .expect("Unable to create component");
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
@@ -221,7 +223,7 @@ async fn insert_for_context_simple(ctx: &DalContext) {
 #[test]
 async fn update_for_context_object(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -247,9 +249,10 @@ async fn update_for_context_object(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Basic component", schema.id())
-        .await
-        .expect("Unable to create component");
+    let (component, _) =
+        Component::new_for_default_variant_from_schema(ctx, "Basic component", *schema.id())
+            .await
+            .expect("Unable to create component");
 
     let component_view = ComponentView::new(ctx, *component.id())
         .await
@@ -410,7 +413,7 @@ async fn update_for_context_object(ctx: &DalContext) {
 #[test]
 async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -425,9 +428,10 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "Array Component", schema.id())
-        .await
-        .expect("Unable to create component");
+    let (component, _) =
+        Component::new_for_default_variant_from_schema(ctx, "Array Component", *schema.id())
+            .await
+            .expect("Unable to create component");
 
     let base_attribute_read_context = AttributeReadContext {
         prop_id: None,
@@ -515,10 +519,9 @@ async fn list_payload(ctx: &DalContext) {
         .default_schema_variant_id()
         .expect("missing default schema variant id");
     let name = generate_name();
-    let (component, _node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, _node) = Component::new(ctx, &name, *schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let payloads = AttributeValue::list_payload_for_read_context(
         ctx,

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -17,7 +17,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -62,10 +62,9 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         .await
         .expect("unable to finalize schema variant");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", schema_variant.id())
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", *schema_variant.id())
+        .await
+        .expect("cannot create component");
 
     // Set a value on the prop to check if our code generation works as intended.
     let read_context = AttributeReadContext {

--- a/lib/dal/tests/integration_test/component/qualification.rs
+++ b/lib/dal/tests/integration_test/component/qualification.rs
@@ -16,7 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn add_and_list_qualifications(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema
         .set_default_schema_variant_id(ctx, Some(schema_variant_id))
@@ -80,10 +80,9 @@ async fn add_and_list_qualifications(ctx: &DalContext) {
         .await
         .expect("unable to finalize schema variant");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", &schema_variant_id)
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", schema_variant_id)
+        .await
+        .expect("cannot create component");
 
     // Set a value on the prop to check if our qualification works as intended.
     let read_context = AttributeReadContext {

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 async fn check_validations_for_component(ctx: &DalContext) {
     // Setup the schema and schema variant and create a validation for a string field.
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -97,10 +97,9 @@ async fn check_validations_for_component(ctx: &DalContext) {
         .expect("cannot finalize SchemaVariant");
 
     // Once setup is complete, create a component and update the target field to an "invalid" value.
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "hundo_gecs", schema_variant.id())
-            .await
-            .expect("could not create component");
+    let (component, _) = Component::new(ctx, "hundo_gecs", *schema_variant.id())
+        .await
+        .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
         component_id: Some(*component.id()),
@@ -284,7 +283,7 @@ async fn check_validations_for_component(ctx: &DalContext) {
 #[test]
 async fn check_js_validation_for_component(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -336,10 +335,9 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
         .await
         .expect("could not finalize");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "Danoth", schema_variant.id())
-            .await
-            .expect("could not create component");
+    let (component, _) = Component::new(ctx, "Danoth", *schema_variant.id())
+        .await
+        .expect("could not create component");
 
     let base_attribute_read_context = AttributeReadContext {
         component_id: Some(*component.id()),

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -23,7 +23,7 @@ pub async fn create_schema_with_object_and_string_prop(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -70,7 +70,7 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -119,7 +119,7 @@ pub async fn create_schema_with_string_props(
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -154,7 +154,7 @@ pub async fn create_schema_with_array_of_string_props(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -196,7 +196,7 @@ pub async fn create_schema_with_nested_array_objects(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -245,7 +245,7 @@ pub async fn create_simple_map(ctx: &DalContext) -> (Schema, SchemaVariant, Prop
     let octx = ctx.clone_with_universal_head();
     let ctx = &octx;
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -287,7 +287,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
     let ctx = &octx;
 
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -337,10 +337,9 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
 async fn only_string_props(ctx: &DalContext) {
     let (_schema, schema_variant, bohemian_prop, killer_prop, root_prop) =
         create_schema_with_string_props(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "capoeira", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "capoeira", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -419,10 +418,9 @@ async fn only_string_props(ctx: &DalContext) {
 async fn one_object_prop(ctx: &DalContext) {
     let (_schema, schema_variant, queen_prop, killer_prop, bohemian_prop, root_prop) =
         create_schema_with_object_and_string_prop(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "santos dumont", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "santos dumont", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -528,10 +526,9 @@ async fn nested_object_prop(ctx: &DalContext) {
         dust_prop,
         root_prop,
     ) = create_schema_with_nested_objects_and_string_prop(ctx).await;
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "free ronaldinho", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "free ronaldinho", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -677,10 +674,9 @@ async fn simple_array_of_strings(ctx: &DalContext) {
     let (_schema, schema_variant, sammy_prop, album_prop, root_prop) =
         create_schema_with_array_of_string_props(ctx).await;
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "tim maia", schema_variant.id())
-            .await
-            .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "tim maia", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -772,10 +768,10 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
         song_name_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
+    let (component, _) = Component::new(
         ctx,
         "An Integralist Doesn't Run, It Flies",
-        schema_variant.id(),
+        *schema_variant.id(),
     )
     .await
     .expect("Unable to create component");
@@ -1014,13 +1010,9 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
 async fn simple_map(ctx: &DalContext) {
     let (_schema, schema_variant, album_prop, album_item_prop, root_prop) =
         create_simple_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "E como isso afeta o Grêmio?",
-        schema_variant.id(),
-    )
-    .await
-    .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "E como isso afeta o Grêmio?", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());
@@ -1112,13 +1104,9 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
         song_map_item_prop,
         root_prop,
     ) = create_schema_with_nested_array_objects_and_a_map(ctx).await;
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "E como isso afeta o Grêmio?",
-        schema_variant.id(),
-    )
-    .await
-    .expect("Unable to create component");
+    let (component, _) = Component::new(ctx, "E como isso afeta o Grêmio?", *schema_variant.id())
+        .await
+        .expect("Unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -17,7 +17,7 @@ use pretty_assertions_sorted::assert_eq;
 async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     // Create and setup the schema and schema variant.
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -181,10 +181,9 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     .await;
 
     // Now that everything is set up, create the component.
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "god-of-war", schema_variant.id())
-            .await
-            .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "god-of-war", *schema_variant.id())
+        .await
+        .expect("unable to create component");
 
     // Confirm the component view renders what we expect
     let component_view = ComponentView::new(ctx, *component.id())
@@ -285,7 +284,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
 #[test]
 async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -450,13 +449,9 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
 
     // Create the component and cache what we need to insert into the map.
     // prototype argument for each item.
-    let (component, _) = Component::new_for_schema_variant_with_node(
-        ctx,
-        "the-game-awards-2022",
-        schema_variant.id(),
-    )
-    .await
-    .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "the-game-awards-2022", *schema_variant.id())
+        .await
+        .expect("unable to create component");
     let component_id = *component.id();
     let insert_context = AttributeContext::builder()
         .set_prop_id(map_prop_id)

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -22,7 +22,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     let schema_variant_id = *schema_variant.id();
     schema
         .set_default_schema_variant_id(ctx, Some(schema_variant_id))
@@ -85,10 +85,9 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
         .finalize(ctx)
         .await
         .expect("unable to finalize schema variant");
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "component", &schema_variant_id)
-            .await
-            .expect("cannot create component");
+    let (component, _) = Component::new(ctx, "component", schema_variant_id)
+        .await
+        .expect("cannot create component");
 
     // Check the view and properties before updating the poop field.
     let component_view = ComponentView::new(ctx, *component.id())

--- a/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
+++ b/lib/dal/tests/integration_test/confirmation_resolver_tree.rs
@@ -12,7 +12,7 @@ use dal_test::{helpers::create_component_and_node_for_schema, test};
 
 async fn create_dummy_schema(ctx: &DalContext) -> BuiltinsResult<(Schema, Socket, Socket)> {
     let mut schema = Schema::new(ctx, "Dummy Schema", &ComponentKind::Standard).await?;
-    let (schema_variant, _root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
+    let (mut schema_variant, _root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0").await?;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await?;

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -24,10 +24,9 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
         .expect("could not find default schema variant id");
     let name = "13700KF".to_string();
 
-    let (component, node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, node) = Component::new(ctx, &name, *schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let component_view = ComponentView::new(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -32,10 +32,9 @@ async fn property_editor_value(ctx: &DalContext) {
         .default_schema_variant_id()
         .expect("missing default schema variant id");
     let name = generate_name();
-    let (component, _node) =
-        Component::new_for_schema_variant_with_node(ctx, &name, schema_variant_id)
-            .await
-            .expect("could not create component");
+    let (component, _node) = Component::new(ctx, &name, *schema_variant_id)
+        .await
+        .expect("could not create component");
 
     let property_editor_values = PropertyEditorValues::for_component(ctx, *component.id())
         .await

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -300,7 +300,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
 // 38.805354552534816, -77.05091482877533
 async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -327,9 +327,10 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
     prop_map.insert("/root/domain/object/source", *source_prop.id());
     prop_map.insert("/root/domain/object/intermediate", *intermediate_prop.id());
 
-    let (component, node) = Component::new_for_schema_with_node(ctx, "esp", schema.id())
-        .await
-        .expect("unable to create component");
+    let (component, node) =
+        Component::new_for_default_variant_from_schema(ctx, "esp", *schema.id())
+            .await
+            .expect("unable to create component");
 
     // The base attribute read context can also be used for generating component views.
     let component_payload = ComponentPayload {
@@ -370,7 +371,7 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
 // 38.82091849697006, -77.05236860190759
 async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -395,9 +396,10 @@ async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     let mut prop_map = HashMap::new();
     prop_map.insert("/root/domain/destination", *destination_prop.id());
 
-    let (component, node) = Component::new_for_schema_with_node(ctx, "swings", schema.id())
-        .await
-        .expect("unable to create component");
+    let (component, node) =
+        Component::new_for_default_variant_from_schema(ctx, "swings", *schema.id())
+            .await
+            .expect("unable to create component");
 
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
@@ -427,7 +429,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     ) = setup_identity_func(ctx).await;
 
     let mut source_schema = create_schema(ctx).await;
-    let (source_schema_variant, source_root) =
+    let (mut source_schema_variant, source_root) =
         create_schema_variant_with_root(ctx, *source_schema.id()).await;
     source_schema
         .set_default_schema_variant_id(ctx, Some(*source_schema_variant.id()))
@@ -490,7 +492,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     .expect("cannot create source external provider attribute prototype argument");
 
     let mut destination_schema = create_schema(ctx).await;
-    let (destination_schema_variant, destination_root) =
+    let (mut destination_schema_variant, destination_root) =
         create_schema_variant_with_root(ctx, *destination_schema.id()).await;
     destination_schema
         .set_default_schema_variant_id(ctx, Some(*destination_schema_variant.id()))
@@ -570,10 +572,13 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     .await
     .expect("cannot create prototype argument for destination");
 
-    let (source_component, _) =
-        Component::new_for_schema_with_node(ctx, "Source Component", source_schema.id())
-            .await
-            .expect("Unable to create source component");
+    let (source_component, _) = Component::new_for_default_variant_from_schema(
+        ctx,
+        "Source Component",
+        *source_schema.id(),
+    )
+    .await
+    .expect("Unable to create source component");
 
     let source_attribute_read_context = AttributeReadContext {
         prop_id: None,
@@ -597,10 +602,13 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             .properties,
     );
 
-    let (destination_component, _) =
-        Component::new_for_schema_with_node(ctx, "Destination Component", destination_schema.id())
-            .await
-            .expect("Unable to create destination component");
+    let (destination_component, _) = Component::new_for_default_variant_from_schema(
+        ctx,
+        "Destination Component",
+        *destination_schema.id(),
+    )
+    .await
+    .expect("Unable to create destination component");
 
     assert_eq!(
         serde_json::json![

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -17,7 +17,7 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn intra_component_identity_update(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -39,9 +39,10 @@ async fn intra_component_identity_update(ctx: &DalContext) {
         .await
         .expect("cannot finalize SchemaVariant");
 
-    let (component, _) = Component::new_for_schema_with_node(ctx, "starfield", schema.id())
-        .await
-        .expect("unable to create component");
+    let (component, _) =
+        Component::new_for_default_variant_from_schema(ctx, "starfield", *schema.id())
+            .await
+            .expect("unable to create component");
 
     // This context can also be used for generating component views.
     let base_attribute_read_context = AttributeReadContext {
@@ -284,7 +285,7 @@ async fn intra_component_identity_update(ctx: &DalContext) {
 #[test]
 async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -376,10 +377,9 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
     .await
     .expect("could not create attribute prototype argument");
 
-    let (component, _) =
-        Component::new_for_schema_variant_with_node(ctx, "valkyrie-queen", schema_variant.id())
-            .await
-            .expect("unable to create component");
+    let (component, _) = Component::new(ctx, "valkyrie-queen", *schema_variant.id())
+        .await
+        .expect("unable to create component");
 
     let mut base_attribute_context = AttributeContext::builder();
     base_attribute_context.set_component_id(*component.id());

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -63,7 +63,7 @@ async fn find_code_item_prop(ctx: &DalContext) {
 #[test]
 async fn find_implicit_internal_providers_for_root_children(ctx: &DalContext) {
     let schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
+    let (mut schema_variant, root_prop) = SchemaVariant::new(ctx, *schema.id(), "v0")
         .await
         .expect("cannot create schema variant");
     schema_variant

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -13,7 +13,7 @@ use dal_test::{
 #[test]
 async fn new(ctx: &DalContext) {
     let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let (mut schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
     schema
         .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
         .await
@@ -50,6 +50,10 @@ async fn new(ctx: &DalContext) {
     .await
     .expect("unable to create validation prototype");
 
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("could not finalize schema variant");
     let component = create_component_for_schema(ctx, schema.id()).await;
 
     let args = FuncBackendValidationArgs::new(Validation::StringEquals {
@@ -95,164 +99,4 @@ async fn new(ctx: &DalContext) {
     )
     .await
     .expect("cannot create new attribute resolver");
-}
-
-#[test]
-async fn find_errors(ctx: &DalContext) {
-    let mut schema = create_schema(ctx).await;
-    let (schema_variant, root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
-    schema
-        .set_default_schema_variant_id(ctx, Some(*schema_variant.id()))
-        .await
-        .expect("cannot set default schema variant");
-    let prop =
-        create_prop_and_set_parent(ctx, PropKind::String, "glaive", root_prop.domain_prop_id).await;
-
-    let func = Func::new(
-        ctx,
-        "test:validateString",
-        FuncBackendKind::Validation,
-        FuncBackendResponseType::Validation,
-    )
-    .await
-    .expect("cannot create func");
-
-    let mut builder = ValidationPrototypeContext::builder();
-    builder.set_prop_id(*prop.id());
-    builder.set_schema_id(*schema.id());
-    builder.set_schema_variant_id(*schema_variant.id());
-    let first_prototype = ValidationPrototype::new(
-        ctx,
-        *func.id(),
-        serde_json::to_value(FuncBackendValidationArgs::new(Validation::StringEquals {
-            value: None,
-            expected: "amon amarth".to_owned(),
-        }))
-        .expect("cannot turn args into json"),
-        builder
-            .to_context(ctx)
-            .await
-            .expect("could not convert builder to context"),
-    )
-    .await
-    .expect("unable to create validation prototype");
-
-    let second_prototype = ValidationPrototype::new(
-        ctx,
-        *func.id(),
-        serde_json::to_value(FuncBackendValidationArgs::new(Validation::StringEquals {
-            value: None,
-            expected: "twisty monkey".to_owned(),
-        }))
-        .expect("cannot turn args into json"),
-        builder
-            .to_context(ctx)
-            .await
-            .expect("could not convert builder to context"),
-    )
-    .await
-    .expect("unable to create validation prototype");
-
-    let first_args = FuncBackendValidationArgs::new(Validation::StringEquals {
-        value: Some("".to_string()),
-        expected: "amon amarth".to_string(),
-    });
-    let first_func_binding = FuncBinding::new(
-        ctx,
-        serde_json::to_value(first_args).expect("cannot turn args into json"),
-        *func.id(),
-        *func.backend_kind(),
-    )
-    .await
-    .expect("cannot create function binding");
-
-    let first_func_binding_return_value = first_func_binding
-        .execute(ctx)
-        .await
-        .expect("failed to execute func binding");
-
-    let component = create_component_for_schema(ctx, schema.id()).await;
-
-    // Note: This is kinda wrong, the func_binding_return_value (and the func_binding) will point to the validation execution
-    // But we want the actual inner value that was used in the validation
-    // Since we never bothered to generate one we just use the validation as a substitute that properly tests the code, but doesn't make sense in the product
-    let context = AttributeContext::builder()
-        .set_prop_id(*prop.id())
-        .set_component_id(*component.id())
-        .to_context()
-        .expect("unable to build attribute context");
-    let attribute_value = AttributeValue::new(
-        ctx,
-        *first_func_binding.id(),
-        *first_func_binding_return_value.id(),
-        context,
-        Option::<&str>::None,
-    )
-    .await
-    .expect("unable to create attribute value");
-
-    let _first_validation_resolver = ValidationResolver::new(
-        ctx,
-        *first_prototype.id(),
-        *attribute_value.id(),
-        *first_func_binding.id(),
-    )
-    .await
-    .expect("cannot create new validation resolver");
-
-    let second_args = FuncBackendValidationArgs::new(Validation::StringEquals {
-        value: Some("not twisty monkey".to_string()),
-        expected: "twisty monkey".to_string(),
-    });
-    let second_func_binding = FuncBinding::new(
-        ctx,
-        serde_json::to_value(second_args).expect("cannot turn args into json"),
-        *func.id(),
-        *func.backend_kind(),
-    )
-    .await
-    .expect("cannot create function binding");
-
-    let _second_func_binding_return_value = second_func_binding
-        .execute(ctx)
-        .await
-        .expect("failed to execute func binding");
-
-    let _second_validation_resolver = ValidationResolver::new(
-        ctx,
-        *second_prototype.id(),
-        *attribute_value.id(),
-        *second_func_binding.id(),
-    )
-    .await
-    .expect("cannot create new validation resolver");
-
-    let mut validation_results = ValidationResolver::find_status(ctx, *component.id())
-        .await
-        .expect("cannot find values");
-
-    let mut got_results = false;
-    for result in &mut validation_results {
-        let av = AttributeValue::get_by_id(ctx, &result.attribute_value_id)
-            .await
-            .unwrap()
-            .unwrap();
-        if av.context.prop_id() == *prop.id() {
-            assert_eq!(2, result.errors.len());
-            // Order of the individual error messages isn't stable, so we'll sort them lexicographically.
-            result.errors.sort_by(|a, b| a.message.cmp(&b.message));
-            assert_eq!(
-                "value () does not match expected (amon amarth)",
-                &result.errors[0].message,
-            );
-            assert_eq!(
-                "value (not twisty monkey) does not match expected (twisty monkey)",
-                &result.errors[1].message,
-            );
-            got_results = true;
-        } else {
-            assert_eq!(0, result.errors.len());
-        }
-    }
-    assert!(got_results, "got expected results");
 }

--- a/lib/dal/tests/integration_test/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/workflow_runner.rs
@@ -154,7 +154,7 @@ async fn run(ctx: &DalContext) {
         .pop()
         .expect("unable to find docker image");
     let (component, _) =
-        Component::new_for_schema_with_node(ctx, "systeminit/whiskers", schema.id())
+        Component::new_for_default_variant_from_schema(ctx, "systeminit/whiskers", *schema.id())
             .await
             .expect("cannot create component");
 

--- a/lib/sdf/src/server/service/diagram/create_node.rs
+++ b/lib/sdf/src/server/service/diagram/create_node.rs
@@ -48,8 +48,7 @@ pub async fn create_node(
         .default_schema_variant_id()
         .ok_or(DiagramError::SchemaVariantNotFound)?;
 
-    let (component, node) =
-        Component::new_for_schema_variant_with_node(&ctx, &name, schema_variant_id).await?;
+    let (component, node) = Component::new(&ctx, &name, *schema_variant_id).await?;
 
     let component_id = *component.id();
 

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -34,7 +34,7 @@ async fn list_components_identification() {
     );
 
     let schema = create_schema(&dal_ctx).await;
-    let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
         .finalize(&dal_ctx)
         .await
@@ -43,19 +43,17 @@ async fn list_components_identification() {
     let component_name1 = "poop";
     let component_name2 = "ilikemybutt";
     for name in &[component_name1, component_name2] {
-        let _component =
-            Component::new_for_schema_variant_with_node(&dal_ctx, &name, schema_variant.id())
-                .await
-                .expect("cannot create new component");
+        let _component = Component::new(&dal_ctx, &name, *schema_variant.id())
+            .await
+            .expect("cannot create new component");
     }
 
     let component_name3 = "bobão";
     let component_name4 = "comédia";
     for name in &[component_name3, component_name4] {
-        let _component =
-            Component::new_for_schema_variant_with_node(&dal_ctx, &name, schema_variant.id())
-                .await
-                .expect("cannot create new component");
+        let _component = Component::new(&dal_ctx, &name, *schema_variant.id())
+            .await
+            .expect("cannot create new component");
     }
 
     let visibility = *dal_ctx.visibility();
@@ -147,7 +145,7 @@ async fn get_components_metadata() {
 
     let schema = create_schema(&dal_ctx).await;
 
-    let schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
+    let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
         .finalize(&dal_ctx)
         .await


### PR DESCRIPTION
## Context 

This is a continuation of the idea from #1629. The aforementioned PR has been closed in favor of this one.

## Description

- Add `finalized_once` column for schema variant
- Do not repeatably finalize when adding leaves for a schema variant
  (performance optimization)
- Ensure schema variants are finalized before creating components in
  existing code
- Rename and refactor component constructor methods (including
  leveraging IDs as copy types)