### PR TITLE
fix(dal): Ensure that an AMI has an ImageID or a filter set

### DIFF
--- a/lib/dal/src/builtins/func/qualificationAmiExists.js
+++ b/lib/dal/src/builtins/func/qualificationAmiExists.js
@@ -7,6 +7,14 @@ async function qualification(input) {
         }
     }
 
+    const filtersCode = JSON.parse(code);
+    if (filtersCode.Filters?.length == 0) {
+        return {
+            result: "failure",
+            message: "Please ensure that Image ID or a Filter is set"
+        }
+    }
+
     if (!input.domain.region) {
         return {
             result: "failure",


### PR DESCRIPTION
Without either of these, a user can produce a 98mb response from
AWS that is unnecessary
