### PR TITLE
fix(web): don't treat empty confirmations as loading state

### DIFF
--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -231,7 +231,6 @@ export const useFixesStore = () => {
             onSuccess: (response) => {
               this.confirmations = response;
               this.populatingFixes =
-                response.length === 0 ||
                 response.some((c) => c.status === "neverStarted") ||
                 response.some((c) => c.status === "running");
             },


### PR DESCRIPTION
If confirmations is empty, then we're not populating fixes. We just don't have any confirmations.