### PR TITLE
feat(web) re-enable component outline search/filter

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -250,12 +250,30 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           });
         },
         componentsByParentId(): Record<ComponentId, FullComponent[]> {
-          // remapping to component id... PLEASE LETS KILL NODE ID!
           return _.groupBy(this.allComponents, (c) =>
+            // remapping to component id... PLEASE LETS KILL NODE ID!
             c.parentNodeId
               ? this.componentsByNodeId[c.parentNodeId].id
               : "root",
           );
+        },
+        parentIdPathByComponentId(): Record<ComponentId, ComponentId[]> {
+          const parentsLookup: Record<ComponentId, ComponentId[]> = {};
+          // using componentsByParentId to do a tree walk
+          const processList = (
+            components: FullComponent[],
+            parentIds: ComponentId[],
+          ) => {
+            _.each(components, (c) => {
+              parentsLookup[c.id] = parentIds;
+              processList(this.componentsByParentId[c.id], [
+                ...parentIds,
+                c.id,
+              ]);
+            });
+          };
+          processList(this.componentsByParentId.root, []);
+          return parentsLookup;
         },
 
         componentsByNodeId(): Record<ComponentNodeId, FullComponent> {


### PR DESCRIPTION
Bringing back search in the outline view, with a cleaner (and easier to implement) UI.
When filtering is active, the list becomes flat, and breadcrumbs of the parent names show in each item.

<img width="265" alt="image" src="https://user-images.githubusercontent.com/1158956/218892855-e90505ce-3a1f-4d1c-b310-5df89329d336.png">
