### PR TITLE
fix(dal): Ensure we fully qualify the docker image name for butane config

### DIFF
--- a/lib/dal/src/builtins/func/dockerImagesToButaneUnits.js
+++ b/lib/dal/src/builtins/func/dockerImagesToButaneUnits.js
@@ -1,46 +1,54 @@
 function dockerImagesToButaneUnits(input) {
-  let units = [];
-  let images = input.images;
-  // Force the images arg to be an Array (and return an empty array if the arg is absent/undefined/null).
-  if (images === undefined) return units;
-  if (images === null) return units;
-  if (!Array.isArray(images)) images = [images];
+    let units = [];
+    let images = input.images;
+    // Force the images arg to be an Array (and return an empty array if the arg is absent/undefined/null).
+    if (images === undefined) return units;
+    if (images === null) return units;
+    if (!Array.isArray(images)) images = [images];
 
-  images.forEach(function (dockerImage) {
-    // Only allow "valid DNS characters" for the container name, and make sure it doesn't
-    // end with a dash character ("-").
-    let name = dockerImage.si.name
-      .replace(/[^A-Za-z0-9]/g, '-')
-      .replace(/-+$/, '')
-      .toLowerCase();
-    let unit = {
-      name: name + ".service",
-      enabled: true
-    };
+    images.forEach(function (dockerImage) {
+        // Only allow "valid DNS characters" for the container name, and make sure it doesn't
+        // end with a dash character ("-").
+        let name = dockerImage.si.name
+            .replace(/[^A-Za-z0-9]/g, '-')
+            .replace(/-+$/, '')
+            .toLowerCase();
+        let unit = {
+            name: name + ".service",
+            enabled: true
+        };
 
-    let ports = "";
-    let dockerImageExposedPorts = dockerImage.domain.ExposedPorts;
-    if (!(dockerImageExposedPorts === undefined || dockerImageExposedPorts === null)) {
-      dockerImageExposedPorts.forEach(function (dockerImageExposedPort) {
-        if (!(dockerImageExposedPort === undefined || dockerImageExposedPort === null)) {
-          let parts = dockerImageExposedPort.split('/');
-          try {
-            // Prefix with a blank space.
-            ports = ports + ` --publish ${parts[0]}:${parts[0]}`;
-          } catch (err) {
-          }
+        let ports = "";
+        let dockerImageExposedPorts = dockerImage.domain.ExposedPorts;
+        if (!(dockerImageExposedPorts === undefined || dockerImageExposedPorts === null)) {
+            dockerImageExposedPorts.forEach(function (dockerImageExposedPort) {
+                if (!(dockerImageExposedPort === undefined || dockerImageExposedPort === null)) {
+                    let parts = dockerImageExposedPort.split('/');
+                    try {
+                        // Prefix with a blank space.
+                        ports = ports + ` --publish ${parts[0]}:${parts[0]}`;
+                    } catch (err) {
+                    }
+                }
+            });
         }
-      });
-    }
 
-    let image = dockerImage.domain.image;
-    let description = name.charAt(0).toUpperCase() + name.slice(1);
+        let image = dockerImage.domain.image;
+        let defaultDockerHost = "docker.io";
+        let imageParts = image.split("/");
+        if (imageParts.length === 1) {
+            image = [defaultDockerHost, "library", imageParts[0]].join("/");
+        } else if (imageParts.length === 2) {
+            image = [defaultDockerHost, imageParts[0], imageParts[1]].join("/");
+        }
 
-    // Ensure there is no space between "name" and "ports" as ports are optional.
-    unit.contents = `[Unit]\nDescription=${description}\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill ${name}\nExecStartPre=-/bin/podman rm ${name}\nExecStartPre=/bin/podman pull ${image}\nExecStart=/bin/podman run --name ${name}${ports} ${image}\n\n[Install]\nWantedBy=multi-user.target`;
+        let description = name.charAt(0).toUpperCase() + name.slice(1);
 
-    units.push(unit);
-  });
+        // Ensure there is no space between "name" and "ports" as ports are optional.
+        unit.contents = `[Unit]\nDescription=${description}\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill ${name}\nExecStartPre=-/bin/podman rm ${name}\nExecStartPre=/bin/podman pull ${image}\nExecStart=/bin/podman run --name ${name}${ports} ${image}\n\n[Install]\nWantedBy=multi-user.target`;
 
-  return units;
+        units.push(unit);
+    });
+
+    return units;
 }

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -597,7 +597,7 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
                         {
                             "name": "nginx.service",
                             "enabled": true,
-                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull nginx\nExecStart=/bin/podman run --name nginx nginx\n\n[Install]\nWantedBy=multi-user.target",
+                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull docker.io/library/nginx\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\n\n[Install]\nWantedBy=multi-user.target",
                         }
                     ],
                 },
