### PR TITLE
Trigger prop tree confirmations upon resource update (ENG-903)

### DIFF
--- a/lib/dal/src/component/confirmation.rs
+++ b/lib/dal/src/component/confirmation.rs
@@ -1,0 +1,106 @@
+use serde::Deserialize;
+use serde::Serialize;
+use telemetry::prelude::*;
+
+use crate::attribute::value::AttributeValue;
+use crate::component::{
+    ComponentResult, LIST_ALL_RESOURCE_IMPLICIT_INTERNAL_PROVIDER_ATTRIBUTE_VALUES,
+};
+use crate::func::binding_return_value::FuncBindingReturnValueId;
+use crate::job::definition::DependentValuesUpdate;
+use crate::ws_event::WsEvent;
+use crate::{standard_model, DalContext, StandardModel, WsEventResult, WsPayload};
+use crate::{Component, ComponentId};
+
+// TODO(nick): replace existing view with this unused view.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfirmationStatusView {
+    Running,
+    Failure,
+    Success,
+}
+
+// TODO(nick): replace existing view with this unused view.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmationView {
+    func_binding_return_value_id: FuncBindingReturnValueId,
+    title: String,
+    component_id: ComponentId,
+    description: Option<String>,
+    output: Option<Vec<String>>,
+    status: ConfirmationStatusView,
+}
+
+// TODO(nick): use this for listing confirmations, like qualifications in the future.
+// FIXME(nick): use the formal types from the new version of function authoring instead of this
+// struct. This struct is a temporary stopgap until that's implemented.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmationEntry {
+    pub success: bool,
+    #[serde(default)]
+    pub recommended_actions: Vec<String>,
+}
+
+impl Component {
+    /// List all [`AttributeValues`](crate::AttributeValue) whose
+    /// [`AttributeContext`](crate::AttributeContext) contains a populated [`ComponentId`](Self)
+    /// and a populated [`InternalProviderId`](crate::InternalProvider) where the latter is the
+    /// ID for the _implicit_ [`InternalProvider`](crate::InternalProvider) corresponding to
+    /// "/root/resource" (child of [`RootProp`](crate::RootProp).
+    ///
+    /// In other words, this query should find as many [`AttributeValues`](crate::AttributeValue)
+    /// as there are [`Components`](Self) in the workspace.
+    #[instrument(skip_all)]
+    pub async fn list_all_resource_implicit_internal_provider_attribute_values(
+        ctx: &DalContext,
+    ) -> ComponentResult<Vec<AttributeValue>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_ALL_RESOURCE_IMPLICIT_INTERNAL_PROVIDER_ATTRIBUTE_VALUES,
+                &[ctx.read_tenancy(), ctx.visibility()],
+            )
+            .await?;
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
+
+    /// Run confirmations for all [`Components`](Self) in the workspace by running a
+    /// [`DependentValuesUpdate`](crate::job::definition::DependentValuesUpdate) job for every
+    /// [`AttributeValue`](crate::AttributeValue) corresponding to the "/root/resource" implicit
+    /// [`InternalProvider`](crate::InternalProvider) for every [`Component`](crate::Component).
+    pub async fn run_all_confirmations(ctx: &DalContext) -> ComponentResult<()> {
+        for resource_attribute_value in
+            Component::list_all_resource_implicit_internal_provider_attribute_values(ctx).await?
+        {
+            ctx.enqueue_job(DependentValuesUpdate::new(
+                ctx,
+                *resource_attribute_value.id(),
+            ))
+            .await;
+        }
+
+        WsEvent::ran_confirmations(ctx).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmationRunPayload {
+    success: bool,
+}
+
+impl WsEvent {
+    pub async fn ran_confirmations(ctx: &DalContext) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::RanConfirmations(ConfirmationRunPayload { success: true }),
+        )
+        .await
+    }
+}

