### PR TITLE
 chore(docs): prepare repo for open-source release 

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -136,7 +136,6 @@ Potentially conflicting services include, but are not limited to, the following:
 * PostgreSQL DB
 * OpenTelemetry
 * NATS
-* Faktory
 * Watchtower
 
 In the case of a port conflict, a good strategy is to temporarily disable the host service until SI is no longer being

--- a/README.md
+++ b/README.md
@@ -2,10 +2,99 @@
 
 This is a monolithic repository containing the source for System Initiative (SI)
 
-## Developing and Running the SI Stack
+## Installation
 
-Please refer to the [DEVELOPING](./DEVELOPING.md) guide for more information.
-You can also refer to the [docs directory](./docs) for even more information.
+First ensure that Docker is installed on your machine and that the `docker` executable is in your `PATH`.
+
+This section is designed for the following architecture + platform combinations:
+
+* `x86_64  (amd64)`: Arch Linux, Fedora, macOS, Pop!_OS, Ubuntu, WSL2
+* `aarch64 (arm64)`: macOS
+
+*aarch64 (arm64) depends on Rosetta 2 to properly execute, install it with `softwareupdate --install-rosetta`*
+
+*If your architecture + platform is not listed above it's probably not supported by the installation script. If that is the case, or you don't want the dependencies to be installed directly in your machine, you can use Nix to encapsulate them. Check the Nix section in the [DEVELOPING](./DEVELOPING.md) document for more information. If doing so, you can skip to the [Configuration](#configuration) section*
+
+To continue the default installation process you must ensure that you have the `rust` toolchain and the `node` toolchain installed and available in your `PATH`. We recommend the following tools to help you manage those toolchains:
+
+* [**rustup**](https://rustup.rs) 🦀: Rust, `cargo`, etc.
+* [**volta**](https://volta.sh) ⚡: `node`, `npm`, etc.
+
+Now you can run the bootstrap script, that will install and update all dependencies.
+
+```bash
+./scripts/bootstrap.sh
+```
+
+For more informations regarding the bootstrap script, or the installation process refer to [DEVELOPING](./DEVELOPING.md). Including troubleshooting and expanding it to support new architectures, or functionalities - generally needed to make more CLI tools available to custom Javascript functions.
+
+*You can also refer to the [docs directory](./docs) for even more details.*
+
+## Configuration
+
+You must authenticate to the AWS console and Docker Hub to ensure System Initiative will work properly.
+
+AWS authentication is required so SI can deploy and manage your infrastructure. Run the following command:
+
+```bash
+aws configure
+```
+
+Docker Hub authentication is not strictly needed if you only access public docker images, but to avoid being rate-limited when qualifying images, you should probably authenticate with the following command:
+
+```bash
+docker login
+```
+
+## Running
+
+You must make sure these docker images are running: `postgresql`, `nats`, `opentelemetry`. To do this run the following command:
+
+*If you have any of these services running locally you should stop them to avoid ports conflicting*
+
+*Note: This will delete all of the SI's docker image database's content*
+
+```bash
+make prepare
+```
+
+Wait for the docker images to be pulled and executed before proceeding.
+
+System Initiative requires 5 processes running to properly execute: `veritech`, `council`, `pinga`, `sdf` and `web`.
+
+*If you can't or don't want to run the processes directly, you can use Nix to encapsulate them. Check [DEVELOPING](./DEVELOPING.md) for more information.*
+
+*Check the section [Architecture](#architecture) for more details about each process.*
+
+Run these in order, each in a new terminal session:
+
+```bash
+make run//bin/veritech
+```
+
+Wait for `veritech` to finish initializing, otherwise the system might behave weirdly, as custom functions execution will fail.
+
+The following should be be started in order, but the previous doesn't need to be fully initialized for the subsequent to start.
+
+```bash
+make run//bin/council
+```
+
+```bash
+make run//bin/pinga
+```
+
+```bash
+make run//bin/sdf
+```
+
+```bash
+make run//app/web
+```
+
+After everything is initialized, access it through: http://localhost:8080
+
+*Note: initial compilation times may be long, depending on the machine used*
 
 ## Contributing
 
@@ -16,18 +105,6 @@ When in doubt, use `feat`, `fix`, or `chore`!
 Moreover, please sign your commits using `git commit -s`.
 You can amend an existing commit with `git commit -s --amend`, if needed.
 
-### Linear Integration
-
-If your pull request addresses a Linear issue in some manner, please refer to the [official guide](https://linear.app/docs/github?tabs=206cad22125a) on linking the two together.
-
-## Engineering Team Links
-
-Welcome to the team! A few handy links:
-
-* [Engineering Team Onboarding](https://docs.google.com/presentation/d/1Ypesl1iZ5KXI9KBxXINYPlo5TexAuln6Dg26yPXEqbM/view) - the foundation of our team
-* [The SI Way](https://docs.google.com/document/d/1llbG8MLv2c9SytLnwCrJU27n5yfGsrI1c4Pi6qscVz4/view) - how we work together
-* [Engineering Maxims](https://docs.google.com/document/d/1l-YCyMbXaVAG6VVDucZVJlO7VbJeTAAwt4jB-1usSQA/view) - some maxims we try to follow
-
 ## Architecture
 
 The diagram (created with [asciiflow](https://asciiflow.com)) below illustrates a _very_ high-level overview of SI's calling stack.
@@ -37,9 +114,9 @@ There are other components and paradigms that aren't displayed, but this diagram
                    ┌───────┐   ┌─────────┐
                    │ pinga ├───│ council │
                    └───┬───┘   └─────────┘
-                       │   ┌─────────┐
-                       ├───┤ faktory │
-                       │   └─────────┘
+                       │
+                       │
+                       │
 ┌─────┐   ┌─────┐   ┌──┴──┐   ┌──────────┐
 │ web ├───┤ sdf ├───┤ dal ├───┤ postgres │
 └─────┘   └─────┘   └──┬──┘   └──────────┘
@@ -57,14 +134,15 @@ There are other components and paradigms that aren't displayed, but this diagram
 - **[web](./app/web/):** the primary frontend web application for SI
 - **[sdf](./bin/sdf/):** the backend webserver for communicating with `web`
 - **[dal](./lib/dal/):** the library used by `sdf` routes to "make stuff happen" (the keystone of SI)
-- **[pinga](./bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `nats` or `faktory`
-- **[council](./bin/council/):** the dependent values updates synchronization service used by the `dal` to avoid race conditions in DependentValuesUpdate the job, communicates via `nats`
-- **[faktory](https://github.com/contribsys/faktory):** one of the job queueing mechanism that can be used by `pinga` to execute non-trivial jobs
+- **[pinga](./bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `nats` (default) or `faktory` (disabled by default)
+- **[council](./bin/council/):** the DependentValuesUpdate job's synchronization service, used by `dal` via `nats` to avoid race conditions when updating attribute values
 - **[postgres](https://postgresql.org):** the database for storing SI data
+- **[nats](https://nats.io):** the messaging system used everywhere in SI, by `pinga`, `council`, `dal` and `sdf` (for multicast websocket events)
 - **[veritech](./bin/veritech/):** a backend webserver for dispatching functions in secure runtime environments
 - **[deadpool-cyclone](./lib/deadpool-cyclone/):** a library used for managing a pool of `cyclone` instances of varying "types" (i.e. HTTP, UDS)
 - **[cyclone](./bin/cyclone/):** the manager for a secure execution runtime environment (e.g. `lang-js`)
 - **[lang-js](./bin/lang-js/):** a secure-ish (don't trust it) execution runtime environment for JS functions
+- **[faktory](https://github.com/contribsys/faktory):** disabled by default, one of the job queueing mechanism that can be used by `pinga` to execute non-trivial jobs
 
 It's worth noting that our database has many stored procedures (i.e. database functions) that perform non-trivial logic.
 While the [dal](./lib/dal) is the primary "data access layer" for the rest of the SI stack, it does not perform _all_ the heavy lifting.

--- a/bin/pinga/README.md
+++ b/bin/pinga/README.md
@@ -1,6 +1,6 @@
 # Pinga
 
-Job Queue Executor integrated with both [Nats](https://nats.io/) and [Faktory](https://contribsys.com/faktory/)
+Job Queue Executor integrated with both [Nats](https://nats.io/) (by default) and [Faktory](https://contribsys.com/faktory/) (opt-in)
 
 ![pinga](./docs/pinga.png)
 
@@ -11,12 +11,6 @@ Job Queue Executor integrated with both [Nats](https://nats.io/) and [Faktory](h
 ![pingando](./docs/pinga.gif)
 
 ## Execution
-
-Run faktory locally in dev mode with (this doesn't persist the queues):
-
-```
-docker run --rm -it -p 127.0.0.1:7419:7419 -p 127.0.0.1:7420:7420 contribsys/faktory:latest
-```
 
 Run pinga:
 
@@ -29,3 +23,14 @@ You can also use the following command in the global workspace:
 ```
 make pinga-run
 ```
+
+## Faktory
+
+If you decide to swap the transport layer from NATS to Faktory, you will have to have faktory running in the background
+
+Run faktory locally in dev mode with (this doesn't persist the queues):
+
+```
+docker run --rm -it -p 127.0.0.1:7419:7419 -p 127.0.0.1:7420:7420 contribsys/faktory:latest
+```
+

--- a/bin/pinga/script/run-container.sh
+++ b/bin/pinga/script/run-container.sh
@@ -34,10 +34,10 @@ main() {
       --add-host "postgres:$gateway" \
       --add-host "nats:$gateway" \
       --add-host "otelcol:$gateway" \
-      --add-host "faktory:$gateway" \
+      # --add-host "faktory:$gateway" \
       --env SI_PINGA__PG__HOSTNAME=postgres \
       --env SI_PINGA__NATS__URL=nats \
-      --env SI_PINGA__FAKTORY__URL=faktory:7419 \
+      # --env SI_PINGA__FAKTORY__URL=faktory:7419 \
       --env OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317 \
       --name "$name" \
       "$@" \

--- a/bin/sdf/script/run-container.sh
+++ b/bin/sdf/script/run-container.sh
@@ -34,10 +34,10 @@ main() {
       --add-host "postgres:$gateway" \
       --add-host "nats:$gateway" \
       --add-host "otelcol:$gateway" \
-      --add-host "faktory:$gateway" \
+      # --add-host "faktory:$gateway" \
       --env SI_SDF__PG__HOSTNAME=postgres \
       --env SI_SDF__NATS__URL=nats \
-      --env SI_SDF__FAKTORY__URL=faktory:7419 \
+      # --env SI_SDF__FAKTORY__URL=faktory:7419 \
       --env OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317 \
       --name "$name" \
       "$@" \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -27,13 +27,13 @@ services:
     environment:
       - "SI_SDF__PG__HOSTNAME=postgres"
       - "SI_SDF__NATS__URL=nats"
-      - "SI_SDF__FAKTORY__URL=faktory:7419"
+      # - "SI_SDF__FAKTORY__URL=faktory:7419"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     extra_hosts:
       - "postgres:${GATEWAY:-I like my butt}"
       - "nats:${GATEWAY:-I like my butt}"
       - "otelcol:${GATEWAY:-I like my butt}"
-      - "faktory:${GATEWAY:-I like my butt}"
+      # - "faktory:${GATEWAY:-I like my butt}"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
       - "com.centurylinklabs.watchtower.lifecycle.pre-update='/reset-database.sh'"
@@ -41,7 +41,7 @@ services:
       - "/opt/deploy/scripts/reset-database.sh:/reset-database.sh:ro"
     depends_on:
       - pg
-      - faktory
+      # - faktory
       - otel
       - nats
     restart: "unless-stopped"
@@ -74,18 +74,18 @@ services:
     environment:
       - "SI_PINGA__PG__HOSTNAME=postgres"
       - "SI_PINGA__NATS__URL=nats"
-      - "SI_PINGA__FAKTORY__URL=faktory:7419"
+      # - "SI_PINGA__FAKTORY__URL=faktory:7419"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     extra_hosts:
       - "postgres:${GATEWAY:-I like my butt}"
       - "nats:${GATEWAY:-I like my butt}"
       - "otelcol:${GATEWAY:-I like my butt}"
-      - "faktory:${GATEWAY:-I like my butt}"
+      # - "faktory:${GATEWAY:-I like my butt}"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:
       - pg
-      - faktory
+      # - faktory
       - otel
       - nats
     restart: "unless-stopped"
@@ -120,11 +120,11 @@ services:
     ports:
       - "5432:5432"
 
-  faktory:
-    image: "index.docker.io/contribsys/faktory:latest"
-    ports:
-      - "7419:7419"
-      - "7420:7420"
+  # faktory:
+  #   image: "index.docker.io/contribsys/faktory:latest"
+  #   ports:
+  #     - "7419:7419"
+  #     - "7420:7420"
 
   nats:
     image: "index.docker.io/systeminit/nats:stable"

--- a/docs/dev/TROUBLESHOOTING.md
+++ b/docs/dev/TROUBLESHOOTING.md
@@ -18,7 +18,7 @@ Where:
 - `clean` removes all Cargo (Rust) build artifacts, and each TypeScript-based
   component will remove its `node_modules/` and associated build artifacts
 - `prepare` brings down the supporting services running in a Docker Compose
-  deployment (i.e. the PostgreSQL database, NATS, and Faktory services), and
+  deployment (i.e. the PostgreSQL database and NATS), and
   then re-deploys them from scratch
 - `build` builds all components, including apps, binaries, and
   libraries/packages

--- a/lib/veritech-server/src/subscriber.rs
+++ b/lib/veritech-server/src/subscriber.rs
@@ -50,7 +50,7 @@ impl Subscriber {
             "subscribing for resolver function requests"
         );
         let inner = nats
-            .subscribe(subject)
+            .queue_subscribe(subject, "resolver")
             .await
             .map_err(SubscriberError::NatsSubscribe)?;
 
@@ -70,7 +70,7 @@ impl Subscriber {
             "subscribing for validation requests"
         );
         let inner = nats
-            .subscribe(subject)
+            .queue_subscribe(subject, "validation")
             .await
             .map_err(SubscriberError::NatsSubscribe)?;
 
@@ -90,7 +90,7 @@ impl Subscriber {
             "subscribing for workflow resolve requests"
         );
         let inner = nats
-            .subscribe(subject)
+            .queue_subscribe(subject, "workflow")
             .await
             .map_err(SubscriberError::NatsSubscribe)?;
 
@@ -110,7 +110,7 @@ impl Subscriber {
             "subscribing for command resolve requests"
         );
         let inner = nats
-            .subscribe(subject)
+            .queue_subscribe(subject, "command")
             .await
             .map_err(SubscriberError::NatsSubscribe)?;
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -75,6 +75,8 @@ function darwin-bootstrap {
     brew upgrade
     brew cleanup
     brew install "${pkgs[@]}"
+
+    install-pnpm-posix
 }
 
 function arch-bootstrap {
@@ -89,8 +91,10 @@ function arch-bootstrap {
     )
 
     sudo pacman -Syu --noconfirm "${pkgs[@]}"
+
     install-kubeval-linux-amd64
     install-butane-linux-amd64
+    install-pnpm-posix
 }
 
 function fedora-bootstrap {
@@ -110,6 +114,8 @@ function fedora-bootstrap {
     sudo dnf upgrade -y --refresh
     sudo dnf autoremove -y
     sudo dnf install -y "${pkgs[@]}"
+
+    install-pnpm-posix
 }
 
 function pop-bootstrap {
@@ -136,6 +142,8 @@ function pop-bootstrap {
     brew upgrade
     brew cleanup
     brew install gcc kubeval butane skopeo awscli
+
+    install-pnpm-posix
 
     if [ "${SI_WSL2}" == "false" ] && [ ! $(command -v docker) ]; then
         sudo apt update
@@ -168,6 +176,7 @@ function ubuntu-bootstrap {
         protobuf-compiler
         skopeo
         wget
+	unzip
     )
 
     . /etc/os-release
@@ -181,9 +190,11 @@ function ubuntu-bootstrap {
     sudo apt upgrade -y
     sudo apt autoremove -y
     sudo apt install -y "${pkgs[@]}"
+
     install-kubeval-linux-amd64
     install-butane-linux-amd64
     install-awscli-linux-amd64
+    install-pnpm-posix
 
     if [ "${SI_WSL2}" == "false" ]; then
         echo "\
@@ -255,13 +266,27 @@ function install-butane-linux-amd64 {
 
 function install-awscli-linux-amd64 {
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    sudo ./aws/install
+    unzip -qo awscliv2.zip
+    sudo ./aws/install --update
     rm -rf ./aws ./awscliv2.zip
-    ln -s /usr/local/bin/aws /usr/bin/aws
+    ln -sf /usr/local/bin/aws /usr/bin/aws
+}
+
+function install-pnpm-posix {
+    echo "Install pnpm"
+    curl -fsSL https://get.pnpm.io/install.sh | sh -
+    if [[ -f ~/.volta/bin/pnpm ]]; then
+      echo "We have detected volta's pnpm, which does not work correctly.";
+      echo "Please remove with \`rm ~/.volta/bin/pnpm\`";
+      echo "";
+      exit 1;
+    fi
 }
 
 function check-dependencies {
+    echo "Check Dependencies"
+    exec $SHELL
+
     # Ensure we can get the absolute path of the required files.
     REALPATH=realpath
     if [ "$SI_OS" = "darwin" ]; then

--- a/scripts/data/required-binaries.txt
+++ b/scripts/data/required-binaries.txt
@@ -7,3 +7,4 @@ npm
 pnpm
 protoc
 skopeo
+aws

--- a/scripts/data/required-commands.txt
+++ b/scripts/data/required-commands.txt
@@ -1,2 +1,1 @@
 docker compose version
-psql --help


### PR DESCRIPTION
- Removed faktory from default dependencies
- Document succintly in the README default way of installing and executing SI
- Remove internal links from the docs
- Error if veritech-server is not running when veritech-client publishes something.
  This prevents the system from blocking permanently if the user starts veritech after some task has been published (as there is no timeout)
- Allow horizontal scaling of veritech by using a nats queue to consume jobs
- Install pnpm as part of the bootstrap script
- Remove volta's pnpm as it's support is experimental and heavily glitched
- Install unzip to ubuntu, and improve logs in aws-cli installation
- exec $SHELL before checking dependencies as the newly installed binaries won't be found without it
- Require aws-cli, and stop requiring psql in the bootstrap script post-install checks