### PR TITLE
Add model flow scenario test and ability to author scenario tests (ENG-997)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,6 +3091,7 @@ dependencies = [
  "names",
  "nix",
  "pathdiff",
+ "pretty_assertions_sorted",
  "rand",
  "serde",
  "serde_json",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -166,12 +166,6 @@ First, we run `veritech`.
 make run//bin/veritech
 ```
 
-In another terminal pane, run `sdf`.
-
-```bash
-make run//bin/sdf
-```
-
 In another terminal pane, run `pinga`.
 
 ```bash
@@ -182,6 +176,12 @@ In another terminal pane, run `council`.
 
 ```bash
 make run//bin/council
+```
+
+In another terminal pane, run `sdf`.
+
+```bash
+make run//bin/sdf
 ```
 
 In a final terminal pane, execute the following command:
@@ -506,8 +506,11 @@ SI_TEST_BUILTIN_SCHEMAS=none cargo test -p dal --test integration <your-test>
 You can also choose individual builtins to migrate with a comma-separated list.
 
 ```shell
-SI_TEST_BUILTIN_SCHEMAS="Schema One,Schema Two" cargo test -p dal --test integration <your-test>
+SI_TEST_BUILTIN_SCHEMAS=Schema One,Schema Two cargo test -p dal --test integration <your-test>
 ```
+
+> Note: you may not want to wrap your list in `"` characters, depending on your development environment as they may
+> be unintentionally included in the list item(s).
 
 If you want migrations to run as they would by default, remove the environment variable or set it to `"all"` or `"true"`
 (or some variant of them).

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -640,7 +640,10 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           position: Vector2d,
           parentId?: string,
         ) {
-          return new ApiRequest<{ componentId: ComponentId }>({
+          return new ApiRequest<{
+            componentId: ComponentId;
+            nodeId: ComponentNodeId;
+          }>({
             method: "post",
             url: "diagram/create_node",
             params: {

--- a/lib/dal-test/src/helpers/component_view.rs
+++ b/lib/dal-test/src/helpers/component_view.rs
@@ -20,6 +20,8 @@ pub struct ComponentViewProperties {
     code: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     qualification: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confirmation: Option<serde_json::Value>,
 }
 
 #[derive(Error, Debug)]
@@ -36,6 +38,11 @@ impl ComponentViewProperties {
 
     pub fn drop_qualification(&mut self) -> &mut Self {
         self.qualification = None;
+        self
+    }
+
+    pub fn drop_confirmation(&mut self) -> &mut Self {
+        self.confirmation = None;
         self
     }
 

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -64,6 +64,7 @@ pub async fn migrate(
         }
         BuiltinSchemaOption::Some(provided_set) => {
             info!("migrating schemas based on a provided set of names (this should only be possible when running tests)");
+            debug!("provided set of builtin schemas: {:?}", &provided_set);
             (false, provided_set)
         }
     };

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -116,7 +116,7 @@ impl Diagram {
     pub async fn assemble(ctx: &DalContext) -> DiagramResult<Self> {
         // let added = ComponentChangeStatus::list_added(ctx).await?;
         let modified = ComponentChangeStatus::list_modified(ctx).await?;
-        println!("{:#?}", modified);
+        println!("{modified:#?}");
 
         let mut nodes = Node::list(ctx).await?;
         nodes.extend(ComponentChangeStatus::list_deleted_nodes(ctx).await?);

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -1,4 +1,3 @@
-use crate::{FuncError, Tenancy};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use si_data_nats::NatsError;
@@ -24,12 +23,13 @@ use crate::func::backend::{
     FuncBackend, FuncDispatch, FuncDispatchContext,
 };
 use crate::func::execution::FuncExecutionPk;
-use crate::DalContext;
+use crate::FuncError;
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
     Func, FuncBackendError, FuncBackendKind, HistoryEventError, StandardModel, StandardModelError,
     Timestamp, Visibility,
 };
+use crate::{DalContext, Tenancy};
 
 use super::{
     binding_return_value::{FuncBindingReturnValue, FuncBindingReturnValueError},
@@ -67,14 +67,11 @@ pub enum FuncBindingError {
 
 pub type FuncBindingResult<T> = Result<T, FuncBindingError>;
 
-// A `FuncBinding` binds an execution context to a `Func`, so that it can be
-// executed. So for example, you would create a `FuncBinding` with the arguments
-// to the Func, and then say that this binding `belongs_to` a `prop`, or a `schema`,
-// etc.
 pk!(FuncBindingPk);
 pk!(FuncBindingId);
 
-// NOTE(nick,jacob): the [`HashMap`] of input sockets will likely live here in the future.
+/// A [`FuncBinding`] binds an execution context (including arguments) to a [`Func`](crate::Func),
+/// so that it can be executed.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct FuncBinding {
     pk: FuncBindingPk,

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -41,6 +41,10 @@ pub enum PropertyEditorError {
     ValidationResolver(#[from] ValidationResolverError),
     #[error("prop not found for id: {0}")]
     PropNotFound(PropId),
+    #[error("no value(s) found for property editor prop id: {0}")]
+    NoValuesFoundForPropertyEditorProp(PropertyEditorPropId),
+    #[error("too many values found (likely not the prop for an element of a map or an array) for property editor prop id: {0}")]
+    TooManyValuesFoundForPropertyEditorProp(PropertyEditorPropId),
 }
 
 pub type PropertyEditorResult<T> = Result<T, PropertyEditorError>;
@@ -51,6 +55,12 @@ pk!(PropertyEditorPropId);
 
 impl From<AttributeValueId> for PropertyEditorValueId {
     fn from(id: AttributeValueId) -> Self {
+        Self::from(ulid::Ulid::from(id))
+    }
+}
+
+impl From<PropertyEditorValueId> for AttributeValueId {
+    fn from(id: PropertyEditorValueId) -> Self {
         Self::from(ulid::Ulid::from(id))
     }
 }

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -98,7 +98,7 @@ impl PropertyEditorProp {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PropertyEditorPropKind {
     Array,

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -9,15 +9,15 @@ use crate::property_editor::{PropertyEditorError, PropertyEditorResult};
 use crate::property_editor::{PropertyEditorPropId, PropertyEditorValueId};
 use crate::{
     AttributeReadContext, AttributeValue, AttributeValueId, Component, ComponentId, DalContext,
-    Prop, StandardModel,
+    Prop, PropId, StandardModel,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyEditorValues {
-    root_value_id: PropertyEditorValueId,
+    pub root_value_id: PropertyEditorValueId,
     pub values: HashMap<PropertyEditorValueId, PropertyEditorValue>,
-    child_values: HashMap<PropertyEditorValueId, Vec<PropertyEditorValueId>>,
+    pub child_values: HashMap<PropertyEditorValueId, Vec<PropertyEditorValueId>>,
 }
 
 impl PropertyEditorValues {
@@ -104,16 +104,24 @@ impl PropertyEditorValues {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyEditorValue {
-    id: PropertyEditorValueId,
+    pub id: PropertyEditorValueId,
     prop_id: PropertyEditorPropId,
-    key: Option<String>,
+    pub key: Option<String>,
     value: Value,
     is_from_external_source: bool,
 }
 
 impl PropertyEditorValue {
+    pub fn attribute_value_id(&self) -> AttributeValueId {
+        self.id.into()
+    }
+
     pub fn value(&self) -> Value {
         self.value.clone()
+    }
+
+    pub fn prop_id(&self) -> PropId {
+        self.prop_id.into()
     }
 
     /// Returns the [`Prop`](crate::Prop) corresponding to the "prop_id" field.

--- a/lib/dal/src/queries/socket/find_by_name_for_edge_kind_and_node.sql
+++ b/lib/dal/src/queries/socket/find_by_name_for_edge_kind_and_node.sql
@@ -1,0 +1,11 @@
+SELECT row_to_json(sockets.*) AS object
+FROM sockets_v1($1, $2) as sockets
+         JOIN socket_many_to_many_schema_variants_v1($1, $2) as socket_to_schema_variant
+              ON sockets.id = socket_to_schema_variant.left_object_id
+                  AND sockets.name = $3
+                  AND sockets.edge_kind = $4
+         JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
+              ON component_belongs_to_schema_variant.belongs_to_id = socket_to_schema_variant.right_object_id
+         JOIN node_belongs_to_component_v1($1, $2) as node_belongs_to_component
+              ON node_belongs_to_component.belongs_to_id = component_belongs_to_schema_variant.object_id
+                  AND node_belongs_to_component.object_id = $5;

--- a/lib/sdf/Cargo.toml
+++ b/lib/sdf/Cargo.toml
@@ -44,4 +44,5 @@ thiserror = { version = "1.0" }
 
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }
+pretty_assertions_sorted = "1.1.2"
 serde_url_params = "0.2.1"

--- a/lib/sdf/src/server/service/component.rs
+++ b/lib/sdf/src/server/service/component.rs
@@ -8,9 +8,9 @@ use dal::change_status::ChangeStatusError;
 use dal::{
     node::NodeError, property_editor::PropertyEditorError, AttributeContextBuilderError,
     AttributePrototypeArgumentError, AttributePrototypeError, AttributeValueError,
-    ComponentError as DalComponentError, DiagramError, ExternalProviderError, FuncBindingError,
-    InternalProviderError, SchemaError as DalSchemaError, StandardModelError, TransactionsError,
-    WsEventError,
+    ComponentError as DalComponentError, ComponentId, DiagramError, ExternalProviderError,
+    FuncBindingError, InternalProviderError, SchemaError as DalSchemaError, StandardModelError,
+    TransactionsError, WsEventError,
 };
 use thiserror::Error;
 
@@ -35,8 +35,8 @@ pub enum ComponentError {
     Component(#[from] DalComponentError),
     #[error("component name not found")]
     ComponentNameNotFound,
-    #[error("component not found")]
-    ComponentNotFound,
+    #[error("component not found for id: {0}")]
+    ComponentNotFound(ComponentId),
     #[error("dal schema error: {0}")]
     DalSchema(#[from] DalSchemaError),
     #[error("invalid request")]

--- a/lib/sdf/src/server/service/component/get_property_editor_schema.rs
+++ b/lib/sdf/src/server/service/component/get_property_editor_schema.rs
@@ -34,7 +34,7 @@ pub async fn get_property_editor_schema(
 
     let component = Component::get_by_id(&ctx, &request.component_id)
         .await?
-        .ok_or(ComponentError::ComponentNotFound)?;
+        .ok_or(ComponentError::ComponentNotFound(request.component_id))?;
     let schema_variant_id = *component
         .schema_variant(&ctx)
         .await?

--- a/lib/sdf/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/insert_property_editor_value.rs
@@ -22,7 +22,7 @@ pub struct InsertPropertyEditorValueRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InsertPropertyEditorValueResponse {
-    success: bool,
+    pub success: bool,
 }
 
 pub async fn insert_property_editor_value(

--- a/lib/sdf/src/server/service/component/set_type.rs
+++ b/lib/sdf/src/server/service/component/set_type.rs
@@ -31,7 +31,7 @@ pub async fn set_type(
 
     let component = Component::get_by_id(&ctx, &request.component_id)
         .await?
-        .ok_or(ComponentError::ComponentNotFound)?;
+        .ok_or(ComponentError::ComponentNotFound(request.component_id))?;
 
     // If no type was found, default to a standard "component".
     let component_type: ComponentType = match request.value {

--- a/lib/sdf/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/update_property_editor_value.rs
@@ -23,7 +23,7 @@ pub struct UpdatePropertyEditorValueRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdatePropertyEditorValueResponse {
-    success: bool,
+    pub success: bool,
 }
 
 pub async fn update_property_editor_value(

--- a/lib/sdf/src/server/service/diagram/create_node.rs
+++ b/lib/sdf/src/server/service/diagram/create_node.rs
@@ -28,6 +28,7 @@ pub struct CreateNodeRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CreateNodeResponse {
     pub component_id: ComponentId,
+    pub node_id: NodeId,
 }
 
 pub async fn create_node(
@@ -95,5 +96,6 @@ pub async fn create_node(
 
     Ok(Json(CreateNodeResponse {
         component_id: *component.id(),
+        node_id: *node.id(),
     }))
 }

--- a/lib/sdf/tests/service_tests/scenario.rs
+++ b/lib/sdf/tests/service_tests/scenario.rs
@@ -1,0 +1,488 @@
+//! This module contains all scenario tests. A scenario test is an `sdf` test that leverages
+//! multiple endpoints to test an end-to-end user scenario.
+
+use dal::qualification::QualificationSubCheckStatus;
+use dal::{ChangeSet, Component, DalContext, Visibility};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+use crate::service_tests::scenario::harness::ScenarioHarness;
+use crate::test_setup;
+
+mod harness;
+
+/// This test runs through the entire model flow and fix flow lifecycle with a non-trivial set
+/// of [`Components`](dal::Component).
+///
+/// It is recommended to run this test with the following environment variable:
+/// ```shell
+/// SI_TEST_BUILTIN_SCHEMAS=aws region,aws ami,aws keypair,aws ec2,aws securitygroup,aws ingress,docker image,coreos butane
+/// ```
+#[test]
+#[ignore]
+async fn model_and_fix_flow() {
+    test_setup!(
+        _sdf_ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        _txn,
+        _nats_conn,
+        _nats,
+        veritech,
+        encr_key,
+        app,
+        _nba,
+        auth_token,
+        ctx,
+        _job_processor,
+        _council_subject_prefix,
+    );
+    // Just borrow it the whole time because old habits die hard.
+    let ctx: &mut DalContext = &mut ctx;
+
+    // Setup the harness to start.
+    let mut harness = ScenarioHarness::new(
+        ctx,
+        app,
+        auth_token,
+        &[
+            "Region",
+            "Key Pair",
+            "EC2 Instance",
+            "Security Group",
+            "Ingress",
+            "AMI",
+            "Docker Image",
+            "Butane",
+        ],
+    )
+    .await;
+
+    // Enter a new change set. We will not go through the routes for this.
+    let new_change_set = ChangeSet::new(ctx, "bruce springsteen", None)
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility(Visibility::new(new_change_set.pk, None));
+    assert!(!ctx.visibility().is_head());
+
+    // Create all AWS components.
+    let region = harness.create_node(ctx, "Region", None).await;
+    let ami = harness.create_node(ctx, "AMI", Some(region.node_id)).await;
+    let key_pair = harness
+        .create_node(ctx, "Key Pair", Some(region.node_id))
+        .await;
+    let ec2 = harness
+        .create_node(ctx, "EC2 Instance", Some(region.node_id))
+        .await;
+    let security_group = harness
+        .create_node(ctx, "Security Group", Some(region.node_id))
+        .await;
+    let ingress = harness
+        .create_node(ctx, "Ingress", Some(region.node_id))
+        .await;
+
+    // Create all other components.
+    let docker = harness.create_node(ctx, "Docker Image", None).await;
+    let butane = harness.create_node(ctx, "Butane", None).await;
+
+    // Connect Docker and Butane to the relevant AWS components.
+    harness
+        .create_connection(ctx, docker.node_id, butane.node_id, "Container Image")
+        .await;
+    harness
+        .create_connection(ctx, docker.node_id, ingress.node_id, "Exposed Ports")
+        .await;
+    harness
+        .create_connection(ctx, butane.node_id, ec2.node_id, "User Data")
+        .await;
+
+    // Connect AMI, Key Pair and Security Group to the relevant AWS components.
+    harness
+        .create_connection(ctx, ami.node_id, ec2.node_id, "Image ID")
+        .await;
+    harness
+        .create_connection(ctx, key_pair.node_id, ec2.node_id, "Key Name")
+        .await;
+    harness
+        .create_connection(
+            ctx,
+            security_group.node_id,
+            ingress.node_id,
+            "Security Group ID",
+        )
+        .await;
+    harness
+        .create_connection(
+            ctx,
+            security_group.node_id,
+            ec2.node_id,
+            "Security Group ID",
+        )
+        .await;
+
+    // Update AMI, Key Pair and Security Group to start.
+    harness
+        .update_value(
+            ctx,
+            ami.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["Fedora CoreOS"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            ami.component_id,
+            &["domain", "ImageId"],
+            Some(serde_json::json!["ami-0bde60638be9bb870"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            key_pair.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-key"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            key_pair.component_id,
+            &["domain", "KeyType"],
+            Some(serde_json::json!["rsa"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            security_group.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-sg"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            security_group.component_id,
+            &["domain", "Description"],
+            Some(serde_json::json!["poop canoe"]),
+        )
+        .await;
+
+    // Now, look at Ingress and EC2 Instance.
+    harness
+        .update_value(
+            ctx,
+            ingress.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-ingress"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            ec2.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-server"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            ec2.component_id,
+            &["domain", "InstanceType"],
+            Some(serde_json::json!["t3.micro"]),
+        )
+        .await;
+
+    // Update Docker Image and Butane.
+    harness
+        .update_value(
+            ctx,
+            docker.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["docker.io/systeminit/whiskers:latest"]),
+        )
+        .await;
+    harness
+        .insert_value(ctx, docker.component_id, &["domain", "ExposedPorts"], None)
+        .await;
+    harness
+        .update_value(
+            ctx,
+            docker.component_id,
+            &["domain", "ExposedPorts", "0"],
+            Some(serde_json::json!["80/tcp"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            butane.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["Butane"]),
+        )
+        .await;
+
+    // Finally, update Region.
+    harness
+        .update_value(
+            ctx,
+            region.component_id,
+            &["domain", "region"],
+            Some(serde_json::json!["us-east-2"]),
+        )
+        .await;
+
+    // Check AMI, Key Pair and Security Group.
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "Fedora CoreOS",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsAmiJSON": {
+                    "code": "{\n\t\"ImageIds\": [\n\t\t\"ami-0bde60638be9bb870\"\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "region": "us-east-2",
+                "ImageId": "ami-0bde60638be9bb870",
+            },
+            "qualification": {
+                "si:qualificationAmiExists": {
+                    "result": "success",
+                    "message": "Image exists",
+                },
+            },
+        }], // expected
+        ami.view(ctx).await.to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "toddhoward-key",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsKeyPairJSON": {
+                    "code": "{\n\t\"KeyName\": \"toddhoward-key\",\n\t\"KeyType\": \"rsa\",\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"key-pair\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"toddhoward-key\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-key",
+                },
+                "region": "us-east-2",
+                "KeyName": "toddhoward-key",
+                "KeyType": "rsa",
+                "awsResourceType": "key-pair",
+            },
+            "qualification": {
+                "si:qualificationKeyPairCanCreate": {
+                    "result": "success",
+                    "message": "component qualified",
+                },
+            },
+        }], // expected
+        key_pair.view(ctx).await.drop_confirmation().to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "toddhoward-sg",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsSecurityGroupJSON": {
+                    "code": "{\n\t\"Description\": \"poop canoe\",\n\t\"GroupName\": \"toddhoward-sg\",\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"security-group\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"toddhoward-sg\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-sg",
+                },
+                "region": "us-east-2",
+                "GroupName": "toddhoward-sg",
+                "Description": "poop canoe",
+                "awsResourceType": "security-group",
+            },
+            "qualification": {
+                "si:qualificationSecurityGroupCanCreate": {
+                    "result": "success",
+                    "message": "component qualified",
+                },
+            },
+        }], // expected
+        security_group
+            .view(ctx)
+            .await
+            .drop_confirmation()
+            .to_value(), // actual
+    );
+
+    // Check Ingress, EC2 Instance and Region.
+    assert_eq!(
+        serde_json::json![{
+          "si": {
+                "name": "toddhoward-ingress",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsIngressJSON": {
+                    "code": "{\n\t\"IpPermissions\": [\n\t\t{\n\t\t\t\"FromPort\": 80,\n\t\t\t\"ToPort\": 80,\n\t\t\t\"IpProtocol\": \"tcp\",\n\t\t\t\"IpRanges\": [\n\t\t\t\t{\n\t\t\t\t\t\"CidrIp\": \"0.0.0.0/0\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t],\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"security-group-rule\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"toddhoward-ingress\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-ingress",
+                },
+                "region": "us-east-2",
+                "IpPermissions": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "ToPort": "80",
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                    },
+                ],
+                "awsResourceType": "security-group-rule",
+            },
+            "qualification": {
+                "si:qualificationIngressCanCreate": {
+                    "result": "success",
+                    "message": "component qualified",
+                },
+            },
+        }], // expected
+        ingress.view(ctx).await.drop_confirmation().to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "toddhoward-server",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsEc2JSON": {
+                    "code": "{\n\t\"ImageId\": \"ami-0bde60638be9bb870\",\n\t\"InstanceType\": \"t3.micro\",\n\t\"KeyName\": \"toddhoward-key\",\n\t\"UserData\": \"\",\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"instance\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"toddhoward-server\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-server",
+                },
+                "region": "us-east-2",
+                "ImageId": "ami-0bde60638be9bb870",
+                "KeyName": "toddhoward-key",
+                "UserData": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers-latest\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers-latest\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers-latest\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers:latest\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers-latest --publish 80:80 docker.io/systeminit/whiskers:latest\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers-latest.service\"\n      }\n    ]\n  }\n}",
+                "InstanceType": "t3.micro",
+                "awsResourceType": "instance",
+            },
+            "qualification": {
+                "si:qualificationEc2CanRun": {
+                    "result": "warning",
+                    "message": "Key Pair must exist. It will be created by the fix flow after merging this change-set",
+                },
+            },
+        }], // expected
+        ec2.view(ctx).await.drop_confirmation().to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-east-2",
+                "type": "configurationFrame",
+                "protected": false,
+            },
+            "domain": {
+                "region": "us-east-2",
+            },
+        }], // expected
+        region.view(ctx).await.to_value(), // actual
+    );
+
+    // Finally, check Docker Image and Butane.
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "docker.io/systeminit/whiskers:latest",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "image": "docker.io/systeminit/whiskers:latest",
+                "ExposedPorts": [
+                    "80/tcp",
+                ],
+            },
+        }], // expected
+        docker.view(ctx).await.drop_qualification().to_value(), // actual
+    );
+
+    // Evaluate Docker Image qualification(s) separately as they may contain a timestamp. Technically,
+    // we should be doing this via an sdf route. However, this test focuses on the model and fix
+    // flow and we only want to know that the qualification(s) passed.
+    for qualification in Component::list_qualifications(ctx, docker.component_id)
+        .await
+        .expect("could not list qualifications")
+    {
+        assert_eq!(
+            QualificationSubCheckStatus::Success,
+            qualification.result.expect("no result found").status
+        );
+    }
+
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "Butane",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateButaneIgnition": {
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers-latest\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers-latest\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers-latest\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers:latest\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers-latest --publish 80:80 docker.io/systeminit/whiskers:latest\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers-latest.service\"\n      }\n    ]\n  }\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "systemd": {
+                    "units": [
+                        {
+                            "name": "docker-io-systeminit-whiskers-latest.service",
+                            "enabled": true,
+                            "contents": "[Unit]\nDescription=Docker-io-systeminit-whiskers-latest\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers-latest\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers-latest\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers:latest\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers-latest --publish 80:80 docker.io/systeminit/whiskers:latest\n\n[Install]\nWantedBy=multi-user.target",
+                        },
+                    ],
+                },
+                "variant": "fcos",
+                "version": "1.4.0",
+            },
+            "qualification": {
+                "si:qualificationButaneIsValidIgnition": {
+                    "result": "success",
+                    "message": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers-latest\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers-latest\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers-latest\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers:latest\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers-latest --publish 80:80 docker.io/systeminit/whiskers:latest\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers-latest.service\"\n      }\n    ]\n  }\n}",
+                },
+            },
+        }], // expected
+        butane.view(ctx).await.to_value(), // actual
+    );
+
+    // TODO(nick): continue this test starting with "change set apply" and then running the fix
+    // flow. Fortunately, this should be much easier now that the groundwork has been laid for
+    // authoring scenario tests.
+}

