### PR TITLE
Ensure only status objects can publish immediately (ENG-1105)

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -91,7 +91,7 @@ impl ChangeSet {
         let object: Self = serde_json::from_value(json)?;
         WsEvent::change_set_created(ctx, object.pk)
             .await?
-            .publish(ctx)
+            .publish_on_commit(ctx)
             .await?;
         Ok(object)
     }
@@ -120,7 +120,7 @@ impl ChangeSet {
 
         WsEvent::change_set_applied(ctx, self.pk)
             .await?
-            .publish(ctx)
+            .publish_on_commit(ctx)
             .await?;
 
         // Update the visibility.

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -123,7 +123,7 @@ impl Component {
 
         WsEvent::checked_qualifications(ctx, component_id)
             .await?
-            .publish(ctx)
+            .publish_on_commit(ctx)
             .await?;
 
         Ok(results)

--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -143,7 +143,7 @@ impl Component {
         if !resources.is_empty() {
             WsEvent::resource_refreshed(ctx, self.id)
                 .await?
-                .publish(ctx)
+                .publish_on_commit(ctx)
                 .await?;
         }
         Ok(())

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -266,7 +266,7 @@ impl JobConsumer for DependentValuesUpdate {
 
             WsEvent::change_set_written(&ctx)
                 .await?
-                .publish(&ctx)
+                .publish_on_commit(&ctx)
                 .await?;
             ctx = self.commit_and_continue(ctx).await?;
 
@@ -315,7 +315,7 @@ impl JobConsumer for DependentValuesUpdate {
 
         WsEvent::change_set_written(&ctx)
             .await?
-            .publish(&ctx)
+            .publish_on_commit(&ctx)
             .await?;
 
         let client = StatusReceiverClient::new(ctx.nats_conn().clone()).await;
@@ -374,7 +374,7 @@ async fn update_value(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     if !single_transaction {
         ctx.commit().await?;

--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -214,7 +214,7 @@ impl JobConsumer for FixesJob {
             logs,
         )
         .await?
-        .publish(ctx)
+        .publish_on_commit(ctx)
         .await?;
 
         if self.fixes.len() == 1 {
@@ -266,7 +266,7 @@ async fn finish_batch(ctx: &DalContext, id: FixBatchId) -> JobConsumerResult<()>
     let batch_completion_status = batch.stamp_finished(ctx).await?;
     WsEvent::fix_batch_return(ctx, *batch.id(), batch_completion_status)
         .await?
-        .publish(ctx)
+        .publish_on_commit(ctx)
         .await?;
 
     Component::run_all_confirmations(ctx).await?;

--- a/lib/dal/src/job/definition/workflow_run.rs
+++ b/lib/dal/src/job/definition/workflow_run.rs
@@ -131,7 +131,7 @@ impl JobConsumer for WorkflowRun {
             logs,
         )
         .await?
-        .publish(ctx)
+        .publish_on_commit(ctx)
         .await?;
         Ok(())
     }

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -274,7 +274,7 @@ impl WorkflowTree {
 
                         WsEvent::command_output(&ctx, run_id, text)
                             .await?
-                            .publish(&ctx)
+                            .publish_on_commit(&ctx)
                             .await?;
                         conns = ctx.commit_into_conns().await?;
                     }

--- a/lib/dal/src/workflow_prototype.rs
+++ b/lib/dal/src/workflow_prototype.rs
@@ -271,7 +271,10 @@ impl WorkflowPrototype {
             .set_func_binding_id(ctx, *func_binding.id())
             .await?;
 
-        WsEvent::change_set_written(ctx).await?.publish(ctx).await?;
+        WsEvent::change_set_written(ctx)
+            .await?
+            .publish_on_commit(ctx)
+            .await?;
 
         Ok(resolver)
     }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -120,19 +120,16 @@ impl WsEvent {
         })
     }
 
-    pub async fn publish(&self, ctx: &DalContext) -> WsEventResult<()> {
+    pub fn billing_account_pks(&self) -> &Vec<BillingAccountPk> {
+        &self.billing_account_pks
+    }
+
+    /// Publishes the [`event`](Self) to the [`NatsTxn`](si_data_nats::NatsTxn). When the
+    /// transaction is committed, the [`event`](Self) will be published for external use.
+    pub async fn publish_on_commit(&self, ctx: &DalContext) -> WsEventResult<()> {
         for billing_account_pk in self.billing_account_pks.iter() {
             let subject = format!("si.billing_account_pk.{billing_account_pk}.event");
             ctx.nats_txn().publish(subject, &self).await?;
-        }
-        Ok(())
-    }
-
-    pub async fn publish_immediately(&self, ctx: &DalContext) -> WsEventResult<()> {
-        for billing_account_pk in self.billing_account_pks.iter() {
-            let subject = format!("si.billing_account_pk.{billing_account_pk}.event");
-            let msg_bytes = serde_json::to_vec(self)?;
-            ctx.nats_conn().publish(subject, msg_bytes).await?;
         }
         Ok(())
     }

--- a/lib/sdf/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/insert_property_editor_value.rs
@@ -47,7 +47,7 @@ pub async fn insert_property_editor_value(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/component/set_type.rs
+++ b/lib/sdf/src/server/service/component/set_type.rs
@@ -42,7 +42,7 @@ pub async fn set_type(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf/src/server/service/component/update_property_editor_value.rs
@@ -49,7 +49,7 @@ pub async fn update_property_editor_value(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/dev/create_builtin_func.rs
+++ b/lib/sdf/src/server/service/dev/create_builtin_func.rs
@@ -52,7 +52,7 @@ pub async fn create_builtin_func(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/dev/save_builtin_func.rs
+++ b/lib/sdf/src/server/service/dev/save_builtin_func.rs
@@ -54,7 +54,7 @@ pub async fn save_builtin_func(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
+++ b/lib/sdf/src/server/service/diagram/connect_component_to_frame.rs
@@ -66,7 +66,7 @@ pub async fn connect_component_to_frame(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/create_connection.rs
+++ b/lib/sdf/src/server/service/diagram/create_connection.rs
@@ -78,7 +78,7 @@ pub async fn create_connection(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/create_node.rs
+++ b/lib/sdf/src/server/service/diagram/create_node.rs
@@ -87,7 +87,7 @@ pub async fn create_node(
 
     WsEvent::component_created(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/delete_component.rs
+++ b/lib/sdf/src/server/service/diagram/delete_component.rs
@@ -29,7 +29,7 @@ pub async fn delete_component(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/delete_connection.rs
+++ b/lib/sdf/src/server/service/diagram/delete_connection.rs
@@ -26,7 +26,7 @@ pub async fn delete_connection(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/restore_component.rs
+++ b/lib/sdf/src/server/service/diagram/restore_component.rs
@@ -25,7 +25,7 @@ pub async fn restore_component(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/restore_connection.rs
+++ b/lib/sdf/src/server/service/diagram/restore_connection.rs
@@ -26,7 +26,7 @@ pub async fn restore_connection(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/diagram/set_node_position.rs
+++ b/lib/sdf/src/server/service/diagram/set_node_position.rs
@@ -85,7 +85,7 @@ pub async fn set_node_position(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/func/create_func.rs
+++ b/lib/sdf/src/server/service/func/create_func.rs
@@ -146,7 +146,7 @@ pub async fn create_func(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/func/exec_func.rs
+++ b/lib/sdf/src/server/service/func/exec_func.rs
@@ -86,7 +86,7 @@ pub async fn exec_func(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/func/revert_func.rs
+++ b/lib/sdf/src/server/service/func/revert_func.rs
@@ -56,7 +56,7 @@ pub async fn revert_func(
 
         WsEvent::change_set_written(&ctx)
             .await?
-            .publish(&ctx)
+            .publish_on_commit(&ctx)
             .await?;
 
         ctx.commit().await?;

--- a/lib/sdf/src/server/service/func/save_func.rs
+++ b/lib/sdf/src/server/service/func/save_func.rs
@@ -602,7 +602,7 @@ pub async fn save_func<'a>(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/pkg/install_pkg.rs
+++ b/lib/sdf/src/server/service/pkg/install_pkg.rs
@@ -43,7 +43,7 @@ pub async fn install_pkg(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/schema/create_schema.rs
+++ b/lib/sdf/src/server/service/schema/create_schema.rs
@@ -30,7 +30,7 @@ pub async fn create_schema(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/secret/create_secret.rs
+++ b/lib/sdf/src/server/service/secret/create_secret.rs
@@ -52,7 +52,7 @@ pub async fn create_secret(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
 
     ctx.commit().await?;

--- a/lib/sdf/src/server/service/variant_definition/clone_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/clone_variant_def.rs
@@ -71,7 +71,7 @@ pub async fn create_variant_def(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/variant_definition/create_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/create_variant_def.rs
@@ -56,7 +56,7 @@ pub async fn create_variant_def(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/exec_variant_def.rs
@@ -83,7 +83,7 @@ pub async fn exec_variant_def(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 

--- a/lib/sdf/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf/src/server/service/variant_definition/save_variant_def.rs
@@ -53,7 +53,7 @@ pub async fn save_variant_def(
 
     WsEvent::change_set_written(&ctx)
         .await?
-        .publish(&ctx)
+        .publish_on_commit(&ctx)
         .await?;
     ctx.commit().await?;
 


### PR DESCRIPTION
- Ensure only status objects (status updater and status receiver) can publish WsEvents immediately
  - Eventually, this will likely only be the status receiver
  - If we discover that other domains need to be able to do this, then we will refactor accordingly (want to ensure that developers use "WsEvent::publish_on_commit" by default)
- Rename "WsEvent::publish" to "WsEvent::publish_on_commit" to better express intent (includes a new doc comment)

<img src="https://media1.giphy.com/media/jlgzuxZVQVkcErf0ar/giphy.gif"/>