### PR TITLE
Ensure we only fetch qualifications as needed (ENG-1011)

### DIFF
--- a/app/web/src/store/qualifications.store.ts
+++ b/app/web/src/store/qualifications.store.ts
@@ -165,8 +165,7 @@ export const useQualificationsStore = () => {
             },
           },
           {
-            // don't think this should be needed, but not getting other event when new component is added
-            eventType: "ChangeSetWritten",
+            eventType: "ComponentCreated",
             callback: () => {
               this.FETCH_QUALIFICATIONS_SUMMARY();
             },

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -60,6 +60,9 @@ export type WsEventPayloadMap = {
     id: string;
     status: FixStatus;
   };
+  ComponentCreated: {
+    success: boolean;
+  };
 
   // Old fake status update
   // UpdateStatus: {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -35,7 +35,8 @@ use crate::{
     InternalProvider, InternalProviderId, Node, NodeError, OrganizationError, Prop, PropError,
     PropId, RootPropChild, Schema, SchemaError, SchemaId, Socket, StandardModel,
     StandardModelError, Tenancy, Timestamp, TransactionsError, ValidationPrototypeError,
-    ValidationResolverError, Visibility, WorkflowRunnerError, WorkspaceError,
+    ValidationResolverError, Visibility, WorkflowRunnerError, WorkspaceError, WsEvent,
+    WsEventResult, WsPayload,
 };
 use crate::{AttributeValueId, QualificationError};
 use crate::{Edge, FixResolverError, NodeKind};
@@ -1129,5 +1130,21 @@ impl Component {
         ctx.enqueue_job(DependentValuesUpdate::new(ctx, ids)).await;
 
         Ok(Component::get_by_id(ctx, &component_id).await?)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentCreatedPayload {
+    success: bool,
+}
+
+impl WsEvent {
+    pub async fn component_created(ctx: &DalContext) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::ComponentCreated(ComponentCreatedPayload { success: true }),
+        )
+        .await
     }
 }

--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -556,7 +556,7 @@ impl Edge {
         ctx.enqueue_job(DependentValuesUpdate::new(ctx, vec![*attr_value.id()]))
             .await;
 
-        println!("Searching for original edge {edge_id}");
+        debug!("searching for original edge: {edge_id}");
 
         Ok(Edge::get_by_id(ctx, &edge_id).await?)
     }

--- a/lib/dal/src/node_position.rs
+++ b/lib/dal/src/node_position.rs
@@ -56,7 +56,6 @@ impl_standard_model! {
 impl NodePosition {
     /// Creates a new [`NodePosition`](Self) and sets its "belongs_to_id" to the provided
     /// [`NodeId`](crate::Node).
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         ctx: &DalContext,
         node_id: NodeId,

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -4,6 +4,7 @@ use si_data_pg::PgError;
 use thiserror::Error;
 
 use crate::component::confirmation::ConfirmationsUpdatedPayload;
+use crate::component::ComponentCreatedPayload;
 use crate::{
     component::{code::CodeGeneratedPayload, resource::ResourceRefreshId},
     fix::{batch::FixBatchReturn, FixReturn},
@@ -40,6 +41,7 @@ pub enum WsPayload {
     ChangeSetApplied(ChangeSetPk),
     ChangeSetCanceled(ChangeSetPk),
     ChangeSetWritten(ChangeSetPk),
+    ComponentCreated(ComponentCreatedPayload),
     SchemaCreated(SchemaPk),
     ResourceRefreshed(ResourceRefreshId),
     ConfirmationsUpdated(ConfirmationsUpdatedPayload),

--- a/lib/sdf/src/server/service/diagram/create_node.rs
+++ b/lib/sdf/src/server/service/diagram/create_node.rs
@@ -85,9 +85,7 @@ pub async fn create_node(
         connect_component_sockets_to_frame(&ctx, frame_id, *node.id()).await?;
     }
 
-    // TODO(nick,theo): create a component-specific event once the endpoints are cleaner (i.e. we
-    // can call routes with more precision).
-    WsEvent::change_set_written(&ctx)
+    WsEvent::component_created(&ctx)
         .await?
         .publish(&ctx)
         .await?;

--- a/lib/sdf/src/server/service/func.rs
+++ b/lib/sdf/src/server/service/func.rs
@@ -326,7 +326,7 @@ async fn attribute_prototypes_into_schema_variants_and_components(
     func_id: FuncId,
 ) -> FuncResult<(Vec<SchemaVariantId>, Vec<ComponentId>)> {
     let schema_variants_components =
-        dbg!(AttributePrototype::find_for_func_as_variant_and_component(ctx, func_id).await?);
+        AttributePrototype::find_for_func_as_variant_and_component(ctx, func_id).await?;
 
     let mut schema_variant_ids = vec![];
     let mut component_ids = vec![];


### PR DESCRIPTION
Primary:
- Add new WsEvent called "ComponentCreated" to ensure that we only fetch
  qualifications when needed in the fix flow (replaces
  "ChangeSetWritten")

Secondary:
- Ensure we always have a NodePosition for configuration Nodes when
  assembling the diagram

Misc:
- Remove unneeded print and debug statements or replace them with
  logging messages

<img src="https://media1.giphy.com/media/3otPoUjeyRisIDxPhK/giphy.gif"/>