### PR TITLE
Ensure we run confirmations on head (ENG-1015,ENG-956)

### DIFF
--- a/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
@@ -6,7 +6,7 @@ use dal_test::{
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
-async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &DalContext) {
+async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut DalContext) {
     let mut harness = SchemaBuiltinsTestHarness::new();
     let tail_docker_image_payload = harness
         .create_component(ctx, "image", Builtin::DockerImage)

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -4,7 +4,7 @@ use dal::{
 };
 use dal_test::{
     helpers::{create_change_set, create_group},
-    test, DalContextHeadRef,
+    test, DalContextHeadMutRef, DalContextHeadRef,
 };
 
 #[test]
@@ -54,7 +54,7 @@ async fn apply(ctx: &mut DalContext, bid: BillingAccountPk) {
 }
 
 #[test]
-async fn list_open(DalContextHeadRef(ctx): DalContextHeadRef<'_>) {
+async fn list_open(DalContextHeadMutRef(ctx): DalContextHeadMutRef<'_>) {
     let a_change_set = create_change_set(ctx).await;
     let b_change_set = create_change_set(ctx).await;
     let mut c_change_set = create_change_set(ctx).await;

--- a/lib/dal/tests/integration_test/standard_model.rs
+++ b/lib/dal/tests/integration_test/standard_model.rs
@@ -22,7 +22,7 @@ async fn get_by_pk(ctx: &DalContext) {
 }
 
 #[test]
-async fn get_by_id(ctx: &DalContext) {
+async fn get_by_id(ctx: &mut DalContext) {
     let schema = create_schema(ctx).await;
     let head_visibility = create_visibility_head();
     let head_ctx = ctx.clone_with_new_visibility(head_visibility);
@@ -228,7 +228,7 @@ async fn unset_belongs_to(ctx: &DalContext) {
 }
 
 #[test]
-async fn belongs_to(ctx: &DalContext) {
+async fn belongs_to(ctx: &mut DalContext) {
     let schema = create_schema(ctx).await;
     let schema_variant = create_schema_variant(ctx, *schema.id()).await;
 

--- a/lib/sdf/src/server/service/change_set/apply_change_set.rs
+++ b/lib/sdf/src/server/service/change_set/apply_change_set.rs
@@ -22,12 +22,12 @@ pub async fn apply_change_set(
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<ApplyChangeSetRequest>,
 ) -> ChangeSetResult<Json<ApplyChangeSetResponse>> {
-    let ctx = builder.build(request_ctx.build_head()).await?;
+    let mut ctx = builder.build(request_ctx.build_head()).await?;
 
     let mut change_set = ChangeSet::get_by_pk(&ctx, &request.change_set_pk)
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    change_set.apply(&ctx).await?;
+    change_set.apply(&mut ctx).await?;
 
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/fix.rs
+++ b/lib/sdf/src/server/service/fix.rs
@@ -13,9 +13,9 @@ use dal::{
     StandardModelError, TransactionsError, UserError, UserId, WorkflowRunnerError,
 };
 
-mod confirmations;
-mod list;
-mod run;
+pub mod confirmations;
+pub mod list;
+pub mod run;
 
 #[derive(Error, Debug)]
 pub enum FixError {

--- a/lib/sdf/src/server/service/fix/list.rs
+++ b/lib/sdf/src/server/service/fix/list.rs
@@ -14,7 +14,7 @@ use crate::service::fix::FixError;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ListRequest {
+pub struct ListFixesRequest {
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -38,21 +38,21 @@ pub struct FixHistoryView {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchHistoryView {
-    id: FixBatchId,
-    status: FixCompletionStatus,
+    pub id: FixBatchId,
+    pub status: FixCompletionStatus,
     author: String,
     fixes: Vec<FixHistoryView>,
     started_at: String,
     finished_at: String,
 }
 
-pub type ListResponse = Vec<BatchHistoryView>;
+pub type ListFixesResponse = Vec<BatchHistoryView>;
 
 pub async fn list(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    Query(request): Query<ListRequest>,
-) -> FixResult<Json<ListResponse>> {
+    Query(request): Query<ListFixesRequest>,
+) -> FixResult<Json<ListFixesResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let mut batch_views = Vec::new();

--- a/lib/sdf/src/server/service/fix/run.rs
+++ b/lib/sdf/src/server/service/fix/run.rs
@@ -28,7 +28,7 @@ pub struct FixesRunRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FixesRunResponse {
-    id: FixBatchId,
+    pub id: FixBatchId,
 }
 
 pub async fn run(

--- a/lib/sdf/src/server/service/variant_definition/clone_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/clone_variant_def.rs
@@ -54,7 +54,7 @@ pub async fn create_variant_def(
         }
     }
 
-    let menu_name = variant_def.menu_name().map(|mn| format!("{} Clone", mn));
+    let menu_name = variant_def.menu_name().map(|mn| format!("{mn} Clone"));
 
     let variant_def = SchemaVariantDefinition::new(
         &ctx,

--- a/lib/sdf/tests/service_tests/scenario.rs
+++ b/lib/sdf/tests/service_tests/scenario.rs
@@ -2,9 +2,10 @@
 //! multiple endpoints to test an end-to-end user scenario.
 
 use dal::qualification::QualificationSubCheckStatus;
-use dal::{Component, DalContext};
+use dal::{Component, DalContext, FixCompletionStatus};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
+use sdf::service::fix::run::FixRunRequest;
 
 use crate::service_tests::scenario::harness::ScenarioHarness;
 use crate::test_setup;
@@ -481,7 +482,163 @@ async fn model_and_fix_flow() {
     );
 
     // Apply the change set and get rolling!
-    harness.apply_change_set_and_update_ctx(ctx).await;
+    harness
+        .apply_change_set_and_update_ctx_visibility_to_head(ctx)
+        .await;
 
     // TODO(nick): now, list confirmations and "select" recommendations, and run fixes.
+}
+
+/// This test runs through the entire model flow and fix flow lifecycle for solely an AWS Key Pair.
+///
+/// It is recommended to run this test with the following environment variable:
+/// ```shell
+/// SI_TEST_BUILTIN_SCHEMAS=aws region,aws keypair
+/// ```
+#[test]
+#[ignore]
+async fn model_and_fix_flow_aws_key_pair() {
+    test_setup!(
+        _sdf_ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        _txn,
+        _nats_conn,
+        _nats,
+        veritech,
+        encr_key,
+        app,
+        _nba,
+        auth_token,
+        ctx,
+        _job_processor,
+        _council_subject_prefix,
+    );
+    // Just borrow it the whole time because old habits die hard.
+    let ctx: &mut DalContext = &mut ctx;
+
+    // Setup the harness to start.
+    let mut harness = ScenarioHarness::new(ctx, app, auth_token, &["Region", "Key Pair"]).await;
+
+    // Enter a new change set. We will not go through the routes for this.
+    harness.create_change_set_and_update_ctx(ctx, "swans").await;
+
+    // Create all AWS components.
+    let region = harness.create_node(ctx, "Region", None).await;
+    let key_pair = harness
+        .create_node(ctx, "Key Pair", Some(region.node_id))
+        .await;
+
+    // Update property editor values.
+    harness
+        .update_value(
+            ctx,
+            key_pair.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-key"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            key_pair.component_id,
+            &["domain", "KeyType"],
+            Some(serde_json::json!["rsa"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            region.component_id,
+            &["domain", "region"],
+            Some(serde_json::json!["us-east-2"]),
+        )
+        .await;
+
+    // Ensure everything looks as expected.
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "toddhoward-key",
+                "type": "component",
+                "protected": false,
+            },
+            "code": {
+                "si:generateAwsKeyPairJSON": {
+                    "code": "{\n\t\"KeyName\": \"toddhoward-key\",\n\t\"KeyType\": \"rsa\",\n\t\"TagSpecifications\": [\n\t\t{\n\t\t\t\"ResourceType\": \"key-pair\",\n\t\t\t\"Tags\": [\n\t\t\t\t{\n\t\t\t\t\t\"Key\": \"Name\",\n\t\t\t\t\t\"Value\": \"toddhoward-key\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}",
+                    "format": "json",
+                },
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-key",
+                },
+                "region": "us-east-2",
+                "KeyName": "toddhoward-key",
+                "KeyType": "rsa",
+                "awsResourceType": "key-pair",
+            },
+            "qualification": {
+                "si:qualificationKeyPairCanCreate": {
+                    "result": "success",
+                    "message": "component qualified",
+                },
+            },
+        }], // expected
+        key_pair.view(ctx).await.drop_confirmation().to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-east-2",
+                "type": "configurationFrame",
+                "protected": false,
+            },
+            "domain": {
+                "region": "us-east-2",
+            },
+        }], // expected
+        region.view(ctx).await.to_value(), // actual
+    );
+
+    // Apply the change set and get rolling!
+    harness
+        .apply_change_set_and_update_ctx_visibility_to_head(ctx)
+        .await;
+
+    // Check the confirmations and ensure they look as we expect.
+    let mut confirmations = harness.list_confirmations(ctx).await;
+    let mut confirmation = confirmations.pop().expect("no confirmations found");
+    assert!(confirmations.is_empty());
+    let recommendation = confirmation
+        .recommendations
+        .pop()
+        .expect("no recommendations found");
+    assert!(confirmation.recommendations.is_empty());
+
+    // Run the fix for the confirmation.
+    let fix_batch_id = harness
+        .run_fixes(
+            ctx,
+            vec![FixRunRequest {
+                attribute_value_id: recommendation.confirmation_attribute_value_id,
+                component_id: recommendation.component_id,
+                action_name: recommendation.recommended_action,
+            }],
+        )
+        .await;
+
+    // Check that the fix succeeded.
+    let mut fix_batch_history_views = harness.list_fixes(ctx).await;
+    let fix_batch_history_view = fix_batch_history_views.pop().expect("no fix batches found");
+    assert!(fix_batch_history_views.is_empty());
+    assert_eq!(
+        fix_batch_id,              // expected
+        fix_batch_history_view.id, // actual
+    );
+    assert_eq!(
+        FixCompletionStatus::Success, // expected
+        fix_batch_history_view.status
+    );
 }


### PR DESCRIPTION
Primary:
- Ensure we run confirmations on head
- Mutate the provided DalContext when applying a ChangeSet (this is huge!)
- Add scenario test for just the AWS Key Pair in order to test the full fix flow

Secondary:
- Add list confirmations, run fixes and list fixes to the ScenarioHarness

<img src="https://media0.giphy.com/media/YEya3QIrZFgWouzhsI/giphy.gif"/>