### PR TITLE
Ensure topologically sorted nodes are stable-y ordered (ENG-1193)

### DIFF
--- a/lib/dal/src/component/confirmation.rs
+++ b/lib/dal/src/component/confirmation.rs
@@ -82,7 +82,8 @@ impl Component {
     // TODO(nick): big query potential here.
     pub async fn list_confirmations(ctx: &DalContext) -> ComponentResult<Vec<ConfirmationView>> {
         let sorted_node_ids =
-            Node::list_topologically_ish_sorted_configuration_nodes(ctx, false).await?;
+            Node::list_topologically_sorted_configuration_nodes_with_stable_ordering(ctx, false)
+                .await?;
 
         // Go through all sorted nodes, assemble confirmations and order them by primary action
         // kind.
@@ -126,7 +127,7 @@ impl Component {
 
         // We need to invert the order of the delete results before we create the final results.
         // The final results are in the following order: destroy, create, other and "no
-        // recommendations" based on a topological-ish sort of the nodes.
+        // recommendations" based on a topological sort of the nodes.
         let mut results = Vec::new();
         delete_results.reverse();
         results.extend(delete_results);

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -152,7 +152,7 @@ impl Diagram {
             }
         }
 
-        let nodes = Node::list_live(ctx_with_deleted).await?;
+        let nodes = Node::list_live(ctx_with_deleted, NodeKind::Configuration).await?;
 
         let mut component_views = Vec::with_capacity(nodes.len());
         for node in &nodes {

--- a/lib/dal/src/queries/node/list_connected_for_kind.sql
+++ b/lib/dal/src/queries/node/list_connected_for_kind.sql
@@ -1,7 +1,0 @@
-SELECT nodes.id AS node_id
-FROM nodes_v1($1, $2) as nodes
-         LEFT JOIN edges_v1($1, $2) as edges
-                   ON edges.head_node_id = nodes.id
-                       OR edges.tail_node_id = nodes.id
-WHERE nodes.kind = $3
-  AND (edges.tail_node_id = nodes.id OR edges.head_node_id = nodes.id)

--- a/lib/dal/src/queries/node/list_for_kind.sql
+++ b/lib/dal/src/queries/node/list_for_kind.sql
@@ -1,3 +1,0 @@
-SELECT nodes.id AS node_id
-FROM nodes_v1($1, $2) as nodes
-WHERE nodes.kind = $3;

--- a/lib/dal/src/queries/node/list_live.sql
+++ b/lib/dal/src/queries/node/list_live.sql
@@ -1,14 +1,17 @@
 SELECT row_to_json(nodes.*) AS object
 FROM nodes_v1($1, $2) AS nodes
-INNER JOIN node_belongs_to_component_v1($1, $2) AS bt ON bt.object_id = nodes.id
-INNER JOIN components_v1($1, $2) AS components ON components.id = bt.belongs_to_id
-WHERE (components.needs_destroy AND ($2 ->> 'visibility_change_set_pk')::ident = ident_nil_v1())
-      OR nodes.visibility_deleted_at IS NULL
+         INNER JOIN node_belongs_to_component_v1($1, $2) AS bt ON bt.object_id = nodes.id
+         INNER JOIN components_v1($1, $2) AS components ON components.id = bt.belongs_to_id
+WHERE ((components.needs_destroy AND ($2 ->> 'visibility_change_set_pk')::ident = ident_nil_v1())
+    OR nodes.visibility_deleted_at IS NULL)
+  AND nodes.kind = $3
+
 UNION ALL
+
 SELECT row_to_json(nodes.*) AS object
 FROM nodes_v1($1, $2) as nodes
-INNER JOIN node_belongs_to_component_v1($1, $2) AS bt ON bt.object_id = nodes.id
-INNER JOIN components_v1($1, $2) AS components ON components.id = bt.belongs_to_id
+         INNER JOIN node_belongs_to_component_v1($1, $2) AS bt ON bt.object_id = nodes.id
+         INNER JOIN components_v1($1, $2) AS components ON components.id = bt.belongs_to_id
 WHERE nodes.id IN (SELECT id
                    FROM nodes
                    WHERE visibility_change_set_pk = ident_nil_v1()
@@ -16,6 +19,8 @@ WHERE nodes.id IN (SELECT id
                      AND visibility_deleted_at IS NULL
                      AND in_tenancy_v1($1, tenancy_workspace_pk))
   AND NOT (components.needs_destroy AND ($2 ->> 'visibility_change_set_pk')::ident = ident_nil_v1())
+  AND nodes.kind = $3
   AND nodes.visibility_change_set_pk = ($2 ->> 'visibility_change_set_pk')::ident
   AND nodes.visibility_deleted_at IS NOT NULL
   AND in_tenancy_v1($1, nodes.tenancy_workspace_pk)
+


### PR DESCRIPTION
Primary:
- Ensure topologically sorted nodes are stable-y ordered regardless of
  node and edge creation order
- Refactor existing topological sort test to check for stable ordering

Secondary:
- Add second test to verify that the sort works with unordered creation
  logic for nodes and edges (i.e. not one specific creation order)
- Remove unused node queries

Misc:
- Rename payload to bag within integration test for topological sort

<img src="https://media4.giphy.com/media/PrGQsOzB9VyPS/giphy.gif"/>