### PR TITLE
Separate recommendation status from ability to run (ENG-1129,ENG-1151)

### DIFF
--- a/app/web/src/components/RecommendationPicker.vue
+++ b/app/web/src/components/RecommendationPicker.vue
@@ -82,7 +82,6 @@
             v-for="recommendation in recommendations"
             :key="`${recommendation.confirmationAttributeValueId}-${recommendation.recommendedAction}`"
           >
-            <!-- TODO(nick,paulo): disable recommendation sprites that aren't ready using "disable-checkbox" -->
             <RecommendationSprite
               :recommendation="recommendation"
               :selected="
@@ -176,7 +175,7 @@ const selectedRecommendations = computed(() => {
     return (
       recommendationSelection[
         `${recommendation.confirmationAttributeValueId}-${recommendation.recommendedAction}`
-      ] && recommendation.status === "unstarted"
+      ] && recommendation.isRunnable === "yes"
     );
   });
 });

--- a/app/web/src/components/RecommendationSprite.vue
+++ b/app/web/src/components/RecommendationSprite.vue
@@ -8,9 +8,8 @@
   >
     <template #prefix>
       <VormInput
-        v-if="recommendation.status === 'unstarted'"
+        v-if="recommendation.isRunnable === 'yes'"
         :model-value="selected"
-        :disabled="disableCheckbox"
         type="checkbox"
         class="flex-none pl-1"
         no-label
@@ -22,7 +21,10 @@
         "
       />
       <Icon
-        v-else-if="recommendation.status === 'running'"
+        v-else-if="
+          recommendation.status === 'running' ||
+          recommendation.isRunnable === 'running'
+        "
         name="loader"
         :class="clsx('flex-none pl-1', statusIconProps.color)"
         size="lg"
@@ -40,7 +42,6 @@
         :class="classes"
       >
         <Icon
-          v-if="recommendation.status !== 'success'"
           :name="recommendationIcon(recommendation.actionKind)"
           size="md"
           :class="recommendationColor(recommendation.actionKind)"
@@ -106,7 +107,6 @@ const props = defineProps({
   recommendation: { type: Object as PropType<Recommendation>, required: true },
   class: { type: String },
   selected: { type: Boolean, default: false },
-  disableCheckbox: { type: Boolean, default: false },
 });
 
 const classes = computed(() => props.class);

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -14,6 +14,7 @@ function nilId(): string {
 }
 
 export type FixStatus = "success" | "failure" | "running" | "unstarted";
+export type RecommendationIsRunnable = "yes" | "no" | "running";
 export type ActionKind = "create" | "other" | "destroy";
 
 export type Confirmation = {
@@ -43,6 +44,7 @@ export type Recommendation = {
   provider: string;
   actionKind: ActionKind;
   status: FixStatus;
+  isRunnable: RecommendationIsRunnable;
 };
 
 // TODO(nick): use real user data and real timestamps. This is dependent on the backend.
@@ -272,6 +274,7 @@ export const useFixesStore = () => {
                     )
                   ) {
                     r.status = "running";
+                    r.isRunnable = "running";
                   }
                 }
                 return c;

--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -18,8 +18,17 @@ use crate::{
 use crate::{RootPropChild, WsEventResult};
 
 impl Component {
+    /// Calls [`Self::resource_by_id`] using the [`ComponentId`](Component) off [`Component`].
     pub async fn resource(&self, ctx: &DalContext) -> ComponentResult<CommandRunResult> {
-        let schema_variant_id = Self::schema_variant_id(ctx, self.id).await?;
+        Self::resource_by_id(ctx, self.id).await
+    }
+
+    /// Find the object corresponding to "/root/resource".
+    pub async fn resource_by_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<CommandRunResult> {
+        let schema_variant_id = Self::schema_variant_id(ctx, component_id).await?;
         let implicit_internal_provider = SchemaVariant::find_root_child_implicit_internal_provider(
             ctx,
             schema_variant_id,
@@ -29,7 +38,7 @@ impl Component {
 
         let value_context = AttributeReadContext {
             internal_provider_id: Some(*implicit_internal_provider.id()),
-            component_id: Some(self.id),
+            component_id: Some(component_id),
             ..AttributeReadContext::default()
         };
 

--- a/lib/dal/src/tasks/status_receiver.rs
+++ b/lib/dal/src/tasks/status_receiver.rs
@@ -175,7 +175,9 @@ impl StatusReceiver {
     /// Evaluate the request from the [`DependentValuesUpdate`](crate::DependentValuesUpdate) job
     /// and perform work accordingly.
     ///
-    /// This function is considered the "critical section" of the [`receiver`](Self).
+    /// This function is considered the "critical section" of the [`receiver`](Self). It _CANNOT_
+    /// mutate rows that [`DependentValuesUpdate`](crate::DependentValuesUpdate) is mutating,
+    /// otherwise a database deadlock may occur.
     async fn process(
         ctx_builder: DalContextBuilder,
         request: Request<StatusReceiverRequest>,


### PR DESCRIPTION
Primary:
- Fix stale recommendations by operating based on their ability to run
  in conjunction with their status
- Add "RecommendationIsRunnable" to track recommendations' ability to
  run

Secondary:
- Ensure label for individual recommendations is intact regardless of
  the status

<img src="https://media0.giphy.com/media/eiqUnZOWZBIZPsNZUY/giphy.gif"/>