### PR TITLE
feat(sdf,dal): create, save and exec variant defs

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@codemirror/commands": "^6.1.2",
     "@codemirror/lang-javascript": "^6.1.2",
+    "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.3.1",
     "@codemirror/legacy-modes": "^6.3.1",
     "@codemirror/lint": "^6.1.0",
@@ -35,6 +36,7 @@
     "@codemirror/view": "^6.7.1",
     "@headlessui/tailwindcss": "^0.1.1",
     "@headlessui/vue": "^1.6.7",
+    "@lezer/highlight": "^1.1.3",
     "@tailwindcss/forms": "^0.5.2",
     "@types/async": "^3.2.15",
     "@typescript/vfs": "^1.3.5",

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <RequestStatusMessage
-      v-if="loadAssetsReqStatus.isPending"
-      :request-status="loadAssetsReqStatus"
+      v-if="loadAssetReqStatus.isPending"
+      :request-status="loadAssetReqStatus"
       show-loader-without-message
     />
     <div v-else-if="assetStore.selectedAsset && assetId" class="flex flex-col">
@@ -15,6 +15,7 @@
         </div>
         <VButton2
           label="Execute"
+          :disabled="disabled"
           tone="action"
           icon="plus"
           size="md"
@@ -22,30 +23,69 @@
         />
       </div>
       <div class="p-sm flex flex-col">
-        <div class="pb-xs font-bold text-xl">Name:</div>
-        <div class="text-md">
-          {{ assetDisplayName(assetStore.selectedAsset) }}
-        </div>
+        <SiTextBox
+          id="name"
+          v-model="assetStore.selectedAsset.name"
+          :disabled="disabled"
+          title="Name"
+          placeholder="Give this asset a name here..."
+          @blur="updateAsset"
+        />
       </div>
       <div class="p-sm flex flex-col">
-        <div class="pb-xs font-bold text-xl">Category:</div>
-        <div class="text-md">{{ assetStore.selectedAsset.category }}</div>
+        <SiTextBox
+          id="menuName"
+          v-model="assetStore.selectedAsset.menuName"
+          :disabled="disabled"
+          title="Display name"
+          placeholder="Optionally, give the asset a shorter name for display here..."
+          @blur="updateAsset"
+        />
       </div>
       <div class="p-sm flex flex-col">
-        <div class="pb-xs font-bold text-xl">Description:</div>
-        <div class="text-md">{{ assetStore.selectedAsset.description }}</div>
+        <SiTextBox
+          id="category"
+          v-model="assetStore.selectedAsset.category"
+          :disabled="disabled"
+          title="Category"
+          placeholder="Pick a category for this asset"
+          @blur="updateAsset"
+        />
       </div>
       <div class="p-sm flex flex-col">
-        <div class="pb-xs font-bold text-xl">Color:</div>
+        <SiTextBox
+          id="description"
+          v-model="assetStore.selectedAsset.description"
+          :disabled="disabled"
+          title="Description"
+          text-area
+          placeholder="Provide a brief description of this asset here..."
+          @blur="updateAsset"
+        />
+      </div>
+      <div class="p-sm flex items-center">
+        <SiTextBox
+          id="color"
+          v-model="assetStore.selectedAsset.color"
+          :disabled="disabled"
+          title="Color"
+          placeholder="Choose a color for this asset"
+          @blur="updateAsset"
+        />
         <div
-          class="text-md"
-          :style="`color: #${assetStore.selectedAsset.color}`"
-        >
-          #{{ assetStore.selectedAsset.color }}
-        </div>
+          class="box-border h-8 w-8 mt-[23px] ml-auto"
+          :style="`background-color: #${assetStore.selectedAsset.color}`"
+        ></div>
       </div>
       <div class="p-sm flex flex-col">
-        <div class="pb-xs font-bold text-xl">Documentation:</div>
+        <SiTextBox
+          id="link"
+          v-model="assetStore.selectedAsset.link"
+          :disabled="disabled"
+          title="Documentation Link"
+          placeholder="Enter a link to the documentation for this asset here..."
+          @blur="updateAsset"
+        />
         <div class="text-md text-action-500 font-bold">
           <a :href="assetStore.selectedAsset.link" target="_blank">
             Documentation Link
