### PR TITLE
fix(web): fix attrbindings reactivity

### DIFF
--- a/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
@@ -62,7 +62,7 @@ import Modal from "@/ui-lib/modals/Modal.vue";
 import SelectMenu, { Option } from "@/components/SelectMenu.vue";
 import { AttributePrototypeView } from "@/store/func/types";
 import { FuncArgument } from "@/api/sdf/dal/func";
-import { FuncId, useFuncStore } from "@/store/func/funcs.store";
+import { useFuncStore } from "@/store/func/funcs.store";
 import { useComponentsStore } from "@/store/components.store";
 
 function nilId(): string {
@@ -83,7 +83,6 @@ const {
 
 const props = defineProps({
   open: { type: Boolean, default: false },
-  funcId: { type: String as PropType<FuncId>, required: true },
   prototype: { type: Object as PropType<AttributePrototypeView> },
 });
 

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -142,8 +142,8 @@
             editingFunc.associations &&
             editingFunc.associations.type === 'attribute'
           "
-          :func-id="selectedFuncId"
-          :associations="editingFunc.associations"
+          v-model="editingFunc.associations"
+          @change="updateFunc"
         />
       </TabGroupItem>
     </TabGroup>

--- a/app/web/src/components/SiColorBox.vue
+++ b/app/web/src/components/SiColorBox.vue
@@ -1,10 +1,6 @@
 <template>
   <div>
-    <label
-      v-if="props.title"
-      :for="props.id"
-      class="block text-sm font-medium"
-    >
+    <label v-if="props.title" :for="props.id" class="block text-sm font-medium">
       {{ title }}
       <span
         v-if="props.required && !formSettings.hideRequiredLabel"
@@ -16,14 +12,14 @@
     <div class="mt-1 relative">
       <span class="flex">
         <span
-	  ref="pickerElement"
           :id="props.id"
+          ref="pickerElement"
           :aria-required="props.required"
           :style="{ backgroundColor: props.modelValue }"
           class="block w-10 h-6 py-2 border rounded-sm shadow-sm focus:outline-none sm:text-sm dark:color-white"
           :class="boxClasses"
         ></span>
-	<span class="p-1">{{props.modelValue}}</span>
+        <span class="p-1">{{ props.modelValue }}</span>
       </span>
 
       <div
@@ -56,11 +52,11 @@
 <script setup lang="ts">
 import { computed, PropType, toRefs, onMounted, ref } from "vue";
 import _ from "lodash";
+import Picker from "vanilla-picker";
 import { useFormSettings } from "@/utils/formSettings";
 import { ValidatorArray, useValidations } from "@/utils/input_validations";
 import Icon from "@/ui-lib/icons/Icon.vue";
 import SiValidation from "./SiValidation.vue";
-import Picker from 'vanilla-picker';
 
 const props = defineProps({
   modelValue: { type: String },

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -158,7 +158,8 @@ export const useFuncStore = () => {
           },
           keyRequestStatusBy: func.id,
           onSuccess: (response) => {
-            this.funcDetailsById[response.id] = response;
+            this.funcDetailsById[func.id].associations = response.associations;
+            this.funcDetailsById[func.id].isRevertible = response.isRevertible;
           },
         });
       },
@@ -206,37 +207,6 @@ export const useFuncStore = () => {
         });
       },
 
-      async removeFuncAttrPrototype(funcId: FuncId, prototypeId: string) {
-        const func = this.funcDetailsById[funcId];
-        if (func?.associations?.type !== "attribute") {
-          return;
-        }
-
-        func.associations.prototypes = func.associations.prototypes.filter(
-          (proto) => proto.id !== prototypeId,
-        );
-        this.funcDetailsById[funcId] = { ...func };
-        await this.saveUpdatedFunc(funcId);
-      },
-      async updateFuncAttrPrototype(
-        funcId: FuncId,
-        prototype: AttributePrototypeView,
-      ) {
-        const func = this.funcDetailsById[funcId];
-        if (func?.associations?.type !== "attribute") {
-          return;
-        }
-
-        if (prototype.id === nilId()) {
-          func.associations.prototypes.push(prototype);
-        } else {
-          const currentPrototypeIdx = func.associations.prototypes.findIndex(
-            (proto) => proto.id === prototype.id,
-          );
-          func.associations.prototypes[currentPrototypeIdx] = prototype;
-        }
-        this.saveUpdatedFunc(funcId);
-      },
       async updateFuncAttrArgs(funcId: FuncId, args: FuncArgument[]) {
         const func = this.funcDetailsById[funcId];
         if (func?.associations?.type !== "attribute") {


### PR DESCRIPTION
reworked save function was not updating the state correctly, and something weird broke with the reactivity deep in the AttributeBindings panel. Refactored to use model-value pattern. Will do the the same with FuncArguments next.