### PR TITLE
chore: use more txns on builtin migration

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -19,7 +19,7 @@ use crate::{
     ActionPrototypeError, AttributeContextBuilderError, AttributePrototypeArgumentError,
     AttributePrototypeError, AttributeReadContext, AttributeValueError, AttributeValueId,
     DalContext, ExternalProviderId, FuncError, PropError, PropId, SchemaError, SchemaVariantId,
-    StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
+    StandardModelError, TransactionsError, ValidationPrototypeError, WorkflowPrototypeError,
 };
 
 // Private builtins modules.
@@ -102,6 +102,8 @@ pub enum BuiltinsError {
     ExternalProviderNotFound(String),
     #[error("schema variant definition error")]
     SchemaVariantDefinition(#[from] SchemaVariantDefinitionError),
+    #[error("error creating new transactions")]
+    Transactions(#[from] TransactionsError),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -73,88 +73,118 @@ pub async fn migrate(
         }
     };
 
+    let ctx_driver = ctx.clone_with_new_transactions().await?;
     // Once we know what to migrate, create the driver.
-    let driver = MigrationDriver::new(ctx).await?;
+    let driver = MigrationDriver::new(&ctx_driver).await?;
+    ctx_driver.commit().await?;
 
     // Perform migrations.
     if migrate_all || specific_builtin_schemas.contains("docker image") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_docker_image(ctx, "Docker", NODE_COLOR_DOCKER)
+            .migrate_docker_image(&ctx, "Docker", NODE_COLOR_DOCKER)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("docker hub credential") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_docker_hub_credential(ctx, "Docker", NODE_COLOR_DOCKER)
+            .migrate_docker_hub_credential(&ctx, "Docker", NODE_COLOR_DOCKER)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("kubernetes deployment") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_kubernetes_deployment(ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
+            .migrate_kubernetes_deployment(&ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("kubernetes namespace") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_kubernetes_namespace(ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
+            .migrate_kubernetes_namespace(&ctx, "Kubernetes", NODE_COLOR_KUBERNETES)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("coreos butane") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_coreos_butane(ctx, "CoreOS", NODE_COLOR_COREOS)
+            .migrate_coreos_butane(&ctx, "CoreOS", NODE_COLOR_COREOS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("aws ami") {
-        driver.migrate_aws_ami(ctx, "AWS", NODE_COLOR_AWS).await?;
+        let ctx = ctx.clone_with_new_transactions().await?;
+        driver.migrate_aws_ami(&ctx, "AWS", NODE_COLOR_AWS).await?;
+        ctx.commit().await?;
     }
     if migrate_all
         || specific_builtin_schemas.contains("aws ec2")
         || specific_builtin_schemas.contains("aws ec2 instance")
     {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_ec2_instance(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_ec2_instance(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("aws region") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_region(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_region(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("aws eip") {
-        driver.migrate_aws_eip(ctx, "AWS", NODE_COLOR_AWS).await?;
+        let ctx = ctx.clone_with_new_transactions().await?;
+        driver.migrate_aws_eip(&ctx, "AWS", NODE_COLOR_AWS).await?;
+        ctx.commit().await?;
     }
     if migrate_all
         || specific_builtin_schemas.contains("aws key pair")
         || specific_builtin_schemas.contains("aws keypair")
     {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_keypair(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_keypair(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("aws ingress") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_ingress(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_ingress(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all || specific_builtin_schemas.contains("aws egress") {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_egress(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_egress(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all
         || specific_builtin_schemas.contains("aws security group")
         || specific_builtin_schemas.contains("aws securitygroup")
     {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_aws_security_group(ctx, "AWS", NODE_COLOR_AWS)
+            .migrate_aws_security_group(&ctx, "AWS", NODE_COLOR_AWS)
             .await?;
+        ctx.commit().await?;
     }
     if migrate_all
         || specific_builtin_schemas.contains("systeminit generic frame")
         || specific_builtin_schemas.contains("si generic frame")
         || specific_builtin_schemas.contains("generic frame")
     {
+        let ctx = ctx.clone_with_new_transactions().await?;
         driver
-            .migrate_systeminit_generic_frame(ctx, "Frames", NODE_COLOR_FRAMES)
+            .migrate_systeminit_generic_frame(&ctx, "Frames", NODE_COLOR_FRAMES)
             .await?;
+        ctx.commit().await?;
     }
     Ok(())
 }

--- a/lib/dal/src/builtins/workflow.rs
+++ b/lib/dal/src/builtins/workflow.rs
@@ -4,8 +4,10 @@ use crate::{
 };
 
 pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
-    poem(ctx).await?;
-    failure(ctx).await?;
+    let ctx = ctx.clone_with_new_transactions().await?;
+    poem(&ctx).await?;
+    failure(&ctx).await?;
+    ctx.commit().await?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds a bunch more transactions to the builtin migrations.

We saw behavior where the system would come up, migrate builtins, and then spend a few minutes cranking through the dependent values updates. That's because the updates themselves are helpfully batched up with the transaction - and we used one giant transaction for all the work.

We now create new context and commit the transactions as we go, which allows the dependent value update jobs to start happening in real time, which makes the total time for the system to boot and quiesce much shorter (maybe 30 seconds to a minute after finishing migration, rather than 5+ minutes.)

<img src="https://media1.giphy.com/media/MgRKCBGvlpqTENUzWk/giphy.gif"/>