### PR TITLE
chore(ci): Update actions/checkout to move to v3

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup pnpm

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build ${{ inputs.component_name }} Docker Image
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
+      - uses: actions/checkout@v3 # pin@v2.3.4
       - id: buildx
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # pin@v1.6.0
       - id: login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup pnpm

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Run FOSSA Scan"
         uses: fossas/fossa-action@v1.1.0
         with:


### PR DESCRIPTION
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
