### PR TITLE
Fix AWS Region not working as a component, but working as a frame (ENG-948, ENG-947, ENG-937)

### DIFF
--- a/app/web/src/organisms/AttributeViewer.vue
+++ b/app/web/src/organisms/AttributeViewer.vue
@@ -27,10 +27,6 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-function nilId(): string {
-  return "00000000000000000000000000";
-}
-
 const componentsStore = useComponentsStore();
 // Note(victor): This component will only be rendered if there's a selected component.
 // To avoid weird data races where the store has already unset the value but we still need to use it, we can default to
@@ -44,24 +40,13 @@ const componentAttributesStore = useComponentAttributesStore();
 
 const editorContext = computed(() => componentAttributesStore.editorContext);
 
-// TODO: not sure why we need to pass this all back to the backend - seems like we should pass the minimal data
-const getAttributeContext = (propId: string) => ({
-  attribute_context_prop_id: propId,
-  attribute_context_internal_provider_id: nilId(),
-  attribute_context_external_provider_id: nilId(),
-  attribute_context_component_id: lastSelectedComponent.value.id,
-});
-
 const updateProperty = (event: UpdatedProperty) => {
   const prop = editorContext.value?.schema.props[event.propId];
 
   if (prop?.name === "type") {
     componentAttributesStore.SET_COMPONENT_TYPE({
-      attributeValueId: event.valueId,
-      parentAttributeValueId: event.parentValueId,
       value: event.value,
-      key: event.key,
-      attributeContext: getAttributeContext(event.propId),
+      componentId: lastSelectedComponent.value.id,
     });
   } else {
     componentAttributesStore.UPDATE_PROPERTY_VALUE({
@@ -70,7 +55,8 @@ const updateProperty = (event: UpdatedProperty) => {
         parentAttributeValueId: event.parentValueId,
         value: event.value,
         key: event.key,
-        attributeContext: getAttributeContext(event.propId),
+        propId: event.propId,
+        componentId: lastSelectedComponent.value.id,
       },
     });
   }
@@ -80,7 +66,8 @@ const addToArray = (event: AddToArray) => {
   componentAttributesStore.UPDATE_PROPERTY_VALUE({
     insert: {
       parentAttributeValueId: event.valueId,
-      attributeContext: getAttributeContext(event.propId),
+      propId: event.propId,
+      componentId: lastSelectedComponent.value.id,
     },
   });
 };
@@ -89,7 +76,8 @@ const addToMap = (event: AddToMap) => {
     insert: {
       parentAttributeValueId: event.valueId,
       key: event.key,
-      attributeContext: getAttributeContext(event.propId),
+      propId: event.propId,
+      componentId: lastSelectedComponent.value.id,
     },
   });
 };

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -3,7 +3,6 @@ import _ from "lodash";
 import { watch } from "vue";
 import { ApiRequest } from "@/utils/pinia_api_tools";
 import { addStoreHooks } from "@/utils/pinia_hooks_plugin";
-
 import {
   PropertyEditorSchema,
   PropertyEditorValidation,
@@ -11,7 +10,6 @@ import {
   PropertyEditorValues,
   PropertyEditorProp,
 } from "@/api/sdf/dal/property_editor";
-import { AttributeContext } from "@/api/sdf/dal/attribute";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import { useComponentsStore } from "./components.store";
@@ -20,16 +18,23 @@ import { useStatusStore } from "./status.store";
 export interface UpdatePropertyEditorValueArgs {
   attributeValueId: string;
   parentAttributeValueId?: string;
-  attributeContext: AttributeContext;
+  propId: string;
+  componentId: string;
   value?: unknown;
   key?: string;
 }
 
 export interface InsertPropertyEditorValueArgs {
   parentAttributeValueId: string;
-  attributeContext: AttributeContext;
+  propId: string;
+  componentId: string;
   value?: unknown;
   key?: string;
+}
+
+export interface SetTypeArgs {
+  componentId: string;
+  value?: unknown;
 }
 
 export const useComponentAttributesStore = () => {
@@ -232,7 +237,7 @@ export const useComponentAttributesStore = () => {
           });
         },
 
