### PR TITLE
fix(dal): ChangeStatus should check component visibility

### DIFF
--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -7,9 +7,8 @@ use crate::diagram::DiagramResult;
 use crate::schema::SchemaUiMenu;
 use crate::socket::{SocketArity, SocketEdgeKind};
 use crate::{
-    history_event, ActorView, ChangeSetPk, Component, ComponentId, ComponentStatus, ComponentType,
-    DalContext, DiagramError, HistoryActorTimestamp, Node, NodeId, ResourceView, SchemaVariant,
-    StandardModel,
+    history_event, ActorView, Component, ComponentId, ComponentStatus, ComponentType, DalContext,
+    DiagramError, HistoryActorTimestamp, Node, NodeId, ResourceView, SchemaVariant, StandardModel,
 };
 
 #[derive(
@@ -195,9 +194,11 @@ impl DiagramComponentView {
         let x = node.x().parse::<f64>()?;
         let y = node.y().parse::<f64>()?;
 
-        let change_status = if node.visibility().deleted_at.is_some() {
+        // Change status should track the component, not the node, since node position is on the
+        // node and the node will change if it is moved
+        let change_status = if component.visibility().deleted_at.is_some() {
             ChangeStatus::Deleted
-        } else if node.visibility().change_set_pk != ChangeSetPk::NONE {
+        } else if !component.exists_in_head(ctx).await? {
             ChangeStatus::Added
         } else if is_modified {
             ChangeStatus::Modified

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -796,6 +796,18 @@ pub trait StandardModel {
 
         Ok(obj)
     }
+
+    #[instrument(skip_all)]
+    async fn exists_in_head(&self, ctx: &DalContext) -> StandardModelResult<bool>
+    where
+        Self: Send + Sync + Sized + Serialize + DeserializeOwned,
+    {
+        let head_ctx = ctx.clone_with_new_visibility(Visibility::new_head(false));
+        let obj: Option<Self> =
+            crate::standard_model::get_by_id(&head_ctx, Self::table_name(), self.id()).await?;
+
+        Ok(obj.is_some())
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
Since nodes have position on them, if they're moved they'll clone into the current change set and break the change status. So we should check the component, not the node itself. 

The diagram node status could be reworked into a single query that includes this change, but for now we need to add a lookup with a head visibility to `DiagramComponentView` to confirm additions.