--- a/lib/sdf/tests/service_tests/scenario/harness.rs
+++ b/lib/sdf/tests/service_tests/scenario/harness.rs
@@ -1,0 +1,370 @@
+//! This module contains [`ScenarioHarness`] and related items, which are used to author scenario
+//! tests. Scenario tests are "sdf" tests intended to cover end-to-end scenarios.
+
+use axum::http::Method;
+use axum::Router;
+use dal::property_editor::values::PropertyEditorValue;
+use dal::socket::SocketEdgeKind;
+use dal::{
+    AttributeValue, AttributeValueId, ComponentId, ComponentView, DalContext, NodeId, Prop,
+    PropKind, Schema, SchemaId, Socket, StandardModel,
+};
+use dal_test::helpers::component_view::ComponentViewProperties;
+use sdf::service::component::get_property_editor_values::{
+    GetPropertyEditorValuesRequest, GetPropertyEditorValuesResponse,
+};
+use sdf::service::component::insert_property_editor_value::{
+    InsertPropertyEditorValueRequest, InsertPropertyEditorValueResponse,
+};
+use sdf::service::component::update_property_editor_value::{
+    UpdatePropertyEditorValueRequest, UpdatePropertyEditorValueResponse,
+};
+use sdf::service::diagram::create_connection::{CreateConnectionRequest, CreateConnectionResponse};
+use sdf::service::diagram::create_node::{CreateNodeRequest, CreateNodeResponse};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{HashMap, VecDeque};
+
+use crate::service_tests::api_request_auth_json_body;
+use crate::service_tests::api_request_auth_query;
+
+/// This struct is a wrapper around metadata related to a [`Component`](dal::Component) for use in
+/// scenario tests.
+pub struct ComponentBag {
+    pub component_id: ComponentId,
+    pub node_id: NodeId,
+}
+
+impl From<CreateNodeResponse> for ComponentBag {
+    fn from(response: CreateNodeResponse) -> Self {
+        Self {
+            component_id: response.component_id,
+            node_id: response.node_id,
+        }
+    }
+}
+
+impl ComponentBag {
+    /// Generate a [`ComponentView`](dal::ComponentView) and return the
+    /// [`properties`](dal_test::helpers::component_view::ComponentViewProperties).
+    pub async fn view(&self, ctx: &DalContext) -> ComponentViewProperties {
+        let component_view = ComponentView::new(ctx, self.component_id)
+            .await
+            .expect("could not create component view");
+        ComponentViewProperties::try_from(component_view)
+            .expect("cannot create component view properties from component view")
+    }
+}
+
+/// A type alias for a collection of values in the [`PropertyEditor`](dal::property_editor).
+type PropertyValues = GetPropertyEditorValuesResponse;
+
+/// This harness provides helpers and caches for writing scenario tests.
+pub struct ScenarioHarness {
+    app: Router,
+    auth_token: String,
+    builtins: HashMap<&'static str, SchemaId>,
+}
+
+impl ScenarioHarness {
+    /// Create a new [`harness`](Self) by caching relevant metadata, including a list of builtin
+    /// [`Schemas`](dal::Schema) by name.
+    pub async fn new(
+        ctx: &DalContext,
+        app: Router,
+        auth_token: String,
+        builtin_schema_names: &[&'static str],
+    ) -> Self {
+        let mut builtins: HashMap<&'static str, SchemaId> = HashMap::new();
+        for builtin_schema_name in builtin_schema_names {
+            let schema = Schema::find_by_attr(ctx, "name", &builtin_schema_name.to_string())
+                .await
+                .expect("could not find schema by name")
+                .pop()
+                .expect("schema not found");
+            builtins.insert(builtin_schema_name, *schema.id());
+        }
+        Self {
+            app,
+            auth_token,
+            builtins,
+        }
+    }
+
+    /// Find the "value" in the property editor for a given [`ComponentId`](dal::Component) and
+    /// path. The path corresponds to the child (in order of lineage) from the
+    /// [`RootProp`](dal::RootProp).
+    ///
+    /// For example: if you want the "value" at "/root/domain/poop/canoe", you would pass in
+    /// \["domain", "poop", "canoe"\] as the path. From that, we would find the target
+    /// [`Prop`](dal::Prop), "canoe".
+    ///
+    /// This also works with elements within maps and arrays. To access a map element, provide
+    /// the key as the path item (e.g. for map "/root/domain/map" and element
+    /// "/root/domain/map/foo", provide \["domain", "map", "foo"\]). To access an array element,
+    /// provide the index as the path item (e.g. for array "/root/domain/array" and element
+    /// "/root/domain/array/bar", provide \["domain", "array", "bar"\]).
+    async fn find_value(
+        &self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+        path: &[&str],
+    ) -> (AttributeValueId, PropertyEditorValue) {
+        // Prepare the queue and pop the first item from it. This will be our identifier to track
+        // the current value that we are looking for.
+        let mut queue = path
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<VecDeque<String>>();
+        let mut identifier = queue.pop_front().expect("provided empty path");
+
+        // Collect the property editor values that we need to traverse.
+        let property_values = self.get_values(ctx, component_id).await;
+
+        // Start with the root's child values.
+        let value_ids = property_values
+            .child_values
+            .get(&property_values.root_value_id)
+            .expect("could not get child props for root")
+            .clone();
+
+        // Initialize our trackers. We use this to help find our target value at every "level".
+        let mut parent_value_id = property_values.root_value_id;
+        let mut target_value = None;
+        let mut parent_kind = PropKind::Object;
+        let mut array_element_attribute_value_id = AttributeValueId::NONE;
+
+        // Alright, here's what's going down: we need to pretend like we are a user in the UI. Well,
+        // we have to perform the equivalent to a user "descending" into fields in the property
+        // editor. We do this by crawling the schema to find the name of the prop at each level
+        // (via the provided queue) or the index/key of a map/array element.
+        let mut work_queue = VecDeque::from(value_ids);
+        'outer: while let Some(value_id) = work_queue.pop_front() {
+            let value = property_values
+                .values
+                .get(&value_id)
+                .expect("could not get value by id");
+
+            // Find the value out of the current sibling group based on the parent's prop kind.
+            // For arrays, we will use the index map. For maps, we will use the key. For everything
+            // else, we will use the prop name.
+            let found_value = match parent_kind {
+                PropKind::Array => value.attribute_value_id() == array_element_attribute_value_id,
+                PropKind::Map => {
+                    let found_key = value.key.as_ref().expect("key not found for child of map");
+                    found_key == &identifier
+                }
+                _ => {
+                    let prop = Prop::get_by_id(ctx, &value.prop_id())
+                        .await
+                        .expect("could not perform get by id")
+                        .expect("prop not found");
+                    prop.name() == identifier
+                }
+            };
+
+            if found_value {
+                // If the queue is empty, we are done. If not, set self as the parent and continue.
+                if queue.is_empty() {
+                    target_value = Some(value.clone());
+                    break 'outer;
+                }
+
+                // Pop the queue and descend to the next set of child values.
+                identifier = queue.pop_front().expect("provided empty queue");
+
+                // Get the prop for the value. If we were not an element of a map or array, we
+                // probably did this once already, but we avoid during upon _every_ iteration
+                // since all map and array elements will share the same prop id.
+                let prop = Prop::get_by_id(ctx, &value.prop_id())
+                    .await
+                    .expect("could not perform get by id")
+                    .expect("prop not found");
+
+                // Before we do anything else, if we are an array, let's prepare the target id in
+                // advance using the newly popped identifier.
+                if *prop.kind() == PropKind::Array {
+                    let array_attribute_value = AttributeValue::get_by_id(ctx, &value_id.into())
+                        .await
+                        .expect("could not perform get by id")
+                        .expect("attribute value not found");
+                    let index_map = array_attribute_value.index_map.expect("no index map found");
+                    let index: usize = identifier
+                        .parse()
+                        .expect("could not convert identifier into index");
+                    array_element_attribute_value_id = index_map.order()[index];
+                }
+
+                // Now, ensure we cache the parent information.
+                parent_value_id = value_id;
+                parent_kind = *prop.kind();
+
+                // Wipe the current set of child values and extend with the new set.
+                #[allow(clippy::eq_op)]
+                work_queue.retain(|&v| v != v);
+                work_queue.extend(
+                    property_values
+                        .child_values
+                        .get(&value_id)
+                        .expect("could not get child values"),
+                );
+            }
+        }
+
+        (
+            parent_value_id.into(),
+            target_value.expect("value not found"),
+        )
+    }
+
+    // Update a "value" for a given path and [`Component`](dal::Component).
+    pub async fn update_value(
+        &self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+        path: &[&str],
+        value: Option<Value>,
+    ) {
+        let (parent_attribute_value_id, property_value) =
+            self.find_value(ctx, component_id, path).await;
+        let request = UpdatePropertyEditorValueRequest {
+            attribute_value_id: property_value.attribute_value_id(),
+            parent_attribute_value_id: Some(parent_attribute_value_id),
+            prop_id: property_value.prop_id(),
+            component_id,
+            value,
+            key: property_value.key.clone(),
+            visibility: *ctx.visibility(),
+        };
+        let response: UpdatePropertyEditorValueResponse = self
+            .query_post("/api/component/update_property_editor_value", &request)
+            .await;
+        assert!(response.success)
+    }
+
+    /// Insert a "value" into a map or an array corresponding to a given path and
+    /// [`Component`](dal::Component).
+    pub async fn insert_value(
+        &self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+        path: &[&str],
+        value: Option<Value>,
+    ) {
+        let (_, property_value) = self.find_value(ctx, component_id, path).await;
+        let request = InsertPropertyEditorValueRequest {
+            parent_attribute_value_id: property_value.attribute_value_id(),
+            prop_id: property_value.prop_id(),
+            component_id,
+            value,
+            key: property_value.key.clone(),
+            visibility: *ctx.visibility(),
+        };
+        let response: InsertPropertyEditorValueResponse = self
+            .query_post("/api/component/insert_property_editor_value", &request)
+            .await;
+        assert!(response.success)
+    }
+
+    /// Get the latest [`PropertyValues`] for a given [`Component`](dal::Component).
+    async fn get_values(&self, ctx: &DalContext, component_id: ComponentId) -> PropertyValues {
+        let request = GetPropertyEditorValuesRequest {
+            component_id,
+            visibility: *ctx.visibility(),
+        };
+        let response: GetPropertyEditorValuesResponse = self
+            .query_get("/api/component/get_property_editor_values", &request)
+            .await;
+        response
+    }
+
+    /// Create a "connection" between two [`Nodes`](dal::Node) via a matching
+    /// [`Socket`](dal::Socket).
+    pub async fn create_connection(
+        &self,
+        ctx: &DalContext,
+        source_node_id: NodeId,
+        destination_node_id: NodeId,
+        shared_socket_name: &str,
+    ) {
+        let source_socket = Socket::find_by_name_for_edge_kind_and_node(
+            ctx,
+            shared_socket_name,
+            SocketEdgeKind::ConfigurationOutput,
+            source_node_id,
+        )
+        .await
+        .expect("could not perform query")
+        .expect("could not find socket");
+        let destination_socket = Socket::find_by_name_for_edge_kind_and_node(
+            ctx,
+            shared_socket_name,
+            SocketEdgeKind::ConfigurationInput,
+            destination_node_id,
+        )
+        .await
+        .expect("could not perform query")
+        .expect("could not find socket");
+
+        let request = CreateConnectionRequest {
+            from_node_id: source_node_id,
+            from_socket_id: *source_socket.id(),
+            to_node_id: destination_node_id,
+            to_socket_id: *destination_socket.id(),
+            visibility: *ctx.visibility(),
+        };
+        let _response: CreateConnectionResponse = self
+            .query_post("/api/diagram/create_connection", &request)
+            .await;
+    }
+
+    /// Create a [`Component`](dal::Component) and [`Node`](dal::Node) for a given
+    /// [`Schema`](dal::Schema). Optionally "place" the [`Node`](dal::Node) into a "frame".
+    pub async fn create_node(
+        &mut self,
+        ctx: &DalContext,
+        schema_name: &str,
+        frame_node_id: Option<NodeId>,
+    ) -> ComponentBag {
+        let schema_id = *self
+            .builtins
+            .get(schema_name)
+            .expect("could not find schema by name");
+        let request = CreateNodeRequest {
+            schema_id,
+            parent_id: frame_node_id,
+            x: "0".to_string(),
+            y: "0".to_string(),
+            visibility: *ctx.visibility(),
+        };
+        let create_node_response: CreateNodeResponse =
+            self.query_post("/api/diagram/create_node", &request).await;
+        create_node_response.into()
+    }
+
+    /// Send a "GET" method query to the backend.
+    async fn query_get<Req: Serialize, Res: DeserializeOwned>(
+        &self,
+        uri: impl AsRef<str>,
+        request: &Req,
+    ) -> Res {
+        api_request_auth_query(self.app.clone(), uri, &self.auth_token, request).await
+    }
+
+    /// Send a "POST" method query to the backend.
+    async fn query_post<Req: Serialize, Res: DeserializeOwned>(
+        &self,
+        uri: impl AsRef<str>,
+        request: &Req,
+    ) -> Res {
+        api_request_auth_json_body(
+            self.app.clone(),
+            Method::POST,
+            uri,
+            &self.auth_token,
+            request,
+        )
+        .await
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the concept as "scenario tests", which are a work-in-progress name for tests that leverage `sdf` routes to test "scenarios" in end-to-end-ish capacities.

The first scenario test is the "model and fix flow" test. For this PR, only the "model flow" section was completed, but I suspect the vast majority of the work to already be done. Tacking on the "fix flow" section should be much easier as the scenario harness can be extended and the groundwork has already been laid.

EDIT: originally, #1746 and #1747 were part of this PR, but I spun them out.

## Commit Description

Primary:
- Add ability to author scenario tests (inclues a new harness)
- Add model flow scenario test with fix flow intended to come soon in
  the same function body (hence the name)

Secondary:
- Add "SchemaVariant::find_by_name_for_edge_kind_and_node()" function,
  query and integration test
  - Required for creating connections with the new harness
- Add the ability to drop the "confirmation" subtree for
  "ComponentViewProperties" (used in new test)
- Add "node_id" to "create_node" response (used in new harness)

Misc:
- Add pretty assertions to sdf dev-deps
- Re-order sdf runtime in DEVELOPING (sdf migration will rely on running
  jobs, which isn't usually an issue, but could become one)
- Fix "FuncBinding" doc comment
- Add debug log tracking the provided set of builtin schemas (as
  applicable)
- Expand "ComponentNotFound" error to include id for service tests
- Expand error scenarios for failed queries in sdf tests (more output)

## GIF

<img src="https://media3.giphy.com/media/1lypzn3ji3T080oaO5/giphy.gif"/>