### PR TITLE
chore(job) Return an error from a job instead of panicing with unexpected council message

### DIFF
--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -51,6 +51,8 @@ pub enum JobConsumerError {
     Nats(#[from] NatsError),
     #[error(transparent)]
     Council(#[from] council_server::client::Error),
+    #[error("Protocol error with council: {0}")]
+    CouncilProtocol(String),
     #[error(transparent)]
     FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
     #[error(transparent)]

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -285,7 +285,11 @@ impl DependentValuesUpdate {
 
                         ctx = self.commit_and_continue(ctx).await?;
                     }
-                    council_server::Response::OkToCreate => unreachable!(),
+                    // If we receive an OkToCreate here, it's because council is telling us that it's Ok to run
+                    // `AttributeValue::create_dependent_values` after it has already told us to do that, and after
+                    // we have told it that we've finished doing so. This should never be able to happen normally,
+                    // as it breaks the protocol contract we have with council.
+                    council_server::Response::OkToCreate => return Err(JobConsumerError::CouncilProtocol("Told to create values again after we've finished creating values. Multiple instances of council running?".to_string())),
                     council_server::Response::Shutdown => break,
                 },
                 // FIXME: reconnect


### PR DESCRIPTION
Being told that we're good to go with creating values, should never happen if we've already been told that we're good to go (and have told council that we've finished). Instead of a panic with no message, we now return a more descriptive error message about what's going on.