--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     AccessBuilder, ActionPrototype, Component, ComponentId, ConfirmationResolverId, DalContext,
     Fix, FixBatch, FixBatchId, FixCompletionStatus, FixId, FixResolver, FixResolverContext,
-    StandardModel, Visibility, WsEvent,
+    RootPropChild, StandardModel, Visibility, WsEvent,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,8 +199,8 @@ impl JobConsumer for FixesJob {
         if !resources.is_empty() {
             let attribute_value = Component::root_child_attribute_value_for_component(
                 ctx,
-                "resource",
                 *component.id(),
+                RootPropChild::Resource,
             )
             .await?;
 

--- a/lib/dal/src/queries/component/list_all_resource_implicit_internal_provider_attribute_values.sql
+++ b/lib/dal/src/queries/component/list_all_resource_implicit_internal_provider_attribute_values.sql
@@ -1,0 +1,17 @@
+SELECT row_to_json(attribute_values.*) AS object
+FROM attribute_values_v1($1, $2) as attribute_values
+         LEFT JOIN internal_providers_v1($1, $2) as internal_providers
+                   ON attribute_values.attribute_context_internal_provider_id = internal_providers.id
+         LEFT JOIN props_v1($1, $2) as props
+                   ON props.id = internal_providers.prop_id
+                       AND props.name = 'resource'
+         JOIN prop_belongs_to_prop_v1($1, $2) AS prop_belongs_to_prop
+              ON prop_belongs_to_prop.object_id = props.id
+                  AND prop_belongs_to_prop.belongs_to_id IN (
+                      SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
+                      FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+                               LEFT JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
+                                         ON component_belongs_to_schema_variant.belongs_to_id =
+                                            prop_many_to_many_schema_variants.right_object_id
+                  )
+WHERE attribute_values.attribute_context_component_id != ident_nil_v1()

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -418,15 +418,6 @@ impl SchemaVariant {
         schema_variant_id: SchemaVariantId,
         root_prop_child: RootPropChild,
     ) -> SchemaVariantResult<InternalProvider> {
-        let root_prop_child_name = match root_prop_child {
-            RootPropChild::Si => "si",
-            RootPropChild::Domain => "domain",
-            RootPropChild::Resource => "resource",
-            RootPropChild::Code => "code",
-            RootPropChild::Qualification => "qualification",
-            RootPropChild::Confirmation => "confirmation",
-        };
-
         let row = ctx
             .txns()
             .pg()
@@ -436,7 +427,7 @@ impl SchemaVariant {
                     ctx.read_tenancy(),
                     ctx.visibility(),
                     &schema_variant_id,
-                    &root_prop_child_name,
+                    &root_prop_child.as_str(),
                 ],
             )
             .await?;

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -26,6 +26,19 @@ pub enum RootPropChild {
     Confirmation,
 }
 
+impl RootPropChild {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Si => "si",
+            Self::Domain => "domain",
+            Self::Resource => "resource",
+            Self::Code => "code",
+            Self::Qualification => "qualification",
+            Self::Confirmation => "confirmation",
+        }
+    }
+}
+
 /// Contains the root [`PropId`](crate::Prop) and its immediate children for a
 /// [`SchemaVariant`](crate::SchemaVariant). These [`Props`](crate::Prop) are also those that
 /// correspond to the "root" [`Props`](crate::Prop) on the [`ComponentView`](crate::ComponentView)

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use thiserror::Error;
 
