### PR TITLE
feat(sdf): Allow ghosted components to be moved in the diagram

### DIFF
--- a/lib/sdf/src/server/service/diagram/set_node_position.rs
+++ b/lib/sdf/src/server/service/diagram/set_node_position.rs
@@ -30,7 +30,8 @@ pub async fn set_node_position(
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<SetNodePositionRequest>,
 ) -> DiagramResult<Json<SetNodePositionResponse>> {
-    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let visibility = Visibility::new_change_set(request.visibility.change_set_pk, true);
+    let ctx = builder.build(request_ctx.build(visibility)).await?;
 
     let (width, height) = {
         let component = dal::Component::find_for_node(&ctx, request.node_id)


### PR DESCRIPTION
![Screenshot 2023-02-14 at 00 49 20](https://user-images.githubusercontent.com/227823/218609640-1a77fb95-43b9-44ca-be1c-359e6bae5d2b.png)
![Screenshot 2023-02-14 at 00 49 24](https://user-images.githubusercontent.com/227823/218609644-bee75609-2213-4fe4-ad73-3c20f3d79e50.png)

Before, this change, the `node::get_by_id` was returning a `NotFound` and therefore not being able to finish `set_node_position` call

Fixes: ENG-999