### PR TITLE
Add func descriptions (ENG-922)

### DIFF
--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -5,6 +5,7 @@ use crate::builtins::schema::MigrationDriver;
 use crate::builtins::BuiltinsError;
 use crate::component::ComponentKind;
 use crate::edit_field::widget::WidgetKind;
+use crate::func::description::FuncDescription;
 use crate::property_editor::SelectWidgetOption;
 use crate::schema::variant::leaves::LeafKind;
 use crate::socket::SocketArity;
@@ -12,6 +13,7 @@ use crate::validation::Validation;
 use crate::{
     action_prototype::ActionKind,
     schema::variant::leaves::{LeafInput, LeafInputLocation},
+    FuncDescriptionContents,
 };
 use crate::{
     attribute::context::AttributeContextBuilder, func::argument::FuncArgument, ActionPrototype,
@@ -810,6 +812,18 @@ impl MigrationDriver {
             .set_success_description(ctx, Some("EC2 instance exists!".to_owned()))
             .await?;
         confirmation_prototype.set_failure_description(ctx, Some("This EC2 instance has not been created yet. Please run the fix above to create it!".to_owned())).await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "EC2 Instance Exists?".to_string(),
+                success_description: Some("EC2 instance exists!".to_string()),
+                failure_description: Some("This EC2 instance has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string())
+            },
+        )
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {
@@ -1362,6 +1376,18 @@ impl MigrationDriver {
                 ),
             )
             .await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "Elastic IP Exists?".to_string(),
+                success_description: Some("Elastic IP exists!".to_string()),
+                failure_description: Some("This Elastic IP has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string())
+            },
+        )
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {
@@ -1801,6 +1827,18 @@ impl MigrationDriver {
                         .to_owned(),
                 ),
             )
+            .await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "Key Pair Exists?".to_string(),
+                success_description: Some("Key Pair exists!".to_string()),
+                failure_description: Some("This Key Pair has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string())
+            },
+        )
             .await?;
 
         let name = "create";

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -4,7 +4,10 @@ use crate::component::ComponentKind;
 use crate::schema::variant::leaves::LeafKind;
 use crate::socket::SocketArity;
 use crate::validation::Validation;
-use crate::{action_prototype::ActionKind, schema::variant::leaves::LeafInputLocation};
+use crate::{
+    action_prototype::ActionKind, schema::variant::leaves::LeafInputLocation, FuncDescription,
+    FuncDescriptionContents,
+};
 use crate::{
     attribute::context::AttributeContextBuilder, func::argument::FuncArgument, ActionPrototype,
     ActionPrototypeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
@@ -565,6 +568,18 @@ impl MigrationDriver {
                 ),
             )
             .await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "Ingress Exists?".to_string(),
+                success_description: Some("Ingress exists!".to_string()),
+                failure_description: Some("This Ingress rule has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string()),
+            },
+        )
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {
@@ -1044,6 +1059,18 @@ impl MigrationDriver {
                 ),
             )
             .await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "Egress Exists?".to_string(),