+use crate::component::confirmation::ConfirmationRunPayload;
 use crate::{
     component::{code::CodeGeneratedPayload, resource::ResourceRefreshId},
     confirmation_status::ConfirmationStatusUpdate,
@@ -38,6 +39,7 @@ pub enum WsPayload {
     ChangeSetWritten(ChangeSetPk),
     SchemaCreated(SchemaPk),
     ResourceRefreshed(ResourceRefreshId),
+    RanConfirmations(ConfirmationRunPayload),
     CheckedQualifications(QualificationCheckPayload),
     CommandOutput(CommandOutput),
     CodeGenerated(CodeGeneratedPayload),

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -29,8 +29,8 @@ async fn new(DalContextHeadRef(ctx): DalContextHeadRef<'_>) {
 async fn apply(ctx: &mut DalContext) {
     let mut change_set = ChangeSet::get_by_pk(ctx, &ctx.visibility().change_set_pk)
         .await
-        .unwrap()
-        .unwrap();
+        .expect("could not perform get by pk")
+        .expect("could not get change set");
 
     let group = create_group(ctx).await;
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -16,6 +16,7 @@ use pretty_assertions_sorted::assert_eq;
 use veritech_client::ResourceStatus;
 
 mod code;
+mod confirmation;
 mod qualification;
 mod validation;
 mod view;

--- a/lib/dal/tests/integration_test/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/component/confirmation.rs
@@ -1,0 +1,212 @@
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
+use dal::func::backend::js_command::CommandRunResult;
+
+use dal::schema::variant::leaves::LeafKind;
+use dal::{
+    generate_name,
+    schema::variant::leaves::{LeafInput, LeafInputLocation},
+    ChangeSet, ChangeSetStatus, Component, ComponentView, DalContext, Func, FuncBackendKind,
+    FuncBackendResponseType, SchemaVariant, StandardModel, Visibility, WorkspaceId,
+};
+
+use dal_test::test;
+use dal_test::test_harness::{create_schema, create_schema_variant_with_root};
+use pretty_assertions_sorted::assert_eq;
+use veritech_client::ResourceStatus;
+
+#[test]
+async fn add_and_run_confirmations(mut octx: DalContext, wid: WorkspaceId) {
+    let ctx = &mut octx;
+    ctx.update_to_universal_head();
+
+    let mut schema = create_schema(ctx).await;
+    let (mut schema_variant, _root_prop) = create_schema_variant_with_root(ctx, *schema.id()).await;
+    let schema_variant_id = *schema_variant.id();
+    schema
+        .set_default_schema_variant_id(ctx, Some(schema_variant_id))
+        .await
+        .expect("cannot set default schema variant");
+
+    // Setup the confirmation function.
+    let mut confirmation_func = Func::new(
+        ctx,
+        "test:confirmation",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::Confirmation,
+    )
+    .await
+    .expect("could not create func");
+    let confirmation_func_id = *confirmation_func.id();
+    let code = "async function exists(input) {
+        if (!input.resource?.value) {
+            return {
+                success: false,
+                recommendedActions: [\"create\"]
+            }
+        }
+        return {
+            success: true,
+            recommendedActions: [],
+        }
+    }";
+    confirmation_func
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    confirmation_func
+        .set_handler(ctx, Some("exists"))
+        .await
+        .expect("set handler");
+    let confirmation_func_argument = FuncArgument::new(
+        ctx,
+        "resource",
+        FuncArgumentKind::String,
+        None,
+        confirmation_func_id,
+    )
+    .await
+    .expect("could not create func argument");
+
+    // Add the leaf for the confirmation.
+    SchemaVariant::add_leaf(
+        ctx,
+        confirmation_func_id,
+        schema_variant_id,
+        None,
+        LeafKind::Confirmation,
+        vec![LeafInput {
+            location: LeafInputLocation::Resource,
+            func_argument_id: *confirmation_func_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add qualification");
+
+    // Finalize the schema variant and create the component.
+    schema_variant
+        .finalize(ctx)
+        .await
+        .expect("unable to finalize schema variant");
+
+    // Update to the workspace tenancy and enter a new change set.
+    ctx.update_to_workspace_tenancies(wid)
+        .await
+        .expect("could not update to workspace tenancies");
+    let new_change_set = ChangeSet::new(ctx, generate_name(), None)
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility(Visibility::new(new_change_set.pk, None));
+
+    // Create a component and immediately apply the change set.
+    let (component, _) = Component::new(ctx, "component", schema_variant_id)
+        .await
+        .expect("cannot create component");
+    assert_eq!(new_change_set.pk, ctx.visibility().change_set_pk);
+    let mut change_set = ChangeSet::get_by_pk(ctx, &ctx.visibility().change_set_pk)
+        .await
+        .expect("could not fetch change set by pk")
+        .expect("no change set found for pk");
+    change_set
+        .apply(ctx)
+        .await
+        .expect("cannot apply change set");
+    assert_eq!(&change_set.status, &ChangeSetStatus::Applied);
+    ctx.update_visibility(Visibility::new_head(false));
+
+    // Observe that the confirmation failed.
+    let component_view = ComponentView::new(ctx, *component.id())
+        .await
+        .expect("could not generate component view");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {},
+            "confirmation": {
+                "test:confirmation": {
+                    "success": false,
+                    "recommendedActions": ["create"]
+                }
+            }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    // "Create" the resource.
+    component
+        .set_resource(
+            ctx,
+            CommandRunResult {
+                status: ResourceStatus::Ok,
+                value: Some(serde_json::json!["poop"]),
+                message: None,
+                logs: vec![],
+            },
+        )
+        .await
+        .expect("could not set resource");
+
+    // Observe that the confirmation worked after "creation".
+    let component_view = ComponentView::new(ctx, *component.id())
+        .await
+        .expect("could not generate component view");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {},
+            "resource": {
+                "logs": [],
+                "value": "poop",
+                "status": "ok"
+            },
+            "confirmation": {
+                "test:confirmation": {
+                    "success": true,
+                    "recommendedActions": []
+                }
+            }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    // "Delete" the resource.
+    component
+        .set_resource(
+            ctx,
+            CommandRunResult {
+                status: ResourceStatus::Ok,
+                value: None,
+                message: None,
+                logs: vec![],
+            },
+        )
+        .await
+        .expect("could not set resource");
+
+    // Observe that the confirmation worked after "deletion".
+    let component_view = ComponentView::new(ctx, *component.id())
+        .await
+        .expect("could not generate component view");
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "component"
+            },
+            "domain": {},
+            "resource": {
+                "logs": [],
+                "status": "ok"
+            },
+            "confirmation": {
+                "test:confirmation": {
+                    "success": false,
+                    "recommendedActions": ["create"]
+                }
+            }
+        }], // expected
+        component_view.properties // actual
+    );
+}

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -157,7 +157,7 @@ async fn hard_delete(ctx: &DalContext, nba: &BillingAccountSignup) {
         standard_model::get_by_pk::<BillingAccountPk, BillingAccount>(
             ctx,
             "billing_accounts",
-            hard_deleted.pk()
+            hard_deleted.pk(),
         )
         .await
         .is_err()
@@ -698,17 +698,17 @@ async fn find_by_attr_in(ctx: &mut DalContext) {
         .await
         .expect("cannot set func backend kind");
 
-    let result: Vec<Func> = dbg!(standard_model::find_by_attr_in(
+    let result: Vec<Func> = standard_model::find_by_attr_in(
         ctx,
         "funcs",
         "backend_kind",
         &[
             &FuncBackendKind::JsWorkflow.as_ref().to_string(),
-            &FuncBackendKind::JsAttribute.as_ref().to_string()
+            &FuncBackendKind::JsAttribute.as_ref().to_string(),
         ],
     )
     .await
-    .expect("cannot find objects by backend_kind in slice"));
+    .expect("cannot find objects by backend_kind in slice");
 
     assert_eq!(2, result.len() - first_result.len());
 


### PR DESCRIPTION
Primary:
- Trigger prop tree confirmations upon updating the resource tree
- Trigger prop tree confirmations upon change set apply
- Ensure mutating the resource tree can only happen on HEAD

Misc:
- Refactor or remove leftover debug statements
- Add "as_str()" for RootPropChild