### PR TITLE
fix(dal): don't run resource sync on components being fixed

### DIFF
--- a/lib/dal/src/tasks/resource_scheduler.rs
+++ b/lib/dal/src/tasks/resource_scheduler.rs
@@ -62,8 +62,8 @@ impl ResourceScheduler {
 
     #[instrument(name = "resource_scheduler.run", skip_all, level = "debug")]
     async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
-        info!("Refresh resources");
         let components = self.components().await?;
+        info!("Refresh resources of {} components", components.len());
 
         for component in components {
             // First we're building a ctx with no tenancy at head, then updating it with a
@@ -124,6 +124,15 @@ impl ResourceScheduler {
                  FROM components
                  WHERE is_visible_v1($1, visibility_change_set_pk, visibility_deleted_at)
                        AND (visibility_deleted_at IS NULL OR needs_destroy)
+                       AND id NOT IN (SELECT DISTINCT(fixes.component_id)
+                                      FROM fixes
+                                      INNER JOIN fix_belongs_to_fix_batch bt ON bt.object_id = fixes.id
+                                            AND is_visible_v1($1, bt.visibility_change_set_pk, bt.visibility_deleted_at)
+                                      INNER JOIN fix_batches ON fix_batches.id = bt.belongs_to_id
+                                            AND is_visible_v1($1, fix_batches.visibility_change_set_pk, fix_batches.visibility_deleted_at)
+                                      WHERE fix_batches.finished_at IS NULL
+                                            AND NOW() - fix_batches.created_at < INTERVAL '3 minutes'
+                                            AND is_visible_v1($1, fixes.visibility_change_set_pk, fixes.visibility_deleted_at))
                  ORDER BY id",
                 &[ctx.visibility()],
             )

--- a/lib/dal/src/workflow_runner.rs
+++ b/lib/dal/src/workflow_runner.rs
@@ -14,7 +14,7 @@ use crate::{
     ComponentId, Func, FuncBindingError, HistoryEventError, InternalProviderError, SchemaId,
     SchemaVariantId, StandardModel, StandardModelError, Tenancy, Timestamp, Visibility,
     WorkflowError, WorkflowPrototype, WorkflowPrototypeError, WorkflowPrototypeId,
-    WorkflowResolverError, WorkflowResolverId, WsEventError,
+    WorkflowResolverError, WorkflowResolverId, WsEvent, WsEventError,
 };
 use crate::{DalContext, FuncError};
 
@@ -185,8 +185,40 @@ impl WorkflowRunner {
         run_id: usize,
         prototype_id: WorkflowPrototypeId,
         component_id: ComponentId,
-        should_trigger_confirmations: bool,
-        trigger_dependent_values_update: bool,
+    ) -> WorkflowRunnerResult<(
+        Self,
+        WorkflowRunnerState,
+        Vec<FuncBindingReturnValue>,
+        Vec<CommandRunResult>,
+    )> {
+        Self::run_raw(ctx, run_id, prototype_id, component_id, false).await
+    }
+
+    /// Create a [`WorkflowRunner`](Self) and "run" it immediately. This not only creates the
+    /// runner, but also a corresponding, _terminating_
+    /// [`WorkflowRunnerState`](crate::workflow_runner::workflow_runner_state::WorkflowRunnerState).
+    ///
+    /// DependentValuesUpdate scheduled will be blocking, so it will be executed before any other job that is enqueued after this call
+    pub async fn run_blocking_value_propagation(
+        ctx: &DalContext,
+        run_id: usize,
+        prototype_id: WorkflowPrototypeId,
+        component_id: ComponentId,
+    ) -> WorkflowRunnerResult<(
+        Self,
+        WorkflowRunnerState,
+        Vec<FuncBindingReturnValue>,
+        Vec<CommandRunResult>,
+    )> {
+        Self::run_raw(ctx, run_id, prototype_id, component_id, true).await
+    }
+
+    async fn run_raw(
+        ctx: &DalContext,
+        run_id: usize,
+        prototype_id: WorkflowPrototypeId,
+        component_id: ComponentId,
+        blocking_dependent_values_update: bool,
     ) -> WorkflowRunnerResult<(
         Self,
         WorkflowRunnerState,
@@ -215,8 +247,7 @@ impl WorkflowRunner {
             ctx,
             &func_binding_return_values,
             component_id,
-            should_trigger_confirmations,
-            trigger_dependent_values_update,
+            blocking_dependent_values_update,
         )
         .await?;
         let (workflow_runner_status, error_message) =
@@ -287,8 +318,7 @@ impl WorkflowRunner {
         ctx: &DalContext,
         func_binding_return_values: &Vec<FuncBindingReturnValue>,
         component_id: ComponentId,
-        should_trigger_confirmations: bool,
-        trigger_dependent_values_update: bool,
+        blocking_dependent_values_update: bool,
     ) -> WorkflowRunnerResult<(FuncId, FuncBindingId, Vec<CommandRunResult>)> {
         let (identity, func_binding, mut func_binding_return_value) =
             Func::identity_with_binding_and_return_value(ctx).await?;
@@ -320,14 +350,14 @@ impl WorkflowRunner {
                 }
 
                 if component
-                    .set_resource(ctx, result.clone(), trigger_dependent_values_update)
+                    .set_resource(ctx, result.clone(), blocking_dependent_values_update)
                     .await
                     .map_err(Box::new)?
-                    && should_trigger_confirmations
                 {
-                    Component::run_all_confirmations(ctx)
-                        .await
-                        .map_err(Box::new)?;
+                    WsEvent::resource_refreshed(ctx, *component.id())
+                        .await?
+                        .publish_on_commit(ctx)
+                        .await?;
                 }
 
                 resources.push(result);

--- a/lib/dal/tests/integration_test/fix.rs
+++ b/lib/dal/tests/integration_test/fix.rs
@@ -37,8 +37,6 @@ async fn confirmation_to_action(ctx: &mut DalContext) {
         run_id,
         action_workflow_prototype_id,
         payload.component_id,
-        true,
-        true,
     )
     .await
     .expect("could not perform workflow runner run");
@@ -110,7 +108,7 @@ async fn confirmation_to_fix(ctx: &mut DalContext) {
     assert!(batch.completion_status().is_none());
 
     let run_id = rand::random();
-    fix.run(ctx, run_id, action_workflow_prototype_id, true, true)
+    fix.run(ctx, run_id, action_workflow_prototype_id, true)
         .await
         .expect("could not run fix");
     assert!(fix.started_at().is_some());

--- a/lib/dal/tests/integration_test/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/workflow_runner.rs
@@ -142,10 +142,9 @@ async fn fail(ctx: &mut DalContext) {
     assert_eq!(&change_set.status, &ChangeSetStatus::Applied);
     ctx.update_visibility(Visibility::new_head(false));
 
-    let (_, state, _, _) =
-        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id(), true, true)
-            .await
-            .expect("unable to run workflow");
+    let (_, state, _, _) = WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id())
+        .await
+        .expect("unable to run workflow");
     assert_eq!(
         state.error_message().expect("no error message found"),
         "oopsie!"
@@ -192,7 +191,7 @@ async fn run(ctx: &mut DalContext) {
     ctx.update_visibility(Visibility::new_head(false));
 
     let (_runner, state, _func_bindings, _) =
-        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id(), true, true)
+        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id())
             .await
             .expect("unable to run workflow runner");
     assert_eq!(state.status(), WorkflowRunnerStatus::Success);


### PR DESCRIPTION
Note: The only open problem here is that we re-run confirmations for the component after the individual fix runs, that's why the recommendation disappears from the panel before the fix batch finishes. Because we have to propagate resource updates so things like SecurityGroupId can be used by subsequent fixes. But this means we have to propagate confirmations. There is no way to exclude a attribute value from a specific propagation of one of their parents.

Since dependent values update doesn't get inlined anymore we don't need to avoid enqueueing it, we just need to ensure it blocks other tasks if needed.

We don't need to schedule all confirmations runs in resource syncing, as confirmations will be automatically run because of their dependency on /root/resource.

Resource sync ignores components in an active fix batch.