### PR TITLE
Allow immediate variant attachment for sockets (ENG-1001)

### DIFF
--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -352,35 +352,29 @@ pub async fn create_schema_variant_with_root(
         .await
         .expect("cannot create schema variant");
 
-    let input_socket = Socket::new(
+    let _input_socket = Socket::new(
         ctx,
         "input",
         SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationInput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
+        Some(*variant.id()),
     )
     .await
     .expect("Unable to create socket");
-    variant
-        .add_socket(ctx, input_socket.id())
-        .await
-        .expect("Unable to add socket to variant");
 
-    let output_socket = Socket::new(
+    let _output_socket = Socket::new(
         ctx,
         "output",
         SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationOutput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
+        Some(*variant.id()),
     )
     .await
     .expect("Unable to create socket");
-    variant
-        .add_socket(ctx, output_socket.id())
-        .await
-        .expect("Unable to add socket to variant");
 
     (variant, root)
 }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -12,6 +12,8 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::{Client, EncryptionKey};
 
+use crate::builtins::BuiltinSchemaOption;
+
 pub mod action_prototype;
 pub mod actor_view;
 pub mod attribute;
@@ -68,7 +70,6 @@ pub mod workflow_runner;
 pub mod workspace;
 pub mod ws_event;
 
-use crate::builtins::BuiltinSchemaOption;
 pub use action_prototype::{
     ActionPrototype, ActionPrototypeContext, ActionPrototypeError, ActionPrototypeId,
 };
@@ -156,6 +157,7 @@ pub use schema::variant::leaves::LeafKind;
 pub use schema::variant::root_prop::component_type::ComponentType;
 pub use schema::variant::root_prop::RootProp;
 pub use schema::variant::root_prop::RootPropChild;
+pub use schema::variant::SchemaVariantError;
 pub use schema::{Schema, SchemaError, SchemaId, SchemaPk, SchemaVariant, SchemaVariantId};
 pub use secret::{
     DecryptedSecret, EncryptedSecret, Secret, SecretAlgorithm, SecretError, SecretId, SecretKind,

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -5,13 +5,12 @@ use thiserror::Error;
 
 use crate::func::binding::FuncBindingId;
 use crate::func::binding_return_value::FuncBindingReturnValueId;
-use crate::schema::variant::SchemaVariantError;
 use crate::socket::{Socket, SocketArity, SocketEdgeKind, SocketError, SocketId, SocketKind};
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_accessor_ro,
     standard_model_has_many, AttributePrototype, AttributePrototypeError, ComponentId, DiagramKind,
-    FuncId, HistoryEventError, InternalProviderId, SchemaVariant, StandardModel,
-    StandardModelError, Tenancy, Timestamp, Visibility,
+    FuncId, HistoryEventError, InternalProviderId, StandardModel, StandardModelError, Tenancy,
+    Timestamp, Visibility,
 };
 use crate::{
     AttributeContext, AttributeContextBuilderError, AttributeContextError, AttributePrototypeId,
@@ -161,24 +160,12 @@ impl ExternalProvider {
             &SocketEdgeKind::ConfigurationOutput,
             &arity,
             &DiagramKind::Configuration,
+            Some(schema_variant_id),
         )
         .await?;
         socket
             .set_external_provider(ctx, external_provider.id())
             .await?;
-
-        let variant = SchemaVariant::get_by_id(ctx, external_provider.schema_variant_id())
-            .await?
-            .ok_or_else(|| {
-                ExternalProviderError::SchemaVariant(
-                    SchemaVariantError::NotFound(*external_provider.schema_variant_id())
-                        .to_string(),
-                )
-            })?;
-        variant
-            .add_socket(ctx, socket.id())
-            .await
-            .map_err(|err| ExternalProviderError::SchemaVariant(err.to_string()))?;
 
         Ok((external_provider, socket))
     }

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -76,15 +76,14 @@ use crate::attribute::context::AttributeContextBuilder;
 use crate::func::backend::identity::FuncBackendIdentityArgs;
 use crate::func::binding::{FuncBindingError, FuncBindingId};
 use crate::func::binding_return_value::FuncBindingReturnValueId;
-use crate::schema::variant::SchemaVariantError;
 use crate::socket::{Socket, SocketArity, SocketEdgeKind, SocketError, SocketId, SocketKind};
 use crate::standard_model::object_option_from_row_option;
 use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_accessor_ro,
     AttributeContextBuilderError, AttributePrototype, AttributePrototypeError,
     AttributePrototypeId, AttributeReadContext, AttributeValueError, AttributeView, DiagramKind,
-    FuncError, FuncId, HistoryEventError, Prop, PropError, SchemaVariant, StandardModel,
-    StandardModelError, Tenancy, Timestamp, Visibility,
+    FuncError, FuncId, HistoryEventError, Prop, PropError, StandardModel, StandardModelError,
+    Tenancy, Timestamp, Visibility,
 };
 use crate::{
     standard_model_has_many, AttributeContext, AttributeContextError, AttributeValue, DalContext,
@@ -345,24 +344,12 @@ impl InternalProvider {
             &SocketEdgeKind::ConfigurationInput,
             &arity,
             &DiagramKind::Configuration,
+            Some(schema_variant_id),
         )
         .await?;
         socket
             .set_internal_provider(ctx, explicit_internal_provider.id())
             .await?;
-
-        let variant = SchemaVariant::get_by_id(ctx, explicit_internal_provider.schema_variant_id())
-            .await?
-            .ok_or_else(|| {
-                InternalProviderError::SchemaVariant(
-                    SchemaVariantError::NotFound(*explicit_internal_provider.schema_variant_id())
-                        .to_string(),
-                )
-            })?;
-        variant
-            .add_socket(ctx, socket.id())
-            .await
-            .map_err(|err| InternalProviderError::SchemaVariant(err.to_string()))?;
 
         Ok((explicit_internal_provider, socket))
     }

--- a/lib/dal/tests/integration_test/socket.rs
+++ b/lib/dal/tests/integration_test/socket.rs
@@ -15,6 +15,7 @@ async fn new(ctx: &DalContext) {
         &SocketEdgeKind::ConfigurationOutput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
+        None,
     )
     .await
     .expect("cannot create schema ui menu");
@@ -32,6 +33,7 @@ async fn set_required(ctx: &DalContext) {
         &SocketEdgeKind::ConfigurationInput,
         &SocketArity::One,
         &DiagramKind::Configuration,
+        None,
     )
     .await
     .expect("unable to create socket");
@@ -111,23 +113,25 @@ async fn list_for_component(ctx: &DalContext) {
         .expect("cannot create schema variant");
 
     // Create some additional sockets from the defaults.
-    Socket::new(
+    let output_socket = Socket::new(
         ctx,
         "output",
         SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationOutput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
+        Some(*schema_variant.id()),
     )
     .await
     .expect("could not create socket");
-    Socket::new(
+    let input_socket = Socket::new(
         ctx,
         "input",
         SocketKind::Standalone,
         &SocketEdgeKind::ConfigurationInput,
         &SocketArity::Many,
         &DiagramKind::Configuration,
+        Some(*schema_variant.id()),
     )
     .await
     .expect("could not create socket");
@@ -157,6 +161,8 @@ async fn list_for_component(ctx: &DalContext) {
         .iter()
         .map(|s| *s.id())
         .collect::<Vec<SocketId>>();
+    assert!(found_sockets.contains(output_socket.id()));
+    assert!(found_sockets.contains(input_socket.id()));
     assert_eq!(
         expected_sockets, // expected
         found_sockets,    // actual


### PR DESCRIPTION
- Allow sockets to be immediately attached to a schema variant during creation
- Fix bug in "list_for_component" sockets test where new sockets were not included in the schema variant (partial reason for why this commit exists)

This was removed from https://github.com/systeminit/si/pull/1745 and is now blocking https://github.com/systeminit/si/pull/1745.