### PR TITLE
fix(dal): qualificationIngressCanCreate should check for GroupId after successful DryRun…

### DIFF
--- a/lib/dal/src/builtins/func/qualificationIngressCanCreate.js
+++ b/lib/dal/src/builtins/func/qualificationIngressCanCreate.js
@@ -27,6 +27,12 @@ async function qualification(input) {
 
     // We have to use `includes` instead of `startsWith` because the line can start with a line feed char
     const success = child.stderr.includes('An error occurred (DryRunOperation)');
+    if (success && !input.domain?.GroupId) {
+      return {
+        result: "warning",
+        message: "GroupId must be set. If a Security Group is connected to this component the id will be automatically set when the fix flow creates the security group after merging this change-set",
+      };
+    }
 
     return {
         result: success ? "success" : "failure",


### PR DESCRIPTION
`aws ec2 authorize-security-group-ingress` reports success on DryRun even if GroupId is not present. We should do the DryRun, but still report a warning if the security group id is not present.

Egress has the correct warning already.