### PR TITLE
chore(ci): improve build/test/run speed of Rust/Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ COMPONENTS = \
 	bin/pinga \
 	bin/council \
 	bin/sdf \
-	bin/si-discord-bot \
 	bin/veritech \
 	lib/council \
 	lib/bytes-lines-codec \
@@ -70,6 +69,11 @@ COMPONENTS = \
 	lib/veritech-client \
 	lib/veritech-core \
 	lib/veritech-server
+
+# TODO(fnichol): si-discord-bot fails to build and is not a pnpm workspace
+# member. We need to restore clean building of this component, this this entry
+# should be re-inserted into $COMPONENTS above
+#	bin/si-discord-bot \
 
 RELEASEABLE_COMPONENTS = \
 	app/web \


### PR DESCRIPTION
This change slightly alters the how each Rust workspace member's Make targets are handled in a way that can greatly improve the time-to-run timing and reduces re-work through re-compilation.

The key difference is that we try to run each Cargo subcommand from the workspace root directory and reference the workspace member by its "pkgid" which is a specification for referring to a crate dependency and/or workspace member. This runs these Cargo commands from the workspace root and not in the member's sub-directory, meaning that all members' compiled caches are taken into account.

As an example running the `make build` in a crate like `lib/dal` ran the follow prior to this change:

```
cargo build
```

Now, roughly the following is ran instead:

```
cd $WORKSPACE_ROOT
carg build --package file:///path/to/systeminit/si/lib/dal#0.1.0
```

where `$WORKSPACE_ROOT` would be `/path/to/systeminit/si` in this example.

You will see that changing directories to build various crates will no longer perform more rebuilding of crates and rather use the already compiled versions.

The root Makefile targets call exactly the same Make targets in the component subdirectories so no-one's developer workflow needs to change (as well as nothing in the CI workflow needs to change). Instead, we all benefit from the speed increase.

Note that this is very similar trick to the `pnpm run dev:backend` workflow where the entire Cargo workspace is built together from the workspace root. In fact, there should be little to no rebuilding even if a developer was using both the pnpm and Make workflows at the same time.

<img src="https://media2.giphy.com/media/l3fQcpYNXvn1DmUy4/giphy.gif"/>