### PR TITLE
Remove `RecommendationIsRunnable` and `RecommendationStatus` (ENG-1304)

### DIFF
--- a/app/web/src/components/RecommendationPicker.vue
+++ b/app/web/src/components/RecommendationPicker.vue
@@ -195,7 +195,7 @@ const selectedRecommendations = computed(() => {
     return (
       recommendationSelection[
         `${recommendation.confirmationAttributeValueId}-${recommendation.recommendedAction}`
-      ] && recommendation.isRunnable === "yes"
+      ] && !recommendation.hasRunningFix
     );
   });
 });

--- a/app/web/src/components/RecommendationProgressOverlay.vue
+++ b/app/web/src/components/RecommendationProgressOverlay.vue
@@ -58,7 +58,8 @@ const fixState = computed(() => {
     let highlightedSummary = "";
     if (rate === 1) {
       summary = "Recommendations are up to date.";
-      const { length } = fixesStore.unstartedRecommendations;
+      const { length } = fixesStore.newRecommendations;
+
       if (length !== 0) {
         highlightedSummary = `${length} recommendation${
           length > 1 ? "s" : ""

--- a/lib/dal/tests/integration_test/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/component/confirmation.rs
@@ -1,5 +1,4 @@
 use dal::action_prototype::ActionKind;
-use dal::component::confirmation::view::RecommendationStatus;
 use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::func::backend::js_command::CommandRunResult;
 use dal::job::definition::{FixItem, FixesJob};
@@ -524,6 +523,10 @@ async fn list_confirmations(mut octx: DalContext) {
         &recommendation.recommended_action  // actual
     );
     assert_eq!(
+        false,                          // expected
+        recommendation.has_running_fix  // actual
+    );
+    assert_eq!(
         None,                    // expected
         recommendation.last_fix  // actual
     );
@@ -658,8 +661,8 @@ async fn list_confirmations(mut octx: DalContext) {
         &recommendation.recommended_action  // actual
     );
     assert_eq!(
-        RecommendationStatus::Success, // expected
-        recommendation.status          // actual
+        false,                          // expected
+        recommendation.has_running_fix  // actual
     );
     assert_eq!(
         FixCompletionStatus::Success, // expected


### PR DESCRIPTION
## Description

This PR continues the work from #1861 to clearly separate the _ability_ to run a `Fix` for a `Recommendation` from the _last known status_ of a `Fix` for a `Recommendation`. However, this time, we cut away the cruft...

- `Recommendations` do not _truly_ have a "status". They (may) have a last ran `Fix` that has a "status".
- `Recommendations` do not need to be known as "runnable". We only need to know if they have a corresponding `Fix` that is actively running.

This will make `Recommendations` easier to debug and work with on the frontend and backend alike.

> Some work that was originally in this PR was split into https://github.com/systeminit/si/pull/2058.

## Commit Description

```
The following changes clear some cruft when working with
recommendations and tracking their associated fix states. This commit
does not fix a known bug where recommendations cannot be re-used if a
resource sync triggers a recommendation that's already been ran for a
given component. However, this commit does remove some of the noise that
may help in solving that bug.

Contents:
- Remove "is_runnable" and "status" fields for recommendations
- Use "last_fix" and "has_running_fix" fields to determine the state of a
  given recommendation (while still ensuring that two concerns are
  separate: the ability to run/re-run the recommendation and the status
  of the last time the recommendation was ran)
```