### PR TITLE
Ensure correct deletion order (ENG-1120,ENG-1200)

### DIFF
--- a/lib/config-file/src/simple_load.rs
+++ b/lib/config-file/src/simple_load.rs
@@ -13,7 +13,7 @@ where
         Some(target) => target,
         None => return Ok(None),
     };
-    let buf = read_from_file(&target)?;
+    let buf = read_from_file(target)?;
     Ok(Some(load_from_str(&buf, file_format)?))
 }
 

--- a/lib/dal/src/change_status.rs
+++ b/lib/dal/src/change_status.rs
@@ -28,7 +28,9 @@ pub enum ChangeStatusError {
 pub type ChangeStatusResult<T> = Result<T, ChangeStatusError>;
 
 /// An enum representing the change_status of an entity in the [`ChangeSet`](crate::ChangeSet).
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Display, EnumString, AsRefStr)]
+#[derive(
+    Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy, Display, EnumString, AsRefStr,
+)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum ChangeStatus {
@@ -134,11 +136,10 @@ impl ComponentChangeStatusGroup {
             let component_name: Option<String> = row.try_get("component_name")?;
             let component_name = component_name.unwrap_or_else(|| "".to_owned());
 
-            // TODO(nick): don't move the enum.
             result.push(Self {
                 component_id,
                 component_name,
-                component_status: component_status.clone(),
+                component_status,
             });
         }
         Ok(result)

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -25,22 +25,20 @@ use crate::standard_model::object_from_row;
 use crate::validation::ValidationConstructorError;
 use crate::ws_event::WsEventError;
 use crate::{
-    func::FuncId, impl_standard_model, node::NodeId, pk, provider::internal::InternalProviderError,
+    impl_standard_model, node::NodeId, pk, provider::internal::InternalProviderError,
     standard_model, standard_model_accessor, standard_model_belongs_to, standard_model_has_many,
     ActionPrototypeError, AttributeContext, AttributeContextBuilderError, AttributeContextError,
     AttributePrototype, AttributePrototypeArgument, AttributePrototypeArgumentError,
-    AttributePrototypeError, AttributePrototypeId, AttributeReadContext, CodeLanguage,
-    ComponentType, DalContext, EdgeError, ExternalProvider, ExternalProviderError,
-    ExternalProviderId, FixError, Func, FuncBackendKind, FuncError, HistoryActor,
-    HistoryEventError, InternalProvider, InternalProviderId, Node, NodeError, Prop, PropError,
-    PropId, RootPropChild, Schema, SchemaError, SchemaId, Socket, StandardModel,
-    StandardModelError, Tenancy, Timestamp, TransactionsError, UserPk, ValidationPrototypeError,
-    ValidationResolverError, Visibility, WorkflowRunnerError, WorkspaceError, WsEvent,
-    WsEventResult, WsPayload,
+    AttributePrototypeError, AttributePrototypeId, AttributeReadContext, ComponentType, DalContext,
+    EdgeError, ExternalProvider, ExternalProviderError, ExternalProviderId, FixError, Func,
+    FuncBackendKind, FuncError, HistoryActor, HistoryEventError, InternalProvider,
+    InternalProviderId, Node, NodeError, PropError, PropId, RootPropChild, Schema, SchemaError,
+    SchemaId, Socket, StandardModel, StandardModelError, Tenancy, Timestamp, TransactionsError,
+    UserPk, ValidationPrototypeError, ValidationResolverError, Visibility, WorkflowRunnerError,
+    WorkspaceError, WsEvent, WsEventResult, WsPayload,
 };
 use crate::{AttributeValueId, QualificationError};
 use crate::{Edge, FixResolverError, NodeKind};
-pub use view::{ComponentView, ComponentViewError, ComponentViewProperties};
 
 pub mod code;
 pub mod confirmation;
@@ -50,6 +48,8 @@ pub mod resource;
 pub mod status;
 pub mod validation;
 pub mod view;
+
+pub use view::{ComponentView, ComponentViewError, ComponentViewProperties};
 
 #[derive(Error, Debug)]
 pub enum ComponentError {
@@ -61,12 +61,6 @@ pub enum ComponentError {
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] AttributeValueError),
-    #[error("attribute value not found for context: {0:?}")]
-    AttributeValueNotFoundForContext(AttributeReadContext),
-    #[error("invalid json pointer: {0} for {1}")]
-    BadJsonPointer(String, String),
-    #[error("code generation function returned unexpected format, expected {0:?}, got {1:?}")]
-    CodeLanguageMismatch(CodeLanguage, CodeLanguage),
     #[error(transparent)]
     CodeView(#[from] CodeViewError),
     #[error("edge error: {0}")]
@@ -75,48 +69,14 @@ pub enum ComponentError {
     FixResolver(#[from] FixResolverError),
     #[error("fix error: {0}")]
     Fix(#[from] Box<FixError>),
-    #[error("unable to delete frame due to attached components")]
-    FrameHasAttachedComponents,
-    #[error("component marked as protected: {0}")]
-    ComponentProtected(ComponentId),
     #[error(transparent)]
     WorkflowRunner(#[from] WorkflowRunnerError),
     #[error(transparent)]
     ActionPrototype(#[from] ActionPrototypeError),
-    #[error("func not found: {0}")]
-    FuncNotFound(FuncId),
     #[error(transparent)]
     FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
     #[error("internal provider error: {0}")]
     InternalProvider(#[from] InternalProviderError),
-    #[error("internal provider not found for prop: {0}")]
-    InternalProviderNotFoundForProp(PropId),
-    #[error("invalid context(s) provided for diff")]
-    InvalidContextForDiff,
-    #[error("invalid func backend kind (0:?) for checking validations (need validation kind)")]
-    InvalidFuncBackendKindForValidations(FuncBackendKind),
-    #[error("missing attribute value for id: ({0})")]
-    MissingAttributeValue(AttributeValueId),
-    #[error("missing index map on attribute value: {0}")]
-    MissingIndexMap(AttributeValueId),
-    #[error("expected one root prop, found multiple: {0:?}")]
-    MultipleRootProps(Vec<Prop>),
-    #[error("root prop not found for schema variant: {0}")]
-    RootPropNotFound(SchemaVariantId),
-    #[error("validation error: {0}")]
-    Validation(#[from] ValidationConstructorError),
-    #[error("attribute value does not have a prototype: {0}")]
-    MissingAttributePrototype(AttributeValueId),
-    #[error("node not found for component: {0}")]
-    NodeNotFoundForComponent(ComponentId),
-    #[error("attribute prototype does not have a function: {0}")]
-    MissingAttributePrototypeFunction(AttributePrototypeId),
-    #[error("/root/si/name is unset for component {0}")]
-    NameIsUnset(ComponentId),
-    #[error(transparent)]
-    ComponentView(#[from] ComponentViewError),
-    #[error("unable to find code generated")]
-    CodeGeneratedNotFound,
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("pg error: {0}")]
@@ -125,6 +85,10 @@ pub enum ComponentError {
     PgPool(#[from] si_data_pg::PgPoolError),
     #[error(transparent)]
     ContextTransaction(#[from] TransactionsError),
+    #[error("validation error: {0}")]
+    Validation(#[from] ValidationConstructorError),
+    #[error(transparent)]
+    ComponentView(#[from] ComponentViewError),
     #[error("nats txn error: {0}")]
     Nats(#[from] NatsError),
     #[error("history event error: {0}")]
@@ -133,30 +97,14 @@ pub enum ComponentError {
     StandardModelError(#[from] StandardModelError),
     #[error("node error: {0}")]
     NodeError(#[from] NodeError),
-    #[error("component not found: {0}")]
-    NotFound(ComponentId),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
     #[error("socket error: {0}")]
     Socket(#[from] SocketError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
-    #[error("no schema variant for component {0}")]
-    NoSchemaVariant(ComponentId),
-    #[error("no schema for component {0}")]
-    NoSchema(ComponentId),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
-    #[error("missing a prop in attribute update: {0} not found")]
-    MissingProp(PropId),
-    #[error("missing a prop in attribute update: {0} not found")]
-    PropNotFound(String),
-    #[error("missing a func in attribute update: {0} not found")]
-    MissingFunc(String),
-    #[error("func binding return value: {0} not found")]
-    FuncBindingReturnValueNotFound(FuncBindingReturnValueId),
-    #[error("invalid prop value kind; expected {0} but found {1}")]
-    InvalidPropValue(&'static str, Value),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("func binding error: {0}")]
@@ -165,18 +113,39 @@ pub enum ComponentError {
     ValidationResolver(#[from] ValidationResolverError),
     #[error("validation prototype error: {0}")]
     ValidationPrototype(#[from] ValidationPrototypeError),
-    #[error("validation prototype does not match component schema variant: {0}")]
-    ValidationPrototypeMismatch(SchemaVariantId),
     #[error("qualification error: {0}")]
     Qualification(#[from] QualificationError),
-    #[error("workspace not found")]
-    WorkspaceNotFound,
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
     #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
-    #[error("invalid AttributeReadContext: {0}")]
-    BadAttributeReadContext(String),
+
+    #[error("attribute value not found for context: {0:?}")]
+    AttributeValueNotFoundForContext(AttributeReadContext),
+    #[error("unable to delete frame due to attached components")]
+    FrameHasAttachedComponents,
+    #[error("component marked as protected: {0}")]
+    ComponentProtected(ComponentId),
+    #[error("invalid context(s) provided for diff")]
+    InvalidContextForDiff,
+    #[error("invalid func backend kind (0:?) for checking validations (need validation kind)")]
+    InvalidFuncBackendKindForValidations(FuncBackendKind),
+    #[error("attribute value does not have a prototype: {0}")]
+    MissingAttributePrototype(AttributeValueId),
+    #[error("node not found for component: {0}")]
+    NodeNotFoundForComponent(ComponentId),
+    #[error("attribute prototype does not have a function: {0}")]
+    MissingAttributePrototypeFunction(AttributePrototypeId),
+    #[error("/root/si/name is unset for component {0}")]
+    NameIsUnset(ComponentId),
+    #[error("component not found: {0}")]
+    NotFound(ComponentId),
+    #[error("no schema variant for component {0}")]
+    NoSchemaVariant(ComponentId),
+    #[error("no schema for component {0}")]
+    NoSchema(ComponentId),
+    #[error("func binding return value: {0} not found")]
+    FuncBindingReturnValueNotFound(FuncBindingReturnValueId),
     #[error("found child attribute value of a map without a key: {0}")]
     FoundMapEntryWithoutKey(AttributeValueId),
     #[error("schema variant has not been finalized at least once: {0}")]
@@ -185,6 +154,8 @@ pub enum ComponentError {
     CannotUpdateResourceTreeInChangeSet,
     #[error("no func binding return value for leaf entry name: {0}")]
     MissingFuncBindingReturnValueIdForLeafEntryName(String),
+    #[error("confirmation view error: {0}")]
+    ConfirmationView(String),
 
     /// Found an [`AttributePrototypeArgumentError`](crate::AttributePrototypeArgumentError).
     #[error("attribute prototype argument error: {0}")]
@@ -192,6 +163,7 @@ pub enum ComponentError {
     /// Found an [`ExternalProviderError`](crate::ExternalProviderError).
     #[error("external provider error: {0}")]
     ExternalProvider(#[from] ExternalProviderError),
+
     /// A parent [`AttributeValue`](crate::AttributeValue) was not found for the specified
     /// [`AttributeValueId`](crate::AttributeValue).
     #[error("parent attribute value not found for attribute value: {0}")]

--- a/lib/dal/src/component/confirmation/view.rs
+++ b/lib/dal/src/component/confirmation/view.rs
@@ -1,0 +1,456 @@
+//! This module contains [`ConfirmationView`] and everything related to it (including the ability
+//! to assemble [`views`](ConfirmationView).
+
+#![warn(missing_docs, clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::action_prototype::ActionKind;
+use crate::component::confirmation::{ConfirmationEntry, ConfirmationMetadataCache};
+use crate::{
+    ActionPrototype, ActionPrototypeError, AttributeValueId, ComponentError, DalContext, Fix,
+    FixResolver, FixResolverError, FuncBindingReturnValue, FuncBindingReturnValueError,
+    FuncDescription, FuncDescriptionContents, FuncError, SchemaId, SchemaVariantId, StandardModel,
+    StandardModelError,
+};
+use crate::{Component, ComponentId};
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum ConfirmationViewError {
+    #[error("ActionPrototypeError: {0}")]
+    ActionPrototype(#[from] ActionPrototypeError),
+    #[error("ComponentError: {0}")]
+    Component(#[from] ComponentError),
+    #[error("FixResolverError: {0}")]
+    FixResolver(#[from] FixResolverError),
+    #[error("FuncError: {0}")]
+    Func(#[from] FuncError),
+    #[error("FuncBindingReturnValueError: {0}")]
+    FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
+    #[error("StandardModelError: {0}")]
+    StandardModel(#[from] StandardModelError),
+
+    #[error("found conflicting recommendations for component: {0}")]
+    FoundConflictingRecommendationsForComponent(ComponentId),
+    #[error("found conflicting recommendations in confirmation view: {0:?}")]
+    FoundConflictingRecommendationsInConfirmationView(Box<ConfirmationView>),
+    #[error("could not find primary action kind for confirmation views: {0:?}")]
+    CouldNotFindPrimaryActionKindForConfirmationViews(Vec<ConfirmationView>),
+    #[error("could not find primary action kind for recommendations: {0:?}")]
+    CouldNotFindPrimaryActionKindForRecommendations(Vec<Recommendation>),
+}
+
+/// Tracks the primary [`ActionKind`](ActionKind) if the [`ConfirmationView`] or
+/// [`Vec<ConfirmationView>`] has at least one [`Recommendation`]. Otherwise, it tracks that there
+/// is _no_ [`Recommendation`](Recommendation).
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PrimaryActionKind {
+    /// Indicates that the [`ConfirmationView`] or group of [`ConfirmationViews`](ConfirmationView)
+    /// has at least one [`Recommendation`] and what the primary [`ActionKind`] is for it/them.
+    HasRecommendations(ActionKind),
+    /// Indicates that the [`ConfirmationView`] or group of [`ConfirmationViews`](ConfirmationView)
+    /// does not have any [`Recommendations`](Recommendation), which means there cannot be
+    /// a primary [`ActionKind`].
+    NoRecommendations,
+}
+
+/// A [`ConfirmationView`] is the view of a conceptual "confirmation" corresponding to a child
+/// [`AttributeValue`](crate::AttributeValue) of a [`Component`]'s "/root/confirmation" map.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmationView {
+    /// The child [`AttributeValue`](crate::AttributeValue) of a [`Component`]'s
+    /// "/root/confirmation" map.
+    ///
+    /// The [`Func`](crate::Func) corresponding to the [`value`](crate::AttributeValue)'s
+    /// [`AttributePrototype`](crate::AttributePrototype) has a
+    /// [`FuncBackendResponseType`](crate::FuncBackendResponseType) of kind
+    /// [`Confirmation`](crate::FuncBackendResponseType::Confirmation).
+    pub attribute_value_id: AttributeValueId,
+    /// The displayed title of the "confirmation".
+    pub title: String,
+    /// The displayed description of the "confirmation".
+    description: Option<String>,
+
+    /// Indicates the [`Schema`](crate::Schema) that the "confirmation" belongs to.
+    pub schema_id: SchemaId,
+    /// Indicates the [`SchemaVariant`](crate::SchemaVariant) that the "confirmation" belongs to.
+    schema_variant_id: SchemaVariantId,
+    /// Indicates the [`Component`](crate::Component) that the "confirmation" belongs to.
+    pub component_id: ComponentId,
+
+    /// The name of the [`Schema`](crate::Schema).
+    schema_name: String,
+    /// The name of the [`Component`](crate::Component).
+    component_name: String,
+    /// Indicates what "group" the [`Schema`](crate::Schema) belongs to. This is purely cosmetic.
+    pub provider: Option<String>,
+
+    /// The resulting output of the last execution of the "confirmation" [`Func`](crate::Func).
+    output: Option<Vec<String>>,
+    /// The overall status of the "confirmation".
+    pub status: ConfirmationStatus,
+    /// A list of [`Recommendations`](Recommendation) that can be used to run [`Fixes`](crate::Fix).
+    pub recommendations: Vec<Recommendation>,
+}
+
+impl ConfirmationView {
+    /// Assembles [`ConfirmationViews`](ConfirmationView) based on the current status of the
+    /// "/root/confirmation" [`Prop`](crate::Prop) tree for a given [`Component`](crate::Component).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfirmationViewError`] if the [`views`](ConfirmationView) could not be assembled.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn assemble_for_component(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        all_confirmations: &HashMap<String, ConfirmationEntry>,
+        cache: &ConfirmationMetadataCache,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+        running_fixes: &[Fix],
+        schema_name: String,
+    ) -> Result<(Vec<Self>, PrimaryActionKind), ConfirmationViewError> {
+        let mut results = Vec::new();
+        let mut primary_action_kind_tracker: Option<PrimaryActionKind> = None;
+
+        for (confirmation_name, entry) in all_confirmations {
+            let (view, individual_primary_action_kind) = Self::assemble_individual_for_component(
+                ctx,
+                component_id,
+                confirmation_name.clone(),
+                entry,
+                cache,
+                schema_id,
+                schema_variant_id,
+                running_fixes,
+                schema_name.clone(),
+            )
+            .await?;
+
+            // Ensure that the action kind is the same for all confirmation views only if there is
+            // at least one recommendation. If the tracker is unset, we will set it.
+            match primary_action_kind_tracker {
+                Some(initialized_primary_action_kind_tracker) => {
+                    match (
+                        initialized_primary_action_kind_tracker,
+                        individual_primary_action_kind,
+                    ) {
+                        (
+                            PrimaryActionKind::HasRecommendations(all_action_kind),
+                            PrimaryActionKind::HasRecommendations(individual_action_kind),
+                        ) => {
+                            // Only check if we have action kind mismatch if there is at least one
+                            // recommendation.
+                            if all_action_kind != individual_action_kind {
+                                return Err(
+                                    ConfirmationViewError::FoundConflictingRecommendationsInConfirmationView(Box::new(view)),
+                                );
+                            }
+                        }
+                        (
+                            PrimaryActionKind::NoRecommendations,
+                            PrimaryActionKind::HasRecommendations(_),
+                        ) => {
+                            // If our tracker was originally set to "NoRecommendations", then we
+                            // will need to override it with the first "ActionKind" found.
+                            primary_action_kind_tracker = Some(individual_primary_action_kind)
+                        }
+                        _ => {}
+                    }
+                }
+                None => {
+                    // Initialize the tracker with the first primary action kind seen.
+                    primary_action_kind_tracker = Some(individual_primary_action_kind)
+                }
+            }
+
+            results.push(view);
+        }
+
+        let all_primary_action_kind = match primary_action_kind_tracker {
+            Some(kind) => kind,
+            None if all_confirmations.is_empty() => PrimaryActionKind::NoRecommendations,
+            None => {
+                return Err(
+                    ConfirmationViewError::CouldNotFindPrimaryActionKindForConfirmationViews(
+                        results.clone(),
+                    ),
+                );
+            }
+        };
+
+        Ok((results, all_primary_action_kind))
+    }
+
+    /// This _private_ method assembles an individual [`ConfirmationView`] based on an individual
+    /// [`ConfirmationEntry`] for a given [`Component`](crate::Component). It should only be called
+    /// by [`Self::assemble_for_component`].
+    #[allow(clippy::too_many_arguments)]
+    async fn assemble_individual_for_component(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        confirmation_name: String,
+        entry: &ConfirmationEntry,
+        cache: &ConfirmationMetadataCache,
+        schema_id: SchemaId,
+        schema_variant_id: SchemaVariantId,
+        running_fixes: &[Fix],
+        schema_name: String,
+    ) -> Result<(Self, PrimaryActionKind), ConfirmationViewError> {
+        let (found_func_binding_return_value_id, found_attribute_value_id, found_func_id) =
+            cache.get(&confirmation_name).ok_or_else(|| {
+                ComponentError::MissingFuncBindingReturnValueIdForLeafEntryName(
+                    confirmation_name.clone(),
+                )
+            })?;
+
+        // Collect the output from the func binding return value.
+        let mut output = Vec::new();
+        if let Some(func_binding_return_value) =
+            FuncBindingReturnValue::get_by_id(ctx, found_func_binding_return_value_id).await?
+        {
+            if let Some(output_streams) = func_binding_return_value.get_output_stream(ctx).await? {
+                for output_stream in output_streams {
+                    output.push(output_stream.message);
+                }
+            }
+        }
+
+        // Determine the status based on the entry's current value.
+        let confirmation_status = match entry.success {
+            Some(true) => ConfirmationStatus::Success,
+            Some(false) => ConfirmationStatus::Failure,
+            None => {
+                // FIXME(nick,paulo,paul,wendy): in the past, the "None" state represented a
+                // running confirmation in order to prevent race conditions. We may or may not
+                // continue this behavior moving forward... we will ponder on this.
+                ConfirmationStatus::NeverStarted
+            }
+        };
+
+        // Dynamically determine the description based on the status.
+        let (description, maybe_title, maybe_provider) =
+            match FuncDescription::find_for_func_and_schema_variant(
+                ctx,
+                *found_func_id,
+                schema_variant_id,
+            )
+            .await?
+            {
+                Some(description) => match description.deserialized_contents()? {
+                    FuncDescriptionContents::Confirmation {
+                        success_description,
+                        failure_description,
+                        name,
+                        provider,
+                    } => match confirmation_status {
+                        ConfirmationStatus::Success => (success_description, Some(name), provider),
+                        ConfirmationStatus::Failure => (failure_description, Some(name), provider),
+                        _ => (None, Some(name), provider),
+                    },
+                },
+                None => (None, None, None),
+            };
+
+        let fix_resolver =
+            FixResolver::find_for_confirmation_attribute_value(ctx, *found_attribute_value_id)
+                .await?;
+
+        // Gather all the action prototypes from the recommended actions raw strings. We'll also
+        // keep track of the primary action kind, which will be "None" if there are no
+        // recommendations.
+        let mut recommendations = Vec::new();
+        let mut maybe_primary_action_kind: Option<ActionKind> = None;
+
+        for action in &entry.recommended_actions {
+            let action_prototype =
+                ActionPrototype::find_by_name(ctx, action, schema_id, schema_variant_id)
+                    .await?
+                    .ok_or_else(|| ActionPrototypeError::NotFoundByName(action.clone()))?;
+
+            // Check if a fix is running before gathering the last recorded status of the
+            // recommendation and the ability to run the recommendation.
+            let is_running = confirmation_status == ConfirmationStatus::Running
+                || running_fixes.iter().any(|r| {
+                    r.component_id() == component_id && r.action() == action_prototype.name()
+                });
+
+            // Track the last recorded status of the recommendation.
+            let recommendation_status = if is_running {
+                RecommendationStatus::Running
+            } else {
+                match fix_resolver.as_ref().and_then(FixResolver::success) {
+                    Some(true) => RecommendationStatus::Success,
+                    Some(false) => RecommendationStatus::Failure,
+                    None => RecommendationStatus::Unstarted,
+                }
+            };
+
+            // Track the ability to run the recommendation.
+            // TODO(nick): we do not need an enum here since "running" will be accurate for the
+            // "is_running" boolean. We should consider replacing the enum with a boolean.
+            let recommendation_is_runnable = if is_running {
+                RecommendationIsRunnable::Running
+            } else {
+                let resource = Component::resource_by_id(ctx, component_id).await?;
+                match (action_prototype.kind(), resource.value) {
+                    (ActionKind::Create, Some(_)) => RecommendationIsRunnable::No,
+                    (ActionKind::Create, None) => RecommendationIsRunnable::Yes,
+                    (ActionKind::Other, Some(_)) => RecommendationIsRunnable::Yes,
+                    (ActionKind::Other, None) => RecommendationIsRunnable::No,
+                    (ActionKind::Destroy, Some(_)) => RecommendationIsRunnable::Yes,
+                    (ActionKind::Destroy, None) => RecommendationIsRunnable::No,
+                }
+            };
+
+            let workflow_prototype = action_prototype.workflow_prototype(ctx).await?;
+            let recommendation_action_kind = action_prototype.kind().to_owned();
+
+            // Ensure that the action kind is the same for all recommendations. If it is unset, we
+            // will set it.
+            if let Some(kind) = maybe_primary_action_kind {
+                if kind != recommendation_action_kind {
+                    return Err(
+                        ConfirmationViewError::FoundConflictingRecommendationsForComponent(
+                            component_id,
+                        ),
+                    );
+                }
+            } else {
+                maybe_primary_action_kind = Some(recommendation_action_kind);
+            }
+
+            recommendations.push(Recommendation {
+                confirmation_attribute_value_id: *found_attribute_value_id,
+                component_id,
+                component_name: Component::find_name(ctx, component_id).await?,
+                provider: maybe_provider.clone(),
+                name: workflow_prototype.title().to_owned(),
+                recommended_action: action_prototype.name().to_owned(),
+                action_kind: recommendation_action_kind,
+                status: recommendation_status,
+                is_runnable: recommendation_is_runnable,
+            });
+        }
+
+        // Find the primary action kind.
+        let primary_action_kind = match maybe_primary_action_kind {
+            Some(kind) => PrimaryActionKind::HasRecommendations(kind),
+            None if recommendations.is_empty() => PrimaryActionKind::NoRecommendations,
+            None => {
+                return Err(
+                    ConfirmationViewError::CouldNotFindPrimaryActionKindForRecommendations(
+                        recommendations.clone(),
+                    ),
+                );
+            }
+        };
+
+        // Assemble the view.
+        let view = ConfirmationView {
+            attribute_value_id: *found_attribute_value_id,
+            title: match maybe_title {
+                Some(title) => title,
+                None => confirmation_name,
+            },
+            component_id,
+            schema_variant_id,
+            schema_id,
+            schema_name: schema_name.clone(),
+            component_name: Component::find_name(ctx, component_id).await?,
+            description,
+            output: Some(output.clone()).filter(|o| !o.is_empty()),
+            recommendations,
+            status: confirmation_status,
+            provider: maybe_provider,
+        };
+
+        Ok((view, primary_action_kind))
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfirmationStatus {
+    Running,
+    Failure,
+    Success,
+    // FIXME(nick,paulo,paul,wendy): probably remove this once the fix flow is working again.
+    NeverStarted,
+}
+
+// TODO(nick,paulo,paul,wendy): yes, the fields for the "Recommendation" struct are technically
+// already on the confirmation itself and we could just map the recommendations back to the
+// confirmations in the frontend, but we want shit to work again before optimizing. Fix the fix
+// flow!
+
+/// A [`Recommendation`] is assembled the result of a "confirmation" and enables users to run
+/// [`Fix(es)`](crate::Fix) for a given [`Component`](crate::Component).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Recommendation {
+    /// The child [`AttributeValue`](crate::AttributeValue) of a [`Component`]'s
+    /// "/root/confirmation" map.
+    ///
+    /// The [`Func`](crate::Func) corresponding to the [`value`](crate::AttributeValue)'s
+    /// [`AttributePrototype`](crate::AttributePrototype) has a
+    /// [`FuncBackendResponseType`](crate::FuncBackendResponseType) of kind
+    /// [`Confirmation`](crate::FuncBackendResponseType::Confirmation).
+    pub confirmation_attribute_value_id: AttributeValueId,
+    /// Indicates the [`Component`](crate::Component) that the "confirmation" belongs to.
+    pub component_id: ComponentId,
+    component_name: String,
+    provider: Option<String>,
+
+    /// The title of a [recommendation](Self). An example: "Create EC2 Instance".
+    name: String,
+    /// Maps to the name of an [`ActionPrototype`](crate::ActionPrototype). An example: "create".
+    pub recommended_action: String,
+    /// The [`kind`](crate::action_prototype::ActionKind) of
+    /// [`ActionPrototype`](crate::ActionPrototype) that the recommended
+    /// [action](crate::ActionPrototype) corresponds to.
+    action_kind: ActionKind,
+    /// The last recorded [`status`](RecommendationStatus) of the [recommendation](Self).
+    pub status: RecommendationStatus,
+    /// Indicates the ability to "run" the [`Fix`](crate::Fix) associated with the
+    /// [recommendation](Self).
+    pub is_runnable: RecommendationIsRunnable,
+}
+
+/// Tracks the last known status of a [`Recommendation`] (corresponds to the
+/// [`FixResolver`](crate::FixResolver)).
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RecommendationStatus {
+    /// The last execution of the [`Recommendation`] succeeded.
+    Success,
+    /// The last execution of the [`Recommendation`] failed.
+    Failure,
+    /// The last execution of the [`Recommendation`] is still running.
+    Running,
+    /// The [`Recommendation`] has never been ran.
+    Unstarted,
+}
+
+/// Tracks the ability to run a [`Recommendation`] (corresponds to the state of "/root/resource"
+/// and the [`ActionKind`](crate::action_prototype::ActionKind) on the corresponding
+/// [`ActionPrototype`](crate::ActionPrototype).
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RecommendationIsRunnable {
+    /// The [`Recommendation`] is ready to be ran.
+    Yes,
+    /// The [`Recommendation`] is not ready to be ran.
+    No,
+    /// There is a [`Fix`](crate::Fix) in-flight that prevents the [`Recommendation`] from being
+    /// able to be ran.
+    Running,
+}

--- a/lib/dal/tests/integration_test/action_prototype.rs
+++ b/lib/dal/tests/integration_test/action_prototype.rs
@@ -12,7 +12,7 @@ async fn new(ctx: &DalContext) {
         ctx,
         WorkflowPrototypeId::NONE,
         name,
-        ActionKind::Other,
+        ActionKind::Create,
         context,
     )
     .await

--- a/lib/dal/tests/integration_test/fix.rs
+++ b/lib/dal/tests/integration_test/fix.rs
@@ -199,7 +199,7 @@ async fn setup_confirmation_resolver_and_get_action_prototype(
         ctx,
         *workflow_prototype.id(),
         name,
-        ActionKind::Other,
+        ActionKind::Create,
         context,
     )
     .await

--- a/lib/dal/tests/integration_test/graph.rs
+++ b/lib/dal/tests/integration_test/graph.rs
@@ -12,6 +12,10 @@ use dal_test::helpers::setup_identity_func;
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
+/// Recommendation: run this test with the following environment variable:
+/// ```shell
+/// SI_TEST_BUILTIN_SCHEMAS=none
+/// ```
 #[test]
 async fn topologically_ish_sorted_configuration_nodes(ctx: &DalContext) {
     let constructor = ConfigurationGraphConstructor::new(ctx).await;

--- a/lib/sdf-server/src/server/service/fix/confirmations.rs
+++ b/lib/sdf-server/src/server/service/fix/confirmations.rs
@@ -1,5 +1,5 @@
 use axum::{extract::Query, Json};
-use dal::component::confirmation::ConfirmationView as DalConfirmationView;
+use dal::component::confirmation::view::ConfirmationView as DalConfirmationView;
 use dal::{Component, Visibility};
 use serde::{Deserialize, Serialize};
 

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -6,12 +6,13 @@ mod model_and_fix_flow_aws_key_pair;
 mod model_and_fix_flow_whiskers;
 mod model_flow_fedora_coreos_ignition;
 
-use axum::{http::Method, Router};
+use axum::http::Method;
+use axum::Router;
+use dal::component::confirmation::view::ConfirmationView;
 use dal::{
-    component::confirmation::ConfirmationView, property_editor::values::PropertyEditorValue,
-    socket::SocketEdgeKind, AttributeValue, AttributeValueId, ComponentId, ComponentView,
-    ComponentViewProperties, DalContext, FixBatchId, NodeId, Prop, PropKind, Schema, SchemaId,
-    Socket, StandardModel, Visibility,
+    property_editor::values::PropertyEditorValue, socket::SocketEdgeKind, AttributeValue,
+    AttributeValueId, ComponentId, ComponentView, ComponentViewProperties, DalContext, FixBatchId,
+    NodeId, Prop, PropKind, Schema, SchemaId, Socket, StandardModel, Visibility,
 };
 use sdf_server::service::{
     change_set::{

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
@@ -1,4 +1,4 @@
-use dal::component::confirmation::ConfirmationStatus;
+use dal::component::confirmation::view::ConfirmationStatus;
 use dal::qualification::QualificationSubCheckStatus;
 use dal::{Component, DalContext, FixBatchId, FixCompletionStatus};
 use dal_test::test;


### PR DESCRIPTION
## Description

This PR introduces two bug fixes:

1. Ensure the order of recommendations (specifically "deletion" ones) is correct
2. Ensure `ConfirmationViews` are not created for `Components` that do not have "confirmations"

This PR also introduces slight refactors due to the increasingly complexity of the "confirmations" and "fix flow" paradigms, including a new submodule underneath the "confirmation" submodule.

## Commit Description

```
Primary:
- Add and track the "PrimaryActionKind" for set of ConfirmationViews for
  a given Component
- Sort all ConfirmationViews in the workspace by "PrimaryActionKind",
  which ensures the correct deletion order for nodes is in place
- Ensure ConfirmationViews aren't generated for Components that do not
  have confirmations

Secondary:
- Re-add "deletion" scenario to the "list_confirmations" integration
  test
- Replace integration test usages of "ActionKind::Other" with
  "ActionKind::Create" where appropriate

Misc:
- Delete unused ComponentError variants and re-order the remaining
  variants
- Fix clippy lint in config-file
- Ensure ChangeStatus can be copied
```

## GIF

<img src="https://media0.giphy.com/media/3o6nV8TW8AZOqkOHVm/giphy.gif"/>