### PR TITLE
chore(dal,si-pkg): add optional category name to schema obj in pkg

### DIFF
--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -175,7 +175,7 @@ async fn set_schema_spec_category_data(
     }
 
     schema_spec_builder.category(schema_ui_menu.category());
-    // TODO(fnichol): schema_spec_builder.category_name(schema_ui_menu.name());
+    schema_spec_builder.category_name(schema_ui_menu.name());
 
     Ok(())
 }

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -118,8 +118,14 @@ async fn create_schema(
     let mut schema = match existing_schema {
         None => {
             let schema = Schema::new(ctx, schema_spec.name(), &ComponentKind::Standard).await?;
-            let ui_menu =
-                SchemaUiMenu::new(ctx, schema_spec.name(), schema_spec.category()).await?;
+            let ui_menu = SchemaUiMenu::new(
+                ctx,
+                schema_spec
+                    .category_name()
+                    .unwrap_or_else(|| schema_spec.name()),
+                schema_spec.category(),
+            )
+            .await?;
             ui_menu.set_schema(ctx, schema.id()).await?;
 
             schema

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -396,6 +396,7 @@ impl<'a> SiPkgFunc<'a> {
 pub struct SiPkgSchema<'a> {
     name: String,
     category: String,
+    category_name: Option<String>,
 
     hash: Hash,
 
@@ -421,6 +422,7 @@ impl<'a> SiPkgSchema<'a> {
         let schema = Self {
             name: schema_node.name,
             category: schema_node.category,
+            category_name: schema_node.category_name,
             hash: schema_hashed_node.hash(),
             source: Source::new(graph, node_idx),
         };
@@ -434,6 +436,10 @@ impl<'a> SiPkgSchema<'a> {
 
     pub fn category(&self) -> &str {
         self.category.as_ref()
+    }
+
+    pub fn category_name(&self) -> Option<&str> {
+        self.category_name.as_deref()
     }
 
     pub fn variants(&self) -> Result<Vec<SiPkgSchemaVariant<'a>>, SiPkgError> {

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -141,6 +141,8 @@ pub struct SchemaSpec {
     pub name: String,
     #[builder(setter(into))]
     pub category: String,
+    #[builder(setter(into, strip_option), default)]
+    pub category_name: Option<String>,
 
     #[builder(setter(each(name = "variant", into)), default)]
     pub variants: Vec<SchemaVariantSpec>,


### PR DESCRIPTION
The category name is used as the "short name" in the asset picker.

<img src="https://media0.giphy.com/media/qve4ShyVV7JyEJYfs6/giphy.gif"/>