### PR TITLE
fix(web): show highlights for code mirror active lines

### DIFF
--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -74,14 +74,26 @@ const language = new Compartment();
 const readOnly = new Compartment();
 const themeCompartment = new Compartment();
 const lintCompartment = new Compartment();
+const styleExtensionCompartment = new Compartment();
 
 const { theme: appTheme } = useTheme();
 const codeMirrorTheme = computed(() =>
   appTheme.value === "dark" ? gruvboxDark : basicLight,
 );
+const styleExtension = computed(() => {
+  const activeLineHighlight = appTheme.value === "dark" ? "#7c6f64" : "#e0dee9";
+  return EditorView.theme({
+    ".cm-scroller": { overflow: "auto" },
+    ".cm-focused .cm-selectionBackground .cm-activeLine, .cm-selectionBackground, .cm-content .cm-activeLine ::selection":
+      { backgroundColor: `${activeLineHighlight} !important` },
+  });
+});
 watch(codeMirrorTheme, () => {
   view.dispatch({
-    effects: [themeCompartment.reconfigure(codeMirrorTheme.value)],
+    effects: [
+      themeCompartment.reconfigure(codeMirrorTheme.value),
+      styleExtensionCompartment.reconfigure(styleExtension.value),
+    ],
   });
 });
 
@@ -112,6 +124,7 @@ const mountEditor = async () => {
     extensions: extensions.concat([
       keymap.of([indentWithTab]),
       themeCompartment.of(codeMirrorTheme.value),
+      styleExtensionCompartment.of(styleExtension.value),
       keymap.of([indentWithTab]),
       readOnly.of(EditorState.readOnly.of(disabled.value)),
       updateListener,
@@ -139,9 +152,5 @@ onMounted(() => {
 
 .cm-editor .cm-gutter {
   font-size: 14px;
-}
-
-.cm-activeLine {
-  background-color: transparent !important;
 }
 </style>

--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -100,12 +100,15 @@ const editorThemeExtension = computed(() => {
 });
 
 const editorStyleExtension = computed(() => {
+  const activeLineHighlight = theme.value === "dark" ? "#7c6f64" : "#e0dee9";
   return EditorView.theme({
     "&": {
       height: "100%",
       ..._.pick(props, "fontSize", "height"),
     },
     ".cm-scroller": { overflow: "auto" },
+    ".cm-focused .cm-selectionBackground .cm-activeLine, .cm-selectionBackground, .cm-content .cm-activeLine ::selection":
+      { backgroundColor: `${activeLineHighlight} !important` },
   });
 });
 
@@ -165,9 +168,3 @@ function copyCodeToClipboard() {
   navigator.clipboard.writeText(code);
 }
 </script>
-
-<style>
-.cm-activeLine {
-  background-color: transparent !important;
-}
-</style>


### PR DESCRIPTION
Add theme-conditional extra highlighting for active line. 
![image](https://user-images.githubusercontent.com/1928978/228930873-0c6045e6-608b-4f14-87d5-485a42b21420.png)
![image](https://user-images.githubusercontent.com/1928978/228933589-8c577317-7e97-40db-b95d-c0ffda4ff8b6.png)

Struggled to find the right color for light mode. Will accept anything recommended!