### PR TITLE
chore(dal,si-pkg): add initial dal/pkg export of an fixture pkg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 name = "council"
 version = "0.1.0"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "serde",
  "serde_json",
@@ -624,7 +624,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "council",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "serde",
  "serde_json",
@@ -820,7 +820,7 @@ dependencies = [
  "bytes-lines-codec",
  "chrono",
  "cyclone-core",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "hyper",
  "pin-project-lite",
@@ -1001,7 +1001,7 @@ dependencies = [
  "cyclone-client",
  "cyclone-core",
  "deadpool",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "nix",
  "serde",
@@ -1062,7 +1062,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -1078,12 +1087,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn",
 ]
 
@@ -1482,7 +1513,7 @@ dependencies = [
  "color-eyre",
  "convert_case 0.6.0",
  "dal",
- "derive_builder",
+ "derive_builder 0.11.2",
  "faktory-async",
  "futures",
  "serde",
@@ -2649,7 +2680,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "dal",
- "derive_builder",
+ "derive_builder 0.11.2",
  "faktory-async",
  "futures",
  "serde",
@@ -3208,7 +3239,7 @@ dependencies = [
  "chrono",
  "dal",
  "dal-test",
- "derive_builder",
+ "derive_builder 0.11.2",
  "faktory-async",
  "futures",
  "hyper",
@@ -3521,6 +3552,7 @@ name = "si-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "derive_builder 0.12.0",
  "object-tree",
  "petgraph",
  "serde",
@@ -3774,7 +3806,7 @@ dependencies = [
 name = "telemetry-application"
 version = "0.1.0"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "telemetry",
@@ -4455,7 +4487,7 @@ name = "veritech-server"
 version = "0.1.0"
 dependencies = [
  "deadpool-cyclone",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "futures-lite",
  "pin-project-lite",

--- a/lib/dal/examples/dal-pkg-export.rs
+++ b/lib/dal/examples/dal-pkg-export.rs
@@ -1,0 +1,107 @@
+use std::{env, path::Path, sync::Arc};
+
+use dal::{
+    pkg::export_pkg, DalContext, JobQueueProcessor, NatsProcessor, ServicesContext, Tenancy,
+    Workspace,
+};
+use si_data_nats::{NatsClient, NatsConfig};
+use si_data_pg::{PgPool, PgPoolConfig};
+use tokio::sync::mpsc;
+use veritech_client::{Client as VeritechClient, EncryptionKey};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
+
+const USAGE: &str = "usage: program <PKG_FILE> <NAME> <VERSION> <CREATED_BY>";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut args = env::args();
+    let tar_file = args.nth(1).expect(USAGE);
+    let name = args.next().expect(USAGE);
+    let version = args.next().expect(USAGE);
+    let created_by = args.next().expect(USAGE);
+
+    let description = format!("{name} created by {created_by}");
+
+    let (mut ctx, _shutdown_rx) = ctx().await?;
+    let workspace = Workspace::builtin(&ctx).await?;
+    ctx.update_tenancy(Tenancy::new(*workspace.pk()));
+
+    println!("--- Exporting pkg: {tar_file}");
+    export_pkg(
+        &ctx,
+        tar_file,
+        name,
+        version,
+        Some(description),
+        created_by,
+        vec![],
+    )
+    .await?;
+
+    println!("--- Committing database transaction");
+    ctx.commit().await?;
+    println!("  - Committed.");
+
+    println!("--- Export complete.");
+    Ok(())
+}
+
+async fn ctx() -> Result<(DalContext, mpsc::Receiver<()>)> {
+    let encryption_key = Arc::new(load_encryption_key().await?);
+    let pg_pool = create_pg_pool().await?;
+    let nats_conn = connect_to_nats().await?;
+    let veritech = create_veritech_client(nats_conn.clone());
+    let council_subject_prefix = "council".to_owned();
+
+    let (alive_marker, job_processor_shutdown_rx) = mpsc::channel(1);
+    let job_processor = connect_processor(nats_conn.clone(), alive_marker).await?;
+
+    let services_context = ServicesContext::new(
+        pg_pool,
+        nats_conn,
+        job_processor,
+        veritech,
+        encryption_key,
+        council_subject_prefix,
+        None,
+    );
+
+    Ok((
+        DalContext::builder(services_context)
+            .build_default()
+            .await?,
+        job_processor_shutdown_rx,
+    ))
+}
+
+async fn create_pg_pool() -> Result<PgPool> {
+    PgPool::new(&PgPoolConfig::default())
+        .await
+        .map_err(Into::into)
+}
+
+async fn connect_to_nats() -> Result<NatsClient> {
+    NatsClient::new(&NatsConfig::default())
+        .await
+        .map_err(Into::into)
+}
+
+fn create_veritech_client(nats: NatsClient) -> VeritechClient {
+    VeritechClient::new(nats)
+}
+
+async fn load_encryption_key() -> Result<EncryptionKey> {
+    let path = Path::new(&env::var("CARGO_MANIFEST_DIR")?)
+        .join("../../lib/cyclone-server/src/dev.encryption.key");
+    EncryptionKey::load(path).await.map_err(Into::into)
+}
+
+async fn connect_processor(
+    job_client: NatsClient,
+    alive_marker: mpsc::Sender<()>,
+) -> Result<Box<dyn JobQueueProcessor + Send + Sync>> {
+    let job_processor = Box::new(NatsProcessor::new(job_client, alive_marker))
+        as Box<dyn JobQueueProcessor + Send + Sync>;
+    Ok(job_processor)
+}

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.23", features = ["serde"] }
+derive_builder = "0.12.0"
 object-tree = { path = "../../lib/object-tree" }
 petgraph = { version = "0.6.2", features = ["serde-1"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/lib/si-pkg/examples/si-pkg-json-to-fs.rs
+++ b/lib/si-pkg/examples/si-pkg-json-to-fs.rs
@@ -1,6 +1,6 @@
 use std::{env::args, fs};
 
-use si_pkg::{spec::Package, SiPkg, SiPkgError, SiPkgProp};
+use si_pkg::{PkgSpec, SiPkg, SiPkgError, SiPkgProp};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let input = args.nth(1).expect("usage: program <JSON_FILE> <DEST_DIR>");
     let dst = args.next().expect("usage: program <JSON_FILE> <DEST_DIR>");
 
-    let spec: Package = {
+    let spec: PkgSpec = {
         let buf = fs::read_to_string(&input)?;
         serde_json::from_str(&buf)?
     };

--- a/lib/si-pkg/examples/si-pkg-json-to-tar.rs
+++ b/lib/si-pkg/examples/si-pkg-json-to-tar.rs
@@ -1,6 +1,6 @@
 use std::{env::args, fs};
 
-use si_pkg::{spec::Package, SiPkg};
+use si_pkg::{PkgSpec, SiPkg};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let input = args.nth(1).expect("usage: program <JSON_FILE> <TARBALL>");
     let tar_file = args.next().expect("usage: program <JSON_FILE> <TARBALL>");
 
-    let spec: Package = {
+    let spec: PkgSpec = {
         let buf = fs::read_to_string(&input)?;
         serde_json::from_str(&buf)?
     };

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -1,8 +1,12 @@
 pub(crate) mod node;
 mod pkg;
-pub mod spec;
+mod spec;
 
 pub use pkg::{SiPkg, SiPkgError, SiPkgMetadata, SiPkgProp, SiPkgSchema, SiPkgSchemaVariant};
+pub use spec::{
+    PkgSpec, PkgSpecBuilder, PropSpec, PropSpecBuilder, PropSpecKind, SchemaSpec,
+    SchemaSpecBuilder, SchemaVariantSpec, SchemaVariantSpecBuilder, SpecError,
+};
 
 #[cfg(test)]
 mod tests {
@@ -10,7 +14,7 @@ mod tests {
 
     use petgraph::dot::Dot;
 
-    use crate::spec::Package;
+    use crate::spec::PkgSpec;
 
     use super::*;
 
@@ -28,7 +32,7 @@ mod tests {
 
     #[test]
     fn create_pkg() {
-        let spec: Package = serde_json::from_str(PACKAGE_JSON).unwrap();
+        let spec: PkgSpec = serde_json::from_str(PACKAGE_JSON).unwrap();
         dbg!(&spec);
 
         let pkg = SiPkg::load_from_spec(spec).expect("failed to load spec");
@@ -42,7 +46,7 @@ mod tests {
 
     #[tokio::test]
     async fn pkg_fs_round_trip() {
-        let spec: Package = serde_json::from_str(PACKAGE_JSON).unwrap();
+        let spec: PkgSpec = serde_json::from_str(PACKAGE_JSON).unwrap();
         let pkg = SiPkg::load_from_spec(spec).expect("failed to load spec");
 
         pkg.write_to_dir(base_path())

--- a/lib/si-pkg/src/node/category.rs
+++ b/lib/si-pkg/src/node/category.rs
@@ -6,7 +6,7 @@ use object_tree::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::spec::Schema;
+use crate::SchemaSpec;
 
 use super::PkgNode;
 
@@ -17,7 +17,7 @@ const KEY_KIND_STR: &str = "kind";
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PackageCategory {
-    Schemas(Vec<Schema>),
+    Schemas(Vec<SchemaSpec>),
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/lib/si-pkg/src/node/package.rs
+++ b/lib/si-pkg/src/node/package.rs
@@ -6,7 +6,7 @@ use object_tree::{
     NodeWithChildren, ReadBytes, WriteBytes,
 };
 
-use crate::spec::Package;
+use crate::PkgSpec;
 
 use super::{category::PackageCategory, PkgNode};
 
@@ -67,7 +67,7 @@ impl ReadBytes for PackageNode {
     }
 }
 
-impl NodeChild for Package {
+impl NodeChild for PkgSpec {
     type NodeType = PkgNode;
 
     fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {

--- a/lib/si-pkg/src/node/prop.rs
+++ b/lib/si-pkg/src/node/prop.rs
@@ -5,7 +5,7 @@ use object_tree::{
     NodeWithChildren, ReadBytes, WriteBytes,
 };
 
-use crate::spec::Prop;
+use crate::PropSpec;
 
 use super::PkgNode;
 
@@ -89,7 +89,7 @@ impl ReadBytes for PropNode {
     }
 }
 
-impl NodeChild for Prop {
+impl NodeChild for PropSpec {
     type NodeType = PkgNode;
 
     fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {

--- a/lib/si-pkg/src/node/schema.rs
+++ b/lib/si-pkg/src/node/schema.rs
@@ -5,7 +5,7 @@ use object_tree::{
     NodeWithChildren, ReadBytes, WriteBytes,
 };
 
-use crate::spec::Schema;
+use crate::SchemaSpec;
 
 use super::PkgNode;
 
@@ -45,7 +45,7 @@ impl ReadBytes for SchemaNode {
     }
 }
 
-impl NodeChild for Schema {
+impl NodeChild for SchemaSpec {
     type NodeType = PkgNode;
 
     fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -6,7 +6,7 @@ use object_tree::{
 };
 use url::Url;
 
-use crate::spec::SchemaVariant;
+use crate::SchemaVariantSpec;
 
 use super::PkgNode;
 
@@ -64,7 +64,7 @@ impl ReadBytes for SchemaVariantNode {
     }
 }
 
-impl NodeChild for SchemaVariant {
+impl NodeChild for SchemaVariantSpec {
     type NodeType = PkgNode;
 
     fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {


### PR DESCRIPTION
This change adds a `dal::pkg::export_pkg` function which will generate a package file using the given metdata (such as name, version, etc). It currently does not process the `Vec<SchemaVariantId>` array, but rather hardcodes one simple schema/variant. An upcoming change will add the db/dal->pkg glue.