### PR TITLE
Remove all "by_json_pointer" functions (ENG-1026,ENG-1043)

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2,6 +2,40 @@
 //! and [`FuncBindingReturnValue`] provide attribute's value. Moreover, it tracks whether the
 //! value is proxied or not. Proxied values "point" to another [`AttributeValue`] to provide
 //! the attribute's value.
+//!
+//! ## Updating [`AttributeValues`](AttributeValue)
+//!
+//! Let's say you want to update a
+//! [`PropertyEditorValue`](crate::property_editor::values::PropertyEditorValue) in the UI or a
+//! "field" on a [`Component`](crate::Component) in general. The key to doing so is the following
+//! process:
+//!
+//! 1) Find the appropriate [`AttributeValue`] in a [`context`](crate::AttributeContext) that is
+//!   either "exactly specific" to what you need or "less specific" than what you need (see the
+//!   [`module`](crate::attribute::context) for more information)
+//! 2) Find its parent, which almost all [`AttributeValues`](AttributeValue) should have if they are
+//!   in the lineage of a [`RootProp`](crate::RootProp) (usually, the
+//!   [`standard model accessor`](crate::standard_accessors) that contains the parent will suffice
+//!   in finding the parent)
+//! 3) Use [`AttributeValue::update_for_context()`] with the appropriate key and
+//!   [`context`](crate::AttributeContext) while ensuring that if you reuse the key and/or
+//!   [`context`](crate::AttributeContext) from the [`AttributeValue`](crate::AttributeValue)
+//!   that you found, that it is _exactly_ what you need (i.e. if the key changes or the
+//!   [`context`](crate::AttributeContext) is in a lesser specificity than what you need, you
+//!   mutate them accordingly)
+//!
+//! Often, you may not have all the information necessary to find the [`AttributeValue`] that you
+//! would like to update. Ideally, you would use one of the existing accessor methods off
+//! [`AttributeValue`] with contextual information such as a [`PropId`](crate::Prop),
+//! a [`ComponentId`](crate::Component)), a parent [`AttributeValue`], a key, etc.
+//!
+//! In situations where we do not have minimal information to find the _correct_ [`AttributeValue`]
+//! from existing accessor queries, we can leveraging existing queries from other structs and write
+//! new queries for those structs and specific use cases. For example, since most members of the
+//! [`RootProp`](crate::RootProp) tree are stable across [`SchemaVariants`](crate::SchemaVariant),
+//! we can use [`Component::root_prop_child_attribute_value_for_component()`](crate::Component::root_prop_child_attribute_value_for_component)
+//! to find the [`AttributeValue`] whose [`context`](crate::AttributeContext) corresponds to a
+//! direct child [`Prop`](crate::Prop) of the [`RootProp`](crate::RootProp).
 
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -140,12 +140,13 @@ impl Component {
         // Use the validation prop tree once available.
         let mut validation_errors = Vec::<(String, ValidationError)>::new();
         for status in ValidationResolver::find_status(ctx, component_id).await? {
-            let full_name = AttributeValue::find_prop_for_value(ctx, status.attribute_value_id)
-                .await?
-                .json_pointer(ctx)
-                .await?;
+            let prop_name_json_pointer =
+                AttributeValue::find_prop_for_value(ctx, status.attribute_value_id)
+                    .await?
+                    .json_pointer(ctx)
+                    .await?;
             for error in status.errors {
-                validation_errors.push((full_name.clone(), error));
+                validation_errors.push((prop_name_json_pointer.clone(), error));
             }
         }
 

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -17,8 +17,8 @@ use crate::schema::variant::SchemaVariantError;
 use crate::socket::SocketError;
 use crate::{
     AttributeContextBuilderError, AttributePrototypeArgumentError, AttributeValueError,
-    ChangeSetPk, ComponentError, DalContext, Edge, EdgeError, Node, NodeError, NodeId, NodeKind,
-    NodePosition, NodePositionError, PropError, SchemaError, SocketId, StandardModel,
+    ChangeSetPk, ComponentError, ComponentId, DalContext, Edge, EdgeError, Node, NodeError, NodeId,
+    NodeKind, NodePosition, NodePositionError, PropError, SchemaError, SocketId, StandardModel,
     StandardModelError,
 };
 
@@ -35,6 +35,8 @@ pub enum DiagramError {
     ChangeStatus(#[from] ChangeStatusError),
     #[error("component not found")]
     ComponentNotFound,
+    #[error("component status not found for component: {0}")]
+    ComponentStatusNotFound(ComponentId),
     #[error("edge error: {0}")]
     Edge(#[from] EdgeError),
     #[error("external provider error: {0}")]

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -305,8 +305,15 @@ impl Prop {
         Ok(objects_from_rows(rows)?)
     }
 
-    // Should JsonPointers be a type of their own?
+    /// Assembles the "json_pointer" representing the full "path" to a [`Prop`] based on its
+    /// lineage.
+    ///
+    /// For examples, if a [`Prop`] named "poop" had a parent named "domain" and a grandparent named
+    /// "root", then the "json_pointer" would be "/root/domain/poop".
     pub async fn json_pointer(&self, ctx: &DalContext) -> PropResult<String> {
+        // NOTE(nick,zack): if this ends up getting used frequently to manage paths corresponding
+        // to attribute (and/or property editor) values, then we should consider strongly typing
+        // "json_pointer".
         Ok([
             "/".to_string(),
             Prop::all_ancestor_props(ctx, *self.id())

--- a/lib/dal/src/queries/component/find_si_child_attribute_value.sql
+++ b/lib/dal/src/queries/component/find_si_child_attribute_value.sql
@@ -2,13 +2,13 @@ SELECT DISTINCT ON (attribute_values.attribute_context_prop_id) row_to_json(attr
 
 FROM attribute_values_v1($1, $2) AS attribute_values
          JOIN (
-    SELECT type_prop.id
-    FROM props_v1($1, $2) AS type_prop
-             JOIN prop_belongs_to_prop_v1($1, $2) AS type_prop_belongs_to_si_prop
-                  ON type_prop_belongs_to_si_prop.object_id = type_prop.id
-                      AND type_prop.name = $4
+    SELECT si_child_prop.id
+    FROM props_v1($1, $2) AS si_child_prop
+             JOIN prop_belongs_to_prop_v1($1, $2) AS si_child_prop_belongs_to_si_prop
+                  ON si_child_prop_belongs_to_si_prop.object_id = si_child_prop.id
+                      AND si_child_prop.name = $4
              JOIN props_v1($1, $2) as si_prop
-                  ON type_prop_belongs_to_si_prop.belongs_to_id = si_prop.id
+                  ON si_child_prop_belongs_to_si_prop.belongs_to_id = si_prop.id
                       AND si_prop.name = 'si'
              JOIN prop_belongs_to_prop_v1($1, $2) AS si_prop_belongs_to_root_prop
                   ON si_prop_belongs_to_root_prop.object_id = si_prop.id
@@ -19,14 +19,14 @@ FROM attribute_values_v1($1, $2) AS attribute_values
                                         ON cbtsv.belongs_to_id = pmtmsv.right_object_id
                                             AND cbtsv.object_id = $3
                       )
-) AS type_prop
-              ON attribute_values.attribute_context_prop_id = type_prop.id
+) AS si_child_prop
+              ON attribute_values.attribute_context_prop_id = si_child_prop.id
 
 -- We will also take the "default" type too (corresponds to the attribute
 -- value whose context has component id unset)
 WHERE in_attribute_context_v1(
               attribute_context_build_from_parts_v1(
-                      type_prop.id, -- PropId
+                      si_child_prop.id, -- PropId
                       ident_nil_v1(), -- InternalProviderId
                       ident_nil_v1(), -- ExternalProviderId
                       $3 -- ComponentId

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -24,7 +24,7 @@ use crate::{
     AttributeValueError, AttributeValueId, BuiltinsError, DalContext, ExternalProvider,
     ExternalProviderError, Func, FuncError, HistoryEventError, InternalProvider, Prop, PropError,
     PropId, PropKind, Schema, SchemaId, SocketArity, StandardModel, StandardModelError, Tenancy,
-    Timestamp, Visibility, WsEventError,
+    Timestamp, ValidationPrototypeError, Visibility, WsEventError,
 };
 use crate::{AttributeReadContext, AttributeValue, RootPropChild};
 use crate::{FuncBackendResponseType, FuncId};
@@ -94,6 +94,8 @@ pub enum SchemaVariantError {
     InvalidSchemaVariant,
     #[error("parent prop not found for prop id: {0}")]
     ParentPropNotFound(PropId),
+    #[error("validation prototype error: {0}")]
+    ValidationPrototype(#[from] ValidationPrototypeError),
 
     // Errors related to definitions.
     #[error("prop not found in cache for name ({0}) and parent prop id ({1})")]
@@ -190,7 +192,7 @@ impl SchemaVariant {
             )
             .await?;
         let object: SchemaVariant = standard_model::finish_create_from_row(ctx, row).await?;
-        let root_prop = RootProp::new(ctx, *object.id()).await?;
+        let root_prop = RootProp::new(ctx, schema_id, *object.id()).await?;
 
         object.set_schema(ctx, &schema_id).await?;
 

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -215,7 +215,7 @@ impl SchemaVariantDefinition {
                 Err(e) => {
                     return Err(
                         SchemaVariantDefinitionError::CouldNotCheckForDefaultVariant(e.to_string()),
-                    )
+                    );
                 }
             },
         )

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -1,4 +1,5 @@
 use dal::edge::EdgeKind;
+use dal::schema::variant::root_prop::SiPropChild;
 use dal::socket::{SocketEdgeKind, SocketKind};
 use dal::{
     func::backend::js_command::CommandRunResult, generate_name, AttributePrototypeArgument,
@@ -144,7 +145,7 @@ async fn find_type_attribute_value_and_set_type(ctx: &mut DalContext) {
 
     // Now, test our query. Ensure we have the right context too.
     let found_attribute_value =
-        Component::find_attribute_value(ctx, *component.id(), "type".to_string())
+        Component::find_si_child_attribute_value(ctx, *component.id(), SiPropChild::Type)
             .await
             .expect("could not find type attribute value");
     assert_eq!(
@@ -183,7 +184,7 @@ async fn find_type_attribute_value_and_set_type(ctx: &mut DalContext) {
     // Check that the type was updated. Ensure that we have the right attribute value too (specific
     // to the component now that's been updated).
     let updated_attribute_value =
-        Component::find_attribute_value(ctx, *component.id(), "type".to_string())
+        Component::find_si_child_attribute_value(ctx, *component.id(), SiPropChild::Type)
             .await
             .expect("could not find type attribute value");
     assert_eq!(

--- a/lib/sdf/tests/service_tests/scenario.rs
+++ b/lib/sdf/tests/service_tests/scenario.rs
@@ -4,6 +4,7 @@
 // Scenario tests below...
 mod model_and_fix_flow_aws_key_pair;
 mod model_and_fix_flow_whiskers;
+mod model_flow_fedora_coreos_ignition;
 
 use axum::http::Method;
 use axum::Router;

--- a/lib/sdf/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
+++ b/lib/sdf/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
@@ -1,0 +1,230 @@
+use dal::qualification::QualificationSubCheckStatus;
+use dal::{Component, DalContext};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+use crate::service_tests::scenario::ScenarioHarness;
+use crate::test_setup;
+
+/// This test runs through the model flow for ensuring
+/// [Ignition](https://coreos.github.io/ignition/) data is populated correctly to the "user data"
+/// field for an [AWS EC2 Instance](https://www.amazonaws.cn/en/ec2). This scenario test includes
+/// testing an array of values being propagated and transformed between
+/// [`Components`](dal::Component) as well as a "code generation" result being propagated to another
+/// [`Component`](dal::Component).
+///
+/// It is recommended to run this test with the following environment variable:
+/// ```shell
+/// SI_TEST_BUILTIN_SCHEMAS=docker image,coreos butane,aws region,aws ec2
+/// ```
+#[test]
+#[ignore]
+async fn model_flow_fedora_coreos_ignition() {
+    test_setup!(
+        _sdf_ctx,
+        _secret_key,
+        _pg,
+        _conn,
+        _txn,
+        _nats_conn,
+        _nats,
+        veritech,
+        encr_key,
+        app,
+        _nba,
+        auth_token,
+        ctx,
+        _job_processor,
+        _council_subject_prefix,
+    );
+
+    // Just borrow it the whole time because old habits die hard.
+    let ctx: &mut DalContext = &mut ctx;
+
+    // Setup the harness to start.
+    let mut harness = ScenarioHarness::new(
+        ctx,
+        app,
+        auth_token,
+        &["Region", "EC2 Instance", "Docker Image", "Butane"],
+    )
+    .await;
+
+    // Enter a new change set. We will not go through the routes for this.
+    harness.create_change_set_and_update_ctx(ctx, "").await;
+
+    // Create all components.
+    let region = harness.create_node(ctx, "Region", None).await;
+    let ec2 = harness
+        .create_node(ctx, "EC2 Instance", Some(region.node_id))
+        .await;
+    let docker = harness.create_node(ctx, "Docker Image", None).await;
+    let butane = harness.create_node(ctx, "Butane", None).await;
+
+    // Make all connections.
+    harness
+        .create_connection(ctx, docker.node_id, butane.node_id, "Container Image")
+        .await;
+    harness
+        .create_connection(ctx, butane.node_id, ec2.node_id, "User Data")
+        .await;
+
+    // Update all components, as needed.
+    harness
+        .update_value(
+            ctx,
+            ec2.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["toddhoward-server"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            docker.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["docker.io/systeminit/whiskers"]),
+        )
+        .await;
+    harness
+        .insert_value(ctx, docker.component_id, &["domain", "ExposedPorts"], None)
+        .await;
+    harness
+        .update_value(
+            ctx,
+            docker.component_id,
+            &["domain", "ExposedPorts", "0"],
+            Some(serde_json::json!["80/tcp"]),
+        )
+        .await;
+    harness
+        .insert_value(ctx, docker.component_id, &["domain", "ExposedPorts"], None)
+        .await;
+    harness
+        .update_value(
+            ctx,
+            docker.component_id,
+            &["domain", "ExposedPorts", "1"],
+            Some(serde_json::json!["443/tcp"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            butane.component_id,
+            &["si", "name"],
+            Some(serde_json::json!["Butane"]),
+        )
+        .await;
+    harness
+        .update_value(
+            ctx,
+            region.component_id,
+            &["domain", "region"],
+            Some(serde_json::json!["us-east-2"]),
+        )
+        .await;
+
+    // Ensure everything worked.
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "toddhoward-server",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "tags": {
+                    "Name": "toddhoward-server",
+                },
+                "region": "us-east-2",
+                "UserData": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers --publish 80:80 --publish 443:443 docker.io/systeminit/whiskers\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers.service\"\n      }\n    ]\n  }\n}",
+                "awsResourceType": "instance",
+            },
+        }], // expected
+        ec2.view(ctx)
+            .await
+            .drop_confirmation()
+            .drop_code()
+            .drop_qualification()
+            .to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "Butane",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "systemd": {
+                    "units": [
+                        {
+                            "name": "docker-io-systeminit-whiskers.service",
+                            "enabled": true,
+                            "contents": "[Unit]\nDescription=Docker-io-systeminit-whiskers\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers --publish 80:80 --publish 443:443 docker.io/systeminit/whiskers\n\n[Install]\nWantedBy=multi-user.target",
+                        },
+                    ],
+                },
+                "variant": "fcos",
+                "version": "1.4.0",
+            },
+            "code": {
+                "si:generateButaneIgnition": {
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers --publish 80:80 --publish 443:443 docker.io/systeminit/whiskers\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers.service\"\n      }\n    ]\n  }\n}",
+                    "format": "json",
+                },
+            },
+            "qualification": {
+                "si:qualificationButaneIsValidIgnition": {
+                    "result": "success",
+                    "message": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Docker-io-systeminit-whiskers\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill docker-io-systeminit-whiskers\\nExecStartPre=-/bin/podman rm docker-io-systeminit-whiskers\\nExecStartPre=/bin/podman pull docker.io/systeminit/whiskers\\nExecStart=/bin/podman run --name docker-io-systeminit-whiskers --publish 80:80 --publish 443:443 docker.io/systeminit/whiskers\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"docker-io-systeminit-whiskers.service\"\n      }\n    ]\n  }\n}",
+                },
+            },
+        }], // expected
+        butane.view(ctx).await.to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "us-east-2",
+                "type": "configurationFrame",
+                "protected": false,
+            },
+            "domain": {
+                "region": "us-east-2",
+            },
+        }], // expected
+        region.view(ctx).await.to_value(), // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "name": "docker.io/systeminit/whiskers",
+                "type": "component",
+                "protected": false,
+            },
+            "domain": {
+                "image": "docker.io/systeminit/whiskers",
+                "ExposedPorts": [
+                    "80/tcp",
+                    "443/tcp",
+                ],
+            },
+        }], // expected
+        docker.view(ctx).await.drop_qualification().to_value(), // actual
+    );
+
+    // Evaluate Docker Image qualification(s) separately as they may contain a timestamp.
+    // Technically, we should be doing this via an sdf route. However, this test focuses on the
+    // model flow and we only want to know that the qualification(s) passed.
+    for qualification in Component::list_qualifications(ctx, docker.component_id)
+        .await
+        .expect("could not list qualifications")
+    {
+        assert_eq!(
+            QualificationSubCheckStatus::Success,
+            qualification.result.expect("no result found").status
+        );
+    }
+}


### PR DESCRIPTION
## Commit Description

```
Primary:
- Remove all "by_json_pointer" functions due to their "happy path"
  behaviors
  - In deleting these, there may be openings to improve developer
    experience and we should tackle those with alternatives (e.g.
    "Component::get_type()" and "Component::get_color()")
- Ensure "find_attribute_value" is scoped to
  "find_si_child_prop_attribute_value", matching the function and
  query's intentions
- Add "get_color" for Component
- Add "/root/si/color" to all SchemaVariants (no longer just on generic
  frames)

Secondary:
- Add scenario test that purely runs through the model flow for frames,
  array value propagation, and code generation ouput propagation (helped
  ensure that this change works)
- Add documentation for how to update "fields" off of a Component
- Prevent users from changing the ComponentType for "generic frames" in
  the UI
```

## GIF

<img src="https://media0.giphy.com/media/hp2yMQLrvuVv8mKZOb/giphy.gif"/>