### PR TITLE
fix(web): fix crash when component is undefined

### DIFF
--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -173,7 +173,7 @@ const onClickRefreshButton = () => {
 };
 
 watch(
-  () => selectedComponent.value.resource.lastSynced,
+  () => selectedComponent.value?.resource?.lastSynced,
   () => {
     refreshing.value = false;
   },


### PR DESCRIPTION
When a component is deleted selectedCompoment can become undefined. 