### PR TITLE
chore(build): Update GHA to ensure we adhere to new save-state and save-output deprecations

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -51,7 +51,7 @@ jobs:
           override: true
       - name: Login Docker
         id: login
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # pin@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,11 +18,11 @@ jobs:
     name: Build ${{ inputs.component_name }} Docker Image
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3 # pin@v2.3.4
+      - uses: actions/checkout@v3
       - id: buildx
-        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # pin@v1.6.0
+        uses: docker/setup-buildx-action@v2
       - id: login
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # pin@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -36,9 +36,9 @@ jobs:
           echo "::group::Manifest info"
           jq . <tmp/release-$(basename ${{ inputs.component_name }}).manifest.json
           echo "::endgroup::"
-          echo "::set-output name=manifest::$(
+          echo "manifest=$(
             cat tmp/release-$(basename ${{ inputs.component_name }}).manifest.json
-          )"
+          )" >> $GITHUB_OUTPUT
       - name: report
         if: success()
         run: |

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -21,7 +21,7 @@ jobs:
       pinga-changed: ${{ steps.check-component-changes.outputs.bin--pinga }}
       council-changed: ${{ steps.check-component-changes.outputs.bin--council }}
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1000
       - id: check-component-changes
@@ -139,6 +139,6 @@ jobs:
       VERITECH_STATUS: ${{ needs.veritech.result }}
       WEB_STATUS: ${{ needs.web.result }}
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
+      - uses: actions/checkout@v2
       - id: check-build-statuses
         run: ./ci/scripts/check-image-build-statuses.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Login Docker
         if: needs.check-run-tests.outputs.run_tests == 'true'
         id: login
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # pin@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -19,7 +19,7 @@ jobs:
     name: Promote ${{ inputs.component_name }}
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2.3.4
+      - uses: actions/checkout@v3
       - id: notify-slack
         uses: voxmedia/github-action-slack-notify-build@212e9f7a9ca33368c8dd879d6053972128258985 # pin@v1.5.0
         env:
@@ -29,7 +29,7 @@ jobs:
           status: executing
           color: "#ffb74d"
       - id: login
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # pin@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
This required updating some of our actions to some that take
advantage of the new github core library

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