+                success_description: Some("Egress exists!".to_string()),
+                failure_description: Some("This Egress rule has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string()),
+            },
+        )
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {
@@ -1512,6 +1539,18 @@ impl MigrationDriver {
             .set_success_description(ctx, Some("Security Group exists!".to_owned()))
             .await?;
         confirmation_prototype.set_failure_description(ctx, Some("This Security Group has not been created yet. Please run the fix above to create it!".to_owned())).await?;
+        FuncDescription::new(
+            ctx,
+            *confirmation_func.id(),
+            *schema_variant.id(),
+            FuncDescriptionContents::Confirmation {
+                name: "Security Group Exists?".to_string(),
+                success_description: Some("Security Group exists!".to_string()),
+                failure_description: Some("This Security Group has not been created yet. Please run the fix above to create it!".to_string()),
+                provider: Some("AWS".to_string()),
+            },
+        )
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_accessor_ro,
-    DalContext, FuncBinding, HistoryEventError, StandardModel, StandardModelError, Timestamp,
-    Visibility, WriteTenancy,
+    DalContext, FuncBinding, FuncDescriptionContents, HistoryEventError, StandardModel,
+    StandardModelError, Timestamp, Visibility, WriteTenancy,
 };
 
 use self::backend::{FuncBackendKind, FuncBackendResponseType};
@@ -18,6 +18,7 @@ pub mod argument;
 pub mod backend;
 pub mod binding;
 pub mod binding_return_value;
+pub mod description;
 pub mod execution;
 
 #[derive(Error, Debug)]
@@ -41,6 +42,8 @@ pub enum FuncError {
     NotFound(FuncId),
     #[error("could not find func by name: {0}")]
     NotFoundByName(String),
+    #[error("contents ({0}) response type does not match func response type: {1}")]
+    ResponseTypeMismatch(FuncDescriptionContents, FuncBackendResponseType),
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;

--- a/lib/dal/src/func/description.rs
+++ b/lib/dal/src/func/description.rs
@@ -1,0 +1,151 @@
+//! This module contains the ability to add a "description" to a [`Func`](crate::Func) for a given
+//! [`SchemaVariant`](crate::SchemaVariant). This is useful in the following scenarios:
+//!
+//! - when the same [`Func`](crate::Func) is used between two
+//!   [`SchemaVariants`](crate::SchemaVariant), but has slightly different meanings based on the
+//!   context and result(s)
+//! - when the [`Func`](crate::Func) has static information that is specific to the
+//!   [`FuncBackendResponseType`](crate::FuncBackendResponseType) and/or
+//!   [`SchemaVariant`](crate::SchemaVariant) (i.e. it doesn't belong on the [`Func`](crate::Func)
+//!   itself
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
+
+use crate::{
+    impl_standard_model, pk, standard_model, DalContext, Func, FuncBackendResponseType, FuncError,
+    FuncId, FuncResult, SchemaVariantId, StandardModel, Timestamp, Visibility, WriteTenancy,
+};
+
+/// The contents of a [`FuncDescription`], which differ based on the [`Func's`](crate::Func)
+/// [`FuncBackendResponseType`](crate::FuncBackendResponseType).
+#[derive(
+    Deserialize, Serialize, Debug, Display, AsRefStr, PartialEq, Eq, EnumIter, EnumString, Clone,
+)]
+pub enum FuncDescriptionContents {
+    /// Corresponds to
+    /// [`FuncBackendResponseType::Confirmation`](crate::FuncBackendResponseType::Confirmation).
+    Confirmation {
+        name: String,
+        success_description: Option<String>,
+        failure_description: Option<String>,
+        provider: Option<String>,
+    },
+}
+
+impl FuncDescriptionContents {
+    /// Return the [`FuncBackendResponseType`](crate::FuncBackendResponseType) corresponding to the
+    /// variant of [`self`](Self).
+    pub fn response_type(&self) -> FuncBackendResponseType {
+        match self {
+            Self::Confirmation { .. } => FuncBackendResponseType::Confirmation,
+        }
+    }
+}
+
+pk!(FuncDescriptionPk);
+pk!(FuncDescriptionId);
+
+/// An additional description for a [`Func`](crate::Func) that is specific to a
+/// [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FuncDescription {
+    pk: FuncDescriptionPk,
+    id: FuncDescriptionId,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+
+    /// Corresponds to the [`Func`](crate::Func) that this description is linked to.
+    func_id: FuncId,
+    /// Scopes this description for a [`Func`](crate::Func) to a specific
+    /// [`SchemaVariant`](crate::SchemaVariant).
+    schema_variant_id: SchemaVariantId,
+    /// Serialized [`FuncDescriptionContents`] which must be
+    /// [`deserialized`](FuncDescription::deserialized_contents()) to use.
+    serialized_contents: Value,
+    response_type: FuncBackendResponseType,
+}
+
+impl_standard_model! {
+    model: FuncDescription,
+    pk: FuncDescriptionPk,
+    id: FuncDescriptionId,
+    table_name: "func_descriptions",
+    history_event_label_base: "func_description",
+    history_event_message_name: "Func Description"
+}
+
+impl FuncDescription {
+    /// Create a [`FuncDescription`], which is unique for a [`FuncId`](crate::FuncId) and
+    /// [`SchemaVariant`](crate::SchemaVariant).
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext,
+        func_id: FuncId,
+        schema_variant_id: SchemaVariantId,
+        contents: FuncDescriptionContents,
+    ) -> FuncResult<Self> {
+        let func = Func::get_by_id(ctx, &func_id)
+            .await?
+            .ok_or(FuncError::NotFound(func_id))?;
+
+        // Ensure response type matches contents.
+        let response_type = contents.response_type();
+        if func.backend_response_type != response_type {
+            return Err(FuncError::ResponseTypeMismatch(
+                contents,
+                func.backend_response_type,
+            ));
+        }
+
+        // Serialize contents due to complex and variable shape.
+        let serialized_contents = serde_json::to_value(contents)?;
+
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM func_description_create_v1($1, $2, $3, $4, $5, $6)",
+                &[
+                    ctx.write_tenancy(),
+                    ctx.visibility(),
+                    &func_id,
+                    &schema_variant_id,
+                    &serialized_contents,
+                    &response_type.as_ref(),
+                ],
+            )
+            .await?;
+        let object: Self = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    pub fn func_id(&self) -> FuncId {
+        self.func_id
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn serialized_contents(&self) -> &Value {
+        &self.serialized_contents
+    }
+
+    pub fn response_type(&self) -> FuncBackendResponseType {
+        self.response_type
+    }
+
+    /// Deserializes the "serialized_contents" field into a [`FuncDescriptionContents`] object.
+    pub fn deserialized_contents(&self) -> FuncResult<FuncDescriptionContents> {
+        let contents: FuncDescriptionContents =
+            serde_json::from_value(self.serialized_contents.clone())?;
+        Ok(contents)
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -128,6 +128,8 @@ pub use fix::resolver::{FixResolver, FixResolverContext, FixResolverError, FixRe
 pub use fix::{Fix, FixCompletionStatus, FixId};
 pub use func::argument::FuncArgument;
 pub use func::binding_return_value::{FuncBindingReturnValue, FuncBindingReturnValueError};
+pub use func::description::FuncDescription;
+pub use func::description::FuncDescriptionContents;
 pub use func::{
     backend::{FuncBackendError, FuncBackendKind, FuncBackendResponseType},
     binding::{FuncBinding, FuncBindingError, FuncBindingId},

--- a/lib/dal/src/migrations/U0078__func_descriptions.sql
+++ b/lib/dal/src/migrations/U0078__func_descriptions.sql
@@ -1,0 +1,76 @@
+CREATE TABLE func_descriptions
+(
+    pk                          ident primary key                 default ident_create_v1(),
+    id                          ident                    not null default ident_create_v1(),
+    tenancy_universal           bool                     NOT NULL,
+    tenancy_billing_account_ids ident[],
+    tenancy_organization_ids    ident[],
+    tenancy_workspace_ids       ident[],
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+
+    func_id                     ident                    NOT NULL,
+    schema_variant_id           ident                    NOT NULL,
+    serialized_contents         jsonb                    NOT NULL,
+    response_type               text                     NOT NULL
+);
+
+CREATE UNIQUE INDEX unique_func_descriptions
+    ON func_descriptions (func_id,
+                          schema_variant_id,
+                          tenancy_universal,
+                          tenancy_billing_account_ids,
+                          tenancy_organization_ids,
+                          tenancy_workspace_ids,
+                          visibility_change_set_pk,
+                          (visibility_deleted_at IS NULL))
+    WHERE visibility_deleted_at IS NULL;
+
+SELECT standard_model_table_constraints_v1('func_descriptions');
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('func_descriptions', 'model', 'func_description', 'Func Description');
+
+CREATE OR REPLACE FUNCTION func_description_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id ident,
+    this_schema_variant_id ident,
+    this_serialized_contents jsonb,
+    this_response_type text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           func_descriptions%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO func_descriptions (tenancy_universal,
+                                   tenancy_billing_account_ids,
+                                   tenancy_organization_ids,
+                                   tenancy_workspace_ids,
+                                   visibility_change_set_pk,
+                                   visibility_deleted_at,
+                                   func_id,
+                                   schema_variant_id,
+                                   serialized_contents,
+                                   response_type)
+    VALUES (this_tenancy_record.tenancy_universal,
+            this_tenancy_record.tenancy_billing_account_ids,
+            this_tenancy_record.tenancy_organization_ids,
+            this_tenancy_record.tenancy_workspace_ids,
+            this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at,
+            this_func_id,
+            this_schema_variant_id,
+            this_serialized_contents,
+            this_response_type)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -15,6 +15,8 @@ use dal_test::{
 };
 use strum::IntoEnumIterator;
 
+mod description;
+
 #[test]
 async fn new(ctx: &DalContext) {
     let _write_tenancy = WriteTenancy::new_universal();

--- a/lib/dal/tests/integration_test/func/description.rs
+++ b/lib/dal/tests/integration_test/func/description.rs
@@ -1,0 +1,83 @@
+use dal::func::description::{FuncDescription, FuncDescriptionContents};
+use dal::{
+    func::argument::{FuncArgument, FuncArgumentKind},
+    DalContext, Func, FuncBackendKind, FuncBackendResponseType, FuncId, StandardModel,
+};
+use dal_test::test;
+use dal_test::test_harness::{create_schema, create_schema_variant};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn new(ctx: &DalContext) {
+    let (func_id, response_type) = create_confirmation_func(ctx).await;
+    let schema = create_schema(ctx).await;
+    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
+
+    let contents = FuncDescriptionContents::Confirmation {
+        name: "TODD HOWARD".to_string(),
+        success_description: None,
+        failure_description: None,
+        provider: None,
+    };
+
+    let description = FuncDescription::new(ctx, func_id, *schema_variant.id(), contents.clone())
+        .await
+        .expect("could not create description");
+
+    assert_eq!(func_id, description.func_id());
+    assert_eq!(*schema_variant.id(), description.schema_variant_id());
+    assert_eq!(
+        contents,
+        description
+            .deserialized_contents()
+            .expect("could not deserialize contents")
+    );
+    assert_eq!(contents.response_type(), description.response_type());
+    assert_eq!(contents.response_type(), response_type);
+}
+
+async fn create_confirmation_func(ctx: &DalContext) -> (FuncId, FuncBackendResponseType) {
+    let func_backend_response_type = FuncBackendResponseType::Confirmation;
+    let mut confirmation_func = Func::new(
+        ctx,
+        "test:confirmation",
+        FuncBackendKind::JsAttribute,
+        func_backend_response_type,
+    )
+    .await
+    .expect("could not create func");
+
+    let code = "async function exists(input) {
+        if (!input.resource?.value) {
+            return {
+                success: false,
+                recommendedActions: [\"create\"]
+            }
+        }
+        return {
+            success: true,
+            recommendedActions: [],
+        }
+    }";
+
+    confirmation_func
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    confirmation_func
+        .set_handler(ctx, Some("exists"))
+        .await
+        .expect("set handler");
+
+    let _confirmation_func_argument = FuncArgument::new(
+        ctx,
+        "resource",
+        FuncArgumentKind::String,
+        None,
+        *confirmation_func.id(),
+    )
+    .await
+    .expect("could not create func argument");
+
+    (*confirmation_func.id(), func_backend_response_type)
+}


### PR DESCRIPTION
- Add FuncDescriptions, which are unique for a SchemaVariantId and
  FuncId and are used to provide additional information for a Func based
  on its FuncBackendResponseType.
- Add FuncDescriptionContents with one variant to start: Confirmation
- Add FuncDescriptions for all Confirmations used in builtins

<img src="https://media3.giphy.com/media/dDRaibb9VgmGjsAA5D/giphy.gif"/>
