### PR TITLE
fix(pinga,cyclone,veritech): disable otel to get depvalupdates working

### DIFF
--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -27,9 +27,9 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
         telemetry.set_verbosity(args.verbose.into()).await?;
     }
     debug!(arguments =?args, "parsed cli arguments");
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
+    //    if args.disable_opentelemetry {
+    telemetry.disable_opentelemetry().await?;
+    //    }
 
     let decryption_key = Server::load_decryption_key(&args.decryption_key).await?;
 

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -42,9 +42,9 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
     }
     debug!(arguments =?args, "parsed cli arguments");
 
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
+    //    if args.disable_opentelemetry {
+    telemetry.disable_opentelemetry().await?;
+    //    }
 
     let config = Config::try_from(args)?;
 

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -27,9 +27,9 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
         telemetry.set_verbosity(args.verbose.into()).await?;
     }
     debug!(arguments =?args, "parsed cli arguments");
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
+    //    if args.disable_opentelemetry {
+    telemetry.disable_opentelemetry().await?;
+    //    }
     let config = Config::try_from(args)?;
 
     start_tracing_level_signal_handler_task(&telemetry)?;


### PR DESCRIPTION
Mutex poisoning is caused by bug in opentelemetry, let's disable otel for now while we work on just getting all the data in Jaeger