### PR TITLE
Ensure si tree appears before domain tree (ENG-954)

### DIFF
--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -127,7 +127,6 @@ pub struct Prop {
     widget_kind: WidgetKind,
     widget_options: Option<Value>,
     doc_link: Option<String>,
-    index: i64,
     hidden: bool,
     #[serde(flatten)]
     tenancy: WriteTenancy,
@@ -188,7 +187,6 @@ impl Prop {
     standard_model_accessor!(widget_kind, Enum(WidgetKind), PropResult);
     standard_model_accessor!(widget_options, Option<Value>, PropResult);
     standard_model_accessor!(doc_link, Option<String>, PropResult);
-    standard_model_accessor!(index, i64, PropResult);
     standard_model_accessor!(hidden, bool, PropResult);
 
     // FIXME(nick): change the relationship to a "belongs to" relationship and the name to

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -28,7 +28,7 @@ impl PropertyEditorValues {
     ) -> PropertyEditorResult<Self> {
         let mut root_value_id = None;
         let mut values = HashMap::new();
-        let mut child_values: HashMap<PropertyEditorValueId, Vec<(PropertyEditorValueId, i64)>> =
+        let mut child_values: HashMap<PropertyEditorValueId, Vec<PropertyEditorValueId>> =
             HashMap::new();
         let mut work_queue = AttributeValue::list_payload_for_read_context(
             ctx,
@@ -85,24 +85,16 @@ impl PropertyEditorValues {
                 child_values
                     .entry(parent_id.into())
                     .or_default()
-                    .push((work_attribute_value_id.into(), work.prop.index()));
+                    .push(work_attribute_value_id.into());
             } else {
                 root_value_id = Some(work_attribute_value_id.into());
             }
         }
 
-        // Note: hackish ordering to ensure consistency in the frontend
-        for value in child_values.values_mut() {
-            value.sort_by_key(|a| a.1)
-        }
-
         if let Some(root_value_id) = root_value_id {
             Ok(PropertyEditorValues {
                 root_value_id,
-                child_values: child_values
-                    .into_iter()
-                    .map(|(k, list)| (k, list.into_iter().map(|(v, _)| v).collect()))
-                    .collect(),
+                child_values,
                 values,
             })
         } else {

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -81,13 +81,17 @@ impl RootProp {
             .await?;
         let root_prop_id = *root_prop.id();
 
+        // FIXME(nick): we rely on ULID ordering for now, so the si prop tree creation has to come
+        // before the domain prop tree creation. Once index maps for objects are added, this
+        // can be moved back to its original location with the other prop tree creation methods.
+        let (si_specific_prop_id, si_child_name_prop_id) =
+            Self::setup_si(ctx, root_prop_id).await?;
+
         let domain_specific_prop = Prop::new(ctx, "domain", PropKind::Object, None).await?;
         domain_specific_prop
             .set_parent_prop(ctx, root_prop_id)
             .await?;
 
-        let (si_specific_prop_id, si_child_name_prop_id) =
-            Self::setup_si(ctx, root_prop_id).await?;
         let resource_specific_prop_id = Self::setup_resource(ctx, root_prop_id).await?;
         let code_specific_prop_id = Self::setup_code(ctx, root_prop_id).await?;
         let qualification_specific_prop_id = Self::setup_qualification(ctx, root_prop_id).await?;


### PR DESCRIPTION
- Ensure si tree appears before domain tree by relying on ULID ordering (will need to be replaced with object index maps)
- Remove "index" field and surrounding hack for prop since ULIDs can be somewhat relied on for their creation ordering
- Ensure property editor schema integration test does not rely on builtin schemas or funcs

<img src="https://media4.giphy.com/media/l2JeiOdMbDfKAPPJC/giphy.gif"/>