### PR TITLE
chore(nix): Require pkgs.darwin.apple_sdk.frameworks.Security on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,10 @@
             nodePackages.typescript
             nodePackages.typescript-language-server
 
-          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
+	    libiconv
+	    pkgs.darwin.apple_sdk.frameworks.Security
+	  ]);
         };
       });
     };


### PR DESCRIPTION
Without this flake, we get the following linker error on macOS when trying to build `veritech-cli`: `ld: framework not found Security`.