### PR TITLE
fix(dal): add Security Group Description regex validation

### DIFF
--- a/lib/dal/src/builtins/func/awsSecurityGroupValidateDescription.js
+++ b/lib/dal/src/builtins/func/awsSecurityGroupValidateDescription.js
@@ -1,0 +1,16 @@
+function validate(value) {
+    const validSecurityGroupDescriptionRe = /^[a-zA-Z0-9. _\-:\/()#,@\[\]+=&;{}!$*]{1,256}$/;
+
+    if ((value?.length ?? "") < 1) {
+      return {
+        valid: false,
+        message: "Security Group description cannot be empty."
+      };
+    }
+  
+    return {
+        valid: validSecurityGroupDescriptionRe.test(value),
+        message: "Security Group description must be no more than 256 characters and can only contain the following characters: a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*",
+    };
+}
+

--- a/lib/dal/src/builtins/func/awsSecurityGroupValidateDescription.json
+++ b/lib/dal/src/builtins/func/awsSecurityGroupValidateDescription.json
@@ -1,0 +1,7 @@
+{
+  "kind": "JsValidation",
+  "response_type": "Validation",
+  "code_file": "awsSecurityGroupValidateDescription.js",
+  "code_entrypoint": "validate",
+  "display_name": "Validate AWS Security Group Description"
+}

--- a/lib/dal/src/builtins/schema/aws_ec2_instance.rs
+++ b/lib/dal/src/builtins/schema/aws_ec2_instance.rs
@@ -1,4 +1,4 @@
-use crate::builtins::schema::MigrationDriver;
+use crate::builtins::schema::{MigrationDriver, ValidationKind};
 use crate::builtins::BuiltinsError;
 use crate::component::ComponentKind;
 use crate::edit_field::widget::WidgetKind;
@@ -79,10 +79,10 @@ impl MigrationDriver {
 
         self.create_validation(
             ctx,
-            Validation::StringHasPrefix {
+            ValidationKind::Builtin(Validation::StringHasPrefix {
                 value: None,
                 expected: "ami-".to_string(),
-            },
+            }),
             *image_id_prop.id(),
             *schema.id(),
             *schema_variant.id(),
@@ -113,11 +113,11 @@ impl MigrationDriver {
 
         self.create_validation(
             ctx,
-            Validation::StringInStringArray {
+            ValidationKind::Builtin(Validation::StringInStringArray {
                 value: None,
                 expected: expected_instance_types,
                 display_expected: false,
-            },
+            }),
             *instance_type_prop.id(),
             *schema.id(),
             *schema_variant.id(),

--- a/lib/dal/src/builtins/schema/aws_region.rs
+++ b/lib/dal/src/builtins/schema/aws_region.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    builtins::schema::MigrationDriver,
+    builtins::schema::{MigrationDriver, ValidationKind},
     builtins::BuiltinsError,
     component::ComponentKind,
     edit_field::widget::WidgetKind,
@@ -89,7 +89,7 @@ impl MigrationDriver {
         // Validation Creation
         self.create_validation(
             ctx,
-            Validation::StringIsNotEmpty { value: None },
+            ValidationKind::Builtin(Validation::StringIsNotEmpty { value: None }),
             *region_prop.id(),
             *schema.id(),
             *schema_variant.id(),
@@ -102,11 +102,11 @@ impl MigrationDriver {
             .collect::<Vec<String>>();
         self.create_validation(
             ctx,
-            Validation::StringInStringArray {
+            ValidationKind::Builtin(Validation::StringInStringArray {
                 value: None,
                 expected,
                 display_expected: true,
-            },
+            }),
             *region_prop.id(),
             *schema.id(),
             *schema_variant.id(),


### PR DESCRIPTION
I noticed we do not check the length or validity of the Security Group description. The create dry run qualification does not seem to check it either, so it won't be noticed until actual security group creation. This is a perfect case for a custom validation function which tests the description against a regex.