### PR TITLE
fix(web): Make deletion indication for frame work correctly

### DIFF
--- a/app/web/src/components/GenericDiagram/DiagramGroup.vue
+++ b/app/web/src/components/GenericDiagram/DiagramGroup.vue
@@ -5,6 +5,7 @@
       id: group.uniqueKey,
       x: position.x,
       y: position.y,
+      ...(isDeleted && { opacity: 0.5 }),
     }"
     @mouseover="onMouseOver"
     @mouseout="onMouseOut"
@@ -192,36 +193,6 @@
         }"
       />
     </v-group>
-
-    <!--  spinner overlay  -->
-    <v-group
-      ref="overlay"
-      :config="{
-        x: -halfWidth,
-        y: 0,
-        opacity: 0,
-        listening: false,
-      }"
-    >
-      <!--  transparent overlay  -->
-      <v-rect
-        :config="{
-          width: nodeWidth,
-          height: nodeBodyHeight,
-          x: 0,
-          y: 0,
-          cornerRadius: [0, 0, CORNER_RADIUS, CORNER_RADIUS],
-          fill: 'rgba(255,255,255,0.70)',
-        }"
-      />
-      <DiagramIcon
-        icon="loader"
-        :color="diagramConfig?.toneColors?.['info'] || '#AAA'"
-        :size="overlayIconSize"
-        :x="halfWidth"
-        :y="nodeBodyHeight / 2"
-      />
-    </v-group>
   </v-group>
 </template>
 
@@ -329,8 +300,6 @@ const connectedEdgesBySocketKey = computed(() => {
   return lookup;
 });
 
-const overlayIconSize = computed(() => nodeWidth.value / 3);
-
 const headerTextHeight = ref(20);
 watch(
   [nodeWidth, () => props.group.def.title, () => props.group.def.subtitle],
@@ -379,19 +348,7 @@ const colors = computed(() => {
   };
 });
 
