### PR TITLE
chore(dal): Small refactor of how we map the region prop to the internal provider

### DIFF
--- a/lib/dal/src/builtins/schema/aws_ami.rs
+++ b/lib/dal/src/builtins/schema/aws_ami.rs
@@ -6,8 +6,8 @@ use crate::{
     schema::variant::leaves::{LeafInput, LeafInputLocation, LeafKind},
     socket::SocketArity,
     validation::Validation,
-    AttributePrototypeArgument, AttributeReadContext, AttributeValue, BuiltinsResult, DalContext,
-    ExternalProvider, InternalProvider, PropKind, SchemaVariant, StandardModel,
+    AttributePrototypeArgument, BuiltinsResult, DalContext, ExternalProvider, InternalProvider,
+    PropKind, SchemaVariant, StandardModel,
 };
 
 // Documentation URL(s)
@@ -170,26 +170,12 @@ impl MigrationDriver {
         )
         .await?;
 
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/aws_ec2_instance.rs
+++ b/lib/dal/src/builtins/schema/aws_ec2_instance.rs
@@ -303,10 +303,10 @@ impl MigrationDriver {
                 identity_func_item.func_id,
                 identity_func_item.func_binding_id,
                 identity_func_item.func_binding_return_value_id,
-                SocketArity::Many,
+                SocketArity::One,
                 false,
             )
-            .await?; // TODO(wendy) - Can an EC2 instance have multiple regions? Idk!
+            .await?;
 
         // Qualifications
         let qualification_func_name = "si:qualificationEc2CanRun";
@@ -416,26 +416,12 @@ impl MigrationDriver {
         .await?;
 
         // Connect props to providers.
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/aws_egress.rs
+++ b/lib/dal/src/builtins/schema/aws_egress.rs
@@ -330,26 +330,12 @@ impl MigrationDriver {
         .await?;
 
         // region from input socket
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 
@@ -440,7 +426,7 @@ impl MigrationDriver {
                 provider: Some("AWS".to_string()),
             },
         )
-        .await?;
+            .await?;
 
         let name = "create";
         let context = ActionPrototypeContext {

--- a/lib/dal/src/builtins/schema/aws_eip.rs
+++ b/lib/dal/src/builtins/schema/aws_eip.rs
@@ -257,26 +257,12 @@ impl MigrationDriver {
         .await?;
 
         // Connect the "region" prop to the "Region" explicit internal provider.
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/aws_ingress.rs
+++ b/lib/dal/src/builtins/schema/aws_ingress.rs
@@ -429,26 +429,12 @@ impl MigrationDriver {
         .await?;
 
         // region from input socket
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/aws_keypair.rs
+++ b/lib/dal/src/builtins/schema/aws_keypair.rs
@@ -318,26 +318,12 @@ impl MigrationDriver {
         .await?;
 
         // Connect the "region" prop to the "Region" explicit internal provider.
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/aws_security_group.rs
+++ b/lib/dal/src/builtins/schema/aws_security_group.rs
@@ -348,26 +348,12 @@ impl MigrationDriver {
         .await?;
 
         // region from input socket
-        let region_attribute_value_read_context =
-            AttributeReadContext::default_with_prop(*region_prop.id());
-        let region_attribute_value =
-            AttributeValue::find_for_context(ctx, region_attribute_value_read_context)
-                .await?
-                .ok_or(BuiltinsError::AttributeValueNotFoundForContext(
-                    region_attribute_value_read_context,
-                ))?;
-        let mut region_attribute_prototype = region_attribute_value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(BuiltinsError::MissingAttributePrototypeForAttributeValue)?;
-        region_attribute_prototype
-            .set_func_id(ctx, identity_func_item.func_id)
-            .await?;
-        AttributePrototypeArgument::new_for_intra_component(
+        self.link_region_prop_to_explicit_internal_provider(
             ctx,
-            *region_attribute_prototype.id(),
+            region_prop.id(),
+            identity_func_item.func_id,
             identity_func_item.func_argument_id,
-            *region_explicit_internal_provider.id(),
+            region_explicit_internal_provider.id(),
         )
         .await?;
 

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -128,7 +128,7 @@ async fn create_delete_and_restore_edges(ctx: &DalContext) {
             s.edge_kind() == &SocketEdgeKind::ConfigurationInput
                 && s.kind() == &SocketKind::Provider
                 && s.diagram_kind() == &DiagramKind::Configuration
-                && s.arity() == &SocketArity::Many
+                && s.arity() == &SocketArity::One
                 && s.name() == "Region"
         })
         .expect("cannot find input socket");


### PR DESCRIPTION
We have a tonne of duplicate code in the AWS Schema - every single
resource will need a region input so this makes it easier
