### PR TITLE
chore(ci): Update fossa action to use the NodeJS version as Node12 is deprecated

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,6 +9,6 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@v1.1.0
+        uses: fossas/fossa-action@v1.3.1
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}


### PR DESCRIPTION
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
