### PR TITLE
fix(ci): run all Rust targets only when necessary

### DIFF
--- a/mk/test-changed.sh
+++ b/mk/test-changed.sh
@@ -57,11 +57,13 @@ if [ -z "${SKIP_CHECK:-}" ]; then
     check_targets="$check_targets $(all_rust_check_targets)"
   fi
 
-  echo "::group::make $check_targets"
-  set -x
-  make CI=true "CI_FROM_REF=$BEFORE_SHA" "CI_TO_REF=$AFTER_SHA" $check_targets
-  set +x
-  echo "::endgroup::"
+  if [[ -n "$check_targets" ]]; then
+    echo "::group::make $check_targets"
+    set -x
+    make CI=true "CI_FROM_REF=$BEFORE_SHA" "CI_TO_REF=$AFTER_SHA" $check_targets
+    set +x
+    echo "::endgroup::"
+  fi
 fi
 
 test_targets="$(while IFS= read -r line; do
@@ -75,8 +77,10 @@ if changed_files_contains_global_rust_config_for_test; then
   test_targets="$test_targets $(all_rust_test_targets)"
 fi
 
-echo "::group::make $test_targets"
-set -x
-make CI=true "CI_FROM_REF=$BEFORE_SHA" "CI_TO_REF=$AFTER_SHA" $test_targets
-set +x
-echo "::endgroup::"
+if [[ -n "$test_targets" ]]; then
+  echo "::group::make $test_targets"
+  set -x
+  make CI=true "CI_FROM_REF=$BEFORE_SHA" "CI_TO_REF=$AFTER_SHA" $test_targets
+  set +x
+  echo "::endgroup::"
+fi


### PR DESCRIPTION
This change updates the intention of the `mk/test-changed.sh` script to run all Rust tests only when a global config file such as `Cargo.toml`/`Cargo.lock`/etc. has been modified in a Git change set.

The prior implementation caused some PRs to run all tests for trivial changes (like *.md files in the root) or to die when a component was living under `component/` (which don't have a `Makefile`).

Now, when the following files are present in the list of changed files, all Rust `test//*` Make tasks will be run:

- `Cargo.lock`
- `Cargo.toml`
- `rust-toolchain`

Additionally, when the following files are present in the list of changed files, all Rust `check//*` Make tasks will be run:

- `rustfmt.toml`
- `clippy.toml`

<img src="https://media4.giphy.com/media/BT4ygwV9vgwAU/giphy.gif"/>