### PR TITLE
build(deps): update Rust dependencies (2023-W13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -120,19 +120,19 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ dependencies = [
  "async-trait",
  "axum-core 0.2.9",
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -174,7 +174,7 @@ dependencies = [
  "sha-1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.17.2",
  "tower",
  "tower-http",
  "tower-layer",
@@ -189,7 +189,7 @@ checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core 0.3.3",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -315,12 +315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
-
-[[package]]
 name = "blake3"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,11 +431,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.11"
+version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
- "bitflags 2.0.2",
+ "bitflags",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -453,15 +447,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -559,7 +552,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.3",
  "tracing",
 ]
 
@@ -619,23 +612,15 @@ dependencies = [
  "clap",
  "color-eyre",
  "council-server",
- "derive_builder 0.11.2",
- "futures",
- "serde",
- "serde_json",
- "si-data-nats",
- "si-settings",
  "telemetry-application",
- "thiserror",
  "tokio",
- "ulid",
 ]
 
 [[package]]
 name = "council-server"
 version = "0.1.0"
 dependencies = [
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "serde",
  "serde_json",
@@ -649,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -750,7 +735,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -767,7 +752,7 @@ checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -786,7 +771,7 @@ name = "cyclone-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.13.1",
+ "base64 0.21.0",
  "cyclone-core",
  "cyclone-server",
  "futures",
@@ -802,7 +787,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.18.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -811,7 +796,7 @@ dependencies = [
 name = "cyclone-core"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "nix",
  "serde",
  "serde_json",
@@ -827,11 +812,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum 0.5.17",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes-lines-codec",
  "chrono",
  "cyclone-core",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "hyper",
  "pin-project-lite",
@@ -855,7 +840,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "backtrace",
- "base64 0.13.1",
+ "base64 0.21.0",
  "chrono",
  "council-server",
  "dal-test",
@@ -1013,7 +998,7 @@ dependencies = [
  "cyclone-client",
  "cyclone-core",
  "deadpool",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "nix",
  "serde",
@@ -1070,32 +1055,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-dependencies = [
- "derive_builder_macro 0.11.2",
-]
-
-[[package]]
-name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro 0.12.0",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -1112,21 +1076,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-dependencies = [
- "derive_builder_core 0.11.2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core 0.12.0",
+ "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -1172,22 +1126,22 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1525,7 +1479,7 @@ dependencies = [
  "color-eyre",
  "convert_case 0.6.0",
  "dal",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "serde",
  "serde_json",
@@ -1874,9 +1828,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1885,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "instant"
@@ -2113,13 +2067,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -2192,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d877cd2e71146efa7065300fc5f5da967f938694b4d65e8bc64cc4a409092c"
+checksum = "2eebb39ba0555bcf232817d42ed3346499f14f6f8d4de1c0ca4517bda99c1a7b"
 dependencies = [
  "base64 0.13.1",
  "base64-url",
@@ -2243,16 +2198,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2408,11 +2363,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2440,9 +2395,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -2766,7 +2721,7 @@ name = "pinga-server"
 version = "0.1.0"
 dependencies = [
  "dal",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "nats-subscriber",
  "serde",
@@ -3050,7 +3005,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -3111,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3227,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc_version"
@@ -3246,7 +3201,7 @@ version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3358,12 +3313,12 @@ dependencies = [
  "async-trait",
  "axum 0.5.17",
  "axum-macros",
- "base64 0.13.1",
+ "base64 0.21.0",
  "chrono",
  "convert_case 0.6.0",
  "dal",
  "dal-test",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "hyper",
  "names",
@@ -3387,7 +3342,7 @@ dependencies = [
  "telemetry",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.18.0",
  "tower",
  "tower-http",
  "veritech-client",
@@ -3413,7 +3368,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3464,7 +3419,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -3496,7 +3451,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -3583,6 +3538,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,7 +3622,7 @@ name = "si-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "derive_builder 0.12.0",
+ "derive_builder",
  "object-tree",
  "petgraph",
  "serde",
@@ -3692,7 +3658,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -3805,6 +3771,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stream-cancel"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.5"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3934,7 +3912,7 @@ dependencies = [
 name = "telemetry-application"
 version = "0.1.0"
 dependencies = [
- "derive_builder 0.11.2",
+ "derive_builder",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "telemetry",
@@ -4004,7 +3982,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -4194,7 +4172,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.17.3",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.18.0",
 ]
 
 [[package]]
@@ -4243,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
  "serde",
@@ -4325,7 +4315,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4474,6 +4464,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4601,7 +4610,7 @@ dependencies = [
 name = "veritech-client"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "cyclone-core",
  "futures",
  "indoc",
@@ -4629,7 +4638,7 @@ name = "veritech-server"
 version = "0.1.0"
 dependencies = [
  "deadpool-cyclone",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "nats-subscriber",
  "serde",
@@ -4656,11 +4665,12 @@ checksum = "ded573c92d7b32013bdab82676be59f56106895e837504568f32804980ec7868"
 
 [[package]]
 name = "vfs-tar"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc4b6f04e3d6f22a7899b3ee07df9a71e3bb0b068e4544961de221a9f851dce"
+checksum = "cb6eea209e00a567e5966323e2e3f83b91b9c662711c6e44a21c479604f8fd52"
 dependencies = [
  "memmap2",
+ "stable_deref_trait",
  "tar-parser2",
  "vfs",
 ]
@@ -4923,9 +4933,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]

--- a/bin/council/Cargo.toml
+++ b/bin/council/Cargo.toml
@@ -12,16 +12,6 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = { version = "0.6.1" }
+council-server = { path = "../../lib/council-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { version = "1.12.0", features = ["full"] }
-thiserror = { version = "1.0" }
-futures = "0.3"
-
-council-server = { path = "../../lib/council-server" }
-si-data-nats = { path = "../../lib/si-data-nats" }
-ulid = { version = "1", features = ["serde"] }
-
-derive_builder = { version = "0.11.2" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-si-settings = { path = "../../lib/si-settings" }

--- a/bin/gen-var-defs/Cargo.toml
+++ b/bin/gen-var-defs/Cargo.toml
@@ -7,24 +7,20 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.51"
 clap = { version = "4.1.6", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = { version = "0.6.1" }
-telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
-thiserror = { version = "1.0" }
-futures = "0.3"
-
-si-data-nats = { path = "../../lib/si-data-nats" }
-si-data-pg = { path = "../../lib/si-data-pg" }
-veritech-client = { path = "../../lib/veritech-client" }
+convert_case = "0.6.0"
 dal = { path = "../../lib/dal" }
-
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
+futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-data-pg = { path = "../../lib/si-data-pg" }
 si-settings = { path = "../../lib/si-settings" }
+telemetry-application = { path = "../../lib/telemetry-application-rs" }
+thiserror = { version = "1.0" }
+tokio = { version = "1.12.0", features = ["full"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
-
-async-trait = "0.1.51"
-convert_case = "0.6.0"
-
+veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/config-file/Cargo.toml
+++ b/lib/config-file/Cargo.toml
@@ -26,11 +26,11 @@ layered-yaml = ["layered", "yaml", "config/yaml"]
 
 [dependencies]
 config = { version = "0.13.1", default-features = false, optional = true }
-directories = "4.0.1"
+directories = "5.0"
 pathdiff = "0.2.1"
 serde = { version = "1.0.136", optional = true }
 serde_json = { version = "1.0.79", optional = true }
-serde_toml = { package = "toml", version = "0.5.8", optional = true }
+serde_toml = { package = "toml", version = "0.7", optional = true }
 serde_yaml = { version = "0.9.10", optional = true }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["fs", "io-util"], optional = true }

--- a/lib/council-server/Cargo.toml
+++ b/lib/council-server/Cargo.toml
@@ -2,17 +2,17 @@
 name = "council-server"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.64"
+publish = false
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-ulid = { version = "1", features = ["serde"] }
-si-data-nats = { path = "../../lib/si-data-nats" }
-thiserror = "1.0.24"
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+derive_builder = { version = "0.12" }
 futures = "0.3.13"
-derive_builder = { version = "0.11.2" }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1.0.64", features = ["preserve_order"] }
+si-data-nats = { path = "../../lib/si-data-nats" }
 si-settings = { path = "../../lib/si-settings" }
 telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = "1.0.24"
 tokio = { version = "1.12.0", features = ["full"] }
+ulid = { version = "1", features = ["serde"] }

--- a/lib/cyclone-client/Cargo.toml
+++ b/lib/cyclone-client/Cargo.toml
@@ -18,10 +18,10 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }
-tokio-tungstenite = { version = "0.17.1" }
+tokio-tungstenite = { version = "0.18" }
 
 [dev-dependencies]
-base64 = { version = "0.13.0" }
+base64 = { version = "0.21" }
 cyclone-server = { path = "../../lib/cyclone-server" }
 sodiumoxide = { version = "0.2.6" }
 tempfile = { version = "3.2.0" }

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -426,6 +426,7 @@ impl Default for ClientConfig {
 mod tests {
     use std::{borrow::Cow, env, path::Path};
 
+    use base64::{engine::general_purpose, Engine};
     use cyclone_core::{
         ComponentKind, ComponentView, FunctionResult, ProgressMessage, ResolverFunctionComponent,
         ValidationRequest,
@@ -518,6 +519,10 @@ mod tests {
         tokio::spawn(async move { server.run().await });
 
         Client::http(socket).expect("failed to create client")
+    }
+
+    fn base64_encode(input: impl AsRef<[u8]>) -> String {
+        general_purpose::STANDARD_NO_PAD.encode(input)
     }
 
     #[test(tokio::test)]
@@ -715,7 +720,7 @@ mod tests {
                 ],
             },
             response_type: cyclone_core::ResolverFunctionResponseType::Object,
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function doit(input) {
                     console.log(`${Object.keys(input).length}`);
                     console.log('my butt');
@@ -804,7 +809,7 @@ mod tests {
                 ],
             },
             response_type: cyclone_core::ResolverFunctionResponseType::Object,
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function doit(input) {
                     console.log(`${Object.keys(input).length}`);
                     console.log('my butt');
@@ -874,7 +879,7 @@ mod tests {
             execution_id: "1337".to_string(),
             handler: "validate".to_string(),
             value: "a string is a sequence of bytes".into(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function validate(value) {
                     console.log('i came here to chew bubblegum and validate prop values');
                     console.log('and i\'m all out of gum');
@@ -973,7 +978,7 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
             args: Default::default(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function workit() {
                     console.log('first');
                     console.log('second');
@@ -1048,7 +1053,7 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
             args: Default::default(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function workit() {
                     console.log('first');
                     console.log('second');
@@ -1122,7 +1127,7 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
             args: Default::default(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function workit() {
                     console.log('first');
                     console.log('second');
@@ -1196,7 +1201,7 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "workit".to_string(),
             args: Default::default(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 r#"function workit() {
                     console.log('first');
                     console.log('second');

--- a/lib/cyclone-core/Cargo.toml
+++ b/lib/cyclone-core/Cargo.toml
@@ -6,8 +6,8 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
-base64 = { version = "0.13.0" }
-nix = { version = "0.25.0" }
+base64 = { version = "0.21" }
+nix = { version = "0.26" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sodiumoxide = { version = "0.2.6" }

--- a/lib/cyclone-core/src/encryption_key.rs
+++ b/lib/cyclone-core/src/encryption_key.rs
@@ -1,5 +1,6 @@
 use std::{io, path::Path};
 
+use base64::{engine::general_purpose, Engine};
 use sodiumoxide::crypto::box_::PublicKey;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -40,7 +41,7 @@ impl EncryptionKey {
 
     pub fn encrypt_and_encode(&self, message: impl AsRef<[u8]>) -> String {
         let crypted = sodiumoxide::crypto::sealedbox::seal(message.as_ref(), &self.public_key);
-        base64::encode_config(crypted, base64::STANDARD_NO_PAD)
+        general_purpose::STANDARD_NO_PAD.encode(crypted)
     }
 }
 

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [dependencies]
 async-trait = { version = "0.1.51" }
 axum = { version = "0.5.4", features = ["ws"] }
-base64 = { version = "0.13.0" }
+base64 = { version = "0.21" }
 bytes-lines-codec = { path = "../bytes-lines-codec" }
 chrono = { version = "0.4.19" }
 cyclone-core = { path = "../../lib/cyclone-core" }
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 futures = { version = "0.3.17" }
 hyper = { version = "0.14", features = ["client", "http1", "runtime", "server"] }
 pin-project-lite = { version = "0.2.7" }

--- a/lib/cyclone-server/src/decryption_key.rs
+++ b/lib/cyclone-server/src/decryption_key.rs
@@ -1,5 +1,6 @@
 use std::{io, path::Path};
 
+use base64::{engine::general_purpose, Engine};
 use sodiumoxide::crypto::box_::{PublicKey as BoxPublicKey, SecretKey as BoxSecretKey};
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -56,7 +57,7 @@ impl DecryptionKey {
         &self,
         base64_encoded: impl AsRef<str>,
     ) -> Result<Vec<u8>, DecryptionKeyError> {
-        let crypted = base64::decode_config(base64_encoded.as_ref(), base64::STANDARD_NO_PAD)?;
+        let crypted = general_purpose::STANDARD_NO_PAD.decode(base64_encoded.as_ref())?;
         sodiumoxide::crypto::sealedbox::open(&crypted, &self.public_key, &self.secret_key)
             .map_err(|_| DecryptionKeyError::DecryptionFailed)
     }

--- a/lib/cyclone-server/src/request.rs
+++ b/lib/cyclone-server/src/request.rs
@@ -243,15 +243,13 @@ impl DecryptRequest for ValidationRequest {
 
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose, Engine};
     use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
 
     use super::*;
 
     fn encrypt_and_encode(message: &[u8], pkey: &PublicKey) -> String {
-        base64::encode_config(
-            sodiumoxide::crypto::sealedbox::seal(message, pkey),
-            base64::STANDARD_NO_PAD,
-        )
+        general_purpose::STANDARD_NO_PAD.encode(sodiumoxide::crypto::sealedbox::seal(message, pkey))
     }
 
     fn gen_keypair() -> (PublicKey, SecretKey) {

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -9,13 +9,15 @@ publish = false
 [dependencies]
 async-recursion = "1.0.0"
 async-trait = "0.1.51"
-base64 = "0.13.0"
+backtrace = "0.3.67"
+base64 = "0.21"
 chrono = { version = "0.4.19", features = ["serde"] }
 council-server = { path = "../../lib/council-server" }
 derive_more = "0.99.16"
 diff = "0.1"
 dyn-clone = "1.0.6"
 futures = "0.3.13"
+hex = "0.4.3"
 iftree = "1.0.3"
 jwt-simple = "0.11.0"
 lazy_static = "1.4.0"
@@ -42,12 +44,10 @@ telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = "1.0.24"
 tokio = { version = "1.2.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.3"
+ulid = { version = "1", features = ["serde"] }
 url = "2.2.2"
 veritech-client = { path = "../../lib/veritech-client" }
 which = "4.3.0"
-ulid = { version = "1", features = ["serde"] }
-hex = "0.4.3"
-backtrace = "0.3.67"
 
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -2,6 +2,8 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use base64::engine::general_purpose;
+use base64::Engine;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
@@ -166,7 +168,7 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
                 .ok_or_else(|| {
                     BuiltinsError::FuncMetadata(format!("Code file not found: {code_file:?}"))
                 })?;
-            let code = base64::encode(code.contents_str);
+            let code = general_purpose::STANDARD_NO_PAD.encode(code.contents_str);
             new_func
                 .set_code_base64(ctx, Some(code))
                 .await

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine};
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
@@ -128,13 +129,11 @@ impl KeyPair {
 }
 
 fn encode_public_key(key: &BoxPublicKey) -> String {
-    let s = base64::encode_config(key.as_ref(), base64::STANDARD_NO_PAD);
-    s
+    general_purpose::STANDARD_NO_PAD.encode(key.as_ref())
 }
 
 fn encode_secret_key(key: &BoxSecretKey) -> String {
-    let s = base64::encode_config(key.as_ref(), base64::STANDARD_NO_PAD);
-    s
+    general_purpose::STANDARD_NO_PAD.encode(key.as_ref())
 }
 
 /// A database-persisted libsodium box public key.

--- a/lib/dal/src/key_pair/key_pair_box_public_key_serde.rs
+++ b/lib/dal/src/key_pair/key_pair_box_public_key_serde.rs
@@ -1,6 +1,8 @@
-use super::encode_public_key;
+use base64::{engine::general_purpose, Engine};
 use serde::{self, Deserialize, Deserializer, Serializer};
 use sodiumoxide::crypto::box_::PublicKey as BoxPublicKey;
+
+use super::encode_public_key;
 
 pub fn serialize<S>(box_public_key: &BoxPublicKey, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -15,8 +17,9 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let box_buffer =
-        base64::decode_config(s, base64::STANDARD_NO_PAD).map_err(serde::de::Error::custom)?;
+    let box_buffer = general_purpose::STANDARD_NO_PAD
+        .decode(s)
+        .map_err(serde::de::Error::custom)?;
 
     BoxPublicKey::from_slice(&box_buffer)
         .ok_or_else(|| serde::de::Error::custom("cannot deserialize public key"))

--- a/lib/dal/src/key_pair/key_pair_box_secret_key_serde.rs
+++ b/lib/dal/src/key_pair/key_pair_box_secret_key_serde.rs
@@ -1,6 +1,8 @@
-use super::encode_secret_key;
+use base64::{engine::general_purpose, Engine};
 use serde::{self, Deserialize, Deserializer, Serializer};
 use sodiumoxide::crypto::box_::SecretKey as BoxSecretKey;
+
+use super::encode_secret_key;
 
 pub fn serialize<S>(box_secret_key: &BoxSecretKey, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -15,8 +17,9 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    let box_buffer =
-        base64::decode_config(s, base64::STANDARD_NO_PAD).map_err(serde::de::Error::custom)?;
+    let box_buffer = general_purpose::STANDARD_NO_PAD
+        .decode(s)
+        .map_err(serde::de::Error::custom)?;
 
     BoxSecretKey::from_slice(&box_buffer)
         .ok_or_else(|| serde::de::Error::custom("cannot deserialize secret key"))

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -1,6 +1,7 @@
 use crate::Tenancy;
 use std::fmt;
 
+use base64::{engine::general_purpose, Engine};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_data_pg::PgError;
@@ -377,10 +378,11 @@ pub enum SecretKind {
 }
 
 fn encode_crypted(crypted: &[u8]) -> String {
-    base64::encode_config(crypted, base64::STANDARD_NO_PAD)
+    general_purpose::STANDARD_NO_PAD.encode(crypted)
 }
 
 mod crypted_serde {
+    use base64::{engine::general_purpose, Engine};
     use serde::{self, Deserialize, Deserializer, Serializer};
 
     use super::encode_crypted;
@@ -398,8 +400,9 @@ mod crypted_serde {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let buffer =
-            base64::decode_config(s, base64::STANDARD_NO_PAD).map_err(serde::de::Error::custom)?;
+        let buffer = general_purpose::STANDARD_NO_PAD
+            .decode(s)
+            .map_err(serde::de::Error::custom)?;
         Ok(buffer)
     }
 }

--- a/lib/dal/tests/integration_test/component/view/cyclone_crypto.rs
+++ b/lib/dal/tests/integration_test/component/view/cyclone_crypto.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine};
 use dal::DalContext;
 
 use dal_test::test;
@@ -38,7 +39,7 @@ async fn cyclone_crypto_e2e(ctx: &DalContext) {
             parents: Vec::new(),
         },
         response_type: ResolverFunctionResponseType::Boolean,
-        code_base64: base64::encode(&code),
+        code_base64: general_purpose::STANDARD_NO_PAD.encode(&code),
     };
     let result = ctx
         .veritech()

--- a/lib/dal/tests/integration_test/pkg.rs
+++ b/lib/dal/tests/integration_test/pkg.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine};
 use dal::{installed_pkg::*, pkg::*, DalContext, Func, Schema, SchemaVariant, StandardModel};
 use dal_test::test;
 use si_pkg::{
@@ -62,7 +63,7 @@ async fn test_install_pkg(ctx: &DalContext) {
         .expect("able to make schema spec");
 
     let code = "function truth() { return true; }";
-    let code_base64 = base64::encode(code.as_bytes());
+    let code_base64 = general_purpose::STANDARD_NO_PAD.encode(code.as_bytes());
 
     let func_spec = FuncSpec::builder()
         .name("si:truthy")

--- a/lib/deadpool-cyclone/Cargo.toml
+++ b/lib/deadpool-cyclone/Cargo.toml
@@ -12,9 +12,9 @@ async-trait = { version = "0.1.51" }
 cyclone-client = { path = "../cyclone-client" }
 cyclone-core = { path = "../cyclone-core" }
 deadpool = { version = "0.9.0", features = ["rt_tokio_1"] }
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 futures = { version = "0.3.17" }
-nix = { version = "0.25.0" }
+nix = { version = "0.26" }
 tempfile = { version = "3.2.0" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }

--- a/lib/object-tree/Cargo.toml
+++ b/lib/object-tree/Cargo.toml
@@ -13,4 +13,4 @@ tempfile = "3.3.0"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full", "tracing"] }
 vfs = "0.9.0"
-vfs-tar = "0.3.0"
+vfs-tar = { version = "0.4.0", features = ["mmap"] }

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 dal = { path = "../../lib/dal" }
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 futures = "0.3"
 nats-subscriber = { path = "../../lib/nats-subscriber" }
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -6,39 +6,39 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+async-trait = "0.1.51"
 axum = { version = "0.5.4", features = ["ws"] }
 axum-macros = { version = "0.2.3", optional = true } # enable: cargo build --features axum-macro
-base64 = "0.13.0"
+base64 = "0.21"
 chrono = { version = "0.4.19", features = ["serde"] }
+convert_case = "0.6.0"
 dal = { path = "../dal" }
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 futures = { version = "0.3.17" }
 hyper = { version = "0.14", features = ["http1", "runtime", "server"] }
 names = { version = "0.14.0", default-features = false }
-nix = { version = "0.25.0" }
+nix = { version = "0.26" }
 pathdiff = "0.2.1"
 rand = "0.8"
+reqwest = { version = "0.11.14", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "2.0.0"
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
+si-pkg = { path = "../../lib/si-pkg"}
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
-si-pkg = { path = "../../lib/si-pkg"}
 sodiumoxide = "0.2.7"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.12.0", features = ["full"] }
-tokio-tungstenite = "0.17.1"
+tokio-tungstenite = "0.18"
 tower = { version = "0.4.10" }
 tower-http = { version = "0.3", features = ["trace"] }
 veritech-client = { path = "../../lib/veritech-client" }
-async-trait = "0.1.51"
-convert_case = "0.6.0"
-reqwest = { version = "0.11.14", features = ["json"] }
 
 [build-dependencies]
 thiserror = { version = "1.0" }

--- a/lib/si-data-nats/Cargo.toml
+++ b/lib/si-data-nats/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 crossbeam-channel = { version = "0.5.1" }
 futures = { version = "0.3.17" }
-nats-client = { package = "nats", version = "0.23.0" }
+nats-client = { package = "nats", version = "0.24.0" }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = { version = "1.0.64" }
 telemetry = { path = "../../lib/telemetry-rs" }

--- a/lib/si-test-macros/Cargo.toml
+++ b/lib/si-test-macros/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.16"
-syn = { version = "1.0.89", features = ["full", "extra-traits"] }
+syn = { version = "2.0.10", features = ["full", "extra-traits"] }

--- a/lib/si-test-macros/src/dal_test.rs
+++ b/lib/si-test-macros/src/dal_test.rs
@@ -15,9 +15,10 @@ use std::sync::Arc;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
-    parse_quote, punctuated::Punctuated, token::Comma, AttributeArgs, Expr, FnArg, ItemFn, Path,
-    ReturnType, Type,
+    parse_quote, punctuated::Punctuated, token::Comma, Expr, FnArg, ItemFn, Path, ReturnType, Type,
 };
+
+use crate::Args;
 
 const LOG_ENV_VAR: &str = "SI_TEST_LOG";
 const SPAN_EVENTS_ENV_VAR: &str = "SI_TEST_LOG_SPAN_EVENTS";
@@ -25,7 +26,7 @@ const SPAN_EVENTS_ENV_VAR: &str = "SI_TEST_LOG_SPAN_EVENTS";
 const RT_DEFAULT_WORKER_THREADS: usize = 2;
 const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
 
-pub(crate) fn expand(item: ItemFn, _args: AttributeArgs) -> TokenStream {
+pub(crate) fn expand(item: ItemFn, _args: Args) -> TokenStream {
     if item.sig.asyncness.is_none() {
         panic!("test function must be async--blocking tests not supported");
     }

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 opentelemetry-otlp = { version = "0.11.0" }
 opentelemetry-semantic-conventions = { version = "0.10.0" }
 tracing-opentelemetry = { version = "0.18.0" }

--- a/lib/veritech-client/Cargo.toml
+++ b/lib/veritech-client/Cargo.toml
@@ -20,8 +20,8 @@ tokio = { version = "1.2.0", features = ["full"] }
 veritech-core = { path = "../../lib/veritech-core" }
 
 [dev-dependencies]
-base64 = "0.13.0"
-indoc = "1.0.3"
+base64 = "0.21"
+indoc = "2.0"
 test-log = { version = "0.2.7", default-features = false, features = ["trace"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt"] }

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -276,6 +276,7 @@ async fn forward_output_task(
 mod tests {
     use std::env;
 
+    use base64::{engine::general_purpose, Engine};
     use si_data_nats::NatsConfig;
     use test_log::test;
     use tokio::task::JoinHandle;
@@ -337,6 +338,10 @@ mod tests {
         tokio::spawn(veritech_server_for_uds_cyclone(subject_prefix).await.run())
     }
 
+    fn base64_encode(input: impl AsRef<[u8]>) -> String {
+        general_purpose::STANDARD_NO_PAD.encode(input)
+    }
+
     #[test(tokio::test)]
     async fn executes_simple_resolver_function() {
         let prefix = nats_prefix();
@@ -362,7 +367,7 @@ mod tests {
                 parents: vec![],
             },
             response_type: ResolverFunctionResponseType::Integer,
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 "function numberOfInputs(input) { return Object.keys(input)?.length ?? 0; }",
             ),
         };
@@ -429,7 +434,7 @@ mod tests {
                     parents: vec![],
                 },
                 response_type,
-                code_base64: base64::encode(
+                code_base64: base64_encode(
                     "function returnInputValue(input) { return input.value; }",
                 ),
             };
@@ -492,7 +497,7 @@ mod tests {
                     parents: vec![],
                 },
                 response_type: response_type.clone(),
-                code_base64: base64::encode(
+                code_base64: base64_encode(
                     "function returnInputValue(input) { return input.value; }",
                 ),
             };
@@ -533,7 +538,7 @@ mod tests {
             execution_id: "31337".to_string(),
             handler: "isThirtyThree".to_string(),
             value: 33.into(),
-            code_base64: base64::encode(
+            code_base64: base64_encode(
                 "function isThirtyThree(value) { return { valid: value === 33 }; };",
             ),
         };
@@ -572,7 +577,7 @@ mod tests {
             execution_id: "112233".to_string(),
             handler: "workItOut".to_string(),
             // TODO(fnichol): rewrite this function once we settle on contract
-            code_base64: base64::encode("function workItOut() { return { name: 'mc fioti', kind: 'vacina butantan - https://www.youtube.com/watch?v=yQ8xJHuW7TY', steps: [] }; }"),
+            code_base64: base64_encode("function workItOut() { return { name: 'mc fioti', kind: 'vacina butantan - https://www.youtube.com/watch?v=yQ8xJHuW7TY', steps: [] }; }"),
             args: Default::default(),
         };
 

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 deadpool-cyclone = { path = "../../lib/deadpool-cyclone" }
-derive_builder = { version = "0.11.2" }
+derive_builder = { version = "0.12" }
 futures = { version = "0.3.17" }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
 serde = "1.0.123"


### PR DESCRIPTION
Some notable changes:

- Upgrade to version 0.21.0 of base64 crate
  - The API usage change fairly substantially and is unfortunately a little longer and more awkward to get default behavior (unless I missed the right example).
  - NOTE: prior to this change we had several parts in our code where we called `base64::encode()` and `base64::decode()` which was not clear about whether padding was included/expected. Due to this library update I've made it 100% explicit that we're using stadard/no padding encoding and decoding. As a result some artifacts like functions in a developer's database *might* have issues decoding with rebuilt SDF/Pinga servers. I'd recommend dropping the database and re-migrating to rule out any funky business there.
- Upgrade to version 2.x of syn
  - This is a major update to a crate which has been stable for years. As a result, I made changes in `si-test-macros` which had our only direct usage.
- Upgrade to version 0.18.x of tokio-tungstenite (this is our websocket implementation library)
- Upgrade to version 0.4.0 of vfs-tar (used when importing pkgs)
  - Changed the API usage and allowed for a different timing of opening the file and reading its contents. There was a small code change in `object-tree` as a result.

<img src="https://media2.giphy.com/media/3rgXBGYrye5vSfhMdO/giphy.gif"/>