### PR TITLE
Allow multiple values for dependent update (ENG-936)

### DIFF
--- a/lib/dal/src/diagram/connection.rs
+++ b/lib/dal/src/diagram/connection.rs
@@ -168,7 +168,7 @@ impl Connection {
         if arg_count > 0 {
             attr_value.update_from_prototype_function(ctx).await?;
 
-            ctx.enqueue_job(DependentValuesUpdate::new(ctx, *attr_value.id()))
+            ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*attr_value.id()]))
                 .await;
         } else {
             let attr_val_context = attr_value.context;
@@ -180,7 +180,7 @@ impl Connection {
                 .await?
                 .ok_or(DiagramError::AttributeValueNotFound)?;
 
-            ctx.enqueue_job(DependentValuesUpdate::new(ctx, *att_val.id()))
+            ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*att_val.id()]))
                 .await;
         }
 

--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -198,7 +198,7 @@ impl JobConsumer for FixesJob {
             )
             .await?;
 
-            DependentValuesUpdate::new(ctx, *attribute_value.id())
+            DependentValuesUpdate::new(ctx, vec![*attribute_value.id()])
                 .run(ctx)
                 .await?;
         }

--- a/lib/dal/src/migrations/U0067__attribute_value_update_graph.sql
+++ b/lib/dal/src/migrations/U0067__attribute_value_update_graph.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION attribute_value_affected_graph_v1(
     this_tenancy jsonb,
     this_visibility jsonb,
-    this_attribute_value_id ident
+    this_attribute_value_id_list ident[]
 )
     RETURNS TABLE
             (
@@ -27,8 +27,8 @@ DECLARE
     tmp_record_ids              ident[];
     tmp_prop                    props%ROWTYPE;
 BEGIN
-    RAISE DEBUG 'attribute_value_affected_graph_v1: Finding graph of AttributeValues affected by AttributeValue(%)', this_attribute_value_id;
-    current_attribute_value_ids := ARRAY [this_attribute_value_id];
+    RAISE DEBUG 'attribute_value_affected_graph_v1: Finding graph of AttributeValues affected by AttributeValues(%)', this_attribute_value_id_list;
+    current_attribute_value_ids := this_attribute_value_id_list;
 
     LOOP
         RAISE DEBUG 'attribute_value_affected_graph_v1: Current set of AttributeValueIds: %', current_attribute_value_ids;

--- a/lib/dal/src/migrations/U0762__status_updates.sql
+++ b/lib/dal/src/migrations/U0762__status_updates.sql
@@ -12,8 +12,7 @@ CREATE TABLE status_updates
     data                        jsonb                    NOT NULL
 );
 
-CREATE OR REPLACE FUNCTION status_update_create_v1(this_attribute_value_id ident,
-                                                   this_change_set_pk ident,
+CREATE OR REPLACE FUNCTION status_update_create_v1(this_change_set_pk ident,
                                                    this_actor jsonb,
                                                    this_tenancy jsonb,
                                                    OUT object json) AS
@@ -26,7 +25,6 @@ BEGIN
     this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
 
     this_data := jsonb_build_object('actor', this_actor,
-                                    'attribute_value_id', this_attribute_value_id,
                                     'dependent_values_metadata', '{}'::jsonb,
                                     'queued_dependent_value_ids', '[]'::jsonb,
                                     'running_dependent_value_ids', '[]'::jsonb,

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -176,7 +176,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
 
     ctx.enqueue_job(DependentValuesUpdate::new(
         ctx,
-        *attribute_value_for_prototype.id(),
+        vec![*attribute_value_for_prototype.id()],
     ))
     .await;
 

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -479,7 +479,7 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
         .update_from_prototype_function(ctx)
         .await
         .expect("update from proto func");
-    ctx.enqueue_job(DependentValuesUpdate::new(ctx, *freya_value.id()))
+    ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*freya_value.id()]))
         .await;
 
     let external_provider_av = AttributeValue::find_for_context(

--- a/lib/dal/tests/integration_test/status_update.rs
+++ b/lib/dal/tests/integration_test/status_update.rs
@@ -1,15 +1,12 @@
-use dal::{AttributeValueId, DalContext, StatusUpdate};
+use dal::{DalContext, StatusUpdate};
 use dal_test::test;
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let attribute_value_id = AttributeValueId::NONE;
-
-    let status_update = StatusUpdate::new(ctx, attribute_value_id)
+    let status_update = StatusUpdate::new(ctx)
         .await
         .expect("failed to create status update");
 
-    assert_eq!(status_update.attribute_value_id(), attribute_value_id);
     assert!(status_update.dependent_values_metadata().is_empty());
     assert!(status_update.queued_dependent_value_ids().is_empty());
     assert!(status_update.running_dependent_value_ids().is_empty());

--- a/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
+++ b/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
@@ -218,8 +218,11 @@ pub async fn connect_component_sockets_to_frame(
                                     attribute_value_context,
                                 ))?;
 
-                        ctx.enqueue_job(DependentValuesUpdate::new(ctx, *attribute_value.id()))
-                            .await;
+                        ctx.enqueue_job(DependentValuesUpdate::new(
+                            ctx,
+                            vec![*attribute_value.id()],
+                        ))
+                        .await;
                     }
                     SocketEdgeKind::ConfigurationOutput => {
                         let provider = ExternalProvider::find_for_socket(ctx, *parent_socket.id())
@@ -263,8 +266,11 @@ pub async fn connect_component_sockets_to_frame(
                                     attribute_value_context,
                                 ))?;
 
-                        ctx.enqueue_job(DependentValuesUpdate::new(ctx, *attribute_value.id()))
-                            .await;
+                        ctx.enqueue_job(DependentValuesUpdate::new(
+                            ctx,
+                            vec![*attribute_value.id()],
+                        ))
+                        .await;
                     }
                 }
             } else if let Some(parent_provider) = parent_socket.external_provider(ctx).await? {
@@ -297,8 +303,11 @@ pub async fn connect_component_sockets_to_frame(
                                         attribute_read_context,
                                     ))?;
 
-                            ctx.enqueue_job(DependentValuesUpdate::new(ctx, *attribute_value.id()))
-                                .await;
+                            ctx.enqueue_job(DependentValuesUpdate::new(
+                                ctx,
+                                vec![*attribute_value.id()],
+                            ))
+                            .await;
                         }
                     }
                 }

--- a/lib/sdf/src/server/service/diagram/create_connection.rs
+++ b/lib/sdf/src/server/service/diagram/create_connection.rs
@@ -84,8 +84,11 @@ pub async fn create_connection(
             attribute_value_context,
         ))?;
 
-    ctx.enqueue_job(DependentValuesUpdate::new(&ctx, *attribute_value.id()))
-        .await;
+    ctx.enqueue_job(DependentValuesUpdate::new(
+        &ctx,
+        vec![*attribute_value.id()],
+    ))
+    .await;
 
     WsEvent::change_set_written(&ctx)
         .await?


### PR DESCRIPTION
- Ensure DependentValuesUpdate can take multiple AttributeValues
- Remove the initial AttributeValue from StatusUpdate since it was a placeholder to begin with (thanks Fletcher!)