### PR TITLE
fix(builtin) Handle undefined input in generateAwsAmiJSON.js

### DIFF
--- a/lib/dal/src/builtins/func/generateAwsAmiJSON.js
+++ b/lib/dal/src/builtins/func/generateAwsAmiJSON.js
@@ -4,29 +4,32 @@ function generateAwsAmiJSON(input) {
         "Filters": [],
     };
 
-    if (input.domain.ExecutableUsers) {
-        object["ExecutableUsers"] = [input.domain.ExecutableUsers]
-    }
-
-    if (input.domain.Owners) {
-        object["Owners"] = [input.domain.Owners]
-    }
-
-    if (input.domain.ImageId) {
-        object["Filters"].push({
-            "Name": "image-id",
-            "Values": [input.domain.ImageId]
-        });
-    }
-
-    if (input.domain.Filters) {
-        for (const filter of input.domain.Filters) {
+    if (input !== undefined && input !== null) {
+        if (input.domain.ExecutableUsers) {
+            object["ExecutableUsers"] = [input.domain.ExecutableUsers]
+        }
+    
+        if (input.domain.Owners) {
+            object["Owners"] = [input.domain.Owners]
+        }
+    
+        if (input.domain.ImageId) {
             object["Filters"].push({
-                "Name": filter.Name,
-                "Values": [filter.Value],
+                "Name": "image-id",
+                "Values": [input.domain.ImageId]
             });
         }
-    }
+    
+        if (input.domain.Filters) {
+            for (const filter of input.domain.Filters) {
+                object["Filters"].push({
+                    "Name": filter.Name,
+                    "Values": [filter.Value],
+                });
+            }
+        }
+    } 
+
 
     return {
         format: "json",


### PR DESCRIPTION
During the initial loading of the builtins, generateAwsAmiJSON would run with `undefined` `input`, and would error because of this. We now skip trying to do anything with `input` if it is either `null` or `undefined`, and return our "base" result to avoid any errors parsing/handling `input`.