### PR TITLE
feat(dal,web,sdf): install package stubs

### DIFF
--- a/app/web/src/components/PackageDetailsPanel.vue
+++ b/app/web/src/components/PackageDetailsPanel.vue
@@ -14,12 +14,14 @@
       <VButton2
         :disabled="disableInstallButton"
         :loading="disableInstallButton"
-        :label="selectedPackage.installed ? 'Remove' : 'Add'"
-        :loading-text="selectedPackage.installed ? 'Removing...' : 'Adding...'"
+        :label="selectedPackage.installed ? 'Remove' : 'Install'"
+        :loading-text="
+          selectedPackage.installed ? 'Removing...' : 'Installing...'
+        "
         tone="action"
         icon="plus"
         size="md"
-        @click="toggleInstalled"
+        @click="installPackage"
       />
     </div>
     <div class="p-sm flex flex-col">
@@ -42,12 +44,9 @@ const disableInstallButton = ref(false);
 
 const selectedPackage = computed(() => packageStore.selectedPackage);
 
-const toggleInstalled = () => {
+const installPackage = async () => {
   disableInstallButton.value = true;
-  setTimeout(() => {
-    packageStore.selectedPackage.installed =
-      !packageStore.selectedPackage.installed;
-    disableInstallButton.value = false;
-  }, 2000);
+  await packageStore.INSTALL_PACKAGE(selectedPackage.value);
+  disableInstallButton.value = false;
 };
 </script>

--- a/app/web/src/store/package.store.ts
+++ b/app/web/src/store/package.store.ts
@@ -85,7 +85,7 @@ export const usePackageStore = () => {
             "00AAFF",
           ])}`;
         },
-        generateMockPackage(id: string, name?: string) {
+        generateMockPackage(id: string, name?: string, installed?: boolean) {
           return {
             id,
             displayName:
@@ -102,7 +102,7 @@ export const usePackageStore = () => {
             icon: (_.sample(_.keys(ICONS)) || "logo-si") as IconNames,
             color: this.generateMockColor(),
             slug: `test${id}`,
-            installed: false,
+            installed: installed ?? false,
             createdAt: new Date(
               new Date().getTime() - Math.random() * 10000000000,
             ),
@@ -134,15 +134,27 @@ export const usePackageStore = () => {
           return mockSchemaVariants;
         },
 
+        async INSTALL_PACKAGE(pkg: Package) {
+          return new ApiRequest({
+            method: "post",
+            url: "/pkg/install_pkg",
+            params: { name: pkg.displayName, ...visibility },
+            onSuccess: (response) => {
+              this.packagesById[pkg.id].installed = true;
+            },
+          });
+        },
+
         async LOAD_PACKAGES() {
           return new ApiRequest({
-            url: "/pkg/list_pkgs", // TODO - replace with real API request
+            url: "/pkg/list_pkgs",
             params: { ...visibility },
             onSuccess: (response) => {
               for (const [idx, pkg] of response.pkgs.entries()) {
                 this.packagesById[idx + 1] = this.generateMockPackage(
                   idx + 1,
                   pkg.name,
+                  pkg.installed,
                 );
               }
             },

--- a/lib/dal/src/installed_pkg.rs
+++ b/lib/dal/src/installed_pkg.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use si_data_nats::NatsError;
+use si_data_pg::PgError;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor, DalContext,
+    HistoryEventError, StandardModel, StandardModelError, Tenancy, Timestamp, Visibility,
+};
+
+#[derive(Error, Debug)]
+pub enum InstalledPkgError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+    #[error("error decoding code_base64: {0}")]
+    Decode(#[from] base64::DecodeError),
+}
+
+pub type InstalledPkgResult<T> = Result<T, InstalledPkgError>;
+
+pk!(InstalledPkgPk);
+pk!(InstalledPkgId);
+
+/// An `InstalledPkg` is a record of the installation of a package. It tracks the
+/// package installation and can be used to prevent duplicate installations and
+/// to remove packages after installation.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct InstalledPkg {
+    pk: InstalledPkgPk,
+    id: InstalledPkgId,
+    name: String,
+    root_hash: Option<String>,    // this will become non-optional
+    pkg_contents: Option<String>, // same
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl_standard_model! {
+    model: InstalledPkg,
+    pk: InstalledPkgPk,
+    id: InstalledPkgId,
+    table_name: "installed_pkgs",
+    history_event_label_base: "installed_pkg",
+    history_event_message_name: "Installed Pkg"
+}
+
+impl InstalledPkg {
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext,
+        name: impl AsRef<str>,
+        root_hash: Option<String>,
+        pkg_contents: Option<String>,
+    ) -> InstalledPkgResult<Self> {
+        let name = name.as_ref();
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM installed_pkg_create_v1($1, $2, $3, $4, $5)",
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &name,
+                    &root_hash,
+                    &pkg_contents,
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(name, String, InstalledPkgResult);
+    standard_model_accessor!(root_hash, Option<String>, InstalledPkgResult);
+    standard_model_accessor!(pkg_contents, Option<String>, InstalledPkgResult);
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -34,6 +34,7 @@ pub mod func;
 pub mod group;
 pub mod history_event;
 pub mod index_map;
+pub mod installed_pkg;
 pub mod job;
 pub mod job_failure;
 pub mod jwt_key;

--- a/lib/dal/src/migrations/U1048__installed_pkgs.sql
+++ b/lib/dal/src/migrations/U1048__installed_pkgs.sql
@@ -1,0 +1,57 @@
+CREATE TABLE installed_pkgs 
+(
+    pk                          ident                    PRIMARY KEY DEFAULT ident_create_v1(),
+    id                          ident                    NOT NULL DEFAULT ident_create_v1(),
+    tenancy_workspace_pk        ident,
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    name                        text                     NOT NULL,
+    root_hash                   text,  -- should become non-null once we are pulling in real packages
+    pkg_contents                text  -- ditto, maybe bytea?
+    -- additional metadata: author? description? 
+    -- should also be paired with a table that links the installed packages to
+    -- the assets they installed so that packages can be removed
+);
+CREATE UNIQUE INDEX unique_pkg_name ON installed_pkgs (
+	name,
+	tenancy_workspace_pk,
+	visibility_change_set_pk,
+	(visibility_deleted_at IS NULL))
+    WHERE visibility_deleted_at IS NULL;
+SELECT standard_model_table_constraints_v1('installed_pkgs');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('installed_pkgs', 'model', 'installed_pkg', 'Installed Package');
+
+CREATE OR REPLACE FUNCTION installed_pkg_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_name text,
+    this_root_hash text,
+    this_pkg_contents text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           schema_variant_definitions%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO installed_pkgs (
+        tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at,
+        name, root_hash, pkg_contents
+    ) VALUES (
+        this_tenancy_record.tenancy_workspace_pk,
+        this_visibility_record.visibility_change_set_pk,
+        this_visibility_record.visibility_deleted_at, this_name,
+        this_root_hash, this_pkg_contents
+    )
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/sdf/src/server/service/pkg/install_pkg.rs
+++ b/lib/sdf/src/server/service/pkg/install_pkg.rs
@@ -1,0 +1,51 @@
+use super::{get_pkgs_path, pkg_lookup, PkgError, PkgResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use axum::Json;
+use dal::{installed_pkg::InstalledPkg, StandardModel, Visibility, WsEvent};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallPkgRequest {
+    pub name: String,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallPkgResponse {
+    pub success: bool,
+}
+
+pub async fn install_pkg(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<InstallPkgRequest>,
+) -> PkgResult<Json<InstallPkgResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let real_pkg_file_name = pkg_lookup(get_pkgs_path(&builder).await?, &request.name).await?;
+
+    let real_pkg_file_name = match real_pkg_file_name {
+        None => return Err(PkgError::PackageNotFound(request.name)),
+        Some(real_pkg_file_name) => real_pkg_file_name,
+    };
+
+    if !InstalledPkg::find_by_attr(&ctx, "name", &real_pkg_file_name)
+        .await?
+        .is_empty()
+    {
+        return Err(PkgError::PackageAlreadyInstalled(real_pkg_file_name));
+    }
+
+    InstalledPkg::new(&ctx, &request.name, None, None).await?;
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish(&ctx)
+        .await?;
+    ctx.commit().await?;
+
+    Ok(Json(InstallPkgResponse { success: true }))
+}

--- a/lib/sdf/src/server/service/pkg/list_pkgs.rs
+++ b/lib/sdf/src/server/service/pkg/list_pkgs.rs
@@ -1,0 +1,46 @@
+use super::{get_pkgs_path, list_pkg_dir_entries, PkgResult, PkgView};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use axum::{extract::Query, Json};
+use dal::{installed_pkg::InstalledPkg, StandardModel, Visibility};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PkgListRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PkgListResponse {
+    pub pkgs: Vec<PkgView>,
+}
+
+pub async fn list_pkgs(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<PkgListRequest>,
+) -> PkgResult<Json<PkgListResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let pkgs_path = get_pkgs_path(&builder).await?;
+
+    let installed_pkgs = InstalledPkg::list(&ctx).await?;
+
+    let mut installed_pkg_map: HashMap<String, bool> = HashMap::new();
+    for installed_pkg in installed_pkgs {
+        installed_pkg_map.insert(installed_pkg.name().to_string(), true);
+    }
+
+    for available_pkg in list_pkg_dir_entries(pkgs_path).await? {
+        installed_pkg_map.entry(available_pkg).or_insert(false);
+    }
+
+    let pkgs: Vec<PkgView> = installed_pkg_map
+        .drain()
+        .map(|(name, installed)| PkgView { name, installed })
+        .collect();
+
+    Ok(Json(PkgListResponse { pkgs }))
+}

--- a/lib/si-settings/src/lib.rs
+++ b/lib/si-settings/src/lib.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 mod canonical_file;
 
-pub use canonical_file::{CanonicalFile, CanonicalFileError};
+pub use canonical_file::{safe_canonically_join, CanonicalFile, CanonicalFileError};
 
 #[derive(Error, Debug)]
 pub enum SettingsError {


### PR DESCRIPTION
Stubs out an installed_pkgs table and adds api routes to install a package. Package listing includes the installed boolean.

Packages are just names now, added a safe join that canonicalizes to ensure we don't allow directory traversal.