### PR TITLE
Revert "fix(dal): don't run resource sync on components being fixed"

### DIFF
--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -85,7 +85,7 @@ impl Component {
         &self,
         ctx: &DalContext,
         result: CommandRunResult,
-        blocking_dependent_values_update: bool,
+        trigger_dependent_values_update: bool,
     ) -> ComponentResult<bool> {
         if !ctx.visibility().is_head() {
             return Err(ComponentError::CannotUpdateResourceTreeInChangeSet);
@@ -113,7 +113,7 @@ impl Component {
                 .set_component_id(self.id)
                 .to_context()?;
 
-        if blocking_dependent_values_update {
+        if trigger_dependent_values_update {
             let (_, _) = AttributeValue::update_for_context(
                 ctx,
                 *resource_attribute_value.id(),
@@ -124,12 +124,11 @@ impl Component {
             )
             .await?;
         } else {
-            // Paulo:
-            // We use this function to ensure the dependent values propagation happens
-            // before any other job that is scheduled after it in this transaction
-            // this means the fix flow can trust that the next fix step will only happen
-            // after the previous one propagated its resource, as they may depend on it
-            let (_, _) = AttributeValue::update_for_context_blocking_dependent_values_update(
+            // Jacob / Paulo / Victor / Paul:
+            // We use this func to stop enqueueing another DependentValuesUpdate job
+            // The fix job was running DependentValuesUpdate inline and this func was also
+            // queueing a DependentValuesUpdate.
+            let (_, _) = AttributeValue::update_for_context_without_propagating_dependent_values(
                 ctx,
                 *resource_attribute_value.id(),
                 Some(*root_attribute_value.id()),
@@ -165,8 +164,14 @@ impl Component {
 
         let prototype = action.workflow_prototype(ctx).await?;
         let run_id: usize = rand::random();
-        let (_runner, _state, _func_binding_return_values, _resources) =
-            WorkflowRunner::run(ctx, run_id, *prototype.id(), self.id).await?;
+        let (_runner, _state, _func_binding_return_values, resources) =
+            WorkflowRunner::run(ctx, run_id, *prototype.id(), self.id, true, true).await?;
+        if !resources.is_empty() {
+            WsEvent::resource_refreshed(ctx, self.id)
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
         Ok(())
     }
 }

--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -253,21 +253,20 @@ impl Fix {
         ctx: &DalContext,
         run_id: usize,
         action_workflow_prototype_id: WorkflowPrototypeId,
-        blocking_dependent_values_update: bool,
+        should_trigger_confirmations: bool,
+        trigger_dependent_values_update: bool,
     ) -> FixResult<Vec<CommandRunResult>> {
         // Stamp started and run the workflow.
         self.stamp_started(ctx).await?;
-        let runner_result = if blocking_dependent_values_update {
-            WorkflowRunner::run_blocking_value_propagation(
-                ctx,
-                run_id,
-                action_workflow_prototype_id,
-                self.component_id,
-            )
-            .await
-        } else {
-            WorkflowRunner::run(ctx, run_id, action_workflow_prototype_id, self.component_id).await
-        };
+        let runner_result = WorkflowRunner::run(
+            ctx,
+            run_id,
+            action_workflow_prototype_id,
+            self.component_id,
+            should_trigger_confirmations,
+            trigger_dependent_values_update,
+        )
+        .await;
 
         // Evaluate the workflow result.
         match runner_result {

--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -10,11 +10,12 @@ use crate::{
         consumer::{
             JobConsumer, JobConsumerError, JobConsumerMetadata, JobConsumerResult, JobInfo,
         },
+        definition::DependentValuesUpdate,
         producer::{JobMeta, JobProducer, JobProducerResult},
     },
     AccessBuilder, ActionPrototype, AttributeValueId, Component, ComponentId, DalContext, Fix,
-    FixBatch, FixBatchId, FixCompletionStatus, FixId, FixResolver, StandardModel, Visibility,
-    WsEvent,
+    FixBatch, FixBatchId, FixCompletionStatus, FixId, FixResolver, RootPropChild, StandardModel,
+    Visibility, WsEvent,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -179,7 +180,9 @@ impl JobConsumer for FixesJob {
             .await?
             .ok_or(FixError::MissingFix(fix_item.id))?;
         let run_id = rand::random();
-        let resources = fix.run(ctx, run_id, workflow_prototype_id, true).await?;
+        let resources = fix
+            .run(ctx, run_id, workflow_prototype_id, false, false)
+            .await?;
         let completion_status: FixCompletionStatus = *fix
             .completion_status()
             .ok_or(FixError::EmptyCompletionStatus)?;
@@ -200,6 +203,19 @@ impl JobConsumer for FixesJob {
             .flat_map(|l| l.split('\n'))
             .map(|l| l.to_owned())
             .collect();
+
+        // Inline dependent values propagation so we can run consecutive fixes that depend on the /root/resource from the previous fix
+        if !resources.is_empty() {
+            let attribute_value = Component::root_prop_child_attribute_value_for_component(
+                ctx,
+                *component.id(),
+                RootPropChild::Resource,
+            )
+            .await?;
+
+            ctx.enqueue_blocking_job(DependentValuesUpdate::new(ctx, vec![*attribute_value.id()]))
+                .await;
+        }
 
         WsEvent::fix_return(
             ctx,

--- a/lib/dal/tests/integration_test/fix.rs
+++ b/lib/dal/tests/integration_test/fix.rs
@@ -37,6 +37,8 @@ async fn confirmation_to_action(ctx: &mut DalContext) {
         run_id,
         action_workflow_prototype_id,
         payload.component_id,
+        true,
+        true,
     )
     .await
     .expect("could not perform workflow runner run");
@@ -108,7 +110,7 @@ async fn confirmation_to_fix(ctx: &mut DalContext) {
     assert!(batch.completion_status().is_none());
 
     let run_id = rand::random();
-    fix.run(ctx, run_id, action_workflow_prototype_id, true)
+    fix.run(ctx, run_id, action_workflow_prototype_id, true, true)
         .await
         .expect("could not run fix");
     assert!(fix.started_at().is_some());

--- a/lib/dal/tests/integration_test/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/workflow_runner.rs
@@ -142,9 +142,10 @@ async fn fail(ctx: &mut DalContext) {
     assert_eq!(&change_set.status, &ChangeSetStatus::Applied);
     ctx.update_visibility(Visibility::new_head(false));
 
-    let (_, state, _, _) = WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id())
-        .await
-        .expect("unable to run workflow");
+    let (_, state, _, _) =
+        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id(), true, true)
+            .await
+            .expect("unable to run workflow");
     assert_eq!(
         state.error_message().expect("no error message found"),
         "oopsie!"
@@ -191,7 +192,7 @@ async fn run(ctx: &mut DalContext) {
     ctx.update_visibility(Visibility::new_head(false));
 
     let (_runner, state, _func_bindings, _) =
-        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id())
+        WorkflowRunner::run(ctx, 0, *prototype.id(), *component.id(), true, true)
             .await
             .expect("unable to run workflow runner");
     assert_eq!(state.status(), WorkflowRunnerStatus::Success);


### PR DESCRIPTION
This PR did way too much stuff, it avoided resource syncing of components being fixed because its dependent values update raced with the fixes. It also avoided rerunning confirmations in moments it didn't need to because the screen was flashing, the components loading and the confirmations updating to weird states.

But it also improved some code that stopped making sense after we removed the inline DependentValuesUpdate, and when doing that I created some bug I don't really understand in the propagation, I will investigate but it's a low priority.

The biggest thing here is that recommendations might be weird, not reloading when they should, or be shown in the wrong state (unstarted for recommendations that just finished, etc). It's not a deal breaker, but we should probably fix it.

This reverts commit 14f9bfbc3f063d0cc3076ca27d99d678a4ecf853.