### PR TITLE
feat(dal,pinga): support nats as jobs execution transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are other components and paradigms that aren't displayed, but this diagram
 - **[web](./app/web/):** the primary frontend web application for SI
 - **[sdf](./bin/sdf/):** the backend webserver for communicating with `web`
 - **[dal](./lib/dal/):** the library used by `sdf` routes to "make stuff happen" (the keystone of SI)
-- **[pinga](./bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `faktory`
+- **[pinga](./bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `nats` or `faktory`
 - **[faktory](https://github.com/contribsys/faktory):** the job queueing mechanism used by `pinga` to execute non-trivial jobs
 - **[postgres](https://postgresql.org):** the database for storing SI data
 - **[veritech](./bin/veritech/):** a backend webserver for dispatching functions in secure runtime environments

--- a/bin/pinga/README.md
+++ b/bin/pinga/README.md
@@ -1,6 +1,6 @@
 # Pinga
 
-Job Queue Executor integrated with [Faktory](https://contribsys.com/faktory/)
+Job Queue Executor integrated with both [Nats](https://nats.io/) and [Faktory](https://contribsys.com/faktory/)
 
 ![pinga](./docs/pinga.png)
 

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -14,7 +14,7 @@ pub(crate) fn parse() -> Args {
 
 /// The System Initiative API service.
 ///
-/// Pinga queue executor system that handles whatever job comes from Faktory.
+/// Pinga queue executor system that handles whatever job comes from Nats or Faktory.
 /// It means "drip" in portuguese and also is a name for Cachaça
 #[derive(Parser, Debug)]
 #[command(name = NAME, max_term_width = 100)]

--- a/bin/pinga/src/transport.rs
+++ b/bin/pinga/src/transport.rs
@@ -1,0 +1,193 @@
+use futures::StreamExt;
+use si_data_nats::NatsClient;
+use telemetry_application::prelude::*;
+use tokio::sync::watch;
+
+use crate::{config, ExecutionState, JobError};
+use dal::{job::consumer::JobInfo, DalContextBuilder};
+
+// pub type Client = faktory_async::Client;
+// pub type Subscription = Client;
+// pub type Processor = dal::FaktoryProcessor;
+// pub async fn connect(config: &config::Config) -> Result<Client, JobError> {
+//     Ok(faktory_connect(config))
+// }
+// pub async fn subscribe(client: &Client) -> Result<Subscription, JobError> {
+//     Ok(client.clone())
+// }
+// pub async fn fetch(
+//     subscription: &Subscription,
+//     shutdown_request_rx: &mut watch::Receiver<()>,
+//     ctx_builder: &DalContextBuilder,
+// ) -> ExecutionState {
+//     faktory_fetch(subscription, shutdown_request_rx, ctx_builder).await
+// }
+// pub async fn post_process(subscription: &Subscription, jid: String, result: Result<(), JobError>) {
+//     faktory_post_process(subscription, jid, result).await
+// }
+
+pub type Client = NatsClient;
+pub type Subscription = si_data_nats::Subscription;
+pub type Processor = dal::NatsProcessor;
+pub async fn connect(config: &config::Config) -> Result<Client, JobError> {
+    nats_connect(config).await
+}
+pub async fn subscribe(client: &Client) -> Result<Subscription, JobError> {
+    nats_subscribe(client).await
+}
+pub async fn fetch(
+    subscription: &mut Subscription,
+    shutdown_request_rx: &mut watch::Receiver<()>,
+    ctx_builder: &DalContextBuilder,
+) -> ExecutionState {
+    nats_fetch(subscription, shutdown_request_rx, ctx_builder).await
+}
+pub async fn post_process(subscription: &Subscription, jid: String, result: Result<(), JobError>) {
+    nats_post_process(subscription, jid, result).await
+}
+
+// ---------------------------------
+// Transport specific implementation
+// ---------------------------------
+
+#[allow(unused)]
+async fn nats_connect(config: &config::Config) -> Result<NatsClient, JobError> {
+    Ok(NatsClient::new(config.nats()).await?)
+}
+#[allow(unused)]
+pub async fn nats_subscribe(client: &NatsClient) -> Result<si_data_nats::Subscription, JobError> {
+    Ok(client.queue_subscribe("pinga-jobs", "pinga").await?)
+}
+#[allow(unused)]
+async fn nats_fetch(
+    subscription: &mut si_data_nats::Subscription,
+    shutdown_request_rx: &mut watch::Receiver<()>,
+    ctx_builder: &DalContextBuilder,
+) -> ExecutionState {
+    tokio::select! {
+        job = subscription.next() => match job {
+            None => ExecutionState::Idle,
+            Some(result) => match result {
+                Ok(msg) => match serde_json::from_slice::<JobInfo>(msg.data()) {
+                    Ok(job) => ExecutionState::Process(job),
+                    Err(err) => {
+                        error!("Unable to deserialize nats' job: {err}");
+                        ExecutionState::Idle
+                    }
+                }
+                Err(err) => {
+                    error!("Internal error in nats, bailing out: {err}");
+                    ExecutionState::Stop
+                }
+            }
+        },
+        _ = shutdown_request_rx.changed() => {
+            info!("Worker task received shutdown notification: stopping");
+            ExecutionState::Stop
+        }
+    }
+}
+
+#[allow(unused)]
+async fn nats_post_process(
+    client: &si_data_nats::Subscription,
+    jid: String,
+    result: Result<(), JobError>,
+) {
+    match result {
+        Ok(()) => {}
+        Err(err) => error!("Job execution failed: {err}"),
+    }
+}
+
+#[allow(unused)]
+fn faktory_connect(config: &config::Config) -> faktory_async::Client {
+    let config = faktory_async::Config::from_uri(
+        &config.faktory().url,
+        Some("pinga".to_string()),
+        Some(uuid::Uuid::new_v4().to_string()),
+    );
+    faktory_async::Client::new(config, 256)
+}
+#[allow(unused)]
+async fn faktory_fetch(
+    client: &faktory_async::Client,
+    shutdown_request_rx: &mut watch::Receiver<()>,
+    ctx_builder: &DalContextBuilder,
+) -> ExecutionState {
+    use faktory_async::BeatState;
+
+    match client.last_beat().await {
+        Ok(BeatState::Ok) => {
+            tokio::select! {
+                job = client.fetch(vec!["default".into()]) => match job {
+                    Ok(Some(job)) => match JobInfo::try_from(job) {
+                        Ok(job) => ExecutionState::Process(job),
+                        Err(err) => {
+                            error!("Unable to deserialize faktory's job: {err}");
+                            ExecutionState::Idle
+                        }
+                    },
+                    Ok(None) => ExecutionState::Idle,
+                    Err(err) => {
+                        error!("Unable to fetch from faktory: {err}");
+                        ExecutionState::Idle
+                    }
+                },
+                _ = shutdown_request_rx.changed() => {
+                    info!("Worker task received shutdown notification: stopping");
+                    ExecutionState::Stop
+                }
+            }
+        }
+        Ok(BeatState::Quiet) => {
+            // Getting a "quiet" state from the faktory server means that
+            // someone has gone to the faktory UI and requested that this
+            // particular worker finish what it's doing, and gracefully
+            // shut down.
+            info!("Gracefully shutting down from Faktory request.");
+            ExecutionState::Stop
+        }
+        Ok(BeatState::Terminate) => {
+            warn!("Faktory asked us to terminate");
+            ExecutionState::Stop
+        }
+        Err(err) => {
+            error!("Internal error in faktory-async, bailing out: {err}");
+            ExecutionState::Stop
+        }
+    }
+}
+
+#[allow(unused)]
+async fn faktory_post_process(
+    client: &faktory_async::Client,
+    jid: String,
+    result: Result<(), JobError>,
+) {
+    use faktory_async::FailConfig;
+    match result {
+        Ok(()) => match client.ack(jid).await {
+            Ok(()) => {}
+            Err(err) => {
+                error!("Ack failed: {err}");
+            }
+        },
+        Err(err) => {
+            error!("Job execution failed: {err}");
+            // TODO: pass backtrace here
+            match client
+                .fail(FailConfig::new(
+                    jid,
+                    format!("{err:?}"),
+                    err.to_string(),
+                    None,
+                ))
+                .await
+            {
+                Ok(()) => {}
+                Err(err) => error!("Fail failed: {err}"),
+            }
+        }
+    }
+}

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -26,7 +26,7 @@ pub struct ServicesContext {
     pg_pool: PgPool,
     /// A connected NATS client
     nats_conn: NatsClient,
-    /// A connected faktory client
+    /// A connected job processor client
     job_processor: Box<dyn JobQueueProcessor + Send + Sync>,
     /// A Veritech client, connected via a NATS connection.
     veritech: VeritechClient,
@@ -625,8 +625,6 @@ impl DalContextBuilder {
 
 #[derive(Debug, Error)]
 pub enum TransactionsError {
-    #[error("faktory error: {0}")]
-    Faktory(#[from] faktory_async::Error),
     #[error(transparent)]
     JobQueueProcessor(#[from] JobQueueProcessorError),
     #[error(transparent)]

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryFrom};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -74,7 +74,7 @@ impl From<JobConsumerError> for std::io::Error {
 pub type JobConsumerResult<T> = Result<T, JobConsumerError>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FaktoryJobInfo {
+pub struct JobInfo {
     pub id: String,
     pub kind: String,
     pub queue: Option<String>,
@@ -82,26 +82,17 @@ pub struct FaktoryJobInfo {
     pub enqueued_at: Option<DateTime<Utc>>,
     pub at: Option<DateTime<Utc>>,
     pub args: Vec<Value>,
+    pub retry: Option<isize>,
     pub custom: JobConsumerCustomPayload,
 }
 
-impl TryFrom<faktory_async::Job> for FaktoryJobInfo {
-    type Error = JobConsumerError;
+impl JobInfo {
+    pub fn args(&self) -> &[Value] {
+        &self.args
+    }
 
-    fn try_from(job: faktory_async::Job) -> Result<Self, Self::Error> {
-        let custom: JobConsumerCustomPayload =
-            serde_json::from_value(serde_json::to_value(job.custom.clone())?)?;
-
-        Ok(FaktoryJobInfo {
-            id: job.id().to_string(),
-            kind: job.kind().to_string(),
-            queue: job.queue.clone(),
-            created_at: job.created_at,
-            enqueued_at: job.enqueued_at,
-            at: job.at,
-            args: job.args().to_vec(),
-            custom,
-        })
+    pub fn kind(&self) -> &str {
+        &self.kind
     }
 }
 

--- a/lib/dal/src/job/definition/confirmations.rs
+++ b/lib/dal/src/job/definition/confirmations.rs
@@ -8,7 +8,7 @@ use crate::job::definition::confirmation::Confirmation;
 
 use crate::{
     job::{
-        consumer::{FaktoryJobInfo, JobConsumer, JobConsumerError, JobConsumerResult},
+        consumer::{JobConsumer, JobConsumerError, JobConsumerResult, JobInfo},
         producer::{JobMeta, JobProducer, JobProducerResult},
     },
     AccessBuilder, Component, ConfirmationPrototype, DalContext, StandardModel, Visibility,
@@ -19,7 +19,7 @@ use crate::{
 pub struct Confirmations {
     access_builder: AccessBuilder,
     visibility: Visibility,
-    faktory_job: Option<FaktoryJobInfo>,
+    job: Option<JobInfo>,
 }
 
 impl Confirmations {
@@ -30,7 +30,7 @@ impl Confirmations {
         Box::new(Self {
             access_builder,
             visibility,
-            faktory_job: None,
+            job: None,
         })
     }
 }
@@ -102,10 +102,10 @@ impl JobConsumer for Confirmations {
     }
 }
 
-impl TryFrom<faktory_async::Job> for Confirmations {
+impl TryFrom<JobInfo> for Confirmations {
     type Error = JobConsumerError;
 
-    fn try_from(job: faktory_async::Job) -> Result<Self, Self::Error> {
+    fn try_from(job: JobInfo) -> Result<Self, Self::Error> {
         if job.args().len() != 3 {
             return Err(JobConsumerError::InvalidArguments(
                 r#"[null, <AccessBuilder>, <Visibility>]"#.to_string(),
@@ -115,12 +115,10 @@ impl TryFrom<faktory_async::Job> for Confirmations {
         let access_builder: AccessBuilder = serde_json::from_value(job.args()[1].clone())?;
         let visibility: Visibility = serde_json::from_value(job.args()[2].clone())?;
 
-        let faktory_job_info = FaktoryJobInfo::try_from(job)?;
-
         Ok(Self {
             access_builder,
             visibility,
-            faktory_job: Some(faktory_job_info),
+            job: Some(job),
         })
     }
 }

--- a/lib/dal/src/job/processor.rs
+++ b/lib/dal/src/job/processor.rs
@@ -6,12 +6,15 @@ use super::producer::{JobProducer, JobProducerError};
 use crate::DalContext;
 
 pub mod faktory_processor;
+pub mod nats_processor;
 pub mod sync_processor;
 
 #[derive(Error, Debug)]
 pub enum JobQueueProcessorError {
     #[error(transparent)]
-    Faktory(#[from] faktory_async::Error),
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Transport(Box<dyn std::error::Error + Sync + Send + 'static>),
     #[error(transparent)]
     JobProducer(#[from] JobProducerError),
 }

--- a/lib/dal/src/job/processor/nats_processor.rs
+++ b/lib/dal/src/job/processor/nats_processor.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use si_data_nats::NatsClient;
+use std::convert::TryInto;
+use telemetry::prelude::*;
+use tokio::sync::mpsc;
+
+use crate::{
+    job::{consumer::JobInfo, producer::JobProducer, queue::JobQueue},
+    DalContext,
+};
+
+use super::{JobQueueProcessor, JobQueueProcessorError, JobQueueProcessorResult};
+
+#[derive(Clone, Debug)]
+pub struct NatsProcessor {
+    client: NatsClient,
+    queue: JobQueue,
+    // Drop guard that will ensure the receiver end never returns until all NatsProcessors are gone
+    // Necessary as since we spawn a task to enqueue the jobs hyper's graceful shutdown won't wait on us
+    // And since we may not have pushed all jobs (or any) `NatsClient::close` will not wait until we have finished
+    //
+    // We never send anything to this, it's just to add reactivity
+    _alive_marker: mpsc::Sender<()>,
+}
+
+impl NatsProcessor {
+    pub fn new(client: NatsClient, _alive_marker: mpsc::Sender<()>) -> Self {
+        Self {
+            client,
+            _alive_marker,
+            queue: JobQueue::new(),
+        }
+    }
+
+    async fn push_all_jobs(&self) -> JobQueueProcessorResult<()> {
+        while let Some(job) = self.queue.fetch_job().await {
+            let job_info: JobInfo = job.try_into()?;
+            if let Err(err) = self
+                .client
+                .publish("pinga-jobs", serde_json::to_vec(&job_info)?)
+                .await
+            {
+                error!("Nats job push failed, some jobs will be dropped");
+                return Err(JobQueueProcessorError::Transport(Box::new(err)));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl JobQueueProcessor for NatsProcessor {
+    async fn enqueue_job(&self, job: Box<dyn JobProducer + Send + Sync>, _ctx: &DalContext) {
+        self.queue.enqueue_job(job).await
+    }
+
+    async fn process_queue(&self) -> JobQueueProcessorResult<()> {
+        let processor = self.clone();
+        tokio::spawn(async move {
+            if let Err(err) = processor.push_all_jobs().await {
+                error!("Unable to push jobs to nats: {err}");
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/lib/dal/src/job/queue.rs
+++ b/lib/dal/src/job/queue.rs
@@ -15,15 +15,11 @@ impl JobQueue {
     }
 
     pub async fn enqueue_job(&self, job: Box<dyn JobProducer + Send + Sync>) {
-        let already_enqueued = self
-            .queue
-            .lock()
-            .await
-            .iter()
-            .any(|j| j.identity() == job.identity());
+        let mut lock = self.queue.lock().await;
+        let already_enqueued = lock.iter().any(|j| j.identity() == job.identity());
 
         if !already_enqueued {
-            self.queue.lock().await.push_back(job);
+            lock.push_back(job);
         }
     }
 

--- a/lib/dal/src/job_failure.rs
+++ b/lib/dal/src/job_failure.rs
@@ -25,7 +25,7 @@ pub type JobFailureResult<T, E = JobFailureError> = Result<T, E>;
 pk!(JobFailurePk);
 pk!(JobFailureId);
 
-/// Background tasks, enqueued with `faktory`, executed by `pinga` may fail.
+/// Background tasks, enqueued on the dynamic transport layer, executed by `pinga` may fail.
 /// And not all failure can be reported to the user by the regular path, so
 /// any fatal failure, like a panic or an `Err` propagated from the `dal will
 /// be stored in the database in the form of a `JobFailure`

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -135,7 +135,10 @@ pub use func::{
 pub use group::{Group, GroupError, GroupId, GroupResult};
 pub use history_event::{HistoryActor, HistoryEvent, HistoryEventError};
 pub use index_map::IndexMap;
-pub use job::processor::{faktory_processor::FaktoryProcessor, JobQueueProcessor};
+pub use job::processor::{
+    faktory_processor::FaktoryProcessor, nats_processor::NatsProcessor,
+    sync_processor::SyncProcessor, JobQueueProcessor,
+};
 pub use job_failure::{JobFailure, JobFailureError, JobFailureResult};
 pub use jwt_key::{create_jwt_key_if_missing, JwtSecretKey};
 pub use key_pair::{KeyPair, KeyPairError, KeyPairResult, PublicKey};

--- a/lib/sdf/src/lib.rs
+++ b/lib/sdf/src/lib.rs
@@ -15,6 +15,6 @@
 mod server;
 pub use server::{
     build_service, service, Config, ConfigError, ConfigFile, FaktoryProcessor, IncomingStream,
-    JobQueueProcessor, JwtSecretKey, MigrationMode, Server, StandardConfig, StandardConfigFile,
-    SyncProcessor,
+    JobQueueProcessor, JwtSecretKey, MigrationMode, NatsProcessor, Server, StandardConfig,
+    StandardConfigFile, SyncProcessor,
 };

--- a/lib/sdf/src/server.rs
+++ b/lib/sdf/src/server.rs
@@ -2,10 +2,7 @@ pub use config::{
     Config, ConfigBuilder, ConfigError, ConfigFile, IncomingStream, JwtSecretKey, StandardConfig,
     StandardConfigFile,
 };
-pub use dal::job::processor::{
-    faktory_processor::FaktoryProcessor, sync_processor::SyncProcessor, JobQueueProcessor,
-};
-pub use dal::MigrationMode;
+pub use dal::{FaktoryProcessor, JobQueueProcessor, MigrationMode, NatsProcessor, SyncProcessor};
 pub use routes::{routes, AppError, AppResult};
 pub use server::{build_service, Server};
 pub use uds::{UdsIncomingStream, UdsIncomingStreamError};

--- a/lib/sdf/tests/service_tests/change_set.rs
+++ b/lib/sdf/tests/service_tests/change_set.rs
@@ -29,7 +29,7 @@ async fn list_open_change_sets() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.update_to_billing_account_tenancies(*nba.billing_account.id());
     let _a_change_set = dal_create_change_set(&dal_ctx).await;
@@ -62,7 +62,7 @@ async fn create_change_set() {
         _nba,
         auth_token,
         _dal_ctx,
-        _faktory,
+        _job_processor,
     );
     let request: CreateChangeSetRequest = CreateChangeSetRequest {
         change_set_name: "mastodon".to_string(),
@@ -94,7 +94,7 @@ async fn get_change_set() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.update_to_billing_account_tenancies(*nba.billing_account.id());
     let change_set = dal_create_change_set(&dal_ctx).await;
@@ -122,7 +122,7 @@ async fn apply_change_set() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.update_to_billing_account_tenancies(*nba.billing_account.id());
     let change_set = dal_create_change_set(&dal_ctx).await;

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -30,7 +30,7 @@ async fn list_components_identification() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
 
     let schema = create_schema(&dal_ctx).await;
@@ -139,7 +139,7 @@ async fn get_components_metadata() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     let visibility = Visibility::new_head(false);
 

--- a/lib/sdf/tests/service_tests/mod.rs
+++ b/lib/sdf/tests/service_tests/mod.rs
@@ -217,14 +217,15 @@ macro_rules! test_setup {
         $nba:ident,
         $auth_token:ident,
         $dal_ctx:ident,
-        $faktory:ident $(,)?
+        $job_processor:ident $(,)?
     ,
     ) => {
         ::dal_test::test_harness::one_time_setup()
             .await
             .expect("one time setup failed");
         let $ctx = ::dal_test::test_harness::TestContext::init().await;
-        let ($pg, $nats_conn, $faktory, $veritech, $encr_key, $jwt_secret_key) = $ctx.entries();
+        let ($pg, $nats_conn, $job_processor, $veritech, $encr_key, $jwt_secret_key) =
+            $ctx.entries();
         let telemetry = $ctx.telemetry();
         let $nats = $nats_conn.transaction();
         let mut $pgconn = $pg.get().await.expect("cannot connect to pg");
@@ -233,7 +234,7 @@ macro_rules! test_setup {
             telemetry,
             $pg.clone(),
             $nats_conn.clone(),
-            $faktory.clone(),
+            $job_processor.clone(),
             $veritech.clone(),
             $encr_key.clone(),
             $jwt_secret_key.clone(),
@@ -246,7 +247,7 @@ macro_rules! test_setup {
             let services_context = ::dal::ServicesContext::new(
                 $pg.clone(),
                 $nats_conn.clone(),
-                $faktory.clone(),
+                $job_processor.clone(),
                 $veritech.clone(),
                 std::sync::Arc::new($encr_key.clone()),
             );
@@ -269,7 +270,7 @@ macro_rules! test_setup {
         let services_context = dal::ServicesContext::new(
             $pg.clone(),
             $nats_conn.clone(),
-            $faktory.clone(),
+            $job_processor.clone(),
             $veritech.clone(),
             std::sync::Arc::new($encr_key.clone()),
         );

--- a/lib/sdf/tests/service_tests/schema.rs
+++ b/lib/sdf/tests/service_tests/schema.rs
@@ -30,7 +30,7 @@ async fn create_schema() {
         _nba,
         auth_token,
         _dal_ctx,
-        _faktory,
+        _job_processor,
     );
     let visibility = Visibility::new_head(false);
     let request = CreateSchemaRequest {
@@ -64,7 +64,7 @@ async fn list_schemas() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.update_to_universal_head();
 
@@ -114,7 +114,7 @@ async fn get_schemas() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.update_to_universal_head();
 

--- a/lib/sdf/tests/service_tests/secret.rs
+++ b/lib/sdf/tests/service_tests/secret.rs
@@ -24,7 +24,7 @@ async fn create_secret() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
 
     let visibility = Visibility::new_head(false);

--- a/lib/sdf/tests/service_tests/session.rs
+++ b/lib/sdf/tests/service_tests/session.rs
@@ -28,7 +28,7 @@ async fn login() {
         nba,
         _auth_token,
         _dal_ctx,
-        _faktory,
+        _job_processor,
     );
 
     let request = LoginRequest {
@@ -85,7 +85,7 @@ async fn restore_authentication() {
         nba,
         auth_token,
         _dal_ctx,
-        _faktory,
+        _job_processor,
     );
 
     let response: RestoreAuthenticationResponse = api_request_auth_empty(
@@ -115,7 +115,7 @@ async fn get_defaults() {
         nba,
         auth_token,
         dal_ctx,
-        _faktory,
+        _job_processor,
     );
     dal_ctx.commit().await.expect("cannot commit txns");
 

--- a/lib/sdf/tests/service_tests/signup.rs
+++ b/lib/sdf/tests/service_tests/signup.rs
@@ -14,14 +14,14 @@ use tower::ServiceExt;
 async fn create_account() {
     one_time_setup().await.expect("cannot setup tests");
     let ctx = TestContext::init().await;
-    let (pg, nats, faktory, _veritech, encr_key, jwt_secret_key) = ctx.entries();
+    let (pg, nats, job_processor, _veritech, encr_key, jwt_secret_key) = ctx.entries();
     let veritech = veritech_client::Client::new(nats.clone());
     let telemetry = ctx.telemetry();
     let (app, _, _) = sdf::build_service(
         telemetry,
         pg.clone(),
         nats.clone(),
-        faktory,
+        job_processor,
         veritech,
         *encr_key,
         jwt_secret_key.clone(),
@@ -61,14 +61,14 @@ async fn create_account() {
 async fn create_account_invalid_signup_secret() {
     one_time_setup().await.expect("cannot setup tests");
     let ctx = TestContext::init().await;
-    let (pg, nats, faktory, _veritech, encr_key, jwt_secret_key) = ctx.entries();
+    let (pg, nats, job_processor, _veritech, encr_key, jwt_secret_key) = ctx.entries();
     let veritech = veritech_client::Client::new(nats.clone());
     let telemetry = ctx.telemetry();
     let (app, _, _) = sdf::build_service(
         telemetry,
         pg.clone(),
         nats.clone(),
-        faktory,
+        job_processor,
         veritech,
         *encr_key,
         jwt_secret_key.clone(),


### PR DESCRIPTION
Note: this is extremely hackish, it was the fastest way to support nats without completely breaking faktory support. The consumer  transport will become a trait, but it doesn't need to be one right now for us to win a speedup.

- Make job execution agnostic in the dal, differing only in the specific processor's implementation file
- Support nats as a job producer
- Make pinga hackishly agnostic to the transport - (un)comment transport specific definitions in src/transport.rs file
- Eventually this hack will be turned into a trait that is implemented for multiple backends, but for now the hack works
- Support nats as a job consumer in pinga