### PR TITLE
Force dependent values update jobs to use non-deleted visibility (ENG-1286)

### DIFF
--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -241,10 +241,19 @@ impl DalContext {
         self.visibility = visibility;
     }
 
+    /// Mutates [`self`](DalContext) with a "deleted" [`Visibility`].
     pub fn update_with_deleted_visibility(&mut self) {
         self.update_visibility(Visibility::new_change_set(
             self.visibility().change_set_pk,
             true,
+        ));
+    }
+
+    /// Mutates [`self`](DalContext) with a "non-deleted" [`Visibility`].
+    pub fn update_without_deleted_visibility(&mut self) {
+        self.update_visibility(Visibility::new_change_set(
+            self.visibility().change_set_pk,
+            false,
         ));
     }
 

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -154,6 +154,9 @@ impl DependentValuesUpdate {
         )
     )]
     async fn run_owned(&self, mut ctx: DalContext) -> JobConsumerResult<()> {
+        // TODO(nick,paulo,zack,jacob): ensure we do not _have_ to do this in the future.
+        ctx.update_without_deleted_visibility();
+
         let mut status_updater = StatusUpdater::initialize(&ctx).await;
 
         let jid = council_server::Id::from_string(&self.job.as_ref().unwrap().id)?;


### PR DESCRIPTION
## Context

There is a bug where (it appears) that manually refreshing `Components` that are tail/source/from `Nodes` in `Edges` cause head/destination/to `Nodes` to have their `/root/domain` properties mangled.

### Impact

The bug should be entirely avoidable by never refreshing (good news), but once it happens, it's impossible to recover without deleting `Components` (bad news).

### Likely Cause

We believe it happens because resource refresh passes a `DalContext` with a **deleted** `Visibility` to “triggered” `DependentValuesUpdate` jobs.

> This is seen in `WorkflowRunner::process_successful_workflow_run`.

### Solution

We think this is solvable by forcing `DependentValuesUpdate` to specifically use a `DalContext` with a **non-deleted** `Visibility`, regardless of what `DalContext` is passed in.

> There’s another conversation to be had about the prevalence of “deleted” `DalContexts` all over the codebase and the lacking traceability that is a consequence of that, but that’s for another day!