### PR TITLE
fix(pinga,dal): ensure that Pinga dedicated its own NATS client per task

### DIFF
--- a/bin/gen-var-defs/src/main.rs
+++ b/bin/gen-var-defs/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
         Box::new(job_processor),
         veritech.clone(),
         Arc::new(encryption_key),
-        "council".to_owned(),
+        "council",
         None,
     );
 

--- a/bin/pinga/src/config.rs
+++ b/bin/pinga/src/config.rs
@@ -32,9 +32,10 @@ pub struct Config {
     #[builder(default = "NatsConfig::default()")]
     nats: NatsConfig,
 
-    #[builder(default = "FaktoryConfig::default()")]
-    faktory: FaktoryConfig,
-
+    // TODO(fnichol): remove when faktory goes away
+    //
+    // #[builder(default = "FaktoryConfig::default()")]
+    // faktory: FaktoryConfig,
     cyclone_encryption_key_path: CanonicalFile,
 }
 
@@ -55,11 +56,13 @@ impl Config {
         &self.nats
     }
 
-    /// Gets a reference to the config's faktory.
-    #[must_use]
-    pub fn faktory(&self) -> &FaktoryConfig {
-        &self.faktory
-    }
+    // TODO(fnichol): remove when faktory goes away
+    //
+    // /// Gets a reference to the config's faktory.
+    // #[must_use]
+    // pub fn faktory(&self) -> &FaktoryConfig {
+    //     &self.faktory
+    // }
 
     /// Gets a reference to the config's cyclone public key path.
     #[must_use]
@@ -115,7 +118,9 @@ impl TryFrom<ConfigFile> for Config {
         let mut config = Config::builder();
         config.pg_pool(value.pg);
         config.nats(value.nats);
-        config.faktory(value.faktory);
+        // TODO(fnichol): remove when faktory goes away
+        //
+        // config.faktory(value.faktory);
         config.cyclone_encryption_key_path(value.cyclone_encryption_key_path.try_into()?);
         config.build().map_err(Into::into)
     }

--- a/lib/dal/examples/dal-pkg-export.rs
+++ b/lib/dal/examples/dal-pkg-export.rs
@@ -60,7 +60,7 @@ async fn ctx() -> Result<(DalContext, mpsc::Receiver<()>)> {
     let pg_pool = create_pg_pool().await?;
     let nats_conn = connect_to_nats().await?;
     let veritech = create_veritech_client(nats_conn.clone());
-    let council_subject_prefix = "council".to_owned();
+    let council_subject_prefix = "council";
 
     let (alive_marker, job_processor_shutdown_rx) = mpsc::channel(1);
     let job_processor = connect_processor(nats_conn.clone(), alive_marker).await?;

--- a/lib/dal/examples/dal-pkg-import.rs
+++ b/lib/dal/examples/dal-pkg-import.rs
@@ -36,7 +36,7 @@ async fn ctx() -> Result<(DalContext, mpsc::Receiver<()>)> {
     let pg_pool = create_pg_pool().await?;
     let nats_conn = connect_to_nats().await?;
     let veritech = create_veritech_client(nats_conn.clone());
-    let council_subject_prefix = "council".to_owned();
+    let council_subject_prefix = "council";
 
     let (alive_marker, job_processor_shutdown_rx) = mpsc::channel(1);
     let job_processor = connect_processor(nats_conn.clone(), alive_marker).await?;

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -47,7 +47,7 @@ impl ServicesContext {
         job_processor: Box<dyn JobQueueProcessor + Send + Sync>,
         veritech: VeritechClient,
         encryption_key: Arc<EncryptionKey>,
-        council_subject_prefix: String,
+        council_subject_prefix: impl Into<String>,
         pkgs_path: Option<PathBuf>,
     ) -> Self {
         Self {
@@ -56,7 +56,7 @@ impl ServicesContext {
             job_processor,
             veritech,
             encryption_key,
-            council_subject_prefix,
+            council_subject_prefix: council_subject_prefix.into(),
             pkgs_path,
         }
     }

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -243,7 +243,7 @@ impl WorkflowTree {
                 ctx.job_processor(),
                 ctx.veritech().clone(),
                 Arc::new(*ctx.encryption_key()),
-                ctx.council_subject_prefix().to_owned(),
+                ctx.council_subject_prefix(),
                 None,
             );
             let ctx_builder = services_context.clone().into_builder();


### PR DESCRIPTION
This change ensures that each of the spawned job execution tasks has their own dedicated NATS client from which to subscribe for work. The previous implementation made `NUM_TASKS=10` subscriptions to the same subject/queue using a common NATS client (i.e. all would use the same `cid` (client id)).

Why?
----

What we are concerned about is what happens when 1 NATS client instance takes 10 subscriptions to the same subject/queue where work is assigned randomly by the NATS service. It seems likely that internal to the NATS client there might be confusion as to which subscription instance to send the de-queued message to. This may be leading to lost messages after the client recieves the message and before it can determine which subscription to send it on.

This updated setup tries to change the `NUM_TASKS` strategy for the moment and instead creates `NUM_TASKS` dedicated NATS client so that each client makes its own subscription.

The NATS Client Math
--------------------

Prior to this change we would have seen 1 NATS client for all subscriptions and 1 NATS client for all `DalContext` instances, so 1 + 1 = 2 NATS clients. This change creates `NUM_TASKS=10` NATS clients for the subscriptions and 1 NATS client for all `DalContext` instances, so 10 + 1 = 11 NATS clients.

Implementation Note
-------------------

Future work should refactor this architecture so that only 1 NATS client is required for 1 subscription which would delegate all further work to a work pool. The current fix here might make it harder to track Pinga NATS consumers as they will take 11 clients to work.

<img src="https://media2.giphy.com/media/3o6Zt5jXXzAzdikVmE/giphy.gif"/>