### PR TITLE
chore: use posthog proxy for e.systeminit.com

### DIFF
--- a/app/web/.env
+++ b/app/web/.env
@@ -23,4 +23,4 @@ DEV_API_PROXY_URL=http://127.0.0.1:5156
 
 # POSTHOG ENV VARS (default is Dev)
 VITE_POSTHOG_PUBLIC_KEY=phc_SoQak5PP054RdTumd69bOz7JhM0ekkxxTXEQsbn3Zg9
-VITE_POSTHOG_API_HOST=https://app.posthog.com
+VITE_POSTHOG_API_HOST=https://e.systeminit.com


### PR DESCRIPTION
Updates the proxy url to be a cloudfront hosted `e.systeminit.com`, which should help avoid some tracking blocking software.