-        async SET_COMPONENT_TYPE(payload: UpdatePropertyEditorValueArgs) {
+        async SET_COMPONENT_TYPE(payload: SetTypeArgs) {
           const statusStore = useStatusStore();
           statusStore.markUpdateStarted();
 

--- a/lib/dal-test/src/helpers/component_payload.rs
+++ b/lib/dal-test/src/helpers/component_payload.rs
@@ -4,8 +4,8 @@
 
 use dal::{
     attribute::context::AttributeContextBuilder, node::NodeId, AttributeContext,
-    AttributeReadContext, AttributeValue, AttributeValueId, ComponentId, ComponentView, DalContext,
-    Prop, PropId, SchemaId, SchemaVariantId, StandardModel,
+    AttributeReadContext, AttributeValue, AttributeValueId, Component, ComponentId, ComponentView,
+    DalContext, Prop, PropId, SchemaId, SchemaVariantId, StandardModel,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -259,5 +259,14 @@ impl ComponentPayload {
 
         // Return the updated attribute value id.
         updated_attribute_value_id
+    }
+
+    /// Get the full [`Component`](dal::Component) using the [`ComponentId`](dal::Component)
+    /// from [`self`](Self).
+    pub async fn component(&self, ctx: &DalContext) -> Component {
+        Component::get_by_id(ctx, &self.component_id)
+            .await
+            .expect("could not get component by id")
+            .expect("no component found")
     }
 }

--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -389,7 +389,7 @@ pub async fn create_component_and_schema(ctx: &DalContext) -> Component {
     let schema = create_schema(ctx).await;
     let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("unable to finalize schema variant");
     let name = generate_fake_name();

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -295,35 +295,6 @@ impl MigrationDriver {
         Err(PropError::ExpectedChildNotFound(child_prop_name.to_string()).into())
     }
 
-    /// A wrapper around [`SchemaVariant::finalize()`](crate::SchemaVariant::finalize()) to perform
-    /// some additional, builtin-specific work when finalizing a
-    /// [`SchemaVariant`](crate::SchemaVariant).
-    pub async fn finalize_schema_variant(
-        &self,
-        ctx: &DalContext,
-        schema_variant: &mut SchemaVariant,
-        root_prop: &RootProp,
-    ) -> BuiltinsResult<()> {
-        schema_variant.finalize(ctx).await?;
-
-        // set the default type for the node to be a component
-        // individual schemas can override this value where appropriate
-        let type_prop = self
-            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "type")
-            .await?;
-        self.set_default_value_for_prop(ctx, *type_prop.id(), serde_json::json!["component"])
-            .await?;
-
-        // set the default value for protected attribute on a component
-        let protected_prop = self
-            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "protected")
-            .await?;
-        self.set_default_value_for_prop(ctx, *protected_prop.id(), serde_json::json![false])
-            .await?;
-
-        Ok(())
-    }
-
     /// Set a default [`Value`](serde_json::Value) for a given [`Prop`](crate::Prop) in a
     /// [`Schema`](crate::Schema) and [`SchemaVariant`](crate::SchemaVariant).
     ///

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -13,7 +13,7 @@ use crate::validation::Validation;
 use crate::{
     action_prototype::ActionKind,
     schema::variant::leaves::{LeafInput, LeafInputLocation},
-    FuncDescriptionContents,
+    ComponentType, FuncDescriptionContents,
 };
 use crate::{
     attribute::context::AttributeContextBuilder, func::argument::FuncArgument, ActionPrototype,
@@ -188,8 +188,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Connect the props to providers.
         let external_provider_attribute_prototype_id = image_id_external_provider
@@ -568,8 +567,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -962,20 +960,9 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
+        schema_variant
+            .finalize(ctx, Some(ComponentType::ConfigurationFrame))
             .await?;
-
-        // set the component as a configuration frame
-        let si_type_prop = self
-            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "type")
-            .await?;
-
-        self.set_default_value_for_prop(
-            ctx,
-            *si_type_prop.id(),
-            serde_json::json!["configurationFrame"],
-        )
-        .await?;
 
         let region_implicit_internal_provider =
             InternalProvider::find_for_prop(ctx, *region_prop.id())
@@ -1241,8 +1228,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -1645,8 +1631,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -341,8 +341,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -893,8 +892,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(
@@ -1342,8 +1340,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up!
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set Defaults
         self.set_default_value_for_prop(

--- a/lib/dal/src/builtins/schema/coreos.rs
+++ b/lib/dal/src/builtins/schema/coreos.rs
@@ -90,8 +90,7 @@ impl MigrationDriver {
         .await?;
 
         // Wrap it up.
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Collect the props we need.
         let prop_cache = maybe_prop_cache

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -87,8 +87,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
         Ok(())
     }
 
@@ -199,8 +198,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/image" field.
         let image_attribute_value = AttributeValue::find_for_context(

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -112,8 +112,7 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Connect the "/root/si/name" field to the "/root/domain/metadata/name" field.
         let metadata_name_prop = self
@@ -311,8 +310,7 @@ impl MigrationDriver {
             )
             .await?;
 
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
-            .await?;
+        schema_variant.finalize(ctx, None).await?;
 
         // Set default values after finalization.
         self.set_default_value_for_prop(ctx, *api_version_prop.id(), serde_json::json!["apps/v1"])

--- a/lib/dal/src/builtins/schema/systeminit.rs
+++ b/lib/dal/src/builtins/schema/systeminit.rs
@@ -1,7 +1,7 @@
 use crate::builtins::schema::MigrationDriver;
 use crate::component::ComponentKind;
 use crate::validation::Validation;
-use crate::{BuiltinsResult, DalContext, PropKind, StandardModel};
+use crate::{BuiltinsResult, ComponentType, DalContext, PropKind, StandardModel};
 
 const FRAME_NODE_COLOR: i64 = 0xFFFFFF;
 
@@ -53,20 +53,9 @@ impl MigrationDriver {
         )
         .await?;
 
-        self.finalize_schema_variant(ctx, &mut schema_variant, &root_prop)
+        schema_variant
+            .finalize(ctx, Some(ComponentType::ConfigurationFrame))
             .await?;
-
-        // set the component as a configuration frame
-        let si_type_prop = self
-            .find_child_prop_by_name(ctx, root_prop.si_prop_id, "type")
-            .await?;
-
-        self.set_default_value_for_prop(
-            ctx,
-            *si_type_prop.id(),
-            serde_json::json!["configurationFrame"],
-        )
-        .await?;
 
         // TODO - PAUL/VICTOR:
         // As this is an actual frame and has no alternative functionality

--- a/lib/dal/src/component/status.rs
+++ b/lib/dal/src/component/status.rs
@@ -1,0 +1,146 @@
+use chrono::DateTime;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::component::{ComponentResult, COMPONENT_STATUS_UPDATE_BY_PK};
+use crate::standard_model::TypeHint;
+use crate::ComponentId;
+use crate::UserId;
+use crate::{
+    impl_standard_model, pk, standard_model, DalContext, HistoryActor, StandardModelError,
+    Timestamp, Visibility, WriteTenancy,
+};
+
+pk!(ComponentStatusPk);
+
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HistoryActorTimestamp {
+    pub actor: HistoryActor,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ComponentStatus {
+    pk: ComponentStatusPk,
+    // This is a `ComponentId` as the underlying table is parallel to the components table
+    id: ComponentId,
+    #[serde(flatten)]
+    tenancy: WriteTenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+    creation_timestamp: DateTime<Utc>,
+    creation_user_id: Option<UserId>,
+    update_timestamp: DateTime<Utc>,
+    update_user_id: Option<UserId>,
+}
+
+impl_standard_model! {
+    model: ComponentStatus,
+    pk: ComponentStatusPk,
+    id: ComponentId,
+    table_name: "component_statuses",
+    history_event_label_base: "component_status",
+    history_event_message_name: "Component Status"
+}
+
+impl ComponentStatus {
+    pub fn creation(&self) -> HistoryActorTimestamp {
+        HistoryActorTimestamp {
+            actor: self.actor(),
+            timestamp: self.creation_timestamp,
+        }
+    }
+
+    pub fn update(&self) -> HistoryActorTimestamp {
+        HistoryActorTimestamp {
+            actor: self.actor(),
+            timestamp: self.update_timestamp,
+        }
+    }
+
+    /// Persists updated 'update' timestamp/actor data by [`ComponentId`] and returns the update
+    /// timestamp.
+    ///
+    /// # Errors
+    ///
+    /// Return [`Err`] if the upsert failed or if there was a connection issue to the database.
+    pub async fn record_update_by_id(
+        ctx: &DalContext,
+        id: ComponentId,
+    ) -> ComponentResult<DateTime<Utc>> {
+        let actor_user_id = Self::user_id(ctx.history_actor());
+
+        // TODO(fnichol): I would *highly* prefer to avoid 2 `UPDATE` statements, but our standard
+        // model update code understands how to properly upsert a record to the correct visibility.
+        // That is, we might be updating a record that exists only so far in HEAD, and therefore a
+        // new change set record must be created. The first `update()` call guarentees this upsert
+        // and the second call is effectively executing the "update-not-insert" code path, but
+        // since we get arbitrary field updates for free and there's only one more field to update,
+        // why not call it again?.
+        //
+        // If we decide to extract the standard model upsert logic, then a custom db function could
+        // be written to use that and called once from here--I'm too nervous to duplicate the
+        // upsert code to save on *1* more db statement call.
+        let update_timestamp = standard_model::update(
+            ctx,
+            "component_statuses",
+            "update_user_id",
+            &id,
+            &actor_user_id,
+            TypeHint::BpChar,
+        )
+        .await?;
+        let _updated_at = standard_model::update(
+            ctx,
+            "component_statuses",
+            "update_timestamp",
+            &id,
+            &update_timestamp,
+            TypeHint::TimestampWithTimeZone,
+        )
+        .await?;
+
+        Ok(update_timestamp)
+    }
+
+    /// Persists updated 'update' timestamp/actor data and returns the update timestamp.
+    ///
+    /// # Errors
+    ///
+    /// Return [`Err`] if there was a connection issue to the database.
+    pub async fn record_update(&mut self, ctx: &DalContext) -> ComponentResult<DateTime<Utc>> {
+        let actor_user_id = Self::user_id(ctx.history_actor());
+
+        let row = ctx
+            .pg_txn()
+            .query_one(COMPONENT_STATUS_UPDATE_BY_PK, &[&self.pk, &actor_user_id])
+            .await?;
+        let updated_at = row.try_get("updated_at").map_err(|_| {
+            StandardModelError::ModelMissing("component_statuses".to_string(), self.pk.to_string())
+        })?;
+        let update_timestamp = row.try_get("update_timestamp").map_err(|_| {
+            StandardModelError::ModelMissing("component_statuses".to_string(), self.pk.to_string())
+        })?;
+        self.timestamp.updated_at = updated_at;
+        self.update_timestamp = update_timestamp;
+        self.update_user_id = actor_user_id;
+
+        Ok(update_timestamp)
+    }
+
+    fn actor(&self) -> HistoryActor {
+        match self.creation_user_id {
+            Some(user_id) => user_id.into(),
+            None => HistoryActor::SystemInit,
+        }
+    }
+
+    fn user_id(history_actor: &HistoryActor) -> Option<UserId> {
+        match history_actor {
+            HistoryActor::User(user_id) => Some(*user_id),
+            _ => None,
+        }
+    }
+}

--- a/lib/dal/src/component/validation.rs
+++ b/lib/dal/src/component/validation.rs
@@ -1,0 +1,152 @@
+//! This module contains the ability to interact with validations for
+//! [`Component(s)`](crate::Component).
+
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::attribute::value::AttributeValue;
+use crate::component::ComponentResult;
+use crate::func::backend::{
+    js_validation::FuncBackendJsValidationArgs, validation::FuncBackendValidationArgs,
+};
+use crate::func::binding::FuncBinding;
+use crate::func::binding_return_value::FuncBindingReturnValue;
+use crate::ComponentError;
+use crate::{
+    AttributeReadContext, Component, DalContext, ExternalProviderId, Func, FuncBackendKind,
+    InternalProviderId, PropError, PropId, StandardModel, ValidationPrototype, ValidationResolver,
+};
+
+impl Component {
+    pub async fn check_single_validation(
+        &self,
+        ctx: &DalContext,
+        validation_prototype: &ValidationPrototype,
+        value_cache: &mut HashMap<PropId, (Option<Value>, AttributeValue)>,
+    ) -> ComponentResult<()> {
+        let base_attribute_read_context = AttributeReadContext {
+            prop_id: None,
+            external_provider_id: Some(ExternalProviderId::NONE),
+            internal_provider_id: Some(InternalProviderId::NONE),
+            component_id: Some(self.id),
+        };
+
+        let prop_id = validation_prototype.context().prop_id();
+
+        let (maybe_value, attribute_value) = match value_cache.get(&prop_id) {
+            Some((value, attribute_value)) => (value.to_owned(), attribute_value.clone()),
+            None => {
+                let attribute_read_context = AttributeReadContext {
+                    prop_id: Some(prop_id),
+                    ..base_attribute_read_context
+                };
+                let attribute_value = AttributeValue::find_for_context(ctx, attribute_read_context)
+                    .await?
+                    .ok_or(ComponentError::AttributeValueNotFoundForContext(
+                        attribute_read_context,
+                    ))?;
+
+                let value = match FuncBindingReturnValue::get_by_id(
+                    ctx,
+                    &attribute_value.func_binding_return_value_id(),
+                )
+                .await?
+                {
+                    Some(func_binding_return_value) => func_binding_return_value.value().cloned(),
+                    None => None,
+                };
+
+                value_cache.insert(prop_id, (value.clone(), attribute_value.clone()));
+                (value, attribute_value)
+            }
+        };
+
+        let func = Func::get_by_id(ctx, &validation_prototype.func_id())
+            .await?
+            .ok_or_else(|| PropError::MissingFuncById(validation_prototype.func_id()))?;
+
+        let mutated_args = match func.backend_kind() {
+            FuncBackendKind::Validation => {
+                // Deserialize the args, update the "value", and serialize the mutated args.
+                let mut args = FuncBackendValidationArgs::deserialize(validation_prototype.args())?;
+                args.validation = args.validation.update_value(&maybe_value)?;
+
+                serde_json::to_value(args)?
+            }
+            FuncBackendKind::JsValidation => serde_json::to_value(FuncBackendJsValidationArgs {
+                value: maybe_value.unwrap_or(serde_json::json!(null)),
+            })?,
+            kind => {
+                return Err(ComponentError::InvalidFuncBackendKindForValidations(*kind));
+            }
+        };
+
+        // Now, we can load in the mutated args!
+        let (func_binding, _) =
+            FuncBinding::create_and_execute(ctx, mutated_args, *func.id()).await?;
+
+        let attribute_value_id = *attribute_value.id();
+
+        // Does a resolver already exist for this validation func and attribute value? If so, we
+        // need to make sure the attribute_value_func_binding_return_value_id matches the
+        // func_binding_return_value_id of the current attribute value, since it could be different
+        // *even if the value is the same*. We also need to be sure to create a resolver for each
+        // attribute_value_id, since the way func_bindings are cached means the validation func
+        // won't be created for the same validation func + value, despite running this on a
+        // completely different attribute value (or even prop).
+        match ValidationResolver::find_for_attribute_value_and_validation_func(
+            ctx,
+            attribute_value_id,
+            *func.id(),
+        )
+        .await?
+        .pop()
+        {
+            Some(mut existing_resolver) => {
+                existing_resolver
+                    .set_validation_func_binding_id(ctx, func_binding.id())
+                    .await?;
+                existing_resolver
+                    .set_attribute_value_func_binding_return_value_id(
+                        ctx,
+                        attribute_value.func_binding_return_value_id(),
+                    )
+                    .await?;
+            }
+            None => {
+                ValidationResolver::new(
+                    ctx,
+                    *validation_prototype.id(),
+                    attribute_value_id,
+                    *func_binding.id(),
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check validations for [`Self`].
+    pub async fn check_validations(&self, ctx: &DalContext) -> ComponentResult<()> {
+        let schema_variant = self
+            .schema_variant(ctx)
+            .await?
+            .ok_or(ComponentError::NoSchemaVariant(self.id))?;
+
+        let validation_prototypes =
+            ValidationPrototype::list_for_schema_variant(ctx, *schema_variant.id()).await?;
+
+        // Cache data necessary for assembling func arguments. We do this since a prop can have
+        // multiple validation prototypes within schema variant.
+        let mut cache: HashMap<PropId, (Option<Value>, AttributeValue)> = HashMap::new();
+
+        for validation_prototype in validation_prototypes {
+            self.check_single_validation(ctx, &validation_prototype, &mut cache)
+                .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -6,6 +6,7 @@ use si_data_pg::PgError;
 use telemetry::prelude::*;
 use thiserror::Error;
 
+use crate::func::argument::FuncArgumentError;
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_accessor_ro,
     DalContext, FuncBinding, FuncDescriptionContents, HistoryEventError, StandardModel,
@@ -20,6 +21,7 @@ pub mod binding;
 pub mod binding_return_value;
 pub mod description;
 pub mod execution;
+pub mod identity;
 
 #[derive(Error, Debug)]
 pub enum FuncError {
@@ -37,6 +39,10 @@ pub enum FuncError {
     Decode(#[from] base64::DecodeError),
     #[error("utf8 encoding error: {0}")]
     FromUtf8(#[from] FromUtf8Error),
+    #[error("func argument error: {0}")]
+    FuncArgument(#[from] FuncArgumentError),
+    #[error("func binding error: {0}")]
+    FuncBinding(String),
 
     #[error("could not find func by id: {0}")]
     NotFound(FuncId),
@@ -44,6 +50,16 @@ pub enum FuncError {
     NotFoundByName(String),
     #[error("contents ({0}) response type does not match func response type: {1}")]
     ResponseTypeMismatch(FuncDescriptionContents, FuncBackendResponseType),
+
+    /// Could not find [`FuncArgument`](crate::FuncArgument) corresponding to the identity [`Func`].
+    #[error("identity func argument not found")]
+    IdentityFuncArgumentNotFound,
+    /// Could not find the identity [`Func`].
+    #[error("identity func not found")]
+    IdentityFuncNotFound,
+    /// When attempting to find the identity [`Func`], there were too many [`Funcs`](Func) returned.
+    #[error("too many funcs found when looking for identity func")]
+    TooManyFuncsFoundForIdentity,
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;

--- a/lib/dal/src/func/identity.rs
+++ b/lib/dal/src/func/identity.rs
@@ -1,0 +1,51 @@
+//! This module contains a special helper for finding the identity [`Func`](crate::Func). Generally
+//! speaking, [`Funcs`](crate::Func) should not receive special treatment, but due to the
+//! prevalence of the identity [`Func`](crate::Func) across the library, this helper should help
+//! ease some friction.
+
+use crate::{
+    DalContext, Func, FuncArgument, FuncBinding, FuncBindingReturnValue, FuncError, FuncResult,
+    StandardModel,
+};
+
+const IDENTITY_FUNC_NAME: &str = "si:identity";
+
+impl Func {
+    /// Returns the identity [`Func`](Self) with its corresponding
+    /// [`FuncBinding`](crate::FuncBinding) and
+    /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue).
+    pub async fn identity_with_binding_and_return_value(
+        ctx: &DalContext,
+    ) -> FuncResult<(Func, FuncBinding, FuncBindingReturnValue)> {
+        let func = Self::identity_func(ctx).await?;
+        let (func_binding, func_binding_return_value) = FuncBinding::create_and_execute(
+            ctx,
+            serde_json::json![{ "identity": null }],
+            *func.id(),
+        )
+        .await
+        .map_err(|e| FuncError::FuncBinding(e.to_string()))?;
+
+        Ok((func, func_binding, func_binding_return_value))
+    }
+
+    /// Returns the identity [`Func`](Self) with its corresponding
+    /// [`FuncArgument`](crate::FuncArgument).
+    pub async fn identity_with_argument(ctx: &DalContext) -> FuncResult<(Func, FuncArgument)> {
+        let func = Self::identity_func(ctx).await?;
+        let func_argument = FuncArgument::find_by_name_for_func(ctx, "identity", *func.id())
+            .await?
+            .ok_or(FuncError::IdentityFuncArgumentNotFound)?;
+        Ok((func, func_argument))
+    }
+
+    /// Returns the identity [`Func`](Self).
+    pub async fn identity_func(ctx: &DalContext) -> FuncResult<Func> {
+        let mut found_funcs = Func::find_by_attr(ctx, "name", &IDENTITY_FUNC_NAME).await?;
+        let func = found_funcs.pop().ok_or(FuncError::IdentityFuncNotFound)?;
+        match found_funcs.is_empty() {
+            true => Ok(func),
+            false => Err(FuncError::TooManyFuncsFoundForIdentity),
+        }
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -99,8 +99,8 @@ pub use capability::{Capability, CapabilityError, CapabilityId, CapabilityPk, Ca
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetPk, ChangeSetStatus};
 pub use code_view::{CodeLanguage, CodeView};
 pub use component::{
-    resource::ResourceView, Component, ComponentError, ComponentId, ComponentStatus, ComponentView,
-    HistoryActorTimestamp,
+    resource::ResourceView, status::ComponentStatus, status::HistoryActorTimestamp, Component,
+    ComponentError, ComponentId, ComponentView,
 };
 pub use context::{
     AccessBuilder, Connections, DalContext, DalContextBuilder, RequestContext, ServicesContext,
@@ -155,6 +155,7 @@ pub use resource_scheduler::{ResourceScheduler, ResourceSchedulerError};
 pub use schema::variant::leaves::LeafInput;
 pub use schema::variant::leaves::LeafInputLocation;
 pub use schema::variant::leaves::LeafKind;
+pub use schema::variant::root_prop::component_type::ComponentType;
 pub use schema::variant::root_prop::RootProp;
 pub use schema::variant::root_prop::RootPropChild;
 pub use schema::{Schema, SchemaError, SchemaId, SchemaPk, SchemaVariant, SchemaVariantId};

--- a/lib/dal/src/queries/component/find_type_attribute_value.sql
+++ b/lib/dal/src/queries/component/find_type_attribute_value.sql
@@ -1,0 +1,39 @@
+SELECT DISTINCT ON (attribute_values.attribute_context_prop_id) row_to_json(attribute_values.*) AS object
+
+FROM attribute_values_v1($1, $2) AS attribute_values
+         JOIN (
+    SELECT type_prop.id
+    FROM props_v1($1, $2) AS type_prop
+             JOIN prop_belongs_to_prop_v1($1, $2) AS type_prop_belongs_to_si_prop
+                  ON type_prop_belongs_to_si_prop.object_id = type_prop.id
+                      AND type_prop.name = 'type'
+             JOIN props_v1($1, $2) as si_prop
+                  ON type_prop_belongs_to_si_prop.belongs_to_id = si_prop.id
+                      AND si_prop.name = 'si'
+             JOIN prop_belongs_to_prop_v1($1, $2) AS si_prop_belongs_to_root_prop
+                  ON si_prop_belongs_to_root_prop.object_id = si_prop.id
+                      AND si_prop_belongs_to_root_prop.belongs_to_id IN (
+                          SELECT pmtmsv.left_object_id AS root_prop_id
+                          FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
+                                   JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
+                                        ON cbtsv.belongs_to_id = pmtmsv.right_object_id
+                                            AND cbtsv.object_id = $3
+                      )
+) AS type_prop
+              ON attribute_values.attribute_context_prop_id = type_prop.id
+
+-- We will also take the "default" type too (corresponds to the attribute
+-- value whose context has component id unset)
+WHERE in_attribute_context_v1(
+              attribute_context_build_from_parts_v1(
+                      type_prop.id, -- PropId
+                      ident_nil_v1(), -- InternalProviderId
+                      ident_nil_v1(), -- ExternalProviderId
+                      $3 -- ComponentId
+                  ),
+              attribute_values
+          )
+ORDER BY attribute_values.attribute_context_prop_id,
+         attribute_values.attribute_context_component_id DESC,
+         attribute_values.tenancy_universal
+-- bools sort false first ascending.

--- a/lib/dal/src/queries/component/get_resource.sql
+++ b/lib/dal/src/queries/component/get_resource.sql
@@ -1,6 +1,0 @@
-SELECT row_to_json(fbrv.*) AS object
-FROM resource_resolvers_v1($1, $2) AS rr
-INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
-    ON fbrv.func_binding_id = rr.func_binding_id
-WHERE
-    rr.component_id = $3

--- a/lib/dal/src/queries/schema_variant/list_root_si_child_props.sql
+++ b/lib/dal/src/queries/schema_variant/list_root_si_child_props.sql
@@ -1,0 +1,14 @@
+SELECT row_to_json(props.*) AS object
+FROM props_v1($1, $2) as props
+         JOIN prop_belongs_to_prop_v1($1, $2) AS si_child_prop_belongs_to_si_prop
+              ON si_child_prop_belongs_to_si_prop.object_id = props.id
+         JOIN props_v1($1, $2) as si_prop
+              ON si_child_prop_belongs_to_si_prop.belongs_to_id = si_prop.id
+                  AND si_prop.name = 'si'
+         JOIN prop_belongs_to_prop_v1($1, $2) AS si_prop_belongs_to_root_prop
+              ON si_child_prop_belongs_to_si_prop.belongs_to_id = si_prop_belongs_to_root_prop.object_id
+                  AND si_prop_belongs_to_root_prop.belongs_to_id IN (
+                      SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
+                      FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
+                      WHERE prop_many_to_many_schema_variants.right_object_id = $3
+                  )

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};
 use crate::{
-    edit_field::widget::WidgetKind, DalContext, DiagramKind, ExternalProvider, Func, FuncBinding,
+    edit_field::widget::WidgetKind, DalContext, DiagramKind, ExternalProvider, Func,
     InternalProvider, Prop, PropId, PropKind, RootProp, SchemaId, SchemaVariant, SocketArity,
     StandardModel,
 };
@@ -172,18 +172,9 @@ impl SchemaVariant {
         if !schema_variant_definition.input_sockets.is_empty()
             || !schema_variant_definition.output_sockets.is_empty()
         {
-            let identity_func = Func::find_by_attr(ctx, "name", &"si:identity".to_string())
-                .await?
-                .pop()
-                .ok_or(SchemaVariantError::IdentityFuncNotFoundByName)?;
+            let (identity_func, identity_func_binding, identity_func_binding_return_value) =
+                Func::identity_with_binding_and_return_value(ctx).await?;
             let identity_func_id = *identity_func.id();
-            let (identity_func_binding, identity_func_binding_return_value) =
-                FuncBinding::create_and_execute(
-                    ctx,
-                    serde_json::json![{ "identity": null }],
-                    identity_func_id,
-                )
-                .await?;
             let identity_func_binding_id = *identity_func_binding.id();
             let identity_func_binding_return_value_id = *identity_func_binding_return_value.id();
 

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -132,7 +132,7 @@ impl SchemaVariant {
             .await?
             .ok_or(SchemaVariantError::NotFound(schema_variant_id))?;
         if !schema_variant.finalized_once() {
-            schema_variant.finalize(ctx).await?;
+            schema_variant.finalize(ctx, None).await?;
         }
 
         // Assemble the values we need to insert an object into the map.

--- a/lib/dal/src/schema/variant/root_prop/component_type.rs
+++ b/lib/dal/src/schema/variant/root_prop/component_type.rs
@@ -1,0 +1,27 @@
+//! This module contains the ability to switch a [`Component's`](crate::Component) type between
+//! a standard [`Component`](crate::Component) and a "frame". This functionality resides in this
+//! location because it corresponds to the "/root/si/type" location in the
+//! [`RootProp`](crate::RootProp) tree.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The possible values of "/root/si/type".
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ComponentType {
+    Component,
+    ConfigurationFrame,
+    AggregationFrame,
+}
+
+impl ComponentType {
+    /// Return the label corresponding to [`self`](Self).
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Component => "Component",
+            Self::ConfigurationFrame => "Configuration Frame",
+            Self::AggregationFrame => "Aggregation Frame",
+        }
+    }
+}

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -97,7 +97,7 @@ async fn list_for_context_with_a_hash(ctx: &DalContext) {
     let hash_key_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "album_hash_key", *album_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("could not finalize schema variant");
 
@@ -358,7 +358,7 @@ async fn remove_component_specific(ctx: &DalContext) {
 
     let prop = create_prop_and_set_parent(ctx, PropKind::String, "god", root.domain_prop_id).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -375,6 +375,8 @@ async fn remove_component_specific(ctx: &DalContext) {
             {
                 "si": {
                     "name": "toddhoward",
+                    "type": "component",
+                    "protected": false
                 },
                 "domain": {}
             }

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -22,7 +22,7 @@ async fn update_for_context_simple(ctx: &DalContext) {
     let name_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "name_prop", root.domain_prop_id).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -42,8 +42,9 @@ async fn update_for_context_simple(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {},
             }
         ],
@@ -97,8 +98,9 @@ async fn update_for_context_simple(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "name_prop": "Miles",
                 },
@@ -126,8 +128,9 @@ async fn update_for_context_simple(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "name_prop": "Iria",
                 },
@@ -154,7 +157,7 @@ async fn insert_for_context_simple(ctx: &DalContext) {
     let array_element =
         create_prop_and_set_parent(ctx, PropKind::String, "array_element", *array_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -173,8 +176,9 @@ async fn insert_for_context_simple(ctx: &DalContext) {
         serde_json::json![{
             "si": {
                 "name": "Array Component",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {},
         }],
         ComponentView::new(ctx, *component.id())
@@ -207,8 +211,9 @@ async fn insert_for_context_simple(ctx: &DalContext) {
         serde_json::json![{
             "si": {
                 "name": "Array Component",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
                 "array_prop": [],
             },
@@ -245,7 +250,7 @@ async fn update_for_context_object(ctx: &DalContext) {
     let _tags_child_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "tag", *tags_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -263,8 +268,9 @@ async fn update_for_context_object(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {},
             }
         ],
@@ -340,20 +346,21 @@ async fn update_for_context_object(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "address": {
-                        "streets": [
-                            "Suite 4",
-                            "14 Main Street"
-                        ],
                         "city": "Plainstown",
-                        "country": "Eurasia",
                         "tags": {
                             "cool": "beans",
                             "alpha": "bet",
                         },
+                        "country": "Eurasia",
+                        "streets": [
+                            "Suite 4",
+                            "14 Main Street"
+                        ],
                     },
                 },
             }
@@ -391,17 +398,18 @@ async fn update_for_context_object(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Basic component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "address": {
-                        "streets": [
-                            "123 Ok",
-                        ],
                         "city": "Nowheresville",
                         "tags": {
                             "new": "one",
                         },
+                        "streets": [
+                            "123 Ok",
+                        ],
                     },
                 },
             }
@@ -424,7 +432,7 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
     let array_element =
         create_prop_and_set_parent(ctx, PropKind::String, "array_element", *array_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -443,8 +451,9 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
         serde_json::json![{
             "si": {
                 "name": "Array Component",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {},
         }],
         ComponentView::new(ctx, *component.id())
@@ -482,8 +491,9 @@ async fn insert_for_context_creates_array_in_final_context(ctx: &DalContext) {
         serde_json::json![{
             "si": {
                 "name": "Array Component",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
                 "array_prop": [
                     "Component Element",

--- a/lib/dal/tests/integration_test/builtins/aws_region.rs
+++ b/lib/dal/tests/integration_test/builtins/aws_region.rs
@@ -1,12 +1,119 @@
 use dal::{
-    validation::ValidationErrorKind, DalContext, Edge, ExternalProvider, InternalProvider,
-    StandardModel, ValidationResolver,
+    validation::ValidationErrorKind, ComponentType, DalContext, Edge, ExternalProvider,
+    InternalProvider, StandardModel, ValidationResolver,
 };
 use dal_test::{
     helpers::builtins::{Builtin, SchemaBuiltinsTestHarness},
     test,
 };
 use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn aws_region_field_validation(ctx: &DalContext) {
+    let mut harness = SchemaBuiltinsTestHarness::new();
+    let region_payload = harness
+        .create_component(ctx, "region", Builtin::AwsRegion)
+        .await;
+
+    let updated_region_attribute_value_id = region_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/region",
+            Some(serde_json::json!["us-poop-1"]),
+        )
+        .await;
+
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-poop-1",
+                "type": "configurationFrame",
+                "protected": false,
+            },
+
+            "domain": {
+                "region": "us-poop-1",
+            }
+        }], // actual
+        region_payload.component_view_properties_raw(ctx).await // expected
+    );
+
+    let validation_statuses = ValidationResolver::find_status(ctx, region_payload.component_id)
+        .await
+        .expect("could not find status for validation(s) of a given component");
+
+    let mut expected_validation_status = None;
+    for validation_status in &validation_statuses {
+        if validation_status.attribute_value_id == updated_region_attribute_value_id {
+            if expected_validation_status.is_some() {
+                panic!(
+                    "found more than one expected validation status: {:?}",
+                    validation_statuses
+                );
+            }
+            expected_validation_status = Some(validation_status.clone());
+        }
+    }
+    let expected_validation_status =
+        expected_validation_status.expect("did not find expected validation status");
+
+    let mut found_expected_validation_error = false;
+    for validation_error in &expected_validation_status.errors {
+        if validation_error.kind == ValidationErrorKind::StringNotInStringArray {
+            if found_expected_validation_error {
+                panic!(
+                    "found more than one expected validation error: {:?}",
+                    validation_error
+                );
+            }
+            found_expected_validation_error = true;
+        }
+    }
+    assert!(found_expected_validation_error);
+
+    let updated_region_attribute_value_id = region_payload
+        .update_attribute_value_for_prop_name(
+            ctx,
+            "/root/domain/region",
+            Some(serde_json::json!["us-east-1"]),
+        )
+        .await;
+
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-east-1",
+                "type": "configurationFrame",
+                "protected": false,
+            },
+            "domain": {
+                "region": "us-east-1",
+            },
+        }], // actual
+        region_payload.component_view_properties_raw(ctx).await // expected
+    );
+
+    // TODO(nick): now, ensure we have the right value! Huzzah.
+    let validation_statuses = ValidationResolver::find_status(ctx, region_payload.component_id)
+        .await
+        .expect("could not find status for validation(s) of a given component");
+
+    let mut expected_validation_status = None;
+    for validation_status in &validation_statuses {
+        if validation_status.attribute_value_id == updated_region_attribute_value_id {
+            if expected_validation_status.is_some() {
+                panic!(
+                    "found more than one expected validation status: {:?}",
+                    validation_statuses
+                );
+            }
+            expected_validation_status = Some(validation_status.clone());
+        }
+    }
+    let expected_validation_status =
+        expected_validation_status.expect("did not find expected validation status");
+    assert!(expected_validation_status.errors.is_empty());
+}
 
 #[test]
 async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
@@ -17,6 +124,17 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
     let region_payload = harness
         .create_component(ctx, "region", Builtin::AwsRegion)
         .await;
+
+    // Ensure the component type is a frame, which should be the default.
+    let region_component = region_payload.component(ctx).await;
+    let component_type = region_component
+        .get_type(ctx)
+        .await
+        .expect("could not get type");
+    assert_eq!(
+        ComponentType::ConfigurationFrame, // expected
+        component_type,                    // actual
+    );
 
     // Initialize the tail name field.
     region_payload
@@ -35,7 +153,6 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
                 "type": "configurationFrame",
                 "protected": false,
             },
-
             "domain": {
                 "region": "us-east-2",
             },
@@ -197,108 +314,211 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
 }
 
 #[test]
-async fn aws_region_field_validation(ctx: &DalContext) {
+async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalContext) {
     let mut harness = SchemaBuiltinsTestHarness::new();
+    let ec2_payload = harness
+        .create_component(ctx, "server", Builtin::AwsEc2)
+        .await;
     let region_payload = harness
         .create_component(ctx, "region", Builtin::AwsRegion)
         .await;
 
-    let updated_region_attribute_value_id = region_payload
+    // Switch the component type to a component, which should not be the default.
+    let region_component = region_payload.component(ctx).await;
+    let component_type = region_component
+        .get_type(ctx)
+        .await
+        .expect("could not get type");
+    assert_eq!(
+        ComponentType::ConfigurationFrame, // expected
+        component_type,                    // actual
+    );
+    region_component
+        .set_type(ctx, ComponentType::Component)
+        .await
+        .expect("could not set component type");
+    let updated_component_type = region_component
+        .get_type(ctx)
+        .await
+        .expect("could not get type");
+    assert_eq!(
+        ComponentType::Component, // expected
+        updated_component_type,   // actual
+    );
+
+    // Initialize the tail name field.
+    region_payload
         .update_attribute_value_for_prop_name(
             ctx,
             "/root/domain/region",
-            Some(serde_json::json!["us-poop-1"]),
+            Some(serde_json::json!["us-east-2"]),
         )
         .await;
 
+    // Ensure setup worked.
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "us-poop-1",
-                "type": "configurationFrame",
+                "name": "us-east-2",
+                "type": "component",
                 "protected": false,
             },
-
             "domain": {
-                "region": "us-poop-1",
-            }
-        }], // actual
-        region_payload.component_view_properties_raw(ctx).await // expected
+                "region": "us-east-2",
+            },
+        }], // expected
+        region_payload
+            .component_view_properties(ctx)
+            .await
+            .drop_qualification()
+            .to_value() // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "server",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "awsResourceType": "instance",
+                "tags": {
+                    "Name": "server",
+                },
+            },
+            "code": {
+                "si:generateAwsEc2JSON": {
+                    "code": "{\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"instance\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"server\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+        }], // expected
+        ec2_payload
+            .component_view_properties(ctx)
+            .await
+            .drop_qualification()
+            .to_value() // actual
     );
 
-    let validation_statuses = ValidationResolver::find_status(ctx, region_payload.component_id)
+    // Find the providers we need for connection.
+    let region_external_provider = ExternalProvider::find_for_schema_variant_and_name(
+        ctx,
+        region_payload.schema_variant_id,
+        "Region",
+    )
+    .await
+    .expect("cannot find external provider")
+    .expect("external provider not found");
+    let ec2_explicit_internal_provider =
+        InternalProvider::find_explicit_for_schema_variant_and_name(
+            ctx,
+            ec2_payload.schema_variant_id,
+            "Region",
+        )
         .await
-        .expect("could not find status for validation(s) of a given component");
+        .expect("cannot find explicit internal provider")
+        .expect("explicit internal provider not found");
 
-    let mut expected_validation_status = None;
-    for validation_status in &validation_statuses {
-        if validation_status.attribute_value_id == updated_region_attribute_value_id {
-            if expected_validation_status.is_some() {
-                panic!(
-                    "found more than one expected validation status: {:?}",
-                    validation_statuses
-                );
-            }
-            expected_validation_status = Some(validation_status.clone());
-        }
-    }
-    let expected_validation_status =
-        expected_validation_status.expect("did not find expected validation status");
+    // Finally, create the inter component connection.
+    Edge::connect_providers_for_components(
+        ctx,
+        *ec2_explicit_internal_provider.id(),
+        ec2_payload.component_id,
+        *region_external_provider.id(),
+        region_payload.component_id,
+    )
+    .await
+    .expect("could not connect providers");
 
-    let mut found_expected_validation_error = false;
-    for validation_error in &expected_validation_status.errors {
-        if validation_error.kind == ValidationErrorKind::StringNotInStringArray {
-            if found_expected_validation_error {
-                panic!(
-                    "found more than one expected validation error: {:?}",
-                    validation_error
-                );
-            }
-            found_expected_validation_error = true;
-        }
-    }
-    assert!(found_expected_validation_error);
+    // Ensure the view did not drift.
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-east-2",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "region": "us-east-2"
+            },
+        }], // expected
+        region_payload.component_view_properties_raw(ctx).await // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "server",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "awsResourceType": "instance",
+                "tags": {
+                    "Name": "server",
+                },
+            },
+            "code": {
+                "si:generateAwsEc2JSON": {
+                    "code": "{\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"instance\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"server\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+        }], // expected
+        ec2_payload
+            .component_view_properties(ctx)
+            .await
+            .drop_qualification()
+            .to_value() // actual
+    );
 
-    let updated_region_attribute_value_id = region_payload
+    // Perform update!
+    region_payload
         .update_attribute_value_for_prop_name(
             ctx,
             "/root/domain/region",
-            Some(serde_json::json!["us-east-1"]),
+            Some(serde_json::json!["us-west-2"]),
         )
         .await;
 
+    // Observed that it worked.
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "us-east-1",
-                "type": "configurationFrame",
+                "name": "us-west-2",
+                "type": "component",
                 "protected": false,
             },
             "domain": {
-                "region": "us-east-1",
+                "region": "us-west-2"
             },
-        }], // actual
-        region_payload.component_view_properties_raw(ctx).await // expected
+        }], // expected
+        region_payload.component_view_properties_raw(ctx).await // actual
     );
-
-    // TODO(nick): now, ensure we have the right value! Huzzah.
-    let validation_statuses = ValidationResolver::find_status(ctx, region_payload.component_id)
-        .await
-        .expect("could not find status for validation(s) of a given component");
-
-    let mut expected_validation_status = None;
-    for validation_status in &validation_statuses {
-        if validation_status.attribute_value_id == updated_region_attribute_value_id {
-            if expected_validation_status.is_some() {
-                panic!(
-                    "found more than one expected validation status: {:?}",
-                    validation_statuses
-                );
-            }
-            expected_validation_status = Some(validation_status.clone());
-        }
-    }
-    let expected_validation_status =
-        expected_validation_status.expect("did not find expected validation status");
-    assert!(expected_validation_status.errors.is_empty());
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "server",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "awsResourceType": "instance",
+                "region": "us-west-2",
+                "tags": {
+                    "Name": "server",
+                },
+            },
+            "code": {
+                "si:generateAwsEc2JSON": {
+                    "code": "{\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"instance\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"server\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+        }], // expected
+        ec2_payload
+            .component_view_properties(ctx)
+            .await
+            .drop_qualification()
+            .to_value() // actual
+    );
 }

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -58,7 +58,7 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
 
     // Finalize the schema variant and create the component.
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("unable to finalize schema variant");
 
@@ -104,15 +104,17 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
             {
                 "si": {
                     "name": "component",
-                },
-                "domain": {
-                    "poop": "canoe",
+                    "type": "component",
+                    "protected": false,
                 },
                 "code": {
                     "si:generateYAML": {
                         "code": "poop: canoe\n",
                         "format": "yaml",
                     },
+                },
+                "domain": {
+                    "poop": "canoe",
                 }
         }], // expected
         component_view.properties // actual

--- a/lib/dal/tests/integration_test/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/component/confirmation.rs
@@ -84,7 +84,7 @@ async fn add_and_run_confirmations(mut octx: DalContext, wid: WorkspaceId) {
 
     // Finalize the schema variant and create the component.
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("unable to finalize schema variant");
 
@@ -120,7 +120,9 @@ async fn add_and_run_confirmations(mut octx: DalContext, wid: WorkspaceId) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "domain": {},
             "confirmation": {
@@ -154,7 +156,9 @@ async fn add_and_run_confirmations(mut octx: DalContext, wid: WorkspaceId) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "domain": {},
             "resource": {
@@ -193,7 +197,9 @@ async fn add_and_run_confirmations(mut octx: DalContext, wid: WorkspaceId) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "domain": {},
             "resource": {

--- a/lib/dal/tests/integration_test/component/qualification.rs
+++ b/lib/dal/tests/integration_test/component/qualification.rs
@@ -76,7 +76,7 @@ async fn add_and_list_qualifications(ctx: &DalContext) {
 
     // Finalize the schema variant and create the component.
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("unable to finalize schema variant");
 
@@ -122,6 +122,8 @@ async fn add_and_list_qualifications(ctx: &DalContext) {
             {
                 "si": {
                     "name": "component",
+                    "type": "component",
+                    "protected": false
                 },
                 "domain": {
                     "poop": true,

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -92,7 +92,7 @@ async fn check_validations_for_component(ctx: &DalContext) {
 
     // Finalize schema
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -175,12 +175,13 @@ async fn check_validations_for_component(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "hundo_gecs"
+                "name": "hundo_gecs",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
+                "thousand_gecs": "wrongLyrics",
                 "the_tree_of_clues": "wrong song title",
-                "thousand_gecs": "wrongLyrics"
             }
         }], // actual
         ComponentView::new(ctx, *component.id())
@@ -254,12 +255,13 @@ async fn check_validations_for_component(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "hundo_gecs"
+                "name": "hundo_gecs",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
-                "the_tree_of_clues": "toothless",
-                "thousand_gecs": "stupidHorse"
+                "thousand_gecs": "stupidHorse",
+                "the_tree_of_clues": "toothless"
             }
         }], // actual
         ComponentView::new(ctx, *component.id())
@@ -331,7 +333,7 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
     .expect("unable to create validation prototype");
 
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("could not finalize");
 
@@ -385,8 +387,9 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
         serde_json::json!({
             "si": {
                 "name": "Danoth",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
                 "Tamarian": "Shaka, when the walls fell",
             }
@@ -469,8 +472,9 @@ async fn check_js_validation_for_component(ctx: &DalContext) {
         serde_json::json!({
             "si": {
                 "name": "Danoth",
+                "type": "component",
+                "protected": false
             },
-
             "domain": {
                 "Tamarian": "Temba, his arms open",
             }

--- a/lib/dal/tests/integration_test/component/view.rs
+++ b/lib/dal/tests/integration_test/component/view.rs
@@ -37,7 +37,7 @@ pub async fn create_schema_with_object_and_string_prop(
         create_prop_and_set_parent(ctx, PropKind::String, "bohemian_rhapsody", *queen_prop.id())
             .await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -93,7 +93,7 @@ pub async fn create_schema_with_nested_objects_and_string_prop(
     )
     .await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -136,7 +136,7 @@ pub async fn create_schema_with_string_props(
         create_prop_and_set_parent(ctx, PropKind::String, "killer_queen", root.domain_prop_id)
             .await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -165,7 +165,7 @@ pub async fn create_schema_with_array_of_string_props(
     let album_string_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "ignoreme", *sammy_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -218,7 +218,7 @@ pub async fn create_schema_with_nested_array_objects(
     )
     .await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -256,7 +256,7 @@ pub async fn create_simple_map(ctx: &DalContext) -> (Schema, SchemaVariant, Prop
     let album_item_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "album_ignore", *album_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -316,7 +316,7 @@ pub async fn create_schema_with_nested_array_objects_and_a_map(
     )
     .await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -401,16 +401,17 @@ async fn only_string_props(ctx: &DalContext) {
         serde_json::json![
             {
                 "si": {
-                    "name": "capoeira"
+                    "name": "capoeira",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
-                    "bohemian_rhapsody": "Galileo",
-                    "killer_queen": "woohoo"
+                    "killer_queen": "woohoo",
+                    "bohemian_rhapsody": "Galileo"
                 }
             }
-        ],
-        component_view.properties,
+        ], // expected
+        component_view.properties, // actual
     );
 }
 
@@ -500,17 +501,20 @@ async fn one_object_prop(ctx: &DalContext) {
         .expect("cannot get component view");
 
     assert_eq!(
-        component_view.properties,
         serde_json::json![{
-            "si": { "name": "santos dumont" },
-
+            "si": {
+                "name": "santos dumont",
+                "type": "component",
+                "protected": false,
+            },
             "domain": {
                 "queen": {
-                    "bohemian_rhapsody": "Galileo",
-                    "killer_queen": "woohoo"
+                    "killer_queen": "woohoo",
+                    "bohemian_rhapsody": "Galileo"
                 }
             }
-        }]
+        }], // expected
+        component_view.properties, // actual
     );
 }
 
@@ -651,16 +655,17 @@ async fn nested_object_prop(ctx: &DalContext) {
         serde_json::json![
             {
                 "si": {
-                    "name": "free ronaldinho"
+                    "name": "free ronaldinho",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "queen": {
-                        "bohemian_rhapsody": "scaramouche",
                         "killer_queen": "cake",
                         "under_pressure": {
                             "another_one_bites_the_dust": "another one gone"
-                        }
+                        },
+                        "bohemian_rhapsody": "scaramouche"
                     }
                 }
             }
@@ -744,9 +749,10 @@ async fn simple_array_of_strings(ctx: &DalContext) {
         serde_json::json![
             {
                 "si": {
-                    "name": "tim maia"
+                    "name": "tim maia",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "sammy_hagar": ["standing_hampton", "voa"]
                 }
@@ -981,8 +987,11 @@ async fn complex_nested_array_of_objects_and_arrays(ctx: &DalContext) {
 
     assert_eq!(
         serde_json::json![{
-            "si": {"name": "An Integralist Doesn't Run, It Flies"},
-
+            "si": {
+                "name": "An Integralist Doesn't Run, It Flies",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "sammy_hagar": [
                     {
@@ -1078,12 +1087,15 @@ async fn simple_map(ctx: &DalContext) {
 
     assert_eq!(
         serde_json::json![{
-            "si": {"name": "E como isso afeta o Grêmio?"},
-
+            "si": {
+                "name": "E como isso afeta o Grêmio?",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "albums": {
-                    "black_dahlia": "nocturnal",
                     "meshuggah": "destroy erase improve",
+                    "black_dahlia": "nocturnal"
                 }
             }
         }], // expected
@@ -1243,14 +1255,17 @@ async fn complex_nested_array_of_objects_with_a_map(ctx: &DalContext) {
 
     assert_eq!(
         serde_json::json![{
-            "si": { "name": "E como isso afeta o Grêmio?" },
-
+            "si": {
+                "name": "E como isso afeta o Grêmio?",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "sammy_hagar": [
                     {
                         "album": "standing_hampton",
                         "songs": [
-                            { "fall in love again": "good", "surrender": "ok"},
+                            { "surrender": "ok", "fall in love again": "good" },
                         ]
                     },
                 ]

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -48,7 +48,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
     .await
     .expect("could not create external provider");
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize schema variant");
 
@@ -193,13 +193,14 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
         serde_json::json![
             {
                 "si": {
-                    "name": "god-of-war"
+                    "name": "god-of-war",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "ragnarok": {
-                        "kratos": "poop",
-                        "atreus": "canoe"
+                        "atreus": "canoe",
+                        "kratos": "poop"
                     }
                 }
             }
@@ -305,7 +306,7 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
     let _canoe_prop =
         create_prop_and_set_parent(ctx, PropKind::String, "canoe", *map_item_prop.id()).await;
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize schema variant");
 
@@ -560,8 +561,9 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
             {
                 "si": {
                     "name": "the-game-awards-2022",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "map": {
                         "first": {
@@ -643,6 +645,8 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
             {
                 "si": {
                     "name": "the-game-awards-2022",
+                    "type": "component",
+                    "protected": false
                 },
                 "domain": {
                     "map": {

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -82,7 +82,7 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
 
     // Finalize the variant and create a component.
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("unable to finalize schema variant");
     let (component, _) = Component::new(ctx, "component", schema_variant_id)
@@ -96,12 +96,14 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
-            "domain": { },
             "code": {
                 "test:codeGeneration": {}
-            }
+            },
+            "domain": {},
         }], // expected
         component_view.properties // actual
     );
@@ -111,7 +113,9 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "domain": {}
         }], // expected
@@ -154,17 +158,19 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
-            },
-            "domain": {
-                "poop": "canoe"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "code": {
                 "test:codeGeneration": {
                     "code": "canoe",
                     "format": "json",
                 }
-            }
+            },
+            "domain": {
+                "poop": "canoe"
+            },
         }], // expected
         component_view.properties // actual
     );
@@ -174,7 +180,9 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
     assert_eq!(
         serde_json::json![{
             "si": {
-                "name": "component"
+                "name": "component",
+                "type": "component",
+                "protected": false
             },
             "domain": {
                 "poop": "canoe"

--- a/lib/dal/tests/integration_test/graph.rs
+++ b/lib/dal/tests/integration_test/graph.rs
@@ -163,7 +163,7 @@ impl ConfigurationGraphConstructor {
         .expect("could not create external provider with socket");
 
         schema_variant
-            .finalize(ctx)
+            .finalize(ctx, None)
             .await
             .expect("could not finalize schema variant");
 

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -21,26 +21,28 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // Ensure setup went as expected.
     assert_eq!(
         serde_json::json![{
-            "domain": {
-                "object": {
-                    "intermediate": "zero-intermediate",
-                    "source": "zero-source",
-                },
-            },
-
             "si": {
                 "name": "esp",
+                "type": "component",
+                "protected": false
+            },
+            "domain": {
+                "object": {
+                    "source": "zero-source",
+                    "intermediate": "zero-intermediate",
+                },
             },
         }], // expected
         esp_payload.component_view_properties_raw(ctx).await // actual
     );
     assert_eq!(
         serde_json::json![{
-
-            "domain": {},
             "si": {
                 "name": "swings",
-            }
+                "type": "component",
+                "protected": false
+            },
+            "domain": {},
         }], // expected
         swings_payload.component_view_properties_raw(ctx).await // actual
     );
@@ -96,26 +98,28 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // Ensure that they look as we expect.
     assert_eq!(
         serde_json::json![{
-
-            "domain": {
-                "object": {
-                    "intermediate": "one",
-                    "source": "one",
-                },
-            },
             "si": {
                 "name": "esp",
+                "type": "component",
+                "protected": false
+            },
+            "domain": {
+                "object": {
+                    "source": "one",
+                    "intermediate": "one",
+                },
             },
         }], // expected
         esp_payload.component_view_properties_raw(ctx).await // actual
     );
     assert_eq!(
         serde_json::json![{
-
-            "domain": {},
             "si": {
                 "name": "swings",
-            }
+                "type": "component",
+                "protected": false
+            },
+            "domain": {},
         }], // expected
         swings_payload.component_view_properties_raw(ctx).await // actual
     );
@@ -196,26 +200,28 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // component identity update working.
     assert_eq!(
         serde_json::json![{
-
+            "si": {
+                "name": "esp",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "object": {
                     "intermediate": "one",
                     "source": "one",
                 },
             },
-            "si": {
-                "name": "esp",
-            },
         }], // expected
         esp_payload.component_view_properties_raw(ctx).await // actual
     );
     assert_eq!(
         serde_json::json![{
-
-            "domain": {},
             "si": {
                 "name": "swings",
-            }
+                "type": "component",
+                "protected": false
+            },
+            "domain": {},
         }], // expected
         swings_payload.component_view_properties_raw(ctx).await // actual
     );
@@ -234,26 +240,28 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // Ensure that both components continue to look as we expect.
     assert_eq!(
         serde_json::json![{
-
+            "si": {
+                "name": "esp",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "object": {
                     "intermediate": "one",
                     "source": "one",
                 },
             },
-            "si": {
-                "name": "esp",
-            },
         }], // expected
         esp_payload.component_view_properties_raw(ctx).await // actual
     );
     assert_eq!(
         serde_json::json![{
-
-            "domain": {},
             "si": {
                 "name": "swings",
-            }
+                "type": "component",
+                "protected": false
+            },
+            "domain": {},
         }], // expected
         swings_payload.component_view_properties_raw(ctx).await // actual
     );
@@ -270,27 +278,29 @@ async fn inter_component_identity_update(ctx: &DalContext) {
     // Observe that inter component identity updating work.
     assert_eq!(
         serde_json::json![{
-
+            "si": {
+                "name": "esp",
+                "type": "component",
+                "protected": false
+            },
             "domain": {
                 "object": {
                     "intermediate": "two",
                     "source": "two",
                 },
             },
-            "si": {
-                "name": "esp",
-            },
         }], // expected
         esp_payload.component_view_properties_raw(ctx).await // actual
     );
     assert_eq!(
         serde_json::json![{
-
-            "domain": {
-                "destination": "two",
-            },
             "si": {
                 "name": "swings",
+                "type": "component",
+                "protected": false
+            },
+            "domain": {
+                "destination": "two",
             },
         }], // expected
         swings_payload.component_view_properties_raw(ctx).await // actual
@@ -319,7 +329,7 @@ async fn setup_esp(ctx: &DalContext) -> ComponentPayload {
         create_prop_and_set_parent(ctx, PropKind::String, "intermediate", *object_prop.id()).await;
 
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemaVariant");
 
@@ -389,7 +399,7 @@ async fn setup_swings(ctx: &DalContext) -> ComponentPayload {
     .await;
 
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize SchemVariant");
 
@@ -458,7 +468,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     )
     .await;
     source_schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize source SchemaVariant");
 
@@ -528,7 +538,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
     )
     .await;
     destination_schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("cannot finalize destination SchemaVariant");
 
@@ -591,8 +601,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Source Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {},
             }
         ],
@@ -615,8 +626,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Destination Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {},
             }
         ],
@@ -694,8 +706,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Source Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "base_object": {
                         "foo_string": "deep update",
@@ -714,8 +727,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Destination Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "parent_object": {
                         "base_object": {
@@ -778,8 +792,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Source Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "base_object": {
                         "foo_string": "deep update",
@@ -799,8 +814,9 @@ async fn with_deep_data_structure(ctx: &DalContext) {
             {
                 "si": {
                     "name": "Destination Component",
+                    "type": "component",
+                    "protected": false
                 },
-
                 "domain": {
                     "parent_object": {
                         "base_object": {

--- a/lib/dal/tests/integration_test/validation_resolver.rs
+++ b/lib/dal/tests/integration_test/validation_resolver.rs
@@ -51,7 +51,7 @@ async fn new(ctx: &DalContext) {
     .expect("unable to create validation prototype");
 
     schema_variant
-        .finalize(ctx)
+        .finalize(ctx, None)
         .await
         .expect("could not finalize schema variant");
     let component = create_component_for_schema(ctx, schema.id()).await;

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -51,6 +51,8 @@ pub enum ComponentError {
     Node(#[from] NodeError),
     #[error("diagram error: {0}")]
     Diagram(#[from] DiagramError),
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
 
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),

--- a/lib/sdf/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/insert_property_editor_value.rs
@@ -1,5 +1,7 @@
 use axum::Json;
-use dal::{AttributeContext, AttributeValue, AttributeValueId, Visibility, WsEvent};
+use dal::{
+    AttributeContext, AttributeValue, AttributeValueId, ComponentId, PropId, Visibility, WsEvent,
+};
 use serde::{Deserialize, Serialize};
 
 use super::ComponentResult;
@@ -9,7 +11,8 @@ use crate::server::extract::{AccessBuilder, HandlerContext};
 #[serde(rename_all = "camelCase")]
 pub struct InsertPropertyEditorValueRequest {
     pub parent_attribute_value_id: AttributeValueId,
-    pub attribute_context: AttributeContext,
+    pub prop_id: PropId,
+    pub component_id: ComponentId,
     pub value: Option<serde_json::Value>,
     pub key: Option<String>,
     #[serde(flatten)]
@@ -29,9 +32,13 @@ pub async fn insert_property_editor_value(
 ) -> ComponentResult<Json<InsertPropertyEditorValueResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
+    let attribute_context = AttributeContext::builder()
+        .set_prop_id(request.prop_id)
+        .set_component_id(request.component_id)
+        .to_context()?;
     let _ = AttributeValue::insert_for_context(
         &ctx,
-        request.attribute_context,
+        attribute_context,
         request.parent_attribute_value_id,
         request.value,
         request.key,

--- a/lib/sdf/src/server/service/component/set_type.rs
+++ b/lib/sdf/src/server/service/component/set_type.rs
@@ -1,10 +1,6 @@
 use axum::Json;
-use dal::attribute::context::AttributeContextBuilder;
-use dal::{
-    AttributeContext, AttributePrototype, AttributePrototypeArgument, AttributeReadContext,
-    AttributeValue, AttributeValueId, Component, ExternalProvider, ExternalProviderId, Func,
-    FuncBinding, InternalProvider, InternalProviderId, PropId, StandardModel, Visibility, WsEvent,
-};
+
+use dal::{Component, ComponentId, ComponentType, StandardModel, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 use super::ComponentResult;
@@ -13,214 +9,36 @@ use crate::service::component::ComponentError;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct UpdatePropertyEditorValueRequest {
-    pub attribute_value_id: AttributeValueId,
-    pub parent_attribute_value_id: Option<AttributeValueId>,
-    pub attribute_context: AttributeContext,
+pub struct SetTypeRequest {
+    pub component_id: ComponentId,
     pub value: Option<serde_json::Value>,
-    pub key: Option<String>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct UpdatePropertyEditorValueResponse {
+pub struct SetTypeRequestResponse {
     success: bool,
 }
 
 pub async fn set_type(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    Json(request): Json<UpdatePropertyEditorValueRequest>,
-) -> ComponentResult<Json<UpdatePropertyEditorValueResponse>> {
+    Json(request): Json<SetTypeRequest>,
+) -> ComponentResult<Json<SetTypeRequestResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let (_, _) = AttributeValue::update_for_context(
-        &ctx,
-        request.attribute_value_id,
-        request.parent_attribute_value_id,
-        request.attribute_context,
-        request.value.clone(),
-        request.key,
-    )
-    .await?;
-
-    let component_id = request.attribute_context.component_id();
-
-    let component = Component::get_by_id(&ctx, &component_id)
+    let component = Component::get_by_id(&ctx, &request.component_id)
         .await?
         .ok_or(ComponentError::ComponentNotFound)?;
 
-    let schema_variant = component
-        .schema_variant(&ctx)
-        .await?
-        .ok_or(ComponentError::SchemaVariantNotFound)?;
-
-    let external_providers =
-        ExternalProvider::list_for_schema_variant(&ctx, *schema_variant.id()).await?;
-
-    let internal_providers =
-        InternalProvider::list_explicit_for_schema_variant(&ctx, *schema_variant.id()).await?;
-
-    if let Some(value) = request.value {
-        if value == "aggregationFrame" {
-            let func_id = *Func::find_by_attr(&ctx, "name", &"si:identity")
-                .await?
-                .first()
-                .ok_or(ComponentError::IdentityFuncNotFound)?
-                .id();
-
-            let (func_binding, fbrv) = FuncBinding::create_and_execute(
-                &ctx,
-                serde_json::json![{ "identity": null }],
-                func_id,
-            )
-            .await?;
-
-            for external_provider in external_providers {
-                let attribute_read_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(InternalProviderId::NONE),
-                    external_provider_id: Some(*external_provider.id()),
-                    component_id: Some(component_id),
-                };
-
-                let attr_write_context =
-                    AttributeContextBuilder::from(attribute_read_context).to_context()?;
-
-                let attribute_value =
-                    AttributeValue::find_for_context(&ctx, attribute_read_context)
-                        .await?
-                        .ok_or(ComponentError::AttributeValueNotFound)?;
-
-                if attribute_value.context.is_component_unset() {
-                    AttributePrototype::new(
-                        &ctx,
-                        func_id,
-                        *func_binding.id(),
-                        *fbrv.id(),
-                        attr_write_context,
-                        None,
-                        None,
-                    )
-                    .await?;
-                } else {
-                    AttributePrototype::new_with_existing_value(
-                        &ctx,
-                        func_id,
-                        attr_write_context,
-                        None,
-                        None,
-                        *attribute_value.id(),
-                    )
-                    .await?;
-                };
-            }
-
-            for internal_provider in internal_providers {
-                let attribute_read_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(*internal_provider.id()),
-                    external_provider_id: Some(ExternalProviderId::NONE),
-                    component_id: Some(component_id),
-                };
-
-                let attr_write_context =
-                    AttributeContextBuilder::from(attribute_read_context).to_context()?;
-
-                let attribute_value =
-                    AttributeValue::find_for_context(&ctx, attribute_read_context)
-                        .await?
-                        .ok_or(ComponentError::AttributeValueNotFound)?;
-
-                let prototype = attribute_value
-                    .attribute_prototype(&ctx)
-                    .await?
-                    .ok_or(ComponentError::AttributePrototypeNotFound)?;
-
-                let arguments = AttributePrototypeArgument::find_by_attr(
-                    &ctx,
-                    "attribute_prototype_id",
-                    prototype.id(),
-                )
-                .await?;
-
-                let new_prototype = if attribute_value.context.is_component_unset() {
-                    AttributePrototype::new(
-                        &ctx,
-                        func_id,
-                        *func_binding.id(),
-                        *fbrv.id(),
-                        attr_write_context,
-                        None,
-                        None,
-                    )
-                    .await?
-                } else {
-                    AttributePrototype::new_with_existing_value(
-                        &ctx,
-                        func_id,
-                        attr_write_context,
-                        None,
-                        None,
-                        *attribute_value.id(),
-                    )
-                    .await?
-                };
-
-                for argument in arguments {
-                    AttributePrototypeArgument::new_for_inter_component(
-                        &ctx,
-                        *new_prototype.id(),
-                        argument.func_argument_id(),
-                        argument.head_component_id(),
-                        argument.tail_component_id(),
-                        argument.external_provider_id(),
-                    )
-                    .await?;
-                }
-            }
-        } else {
-            for external_provider in external_providers {
-                let attribute_read_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(InternalProviderId::NONE),
-                    external_provider_id: Some(*external_provider.id()),
-                    component_id: Some(component_id),
-                };
-
-                let mut attribute_value =
-                    AttributeValue::find_for_context(&ctx, attribute_read_context)
-                        .await?
-                        .ok_or(ComponentError::AttributeValueNotFound)?;
-
-                if !attribute_value.context.is_component_unset() {
-                    attribute_value.unset_attribute_prototype(&ctx).await?;
-                    attribute_value.delete_by_id(&ctx).await?;
-                }
-            }
-
-            for internal_provider in internal_providers {
-                let attribute_read_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(*internal_provider.id()),
-                    external_provider_id: Some(ExternalProviderId::NONE),
-                    component_id: Some(component_id),
-                };
-
-                let mut attribute_value =
-                    AttributeValue::find_for_context(&ctx, attribute_read_context)
-                        .await?
-                        .ok_or(ComponentError::AttributeValueNotFound)?;
-
-                if !attribute_value.context.is_component_unset() {
-                    attribute_value.unset_attribute_prototype(&ctx).await?;
-                    attribute_value.delete_by_id(&ctx).await?;
-                }
-            }
-        }
-    }
+    // If no type was found, default to a standard "component".
+    let component_type: ComponentType = match request.value {
+        Some(value) => serde_json::from_value(value)?,
+        None => ComponentType::Component,
+    };
+    component.set_type(&ctx, component_type).await?;
 
     WsEvent::change_set_written(&ctx)
         .await?
@@ -229,5 +47,5 @@ pub async fn set_type(
 
     ctx.commit().await?;
 
-    Ok(Json(UpdatePropertyEditorValueResponse { success: true }))
+    Ok(Json(SetTypeRequestResponse { success: true }))
 }

--- a/lib/sdf/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/update_property_editor_value.rs
@@ -1,5 +1,7 @@
 use axum::Json;
-use dal::{AttributeContext, AttributeValue, AttributeValueId, Visibility, WsEvent};
+use dal::{
+    AttributeContext, AttributeValue, AttributeValueId, ComponentId, PropId, Visibility, WsEvent,
+};
 use serde::{Deserialize, Serialize};
 
 use super::ComponentResult;
@@ -10,7 +12,8 @@ use crate::server::extract::{AccessBuilder, HandlerContext};
 pub struct UpdatePropertyEditorValueRequest {
     pub attribute_value_id: AttributeValueId,
     pub parent_attribute_value_id: Option<AttributeValueId>,
-    pub attribute_context: AttributeContext,
+    pub prop_id: PropId,
+    pub component_id: ComponentId,
     pub value: Option<serde_json::Value>,
     pub key: Option<String>,
     #[serde(flatten)]
@@ -30,11 +33,15 @@ pub async fn update_property_editor_value(
 ) -> ComponentResult<Json<UpdatePropertyEditorValueResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
+    let attribute_context = AttributeContext::builder()
+        .set_prop_id(request.prop_id)
+        .set_component_id(request.component_id)
+        .to_context()?;
     let (_, _) = AttributeValue::update_for_context(
         &ctx,
         request.attribute_value_id,
         request.parent_attribute_value_id,
-        request.attribute_context,
+        attribute_context,
         request.value,
         request.key,
     )

--- a/lib/sdf/tests/service_tests/component.rs
+++ b/lib/sdf/tests/service_tests/component.rs
@@ -37,7 +37,7 @@ async fn list_components_identification() {
     let schema = create_schema(&dal_ctx).await;
     let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
-        .finalize(&dal_ctx)
+        .finalize(&dal_ctx, None)
         .await
         .expect("unable to finalize schema variant");
 
@@ -149,7 +149,7 @@ async fn get_components_metadata() {
 
     let mut schema_variant = create_schema_variant(&dal_ctx, *schema.id()).await;
     schema_variant
-        .finalize(&dal_ctx)
+        .finalize(&dal_ctx, None)
         .await
         .expect("could not finalize schema variant");
 


### PR DESCRIPTION
### UPDATE: the bug was fixed indirectly when moving "protected" and "type" to the `RootProp` creation methods. This also may explain why the fields were not showing up in `ComponentViews`: it was likely a setup issue that caused undesired behavior. Keeping the PR description mostly in tact, but I'll emphasize: the bug was indirectly fixed during refactoring, so language and comments implying that it has not yet been fixed are outdated.

## Description

This PR primarily focuses on refactoring the `set_type` logic for fixing a bug related to AWS Region no longer working as a standard component (despite it working as a frame).

It also includes some refactoring along the way, a new identity finder module, a reduction in request fields for the `set_type` route, and more changes.

This PR may also be a good PR for those wanting to learn more a little bit about our domain layout, what goes in `sdf` vs. the `dal`, writing queries and integration tests for them, and using our domain-driven architecture to find bugs via integration tests.

It's a bit of a weird PR since the original bug that started this journey was not actually fixed here. However, all the little side changes and such likely makes this a more palatable example for where to start with regards to the the integration feedback loop than a net-new big feature or in-depth bug fix PR.

## Note to Reviewers

This PR contains more comments than usual in light of the aforementioned comment: this may be a good PR for those wanting to learn a bunch of a stuff. Here are some comments worth pointing out:

- [Primary motivation behind this PR](https://github.com/systeminit/si/pull/1702#discussion_r1080627466)
- [Strongly typed enums serialized for intended use on a string field](https://github.com/systeminit/si/pull/1702#discussion_r1080625835)
- [Showcasing the feedback loop for writing an integration test using a new query, a new method and the new enum](https://github.com/systeminit/si/pull/1702#discussion_r1080628814)
- [Quick way to know if your query works](https://github.com/systeminit/si/pull/1702#discussion_r1080629731)
- [Benefits of moving `set_type` logic to the `dal`](https://github.com/systeminit/si/pull/1702#discussion_r1080630104)

## Commit Description

```
Primary:
- Fix AWS Region bug where being a component does not work (likely fixed
  from moving to the root prop setup process)
  - This is also likely why the component views for the integration
    tests now contain both the "protected" and the "type" fields under
    the "si" tree
- Refactor "set_type" logic for finding bugs related to AWS Region
  working a regular component (not a frame)
- Move "type" and "protected" props to the root prop module
- Add "type" and "protected" initialization to schema variant
  finalization (with the ability to set defaults)

Secondary:
- Reduce the request requirements for the "set_type" route (less work
  for sdf and app)
- Add queries for finding "type" and "si" child props

Builtins:
- Remove special finalize wrapper
- For AWS Region and Generic Frame, use the new finalize logic for
  setting the type

Identity:
- Add "identity" submodule for func for the purpose of finding the
  identity func outside of builtins
- Replace all manual queries of "identity" and its corresponding data
  with new functions from the "identity" module

Organization:
- Move component status and component validation content to sub modules
  of component

Misc:
- Delete unused "get_resource" component query
```