### PR TITLE
feat: add a legal page regarding oss compliance

### DIFF
--- a/app/auth-portal/src/content/legal/2023-03-30/5-oss.md
+++ b/app/auth-portal/src/content/legal/2023-03-30/5-oss.md
@@ -1,0 +1,12 @@
+---
+title: Open Source Software
+---
+
+# Open Source Software used in System Initiative software
+
+System Initiative software uses many open source components, and takes care to be in compliance with their terms.
+
+Should you find a case where we aren't in compliance, email info@systeminit.com, or file an issue in GitHub, and
+we will address your concerns promptly.
+
+[A complete list of all our direct dependencies and their licenses can be downloaded from FOSSA](https://app.fossa.com/attribution/6b812be7-43c6-49b6-8c34-41040f5205b0).

--- a/app/auth-portal/src/content/legal/LICENSE
+++ b/app/auth-portal/src/content/legal/LICENSE
@@ -1,0 +1,5 @@
+All the content in this directory (and sub-directories) is:
+
+Copyright System Initiative, Inc., All rights reserved.
+
+Permission is granted to use the contents when developing System Initiative software directly.


### PR DESCRIPTION
Add a small snippet to our legal folder with a link to a full open source compliance document, and a small bit of text relating how to report compliance problems.

It also adds a LICENSE file in the sub-directory, making it clear that the contents belong to System Initiative, Inc., and are not open source.