### PR TITLE
fix(dal): Ensure deletions happen by id rather than pk

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -388,7 +388,7 @@ impl AttributePrototype {
     /// all [`AttributePrototypeArguments`](crate::AttributePrototypeArgument) that belong to the
     /// prototype.
     ///
-    /// Caution: this should be used rather than [`StandardModel::delete()`] when deleting an
+    /// Caution: this should be used rather than [`StandardModel::delete_by_id()`] when deleting an
     /// [`AttributePrototype`]. That method should never be called directly.
     pub async fn remove(
         ctx: &DalContext,
@@ -415,7 +415,7 @@ impl AttributePrototype {
             AttributePrototypeArgument::list_for_attribute_prototype(ctx, *attribute_prototype_id)
                 .await?
         {
-            argument.delete(ctx).await?;
+            argument.delete_by_id(ctx).await?;
         }
         standard_model::unset_all_belongs_to(
             ctx,
@@ -423,7 +423,7 @@ impl AttributePrototype {
             attribute_prototype.id(),
         )
         .await?;
-        attribute_prototype.delete(ctx).await?;
+        attribute_prototype.delete_by_id(ctx).await?;
 
         // Start with the initial value(s) from the prototype and build a work queue based on the
         // value's children (and their children, recursively). Once we find the child values,
@@ -451,7 +451,7 @@ impl AttributePrototype {
                 )
                 .await?
                 {
-                    argument.delete(ctx).await?;
+                    argument.delete_by_id(ctx).await?;
                 }
                 standard_model::unset_all_belongs_to(
                     ctx,
@@ -459,7 +459,7 @@ impl AttributePrototype {
                     current_prototype.id(),
                 )
                 .await?;
-                current_prototype.delete(ctx).await?;
+                current_prototype.delete_by_id(ctx).await?;
             }
 
             // Delete the value if its context is not "least-specific".
@@ -478,7 +478,7 @@ impl AttributePrototype {
                 current_value.id(),
             )
             .await?;
-            current_value.delete(ctx).await?;
+            current_value.delete_by_id(ctx).await?;
         }
         Ok(())
     }

--- a/lib/dal/src/diagram/connection.rs
+++ b/lib/dal/src/diagram/connection.rs
@@ -142,8 +142,8 @@ impl Connection {
         .await?
         .ok_or(DiagramError::AttributePrototypeNotFound)?;
 
-        edge_argument.delete(ctx).await?;
-        edge.delete(ctx).await?;
+        edge_argument.delete_by_id(ctx).await?;
+        edge.delete_by_id(ctx).await?;
 
         let read_context = AttributeReadContext {
             prop_id: Some(PropId::NONE),
@@ -174,7 +174,7 @@ impl Connection {
             let attr_val_context = attr_value.context;
             attr_value.unset_attribute_prototype(ctx).await?;
 
-            attr_value.delete(ctx).await?;
+            attr_value.delete_by_id(ctx).await?;
 
             let att_val = AttributeValue::find_for_context(ctx, attr_val_context.into())
                 .await?

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -216,7 +216,7 @@ impl FuncArgument {
     }
 
     /// Remove the [`FuncArgument`](Self) along with any [`AttributePrototypeArgument`](crate::AttributePrototypeArgument) rows that reference it.
-    /// This should be used instead of the [`delete`](Self::delete) method since it keeps the two tables in sync.
+    /// This should be used instead of the [`delete_by_id`](Self::delete_by_id) method since it keeps the two tables in sync.
     pub async fn remove(
         ctx: &DalContext,
         func_argument_id: &FuncArgumentId,
@@ -229,10 +229,10 @@ impl FuncArgument {
         for prototype_argument in
             AttributePrototypeArgument::list_by_func_argument_id(ctx, *func_argument_id).await?
         {
-            prototype_argument.delete(ctx).await?;
+            prototype_argument.delete_by_id(ctx).await?;
         }
 
-        func_arg.delete(ctx).await?;
+        func_arg.delete_by_id(ctx).await?;
 
         Ok(())
     }

--- a/lib/dal/src/prototype_context.rs
+++ b/lib/dal/src/prototype_context.rs
@@ -131,7 +131,7 @@ where
             || schema_variant_id.is_some()
                 && !prototype_context_field_ids.contains(&schema_variant_id.into())
         {
-            proto.delete(ctx).await?;
+            proto.delete_by_id(ctx).await?;
             continue;
         } else if component_id.is_some() {
             existing_field_ids.push(component_id.into());

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -127,9 +127,10 @@ async fn update(ctx: &mut DalContext, nba: &BillingAccountSignup) {
 
 #[test]
 async fn delete(ctx: &DalContext, nba: &BillingAccountSignup) {
-    let _updated_at = standard_model::delete(ctx, "billing_accounts", nba.billing_account.pk())
-        .await
-        .expect("cannot delete field");
+    let _updated_at =
+        standard_model::delete_by_pk(ctx, "billing_accounts", nba.billing_account.pk())
+            .await
+            .expect("cannot delete field");
 
     let soft_deleted: BillingAccount =
         standard_model::get_by_pk(ctx, "billing_accounts", nba.billing_account.pk())
@@ -166,9 +167,10 @@ async fn hard_delete(ctx: &DalContext, nba: &BillingAccountSignup) {
 
 #[test]
 async fn undelete(ctx: &DalContext, nba: &BillingAccountSignup) {
-    let _updated_at = standard_model::delete(ctx, "billing_accounts", nba.billing_account.pk())
-        .await
-        .expect("cannot delete field");
+    let _updated_at =
+        standard_model::delete_by_pk(ctx, "billing_accounts", nba.billing_account.pk())
+            .await
+            .expect("cannot delete field");
 
     let soft_deleted: BillingAccount =
         standard_model::get_by_pk(ctx, "billing_accounts", nba.billing_account.pk())

--- a/lib/sdf/src/server/service/component/set_type.rs
+++ b/lib/sdf/src/server/service/component/set_type.rs
@@ -197,7 +197,7 @@ pub async fn set_type(
 
                 if !attribute_value.context.is_component_unset() {
                     attribute_value.unset_attribute_prototype(&ctx).await?;
-                    attribute_value.delete(&ctx).await?;
+                    attribute_value.delete_by_id(&ctx).await?;
                 }
             }
 
@@ -216,7 +216,7 @@ pub async fn set_type(
 
                 if !attribute_value.context.is_component_unset() {
                     attribute_value.unset_attribute_prototype(&ctx).await?;
-                    attribute_value.delete(&ctx).await?;
+                    attribute_value.delete_by_id(&ctx).await?;
                 }
             }
         }

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -52,7 +52,7 @@ async fn save_attr_func_proto_arguments(
         for proto_arg in
             AttributePrototypeArgument::list_for_attribute_prototype(ctx, *proto.id()).await?
         {
-            proto_arg.delete(ctx).await?;
+            proto_arg.delete_by_id(ctx).await?;
         }
     }
 
@@ -114,7 +114,7 @@ async fn save_attr_func_proto_arguments(
         AttributePrototypeArgument::list_for_attribute_prototype(ctx, *proto.id()).await?
     {
         if !id_set.contains(proto_arg.id()) {
-            proto_arg.delete(ctx).await?;
+            proto_arg.delete_by_id(ctx).await?;
         }
     }
 
@@ -379,7 +379,7 @@ async fn reset_prototype_and_value_to_builtin_function(
     for proto_arg in
         AttributePrototypeArgument::list_for_attribute_prototype(ctx, *proto.id()).await?
     {
-        proto_arg.delete(ctx).await?;
+        proto_arg.delete_by_id(ctx).await?;
     }
 
     // This should reset the prototype to a builtin value function
@@ -476,7 +476,7 @@ async fn save_validation_func_prototypes(
     for proto in ValidationPrototype::list_for_func(ctx, *func.id()).await? {
         if !id_set.contains(proto.id()) {
             if let Some(proto) = ValidationPrototype::get_by_id(ctx, proto.id()).await? {
-                proto.delete(ctx).await?;
+                proto.delete_by_id(ctx).await?;
             }
         }
     }


### PR DESCRIPTION
When deleting edges, we were deleting by pk which was deleting the
edge listed in HEAD rather than using the id of the edge in the
changeset. We have fixed that behaviour now to work across the board
and to only make a deletion for the current changeset

Co-authored-by: Victor Bustamante <victor@systeminit.com>
Co-authored-by: Jacob Helwig <jacob@systeminit.com>
Co-authored-by: Theo Ephraim <theo@systeminit.com>