@@ -606,7 +606,7 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
             },
             "code": {
                 "si:generateButaneIgnition": {
-                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull nginx\\nExecStart=/bin/podman run --name nginx nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      }\n    ]\n  }\n}",
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull docker.io/library/nginx\\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      }\n    ]\n  }\n}",
                     "format": "json",
                 },
             },
@@ -685,7 +685,7 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
                         {
                             "name": "nginx.service",
                             "enabled": true,
-                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull nginx\nExecStart=/bin/podman run --name nginx nginx\n\n[Install]\nWantedBy=multi-user.target",
+                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull docker.io/library/nginx\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\n\n[Install]\nWantedBy=multi-user.target",
                         }
                     ],
                 },
@@ -694,7 +694,7 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
             },
             "code": {
                 "si:generateButaneIgnition": {
-                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull nginx\\nExecStart=/bin/podman run --name nginx nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      }\n    ]\n  }\n}",
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull docker.io/library/nginx\\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      }\n    ]\n  }\n}",
                     "format": "json",
                 },
             },

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -368,12 +368,12 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
                         {
                             "name": "nginx.service",
                             "enabled": true,
-                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull nginx\nExecStart=/bin/podman run --name nginx nginx\n\n[Install]\nWantedBy=multi-user.target",
+                            "contents": "[Unit]\nDescription=Nginx\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill nginx\nExecStartPre=-/bin/podman rm nginx\nExecStartPre=/bin/podman pull docker.io/library/nginx\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\n\n[Install]\nWantedBy=multi-user.target",
                         },
                         {
                             "name": "apache2.service",
                             "enabled": true,
-                            "contents": "[Unit]\nDescription=Apache2\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill apache2\nExecStartPre=-/bin/podman rm apache2\nExecStartPre=/bin/podman pull apache2\nExecStart=/bin/podman run --name apache2 apache2\n\n[Install]\nWantedBy=multi-user.target",
+                            "contents": "[Unit]\nDescription=Apache2\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill apache2\nExecStartPre=-/bin/podman rm apache2\nExecStartPre=/bin/podman pull docker.io/library/apache2\nExecStart=/bin/podman run --name apache2 docker.io/library/apache2\n\n[Install]\nWantedBy=multi-user.target",
                         },
                     ],
                 },
@@ -382,7 +382,7 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
             },
             "code": {
                 "si:generateButaneIgnition": {
-                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull nginx\\nExecStart=/bin/podman run --name nginx nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      },\n      {\n        \"contents\": \"[Unit]\\nDescription=Apache2\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill apache2\\nExecStartPre=-/bin/podman rm apache2\\nExecStartPre=/bin/podman pull apache2\\nExecStart=/bin/podman run --name apache2 apache2\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"apache2.service\"\n      }\n    ]\n  }\n}",
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Nginx\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill nginx\\nExecStartPre=-/bin/podman rm nginx\\nExecStartPre=/bin/podman pull docker.io/library/nginx\\nExecStart=/bin/podman run --name nginx docker.io/library/nginx\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"nginx.service\"\n      },\n      {\n        \"contents\": \"[Unit]\\nDescription=Apache2\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill apache2\\nExecStartPre=-/bin/podman rm apache2\\nExecStartPre=/bin/podman pull docker.io/library/apache2\\nExecStart=/bin/podman run --name apache2 docker.io/library/apache2\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"apache2.service\"\n      }\n    ]\n  }\n}",
                     "format": "json",
                 },
             },
