### PR TITLE
Tighten rustdoc checks (ENG-1079)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -246,8 +246,14 @@ Let's say you want to learn about what a `Component` is.
 You can generate and open the Rust documentation locally via the following command:
 
 ```bash
-cargo doc --open -p dal
+cargo doc --no-deps --document-private-items --open
 ```
+
+> If you have `nix` installed, you can open SI documentation without needing to install Rust or other dependencies.
+>
+> ```shell
+> nix develop --command cargo doc --no-deps --document-private-items --open
+> ```
 
 Moreover, there are resources in [docs](./docs), [designs](./designs), our Miro boards, and our Figma projects that
 may prove useful as well.

--- a/bin/council/package.json
+++ b/bin/council/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test",

--- a/bin/cyclone/package.json
+++ b/bin/cyclone/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/bin/pinga/package.json
+++ b/bin/pinga/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test",

--- a/bin/sdf/package.json
+++ b/bin/sdf/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test",

--- a/bin/veritech/package.json
+++ b/bin/veritech/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test",

--- a/docs/dev/CODE_DOCUMENTATION.md
+++ b/docs/dev/CODE_DOCUMENTATION.md
@@ -9,7 +9,7 @@ Where do you look?
 You can generate and open the docs in your browser to find out!
 
 ```bash
-cargo doc --open -p dal
+cargo doc --no-deps --document-private-items --open
 ```
 
 Our Rust crates contain module and documentation comments that can be generated into static webpages by `rustdoc`.
