### PR TITLE
Ensure deleted nodes are available for confirmations (ENG-1225,ENG-1226,ENG-1210)

### DIFF
--- a/lib/dal/src/queries/node/list_for_kind.sql
+++ b/lib/dal/src/queries/node/list_for_kind.sql
@@ -1,0 +1,3 @@
+SELECT nodes.id AS node_id
+FROM nodes_v1($1, $2) as nodes
+WHERE nodes.kind = $3;


### PR DESCRIPTION
- Ensure deleted nodes are available when assembling confirmations
  - This was caused by PR #1909 because the "list_live" query did not work as intended (i.e. recommendations were empty in the frontend because the nodes list was empty)
- Ensure FixHistoryView assembly works with deleted components
  - This was uncovered by fixing the titularly mentioned bug: failed deletion fixes would caused subsequent "/fix/confirmations" route calls to fail because assembling the FixHistoryView would encounter deleted components (i.e. the DalContext was too narrowly scoped)