### PR TITLE
Add frame socket kind and related queries (ENG-955)

### DIFF
--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -355,7 +355,7 @@ pub async fn create_schema_variant_with_root(
     let input_socket = Socket::new(
         ctx,
         "input",
-        SocketKind::Provider,
+        SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationInput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
@@ -370,7 +370,7 @@ pub async fn create_schema_variant_with_root(
     let output_socket = Socket::new(
         ctx,
         "output",
-        SocketKind::Provider,
+        SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationOutput,
         &SocketArity::Many,
         &DiagramKind::Configuration,

--- a/lib/dal/src/builtins/schema/aws/core.rs
+++ b/lib/dal/src/builtins/schema/aws/core.rs
@@ -18,8 +18,8 @@ use crate::{
 use crate::{
     attribute::context::AttributeContextBuilder, func::argument::FuncArgument, ActionPrototype,
     ActionPrototypeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
-    BuiltinsResult, DalContext, DiagramKind, ExternalProvider, Func, InternalProvider, PropKind,
-    SchemaError, StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
+    BuiltinsResult, DalContext, ExternalProvider, Func, InternalProvider, PropKind, SchemaError,
+    StandardModel, WorkflowPrototype, WorkflowPrototypeContext,
 };
 use crate::{AttributeValueError, SchemaVariant};
 
@@ -153,7 +153,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -166,7 +166,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -477,7 +477,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -490,7 +490,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -503,7 +503,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -516,7 +516,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?; // TODO(wendy) - Can an EC2 instance have multiple regions? Idk!
 
@@ -529,7 +529,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -955,7 +955,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -1174,7 +1174,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -1190,7 +1190,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -1579,7 +1579,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -1593,7 +1593,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?; // TODO(wendy) - Can a key pair have multiple regions? Idk!
 

--- a/lib/dal/src/builtins/schema/aws/vpc.rs
+++ b/lib/dal/src/builtins/schema/aws/vpc.rs
@@ -11,9 +11,9 @@ use crate::{
 use crate::{
     attribute::context::AttributeContextBuilder, func::argument::FuncArgument, ActionPrototype,
     ActionPrototypeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
-    AttributeValueError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider, Func,
-    FuncBinding, InternalProvider, PropKind, SchemaError, SchemaVariant, StandardModel,
-    WorkflowPrototype, WorkflowPrototypeContext,
+    AttributeValueError, BuiltinsResult, DalContext, ExternalProvider, Func, FuncBinding,
+    InternalProvider, PropKind, SchemaError, SchemaVariant, StandardModel, WorkflowPrototype,
+    WorkflowPrototypeContext,
 };
 use crate::{
     builtins::schema::aws::{AWS_NODE_COLOR, EC2_TAG_DOCS_URL},
@@ -259,7 +259,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -273,7 +273,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -286,7 +286,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -824,7 +824,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -837,7 +837,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -1256,7 +1256,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -1281,7 +1281,7 @@ impl MigrationDriver {
                 *transformation_func_binding.id(),
                 *transformation_func_binding_return_value.id(),
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 

--- a/lib/dal/src/builtins/schema/docker.rs
+++ b/lib/dal/src/builtins/schema/docker.rs
@@ -6,9 +6,9 @@ use crate::{builtins::schema::MigrationDriver, schema::variant::leaves::LeafInpu
 use crate::{
     component::ComponentKind, edit_field::widget::*, socket::SocketArity, ActionPrototype,
     ActionPrototypeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
-    AttributeValueError, BuiltinsError, BuiltinsResult, DalContext, DiagramKind, ExternalProvider,
-    Func, InternalProvider, Prop, PropKind, SchemaError, SchemaVariant, StandardModel,
-    WorkflowPrototype, WorkflowPrototypeContext,
+    AttributeValueError, BuiltinsError, BuiltinsResult, DalContext, ExternalProvider, Func,
+    InternalProvider, Prop, PropKind, SchemaError, SchemaVariant, StandardModel, WorkflowPrototype,
+    WorkflowPrototypeContext,
 };
 
 // Reference: https://www.docker.com/company/newsroom/media-resources/
@@ -83,7 +83,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -145,7 +145,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -159,7 +159,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -173,7 +173,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/kubernetes.rs
+++ b/lib/dal/src/builtins/schema/kubernetes.rs
@@ -4,8 +4,7 @@ use crate::{component::ComponentKind, schema::variant::leaves::LeafInput};
 use crate::{
     func::argument::FuncArgument, socket::SocketArity, AttributePrototypeArgument,
     AttributeReadContext, AttributeValue, AttributeValueError, BuiltinsError, BuiltinsResult,
-    DalContext, DiagramKind, ExternalProvider, InternalProvider, PropKind, SchemaVariant,
-    StandardModel,
+    DalContext, ExternalProvider, InternalProvider, PropKind, SchemaVariant, StandardModel,
 };
 
 mod kubernetes_deployment_spec;
@@ -108,7 +107,7 @@ impl MigrationDriver {
             identity_func_item.func_binding_id,
             identity_func_item.func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await?;
 
@@ -293,7 +292,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 
@@ -306,7 +305,7 @@ impl MigrationDriver {
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await?;
 

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -134,6 +134,7 @@ pub use job_failure::{JobFailure, JobFailureError, JobFailureResult};
 pub use jwt_key::{create_jwt_key_if_missing, JwtSecretKey};
 pub use key_pair::{KeyPair, KeyPairError, KeyPairResult, PublicKey};
 pub use label_list::{LabelEntry, LabelList, LabelListError};
+pub use node::NodeId;
 pub use node::{Node, NodeError, NodeKind};
 pub use node_menu::NodeMenuError;
 pub use node_position::{

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -112,7 +112,7 @@ impl ExternalProvider {
         func_binding_id: FuncBindingId,
         func_binding_return_value_id: FuncBindingReturnValueId,
         arity: SocketArity,
-        diagram_kind: DiagramKind,
+        frame_socket: bool,
     ) -> ExternalProviderResult<(Self, Socket)> {
         let name = name.as_ref();
         let row = ctx
@@ -154,10 +154,13 @@ impl ExternalProvider {
         let socket = Socket::new(
             ctx,
             name,
-            SocketKind::Provider,
+            match frame_socket {
+                true => SocketKind::Frame,
+                false => SocketKind::Provider,
+            },
             &SocketEdgeKind::ConfigurationOutput,
             &arity,
-            &diagram_kind,
+            &DiagramKind::Configuration,
         )
         .await?;
         socket

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -290,7 +290,7 @@ impl InternalProvider {
         func_binding_id: FuncBindingId,
         func_binding_return_value_id: FuncBindingReturnValueId,
         arity: SocketArity,
-        diagram_kind: DiagramKind,
+        frame_socket: bool,
     ) -> InternalProviderResult<(Self, Socket)> {
         let name = name.as_ref();
         let prop_id = PropId::NONE;
@@ -338,10 +338,13 @@ impl InternalProvider {
         let socket = Socket::new(
             ctx,
             name,
-            SocketKind::Provider,
+            match frame_socket {
+                true => SocketKind::Frame,
+                false => SocketKind::Provider,
+            },
             &SocketEdgeKind::ConfigurationInput,
             &arity,
-            &diagram_kind,
+            &DiagramKind::Configuration,
         )
         .await?;
         socket

--- a/lib/dal/src/queries/socket/find_frame_socket_for_node.sql
+++ b/lib/dal/src/queries/socket/find_frame_socket_for_node.sql
@@ -1,0 +1,11 @@
+SELECT row_to_json(sockets.*) AS object
+FROM sockets_v1($1, $2) as sockets
+         JOIN socket_many_to_many_schema_variants_v1($1, $2) as socket_to_schema_variant
+              ON sockets.id = socket_to_schema_variant.left_object_id
+                  AND sockets.edge_kind = $4
+                  AND sockets.kind = 'frame'
+         JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
+              ON component_belongs_to_schema_variant.belongs_to_id = socket_to_schema_variant.right_object_id
+         JOIN node_belongs_to_component_v1($1, $2) as node_belongs_to_component
+              ON node_belongs_to_component.belongs_to_id = component_belongs_to_schema_variant.object_id
+                  AND node_belongs_to_component.object_id = $3;

--- a/lib/dal/src/queries/socket/list_for_component.sql
+++ b/lib/dal/src/queries/socket/list_for_component.sql
@@ -1,0 +1,7 @@
+SELECT row_to_json(sockets.*) AS object
+FROM sockets_v1($1, $2) as sockets
+         JOIN socket_many_to_many_schema_variants_v1($1, $2) as socket_to_schema_variant
+              ON sockets.id = socket_to_schema_variant.left_object_id
+         JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
+              ON component_belongs_to_schema_variant.belongs_to_id = socket_to_schema_variant.right_object_id
+                  AND component_belongs_to_schema_variant.object_id = $3;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -20,10 +20,10 @@ use crate::{
     standard_model::{self, objects_from_rows},
     standard_model_accessor, standard_model_belongs_to, standard_model_many_to_many,
     AttributeContextBuilderError, AttributePrototypeArgumentError, AttributePrototypeError,
-    AttributeValueError, AttributeValueId, BuiltinsError, DalContext, DiagramKind,
-    ExternalProvider, ExternalProviderError, Func, FuncError, HistoryEventError, InternalProvider,
-    Prop, PropError, PropId, PropKind, Schema, SchemaId, SocketArity, StandardModel,
-    StandardModelError, Timestamp, Visibility, WriteTenancy, WsEventError,
+    AttributeValueError, AttributeValueId, BuiltinsError, DalContext, ExternalProvider,
+    ExternalProviderError, Func, FuncError, HistoryEventError, InternalProvider, Prop, PropError,
+    PropId, PropKind, Schema, SchemaId, SocketArity, StandardModel, StandardModelError, Timestamp,
+    Visibility, WriteTenancy, WsEventError,
 };
 use crate::{AttributeReadContext, AttributeValue, RootPropChild};
 use crate::{FuncBackendResponseType, FuncId};
@@ -204,7 +204,7 @@ impl SchemaVariant {
             *identity_func_binding.id(),
             *identity_func_binding_return_value.id(),
             SocketArity::Many,
-            DiagramKind::Configuration,
+            true,
         )
         .await?;
 
@@ -218,7 +218,7 @@ impl SchemaVariant {
             *identity_func_binding.id(),
             *identity_func_binding_return_value.id(),
             SocketArity::One,
-            DiagramKind::Configuration,
+            true,
         )
         .await?;
 

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -8,9 +8,8 @@ use std::collections::HashMap;
 
 use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};
 use crate::{
-    edit_field::widget::WidgetKind, DalContext, DiagramKind, ExternalProvider, Func,
-    InternalProvider, Prop, PropId, PropKind, RootProp, SchemaId, SchemaVariant, SocketArity,
-    StandardModel,
+    edit_field::widget::WidgetKind, DalContext, ExternalProvider, Func, InternalProvider, Prop,
+    PropId, PropKind, RootProp, SchemaId, SchemaVariant, SocketArity, StandardModel,
 };
 
 /// A cache of [`PropIds`](crate::Prop) where the _key_ is a tuple corresponding to the
@@ -191,7 +190,7 @@ impl SchemaVariant {
                     identity_func_binding_id,
                     identity_func_binding_return_value_id,
                     arity,
-                    DiagramKind::Configuration,
+                    false,
                 )
                 .await?;
                 explicit_internal_providers.push(explicit_internal_provider);
@@ -212,7 +211,7 @@ impl SchemaVariant {
                     identity_func_binding_id,
                     identity_func_binding_return_value_id,
                     arity,
-                    DiagramKind::Configuration,
+                    false,
                 )
                 .await?;
                 external_providers.push(external_provider);

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -6,11 +6,15 @@ use thiserror::Error;
 
 use crate::{
     impl_standard_model, label_list::ToLabelList, pk, standard_model, standard_model_accessor,
-    standard_model_belongs_to, standard_model_many_to_many, DalContext, DiagramKind,
+    standard_model_belongs_to, standard_model_many_to_many, ComponentId, DalContext, DiagramKind,
     ExternalProvider, ExternalProviderId, HistoryEventError, InternalProvider, InternalProviderId,
-    SchemaVariant, SchemaVariantId, StandardModel, StandardModelError, Timestamp, Visibility,
-    WriteTenancy,
+    NodeId, SchemaVariant, SchemaVariantId, StandardModel, StandardModelError, Timestamp,
+    Visibility, WriteTenancy,
 };
+
+const FIND_FRAME_SOCKET_FOR_NODE: &str =
+    include_str!("queries/socket/find_frame_socket_for_node.sql");
+const LIST_FOR_COMPONENT: &str = include_str!("queries/socket/list_for_component.sql");
 
 #[derive(Error, Debug)]
 pub enum SocketError {
@@ -46,8 +50,15 @@ pk!(SocketId);
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum SocketKind {
-    /// Indicates that this [`Socket`](Socket) was created alongside a [`provider`](crate::provider).
+    /// Indicates that this [`Socket`](Socket) is for use with "frames"  _and_ was created
+    /// alongside [`provider`](crate::provider).
+    Frame,
+    /// Indicates that this [`Socket`](Socket) was created alongside a
+    /// [`provider`](crate::provider).
     Provider,
+    /// Indicates that this [`Socket`](Socket) was _not_ created alongside a
+    /// [`provider`](crate::provider).
+    Standalone,
 }
 
 #[derive(
@@ -183,4 +194,45 @@ impl Socket {
         returns: ExternalProvider,
         result: SocketResult,
     );
+
+    /// Finds the "Frame" [`Socket`] for a given [`Node`](crate::Node) and
+    /// [`SocketEdgeKind`].
+    #[instrument(skip_all)]
+    pub async fn find_frame_socket_for_node(
+        ctx: &DalContext,
+        node_id: NodeId,
+        socket_edge_kind: SocketEdgeKind,
+    ) -> SocketResult<Self> {
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                FIND_FRAME_SOCKET_FOR_NODE,
+                &[
+                    ctx.read_tenancy(),
+                    ctx.visibility(),
+                    &node_id,
+                    &socket_edge_kind.as_ref(),
+                ],
+            )
+            .await?;
+        Ok(standard_model::object_from_row(row)?)
+    }
+
+    /// List all [`Sockets`](Self) for the given [`ComponentId`](crate::Component).
+    #[instrument(skip_all)]
+    pub async fn list_for_component(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> SocketResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_FOR_COMPONENT,
+                &[ctx.read_tenancy(), ctx.visibility(), &component_id],
+            )
+            .await?;
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
 }

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -1,8 +1,8 @@
 use dal::{
     func::backend::js_command::CommandRunResult, generate_name, AttributePrototypeArgument,
     AttributeReadContext, AttributeValue, ChangeSet, ChangeSetStatus, Component, ComponentType,
-    ComponentView, DalContext, DiagramKind, Edge, ExternalProvider, InternalProvider, Prop, PropId,
-    PropKind, SchemaVariant, SocketArity, StandardModel, Visibility, WorkspaceId,
+    ComponentView, DalContext, Edge, ExternalProvider, InternalProvider, Prop, PropId, PropKind,
+    SchemaVariant, SocketArity, StandardModel, Visibility, WorkspaceId,
 };
 use dal_test::{
     helpers::setup_identity_func,
@@ -263,7 +263,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");
@@ -292,7 +292,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext, wid: Works
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create explicit internal provider");

--- a/lib/dal/tests/integration_test/component/view/complex_func.rs
+++ b/lib/dal/tests/integration_test/component/view/complex_func.rs
@@ -2,8 +2,8 @@ use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::job::definition::DependentValuesUpdate;
 use dal::{
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue, Component,
-    ComponentView, DalContext, DiagramKind, ExternalProvider, Func, FuncBackendKind,
-    FuncBackendResponseType, FuncBinding, InternalProvider, PropKind, SocketArity, StandardModel,
+    ComponentView, DalContext, ExternalProvider, Func, FuncBackendKind, FuncBackendResponseType,
+    FuncBinding, InternalProvider, PropKind, SocketArity, StandardModel,
 };
 use dal_test::helpers::setup_identity_func;
 use dal_test::test_harness::create_prop_and_set_parent;
@@ -43,7 +43,7 @@ async fn nested_object_prop_with_complex_func(ctx: &DalContext) {
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");
@@ -424,7 +424,7 @@ async fn map_with_object_entries_and_complex_funcs(ctx: &DalContext) {
         *canoe_from_second_func_binding.id(),
         *canoe_from_second_func_binding_return_value.id(),
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");

--- a/lib/dal/tests/integration_test/graph.rs
+++ b/lib/dal/tests/integration_test/graph.rs
@@ -5,8 +5,8 @@ use dal::component::ComponentKind;
 use dal::node::NodeId;
 use dal::{
     edge::{EdgeKind, EdgeObjectId, VertexObjectKind},
-    Component, DalContext, DiagramKind, Edge, ExternalProvider, InternalProvider, Node, Schema,
-    SchemaVariant, SchemaVariantId, SocketArity, SocketId, StandardModel,
+    Component, DalContext, Edge, ExternalProvider, InternalProvider, Node, Schema, SchemaVariant,
+    SchemaVariantId, SocketArity, SocketId, StandardModel,
 };
 use dal_test::helpers::setup_identity_func;
 use dal_test::test;
@@ -142,7 +142,7 @@ impl ConfigurationGraphConstructor {
                 identity_func_binding_id,
                 identity_func_binding_return_value_id,
                 SocketArity::Many,
-                DiagramKind::Configuration,
+                false,
             )
             .await
             .expect("could not create explicit internal provider with socket");
@@ -157,7 +157,7 @@ impl ConfigurationGraphConstructor {
             identity_func_binding_id,
             identity_func_binding_return_value_id,
             SocketArity::Many,
-            DiagramKind::Configuration,
+            false,
         )
         .await
         .expect("could not create external provider with socket");

--- a/lib/dal/tests/integration_test/provider.rs
+++ b/lib/dal/tests/integration_test/provider.rs
@@ -1,6 +1,4 @@
-use dal::{
-    socket::SocketArity, DalContext, DiagramKind, ExternalProvider, InternalProvider, StandardModel,
-};
+use dal::{socket::SocketArity, DalContext, ExternalProvider, InternalProvider, StandardModel};
 use dal_test::{
     helpers::setup_identity_func,
     test,
@@ -31,7 +29,7 @@ async fn new_external(ctx: &DalContext) {
         func_binding_id,
         func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");
@@ -66,7 +64,7 @@ async fn new_implicit_internal(ctx: &DalContext) {
         func_binding_id,
         func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create (explicit internal provider");

--- a/lib/dal/tests/integration_test/provider/inter_component.rs
+++ b/lib/dal/tests/integration_test/provider/inter_component.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use dal::{
     socket::SocketArity, AttributeContext, AttributePrototypeArgument, AttributeReadContext,
-    AttributeValue, Component, ComponentView, DalContext, DiagramKind, Edge, ExternalProvider,
-    InternalProvider, PropKind, StandardModel,
+    AttributeValue, Component, ComponentView, DalContext, Edge, ExternalProvider, InternalProvider,
+    PropKind, StandardModel,
 };
 use dal_test::{
     helpers::{component_payload::ComponentPayload, setup_identity_func},
@@ -135,7 +135,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");
@@ -166,7 +166,7 @@ async fn inter_component_identity_update(ctx: &DalContext) {
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create explicit internal provider");
@@ -482,7 +482,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("cannot create source external provider");
@@ -569,7 +569,7 @@ async fn with_deep_data_structure(ctx: &DalContext) {
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::One,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("cannot create destination explicit internal provider");

--- a/lib/dal/tests/integration_test/provider/intra_component.rs
+++ b/lib/dal/tests/integration_test/provider/intra_component.rs
@@ -4,8 +4,8 @@ use dal::{
     job::definition::DependentValuesUpdate,
     provider::internal::InternalProvider,
     AttributeContext, AttributePrototypeArgument, AttributeReadContext, AttributeValue, Component,
-    ComponentView, DalContext, DiagramKind, ExternalProvider, Func, FuncBackendKind,
-    FuncBackendResponseType, PropKind, SocketArity, StandardModel,
+    ComponentView, DalContext, ExternalProvider, Func, FuncBackendKind, FuncBackendResponseType,
+    PropKind, SocketArity, StandardModel,
 };
 use dal_test::{
     helpers::setup_identity_func,
@@ -300,7 +300,7 @@ async fn intra_component_custom_func_update_to_external_provider(ctx: &DalContex
         identity_func_binding_id,
         identity_func_binding_return_value_id,
         SocketArity::Many,
-        DiagramKind::Configuration,
+        false,
     )
     .await
     .expect("could not create external provider");

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -1,15 +1,17 @@
 use dal::{
     socket::{Socket, SocketArity, SocketEdgeKind, SocketKind},
-    DalContext, DiagramKind,
+    Component, DalContext, DiagramKind, SchemaVariant, SocketId, StandardModel,
 };
+use dal_test::test_harness::create_schema;
 use dal_test::{helpers::generate_fake_name, test};
+use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn new(ctx: &DalContext) {
     let socket = Socket::new(
         ctx,
         "jane",
-        SocketKind::Provider,
+        SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationOutput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
@@ -26,7 +28,7 @@ async fn set_required(ctx: &DalContext) {
     let mut socket = Socket::new(
         ctx,
         generate_fake_name(),
-        SocketKind::Provider,
+        SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationInput,
         &SocketArity::One,
         &DiagramKind::Configuration,
@@ -39,4 +41,124 @@ async fn set_required(ctx: &DalContext) {
         .await
         .expect("cannot set required");
     assert!(socket.required());
+}
+
+#[test]
+async fn find_frame_socket_for_node(ctx: &DalContext) {
+    let schema = create_schema(ctx).await;
+    let (mut schema_variant, _) = SchemaVariant::new(ctx, *schema.id(), "v0")
+        .await
+        .expect("cannot create schema variant");
+    schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("cannot finalize schema variant");
+    let (_, node) = Component::new(ctx, "MUSTANG GT PERFORMANCE PACK", *schema_variant.id())
+        .await
+        .expect("could not create component");
+
+    // Gather what we expect. We do not exit early out of the loop in order to ensure that we get
+    // the exact sockets and nothing more.
+    let mut maybe_expected_output_socket_id = None;
+    let mut maybe_expected_input_socket_id = None;
+    for socket in schema_variant
+        .sockets(ctx)
+        .await
+        .expect("could not get sockets")
+    {
+        if socket.kind() == &SocketKind::Frame {
+            match socket.edge_kind() {
+                SocketEdgeKind::ConfigurationOutput => {
+                    assert!(maybe_expected_output_socket_id.is_none());
+                    maybe_expected_output_socket_id = Some(*socket.id())
+                }
+                SocketEdgeKind::ConfigurationInput => {
+                    assert!(maybe_expected_input_socket_id.is_none());
+                    maybe_expected_input_socket_id = Some(*socket.id())
+                }
+            }
+        }
+    }
+    let expected_output_socket_id =
+        maybe_expected_output_socket_id.expect("did not find expected output socket id");
+    let expected_input_socket_id =
+        maybe_expected_input_socket_id.expect("did not find expected input socket id");
+
+    // Test our query.
+    let found_output_socket =
+        Socket::find_frame_socket_for_node(ctx, *node.id(), SocketEdgeKind::ConfigurationOutput)
+            .await
+            .expect("could not find frame socket for component");
+    let found_input_socket =
+        Socket::find_frame_socket_for_node(ctx, *node.id(), SocketEdgeKind::ConfigurationInput)
+            .await
+            .expect("could not find frame socket for component");
+    assert_eq!(
+        expected_output_socket_id, // expected
+        *found_output_socket.id(), // actual
+    );
+    assert_eq!(
+        expected_input_socket_id, // expected
+        *found_input_socket.id(), // actual
+    );
+}
+
+#[test]
+async fn list_for_component(ctx: &DalContext) {
+    let schema = create_schema(ctx).await;
+    let (mut schema_variant, _) = SchemaVariant::new(ctx, *schema.id(), "v0")
+        .await
+        .expect("cannot create schema variant");
+
+    // Create some additional sockets from the defaults.
+    Socket::new(
+        ctx,
+        "output",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+    )
+    .await
+    .expect("could not create socket");
+    Socket::new(
+        ctx,
+        "input",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationInput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+    )
+    .await
+    .expect("could not create socket");
+
+    // Finalize the schema variant and create the component.
+    schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("cannot finalize schema variant");
+    let (component, _) = Component::new(ctx, "MUSTANG GT PERFORMANCE PACK", *schema_variant.id())
+        .await
+        .expect("could not create component");
+
+    // Gather what we expect.
+    let expected_sockets = schema_variant
+        .sockets(ctx)
+        .await
+        .expect("could not get sockets")
+        .iter()
+        .map(|s| *s.id())
+        .collect::<Vec<SocketId>>();
+
+    // Test our query.
+    let found_sockets = Socket::list_for_component(ctx, *component.id())
+        .await
+        .expect("could not list for component")
+        .iter()
+        .map(|s| *s.id())
+        .collect::<Vec<SocketId>>();
+    assert_eq!(
+        expected_sockets, // expected
+        found_sockets,    // actual
+    );
 }

--- a/lib/sdf/src/server/service/diagram.rs
+++ b/lib/sdf/src/server/service/diagram.rs
@@ -7,8 +7,8 @@ use dal::provider::external::ExternalProviderError as DalExternalProviderError;
 use dal::socket::{SocketError, SocketId};
 use dal::{
     node::NodeId, schema::variant::SchemaVariantError, AttributeValueError, ComponentError,
-    DiagramError as DalDiagramError, EdgeError, InternalProviderError, NodeError, NodeKind,
-    NodeMenuError, NodePositionError, ReadTenancyError, SchemaError as DalSchemaError,
+    ComponentType, DiagramError as DalDiagramError, EdgeError, InternalProviderError, NodeError,
+    NodeKind, NodeMenuError, NodePositionError, ReadTenancyError, SchemaError as DalSchemaError,
     SchemaVariantId, StandardModelError, TransactionsError,
 };
 use dal::{AttributeReadContext, WsEventError};
@@ -97,6 +97,8 @@ pub enum DiagramError {
     InvalidParentNode(NodeKind),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
+    #[error("invalid component type ({0:?}) for frame")]
+    InvalidComponentTypeForFrame(ComponentType),
 }
 
 pub type DiagramResult<T> = Result<T, DiagramError>;

--- a/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
+++ b/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
@@ -1,12 +1,13 @@
 use axum::Json;
 use dal::edge::{EdgeKind, EdgeObjectId, VertexObjectKind};
 use dal::job::definition::DependentValuesUpdate;
-use dal::socket::SocketEdgeKind;
+use dal::socket::{SocketEdgeKind, SocketKind};
 use dal::{
     node::NodeId, AttributeReadContext, AttributeValue, Component, Connection, DalContext, Edge,
-    EdgeError, ExternalProvider, InternalProvider, InternalProviderId, Node, PropId, StandardModel,
+    EdgeError, ExternalProvider, InternalProvider, InternalProviderId, PropId, StandardModel,
     Visibility, WsEvent,
 };
+use dal::{ComponentType, Socket};
 use serde::{Deserialize, Serialize};
 
 use crate::server::extract::{AccessBuilder, HandlerContext};
@@ -38,84 +39,25 @@ pub async fn connect_component_to_frame(
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     // Connect children to parent through frame edge
-    let from_socket_id = {
-        let from_node = Node::get_by_id(&ctx, &request.child_node_id)
-            .await?
-            .ok_or(DiagramError::NodeNotFound(request.child_node_id))?;
-
-        let from_component = from_node
-            .component(&ctx)
-            .await?
-            .ok_or(DiagramError::ComponentNotFound)?;
-
-        let schema_variant = from_component
-            .schema_variant(&ctx)
-            .await?
-            .ok_or(DiagramError::SchemaVariantNotFound)?;
-
-        let from_sockets = schema_variant.sockets(&ctx).await?;
-
-        let mut from_socket_id = None;
-
-        for socket in from_sockets {
-            if let Some(provider) = socket.external_provider(&ctx).await? {
-                if provider.name() == "Frame" {
-                    from_socket_id = Some(*socket.id());
-                    break;
-                }
-            }
-        }
-
-        match from_socket_id {
-            None => {
-                return Err(DiagramError::FrameSocketNotFound(*schema_variant.id()));
-            }
-            Some(socket_id) => socket_id,
-        }
-    };
-
-    let to_socket_id = {
-        let node = Node::get_by_id(&ctx, &request.parent_node_id)
-            .await?
-            .ok_or(DiagramError::NodeNotFound(request.parent_node_id))?;
-
-        let component = node
-            .component(&ctx)
-            .await?
-            .ok_or(DiagramError::ComponentNotFound)?;
-
-        let schema_variant = component
-            .schema_variant(&ctx)
-            .await?
-            .ok_or(DiagramError::SchemaVariantNotFound)?;
-
-        let sockets = schema_variant.sockets(&ctx).await?;
-
-        let mut socket_id = None;
-
-        for socket in sockets {
-            if let Some(provider) = socket.internal_provider(&ctx).await? {
-                if provider.name() == "Frame" {
-                    socket_id = Some(*socket.id());
-                    break;
-                }
-            }
-        }
-
-        match socket_id {
-            None => {
-                return Err(DiagramError::FrameSocketNotFound(*schema_variant.id()));
-            }
-            Some(socket_id) => socket_id,
-        }
-    };
+    let from_socket = Socket::find_frame_socket_for_node(
+        &ctx,
+        request.child_node_id,
+        SocketEdgeKind::ConfigurationOutput,
+    )
+    .await?;
+    let to_socket = Socket::find_frame_socket_for_node(
+        &ctx,
+        request.parent_node_id,
+        SocketEdgeKind::ConfigurationInput,
+    )
+    .await?;
 
     let connection = Connection::new(
         &ctx,
         request.child_node_id,
-        from_socket_id,
+        *from_socket.id(),
         request.parent_node_id,
-        to_socket_id,
+        *to_socket.id(),
         EdgeKind::Symbolic,
     )
     .await?;
@@ -142,128 +84,152 @@ pub async fn connect_component_sockets_to_frame(
     let parent_component = Component::find_for_node(ctx, parent_node_id)
         .await?
         .ok_or(DiagramError::NodeNotFound(parent_node_id))?;
-
-    let parent_schema_variant = parent_component
-        .schema_variant(ctx)
-        .await?
-        .ok_or(DiagramError::SchemaVariantNotFound)?;
-
-    let parent_sockets = parent_schema_variant.sockets(ctx).await?;
+    let parent_sockets = Socket::list_for_component(ctx, *parent_component.id()).await?;
 
     let child_component = Component::find_for_node(ctx, child_node_id)
         .await?
         .ok_or(DiagramError::NodeNotFound(child_node_id))?;
+    let child_sockets = Socket::list_for_component(ctx, *child_component.id()).await?;
 
-    let child_sockets = child_component
-        .schema_variant(ctx)
-        .await?
-        .ok_or(DiagramError::SchemaVariantNotFound)?
-        .sockets(ctx)
-        .await?;
+    let aggregation_frame = match parent_component.get_type(ctx).await? {
+        ComponentType::AggregationFrame => true,
+        ComponentType::ConfigurationFrame => false,
+        component_type => return Err(DiagramError::InvalidComponentTypeForFrame(component_type)),
+    };
 
     for parent_socket in parent_sockets {
-        if parent_socket.name() == "Frame" {
+        if parent_socket.kind() == &SocketKind::Frame {
             continue;
         }
 
-        let frame_type_opt = parent_component
-            .find_value_by_json_pointer::<String>(ctx, "/root/si/type")
-            .await?;
-
-        // TODO(victor) This could be improved, frame_type should be compared to an enum
-        if let Some(frame_type) = frame_type_opt {
-            if frame_type == "aggregationFrame" {
-                match *parent_socket.edge_kind() {
-                    SocketEdgeKind::ConfigurationInput => {
-                        let provider =
-                            InternalProvider::find_explicit_for_socket(ctx, *parent_socket.id())
-                                .await?
-                                .ok_or(EdgeError::InternalProviderNotFoundForSocket(
-                                    *parent_socket.id(),
-                                ))?;
-
-                        // We don't want to connect the provider when we are not using configuration edge kind
-                        Edge::connect_internal_providers_for_components(
-                            ctx,
-                            *provider.id(),
-                            *child_component.id(),
-                            *parent_component.id(),
-                        )
-                        .await?;
-
-                        Edge::new(
-                            ctx,
-                            EdgeKind::Configuration,
-                            child_node_id,
-                            VertexObjectKind::Configuration,
-                            EdgeObjectId::from(*child_component.id()),
-                            *parent_socket.id(),
-                            parent_node_id,
-                            VertexObjectKind::Configuration,
-                            EdgeObjectId::from(*parent_component.id()),
-                            *parent_socket.id(),
-                        )
-                        .await?;
-
-                        let attribute_value_context = AttributeReadContext {
-                            component_id: Some(*parent_component.id()),
-                            internal_provider_id: Some(*provider.id()),
-                            ..Default::default()
-                        };
-
-                        let attribute_value =
-                            AttributeValue::find_for_context(ctx, attribute_value_context)
-                                .await?
-                                .ok_or(DiagramError::AttributeValueNotFoundForContext(
-                                    attribute_value_context,
-                                ))?;
-
-                        ctx.enqueue_job(DependentValuesUpdate::new(
-                            ctx,
-                            vec![*attribute_value.id()],
-                        ))
-                        .await;
-                    }
-                    SocketEdgeKind::ConfigurationOutput => {
-                        let provider = ExternalProvider::find_for_socket(ctx, *parent_socket.id())
+        if aggregation_frame {
+            match *parent_socket.edge_kind() {
+                SocketEdgeKind::ConfigurationInput => {
+                    let provider =
+                        InternalProvider::find_explicit_for_socket(ctx, *parent_socket.id())
                             .await?
-                            .ok_or(EdgeError::ExternalProviderNotFoundForSocket(
+                            .ok_or(EdgeError::InternalProviderNotFoundForSocket(
                                 *parent_socket.id(),
                             ))?;
 
-                        Edge::connect_external_providers_for_components(
-                            ctx,
-                            *provider.id(),
-                            *parent_component.id(),
-                            *child_component.id(),
-                        )
-                        .await?;
+                    // We don't want to connect the provider when we are not using configuration edge kind
+                    Edge::connect_internal_providers_for_components(
+                        ctx,
+                        *provider.id(),
+                        *child_component.id(),
+                        *parent_component.id(),
+                    )
+                    .await?;
 
-                        Edge::new(
+                    Edge::new(
+                        ctx,
+                        EdgeKind::Configuration,
+                        child_node_id,
+                        VertexObjectKind::Configuration,
+                        EdgeObjectId::from(*child_component.id()),
+                        *parent_socket.id(),
+                        parent_node_id,
+                        VertexObjectKind::Configuration,
+                        EdgeObjectId::from(*parent_component.id()),
+                        *parent_socket.id(),
+                    )
+                    .await?;
+
+                    let attribute_value_context = AttributeReadContext {
+                        component_id: Some(*parent_component.id()),
+                        internal_provider_id: Some(*provider.id()),
+                        ..Default::default()
+                    };
+
+                    let attribute_value =
+                        AttributeValue::find_for_context(ctx, attribute_value_context)
+                            .await?
+                            .ok_or(DiagramError::AttributeValueNotFoundForContext(
+                                attribute_value_context,
+                            ))?;
+
+                    ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*attribute_value.id()]))
+                        .await;
+                }
+                SocketEdgeKind::ConfigurationOutput => {
+                    let provider = ExternalProvider::find_for_socket(ctx, *parent_socket.id())
+                        .await?
+                        .ok_or(EdgeError::ExternalProviderNotFoundForSocket(
+                            *parent_socket.id(),
+                        ))?;
+
+                    Edge::connect_external_providers_for_components(
+                        ctx,
+                        *provider.id(),
+                        *parent_component.id(),
+                        *child_component.id(),
+                    )
+                    .await?;
+
+                    Edge::new(
+                        ctx,
+                        EdgeKind::Configuration,
+                        parent_node_id,
+                        VertexObjectKind::Configuration,
+                        EdgeObjectId::from(*parent_component.id()),
+                        *parent_socket.id(),
+                        child_node_id,
+                        VertexObjectKind::Configuration,
+                        EdgeObjectId::from(*child_component.id()),
+                        *parent_socket.id(),
+                    )
+                    .await?;
+
+                    let attribute_value_context = AttributeReadContext {
+                        component_id: Some(*child_component.id()),
+                        external_provider_id: Some(*provider.id()),
+                        ..Default::default()
+                    };
+
+                    let attribute_value =
+                        AttributeValue::find_for_context(ctx, attribute_value_context)
+                            .await?
+                            .ok_or(DiagramError::AttributeValueNotFoundForContext(
+                                attribute_value_context,
+                            ))?;
+
+                    ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*attribute_value.id()]))
+                        .await;
+                }
+            }
+        } else if let Some(parent_provider) = parent_socket.external_provider(ctx).await? {
+            for child_socket in &child_sockets {
+                // Skip child sockets corresponding to frames.
+                if child_socket.kind() == &SocketKind::Frame {
+                    continue;
+                }
+
+                if let Some(child_provider) = child_socket.internal_provider(ctx).await? {
+                    // TODO(nick): once type definitions used for providers, we should not
+                    // match on name.
+                    if parent_provider.name() == child_provider.name() {
+                        Connection::new(
                             ctx,
-                            EdgeKind::Configuration,
                             parent_node_id,
-                            VertexObjectKind::Configuration,
-                            EdgeObjectId::from(*parent_component.id()),
                             *parent_socket.id(),
                             child_node_id,
-                            VertexObjectKind::Configuration,
-                            EdgeObjectId::from(*child_component.id()),
-                            *parent_socket.id(),
+                            *child_socket.id(),
+                            EdgeKind::Configuration,
                         )
                         .await?;
 
-                        let attribute_value_context = AttributeReadContext {
-                            component_id: Some(*child_component.id()),
-                            external_provider_id: Some(*provider.id()),
-                            ..Default::default()
+                        let attribute_read_context = AttributeReadContext {
+                            prop_id: Some(PropId::NONE),
+                            internal_provider_id: Some(InternalProviderId::NONE),
+                            external_provider_id: Some(*parent_provider.id()),
+                            component_id: Some(*parent_component.id()),
                         };
 
                         let attribute_value =
-                            AttributeValue::find_for_context(ctx, attribute_value_context)
+                            AttributeValue::find_for_context(ctx, attribute_read_context)
                                 .await?
                                 .ok_or(DiagramError::AttributeValueNotFoundForContext(
-                                    attribute_value_context,
+                                    attribute_read_context,
                                 ))?;
 
                         ctx.enqueue_job(DependentValuesUpdate::new(
@@ -271,44 +237,6 @@ pub async fn connect_component_sockets_to_frame(
                             vec![*attribute_value.id()],
                         ))
                         .await;
-                    }
-                }
-            } else if let Some(parent_provider) = parent_socket.external_provider(ctx).await? {
-                for child_socket in &child_sockets {
-                    if let Some(child_provider) = child_socket.internal_provider(ctx).await? {
-                        if parent_provider.name() != "Frame"
-                            && parent_provider.name() == child_provider.name()
-                        {
-                            Connection::new(
-                                ctx,
-                                parent_node_id,
-                                *parent_socket.id(),
-                                child_node_id,
-                                *child_socket.id(),
-                                EdgeKind::Configuration,
-                            )
-                            .await?;
-
-                            let attribute_read_context = AttributeReadContext {
-                                prop_id: Some(PropId::NONE),
-                                internal_provider_id: Some(InternalProviderId::NONE),
-                                external_provider_id: Some(*parent_provider.id()),
-                                component_id: Some(*parent_component.id()),
-                            };
-
-                            let attribute_value =
-                                AttributeValue::find_for_context(ctx, attribute_read_context)
-                                    .await?
-                                    .ok_or(DiagramError::AttributeValueNotFoundForContext(
-                                        attribute_read_context,
-                                    ))?;
-
-                            ctx.enqueue_job(DependentValuesUpdate::new(
-                                ctx,
-                                vec![*attribute_value.id()],
-                            ))
-                            .await;
-                        }
                     }
                 }
             }

--- a/lib/sdf/src/server/service/diagram/list_schema_variants.rs
+++ b/lib/sdf/src/server/service/diagram/list_schema_variants.rs
@@ -1,6 +1,6 @@
 use axum::extract::{Json, Query};
 use dal::{
-    socket::{SocketEdgeKind, SocketId, SocketKind},
+    socket::{SocketEdgeKind, SocketId},
     DiagramKind, ExternalProviderId, InternalProviderId, SchemaId, SchemaVariant, SchemaVariantId,
     StandardModel, Visibility,
 };
@@ -79,37 +79,35 @@ pub async fn list_schema_variants(
 
         let sockets = variant.sockets(&ctx).await?;
         for socket in sockets {
-            match socket.kind() {
-                SocketKind::Provider => match socket.edge_kind() {
-                    SocketEdgeKind::ConfigurationOutput => {
-                        let provider = socket.external_provider(&ctx).await?.ok_or_else(|| {
-                            DiagramError::ExternalProviderNotFoundForSocket(*socket.id())
-                        })?;
-                        output_sockets.push(OutputSocketView {
-                            id: *socket.id(),
-                            name: socket.name().to_owned(),
-                            diagram_kind: *socket.diagram_kind(),
-                            provider: OutputProviderView {
-                                id: *provider.id(),
-                                ty: socket.name().to_owned(),
-                            },
-                        })
-                    }
-                    SocketEdgeKind::ConfigurationInput => {
-                        let provider = socket.internal_provider(&ctx).await?.ok_or_else(|| {
-                            DiagramError::InternalProviderNotFoundForSocket(*socket.id())
-                        })?;
-                        input_sockets.push(InputSocketView {
-                            id: *socket.id(),
-                            name: socket.name().to_owned(),
-                            diagram_kind: *socket.diagram_kind(),
-                            provider: InputProviderView {
-                                id: *provider.id(),
-                                ty: socket.name().to_owned(),
-                            },
-                        })
-                    }
-                },
+            match socket.edge_kind() {
+                SocketEdgeKind::ConfigurationOutput => {
+                    let provider = socket.external_provider(&ctx).await?.ok_or_else(|| {
+                        DiagramError::ExternalProviderNotFoundForSocket(*socket.id())
+                    })?;
+                    output_sockets.push(OutputSocketView {
+                        id: *socket.id(),
+                        name: socket.name().to_owned(),
+                        diagram_kind: *socket.diagram_kind(),
+                        provider: OutputProviderView {
+                            id: *provider.id(),
+                            ty: socket.name().to_owned(),
+                        },
+                    })
+                }
+                SocketEdgeKind::ConfigurationInput => {
+                    let provider = socket.internal_provider(&ctx).await?.ok_or_else(|| {
+                        DiagramError::InternalProviderNotFoundForSocket(*socket.id())
+                    })?;
+                    input_sockets.push(InputSocketView {
+                        id: *socket.id(),
+                        name: socket.name().to_owned(),
+                        diagram_kind: *socket.diagram_kind(),
+                        provider: InputProviderView {
+                            id: *provider.id(),
+                            ty: socket.name().to_owned(),
+                        },
+                    })
+                }
             }
         }
 


### PR DESCRIPTION
Primary:
- Add "Frame" SocketKind for use in queries and type-safe content
- Add queries relying on the "Frame" SocketKind for use in frame-related routes

Secondary:
- Add "Standalone" SocketKind for use in integration tests (existing places where the "Provider" kind did not make sense)
- Remove DiagramKind from provider constructor methods (their underlying Sockets are always for Configuration Diagrams)

<img src="https://media0.giphy.com/media/ZdilASsUTJW4o/giphy.gif"/>