### PR TITLE
chore(pg) Temporarily remove pganalyze from the PG container setup

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -22,7 +22,6 @@ partial-pganalyze: init-partial
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
-			-f $(MAKEPATH)/docker-compose.pganalyze.yml \
 			up --detach
 
 partial-local-pg: init-partial
@@ -52,7 +51,6 @@ prod:
 		docker compose \
 			-f $(MAKEPATH)/docker-compose.yml \
 			-f $(MAKEPATH)/docker-compose.env.yml \
-			-f $(MAKEPATH)/docker-compose.pganalyze.yml \
 			-f $(MAKEPATH)/docker-compose.prod.yml \
 			--profile si \
 			up --detach

--- a/deploy/docker-compose.pganalyze.yml
+++ b/deploy/docker-compose.pganalyze.yml
@@ -5,6 +5,6 @@ services:
   pg:
     environment:
       - PGANALYZE=true
-      - PGA_API_KEY=5GY4FNPNS4ZZVOG7
+      - PGA_API_KEY=REPLACE_ME
       - PGA_DB_HOST=127.0.0.1
       - PGA_DB_PASSWORD=tSYwfHHdBBlfWlxa


### PR DESCRIPTION
We don't want to be running pganalyze whenever LOCAL_PG=true is used in development, and we don't want to have the collector API key checked in to the repo. For now, this removes the addition to have the pganalyze collector submit stats to the API at all (both in dev and prod), until we set up the production container to get the API key without having it checked in to the repo.

I have removed the API key from our pganalyze account, so that was was checked in is no longer valid.