### PR TITLE
chore(*): add a full mailmap for every name conflict

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,17 @@
+Adam Jacob <adam@systeminit.com> <adam@stalecoffee.org>
+Adam Jacob <adam@systeminit.com> Adam Jacob <adam@chef.org>
+Adam Jacob <adam@systeminit.com> Adam Jacob <adam@chef.io>
+Paulo Cabral Sanz <paulo@systeminit.com> <paulosanz@poli.ufrj.br>
+Paulo Cabral Sanz <paulo@systeminit.com> Paulo Cabral <paulo@systeminit.com>
+Paulo Cabral Sanz <paulo@systeminit.com> = <paulo@systeminit.com>
 Jacob Helwig <jacob@systeminit.com> <jacob@technosorcery.net>
+Wendy Bujalski <wendy@systeminit.com> <wendydbujalski@gmail.com>
+Wendy Bujalski <wendy@systeminit.com>  wendybujalski <wendydbujalski@gmail.com>
+Wendy Bujalski <wendy@systeminit.com>  wendybujalski <wendy@systeminit.com>
+Alex Ethier <alex@systeminit.com> <51493434+alex-init@users.noreply.github.com>
+Alex Ethier <alex@systeminit.com> <alex@tower3.io>
+Nick Gerace <nick@systeminit.com> <nickagerace@gmail.com>
+Victor Bustamante <victor@systeminit.com> <victorbustamante12@gmail.com>
+Zachary Hamm <zack@systeminit.com> <zsh@imipolexg.org>
+Paul Stack <paul@systeminit.com> stack72 <public@paulstack.co.uk>
+Fletcher Nichol <fletcher@systeminit.com> <fnichol@nichol.ca>


### PR DESCRIPTION
Maps everyone onto their systeminit.com email.

The shortlog produced is now:

  1018  si-bors-ng[bot] <98984439+si-bors-ng[bot]@users.noreply.github.com>
   369  Fletcher Nichol <fletcher@systeminit.com>
   364  Adam Jacob <adam@systeminit.com>
   286  Paulo Cabral Sanz <paulo@systeminit.com>
   264  Nick Gerace <nick@systeminit.com>
   230  Jacob Helwig <jacob@systeminit.com>
   220  Zachary Hamm <zack@systeminit.com>
   213  Wendy Bujalski <wendy@systeminit.com>
   154  Victor Bustamante <victor@systeminit.com>
   105  Alex Ethier <alex@systeminit.com>
    99  Theo Ephraim <theo@systeminit.com>
    66  Paul Stack <paul@systeminit.com>
    23  dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>