### PR TITLE
fix(dal): don't show qualifications that haven't run

### DIFF
--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -183,7 +183,7 @@ export const useFuncStore = () => {
         return new ApiRequest<{ success: true }>({
           method: "post",
           url: "func/exec_func",
-          params: { id: funcId },
+          params: { id: funcId, ...visibility },
         });
       },
 

--- a/lib/dal/src/func/binding_return_value.rs
+++ b/lib/dal/src/func/binding_return_value.rs
@@ -11,8 +11,9 @@ use crate::func::FuncMetadataView;
 use crate::{
     func::binding::FuncBindingId,
     func::execution::{FuncExecution, FuncExecutionError, FuncExecutionPk},
-    impl_standard_model, pk, standard_model, standard_model_accessor, DalContext, FuncId,
-    HistoryEventError, StandardModel, StandardModelError, Timestamp, Visibility,
+    impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_accessor_ro,
+    DalContext, FuncId, HistoryEventError, StandardModel, StandardModelError, Timestamp,
+    Visibility,
 };
 
 #[derive(Error, Debug)]
@@ -122,6 +123,7 @@ impl FuncBindingReturnValue {
         FuncBindingReturnValueResult
     );
     standard_model_accessor!(value, OptionJson<JsonValue>, FuncBindingReturnValueResult);
+    standard_model_accessor_ro!(func_id, FuncId);
 
     pub async fn get_output_stream(
         &self,


### PR DESCRIPTION
If a qualification exists on the qualification map but the function has not yet run we show the wrong thing in list_qualifications. If a qualification has not run, we should not show it yet. We can detect this by checking the func binding return value's func id and comparing it to the func id on the attribute prototype.

This fixes the "si:setObject" qualification displaying.

To see a newly authored qualification it must be executed from the func details panel or an attribute on the component's domain must be updated so that it is run via a dependent values update.

Also fixes exec_func api call.