### PR TITLE
fix(dal) Handle empty/uninitialized codegen in awsAmiImageIdFromApi

### DIFF
--- a/lib/dal/src/builtins/func/awsAmiImageIdFromApi.js
+++ b/lib/dal/src/builtins/func/awsAmiImageIdFromApi.js
@@ -4,6 +4,9 @@ async function extract(input) {
     }
 
     const code = input.code?.["si:generateAwsAmiJSON"]?.code;
+    if (!code) {
+        return ""
+    }
     // Ensure we have filters (an ami id or filters are set)
     const filters = JSON.parse(code)?.Filters ?? [];
     if (filters.length == 0) {


### PR DESCRIPTION
It's possible for the expected codegen entry to exist, but for the value to be unset, which previously caused the function to bail out with an error about trying to parse `undefined` as JSON.