### PR TITLE
fix(dal): avoid duplicating rows with the same id in the same change-set

### DIFF
--- a/lib/dal/src/migrations/U0004__standard_model.sql
+++ b/lib/dal/src/migrations/U0004__standard_model.sql
@@ -204,17 +204,15 @@ BEGIN
                       )
               AND information_schema.columns.is_generated = 'NEVER'
             INTO copy_change_set_column_names;
-            EXECUTE format('INSERT INTO %1$I ( '
-                               '    %2$s, '
-                               '    visibility_change_set_pk, '
-                               '    tenancy_workspace_pk, '
-                               '    %3$s) '
-                               ' SELECT %4$L, %5$L, %8$L, %3$s FROM %1$I WHERE '
-                               ' %1$I.id = %6$L '
-                               ' AND in_tenancy_v1(%7$L, %1$I.tenancy_workspace_pk) '
-                               ' AND %1$I.visibility_change_set_pk = ident_nil_v1() '
-                               ' AND CASE WHEN %9$L IS NULL THEN %1$I.visibility_deleted_at IS NULL ELSE %1$I.visibility_deleted_at IS NOT NULL END '
-                               ' RETURNING updated_at',
+            EXECUTE format('INSERT INTO %1$I (%2$s, visibility_change_set_pk, tenancy_workspace_pk, %3$s) '
+                           '   SELECT %4$L, %5$L, %8$L, %3$s '
+			   '   FROM %1$I '
+			   '   WHERE %1$I.id = %6$L '
+                           '         AND in_tenancy_v1(%7$L, %1$I.tenancy_workspace_pk) '
+                           '         AND %1$I.visibility_change_set_pk = ident_nil_v1() '
+                           '         AND CASE WHEN %9$L IS NULL THEN %1$I.visibility_deleted_at IS NULL ELSE %1$I.visibility_deleted_at IS NOT NULL END '
+		           ' ON CONFLICT (id, tenancy_workspace_pk, visibility_change_set_pk) DO NOTHING ' 
+                           ' RETURNING updated_at',
                            this_table,
                            this_column,
                            copy_change_set_column_names,
@@ -600,8 +598,7 @@ BEGIN
                            '); '
                            'CREATE UNIQUE INDEX %1$s_visibility_tenancy ON %1$I (id, '
                            '                                    tenancy_workspace_pk, '
-                           '                                    visibility_change_set_pk, '
-                           '                                    (visibility_deleted_at IS NULL)); '
+                           '                                    visibility_change_set_pk); '
                            'ALTER TABLE %1$I '
                            '    ADD CONSTRAINT %1$s_object_id_is_valid '
                            '        CHECK (check_id_in_table_v1(%2$L, object_id)); '
@@ -610,8 +607,7 @@ BEGIN
                            '        CHECK (check_id_in_table_v1(%3$L, belongs_to_id)); '
                            'CREATE UNIQUE INDEX %1$s_single_association ON %1$I (object_id, '
                            '                                        tenancy_workspace_pk, '
-                           '                                        visibility_change_set_pk, '
-                           '                                        (visibility_deleted_at IS NULL)); '
+                           '                                        visibility_change_set_pk); '
                            'CREATE INDEX ON %1$I (object_id); '
                            'CREATE INDEX ON %1$I (belongs_to_id); '
                            'CREATE FUNCTION is_visible_v1( '
@@ -693,8 +689,7 @@ DECLARE
 BEGIN
     alter_query := format('CREATE UNIQUE INDEX %1$s_visibility_tenancy ON %1$I (id, '
                           '                                    tenancy_workspace_pk, '
-                          '                                    visibility_change_set_pk, '
-                          '                                    (visibility_deleted_at IS NULL)); '
+                          '                                    visibility_change_set_pk); '
                           'CREATE INDEX ON %1$I (id); '
                           'CREATE INDEX ON %1$I (visibility_deleted_at NULLS FIRST); '
                           'CREATE INDEX ON %1$I (visibility_change_set_pk); '
@@ -796,8 +791,7 @@ BEGIN
                            '); '
                            'CREATE UNIQUE INDEX %1$s_visibility_tenancy ON %1$I (id, '
                            '                                    tenancy_workspace_pk, '
-                           '                                    visibility_change_set_pk, '
-                           '                                    (visibility_deleted_at IS NULL)); '
+                           '                                    visibility_change_set_pk); '
                            'ALTER TABLE %1$I '
                            '    ADD CONSTRAINT %1$s_left_object_id_is_valid '
                            '        CHECK (check_id_in_table_v1(%2$L, left_object_id)); '

--- a/lib/dal/src/migrations/U0022__change_sets.sql
+++ b/lib/dal/src/migrations/U0022__change_sets.sql
@@ -92,6 +92,7 @@ BEGIN
                            '      SELECT id ' ||
                            '      FROM %1$I ' ||
                            '      WHERE visibility_change_set_pk = %2$L ' ||
+                           '        AND in_tenancy_v1(%3$L, tenancy_workspace_pk) ' ||
                            '        AND visibility_deleted_at IS NOT NULL ' ||
                            '  )', this_table_name, this_change_set_pk, this_tenancy);
 
@@ -100,8 +101,7 @@ BEGIN
                             '                            AND in_tenancy_v1(%5$L, tenancy_workspace_pk) ' ||
                             'ON CONFLICT (id, ' ||
                             '              tenancy_workspace_pk, ' ||
-                            '              visibility_change_set_pk, ' ||
-                            '              (visibility_deleted_at IS NULL)) ' ||
+                            '              visibility_change_set_pk) ' ||
                             'DO UPDATE SET updated_at = clock_timestamp(), %4$s ' ||
                             'RETURNING pk, id, tenancy_workspace_pk',
                             this_table_name, insert_column_names, this_change_set_pk, update_set_names, this_tenancy);

--- a/lib/dal/src/migrations/U0032__schema_ui_menus.sql
+++ b/lib/dal/src/migrations/U0032__schema_ui_menus.sql
@@ -15,8 +15,7 @@ CREATE UNIQUE INDEX unique_schema_ui_menus
     ON schema_ui_menus (name,
                         category,
                         tenancy_workspace_pk,
-                        visibility_change_set_pk,
-                        (visibility_deleted_at IS NULL));
+                        visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('schema_ui_menus');
 SELECT belongs_to_table_create_v1('schema_ui_menu_belongs_to_schema', 'schema_ui_menus', 'schemas');

--- a/lib/dal/src/migrations/U0042__funcs.sql
+++ b/lib/dal/src/migrations/U0042__funcs.sql
@@ -22,8 +22,7 @@ CREATE TABLE funcs
 CREATE UNIQUE INDEX unique_func_name_live ON funcs (
 	name,
 	tenancy_workspace_pk,
-	visibility_change_set_pk,
-	(visibility_deleted_at IS NULL));
+	visibility_change_set_pk);
 SELECT standard_model_table_constraints_v1('funcs');
 
 CREATE TABLE func_bindings
