### PR TITLE
fix(dal): avoid lingering transactions in dependent values update

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -66,7 +66,7 @@ use crate::{
     AttributeContextError, AttributePrototypeArgumentError, Component, ComponentId, DalContext,
     Func, FuncBinding, FuncError, HistoryEventError, IndexMap, InternalProvider,
     InternalProviderId, Prop, PropError, PropId, PropKind, StandardModel, StandardModelError,
-    StatusUpdaterError, Tenancy, Timestamp, TransactionsError, Visibility, WsEventError,
+    Tenancy, Timestamp, TransactionsError, Visibility, WsEventError,
 };
 
 pub mod view;
@@ -209,8 +209,6 @@ pub enum AttributeValueError {
     MissingComponentInReadContext(AttributeReadContext),
     #[error("component not found by id: {0}")]
     ComponentNotFoundById(ComponentId),
-    #[error(transparent)]
-    StatusUpdater(#[from] Box<StatusUpdaterError>),
     #[error("schema variant missing in context")]
     SchemaVariantMissing,
     #[error("schema missing in context")]

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -155,6 +155,10 @@ impl DalContext {
         Ok(())
     }
 
+    pub fn services_context(&self) -> ServicesContext {
+        self.services_context.clone()
+    }
+
     /// Rolls all inner transactions back, discarding all changes made within them, and returns
     /// underlying connections.
     ///


### PR DESCRIPTION
We were keeping a transaction open when waiting for attribute values to process because tests can't just commit and create another one.

This open transaction may exhaust deadpool's connections limit, making things hang waiting for a connection to be available. It's less likely to cause a dead-lock than the previous similar bug we fixed. But it can still make things slow and at worse hang with one job getting a transaction to wait for council and the other, that got a message from council that has just finished processing the last one trying to clone with new transaction.

This touches complicated parts of the system so I'm not eager to merge this so close to the deadline, but it may be important enough. We should review it thoroughly and play with it before merging it though.