### PR TITLE
fix(veritech): notify requestor if resolverFunction fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,6 +4568,7 @@ version = "0.1.0"
 name = "veritech-server"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "deadpool-cyclone",
  "derive_builder",
  "futures",

--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -25,10 +25,10 @@ pub use cyclone_client::{
     ClientError, CycloneClient, EncryptionKey, EncryptionKeyError, ExecutionError,
 };
 pub use cyclone_core::{
-    CommandRunRequest, CommandRunResultSuccess, ComponentView, FunctionResult, OutputStream,
-    ProgressMessage, ResolverFunctionRequest, ResolverFunctionResultSuccess, ResourceStatus,
-    ValidationRequest, ValidationResultSuccess, WorkflowResolveRequest,
-    WorkflowResolveResultSuccess,
+    CommandRunRequest, CommandRunResultSuccess, ComponentView, FunctionResult,
+    FunctionResultFailure, FunctionResultFailureError, OutputStream, ProgressMessage,
+    ResolverFunctionRequest, ResolverFunctionResultSuccess, ResourceStatus, ValidationRequest,
+    ValidationResultSuccess, WorkflowResolveRequest, WorkflowResolveResultSuccess,
 };
 
 /// [`Instance`] implementations.

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+chrono = "0.4.24"
 deadpool-cyclone = { path = "../../lib/deadpool-cyclone" }
 derive_builder = { version = "0.12" }
 futures = { version = "0.3.17" }


### PR DESCRIPTION
This change only updates the resolverFunction code path--future work will address the rest in a similar fashion.

Prior to this change, errors that could occur during a function dispatch such as:

- failing to get a healthy cyclone server instance
- failing to get a healthy cyclone server instance before a pool timeout
- ensuring that a result message was received from cyclone (by way of lang-js)
- if an i/o error happens reading from cyclone's websocket and/or writing to nats
- other things!

Previously, in these error cases we early returned and ended the processing task, never notifying the requestor that something went wrong. So from the client's point of view, no messages ever come back from veritech--and our clients are currently extremely patient (i.e. no timeout yet, heheh) and so will wait forever. Forever!