### PR TITLE
fix(dal): fix slow ami extractor when ami has no settings yet

### DIFF
--- a/lib/dal/src/builtins/func/awsAmiImageIdFromApi.js
+++ b/lib/dal/src/builtins/func/awsAmiImageIdFromApi.js
@@ -4,6 +4,12 @@ async function extract(input) {
     }
 
     const code = input.code?.["si:generateAwsAmiJSON"]?.code;
+    // Ensure we have filters (an ami id or filters are set)
+    const filters = JSON.parse(code)?.Filters ?? [];
+    if (filters.length == 0) {
+      return "";
+    }
+
     const imageResponse = await siExec.waitUntilEnd("aws", [
         "ec2",
         "describe-images",


### PR DESCRIPTION
If describe-images runs without any Filters it fetches all AMIs, pauses the lang-js execution and makes the updates appear to hang.