### PR TITLE
Ensure confirmations are reloaded (ENG-1009)

### DIFF
--- a/app/web/src/components/RecommendationPicker.vue
+++ b/app/web/src/components/RecommendationPicker.vue
@@ -64,7 +64,7 @@
             <span class="pl-1">{{ creationRecommendations.length }}</span>
           </div>
           <Icon
-            v-if="fixesStore.populatingFixes"
+            v-if="confirmationsInFlight || fixesStore.populatingFixes"
             name="loader"
             size="md"
             class="text-action-500 dark:text-action-100"
@@ -84,6 +84,7 @@
               v-for="recommendation in creationRecommendations"
               :key="`${recommendation.confirmationAttributeValueId}-${recommendation.recommendedAction}`"
             >
+              <!-- TODO(nick,paulo): disable recommendation sprites that aren't ready using "disable-checkbox" -->
               <RecommendationSprite
                 :recommendation="recommendation"
                 :selected="
@@ -191,6 +192,15 @@ const selectedRecommendations = computed(() => {
 const runFixes = () => {
   fixesStore.EXECUTE_FIXES_FROM_RECOMMENDATIONS(selectedRecommendations.value);
 };
+
+const confirmationsInFlight = computed(() => {
+  for (const c of fixesStore.confirmations) {
+    if (c.status === "neverStarted") {
+      return true;
+    }
+  }
+  return false;
+});
 
 const disableApply = computed(
   () =>

--- a/app/web/src/components/RecommendationSprite.vue
+++ b/app/web/src/components/RecommendationSprite.vue
@@ -10,6 +10,7 @@
       <VormInput
         v-if="recommendation.status === 'unstarted'"
         :model-value="selected"
+        :disabled="disableCheckbox"
         type="checkbox"
         class="flex-none pl-1"
         no-label
@@ -106,6 +107,7 @@ const props = defineProps({
   recommendation: { type: Object as PropType<Recommendation>, required: true },
   class: { type: String },
   selected: { type: Boolean, default: false },
+  disableCheckbox: { type: Boolean, default: false },
 });
 
 const classes = computed(() => props.class);

--- a/app/web/src/store/fixes/fixes.store.ts
+++ b/app/web/src/store/fixes/fixes.store.ts
@@ -319,13 +319,9 @@ export const useFixesStore = () => {
         const realtimeStore = useRealtimeStore();
         realtimeStore.subscribe(this.$id, `workspace/${workspacePk}/head`, [
           {
-            eventType: "RanConfirmations",
+            eventType: "ConfirmationsUpdated",
             callback: (_update) => {
               this.runningFixBatch = undefined;
-
-              // NOTE(nick): this could be better with us only updating confirmations as they run.
-              // Although, there's a counter-argument: all confirmations should be re-ran once the
-              // "real world" changes, so is incremental updating really better? Maybe?
               this.LOAD_CONFIRMATIONS();
               this.LOAD_FIX_BATCHES();
             },

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -29,10 +29,6 @@ export type WsEventPayloadMap = {
     componentId: string;
   };
 
-  RanConfirmations: {
-    success: boolean;
-  };
-
   // NOT CURRENTLY USED - but leaving here so we remember these events exist
   // SecretCreated: number;
   // ResourceRefreshed: {
@@ -48,6 +44,10 @@ export type WsEventPayloadMap = {
   //   output: string[];
   //   runnerState: WorkflowRunnerState;
   // };
+
+  ConfirmationsUpdated: {
+    success: boolean;
+  };
   FixReturn: {
     id: string;
     batchId: string;

--- a/lib/dal/src/component/confirmation.rs
+++ b/lib/dal/src/component/confirmation.rs
@@ -10,13 +10,12 @@ use crate::component::{
 };
 use crate::func::binding_return_value::FuncBindingReturnValueId;
 use crate::job::definition::DependentValuesUpdate;
-use crate::ws_event::WsEvent;
 use crate::{
     standard_model, ActionPrototype, ActionPrototypeError, AttributeReadContext,
     AttributeValueError, AttributeValueId, ComponentError, DalContext, Fix, FixResolver,
     FuncBindingReturnValue, FuncDescription, FuncDescriptionContents, FuncId, Node, NodeError,
-    RootPropChild, Schema, SchemaId, SchemaVariant, SchemaVariantId, StandardModel, WsEventResult,
-    WsPayload,
+    RootPropChild, Schema, SchemaId, SchemaVariant, SchemaVariantId, StandardModel, WsEvent,
+    WsEventResult, WsPayload,
 };
 use crate::{Component, ComponentId};
 
@@ -56,8 +55,8 @@ pub struct Recommendation {
     // TODO(nick,paulo,paul,wendy): yes, these fields are technically already on the confirmation
     // itself and we could just map the recommendations back to the confirmations in the frontend,
     // but we want shit to work again before optimizing. Fix the fix flow!
-    confirmation_attribute_value_id: AttributeValueId,
-    component_id: ComponentId,
+    pub confirmation_attribute_value_id: AttributeValueId,
+    pub component_id: ComponentId,
     component_name: String,
     provider: Option<String>,
 
@@ -136,8 +135,6 @@ impl Component {
                 .collect::<Vec<AttributeValueId>>(),
         ))
         .await;
-
-        WsEvent::ran_confirmations(ctx).await?;
 
         Ok(())
     }
@@ -456,15 +453,15 @@ impl Component {
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct ConfirmationRunPayload {
+pub struct ConfirmationsUpdatedPayload {
     success: bool,
 }
 
 impl WsEvent {
-    pub async fn ran_confirmations(ctx: &DalContext) -> WsEventResult<Self> {
+    pub async fn confirmations_updated(ctx: &DalContext) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
-            WsPayload::RanConfirmations(ConfirmationRunPayload { success: true }),
+            WsPayload::ConfirmationsUpdated(ConfirmationsUpdatedPayload { success: true }),
         )
         .await
     }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -3,7 +3,7 @@ use si_data_nats::NatsError;
 use si_data_pg::PgError;
 use thiserror::Error;
 
-use crate::component::confirmation::ConfirmationRunPayload;
+use crate::component::confirmation::ConfirmationsUpdatedPayload;
 use crate::{
     component::{code::CodeGeneratedPayload, resource::ResourceRefreshId},
     fix::{batch::FixBatchReturn, FixReturn},
@@ -42,7 +42,7 @@ pub enum WsPayload {
     ChangeSetWritten(ChangeSetPk),
     SchemaCreated(SchemaPk),
     ResourceRefreshed(ResourceRefreshId),
-    RanConfirmations(ConfirmationRunPayload),
+    ConfirmationsUpdated(ConfirmationsUpdatedPayload),
     CheckedQualifications(QualificationCheckPayload),
     CommandOutput(CommandOutput),
     CodeGenerated(CodeGeneratedPayload),


### PR DESCRIPTION
Primary:
- Ensure confirmations are reloaded by sending a WsEvent when we have a
  DependentValuesUpdate job that contains AttributeValues corresponding
  to "/root/resource" for Components
  - Blind spot: if Confirmations are updated independently of
    "/root/resource", then we will not know to send this event
  - Fortunately, that should not happen outside of Func authoring
- Remove "RanConfirmations" WsEvent as it was inaccurate (technically,
  it scheduled confirmations to be ran)

Secondary:
- Prepare the recommendations UI to disabling the checkbox for
  recommendations that belong to "neverStarted" confirmations
- Run an actual FixBatch in the "list_confirmations" integration test