@@ -67,23 +107,31 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import VButton2 from "@/ui-lib/VButton2.vue";
 import { useAssetStore, assetDisplayName } from "@/store/asset.store";
 import RequestStatusMessage from "@/ui-lib/RequestStatusMessage.vue";
 import Modal from "@/ui-lib/modals/Modal.vue";
+import SiTextBox from "@/components/SiTextBox.vue";
 import NodeSkeleton from "./NodeSkeleton.vue";
 
 const assetStore = useAssetStore();
-const loadAssetsReqStatus = assetStore.getRequestStatus("LOAD_ASSET_LIST");
+const loadAssetReqStatus = assetStore.getRequestStatus("LOAD_ASSET");
 const executeAssetModalRef = ref();
 const assetModalTitle = ref("New Asset Created");
+
+const updateAsset = () => {
+  assetStore.SAVE_ASSET(assetStore.selectedAsset);
+};
+
+const disabled = computed(() => assetStore.selectedAsset.variantExists);
 
 defineProps<{
   assetId?: string;
 }>();
 
-const executeAsset = () => {
+const executeAsset = async () => {
+  await assetStore.EXEC_ASSET(assetStore.selectedAsset.id);
   executeAssetModalRef.value.open();
 };
 </script>

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -33,7 +33,6 @@
 
 <script lang="ts" setup>
 import _ from "lodash";
-import { useRouter } from "vue-router";
 import { onMounted } from "vue";
 import SiSearch from "@/components/SiSearch.vue";
 import { useAssetStore } from "@/store/asset.store";
@@ -41,7 +40,6 @@ import RequestStatusMessage from "@/ui-lib/RequestStatusMessage.vue";
 import VButton2 from "@/ui-lib/VButton2.vue";
 import AssetListItem from "./AssetListItem.vue";
 
-const router = useRouter();
 const assetStore = useAssetStore();
 const loadAssetsReqStatus = assetStore.getRequestStatus("LOAD_ASSET_LIST");
 
@@ -55,12 +53,10 @@ onMounted(() => {
   }
 });
 
