### PR TITLE
fix(web): Resizing frames doesn't mess up positioning anymore

### DIFF
--- a/app/web/src/components/GenericDiagram/GenericDiagram.vue
+++ b/app/web/src/components/GenericDiagram/GenericDiagram.vue
@@ -1359,12 +1359,13 @@ function beginResizeElement() {
 }
 function endResizeElement() {
   if (!resizeElement.value) return;
-  const newNodeSize = resizedElementSizes[resizeElement.value.uniqueKey];
+  const size = resizedElementSizes[resizeElement.value.uniqueKey];
+  const position = movedElementPositions[resizeElement.value.uniqueKey];
 
   emit("resize-element", {
     element: resizeElement.value,
-    position: resizeElement.value.def.position,
-    size: newNodeSize,
+    position,
+    size,
     isFinal: true,
   });
 


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/uWcrVUI1JQ8a2dDp09/giphy.gif"/>