### PR TITLE
fix(dal): ignore removed qualification results

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -183,6 +183,8 @@ pub enum ComponentError {
     /// No "protected" boolean was found for the appropriate
     #[error("component({0}) can't be restored because it's inside a deleted frame ({1})")]
     InsideDeletedFrame(ComponentId, ComponentId),
+    #[error("qualification result for {0} on component {1} has no value")]
+    QualificationResultEmpty(String, ComponentId),
 }
 
 pub type ComponentResult<T> = Result<T, ComponentError>;

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -154,7 +154,7 @@ pub struct QualificationView {
 impl QualificationView {
     pub async fn new(
         ctx: &DalContext,
-        qualification_name: String,
+        qualification_name: &str,
         qualification_entry: QualificationEntry,
         attribute_prototype_func_id: FuncId,
         func_binding_return_value_id: FuncBindingReturnValueId,
@@ -211,7 +211,7 @@ impl QualificationView {
             link: func_metadata.link.map(Into::into),
             output,
             result,
-            qualification_name,
+            qualification_name: qualification_name.to_string(),
         }))
     }
 }


### PR DESCRIPTION
Use the implicit attribute cache for the qualification map to avoid reading attribute values for keys that no longer have prototypes on the map. Should be followed up with proper map entry deletion when removing a qualification from the component.