-const newAsset = () => {
-  const asset = assetStore.createNewAsset();
-  assetStore.SELECT_ASSET(asset.id);
-  router.push({
-    name: "workspace-lab-assets",
-    params: { assetId: asset.id },
-  });
+const newAsset = async () => {
+  const result = await assetStore.CREATE_ASSET(assetStore.createNewAsset());
+  if (result.result.success) {
+    assetStore.SELECT_ASSET(result.result.data.id);
+  }
 };
 </script>

--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -1,0 +1,143 @@
+<template>
+  <div
+    class="w-full h-full border-neutral-300 dark:border-neutral-600 border-x p-2"
+  >
+    <div
+      ref="editorMount"
+      class="border border-neutral-300 dark:border-neutral-600"
+      @keyup.stop
+      @keydown.stop
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, ref, toRef, watch } from "vue";
+import { basicSetup, EditorView } from "codemirror";
+import { Compartment, EditorState } from "@codemirror/state";
+import { keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
+import { gruvboxDark } from "cm6-theme-gruvbox-dark";
+import { basicLight } from "cm6-theme-basic-light";
+import { javascript } from "@codemirror/lang-javascript";
+import { json } from "@codemirror/lang-json";
+import { linter, lintGutter } from "@codemirror/lint";
+import { createLintSource } from "@/utils/typescriptLinter";
+import { useTheme } from "@/ui-lib/theme_tools";
+
+const props = defineProps<{
+  modelValue: string;
+  disabled?: boolean;
+  json?: boolean;
+  typescript?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: string): void;
+  (e: "change", v: string): void;
+}>();
+
+const editorMount = ref();
+let view: EditorView;
+
+const modelValue = toRef(props, "modelValue", "");
+const disabled = toRef(props, "disabled", false);
+const useJson = toRef(props, "json", false);
+const useTypescript = toRef(props, "typescript", false);
+const currentCode = ref<string>(modelValue.value ?? "");
+
+watch(
+  () => modelValue.value,
+  async (currentMv) => {
+    currentCode.value = currentMv ?? "";
+    const currentDoc = view?.state.doc.toString();
+
+    // We only care about this if the code changes from outside the editor itself
+    // and we didn't just switch to a new doc. This condition prevents a cycle
+    // with the updateListener
+    if (currentDoc === currentCode.value || typeof view === "undefined") {
+      return;
+    }
+
+    const updateTransaction = view.state.update({
+      changes: {
+        from: 0,
+        to: view.state.doc.length,
+        insert: currentCode.value,
+      },
+    });
+    view.update([updateTransaction]);
+  },
+);
+
+const language = new Compartment();
+const readOnly = new Compartment();
+const themeCompartment = new Compartment();
+const lintCompartment = new Compartment();
+
+const { theme: appTheme } = useTheme();
+const codeMirrorTheme = computed(() =>
+  appTheme.value === "dark" ? gruvboxDark : basicLight,
+);
+watch(codeMirrorTheme, () => {
+  view.dispatch({
+    effects: [themeCompartment.reconfigure(codeMirrorTheme.value)],
+  });
+});
+
+const mountEditor = async () => {
+  currentCode.value = modelValue.value ?? "";
+  const updateListener = EditorView.updateListener.of((update) => {
+    if (!update.docChanged) return;
+    const updatedCode = update.view.state.doc.toString();
+    emit("update:modelValue", updatedCode);
+    emit("change", updatedCode);
+  });
+
+  const extensions = [basicSetup];
+
+  if (useTypescript.value) {
+    const lintSource = createLintSource();
+    extensions.push(lintCompartment.of(linter(await lintSource)));
+    extensions.push(lintGutter());
+    extensions.push(language.of(javascript()));
+  }
+
+  if (useJson.value) {
+    extensions.push(language.of(json()));
+  }
+
+  const editorState = EditorState.create({
+    doc: currentCode.value,
+    extensions: extensions.concat([
+      keymap.of([indentWithTab]),
+      themeCompartment.of(codeMirrorTheme.value),
+      keymap.of([indentWithTab]),
+      readOnly.of(EditorState.readOnly.of(disabled.value)),
+      updateListener,
+      EditorView.lineWrapping,
+    ]),
+  });
+
+  view = new EditorView({
+    state: editorState,
+    parent: editorMount.value,
+  });
+};
+
+onMounted(() => {
+  if (editorMount.value) {
+    mountEditor();
+  }
+});
+</script>
+
+<style>
+.cm-editor .cm-content {
+  font-size: 14px;
+}
+
+.cm-editor .cm-gutter {
+  font-size: 14px;
+}
+</style>

--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -60,7 +60,6 @@ import { yaml as YamlModeParser } from "@codemirror/legacy-modes/mode/yaml";
 import { diff as DiffModeParser } from "@codemirror/legacy-modes/mode/diff";
 import clsx from "clsx";
 import { CodeLanguage } from "@/api/sdf/dal/code_view";
-// NOTE(nick): this took a long ass time to find. Javascript's JSON mode doesn't work. This does.
 
 import SiButtonIcon from "@/components/SiButtonIcon.vue";
 import { themeClasses, useTheme } from "@/ui-lib/theme_tools";

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -1,140 +1,39 @@
 <template>
-  <div
-    class="w-full h-full border-neutral-300 dark:border-neutral-600 border-x p-2"
-  >
-    <div
-      ref="editorMount"
-      class="border border-neutral-300 dark:border-neutral-600"
-      @keyup.stop
-      @keydown.stop
-    />
-  </div>
+  <CodeEditor
+    v-model="editingFunc"
+    typescript
+    :disabled="!isDevMode && isBuiltin"
+    @change="updateFuncCode"
+  />
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, toRef, watch } from "vue";
-import { basicSetup, EditorView } from "codemirror";
-import { Compartment, EditorState } from "@codemirror/state";
-import { keymap } from "@codemirror/view";
-import { indentWithTab } from "@codemirror/commands";
-import { gruvboxDark } from "cm6-theme-gruvbox-dark";
-import { basicLight } from "cm6-theme-basic-light";
-import { javascript } from "@codemirror/lang-javascript";
-import { linter, lintGutter } from "@codemirror/lint";
+import { ref, watch } from "vue";
 import { storeToRefs } from "pinia";
