### PR TITLE
feat(dal,sdf): track installed assets when installing pkg

### DIFF
--- a/lib/dal/src/installed_pkg.rs
+++ b/lib/dal/src/installed_pkg.rs
@@ -9,6 +9,9 @@ use crate::{
     HistoryEventError, StandardModel, StandardModelError, Tenancy, Timestamp, Visibility,
 };
 
+pub mod asset;
+pub use asset::*;
+
 #[derive(Error, Debug)]
 pub enum InstalledPkgError {
     #[error("error serializing/deserializing json: {0}")]
@@ -23,6 +26,14 @@ pub enum InstalledPkgError {
     StandardModelError(#[from] StandardModelError),
     #[error("error decoding code_base64: {0}")]
     Decode(#[from] base64::DecodeError),
+    #[error("error decoding ulid: {0}")]
+    UlidDecode(#[from] ulid::DecodeError),
+    #[error("Installed package asset {0} was expected to be {1} but was {2}")]
+    InstalledPkgKindMismatch(
+        InstalledPkgAssetId,
+        InstalledPkgAssetKind,
+        InstalledPkgAssetKind,
+    ),
 }
 
 pub type InstalledPkgResult<T> = Result<T, InstalledPkgError>;

--- a/lib/dal/src/installed_pkg/asset.rs
+++ b/lib/dal/src/installed_pkg/asset.rs
@@ -1,0 +1,270 @@
+use super::{InstalledPkgId, InstalledPkgResult};
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+
+use crate::{
+    impl_standard_model, pk, standard_model, standard_model_accessor, DalContext, SchemaId,
+    SchemaVariantId, StandardModel, Tenancy, Timestamp, Visibility,
+};
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+
+const LIST_FOR_KIND_AND_HASH: &str =
+    include_str!("../queries/installed_pkg/list_asset_for_kind_and_hash.sql");
+
+const LIST_FOR_INSTALLED_PKG_ID: &str =
+    include_str!("../queries/installed_pkg/list_asset_for_installed_pkg_id.sql");
+
+pk!(InstalledPkgAssetPk);
+pk!(InstalledPkgAssetId);
+pk!(InstalledPkgAssetAssetId);
+
+#[derive(
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum InstalledPkgAssetKind {
+    Schema,
+    SchemaVariant,
+}
+
+/// An `InstalledPkgAsset` is a record of the installation of a package asset. It tracks the
+/// asset installation and can be used to prevent duplicate installations and to remove packages
+/// after installation.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct InstalledPkgAsset {
+    pk: InstalledPkgAssetPk,
+    id: InstalledPkgAssetId,
+    installed_pkg_id: InstalledPkgId,
+    asset_id: InstalledPkgAssetAssetId,
+    asset_hash: String,
+    asset_kind: InstalledPkgAssetKind,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum InstalledPkgAssetTyped {
+    Schema {
+        installed_pkg_asset_id: InstalledPkgAssetId,
+        installed_pkg_id: InstalledPkgId,
+        id: SchemaId,
+        hash: String,
+    },
+    SchemaVariant {
+        installed_pkg_asset_id: InstalledPkgAssetId,
+        installed_pkg_id: InstalledPkgId,
+        id: SchemaVariantId,
+        hash: String,
+    },
+}
+
+impl InstalledPkgAssetTyped {
+    pub fn new_for_schema(
+        schema_id: SchemaId,
+        installed_pkg_id: InstalledPkgId,
+        hash: String,
+    ) -> Self {
+        Self::Schema {
+            installed_pkg_asset_id: InstalledPkgAssetId::NONE,
+            installed_pkg_id,
+            id: schema_id,
+            hash,
+        }
+    }
+
+    pub fn new_for_schema_variant(
+        schema_variant_id: SchemaVariantId,
+        installed_pkg_id: InstalledPkgId,
+        hash: String,
+    ) -> Self {
+        Self::SchemaVariant {
+            installed_pkg_asset_id: InstalledPkgAssetId::NONE,
+            installed_pkg_id,
+            id: schema_variant_id,
+            hash,
+        }
+    }
+}
+
+impl From<&InstalledPkgAsset> for InstalledPkgAssetTyped {
+    fn from(value: &InstalledPkgAsset) -> Self {
+        let installed_pkg_asset_id = *value.id();
+        let installed_pkg_id = value.installed_pkg_id();
+        let hash = value.asset_hash().to_string();
+
+        match value.asset_kind {
+            InstalledPkgAssetKind::Schema => {
+                let id: SchemaId = Into::<ulid::Ulid>::into(value.asset_id()).into();
+
+                Self::Schema {
+                    installed_pkg_asset_id,
+                    installed_pkg_id,
+                    id,
+                    hash,
+                }
+            }
+            InstalledPkgAssetKind::SchemaVariant => {
+                let id: SchemaVariantId = Into::<ulid::Ulid>::into(value.asset_id()).into();
+
+                Self::SchemaVariant {
+                    installed_pkg_asset_id,
+                    installed_pkg_id,
+                    id,
+                    hash,
+                }
+            }
+        }
+    }
+}
+
+impl_standard_model! {
+    model: InstalledPkgAsset,
+    pk: InstalledPkgAssetPk,
+    id: InstalledPkgAssetId,
+    table_name: "installed_pkg_assets",
+    history_event_label_base: "installed_pkg_asset",
+    history_event_message_name: "Installed Pkg Asset"
+}
+
+impl InstalledPkgAsset {
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext,
+        pkg_asset: InstalledPkgAssetTyped,
+    ) -> InstalledPkgResult<(Self, InstalledPkgAssetTyped)> {
+        let (installed_pkg_id, asset_id, asset_hash, asset_kind): (
+            InstalledPkgId,
+            InstalledPkgAssetAssetId,
+            String,
+            InstalledPkgAssetKind,
+        ) = match pkg_asset {
+            InstalledPkgAssetTyped::Schema {
+                installed_pkg_id,
+                id,
+                hash,
+                ..
+            } => (
+                installed_pkg_id,
+                Into::<ulid::Ulid>::into(id).into(),
+                hash,
+                InstalledPkgAssetKind::Schema,
+            ),
+            InstalledPkgAssetTyped::SchemaVariant {
+                installed_pkg_id,
+                id,
+                hash,
+                ..
+            } => (
+                installed_pkg_id,
+                Into::<ulid::Ulid>::into(id).into(),
+                hash,
+                InstalledPkgAssetKind::SchemaVariant,
+            ),
+        };
+
+        let row = ctx
+            .txns()
+            .pg()
+            .query_one(
+                "SELECT object FROM installed_pkg_asset_create_v1($1, $2, $3, $4, $5, $6)",
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &installed_pkg_id,
+                    &asset_id,
+                    &asset_kind.as_ref(),
+                    &asset_hash,
+                ],
+            )
+            .await?;
+        let object: InstalledPkgAsset = standard_model::finish_create_from_row(ctx, row).await?;
+        let asset_typed: InstalledPkgAssetTyped = (&object).into();
+        Ok((object, asset_typed))
+    }
+
+    pub fn as_installed_schema(&self) -> InstalledPkgResult<InstalledPkgAssetTyped> {
+        let typed: InstalledPkgAssetTyped = self.into();
+
+        match typed {
+            InstalledPkgAssetTyped::Schema { .. } => Ok(typed),
+            InstalledPkgAssetTyped::SchemaVariant {
+                installed_pkg_asset_id,
+                ..
+            } => Err(super::InstalledPkgError::InstalledPkgKindMismatch(
+                installed_pkg_asset_id,
+                InstalledPkgAssetKind::Schema,
+                InstalledPkgAssetKind::SchemaVariant,
+            )),
+        }
+    }
+
+    pub fn as_installed_schema_variant(&self) -> InstalledPkgResult<InstalledPkgAssetTyped> {
+        let typed: InstalledPkgAssetTyped = self.into();
+
+        match typed {
+            InstalledPkgAssetTyped::SchemaVariant { .. } => Ok(typed),
+            InstalledPkgAssetTyped::Schema {
+                installed_pkg_asset_id,
+                ..
+            } => Err(super::InstalledPkgError::InstalledPkgKindMismatch(
+                installed_pkg_asset_id,
+                InstalledPkgAssetKind::SchemaVariant,
+                InstalledPkgAssetKind::Schema,
+            )),
+        }
+    }
+
+    pub async fn list_for_installed_pkg_id(
+        ctx: &DalContext,
+        installed_pkg_id: InstalledPkgId,
+    ) -> InstalledPkgResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_FOR_INSTALLED_PKG_ID,
+                &[ctx.tenancy(), ctx.visibility(), &installed_pkg_id],
+            )
+            .await?;
+
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
+
+    pub async fn list_for_kind_and_hash(
+        ctx: &DalContext,
+        kind: InstalledPkgAssetKind,
+        hash: &str,
+    ) -> InstalledPkgResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .pg()
+            .query(
+                LIST_FOR_KIND_AND_HASH,
+                &[ctx.tenancy(), ctx.visibility(), &kind.as_ref(), &hash],
+            )
+            .await?;
+
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
+
+    standard_model_accessor!(asset_id, Pk(InstalledPkgAssetAssetId), InstalledPkgResult);
+    standard_model_accessor!(installed_pkg_id, Pk(InstalledPkgId), InstalledPkgResult);
+    standard_model_accessor!(asset_hash, String, InstalledPkgResult);
+    standard_model_accessor!(asset_kind, Enum(InstalledPkgAssetKind), InstalledPkgResult);
+}

--- a/lib/dal/src/migrations/U1048__installed_pkgs.sql
+++ b/lib/dal/src/migrations/U1048__installed_pkgs.sql
@@ -49,3 +49,60 @@ BEGIN
     object := row_to_json(this_new_row);
 END;
 $$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE TABLE installed_pkg_assets 
+(
+    pk                          ident                    PRIMARY KEY DEFAULT ident_create_v1(),
+    id                          ident                    NOT NULL DEFAULT ident_create_v1(),
+    tenancy_workspace_pk        ident,
+    visibility_change_set_pk    ident                    NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    installed_pkg_id            ident                    NOT NULL,
+    asset_id                    ident                    NOT NULL,
+    asset_kind                  text                     NOT NULL,
+    asset_hash                  text                     NOT NULL
+);
+
+CREATE INDEX ON installed_pkg_assets (installed_pkg_id);
+CREATE INDEX ON installed_pkg_assets (asset_id);
+CREATE INDEX ON installed_pkg_assets (asset_hash);
+CREATE INDEX ON installed_pkg_assets (asset_kind);
+
+SELECT standard_model_table_constraints_v1('installed_pkg_assets');
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('installed_pkg_assets', 'model', 'installed_pkg_assets', 'Installed Package Assets');
+
+CREATE OR REPLACE FUNCTION installed_pkg_asset_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_installed_pkg_id ident,
+    this_asset_id ident,
+    this_asset_kind text,
+    this_asset_hash text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           installed_pkg_assets%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO installed_pkg_assets (
+        tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at,
+        installed_pkg_id, asset_id, asset_kind, asset_hash
+    ) VALUES (
+        this_tenancy_record.tenancy_workspace_pk,
+        this_visibility_record.visibility_change_set_pk,
+        this_visibility_record.visibility_deleted_at, this_installed_pkg_id,
+        this_asset_id, this_asset_kind, this_asset_hash
+    )
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+

--- a/lib/dal/src/queries/installed_pkg/list_asset_for_installed_pkg_id.sql
+++ b/lib/dal/src/queries/installed_pkg/list_asset_for_installed_pkg_id.sql
@@ -1,0 +1,4 @@
+SELECT row_to_json(ipa.*) AS object
+FROM installed_pkg_assets_v1($1, $2) as ipa 
+WHERE 
+  ipa.installed_pkg_id = $3

--- a/lib/dal/src/queries/installed_pkg/list_asset_for_kind_and_hash.sql
+++ b/lib/dal/src/queries/installed_pkg/list_asset_for_kind_and_hash.sql
@@ -1,0 +1,5 @@
+SELECT row_to_json(ipa.*) AS object
+FROM installed_pkg_assets_v1($1, $2) as ipa -- norcal style
+WHERE 
+  ipa.asset_kind = $3 
+  AND ipa.asset_hash = $4

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -19,6 +19,7 @@ mod node;
 mod node_menu;
 mod node_position;
 mod organization;
+mod pkg;
 mod prop;
 mod property_editor;
 mod provider;

--- a/lib/dal/tests/integration_test/pkg.rs
+++ b/lib/dal/tests/integration_test/pkg.rs
@@ -1,0 +1,190 @@
+use dal::{installed_pkg::*, pkg::*, DalContext, Schema, SchemaVariant, StandardModel};
+use dal_test::test;
+use si_pkg::{PkgSpec, PropSpec, PropSpecKind, SchemaSpec, SchemaVariantSpec, SiPkg};
+
+#[test]
+async fn test_install_pkg(ctx: &DalContext) {
+    let schema_a = SchemaSpec::builder()
+        .name("Tyrone Slothrop")
+        .category("Banana Puddings")
+        .variant(
+            SchemaVariantSpec::builder()
+                .name("Pig Bodine")
+                .color("baddad")
+                .prop(
+                    PropSpec::builder()
+                        .name("ImpolexG")
+                        .kind(PropSpecKind::String)
+                        .build()
+                        .expect("able to make prop spec"),
+                )
+                .prop(
+                    PropSpec::builder()
+                        .name("TheZone")
+                        .kind(PropSpecKind::String)
+                        .build()
+                        .expect("able to make prop spec"),
+                )
+                .build()
+                .expect("able to make schema variant spec"),
+        )
+        .build()
+        .expect("able to make schema spec");
+
+    let schema_b = SchemaSpec::builder()
+        .name("Roger Mexico")
+        .category("Banana Puddings")
+        .variant(
+            SchemaVariantSpec::builder()
+                .name("The Light Bulb Conspiracy")
+                .color("baddad")
+                .prop(
+                    PropSpec::builder()
+                        .name("distress_jess")
+                        .kind(PropSpecKind::Number)
+                        .build()
+                        .expect("able to make prop spec"),
+                )
+                .prop(
+                    PropSpec::builder()
+                        .name("sixes_and_sevens")
+                        .kind(PropSpecKind::Number)
+                        .build()
+                        .expect("able to make prop spec"),
+                )
+                .build()
+                .expect("able to make schema variant spec"),
+        )
+        .build()
+        .expect("able to make schema spec");
+
+    let spec_a = PkgSpec::builder()
+        .name("The White Visitation")
+        .version("0.1")
+        .created_by("Pirate Prentice")
+        .schema(schema_a.clone())
+        .build()
+        .expect("able to build package spec");
+
+    let pkg_a = SiPkg::load_from_spec(spec_a).expect("able to load from spec");
+
+    let spec_b = PkgSpec::builder()
+        .name("The Kenosha Kid")
+        .version("0.1")
+        .created_by("Pointsman")
+        .schema(schema_a)
+        .schema(schema_b)
+        .build()
+        .expect("able to build package spec");
+
+    let pkg_b = SiPkg::load_from_spec(spec_b).expect("able to load pkg from spec");
+
+    import_pkg_from_pkg(ctx, &pkg_a, "pkg_a")
+        .await
+        .expect("able to install pkg");
+
+    // We should refuse to install the same package twice
+    let second_import_result = import_pkg_from_pkg(ctx, &pkg_a, "pkg_a").await;
+    assert!(matches!(
+        second_import_result,
+        Err(PkgError::PackageAlreadyInstalled(_))
+    ));
+
+    // for now just assert that the installed package records are written. we should also verify
+    // the structure of the installed schemas but punting on that for the moment
+    let pkg_a_root_hash = pkg_a.hash().expect("pkg a has a hash").to_string();
+    let installed_pkgs = InstalledPkg::find_by_attr(ctx, "root_hash", &pkg_a_root_hash)
+        .await
+        .expect("find by attr");
+    assert_eq!(1, installed_pkgs.len());
+    let installed_pkg_a = installed_pkgs.get(0).expect("pkg should be there");
+
+    assert_eq!("pkg_a", installed_pkg_a.name());
+
+    let pkg_a_ipas = InstalledPkgAsset::list_for_installed_pkg_id(ctx, *installed_pkg_a.id())
+        .await
+        .expect("able to fetch installed pkgs for pkg a");
+
+    // One schema, one variant
+    assert_eq!(2, pkg_a_ipas.len());
+
+    for ipa in pkg_a_ipas {
+        match ipa.asset_kind() {
+            InstalledPkgAssetKind::Schema => {
+                let typed: InstalledPkgAssetTyped =
+                    ipa.as_installed_schema().expect("get schema ipa type");
+                match typed {
+                    InstalledPkgAssetTyped::Schema { id, .. } => {
+                        let schema = Schema::get_by_id(ctx, &id)
+                            .await
+                            .expect("able to get schema")
+                            .expect("schema is there");
+
+                        assert_eq!("Tyrone Slothrop", schema.name())
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            InstalledPkgAssetKind::SchemaVariant => {
+                let typed: InstalledPkgAssetTyped = ipa
+                    .as_installed_schema_variant()
+                    .expect("get schema ipa type");
+                match typed {
+                    InstalledPkgAssetTyped::SchemaVariant { id, .. } => {
+                        let schema_variant = SchemaVariant::get_by_id(ctx, &id)
+                            .await
+                            .expect("able to get schema variant")
+                            .expect("schema variant is there");
+
+                        assert_eq!("Pig Bodine", schema_variant.name())
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    import_pkg_from_pkg(ctx, &pkg_b, "pkg_b")
+        .await
+        .expect("install pkg b");
+
+    let installed_pkgs = InstalledPkg::find_by_attr(
+        ctx,
+        "root_hash",
+        &pkg_b.hash().expect("get pkg b hash").to_string(),
+    )
+    .await
+    .expect("find by attr");
+    assert_eq!(1, installed_pkgs.len());
+    let installed_pkg_b = installed_pkgs.get(0).expect("pkg should be there");
+
+    assert_eq!("pkg_b", installed_pkg_b.name());
+
+    let pkg_b_ipas = InstalledPkgAsset::list_for_installed_pkg_id(ctx, *installed_pkg_b.id())
+        .await
+        .expect("able to fetch installed pkgs for pkg a");
+
+    // Two schemas, two variants
+    assert_eq!(4, pkg_b_ipas.len());
+
+    // Ensure we did not install the schema that is in both packages
+    let schemas = Schema::find_by_attr(ctx, "name", &"Tyrone Slothrop".to_string())
+        .await
+        .expect("get tyrones");
+    assert_eq!(1, schemas.len());
+    let schema_variants = SchemaVariant::find_by_attr(ctx, "name", &"Pig Bodine".to_string())
+        .await
+        .expect("get bodines");
+    assert_eq!(1, schema_variants.len());
+
+    // Ensure the new schemas were installed
+    let schemas = Schema::find_by_attr(ctx, "name", &"Roger Mexico".to_string())
+        .await
+        .expect("roger roger roger roger");
+    assert_eq!(1, schemas.len());
+    let schema_variants =
+        SchemaVariant::find_by_attr(ctx, "name", &"The Light Bulb Conspiracy".to_string())
+            .await
+            .expect("above your head like you had an idea");
+    assert_eq!(1, schema_variants.len());
+}


### PR DESCRIPTION
Assets installed by a package are added to the installed_pkg_assets
table during install. If an asset is already installed, we do not
install the asset but we still make a record of it as if it had been
installed by the package. This way we can prevent removal of an asset if
it is shared by more than one package. Using the hash, we also prevent
installing the same package twice.