### PR TITLE
Add code generation events to status receiver (ENG-1062)

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -811,12 +811,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           {
             eventType: "CodeGenerated",
             callback: (codeGeneratedEvent) => {
-              // probably ideally just push the new code over the websocket
-              // but for now we'll re-fetch if the component is currently selected
-              // topic subscription would also help to know if we're talking about the component in the correct changeset
-              if (this.selectedComponentId === codeGeneratedEvent.componentId) {
-                this.FETCH_COMPONENT_CODE(this.selectedComponentId);
-              }
+              this.FETCH_COMPONENT_CODE(codeGeneratedEvent.componentId);
             },
           },
         ]);

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -161,8 +161,8 @@ export const useRealtimeStore = defineStore("realtime", () => {
     eventData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     eventMetadata: RealtimeEventMetadata,
   ) {
-    // Set your env variable LOG_WS to true if you want to see these console logs!
-    if (import.meta.env.LOG_WS) {
+    // Set the "VITE_LOG_WS" environment variable to true if you want to see logs for received WsEvents.
+    if (import.meta.env.VITE_LOG_WS) {
       /* eslint-disable-next-line no-console */
       console.log("WS message", eventKind, eventData);
     }

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -182,6 +182,9 @@ impl JobConsumer for DependentValuesUpdate {
             return Ok(());
         }
 
+        // Cache the original dependency graph to send the status receiver.
+        let original_dependency_graph = dependency_graph.clone();
+
         council
             .register_dependency_graph(
                 dependency_graph
@@ -319,7 +322,8 @@ impl JobConsumer for DependentValuesUpdate {
         if let Err(e) = client
             .publish(&StatusReceiverRequest {
                 visibility: *ctx.visibility(),
-                dependent_graph: dependency_graph.clone(),
+                tenancy: *ctx.tenancy(),
+                dependent_graph: original_dependency_graph,
             })
             .await
         {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -264,6 +264,7 @@ impl SchemaVariant {
         };
 
         // Find props that we need to set defaults on for _all_ schema variants.
+        // FIXME(nick): use the enum and create an appropriate query.
         let mut maybe_type_prop_id = None;
         let mut maybe_protected_prop_id = None;
         for root_si_child_prop in Self::list_root_si_child_props(ctx, self.id).await? {

--- a/lib/dal/tests/integration_test/component/code.rs
+++ b/lib/dal/tests/integration_test/component/code.rs
@@ -1,8 +1,10 @@
-use dal::func::argument::FuncArgument;
+use dal::component::ComponentKind;
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::schema::variant::leaves::LeafKind;
 use dal::{
     attribute::context::AttributeContextBuilder,
     schema::variant::leaves::{LeafInput, LeafInputLocation},
+    FuncBackendKind, FuncBackendResponseType, Prop, Schema,
 };
 use dal::{
     AttributeReadContext, AttributeValue, CodeLanguage, Component, ComponentView, DalContext, Func,
@@ -29,18 +31,30 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         create_prop_and_set_parent(ctx, PropKind::String, "poop", root_prop.domain_prop_id).await;
 
     // Create code prototype(s).
-    let func_name = "si:generateYAML".to_owned();
-    let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
+    let mut func = Func::new(
+        ctx,
+        "test:codeGeneration",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    let code = "function generateYAML(input) {
+      return {
+        format: \"yaml\",
+        code: Object.keys(input.domain).length > 0 ? YAML.stringify(input.domain) : \"\"
+      };
+    }";
+    func.set_code_plaintext(ctx, Some(code))
         .await
-        .expect("Error fetching builtin function");
-    let func = funcs
-        .pop()
-        .expect("Missing builtin function si:generateYAML");
-    let code_generation_func_argument =
-        FuncArgument::find_by_name_for_func(ctx, "domain", *func.id())
+        .expect("set code");
+    func.set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_argument =
+        FuncArgument::new(ctx, "domain", FuncArgumentKind::Object, None, *func.id())
             .await
-            .expect("could not perform func argument find")
-            .expect("no func argument found");
+            .expect("could not create func argument");
 
     SchemaVariant::add_leaf(
         ctx,
@@ -50,7 +64,7 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
         LeafKind::CodeGeneration,
         vec![LeafInput {
             location: LeafInputLocation::Domain,
-            func_argument_id: *code_generation_func_argument.id(),
+            func_argument_id: *func_argument.id(),
         }],
     )
     .await
@@ -108,7 +122,7 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
                     "protected": false,
                 },
                 "code": {
-                    "si:generateYAML": {
+                    "test:codeGeneration": {
                         "code": "poop: canoe\n",
                         "format": "yaml",
                     },
@@ -128,4 +142,280 @@ async fn add_code_generation_and_list_code_views(ctx: &DalContext) {
     assert!(code_views.is_empty());
     assert_eq!(CodeLanguage::Yaml, code_view.language);
     assert_eq!(Some("poop: canoe\n".to_string()), code_view.code);
+}
+
+#[test]
+async fn all_code_generation_attribute_values(ctx: &DalContext) {
+    // Create two schemas and variants.
+    let mut navi_schema = Schema::new(ctx, "navi", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
+    let (mut navi_schema_variant, navi_root_prop) =
+        create_schema_variant_with_root(ctx, *navi_schema.id()).await;
+    navi_schema
+        .set_default_schema_variant_id(ctx, Some(*navi_schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+    let ange1_prop = create_prop_and_set_parent(
+        ctx,
+        PropKind::String,
+        "ange1",
+        navi_root_prop.domain_prop_id,
+    )
+    .await;
+
+    let mut kru_schema = Schema::new(ctx, "kru", &ComponentKind::Standard)
+        .await
+        .expect("cannot create schema");
+    let (mut kru_schema_variant, kru_root_prop) =
+        create_schema_variant_with_root(ctx, *kru_schema.id()).await;
+    kru_schema
+        .set_default_schema_variant_id(ctx, Some(*kru_schema_variant.id()))
+        .await
+        .expect("cannot set default schema variant");
+    let _melser_prop = create_prop_and_set_parent(
+        ctx,
+        PropKind::String,
+        "melser",
+        kru_root_prop.domain_prop_id,
+    )
+    .await;
+
+    // Create two code generation funcs.
+    let code = "function generateYAML(input) {
+      return {
+        format: \"yaml\",
+        code: Object.keys(input.domain).length > 0 ? YAML.stringify(input.domain) : \"\"
+      };
+    }";
+
+    let mut func_one = Func::new(
+        ctx,
+        "test:codeGenerationOne",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    func_one
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    func_one
+        .set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_one_domain_argument = FuncArgument::new(
+        ctx,
+        "domain",
+        FuncArgumentKind::Object,
+        None,
+        *func_one.id(),
+    )
+    .await
+    .expect("could not create func argument");
+
+    let mut func_two = Func::new(
+        ctx,
+        "test:codeGenerationTwo",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::CodeGeneration,
+    )
+    .await
+    .expect("could not create func");
+    func_two
+        .set_code_plaintext(ctx, Some(code))
+        .await
+        .expect("set code");
+    func_two
+        .set_handler(ctx, Some("generateYAML"))
+        .await
+        .expect("set handler");
+    let func_two_domain_argument = FuncArgument::new(
+        ctx,
+        "domain",
+        FuncArgumentKind::Object,
+        None,
+        *func_two.id(),
+    )
+    .await
+    .expect("could not create func argument");
+
+    // Add two leaves to one variant and one leaf of the same func as one of prior to the other.
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_one.id(),
+        *navi_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_one_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_two.id(),
+        *navi_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_two_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+    SchemaVariant::add_leaf(
+        ctx,
+        *func_one.id(),
+        *kru_schema_variant.id(),
+        None,
+        LeafKind::CodeGeneration,
+        vec![LeafInput {
+            location: LeafInputLocation::Domain,
+            func_argument_id: *func_one_domain_argument.id(),
+        }],
+    )
+    .await
+    .expect("could not add code generation");
+
+    // Finalize both variants and create three components.
+    navi_schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("unable to finalize schema variant");
+    kru_schema_variant
+        .finalize(ctx, None)
+        .await
+        .expect("unable to finalize schema variant");
+    let (navi_component, _) = Component::new(ctx, "navi", *navi_schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let (_kru_one_component, _) = Component::new(ctx, "kru-one", *kru_schema_variant.id())
+        .await
+        .expect("cannot create component");
+    let (_kru_two_component, _) = Component::new(ctx, "kru-two", *kru_schema_variant.id())
+        .await
+        .expect("cannot create component");
+
+    // Test our function and perform assertions on the results.
+    check_results(ctx).await;
+
+    // Update a value and check the component view.
+    let attribute_read_context = AttributeReadContext {
+        prop_id: Some(*ange1_prop.id()),
+        component_id: Some(*navi_component.id()),
+        ..AttributeReadContext::default()
+    };
+    let attribute_value = AttributeValue::find_for_context(ctx, attribute_read_context)
+        .await
+        .expect("could not perform find for context")
+        .expect("attribute value not found");
+    let parent_attribute_value = attribute_value
+        .parent_attribute_value(ctx)
+        .await
+        .expect("could not perform find parent attribute value")
+        .expect("no parent attribute value found");
+    let context = AttributeContextBuilder::from(attribute_read_context)
+        .to_context()
+        .expect("could not convert builder to attribute context");
+    AttributeValue::update_for_context(
+        ctx,
+        *attribute_value.id(),
+        Some(*parent_attribute_value.id()),
+        context,
+        Some(serde_json::json!["omen"]),
+        None,
+    )
+    .await
+    .expect("could not perform update for context");
+    let component_view = ComponentView::new(ctx, *navi_component.id())
+        .await
+        .expect("could not generate component view");
+    assert_eq!(
+        serde_json::json![
+            {
+                "si": {
+                    "name": "navi",
+                    "type": "component",
+                    "protected": false,
+                },
+                "code": {
+                    "test:codeGenerationOne": {
+                        "code": "ange1: omen\n",
+                        "format": "yaml",
+                    },
+                    "test:codeGenerationTwo": {
+                        "code": "ange1: omen\n",
+                        "format": "yaml",
+                    },
+                },
+                "domain": {
+                    "ange1": "omen",
+                }
+        }], // expected
+        component_view.properties // actual
+    );
+
+    // Finally, check the results again to ensure that they didn't drift.
+    check_results(ctx).await;
+}
+
+async fn check_results(ctx: &DalContext) {
+    let all_values = Component::all_code_generation_attribute_values(ctx)
+        .await
+        .expect("could not get all code generation attribute values");
+    assert_eq!(
+        4,                // expected
+        all_values.len(), // actual
+    );
+
+    let mut found_navi_code_generation_one = false;
+    let mut found_navi_code_generation_two = false;
+    let mut found_kru_one_code_generation_one = false;
+    let mut found_kru_two_code_generation_one = false;
+    for id in all_values {
+        let attribute_value = AttributeValue::get_by_id(ctx, &id)
+            .await
+            .expect("could not perform get by id")
+            .expect("attribute value not found");
+        let key = attribute_value.key.expect("key not found");
+        let code_item_prop = Prop::get_by_id(ctx, &attribute_value.context.prop_id())
+            .await
+            .expect("could not perform get by id")
+            .expect("prop not found");
+        assert_eq!(
+            "codeItem",            // expected
+            code_item_prop.name(), // actual
+        );
+        let component = Component::get_by_id(ctx, &attribute_value.context.component_id())
+            .await
+            .expect("could not perform get by id")
+            .expect("component not found");
+        let component_name = component.name(ctx).await.expect("could not get name");
+
+        if "test:codeGenerationOne" == &key && "navi" == &component_name {
+            assert!(!found_navi_code_generation_one);
+            found_navi_code_generation_one = true;
+        } else if "test:codeGenerationTwo" == &key && "navi" == &component_name {
+            assert!(!found_navi_code_generation_two);
+            found_navi_code_generation_two = true;
+        } else if "test:codeGenerationOne" == &key && "kru-one" == &component_name {
+            assert!(!found_kru_one_code_generation_one);
+            found_kru_one_code_generation_one = true;
+        } else if "test:codeGenerationOne" == &key && "kru-two" == &component_name {
+            assert!(!found_kru_two_code_generation_one);
+            found_kru_two_code_generation_one = true;
+        }
+    }
+
+    // Ensure that we found every code generation. We ensured that we could only find them exactly
+    // once in the loop above, but now we need to ensure that we found them at all.
+    assert!(found_navi_code_generation_one);
+    assert!(found_navi_code_generation_two);
+    assert!(found_kru_one_code_generation_one);
+    assert!(found_kru_two_code_generation_one);
 }


### PR DESCRIPTION
Primary:
- Add code generation events to status receiver
- Add ability to collect all code generation attribute values in the
  workspace (with integration test)
- Ensure code generation and confirmation events are published
  immediately in the status receiver

Secondary:
- Ensure existing code generation integration test does not rely on
  builtins
- Fix "VITE_LOG_WS" variable