### PR TITLE
chore(ci) Increase job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ci:
-    timeout-minutes: 20
+    timeout-minutes: 30
     name: Pull Request Checks
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
We have more tests, and that means they take more time overall.

@paulocsanz Not sure how this didn't come up before when searching for this setting, but it certainly explains the timeouts you're seeing.