### PR TITLE
fix(web): Center component loader rotation correctly

### DIFF
--- a/app/web/src/organisms/GenericDiagram/KonvaSvgImage.vue
+++ b/app/web/src/organisms/GenericDiagram/KonvaSvgImage.vue
@@ -38,12 +38,9 @@ const konvaConfig = computed(() => {
   return {
     ...props.config,
     image: imageEl.value,
-    // offset: { x: offsetX, y: offsetY },
-    // x: (props.config.x || 0) + offsetX,
-    // y: (props.config.y || 0) + offsetY,
-
-    x: props.config.x || 0,
-    y: props.config.y || 0,
+    offset: { x: offsetX, y: offsetY },
+    x: (props.config.x || 0) + offsetX,
+    y: (props.config.y || 0) + offsetY,
   };
 });
 


### PR DESCRIPTION
<img width="495" alt="image" src="https://user-images.githubusercontent.com/6564471/213284332-b41c355a-fa86-4e5b-b4c4-60870f88d933.png">