### PR TITLE
fix(dal): Set butane unit contexts to be a textArea not a string

### DIFF
--- a/lib/dal/src/builtins/schema/definitions/core_os_butane.json
+++ b/lib/dal/src/builtins/schema/definitions/core_os_butane.json
@@ -19,7 +19,10 @@
                 "name": "contents",
                 "kind": "string",
                 "docLink": "https://coreos.github.io/butane/config-fcos-v1_4/",
-                "children": []
+                "children": [],
+                "widget": {
+                  "kind": "textArea"
+                }
               },
               {
                 "name": "enabled",


### PR DESCRIPTION
![Screenshot 2023-03-30 at 17 04 58](https://user-images.githubusercontent.com/227823/228896869-c2965e0e-ae8a-4588-9f9b-1d4dacb82554.png)
