### PR TITLE
feat(dal,web): add color picker widget

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -67,6 +67,7 @@
     "tinycolor2": "^1.4.2",
     "typescript": "^4.9.5",
     "validator": "^13.7.0",
+    "vanilla-picker": "^2.12.1",
     "vue": "^3.2.45",
     "vue-konva": "^3.0.1",
     "vue-router": "^4.1.6"

--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -58,6 +58,10 @@ export interface PropertyEditorPropWidgetKindSecretSelect {
   options: LabelList<string | number>;
 }
 
+export interface PropertyEditorPropWidgetKindColor {
+  kind: "color";
+}
+
 export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindText
   | PropertyEditorPropWidgetKindTextArea
@@ -68,7 +72,8 @@ export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindArray
   | PropertyEditorPropWidgetKindComboBox
   | PropertyEditorPropWidgetKindSelect
-  | PropertyEditorPropWidgetKindSecretSelect;
+  | PropertyEditorPropWidgetKindSecretSelect
+  | PropertyEditorPropWidgetKindColor;
 
 export interface PropertyEditorProp {
   id: string;

--- a/app/web/src/components/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/components/PropertyEditor/PropertyWidget.vue
@@ -118,6 +118,20 @@
       :class="INPUT_CLASSES"
       @updated-property="updatedProperty($event)"
     />
+    <WidgetColorBox
+      v-else-if="schemaProp.widgetKind.kind === 'color'"
+      :name="schemaProp.name"
+      :path="path"
+      :collapsed-paths="collapsedPaths"
+      :value="propValue.value"
+      :prop-id="propValue.propId"
+      :value-id="propValue.id"
+      :doc-link="schemaProp.docLink"
+      :validation="validation"
+      :disabled="disabled"
+      :class="INPUT_CLASSES"
+      @updated-property="updatedProperty($event)"
+    />
 
     <!-- restricting to text props for now -->
 
@@ -164,6 +178,7 @@ import WidgetSelectBox from "./WidgetSelectBox.vue";
 import WidgetArray from "./WidgetArray.vue";
 import WidgetMap from "./WidgetMap.vue";
 import WidgetComboBox from "./WidgetComboBox.vue";
+import WidgetColorBox from "./WidgetColorBox.vue";
 
 const INPUT_CLASSES = tw`pl-lg pr-sm pt-sm`;
 

--- a/app/web/src/components/PropertyEditor/WidgetColorBox.vue
+++ b/app/web/src/components/PropertyEditor/WidgetColorBox.vue
@@ -1,0 +1,121 @@
+<template>
+  <div v-show="isShown" class="flex content-center">
+    <div class="flex grow">
+      <div class="w-full">
+        <SiColorBox
+          :id="fieldId"
+          v-model="currentValue"
+          :title="props.name"
+          :doc-link="docLink"
+          :validations="validations"
+          :disabled="disabled"
+          always-validate
+          @blur="setField"
+          @keyup.enter="triggerBlur($event)"
+        />
+      </div>
+    </div>
+
+    <UnsetButton
+      v-if="!disabled"
+      :disabled="disableUnset"
+      @click="unsetField"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, toRefs, computed, watch, onBeforeUnmount } from "vue";
+import _, { parseInt } from "lodash";
+import SiColorBox from "@/components/SiColorBox.vue";
+import { usePropertyEditorIsShown } from "@/utils/usePropertyEditorIsShown";
+import {
+  PropertyEditorValidation,
+  UpdatedProperty,
+  PropertyPath,
+  PropertyEditorPropKind,
+} from "@/api/sdf/dal/property_editor";
+import { usePropertyEditorValidations } from "@/utils/input_validations";
+import UnsetButton from "./UnsetButton.vue";
+
+const props = defineProps<{
+  name: string;
+  path?: PropertyPath;
+  collapsedPaths: Array<Array<string>>;
+  value: unknown;
+  propId: string;
+  valueId: string;
+  docLink?: string;
+  validation?: PropertyEditorValidation;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "updatedProperty", v: UpdatedProperty): void;
+}>();
+
+const { name, path, collapsedPaths, valueId, propId, value, validation } =
+  toRefs(props);
+
+const currentValue = ref<string>("");
+watch(
+  value,
+  (newValue, oldValue) => {
+    if (oldValue !== newValue) {
+      if (_.isString(newValue)) {
+        currentValue.value = newValue;
+      } else if (_.isNumber(newValue)) {
+        currentValue.value = `${newValue}`;
+      } else {
+        currentValue.value = "";
+      }
+    }
+  },
+  { immediate: true },
+);
+
+const disableUnset = computed(() => {
+  if (_.isNull(value.value)) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
+// @ts-ignore
+const fieldId = ref(props.path.triggerPath.join("."));
+
+const { isShown } = usePropertyEditorIsShown(name, collapsedPaths, path);
+
+const setField = () => {
+  if (
+    !_.isNull(currentValue.value) &&
+    currentValue.value !== props.value &&
+    ((!props.value && currentValue.value) || props.value)
+  ) {
+    emit("updatedProperty", {
+      value: currentValue.value,
+      propId: propId.value,
+      valueId: valueId.value,
+    });
+  }
+};
+
+const unsetField = () => {
+  emit("updatedProperty", {
+    value: null,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+};
+
+const validations = usePropertyEditorValidations(validation);
+
+const triggerBlur = (event: KeyboardEvent) => {
+  if (event?.target instanceof HTMLElement) {
+    event.target.blur();
+  }
+};
+
+onBeforeUnmount(setField);
+</script>

--- a/app/web/src/components/SiColorBox.vue
+++ b/app/web/src/components/SiColorBox.vue
@@ -1,0 +1,144 @@
+<template>
+  <div>
+    <label
+      v-if="props.title"
+      :for="props.id"
+      class="block text-sm font-medium"
+    >
+      {{ title }}
+      <span
+        v-if="props.required && !formSettings.hideRequiredLabel"
+        :class="formSettings.requiredLabelClasses"
+        >{{ formSettings.requiredLabel }}</span
+      >
+    </label>
+
+    <div class="mt-1 relative">
+      <span class="flex">
+        <span
+	  ref="pickerElement"
+          :id="props.id"
+          :aria-required="props.required"
+          :style="{ backgroundColor: props.modelValue }"
+          class="block w-10 h-6 py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm dark:color-white"
+          :class="boxClasses"
+        ></span>
+	<span class="p-1">{{props.modelValue}}</span>
+      </span>
+
+      <div
+        v-if="inError"
+        class="absolute inset-y-0 right-0 pr-2 flex items-center text-destructive-400"
+      >
+        <Icon name="exclamation-circle" />
+      </div>
+    </div>
+
+    <p v-if="props.docLink" class="mt-2 text-xs text-action-500">
+      <a :href="props.docLink" target="_blank" class="hover:underline">
+        Documentation
+      </a>
+    </p>
+
+    <p v-if="props.description" class="mt-2 text-xs text-neutral-300">
+      {{ description }}
+    </p>
+
+    <SiValidation
+      :value="String(inputValue)"
+      :validations="props.validations"
+      class="mt-2"
+      @errors="setInError($event)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, toRefs, onMounted, ref } from "vue";
+import _ from "lodash";
+import { useFormSettings } from "@/utils/formSettings";
+import { ValidatorArray, useValidations } from "@/utils/input_validations";
+import Icon from "@/ui-lib/icons/Icon.vue";
+import SiValidation from "./SiValidation.vue";
+import Picker from 'vanilla-picker';
+
+const props = defineProps({
+  modelValue: { type: String },
+  title: String,
+  id: { type: String, required: true },
+  description: String,
+
+  validations: { type: Array as PropType<ValidatorArray> },
+  required: Boolean,
+  alwaysValidate: Boolean,
+
+  docLink: String,
+
+  disabled: Boolean,
+});
+
+const pickerElement = ref<HTMLElement | null>(null);
+const picker = ref<Picker | null>(null);
+onMounted(() => {
+  if (!props.disabled) {
+    const p = new Picker(pickerElement.value as HTMLElement);
+    p.onDone = valueChanged;
+    picker.value = p;
+  }
+});
+
+const { alwaysValidate } = toRefs(props);
+
+const formSettings = useFormSettings();
+
+const emit = defineEmits(["update:modelValue", "error", "blur"]);
+
+const inputValue = computed<string>({
+  get() {
+    return props.modelValue ?? "";
+  },
+  set(value) {
+    emit("update:modelValue", value);
+  },
+});
+
+const { inError, setInError, setDirty } = useValidations(
+  alwaysValidate,
+  () => emit("blur", inputValue),
+  (inError: boolean) => emit("error", inError),
+);
+
+const boxClasses = computed((): Record<string, boolean> => {
+  const results: Record<string, boolean> = {};
+  if (!props.disabled) {
+    results["cursor-pointer"] = true;
+  }
+  return results;
+});
+
+const valueChanged = (color: { hex: string }) => {
+  setDirty();
+  emit("update:modelValue", color.hex);
+  emit("blur");
+};
+</script>
+
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+};
+</script>
+
+<style>
+.picker_wrapper.popup,
+.picker_wrapper.popup .picker_arrow::before,
+.picker_wrapper.popup .picker_arrow::after {
+  background: unset;
+}
+
+.picker_wrapper,
+.picker_editor,
+.picker_editor input::placeholder {
+  color: inherit !important;
+}
+</style>

--- a/app/web/src/components/SiTextBox.vue
+++ b/app/web/src/components/SiTextBox.vue
@@ -25,7 +25,10 @@
         :data-test="id"
         class="appearance-none block w-full py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm"
         :class="textBoxClasses"
+        required
+        :disabled="disabled"
         @input="valueChanged"
+        @blur="setDirty"
       />
       <input
         v-else

--- a/lib/dal/src/edit_field/widget.rs
+++ b/lib/dal/src/edit_field/widget.rs
@@ -14,6 +14,7 @@ pub enum WidgetKind {
     SecretSelect,
     Text,
     TextArea,
+    Color,
     /// Provides a select box for corresponding "primitive" (e.g. string, number, boolean)
     /// [`PropKinds`](crate::PropKind).
     Select,

--- a/lib/dal/src/func/backend/validation.rs
+++ b/lib/dal/src/func/backend/validation.rs
@@ -76,7 +76,7 @@ impl FuncBackend for FuncBackendValidation {
             },
             Validation::StringIsHexColor { value } => match value {
                 Some(value) => {
-                    let re = Regex::new(r"^#[\dA-Fa-f]{6}$").unwrap();
+                    let re = Regex::new(r"^#[\dA-Fa-f]{6,8}$").unwrap();
                     if re.is_match(value.as_str()) {
                         None
                     } else {

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -133,6 +133,7 @@ pub enum PropertyEditorPropWidgetKind {
     SecretSelect { options: LabelList<SecretId> },
     Select { options: Option<Value> },
     ComboBox { options: Option<Value> },
+    Color,
     Text,
     TextArea,
 }
@@ -151,6 +152,7 @@ impl PropertyEditorPropWidgetKind {
             WidgetKind::Select => Self::Select {
                 options: widget_options,
             },
+            WidgetKind::Color => Self::Color,
             WidgetKind::SecretSelect => Self::SecretSelect {
                 options: LabelList::new(
                     Secret::list(ctx)

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -309,8 +309,9 @@ impl RootProp {
         type_prop.set_parent_prop(ctx, si_prop_id).await?;
 
         // Override the schema variant color for nodes on the diagram.
-        let color_prop = Prop::new(ctx, "color", PropKind::String, None).await?;
+        let mut color_prop = Prop::new(ctx, "color", PropKind::String, None).await?;
         color_prop.set_parent_prop(ctx, si_prop_id).await?;
+        color_prop.set_widget_kind(ctx, WidgetKind::Color).await?;
         Self::create_validation(
             ctx,
             *color_prop.id(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,7 @@ importers:
       typescript: ^4.9.5
       unplugin-icons: ^0.14.14
       validator: ^13.7.0
+      vanilla-picker: ^2.12.1
       vite: ^4.1.4
       vite-plugin-checker: ^0.5.6
       vite-svg-loader: ^3.4.0
@@ -150,6 +151,7 @@ importers:
       tinycolor2: 1.4.2
       typescript: 4.9.5
       validator: 13.7.0
+      vanilla-picker: 2.12.1
       vue: 3.2.45
       vue-konva: 3.0.2_konva@8.3.13
       vue-router: 4.1.6_vue@3.2.45
@@ -1677,6 +1679,10 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.5
     dev: true
+
+  /@sphinxxxx/color-conversion/2.2.2:
+    resolution: {integrity: sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==}
+    dev: false
 
   /@swc/core-darwin-arm64/1.3.36:
     resolution: {integrity: sha512-lsP+C8p9cC/Vd9uAbtxpEnM8GoJI/MMnVuXak7OlxOtDH9/oTwmAcAQTfNGNaH19d2FAIRwf+5RbXCPnxa2Zjw==}
@@ -8082,6 +8088,12 @@ packages:
   /validator/13.7.0:
     resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /vanilla-picker/2.12.1:
+    resolution: {integrity: sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==}
+    dependencies:
+      '@sphinxxxx/color-conversion': 2.2.2
     dev: false
 
   /vary/1.1.2:


### PR DESCRIPTION
The background of the picker is transparent because I wasn't able to change the color depending on the light/dark mode. I'm open to suggestions.