@@ -20,35 +20,6 @@ When in doubt, see if `cargo doc` has what you are looking for.
 As previously mentioned, for our Rust crates, we leverage `rustdoc` for seamless integration with `cargo doc`
 , [IntelliJ Rust](https://www.jetbrains.com/rust/),
 [rust-analyzer](https://rust-analyzer.github.io/), and more.
-
-## Reading Rust Documentation
-
-Build the docs for all of our crates and open the docs in your browser at [dal](./lib/dal) by executing
-the following make target:
-
-```bash
-make docs-open
-```
-
-You can also execute the following:
-
-```bash
-cargo doc --open -p dal
-```
-
-If you would like to live-recompile docs while making changes on your development branch, you can execute the following
-make target:
-
-```bash
-make docs-watch
-```
-
-> Please note: [cargo-watch](https://github.com/watchexec/cargo-watch) needs to be installed before using the above make
-> target.
->
-> ```bash
-> cargo install --locked cargo-watch
-> ```
 
 ## Writing Rust Documentation
 

--- a/lib/bytes-lines-codec/package.json
+++ b/lib/bytes-lines-codec/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/config-file/package.json
+++ b/lib/config-file/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/council/package.json
+++ b/lib/council/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/cyclone-client/package.json
+++ b/lib/cyclone-client/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/cyclone-core/package.json
+++ b/lib/cyclone-core/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/cyclone-server/package.json
+++ b/lib/cyclone-server/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/dal-test/package.json
+++ b/lib/dal-test/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/dal-test/src/helpers/builtins.rs
+++ b/lib/dal-test/src/helpers/builtins.rs
@@ -53,8 +53,8 @@ struct BuiltinMetadata {
     prop_map: PropMap,
 }
 
-/// A hash map of [`PropId`s](PropId) where the key is the JSON pointer to the [`Prop`] on the
-/// [`SchemaVariant`].
+/// A hash map of [`PropId`s](PropId) where the key is the JSON pointer to the [`Prop`](dal::Prop)
+/// on the [`SchemaVariant`](dal::SchemaVariant).
 type PropMap = HashMap<&'static str, PropId>;
 
 /// This harness provides methods to create [`Component`s](Component) from builtin schemas. All

--- a/lib/dal/package.json
+++ b/lib/dal/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/dal/src/status_receiver.rs
+++ b/lib/dal/src/status_receiver.rs
@@ -25,7 +25,7 @@ use crate::{
 pub mod client;
 
 /// The [NATS](https://nats.io) subject for publishing and subscribing to
-/// [`requests`](DependentValuesUpdateRequest).
+/// [`requests`](StatusReceiverRequest).
 const STATUS_RECEIVER_REQUEST_SUBJECT: &str = "dependentValuesUpdateStatus.request";
 /// The queue name for [NATS](https://nats.io).
 const STATUS_RECEIVER_QUEUE_NAME: &str = "dependentValuesUpdateStatus";

--- a/lib/deadpool-cyclone/package.json
+++ b/lib/deadpool-cyclone/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/object-tree/package.json
+++ b/lib/object-tree/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/pinga-server/package.json
+++ b/lib/pinga-server/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/sdf/package.json
+++ b/lib/sdf/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -121,8 +121,8 @@ async fn save_attr_func_proto_arguments(
     Ok(())
 }
 
-/// Determines what we should do with the [`AttributePrototype`](crate::AttributePrototype) and
-/// [`AttributeValues`](crate:AttributeValue) that are currently associated with a function but
+/// Determines what we should do with the [`AttributePrototype`](dal::AttributePrototype) and
+/// [`AttributeValues`](dal::AttributeValue) that are currently associated with a function but
 /// that are having their association removed.
 ///
 /// `RemovedPrototypeOp::Reset` takes the currenty value and resets the prototype to set it to that

--- a/lib/si-data-nats/package.json
+++ b/lib/si-data-nats/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/si-data-pg/package.json
+++ b/lib/si-data-pg/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/si-pkg/package.json
+++ b/lib/si-pkg/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/si-settings/package.json
+++ b/lib/si-settings/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/si-std/package.json
+++ b/lib/si-std/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/si-test-macros/package.json
+++ b/lib/si-test-macros/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/telemetry-application-rs/package.json
+++ b/lib/telemetry-application-rs/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/telemetry-rs/package.json
+++ b/lib/telemetry-rs/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/veritech-client/package.json
+++ b/lib/veritech-client/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/veritech-core/package.json
+++ b/lib/veritech-core/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/lib/veritech-server/package.json
+++ b/lib/veritech-server/package.json
@@ -12,7 +12,7 @@
     "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
     "fix": "pnpm fix:format && pnpm fix:lint",
     "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+    "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
     "check:format": "cargo fmt -- --check",
     "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
     "prepush": "pnpm check && pnpm test"

--- a/mk/rust.mk
+++ b/mk/rust.mk
@@ -25,7 +25,7 @@ default--check-lint:
 ## check-doc: Checks all documentation for the Rust crate
 default--check-doc:
 	$(call header,$@)
-	env RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
+	env RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps --document-private-items
 .PHONY: default--check-doc
 
 ## check-format: Checks all code formatting for the Rust crate

--- a/scripts/generate-rust-package-json.js
+++ b/scripts/generate-rust-package-json.js
@@ -50,7 +50,7 @@ for (const tomlPath of cargoTomlFiles) {
       "fix:lint": "cargo fix --edition-idioms --allow-dirty --allow-staged",
       "fix": "pnpm fix:format && pnpm fix:lint",
       "check:lint": "cargo clippy --no-deps --all-targets -- -D warnings",
-      "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps",
+      "check:doc": "env RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --document-private-items",
       "check:format": "cargo fmt -- --check",
       "check": "pnpm check:format && pnpm check:lint && pnpm check:doc",
       "prepush": "pnpm check && pnpm test",


### PR DESCRIPTION
- Tighten rust doc checks to include "--document-private-items"
  - Negligible overhead as far as CI times go
- Fix locations that the tightening caught
- Remove outdated section of "CODE_DOCUMENTATION" (already covered in the file)
- Update docs command in "DEVELOPING" and add nix command alongside it

<img src="https://media2.giphy.com/media/jriyttiYW9eX7cj8ln/giphy.gif"/>