### PR TITLE
fix(dal): filter by workspace when applying change-sets

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -103,8 +103,8 @@ impl ChangeSet {
             .txns()
             .pg()
             .query_one(
-                "SELECT timestamp_updated_at FROM change_set_apply_v1($1, $2)",
-                &[&self.pk, &actor],
+                "SELECT timestamp_updated_at FROM change_set_apply_v1($1, $2, $3)",
+                &[&self.pk, &actor, &self.tenancy],
             )
             .await?;
         let updated_at: DateTime<Utc> = row.try_get("timestamp_updated_at")?;


### PR DESCRIPTION
Removing universal tenancy made builtins share id across workspaces, but the change-set apply logic was not filtering by workspace, just by row id. And now since rows have the same id across workspace, when a change would be applied to head on your workspace, it would be applied to head on all workspaces.

Meaning a user could write to a different workspace.

<img src="https://media2.giphy.com/media/f4ytEvdDjIpysVCpzz/giphy.gif"/>