### PR TITLE
feat: Create base Nix development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675956056,
+        "narHash": "sha256-qDSD14/rUiOfBCUHtNQF5tN5eWrHK28NIaDnDsk/A5E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7b2a482ea0240ef989001c6a6c28b47db7790483",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1675823425,
+        "narHash": "sha256-o/uLXQdq3OrRAv4BZVVY0VmhMmQBLWw6Y4o+p6ZiaR4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "02e1abbdcbc2d516193ff8a7add71f44cd976ba0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Development environment for System Initiative";
+
+  # Flake inputs
+  inputs = {
+    # Unstable nixpkgs to get pnpm
+    nixpkgs.url = "github:NixOS/nixpkgs/master"; # also valid: "nixpkgs"
+    rust-overlay.url = "github:oxalica/rust-overlay"; # A helper for Rust + Nix
+  };
+
+  # Flake outputs
+  outputs = { self, nixpkgs, rust-overlay }:
+    let
+      # Overlays enable you to customize the Nixpkgs attribute set
+      overlays = [
+        # Makes a `rust-bin` attribute available in Nixpkgs
+        (import rust-overlay)
+        # Provides a `rustToolchain` attribute for Nixpkgs that we can use to 
+        # create a Rust environment
+        (self: super: {
+          rustToolchain = super.rust-bin.stable.latest.default;
+        })
+      ];
+
+      # Helper to provide system-specific attributes
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit overlays system; };
+      });
+    in
+    {
+      # Development environment output
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          # The Nix packages provided in the environment
+          buildInputs = (with pkgs; [
+            rustToolchain
+
+            automake
+            awscli
+            bash
+            butane
+            coreutils
+            docker-compose
+            gcc
+            git
+            kubeval
+            libtool
+            gnumake
+            protobuf
+            skopeo
+            jq
+            nodejs-16_x
+            nodePackages.pnpm
+            nodePackages.typescript
+            nodePackages.typescript-language-server
+
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
+        };
+      });
+    };
+}


### PR DESCRIPTION
Very rough first-pass at using Nix to make sure all build & run dependencies are available for developing System Initiative.

If you have Nix installed already (https://zero-to-nix.com/start/install is a good option), you can run `nix develop` from the root of the repo, and it will make sure that (most of) the requirements are available. Docker needs to already be available on the system, but the intent is that everything else should be available via the `nix develop` environment.

To run a one-off command in the Nix development environment: `nix develop --command <command>` (Ex. `nix develop --command make prepare`, `nix develop --command make build//bin/veritech`, etc.)