### PR TITLE
fix(dal): unset deleted_at on component restore

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1063,7 +1063,7 @@ impl Component {
         component_id: ComponentId,
     ) -> ComponentResult<Option<Self>> {
         // Check if component has deleted frame before restoring
-        {
+        let component = {
             let ctx_with_deleted = &ctx.clone_with_delete_visibility();
 
             let component = Self::get_by_id(ctx_with_deleted, &component_id)
@@ -1102,7 +1102,11 @@ impl Component {
                     return Err(ComponentError::InsideDeletedFrame(component_id, parent_id));
                 }
             }
-        }
+
+            component
+        };
+
+        component.set_deleted_at(ctx, None).await?;
 
         let rows = ctx
             .txns()


### PR DESCRIPTION
Restored components still had deleted_at set, producing deletion recommendations. Unsetting the attribute on restore fixes this.