@@ -60,8 +59,7 @@ CREATE TABLE func_binding_return_values
 CREATE UNIQUE INDEX unique_value_func_binding_return_value_live ON func_binding_return_values (
   func_binding_id,
   tenancy_workspace_pk,
-  visibility_change_set_pk,
-  (visibility_deleted_at IS NULL));
+  visibility_change_set_pk);
 SELECT standard_model_table_constraints_v1('func_binding_return_values');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0044__validation_resolvers.sql
+++ b/lib/dal/src/migrations/U0044__validation_resolvers.sql
@@ -17,8 +17,7 @@ CREATE UNIQUE INDEX unique_validation_resolver_value_live ON validation_resolver
 	validation_func_binding_id,
 	attribute_value_id,
 	tenancy_workspace_pk,
-	visibility_change_set_pk,
-	(visibility_deleted_at IS NULL));
+	visibility_change_set_pk);
 SELECT standard_model_table_constraints_v1('validation_resolvers');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0058__internal_providers.sql
+++ b/lib/dal/src/migrations/U0058__internal_providers.sql
@@ -19,19 +19,15 @@ CREATE UNIQUE INDEX unique_implicit_internal_providers
     ON internal_providers (prop_id,
                            schema_variant_id,
                            tenancy_workspace_pk,
-                           visibility_change_set_pk,
-                           (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL
-        AND NOT prop_id = ident_nil_v1();
+                           visibility_change_set_pk)
+    WHERE prop_id != ident_nil_v1();
 
 CREATE UNIQUE INDEX unique_explicit_internal_providers
     ON internal_providers (name,
                            schema_variant_id,
                            tenancy_workspace_pk,
-                           visibility_change_set_pk,
-                           (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL
-        AND prop_id = ident_nil_v1();
+                           visibility_change_set_pk)
+    WHERE prop_id = ident_nil_v1();
 
 CREATE INDEX ON internal_providers (prop_id);
 CREATE INDEX ON internal_providers (schema_variant_id);

--- a/lib/dal/src/migrations/U0059__external_providers.sql
+++ b/lib/dal/src/migrations/U0059__external_providers.sql
@@ -19,9 +19,7 @@ CREATE UNIQUE INDEX unique_external_providers
                            schema_id,
                            schema_variant_id,
                            tenancy_workspace_pk,
-                           visibility_change_set_pk,
-                           (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                           visibility_change_set_pk);
 
 CREATE INDEX ON external_providers (schema_id);
 CREATE INDEX ON external_providers (schema_variant_id);

--- a/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
+++ b/lib/dal/src/migrations/U0060__attribute_prototype_arguments.sql
@@ -22,21 +22,17 @@ CREATE UNIQUE INDEX intra_component_argument_with_two_internal_providers
                                       head_component_id,
                                       tail_component_id,
                                       tenancy_workspace_pk,
-                                      visibility_change_set_pk,
-                                      (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL
-        AND external_provider_id = ident_nil_v1();
+                                      visibility_change_set_pk)
+    WHERE external_provider_id = ident_nil_v1();
 
 CREATE UNIQUE INDEX intra_component_argument
     ON attribute_prototype_arguments (attribute_prototype_id,
                                       func_argument_id,
                                       internal_provider_id,
                                       tenancy_workspace_pk,
-                                      visibility_change_set_pk,
-                                      (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL
-        AND (head_component_id = ident_nil_v1()
-            AND tail_component_id = ident_nil_v1());
+                                      visibility_change_set_pk)
+    WHERE head_component_id = ident_nil_v1()
+          AND tail_component_id = ident_nil_v1();
 
 CREATE UNIQUE INDEX inter_component_argument
     ON attribute_prototype_arguments (attribute_prototype_id,
@@ -45,10 +41,8 @@ CREATE UNIQUE INDEX inter_component_argument
                                       tail_component_id,
                                       head_component_id,
                                       tenancy_workspace_pk,
-                                      visibility_change_set_pk,
-                                      (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL
-        AND internal_provider_id = ident_nil_v1();
+                                      visibility_change_set_pk)
+    WHERE internal_provider_id = ident_nil_v1();
 
 CREATE INDEX ON attribute_prototype_arguments (attribute_prototype_id);
 CREATE INDEX ON attribute_prototype_arguments (external_provider_id);

--- a/lib/dal/src/migrations/U0065__workflow_prototypes.sql
+++ b/lib/dal/src/migrations/U0065__workflow_prototypes.sql
@@ -20,8 +20,7 @@ CREATE UNIQUE INDEX unique_workflow_prototypes_for_schema_variants
     ON workflow_prototypes (func_id,
                             schema_variant_id,
                             tenancy_workspace_pk,
-                            visibility_change_set_pk,
-                            (visibility_deleted_at IS NULL));
+                            visibility_change_set_pk);
 SELECT standard_model_table_constraints_v1('workflow_prototypes');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0069__workflow_runner_states.sql
+++ b/lib/dal/src/migrations/U0069__workflow_runner_states.sql
@@ -17,9 +17,7 @@ CREATE TABLE workflow_runner_states
 CREATE UNIQUE INDEX unique_workflow_runner_states
     ON workflow_runner_states (workflow_runner_id,
                                tenancy_workspace_pk,
-                               visibility_change_set_pk,
-                               (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                               visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('workflow_runner_states');
 

--- a/lib/dal/src/migrations/U0070__func_arguments.sql
+++ b/lib/dal/src/migrations/U0070__func_arguments.sql
@@ -18,9 +18,7 @@ CREATE UNIQUE INDEX func_argument_name
     ON func_arguments (func_id,
                        name,
                        tenancy_workspace_pk,
-                       visibility_change_set_pk,
-                       (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                       visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('func_arguments');
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0072__action_prototype.sql
+++ b/lib/dal/src/migrations/U0072__action_prototype.sql
@@ -20,9 +20,7 @@ CREATE UNIQUE INDEX unique_action_prototypes
                           schema_id,
                           schema_variant_id,
                           tenancy_workspace_pk,
-                          visibility_change_set_pk,
-                          (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                          visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('action_prototypes');
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0075__fix_resolver.sql
+++ b/lib/dal/src/migrations/U0075__fix_resolver.sql
@@ -16,9 +16,7 @@ CREATE TABLE fix_resolvers
 CREATE UNIQUE INDEX unique_fix_resolvers
     ON fix_resolvers (attribute_value_id,
                       tenancy_workspace_pk,
-                      visibility_change_set_pk,
-                      (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                      visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('fix_resolvers');
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U0076__fixes.sql
+++ b/lib/dal/src/migrations/U0076__fixes.sql
@@ -22,9 +22,7 @@ CREATE TABLE fixes
 --     ON fixes (attribute_value_id,
 --               component_id,
 --               tenancy_workspace_pk,
---               visibility_change_set_pk,
---               (visibility_deleted_at IS NULL))
---     WHERE visibility_deleted_at IS NULL;
+--               visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('fixes');
 SELECT belongs_to_table_create_v1(

--- a/lib/dal/src/migrations/U0078__func_descriptions.sql
+++ b/lib/dal/src/migrations/U0078__func_descriptions.sql
@@ -18,9 +18,7 @@ CREATE UNIQUE INDEX unique_func_descriptions
     ON func_descriptions (func_id,
                           schema_variant_id,
                           tenancy_workspace_pk,
-                          visibility_change_set_pk,
-                          (visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+                          visibility_change_set_pk);
 
 SELECT standard_model_table_constraints_v1('func_descriptions');
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)

--- a/lib/dal/src/migrations/U1048__installed_pkgs.sql
+++ b/lib/dal/src/migrations/U1048__installed_pkgs.sql
@@ -13,9 +13,7 @@ CREATE TABLE installed_pkgs
 CREATE UNIQUE INDEX unique_pkg_hash ON installed_pkgs (
 	root_hash,
 	tenancy_workspace_pk,
-	visibility_change_set_pk,
-	(visibility_deleted_at IS NULL))
-    WHERE visibility_deleted_at IS NULL;
+	visibility_change_set_pk);
 SELECT standard_model_table_constraints_v1('installed_pkgs');
 
 INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)


### PR DESCRIPTION
Note: do not merge this yet, I need to test it more because we uncovered a lot of bugs and fixing them might uncover other bugs that were hidden by the former. Also we need to discuss on how to fix the underlying issue described at the bottom of this comment, something in dependent values update is deleting something already deleted.

Makes visibility_tenancy UNIQUE INDEXES more strict, only allowing one row with each id in each change-set, instead of allowing one deleted and one live. This would block the change-set-apply of the broken change-set instead of making them duplicate on head too.

Makes change_set apply more strict by checking for the tenancy (not strictly needed as the change_set_pk should be unique on that call, but it's more correct.

And the most important part of this change, now we prevent rows from being incorrectly duplicated by `update_by_id_v1`. Before if a element was deleted in the change-set, updating it without seeing deleted stuff would duplicated it. As the update would not find it, hitting the insert branch of update_by_id_v1, which would see that the element is live on head and clone it to the change-set. Effectively ending up with two rows with the same id in the same change-set, only differing by visibility_deleted_at.

Now it will throw an exception, as an update is happening to something that is not visible.

This won't fix the root cause that was deleting an attribute_value_remove_value_and_children_v1 that was already deleted without the visibility_deleted_at set in the context. We need to figure that out.