### PR TITLE
fix(web): fix attr func prototype parsing

### DIFF
--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -94,6 +94,7 @@ const {
   providerIdToSourceName,
   schemaVariantOptions,
   componentOptions,
+  propForId,
 } = storeToRefs(funcStore);
 
 function nilId(): string {
@@ -103,7 +104,6 @@ function nilId(): string {
 const editingPrototype = ref<AttributePrototypeView | undefined>(undefined);
 const makeEmptyPrototype = (): AttributePrototypeView => ({
   id: nilId(),
-  schemaVariantId: nilId(),
   componentId: nilId(),
   propId: nilId(),
   prototypeArguments: associations.value.arguments.map(({ id }) => ({
@@ -154,10 +154,10 @@ const associations = toRef(props, "associations", {
 
 const prototypeView = computed(() => {
   return associations.value.prototypes.map((proto) => {
+    const schemaVariantId = propForId.value?.(proto.propId)?.schemaVariantId;
     const schemaVariant =
-      schemaVariantOptions.value.find(
-        (sv) => sv.value === proto.schemaVariantId,
-      )?.label ?? "none";
+      schemaVariantOptions.value.find((sv) => sv.value === schemaVariantId)
+        ?.label ?? "none";
 
     const component =
       componentOptions.value.find((c) => c.value === proto.componentId)

--- a/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
@@ -78,6 +78,7 @@ const {
   inputSourceSockets,
   inputSourceProps,
   propsAsOptionsForSchemaVariant,
+  propForId,
 } = storeToRefs(funcStore);
 
 const props = defineProps({
@@ -252,10 +253,12 @@ watch(
 watch(
   () => props.open,
   () => {
+    const schemaVariantId = propForId.value?.(
+      prototype.value?.propId,
+    )?.schemaVariantId;
     selectedVariant.value =
-      schemaVariantOptions?.value.find(
-        (sv) => sv.value === prototype.value?.schemaVariantId,
-      ) ?? noneVariant;
+      schemaVariantOptions?.value.find((sv) => sv.value === schemaVariantId) ??
+      noneVariant;
     selectedComponent.value =
       filteredComponentOptions.value.find(
         (c) => c.value === prototype.value?.id,

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -68,7 +68,12 @@ export const useFuncStore = () => {
         return this.funcDetailsById[this.urlSelectedFuncId || ""];
       },
 
+      funcById: (state) => (funcId: string) => state.funcDetailsById[funcId],
+
       funcList: (state) => _.values(state.funcsById),
+
+      propForId: (state) => (propId: string) =>
+        state.inputSourceProps.find((prop) => prop.propId === propId),
 
       // Filter props by schema variant
       propsAsOptionsForSchemaVariant: (state) => (schemaVariantId: string) =>

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -38,7 +38,6 @@ export interface AttributePrototypeArgumentView {
 
 export interface AttributePrototypeView {
   id: string;
-  schemaVariantId: string;
   componentId?: string;
   propId: string;
   prototypeArguments: AttributePrototypeArgumentView[];


### PR DESCRIPTION
Restore displaying the correct schema variant for an attribute binding.