-import { createLintSource } from "@/utils/typescriptLinter";
-import { useFuncStore, nullEditingFunc } from "@/store/func/funcs.store";
-import { useTheme } from "@/ui-lib/theme_tools";
-import { EditingFunc } from "@/store/func/types";
+import { useFuncStore } from "@/store/func/funcs.store";
+import CodeEditor from "@/components/CodeEditor.vue";
 
 const funcStore = useFuncStore();
-const { selectedFunc, getFuncById } = storeToRefs(funcStore);
+const { selectedFunc } = storeToRefs(funcStore);
 
 const isDevMode = import.meta.env.DEV;
 
-const editingFunc = ref<EditingFunc>(selectedFunc.value);
-const editorMount = ref();
-let view: EditorView;
-
-const props = defineProps<{
-  funcId?: string;
-}>();
-
-function nilId(): string {
-  return "00000000000000000000000000";
-}
-
-const funcId = toRef(props, "funcId", nilId());
+const editingFunc = ref<string>(selectedFunc.value?.code ?? "");
+const isBuiltin = ref<boolean>(selectedFunc.value?.isBuiltin ?? false);
 
 watch(
   () => selectedFunc.value,
-  async (selectedFunc, prevFunc) => {
-    editingFunc.value = selectedFunc ?? nullEditingFunc;
-    const currentDoc = view?.state.doc.toString();
-    const funcCode = editingFunc.value.code;
-
-    // We only care about this if the code changes from outside the editor itself
-    // and we didn't just switch to a new doc. This condition prevents a cycle
-    // with the updateListener
-    if (
-      editingFunc.value?.id !== prevFunc?.id ||
-      currentDoc === funcCode ||
-      typeof view === "undefined"
-    ) {
-      return;
+  async (selectedFunc) => {
+    if (editingFunc.value !== selectedFunc.code) {
+      editingFunc.value = selectedFunc.code ?? "";
     }
 
-    const updateTransaction = view.state.update({
-      changes: {
-        from: 0,
-        to: view.state.doc.length,
-        insert: editingFunc.value.code,
-      },
-    });
-    view.update([updateTransaction]);
+    isBuiltin.value = selectedFunc.isBuiltin;
   },
+  { immediate: true },
 );
 
-const language = new Compartment();
-const readOnly = new Compartment();
-const themeCompartment = new Compartment();
-const lintCompartment = new Compartment();
-const lintSource = createLintSource();
-
-const { theme: appTheme } = useTheme();
-const codeMirrorTheme = computed(() =>
-  appTheme.value === "dark" ? gruvboxDark : basicLight,
-);
-watch(codeMirrorTheme, () => {
-  view.dispatch({
-    effects: [themeCompartment.reconfigure(codeMirrorTheme.value)],
-  });
-});
-
-const mountEditor = async () => {
-  editingFunc.value = getFuncById.value(funcId.value) ?? nullEditingFunc;
-  const updateListener = EditorView.updateListener.of((update) => {
-    if (!update.docChanged) return;
-    funcStore.updateFuncCode(funcId.value, update.view.state.doc.toString());
-  });
-
-  const editorState = EditorState.create({
-    doc: editingFunc.value.code,
-    extensions: [
-      lintCompartment.of(linter(await lintSource)),
-      lintGutter(),
-      basicSetup,
-      language.of(javascript()),
-      keymap.of([indentWithTab]),
-      themeCompartment.of(codeMirrorTheme.value),
-      keymap.of([indentWithTab]),
-      readOnly.of(
-        EditorState.readOnly.of(!isDevMode && editingFunc.value.isBuiltin),
-      ),
-      updateListener,
-      EditorView.lineWrapping,
-    ],
-  });
-
-  view = new EditorView({
-    state: editorState,
-    parent: editorMount.value,
-  });
+const updateFuncCode = (code: string) => {
+  funcStore.updateFuncCode(selectedFunc.value.id, code);
 };
-
-onMounted(() => {
-  if (editorMount.value) {
-    mountEditor();
-  }
-});
 </script>
-
-<style>
-.cm-editor .cm-content {
-  font-size: 14px;
-}
-
-.cm-editor .cm-gutter {
-  font-size: 14px;
-}
-</style>

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -14,7 +14,7 @@
     class="grow overflow-hidden bg-shade-0 dark:bg-neutral-800 dark:text-shade-0 text-lg font-semi-bold flex flex-col relative"
   >
     <div class="inset-2 bottom-0 absolute w-full h-full">
-      <AssetDisplay :asset-id="assetId" />
+      <AssetEditor :asset-id="assetId" />
     </div>
   </div>
   <SiPanel remember-size-key="func-details" side="right" :min-size="200">
@@ -30,7 +30,7 @@ import ChangeSetPanel from "../ChangeSetPanel.vue";
 import SiPanel from "../SiPanel.vue";
 import AssetListPanel from "../AssetListPanel.vue";
 import CustomizeTabs from "../CustomizeTabs.vue";
-import AssetDisplay from "../AssetDisplay.vue";
+import AssetEditor from "../AssetEditor.vue";
 import AssetDetailsPanel from "../AssetDetailsPanel.vue";
 
 const assetStore = useAssetStore();

--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -188,7 +188,7 @@ impl TryFrom<&Func> for FuncVariant {
                 _ => Ok(FuncVariant::Attribute),
             },
             (FuncBackendKind::JsCommand, _) => Ok(FuncVariant::Command),
-            (FuncBackendKind::Validation, _) => Ok(FuncVariant::Validation),
+            (FuncBackendKind::JsValidation, _) => Ok(FuncVariant::Validation),
             _ => Err(FuncError::FuncCannotBeTurnedIntoVariant(*func.id())),
         }
     }

--- a/lib/sdf/src/server/service/variant_definition.rs
+++ b/lib/sdf/src/server/service/variant_definition.rs
@@ -13,6 +13,7 @@ use dal::{
 use thiserror::Error;
 
 pub mod create_variant_def;
+pub mod exec_variant_def;
 pub mod get_variant_def;
 pub mod list_variant_defs;
 pub mod save_variant_def;
@@ -37,6 +38,8 @@ pub enum SchemaVariantDefinitionError {
     SchemaVariantDefinition(#[from] DalSchemaVariantDefinitionError),
     #[error("Schema Variant Definition {0} not found")]
     VariantDefnitionNotFound(SchemaVariantDefinitionId),
+    #[error("error creating schema variant from definition: {0}")]
+    CouldNotCreateSchemaVariantFromDefinition(String),
 }
 
 pub type SchemaVariantDefinitionResult<T> = Result<T, SchemaVariantDefinitionError>;
@@ -67,5 +70,9 @@ pub fn routes() -> Router {
         .route(
             "/create_variant_def",
             post(create_variant_def::create_variant_def),
+        )
+        .route(
+            "/exec_variant_def",
+            post(exec_variant_def::exec_variant_def),
         )
 }

--- a/lib/sdf/src/server/service/variant_definition/create_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/create_variant_def.rs
@@ -8,6 +8,12 @@ use dal::{
 };
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_ASSET_CODE: &str = r#"{
+  "props": [],
+  "inputSockets": [],
+  "outputSockets": []
+}"#;
+
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateVariantDefRequest {
@@ -44,7 +50,7 @@ pub async fn create_variant_def(
         request.color,
         ComponentKind::Standard,
         request.description,
-        "".to_string(),
+        DEFAULT_ASSET_CODE.to_string(),
     )
     .await?;
 

--- a/lib/sdf/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/exec_variant_def.rs
@@ -1,0 +1,94 @@
+use super::{SchemaVariantDefinitionError, SchemaVariantDefinitionResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use axum::Json;
+use dal::{
+    schema::variant::definition::{
+        SchemaVariantDefinition, SchemaVariantDefinitionId, SchemaVariantDefinitionJson,
+        SchemaVariantDefinitionMetadataJson,
+    },
+    schema::SchemaUiMenu,
+    Schema, SchemaVariant, SchemaVariantId, StandardModel, Visibility, WsEvent,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecVariantDefRequest {
+    pub id: SchemaVariantDefinitionId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecVariantDefResponse {
+    pub id: SchemaVariantId,
+    pub success: bool,
+}
+
+pub async fn exec_variant_def(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<ExecVariantDefRequest>,
+) -> SchemaVariantDefinitionResult<Json<ExecVariantDefResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let variant_def = SchemaVariantDefinition::get_by_id(&ctx, &request.id)
+        .await?
+        .ok_or(SchemaVariantDefinitionError::VariantDefnitionNotFound(
+            request.id,
+        ))?;
+
+    let metadata: SchemaVariantDefinitionMetadataJson = variant_def.clone().into();
+    let definition: SchemaVariantDefinitionJson = variant_def.try_into()?;
+
+    let mut schema = Schema::new(&ctx, metadata.name.clone(), &metadata.component_kind)
+        .await
+        .map_err(|e| {
+            SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(e.to_string())
+        })?;
+
+    let ui_menu_name = match metadata.menu_name {
+        Some(ref provided_override) => provided_override.to_owned(),
+        None => metadata.name.clone(),
+    };
+    let ui_menu = SchemaUiMenu::new(&ctx, ui_menu_name, &metadata.category)
+        .await
+        .map_err(|e| {
+            SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(e.to_string())
+        })?;
+    ui_menu.set_schema(&ctx, schema.id()).await.map_err(|e| {
+        SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(e.to_string())
+    })?;
+
+    let (mut schema_variant, _, _, _, _) =
+        SchemaVariant::new_with_definition(&ctx, metadata, definition)
+            .await
+            .map_err(|e| {
+                SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(
+                    e.to_string(),
+                )
+            })?;
+
+    schema
+        .set_default_schema_variant_id(&ctx, Some(*schema_variant.id()))
+        .await
+        .map_err(|e| {
+            SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(e.to_string())
+        })?;
+
+    schema_variant.finalize(&ctx, None).await.map_err(|e| {
+        SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(e.to_string())
+    })?;
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish(&ctx)
+        .await?;
+    ctx.commit().await?;
+
+    Ok(Json(ExecVariantDefResponse {
+        id: *schema_variant.id(),
+        success: true,
+    }))
+}

--- a/lib/sdf/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/save_variant_def.rs
@@ -2,7 +2,6 @@ use super::{SchemaVariantDefinitionError, SchemaVariantDefinitionResult};
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use axum::Json;
 use dal::{
-    component::ComponentKind,
     schema::variant::definition::{SchemaVariantDefinition, SchemaVariantDefinitionId},
     StandardModel, Visibility, WsEvent,
 };
@@ -16,9 +15,9 @@ pub struct SaveVariantDefRequest {
     pub menu_name: Option<String>,
     pub category: String,
     pub color: String,
-    pub component_kind: ComponentKind,
     pub link: Option<String>,
     pub definition: String,
+    pub description: Option<String>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -46,10 +45,10 @@ pub async fn save_variant_def(
     variant_def.set_menu_name(&ctx, request.menu_name).await?;
     variant_def.set_category(&ctx, request.category).await?;
     variant_def.set_color(&ctx, request.color).await?;
-    variant_def
-        .set_component_kind(&ctx, request.component_kind)
-        .await?;
     variant_def.set_link(&ctx, request.link).await?;
+    variant_def
+        .set_description(&ctx, request.description)
+        .await?;
     variant_def.set_definition(&ctx, request.definition).await?;
 
     WsEvent::change_set_written(&ctx)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ importers:
     specifiers:
       '@codemirror/commands': ^6.1.2
       '@codemirror/lang-javascript': ^6.1.2
+      '@codemirror/lang-json': ^6.0.1
       '@codemirror/language': ^6.3.1
       '@codemirror/legacy-modes': ^6.3.1
       '@codemirror/lint': ^6.1.0
@@ -24,6 +25,7 @@ importers:
       '@headlessui/tailwindcss': ^0.1.1
       '@headlessui/vue': ^1.6.7
       '@iconify/json': ^2.1.142
+      '@lezer/highlight': ^1.1.3
       '@tailwindcss/forms': ^0.5.2
       '@tailwindcss/line-clamp': ^0.4.2
       '@types/async': ^3.2.15
@@ -94,6 +96,7 @@ importers:
     dependencies:
       '@codemirror/commands': 6.1.2
       '@codemirror/lang-javascript': 6.1.2
+      '@codemirror/lang-json': 6.0.1
       '@codemirror/language': 6.3.1
       '@codemirror/legacy-modes': 6.3.1
       '@codemirror/lint': 6.1.0
@@ -101,6 +104,7 @@ importers:
       '@codemirror/view': 6.7.1
       '@headlessui/tailwindcss': 0.1.1_tailwindcss@3.2.2
       '@headlessui/vue': 1.7.4_vue@3.2.45
+      '@lezer/highlight': 1.1.3
       '@tailwindcss/forms': 0.5.3_tailwindcss@3.2.2
       '@types/async': 3.2.16
       '@typescript/vfs': 1.4.0
@@ -108,8 +112,8 @@ importers:
       async: 3.2.4
       axios: 0.27.2
       clsx: 1.2.1
-      cm6-theme-basic-light: 0.2.0_3qgb4z7z7yhytllqnwax2bsasy
-      cm6-theme-gruvbox-dark: 0.2.0_3qgb4z7z7yhytllqnwax2bsasy
+      cm6-theme-basic-light: 0.2.0_sm4njlkrsme4ayd2l27atm55cu
+      cm6-theme-gruvbox-dark: 0.2.0_sm4njlkrsme4ayd2l27atm55cu
       codemirror: 6.0.1
       date-fns: 2.29.3
       floating-vue: 2.0.0-beta.20_vue@3.2.45
@@ -868,13 +872,20 @@ packages:
       '@lezer/javascript': 1.0.2
     dev: false
 
+  /@codemirror/lang-json/6.0.1:
+    resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
+    dependencies:
+      '@codemirror/language': 6.3.1
+      '@lezer/json': 1.0.0
+    dev: false
+
   /@codemirror/language/6.3.1:
     resolution: {integrity: sha512-MK+G1QKaGfSEUg9YEFaBkMBI6j1ge4VMBPZv9fDYotw7w695c42x5Ba1mmwBkesYnzYFBfte6Hh9TDcKa6xORQ==}
     dependencies:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.7.1
       '@lezer/common': 1.0.1
-      '@lezer/highlight': 1.1.2
+      '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.4
       style-mod: 4.0.0
     dev: false
@@ -1309,8 +1320,8 @@ packages:
     resolution: {integrity: sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==}
     dev: false
 
-  /@lezer/highlight/1.1.2:
-    resolution: {integrity: sha512-CAun1WR1glxG9ZdOokTZwXbcwB7PXkIEyZRUMFBVwSrhTcogWq634/ByNImrkUnQhjju6xsIaOBIxvcRJtplXQ==}
+  /@lezer/highlight/1.1.3:
+    resolution: {integrity: sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==}
     dependencies:
       '@lezer/common': 1.0.1
     dev: false
@@ -1318,7 +1329,14 @@ packages:
   /@lezer/javascript/1.0.2:
     resolution: {integrity: sha512-IjOVeIRhM8IuafWNnk+UzRz7p4/JSOKBNINLYLsdSGuJS9Ju7vFdc82AlTt0jgtV5D8eBZf4g0vK4d3ttBNz7A==}
     dependencies:
-      '@lezer/highlight': 1.1.2
+      '@lezer/highlight': 1.1.3
+      '@lezer/lr': 1.2.4
+    dev: false
+
+  /@lezer/json/1.0.0:
+    resolution: {integrity: sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==}
+    dependencies:
+      '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.4
     dev: false
 
@@ -2639,7 +2657,7 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /cm6-theme-basic-light/0.2.0_3qgb4z7z7yhytllqnwax2bsasy:
+  /cm6-theme-basic-light/0.2.0_sm4njlkrsme4ayd2l27atm55cu:
     resolution: {integrity: sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -2650,9 +2668,10 @@ packages:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.7.1
+      '@lezer/highlight': 1.1.3
     dev: false
 
-  /cm6-theme-gruvbox-dark/0.2.0_3qgb4z7z7yhytllqnwax2bsasy:
+  /cm6-theme-gruvbox-dark/0.2.0_sm4njlkrsme4ayd2l27atm55cu:
     resolution: {integrity: sha512-xyqsG19qV+nb7ZHTMocSNWwZHMExfQxDm0FlbNMqEGKeQR96WryssXJH/IZZQudwrPpWU2dCoyOgMFhti2UTYA==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -2663,6 +2682,7 @@ packages:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.7.1
+      '@lezer/highlight': 1.1.3
     dev: false
 
   /co/4.6.0:


### PR DESCRIPTION
Make the function editor reusable and use for both asset editor and func editor. Add save/create/exec endpoints and use them in the frontend for creating new schema variants (assets).