### PR TITLE
fix(sdf): restore code authoring for confirmation funcs

### DIFF
--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -188,6 +188,7 @@ impl TryFrom<&Func> for FuncVariant {
             (FuncBackendKind::JsAttribute, response_type) => match response_type {
                 FuncBackendResponseType::CodeGeneration => Ok(FuncVariant::CodeGeneration),
                 FuncBackendResponseType::Qualification => Ok(FuncVariant::Qualification),
+                FuncBackendResponseType::Confirmation => Ok(FuncVariant::Confirmation),
                 _ => Ok(FuncVariant::Attribute),
             },
             (FuncBackendKind::JsCommand, _) => Ok(FuncVariant::Command),

--- a/lib/sdf/src/server/service/func/create_func.rs
+++ b/lib/sdf/src/server/service/func/create_func.rs
@@ -101,7 +101,7 @@ async fn create_attribute_func(ctx: &DalContext, variant: FuncVariant) -> FuncRe
         ),
         FuncVariant::Confirmation => (
             DEFAULT_CONFIRMATION_CODE,
-            DEFAULT_CODE_GENERATION_HANDLER,
+            DEFAULT_CONFIRMATION_HANDLER,
             FuncBackendResponseType::Confirmation,
         ),
         FuncVariant::Qualification => (

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -540,7 +540,7 @@ pub async fn save_func<'a>(
                         &func,
                         schema_variant_ids,
                         component_ids,
-                        LeafKind::CodeGeneration,
+                        LeafKind::Confirmation,
                     )
                     .await?;
                 }


### PR DESCRIPTION
Just a few things were missing for confirmation funcs to be editable again.

Co-Authored-By: wendy@systeminit.com