-const overlay = ref();
-watch([() => props.group.def.isLoading, overlay], ([isLoading]) => {
-  if (_.isNil(overlay)) return;
-  const node = overlay.value.getNode();
-
-  const transition = new Tween({
-    node,
-    duration: 0.1,
-    opacity: isLoading ? 1 : 0,
-  });
-
-  transition.play();
-});
+const isDeleted = computed(() => props.group?.def.changeStatus === "deleted");
 
 function onMouseOver(evt: KonvaEventObject<MouseEvent>) {
   evt.cancelBubble = true;
@@ -405,9 +362,11 @@ function onResizeHover(
   evt.cancelBubble = true;
   emit("hover:start", { type: "resize", direction });
 }
+
 function onSocketHoverStart(socket: DiagramSocketData) {
   emit("hover:start", { type: "socket", socket });
 }
+
 function onSocketHoverEnd(_socket: DiagramSocketData) {
   emit("hover:end");
 }

--- a/app/web/src/components/GenericDiagram/DiagramGroupOverlay.vue
+++ b/app/web/src/components/GenericDiagram/DiagramGroupOverlay.vue
@@ -1,0 +1,179 @@
+<template>
+  <v-group
+    ref="groupRef"
+    :config="{
+      id: group.uniqueKey,
+      x: position.x,
+      y: position.y,
+      listening: false,
+    }"
+  >
+    <!--  spinner overlay  -->
+    <v-group
+      ref="overlay"
+      :config="{
+        x: -halfWidth,
+        y: 0,
+        opacity: 0,
+        listening: false,
+      }"
+    >
+      <!--  transparent overlay  -->
+      <v-rect
+        :config="{
+          width: nodeWidth,
+          height: nodeBodyHeight,
+          x: 0,
+          y: 0,
+          cornerRadius: [0, 0, CORNER_RADIUS, CORNER_RADIUS],
+          fill: 'rgba(255,255,255,0.70)',
+        }"
+      />
+      <DiagramIcon
+        icon="loader"
+        :color="diagramConfig?.toneColors?.['info'] || '#AAA'"
+        :size="overlayIconSize"
+        :x="halfWidth"
+        :y="nodeBodyHeight / 2"
+      />
+    </v-group>
+
+    <DiagramIcon
+      v-if="isDeleted"
+      icon="x"
+      :color="diagramConfig?.toneColors?.destructive"
+      :size="deletedXSize"
+      :x="0"
+      :y="nodeHeight / 2"
+    />
+  </v-group>
+</template>
+
+<script lang="ts" setup>
+import { computed, nextTick, PropType, ref, watch } from "vue";
+import _ from "lodash";
+import tinycolor from "tinycolor2";
+
+import { KonvaEventObject } from "konva/lib/Node";
+import { Tween } from "konva/lib/Tween";
+import { Vector2d } from "konva/lib/types";
+import { useTheme } from "@/ui-lib/theme_tools";
+import DiagramNodeSocket from "@/components/GenericDiagram/DiagramNodeSocket.vue";
+import {
+  SOCKET_GAP,
+  SOCKET_MARGIN_TOP,
+  CORNER_RADIUS,
+  DEFAULT_NODE_COLOR,
+  DIAGRAM_FONT_FAMILY,
+  SELECTION_COLOR,
+  GROUP_HEADER_BOTTOM_MARGIN,
+  GROUP_TITLE_FONT_SIZE,
+  GROUP_RESIZE_HANDLE_SIZE,
+} from "@/components/GenericDiagram/diagram_constants";
+import {
+  DiagramDrawEdgeState,
+  DiagramEdgeData,
+  DiagramElementUniqueKey,
+  DiagramGroupData,
+  Size2D,
+  SideAndCornerIdentifiers,
+  DiagramSocketData,
+  ElementHoverMeta,
+} from "./diagram_types";
+
+import DiagramIcon from "./DiagramIcon.vue";
+import { useDiagramConfig } from "./utils/use-diagram-context-provider";
+
+const props = defineProps({
+  group: {
+    type: Object as PropType<DiagramGroupData>,
+    required: true,
+  },
+  tempPosition: {
+    type: Object as PropType<Vector2d>,
+  },
+  tempSize: {
+    type: Object as PropType<Size2D>,
+  },
+  isHovered: Boolean,
+  isSelected: Boolean,
+});
+
+const { theme } = useTheme();
+const diagramConfig = useDiagramConfig();
+
+const titleTextRef = ref();
+const groupRef = ref();
+
+const size = computed(
+  () => props.tempSize || props.group.def.size || { width: 500, height: 500 },
+);
+
+const nodeWidth = computed(() => size.value.width);
+const halfWidth = computed(() => nodeWidth.value / 2);
+// TODO(Victor): this is wrong. headerWidth should be the smallest value between the actual text width and nodeWidth
+const headerWidth = computed(() => nodeWidth.value * 0.75);
+
+const overlayIconSize = computed(() => nodeWidth.value / 3);
+
+const headerTextHeight = ref(20);
+watch(
+  [nodeWidth, () => props.group.def.title, () => props.group.def.subtitle],
+  () => {
+    // we have to let the new header be drawn on the canvas before we can check the height
+    nextTick(recalcHeaderHeight);
+  },
+  { immediate: true },
+);
+
+function recalcHeaderHeight() {
+  headerTextHeight.value =
+    titleTextRef.value?.getNode()?.getSelfRect().height || 20;
+}
+
+const nodeHeaderHeight = computed(() => headerTextHeight.value);
+const nodeBodyHeight = computed(() => size.value.height);
+const nodeHeight = computed(
+  () =>
+    nodeHeaderHeight.value + GROUP_HEADER_BOTTOM_MARGIN + nodeBodyHeight.value,
+);
+
+const position = computed(() => props.tempPosition || props.group.def.position);
+
+const colors = computed(() => {
+  const primaryColor = tinycolor(props.group.def.color || DEFAULT_NODE_COLOR);
+  const headerText = primaryColor.isDark() ? "#FFF" : "#000";
+
+  // body bg
+  const bodyBgHsl = primaryColor.toHsl();
+  bodyBgHsl.l = theme.value === "dark" ? 0.08 : 0.95;
+  const bodyBg = tinycolor(bodyBgHsl);
+
+  const bodyText = theme.value === "dark" ? "#FFF" : "#000";
+  return {
+    headerBg: primaryColor.toRgbString(),
+    headerText,
+    bodyBg: bodyBg.toRgbString(),
+    bodyText,
+  };
+});
+
+const isDeleted = computed(() => props.group?.def.changeStatus === "deleted");
+const deletedXSize = computed(() =>
+  Math.min(nodeHeight.value, nodeWidth.value),
+);
+
+const overlay = ref();
+watch([() => props.group.def.isLoading, overlay], ([isLoading]) => {
+  if (_.isNil(overlay)) return;
+  const node = overlay.value.getNode();
+
+  const transition = new Tween({
+    node,
+    duration: 0.1,
+    opacity: isLoading ? 1 : 0,
+  });
+
+  transition.play();
+});
+</script>

--- a/app/web/src/components/GenericDiagram/GenericDiagram.vue
+++ b/app/web/src/components/GenericDiagram/GenericDiagram.vue
@@ -85,6 +85,15 @@ overflow hidden */
           @hover:start="onElementHoverStart(edge)"
           @hover:end="onElementHoverEnd(edge)"
         />
+        <DiagramGroupOverlay
+          v-for="group in groups"
+          :key="group.uniqueKey"
+          :group="group"
+          :temp-position="movedElementPositions[group.uniqueKey]"
+          :temp-size="resizedElementSizes[group.uniqueKey]"
+          @resize="onNodeLayoutOrLocationChange(group)"
+        />
+
         <!-- placeholders for new inserted elements still processing -->
         <template
           v-for="(pendingInsert, pendingInsertId) in pendingInsertedElements"
@@ -158,6 +167,7 @@ import tinycolor from "tinycolor2";
 import { useCustomFontsLoaded } from "@/utils/useFontLoaded";
 import DiagramGroup from "@/components/GenericDiagram/DiagramGroup.vue";
 import { useComponentsStore } from "@/store/components.store";
+import DiagramGroupOverlay from "@/components/GenericDiagram/DiagramGroupOverlay.vue";
 import DiagramGridBackground from "./DiagramGridBackground.vue";
 import {
   DeleteElementsEvent,


### PR DESCRIPTION
<img width="763" alt="image" src="https://user-images.githubusercontent.com/6564471/225694263-5907f719-d2bd-4414-976f-08d98ff191f5.png">

This PR also moved the frame spinner overlay to the new `DiagramGroupOverlay` component, so that it sits on top of the group's children when rendered