### PR TITLE
Fix code gen reactivity in the UI (ENG-1036)

### DIFF
--- a/lib/dal/src/component/code.rs
+++ b/lib/dal/src/component/code.rs
@@ -1,14 +1,14 @@
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use telemetry::prelude::*;
 
 use crate::attribute::value::AttributeValue;
 use crate::attribute::value::AttributeValueError;
 use crate::component::ComponentResult;
 use crate::{
-    AttributeReadContext, CodeLanguage, CodeView, ComponentError, ComponentId, DalContext,
-    StandardModel, WsEvent, WsPayload,
+    AttributeReadContext, AttributeValueId, CodeLanguage, CodeView, ComponentError, ComponentId,
+    DalContext, StandardModel, WsEvent, WsPayload,
 };
 use crate::{Component, SchemaVariant};
 use crate::{RootPropChild, WsEventResult};
@@ -20,6 +20,8 @@ struct CodeGenerationEntry {
 }
 
 impl Component {
+    /// List all [`CodeViews`](crate::CodeView) for based on the "code generation"
+    /// [`leaves`](crate::schema::variant::leaves) for a given [`ComponentId`](Self).
     #[instrument(skip_all)]
     pub async fn list_code_generated(
         ctx: &DalContext,
@@ -78,7 +80,7 @@ impl Component {
                     CodeLanguage::try_from(format.to_owned())?
                 };
 
-                // TODO(nick): determine how we handle empty code generation or generation in
+                // NOTE(nick): determine how we handle empty code generation or generation in
                 // progress. Maybe we never need to? Just re-run?
                 let code = if code.is_empty() {
                     None
@@ -91,16 +93,54 @@ impl Component {
         }
         Ok(code_views)
     }
+
+    // TODO(nick): big query potential.
+    /// Returns a [`HashSet`](std::collections::HashSet) of all the
+    /// [`AttributeValueIds`](crate::AttributeValue) corresponding to "code generation"
+    /// [`leaves`](crate::schema::variant::leaves) in the workspace.
+    pub async fn all_code_generation_attribute_values(
+        ctx: &DalContext,
+    ) -> ComponentResult<HashSet<AttributeValueId>> {
+        let mut values = HashSet::new();
+        for component in Component::list(ctx).await? {
+            values.extend(
+                Self::all_code_generation_attribute_values_for_component(ctx, *component.id())
+                    .await?,
+            );
+        }
+        Ok(values)
+    }
+
+    // TODO(nick): big query potential.
+    /// Returns a [`HashSet`](std::collections::HashSet) of all the
+    /// [`AttributeValueIds`](crate::AttributeValue) corresponding to "code generation"
+    /// [`leaves`](crate::schema::variant::leaves) for a given [`ComponentId`](Self).
+    async fn all_code_generation_attribute_values_for_component(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<HashSet<AttributeValueId>> {
+        let code_map_attribute_value = Self::root_prop_child_attribute_value_for_component(
+            ctx,
+            component_id,
+            RootPropChild::Code,
+        )
+        .await?;
+        Ok(HashSet::from_iter(
+            code_map_attribute_value
+                .child_attribute_values(ctx)
+                .await?
+                .iter()
+                .map(|av| *av.id()),
+        ))
+    }
 }
 
-// NOTE(nick): consider moving this somewhere else.
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeGeneratedPayload {
     component_id: ComponentId,
 }
 
-// NOTE(nick): consider moving this somewhere else.
 impl WsEvent {
     pub async fn code_generated(
         ctx: &DalContext,

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -264,6 +264,7 @@ impl SchemaVariant {
         };
 
         // Find props that we need to set defaults on for _all_ schema variants.
+        // FIXME(nick): use the enum and create an appropriate query.
         let mut maybe_type_prop_id = None;
         let mut maybe_protected_prop_id = None;
         for root_si_child_prop in Self::list_root_si_child_props(ctx, self.id).await? {

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -1,8 +1,10 @@
-use dal::func::argument::FuncArgument;
+use dal::component::ComponentKind;
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::schema::variant::leaves::LeafKind;
 use dal::{
     attribute::context::AttributeContextBuilder,
     schema::variant::leaves::{LeafInput, LeafInputLocation},
+    FuncBackendKind, FuncBackendResponseType, Prop, Schema,
 };
 use dal::{
     AttributeReadContext, AttributeValue, CodeLanguage, Component, ComponentView, DalContext, Func,
@@ -29,19 +31,30 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         create_prop_and_set_parent(ctx, PropKind::String, "poop", root_prop.domain_prop_id).await;
 
     // Create code prototype(s).
-    let func_name = "si:generateYAML".to_owned();
-    let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
+    let mut func = Func::new(
+        ctx,
+        "test:codeGeneration",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    let code = "function generateYAML(input) {
+      return {
+        format: \"yaml\",
+        code: Object.keys(input.domain).length > 0 ? YAML.stringify(input.domain) : \"\"
+      };
+    }";
+    func.set_code_plaintext(ctx, Some(code))
         .await
-        .expect("Error fetching builtin function");
-    let func = funcs
-        .pop()
-        .expect("Missing builtin function si:generateYAML");
-    let code_generation_func_argument =
-        FuncArgument::find_by_name_for_func(ctx, "domain", *func.id())
+        .expect("set code");
+    func.set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_argument =
+        FuncArgument::new(ctx, "domain", FuncArgumentKind::Object, None, *func.id())
             .await
-            .expect("could not perform func argument find")
-            .expect("no func argument found");
-
+            .expect("could not create func argument");
     SchemaVariant::add_leaf(
         ctx,
         *func.id(),
@@ -50,7 +63,7 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         LeafKind::CodeGeneration,
         vec![LeafInput {
             location: LeafInputLocation::Domain,
-            func_argument_id: *code_generation_func_argument.id(),
+            func_argument_id: *func_argument.id(),
         }],
     )
     .await
@@ -108,7 +121,7 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
                     "protected": false,
                 },
                 "code": {
-                    "si:generateYAML": {
+                    "test:codeGeneration": {
                         "code": "poop: canoe\n",
                         "format": "yaml",
                     },
@@ -128,4 +141,280 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
     assert!(code_views.is_empty());
     assert_eq!(CodeLanguage::Yaml, code_view.language);
     assert_eq!(Some("poop: canoe\n".to_string()), code_view.code);
+}
+
+#[test]
+async fn all_code_generation_attribute_values(ctx: &DalContext) {
+    // Create two schemas and variants.
+    let mut navi_schema = Schema::new(ctx, "navi", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
+    let (mut navi_schema_variant, navi_root_prop) =
+        create_schema_variant_with_root(ctx, *navi_schema.id()).await;
+    navi_schema
+        .set_default_schema_variant_id(ctx, Some(*navi_schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+    let ange1_prop = create_prop_and_set_parent(
+        ctx,
+        PropKind::String,
+        "ange1",
+        navi_root_prop.domain_prop_id,
+    )
+    .await;
+
+    let mut kru_schema = Schema::new(ctx, "kru", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
+    let (mut kru_schema_variant, kru_root_prop) =
+        create_schema_variant_with_root(ctx, *kru_schema.id()).await;
+    kru_schema
+        .set_default_schema_variant_id(ctx, Some(*kru_schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+    let _melser_prop = create_prop_and_set_parent(
+        ctx,
+        PropKind::String,
+        "melser",
+        kru_root_prop.domain_prop_id,
+    )
+    .await;
+
+    // Create two code generation funcs.
+    let code = "function generateYAML(input) {
+      return {
+        format: \"yaml\",
+        code: Object.keys(input.domain).length > 0 ? YAML.stringify(input.domain) : \"\"
+      };
+    }";
+
+    let mut func_one = Func::new(
+        ctx,
+        "test:codeGenerationOne",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    func_one
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    func_one
+        .set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_one_domain_argument = FuncArgument::new(
+        ctx,
+        "domain",
+        FuncArgumentKind::Object,
+        None,
+        *func_one.id(),
+    )
+    .await
+    .expect("could not create func argument");
+
+    let mut func_two = Func::new(
+        ctx,
+        "test:codeGenerationTwo",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    func_two
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    func_two
+        .set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_two_domain_argument = FuncArgument::new(
+        ctx,
+        "domain",
+        FuncArgumentKind::Object,
+        None,
+        *func_two.id(),
+    )
+    .await
+    .expect("could not create func argument");
+
+    // Add two leaves to one variant and one leaf of the same func as one of prior to the other.
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_one.id(),
+        *navi_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_one_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_two.id(),
+        *navi_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_two_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_one.id(),
+        *kru_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_one_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+
+    // Finalize both variants and create three components.
+    navi_schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("unable to finalize schema variant");
+    kru_schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("unable to finalize schema variant");
+    let (navi_component, _) = Component::new(ctx, "navi", *navi_schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let (_kru_one_component, _) = Component::new(ctx, "kru-one", *kru_schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let (_kru_two_component, _) = Component::new(ctx, "kru-two", *kru_schema_variant.id())
+        .await
+        .expect("cannot create component");
+
+    // Test our function and perform assertions on the results.
+    check_results(ctx).await;
+
+    // Update a value and check the component view.
+    let attribute_read_context = AttributeReadContext {
+        prop_id: Some(*ange1_prop.id()),
+        component_id: Some(*navi_component.id()),
+        ..AttributeReadContext::default()
+    };
+    let attribute_value = AttributeValue::find_for_context(ctx, attribute_read_context)
+        .await
+        .expect("could not perform find for context")
+        .expect("attribute value not found");
+    let parent_attribute_value = attribute_value
+        .parent_attribute_value(ctx)
+        .await
+        .expect("could not perform find parent attribute value")
+        .expect("no parent attribute value found");
+    let context = AttributeContextBuilder::from(attribute_read_context)
+        .to_context()
+        .expect("could not convert builder to attribute context");
+    AttributeValue::update_for_context(
+        ctx,
+        *attribute_value.id(),
+        Some(*parent_attribute_value.id()),
+        context,
+        Some(serde_json::json!["omen"]),
+        None,
+    )
+    .await
+    .expect("could not perform update for context");
+    let component_view = ComponentView::new(ctx, *navi_component.id())
+        .await
+        .expect("could not generate component view");
+    assert_eq!(
+        serde_json::json![
+            {
+                "si": {
+                    "name": "navi",
+                    "type": "component",
+                    "protected": false,
+                },
+                "code": {
+                    "test:codeGenerationOne": {
+                        "code": "ange1: omen\n",
+                        "format": "yaml",
+                    },
+                    "test:codeGenerationTwo": {
+                        "code": "ange1: omen\n",
+                        "format": "yaml",
+                    },
+                },
+                "domain": {
+                    "ange1": "omen",
+                }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    // Finally, check the results again to ensure that they didn't drift.
+    check_results(ctx).await;
+}
+
+async fn check_results(ctx: &DalContext) {
+    let all_values = Component::all_code_generation_attribute_values(ctx)
+        .await
+        .expect("could not get all code generation attribute values");
+    assert_eq!(
+        4,                // expected
+        all_values.len(), // actual
+    );
+
+    let mut found_navi_code_generation_one = false;
+    let mut found_navi_code_generation_two = false;
+    let mut found_kru_one_code_generation_one = false;
+    let mut found_kru_two_code_generation_one = false;
+    for id in all_values {
+        let attribute_value = AttributeValue::get_by_id(ctx, &id)
+            .await
+            .expect("could not perform get by id")
+            .expect("attribute value not found");
+        let key = attribute_value.key.expect("key not found");
+        let code_item_prop = Prop::get_by_id(ctx, &attribute_value.context.prop_id())
+            .await
+            .expect("could not perform get by id")
+            .expect("prop not found");
+        assert_eq!(
+            "codeItem",            // expected
+            code_item_prop.name(), // actual
+        );
+        let component = Component::get_by_id(ctx, &attribute_value.context.component_id())
+            .await
+            .expect("could not perform get by id")
+            .expect("component not found");
+        let component_name = component.name(ctx).await.expect("could not get name");
+
+        if "test:codeGenerationOne" == &key && "navi" == &component_name {
+            assert!(!found_navi_code_generation_one);
+            found_navi_code_generation_one = true;
+        } else if "test:codeGenerationTwo" == &key && "navi" == &component_name {
+            assert!(!found_navi_code_generation_two);
+            found_navi_code_generation_two = true;
+        } else if "test:codeGenerationOne" == &key && "kru-one" == &component_name {
+            assert!(!found_kru_one_code_generation_one);
+            found_kru_one_code_generation_one = true;
+        } else if "test:codeGenerationOne" == &key && "kru-two" == &component_name {
+            assert!(!found_kru_two_code_generation_one);
+            found_kru_two_code_generation_one = true;
+        }
+    }
+
+    // Ensure that we found every code generation. We ensured that we could only find them exactly
+    // once in the loop above, but now we need to ensure that we found them at all.
+    assert!(found_navi_code_generation_one);
+    assert!(found_navi_code_generation_two);
+    assert!(found_kru_one_code_generation_one);
+    assert!(found_kru_two_code_generation_one);
 }


### PR DESCRIPTION
Primary:
- Fix code gen reactivity in the UI by ensuring we publish WsEvent(s) when working with AttributeValues that would trigger code gen Funcs to run
- Add ability to find all AttributeValueIds corresponding to all code gen leaves in the workspace (alongisde a new integration test that does not leverage builtins)

Secondary:
- Replace usage of builtin code generation func in existing code gen integration test with an in-line created func (now, there's no reliance on builtins)