### PR TITLE
bug(pg): Do not consume an entire core waiting for PG to finish booting

### DIFF
--- a/scripts/wait-for-pg.sh
+++ b/scripts/wait-for-pg.sh
@@ -7,5 +7,6 @@ while :; do
   if [ "$?" = "0" ]; then
     break
   fi
+  sleep 1
 done
 echo "ready"


### PR DESCRIPTION
Turns out that the timeout on `pg_isready` doesn't apply if there is nothing listening on the TCP port at all, and the command exits immediately. Introducing the `sleep 1` means that we don't spin as fast as we can, tying up a CPU core checking if PG is up yet.