### PR TITLE
chore(*): change PropObject to Object

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -13,7 +13,7 @@ export enum FuncBackendResponseType {
   Identity = "Identity",
   Integer = "Integer",
   Map = "Map",
-  PropObject = "PropObject",
+  Object = "Object",
   Qualification = "Qualification",
   CodeGeneration = "CodeGeneration",
   Confirmation = "Confirmation",

--- a/bin/lang-js/src/resolver_function.ts
+++ b/bin/lang-js/src/resolver_function.ts
@@ -26,7 +26,7 @@ export enum FuncBackendResponseType {
   Identity = "Identity",
   Integer = "Integer",
   Map = "Map",
-  PropObject = "PropObject",
+  Object = "Object",
   Qualification = "Qualification",
   CodeGeneration = "CodeGeneration",
   Confirmation = "Confirmation",
@@ -129,7 +129,7 @@ const typeChecks: {
   [FuncBackendResponseType.Array]: isArray,
   [FuncBackendResponseType.Boolean]: isBoolean,
   [FuncBackendResponseType.Integer]: isInteger,
-  [FuncBackendResponseType.PropObject]: isObject,
+  [FuncBackendResponseType.Object]: isObject,
   [FuncBackendResponseType.String]: isString,
   [FuncBackendResponseType.Map]: isObject, // map funcs return js objects
 
@@ -140,7 +140,7 @@ const nullables: { [key in FuncBackendResponseType]?: boolean } = {
   [FuncBackendResponseType.Array]: true,
   [FuncBackendResponseType.Boolean]: true,
   [FuncBackendResponseType.Integer]: true,
-  [FuncBackendResponseType.PropObject]: true,
+  [FuncBackendResponseType.Object]: true,
   [FuncBackendResponseType.String]: true,
   [FuncBackendResponseType.Map]: true,
 

--- a/designs/providers/input-output-sockets.md
+++ b/designs/providers/input-output-sockets.md
@@ -322,9 +322,9 @@ pub struct AttributeResolverContext {
 - Worst Case: 3 days
 - Likely Case: 2 days
 
-### Create root `Prop` of kind `PropObject` for all `SchemaVariant`s
+### Create root `Prop` of kind `Object` for all `SchemaVariant`s
 
-This root `Prop` will have two child `Prop`s (both are also of kind `PropObject`):
+This root `Prop` will have two child `Prop`s (both are also of kind `Object`):
 
 1. SI-based attributes (e.g. "name")
 2. Domain-based attributes (i.e. model representing the domain concept)
@@ -359,8 +359,8 @@ Visiblity | No
 Veritech and Cyclone | Yes, but only in the function payload shapes (if at all?)
 SDF and the Frontend App | Yes, but they are descoped and affected routes and behavior will be disabled
 Assumptions based on attributes that are not currently props | Yes
-Schema and schema variant builtins migration | Yes, but only with concern to the _depth_ of props changed since schemavariants will now have a root `Prop` of kind `PropObject`
-Qualifications | Yes, `ComponentView` from `cyclone` might change its shape and/or behavior to match the new root `Prop` of kind `PropObject` shape
+Schema and schema variant builtins migration | Yes, but only with concern to the _depth_ of props changed since schemavariants will now have a root `Prop` of kind `Object`
+Qualifications | Yes, `ComponentView` from `cyclone` might change its shape and/or behavior to match the new root `Prop` of kind `Object` shape
 Validations | No, since their comparison is internal to the `Prop`
 Resource | Likely no since we have to ensure that resource sync on the component still works after refactor
 Frontend Sockets, NodeView, and Schematic | Yes, but have descoped fixing the SDF and frontend focused portions from this plan (they may become disabled in the interim)

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -730,7 +730,7 @@ mod tests {
                     },
                 ],
             },
-            response_type: cyclone_core::ResolverFunctionResponseType::PropObject,
+            response_type: cyclone_core::ResolverFunctionResponseType::Object,
             code_base64: base64::encode(
                 r#"function doit(input) {
                     console.log(`${Object.keys(input).length}`);
@@ -819,7 +819,7 @@ mod tests {
                     },
                 ],
             },
-            response_type: cyclone_core::ResolverFunctionResponseType::PropObject,
+            response_type: cyclone_core::ResolverFunctionResponseType::Object,
             code_base64: base64::encode(
                 r#"function doit(input) {
                     console.log(`${Object.keys(input).length}`);

--- a/lib/cyclone-core/src/resolver_function.rs
+++ b/lib/cyclone-core/src/resolver_function.rs
@@ -29,7 +29,7 @@ pub enum ResolverFunctionResponseType {
     Identity,
     Integer,
     Map,
-    PropObject,
+    Object,
     Qualification,
     CodeGeneration,
     Confirmation,

--- a/lib/dal/src/builtins/func/setObject.json
+++ b/lib/dal/src/builtins/func/setObject.json
@@ -1,0 +1,4 @@
+{
+  "kind": "Object",
+  "response_type": "Object"
+}

--- a/lib/dal/src/builtins/func/setPropObject.json
+++ b/lib/dal/src/builtins/func/setPropObject.json
@@ -1,4 +1,0 @@
-{
-  "kind": "PropObject",
-  "response_type": "PropObject"
-}

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -21,7 +21,7 @@ pub mod js_confirmation;
 pub mod js_validation;
 pub mod js_workflow;
 pub mod map;
-pub mod prop_object;
+pub mod object;
 pub mod string;
 pub mod validation;
 
@@ -80,7 +80,7 @@ pub enum FuncBackendKind {
     JsCommand,
     JsValidation,
     Map,
-    PropObject,
+    Object,
     String,
     Unset,
     Json,
@@ -107,7 +107,7 @@ pub enum FuncBackendResponseType {
     Identity,
     Integer,
     Map,
-    PropObject,
+    Object,
     Qualification,
     CodeGeneration,
     Confirmation,
@@ -127,7 +127,7 @@ impl From<ResolverFunctionResponseType> for FuncBackendResponseType {
             ResolverFunctionResponseType::Identity => FuncBackendResponseType::Identity,
             ResolverFunctionResponseType::Integer => FuncBackendResponseType::Integer,
             ResolverFunctionResponseType::Map => FuncBackendResponseType::Map,
-            ResolverFunctionResponseType::PropObject => FuncBackendResponseType::PropObject,
+            ResolverFunctionResponseType::Object => FuncBackendResponseType::Object,
             ResolverFunctionResponseType::Qualification => FuncBackendResponseType::Qualification,
             ResolverFunctionResponseType::CodeGeneration => FuncBackendResponseType::CodeGeneration,
             ResolverFunctionResponseType::Confirmation => FuncBackendResponseType::Confirmation,
@@ -149,7 +149,7 @@ impl From<FuncBackendResponseType> for ResolverFunctionResponseType {
             FuncBackendResponseType::Integer => ResolverFunctionResponseType::Integer,
             FuncBackendResponseType::Identity => ResolverFunctionResponseType::Identity,
             FuncBackendResponseType::Map => ResolverFunctionResponseType::Map,
-            FuncBackendResponseType::PropObject => ResolverFunctionResponseType::PropObject,
+            FuncBackendResponseType::Object => ResolverFunctionResponseType::Object,
             FuncBackendResponseType::Qualification => ResolverFunctionResponseType::Qualification,
             FuncBackendResponseType::CodeGeneration => ResolverFunctionResponseType::CodeGeneration,
             FuncBackendResponseType::Confirmation => ResolverFunctionResponseType::Confirmation,

--- a/lib/dal/src/func/backend/object.rs
+++ b/lib/dal/src/func/backend/object.rs
@@ -5,24 +5,24 @@ use serde_json::{Map, Value};
 use crate::func::backend::{FuncBackend, FuncBackendResult};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct FuncBackendPropObjectArgs {
+pub struct FuncBackendObjectArgs {
     pub value: Map<String, Value>,
 }
 
-impl FuncBackendPropObjectArgs {
+impl FuncBackendObjectArgs {
     pub fn new(value: Map<String, Value>) -> Self {
         Self { value }
     }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct FuncBackendPropObject {
-    args: FuncBackendPropObjectArgs,
+pub struct FuncBackendObject {
+    args: FuncBackendObjectArgs,
 }
 
 #[async_trait]
-impl FuncBackend for FuncBackendPropObject {
-    type Args = FuncBackendPropObjectArgs;
+impl FuncBackend for FuncBackendObject {
+    type Args = FuncBackendObjectArgs;
 
     fn new(args: Self::Args) -> Box<Self> {
         Box::new(Self { args })

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -19,7 +19,7 @@ use crate::func::backend::{
     js_validation::FuncBackendJsValidation,
     js_workflow::FuncBackendJsWorkflow,
     map::FuncBackendMap,
-    prop_object::FuncBackendPropObject,
+    object::FuncBackendObject,
     string::FuncBackendString,
     validation::FuncBackendValidation,
     FuncBackend, FuncDispatch, FuncDispatchContext,
@@ -256,9 +256,7 @@ impl FuncBinding {
             }
             FuncBackendKind::Integer => FuncBackendInteger::create_and_execute(&self.args).await?,
             FuncBackendKind::Map => FuncBackendMap::create_and_execute(&self.args).await?,
-            FuncBackendKind::PropObject => {
-                FuncBackendPropObject::create_and_execute(&self.args).await?
-            }
+            FuncBackendKind::Object => FuncBackendObject::create_and_execute(&self.args).await?,
             FuncBackendKind::String => FuncBackendString::create_and_execute(&self.args).await?,
             FuncBackendKind::Unset => (None, None),
             FuncBackendKind::Validation => {
@@ -323,7 +321,7 @@ impl FuncBinding {
             | FuncBackendKind::Identity
             | FuncBackendKind::Integer
             | FuncBackendKind::Map
-            | FuncBackendKind::PropObject
+            | FuncBackendKind::Object
             | FuncBackendKind::String
             | FuncBackendKind::Unset
             | FuncBackendKind::Validation => {}

--- a/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
+++ b/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
@@ -1052,7 +1052,7 @@ BEGIN
         CASE
             WHEN typeof_value = 'object' THEN
                 -- It's an array/map, but since we're setting the value for a Provider, then it's an Object.
-                func_name := 'si:setPropObject';
+                func_name := 'si:setObject';
             WHEN typeof_value = 'array' THEN
                 func_name := 'si:setArray';
             WHEN typeof_value = 'string' THEN
@@ -1100,7 +1100,7 @@ BEGIN
         ELSIF prop.kind = 'map' THEN
             func_name := 'si:setMap';
         ELSIF prop.kind = 'object' THEN
-            func_name := 'si:setPropObject';
+            func_name := 'si:setObject';
         ELSIF prop.kind = 'string' THEN
             func_name := 'si:setString';
         ELSE
@@ -1759,7 +1759,7 @@ BEGIN
             result_value_processed := result_value;
         WHEN func_binding.backend_kind = 'Map' THEN
             result_value_processed := '{}'::json;
-        WHEN func_binding.backend_kind = 'PropObject' THEN
+        WHEN func_binding.backend_kind = 'Object' THEN
             result_value_processed := '{}'::json;
         WHEN func_binding.backend_kind = 'String' THEN
             result_value_processed := result_value;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -111,7 +111,7 @@ impl From<PropKind> for FuncBackendResponseType {
             PropKind::Array => Self::Array,
             PropKind::Boolean => Self::Boolean,
             PropKind::Integer => Self::Integer,
-            PropKind::Object => Self::PropObject,
+            PropKind::Object => Self::Object,
             PropKind::Map => Self::Map,
             PropKind::String => Self::String,
         }

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -127,7 +127,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
         ctx,
         "test:complexObject",
         FuncBackendKind::JsAttribute,
-        FuncBackendResponseType::PropObject,
+        FuncBackendResponseType::Object,
     )
     .await
     .expect("could not create func");
@@ -314,7 +314,7 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
         ctx,
         "test:complexObjectPrefix",
         FuncBackendKind::JsAttribute,
-        FuncBackendResponseType::PropObject,
+        FuncBackendResponseType::Object,
     )
     .await
     .expect("could not create func");
@@ -348,7 +348,7 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
         ctx,
         "test:complexObjectSuffix",
         FuncBackendKind::JsAttribute,
-        FuncBackendResponseType::PropObject,
+        FuncBackendResponseType::Object,
     )
     .await
     .expect("could not create func");

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -410,7 +410,7 @@ mod tests {
             ResolverFunctionResponseType::Boolean,
             ResolverFunctionResponseType::String,
             ResolverFunctionResponseType::Map,
-            ResolverFunctionResponseType::PropObject,
+            ResolverFunctionResponseType::Object,
         ] {
             let value = match response_type {
                 ResolverFunctionResponseType::Array => serde_json::json!({ "value": [1, 2, 3, 4] }),
@@ -419,7 +419,7 @@ mod tests {
                 ResolverFunctionResponseType::String => {
                     serde_json::json!({ "value": "a string is a sequence of characters" })
                 }
-                ResolverFunctionResponseType::Map | ResolverFunctionResponseType::PropObject => {
+                ResolverFunctionResponseType::Map | ResolverFunctionResponseType::Object => {
                     serde_json::json!({ "value": { "an_object": "has keys" } })
                 }
                 _ => serde_json::json!({ "value": null }),
@@ -475,14 +475,14 @@ mod tests {
             ResolverFunctionResponseType::Boolean,
             ResolverFunctionResponseType::String,
             ResolverFunctionResponseType::Map,
-            ResolverFunctionResponseType::PropObject,
+            ResolverFunctionResponseType::Object,
         ] {
             let value = match response_type {
                 ResolverFunctionResponseType::Array => serde_json::json!({ "value": "foo"}),
                 ResolverFunctionResponseType::Integer => serde_json::json!({ "value": "a string" }),
                 ResolverFunctionResponseType::Boolean => serde_json::json!({ "value": "a string" }),
                 ResolverFunctionResponseType::String => serde_json::json!({ "value": 12345 }),
-                ResolverFunctionResponseType::Map | ResolverFunctionResponseType::PropObject => {
+                ResolverFunctionResponseType::Map | ResolverFunctionResponseType::Object => {
                     serde_json::json!({ "value": ["an_object", "has keys" ] })
                 }
                 _ => serde_json::json!({ "value": null }),


### PR DESCRIPTION
I think this was indirectly(?) my fault, but now it's gone. Now, we are
consistent.

The AttributeValuePayload-related content still uses "prop_object" since
"object" is a special word for standard model row conversions.

<img src="https://media3.giphy.com/media/3ohjV6LMJ1EgNV0EsE/giphy.gif"/>