@@ -413,7 +413,7 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
                         {
                             "name": "apache2.service",
                             "enabled": true,
-                            "contents": "[Unit]\nDescription=Apache2\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill apache2\nExecStartPre=-/bin/podman rm apache2\nExecStartPre=/bin/podman pull apache2\nExecStart=/bin/podman run --name apache2 apache2\n\n[Install]\nWantedBy=multi-user.target",
+                            "contents": "[Unit]\nDescription=Apache2\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nTimeoutStartSec=0\nExecStartPre=-/bin/podman kill apache2\nExecStartPre=-/bin/podman rm apache2\nExecStartPre=/bin/podman pull docker.io/library/apache2\nExecStart=/bin/podman run --name apache2 docker.io/library/apache2\n\n[Install]\nWantedBy=multi-user.target",
                         },
                     ],
                 },
@@ -422,7 +422,7 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
             },
             "code": {
                 "si:generateButaneIgnition": {
-                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Apache2\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill apache2\\nExecStartPre=-/bin/podman rm apache2\\nExecStartPre=/bin/podman pull apache2\\nExecStart=/bin/podman run --name apache2 apache2\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"apache2.service\"\n      }\n    ]\n  }\n}",
+                    "code": "{\n  \"ignition\": {\n    \"version\": \"3.3.0\"\n  },\n  \"systemd\": {\n    \"units\": [\n      {\n        \"contents\": \"[Unit]\\nDescription=Apache2\\nAfter=network-online.target\\nWants=network-online.target\\n\\n[Service]\\nTimeoutStartSec=0\\nExecStartPre=-/bin/podman kill apache2\\nExecStartPre=-/bin/podman rm apache2\\nExecStartPre=/bin/podman pull docker.io/library/apache2\\nExecStart=/bin/podman run --name apache2 docker.io/library/apache2\\n\\n[Install]\\nWantedBy=multi-user.target\",\n        \"enabled\": true,\n        \"name\": \"apache2.service\"\n      }\n    ]\n  }\n}",
                     "format": "json",
                 },
             },


### PR DESCRIPTION
docker iamge for nginx resolves to docker.io/library/nginx

so if a user specified an offical docker image that wasn't qualified
then we defaulted to docker.io/library/<name>

if a user specified something like systeminit/whiskers then we fully
qualified it to docker.io/systeminit/whiskers

We can see that podman likes these names:

```
podman pull docker.io/library/nginx
Trying to pull docker.io/library/nginx:latest...
Getting image source signatures
Copying blob sha256:0c5a4ea56b12fc10c85785c4492b17457221eadcf98522d9c9921c53c5b9bc39
Copying blob sha256:fcdb9667c46b09d1c1d058681ea4a1db41e66bbc1a71d873a0c9da4f7a92947d
Copying blob sha256:37800f4fe3edb87062659385e565813530bf5de915e65169ef45d5c052de4537
Copying blob sha256:dc97894793e675034e6e1a10ed76bebcd561574026502583f3672bdbb273c285
Copying blob sha256:f14edee3dfac1a7e93d9b4a32ef2ecb9b88d7b041db5d123f8f10cafa7a0f833
Copying blob sha256:36bec90788584510d38bee3af79ee34ea4e44181c1ecc9aef0918fd47fb1db59
Copying config sha256:f71a4866129b6332cfd0dddb38f2fec26a5a125ebb0adde99fbaa4cb87149ead
Writing manifest to image destination
Storing signatures
f71a4866129b6332cfd0dddb38f2fec26a5a125ebb0adde99fbaa4cb87149ead
```
