### PR TITLE
chore(dal,sdf): remove whitespace for provided builtin schema names

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -504,9 +504,13 @@ SI_TEST_BUILTIN_SCHEMAS=none cargo test -p dal --test integration <your-test>
 ```
 
 You can also choose individual builtins to migrate with a comma-separated list.
+Feel free to use camel casing for readability, but the individual `Schema` names provided will be converted to all
+lowercase letters.
+To find which builtin `Schemas` are available for selection, please see the
+[file where provided names are evaluated](lib/dal/src/builtins/schema.rs).
 
 ```shell
-SI_TEST_BUILTIN_SCHEMAS=Schema One,Schema Two cargo test -p dal --test integration <your-test>
+SI_TEST_BUILTIN_SCHEMAS=schemaOne,schemaTwo cargo test -p dal --test integration <your-test>
 ```
 
 > Note: you may not want to wrap your list in `"` characters, depending on your development environment as they may

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -73,81 +73,68 @@ pub async fn migrate(
     let driver = MigrationDriver::new(ctx).await?;
 
     // Perform migrations.
-    if migrate_all || specific_builtin_schemas.contains("docker image") {
+    if migrate_all || specific_builtin_schemas.contains("dockerimage") {
         driver
             .migrate_docker_image(ctx, "Docker", NODE_COLOR_DOCKER)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("docker hub credential") {
+    if migrate_all || specific_builtin_schemas.contains("dockerhubcredential") {
         driver
             .migrate_docker_hub_credential(ctx, "Docker", NODE_COLOR_DOCKER)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("kubernetes deployment") {
+    if migrate_all || specific_builtin_schemas.contains("kubernetesdeployment") {
         driver
             .migrate_kubernetes_deployment(ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("kubernetes namespace") {
+    if migrate_all || specific_builtin_schemas.contains("kubernetesnamespace") {
         driver
             .migrate_kubernetes_namespace(ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("coreos butane") {
+    if migrate_all || specific_builtin_schemas.contains("coreosbutane") {
         driver
             .migrate_coreos_butane(ctx, "CoreOS", NODE_COLOR_COREOS)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("aws ami") {
+    if migrate_all || specific_builtin_schemas.contains("awsami") {
         driver.migrate_aws_ami(ctx, "AWS", NODE_COLOR_AWS).await?;
     }
-    if migrate_all
-        || specific_builtin_schemas.contains("aws ec2")
-        || specific_builtin_schemas.contains("aws ec2 instance")
-    {
+    if migrate_all || specific_builtin_schemas.contains("awsec2") {
         driver
             .migrate_aws_ec2_instance(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("aws region") {
+    if migrate_all || specific_builtin_schemas.contains("awsregion") {
         driver
             .migrate_aws_region(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("aws eip") {
+    if migrate_all || specific_builtin_schemas.contains("awseip") {
         driver.migrate_aws_eip(ctx, "AWS", NODE_COLOR_AWS).await?;
     }
-    if migrate_all
-        || specific_builtin_schemas.contains("aws key pair")
-        || specific_builtin_schemas.contains("aws keypair")
-    {
+    if migrate_all || specific_builtin_schemas.contains("awskeypair") {
         driver
             .migrate_aws_keypair(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("aws ingress") {
+    if migrate_all || specific_builtin_schemas.contains("awsingress") {
         driver
             .migrate_aws_ingress(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all || specific_builtin_schemas.contains("aws egress") {
+    if migrate_all || specific_builtin_schemas.contains("awsegress") {
         driver
             .migrate_aws_egress(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all
-        || specific_builtin_schemas.contains("aws security group")
-        || specific_builtin_schemas.contains("aws securitygroup")
-    {
+    if migrate_all || specific_builtin_schemas.contains("awssecuritygroup") {
         driver
             .migrate_aws_security_group(ctx, "AWS", NODE_COLOR_AWS)
             .await?;
     }
-    if migrate_all
-        || specific_builtin_schemas.contains("systeminit generic frame")
-        || specific_builtin_schemas.contains("si generic frame")
-        || specific_builtin_schemas.contains("generic frame")
-    {
+    if migrate_all || specific_builtin_schemas.contains("genericframe") {
         driver
             .migrate_systeminit_generic_frame(ctx, "Frames", NODE_COLOR_FRAMES)
             .await?;

--- a/lib/sdf/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
+++ b/lib/sdf/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
@@ -10,7 +10,7 @@ use crate::test_setup;
 ///
 /// It is recommended to run this test with the following environment variable:
 /// ```shell
-/// SI_TEST_BUILTIN_SCHEMAS=aws region,aws keypair
+/// SI_TEST_BUILTIN_SCHEMAS=awsRegion,awsKeyPair
 /// ```
 #[test]
 #[ignore]

--- a/lib/sdf/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
+++ b/lib/sdf/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
@@ -14,7 +14,7 @@ use crate::test_setup;
 ///
 /// It is recommended to run this test with the following environment variable:
 /// ```shell
-/// SI_TEST_BUILTIN_SCHEMAS=aws region,aws ami,aws keypair,aws ec2,aws securitygroup,aws ingress,docker image,coreos butane
+/// SI_TEST_BUILTIN_SCHEMAS=awsRegion,awsAmi,awsKeyPair,awsEC2,awsSecurityGroup,awsIngress,dockerImage,coreosButane
 /// ```
 #[test]
 #[ignore]


### PR DESCRIPTION
Remove whitespace for provided builtin schema names (set by `SI_TEST_BUILTIN_SCHEMAS`). Based on the development environment, whitespaces can cause issues. Since the values are evaluated in lowercase anyway, the user can use camel case or casings of their choosing for readability.