### PR TITLE
fix(dal): use ISO timestamps for resource sync timestamp

### DIFF
--- a/lib/dal/src/func/backend/js_command.rs
+++ b/lib/dal/src/func/backend/js_command.rs
@@ -97,7 +97,7 @@ impl ExtractPayload for CommandRunResultSuccess {
             status: self.status,
             message: self.message.or(self.error),
             logs: Default::default(),
-            last_synced: Some(Utc::now().to_string()),
+            last_synced: Some(Utc::now().to_rfc3339()),
         })
     }
 }


### PR DESCRIPTION
This fixes resource rendering on Firefox.