### PR TITLE
 fix(dal): fix delete handler and ec2 delete function

### DIFF
--- a/lib/dal/src/builtins/func/awsEc2DeleteCommand.js
+++ b/lib/dal/src/builtins/func/awsEc2DeleteCommand.js
@@ -1,5 +1,10 @@
 async function deleteResource(component) {
     const resource = component.properties.resource?.value;
+
+    const instances = Array.isArray(resource) ? resource : [resource];
+    const instanceIds = instances.flatMap((i) => i.Instances).map((i) => i.InstanceId).filter((id) => !!id);
+    if (!instanceIds || instanceIds.length === 0) return { status: "error", value: resource, message: "No EC2 instance id found" };
+
     // Now, delete the Ec2 Instance.
     const child = await siExec.waitUntilEnd("aws", [
         "ec2",
@@ -7,7 +12,7 @@ async function deleteResource(component) {
         "--region",
         component.properties.domain.region,
         "--instance-ids",
-        resource.InstanceId,
+        ...instanceIds,
     ]);
 
     if (child.exitCode !== 0) {

--- a/lib/dal/src/builtins/func/awsEc2DeleteWorkflow.js
+++ b/lib/dal/src/builtins/func/awsEc2DeleteWorkflow.js
@@ -1,4 +1,4 @@
-async function create(arg) {
+async function deleteResource(arg) {
     return {
         name: "si:awsEc2DeleteWorkflow",
         kind: "conditional",

--- a/lib/dal/src/builtins/func/awsEgressDeleteWorkflow.js
+++ b/lib/dal/src/builtins/func/awsEgressDeleteWorkflow.js
@@ -1,4 +1,4 @@
-async function create(arg) {
+async function deleteResource(arg) {
   return {
     name: "si:awsIngressDeleteWorkflow",
     kind: "conditional",

--- a/lib/dal/src/builtins/func/awsIngressDeleteWorkflow.js
+++ b/lib/dal/src/builtins/func/awsIngressDeleteWorkflow.js
@@ -1,4 +1,4 @@
-async function create(arg) {
+async function deleteResource(arg) {
   return {
     name: "si:awsIngressDeleteWorkflow",
     kind: "conditional",

--- a/lib/dal/src/builtins/func/awsSecurityGroupDeleteWorkflow.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupDeleteWorkflow.js
@@ -1,4 +1,4 @@
-async function create(arg) {
+async function deleteResource(arg) {
   return {
     name: "si:awsSecurityGroupDeleteWorkflow",
     kind: "conditional",


### PR DESCRIPTION
Rename delete workflow functions to have the appropriate handler.
Use the correct InstanceId when deleting the ec2 instance.

Update resources of deleted components. This means if someone deletes the real life resource of a deleted component, the component will go away instead of waiting for the delete workflow to execute (which will fail, as the thing is not there anymore)