### PR TITLE
fix(dal): fix timestamps should be ISO 8601/RFC 3339

### DIFF
--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -304,7 +304,7 @@ impl Fix {
         completion_message: Option<String>,
     ) -> FixResult<()> {
         if self.started_at.is_some() {
-            self.set_finished_at(ctx, Some(Utc::now().to_string()))
+            self.set_finished_at(ctx, Some(Utc::now().to_rfc3339()))
                 .await?;
             self.set_completion_status(ctx, Some(completion_status))
                 .await?;
@@ -324,7 +324,7 @@ impl Fix {
         } else if self.finished_at.is_some() {
             Err(FixError::AlreadyFinished)
         } else {
-            self.set_started_at(ctx, Some(format!("{}", Utc::now())))
+            self.set_started_at(ctx, Some(Utc::now().to_rfc3339()))
                 .await?;
             Ok(())
         }

--- a/lib/dal/src/fix/batch.rs
+++ b/lib/dal/src/fix/batch.rs
@@ -88,7 +88,7 @@ impl FixBatch {
     /// A safe wrapper around setting the finished and completion status columns.
     pub async fn stamp_finished(&mut self, ctx: &DalContext) -> FixResult<FixCompletionStatus> {
         if self.started_at.is_some() {
-            self.set_finished_at(ctx, Some(format!("{}", Utc::now())))
+            self.set_finished_at(ctx, Some(Utc::now().to_rfc3339()))
                 .await?;
 
             // TODO(nick): getting what the batch completion status should be can be a query.
@@ -128,7 +128,7 @@ impl FixBatch {
         } else if self.fixes(ctx).await?.is_empty() {
             Err(FixError::NoFixesInBatch(self.id))
         } else {
-            self.set_started_at(ctx, Some(format!("{}", Utc::now())))
+            self.set_started_at(ctx, Some(Utc::now().to_rfc3339()))
                 .await?;
             Ok(())
         }


### PR DESCRIPTION
Fixes weren't rendering for me because the timestamps could not be parsed. They should be ISO 8601 until we can save an Option<DateTime<Utc>> directly.