### PR TITLE
fix(dal): allow deletion of map key prototypes

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -387,7 +387,10 @@ impl AttributePrototype {
                 Some(v) => v,
                 None => return Ok(()),
             };
-        if attribute_prototype.context.is_least_specific() {
+
+        let parent_proto_is_map_or_array_element = attribute_prototype.key().is_some();
+        if attribute_prototype.context.is_least_specific() && !parent_proto_is_map_or_array_element
+        {
             return Err(
                 AttributePrototypeError::LeastSpecificContextPrototypeRemovalNotAllowed(
                     *attribute_prototype_id,
@@ -423,7 +426,9 @@ impl AttributePrototype {
 
             // Delete the prototype if we find one and if its context is not "least-specific".
             if let Some(mut current_prototype) = current_value.attribute_prototype(ctx).await? {
-                if current_prototype.context.is_least_specific() {
+                if current_prototype.context.is_least_specific()
+                    && !parent_proto_is_map_or_array_element
+                {
                     return Err(
                         AttributePrototypeError::LeastSpecificContextPrototypeRemovalNotAllowed(
                             *current_prototype.id(),
@@ -449,7 +454,7 @@ impl AttributePrototype {
             }
 
             // Delete the value if its context is not "least-specific".
-            if current_value.context.is_least_specific() {
+            if current_value.context.is_least_specific() && !parent_proto_is_map_or_array_element {
                 return Err(
                     AttributePrototypeError::LeastSpecificContextValueRemovalNotAllowed(
                         *current_value.id(),


### PR DESCRIPTION
In order to remove qualification and code generation funcs set at the schema variant level from running on a schema variant we need to remove the prototype that sets the qualification result on the `/root/qualification` map. The context for that prototype is prop_id only, so "least specific", but should be safe to remove it and its child attribute values / prototypes as well, anyway.