### PR TITLE
chore(cyclone,telemetry): set Cyclone server default logging to `warn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
           HONEYCOMB_TOKEN: ${{ secrets.HONEYCOMB_TOKEN }}
           RUSTC_WRAPPER: /usr/local/bin/sccache
           CARGO_INCREMENTAL: false
-          SI_LOG: info,cyclone_server=warn
   comment-notification:
     if: github.event_name == 'repository_dispatch'
     name: comment-notification

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -7,6 +7,14 @@ use telemetry_application::{
 
 mod args;
 
+// Override the default tracing level of `info` to warn.
+//
+// Note: Cyclone servers are spawned as child processes (or managed processes) of a Veritech server
+// instance so in many cases the logging output of a Cyclone server is written to the same output
+// stream (i.e. terminal, console) as the Veritech server's logging output. This higher threshold
+// is an attempt to reduce the amount of "normal" logging that is emited for Cyclone instances.
+const CUSTOM_DEFAULT_TRACING_LEVEL: &str = "warn";
+
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
@@ -15,6 +23,7 @@ async fn main() -> Result<()> {
         .service_namespace("si")
         .log_env_var_prefix("SI")
         .app_modules(vec!["cyclone", "cyclone_server"])
+        .custom_default_tracing_level(CUSTOM_DEFAULT_TRACING_LEVEL)
         .build()?;
     let telemetry = telemetry_application::init(config)?;
     let args = args::parse();

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -69,6 +69,9 @@ pub struct TelemetryConfig {
     #[builder(default)]
     app_modules: Vec<&'static str>,
 
+    #[builder(setter(into, strip_option), default = "None")]
+    custom_default_tracing_level: Option<String>,
+
     #[allow(dead_code)]
     #[builder(
         setter(into, strip_option),
@@ -225,7 +228,11 @@ fn default_tracing_level(config: &TelemetryConfig) -> TracingLevel {
         }
     }
 
-    TracingLevel::new(Verbosity::default(), Some(config.app_modules.as_ref()))
+    if let Some(ref directives) = config.custom_default_tracing_level {
+        TracingLevel::custom(directives)
+    } else {
+        TracingLevel::new(Verbosity::default(), Some(config.app_modules.as_ref()))
+    }
 }
 
 fn default_span_events_fmt(config: &TelemetryConfig) -> Result<FmtSpan> {


### PR DESCRIPTION
This change changes the default logging verbosity of Cyclone server instance to `warn` rather than the previous default of `info`. Prior to this change Cyclone server logging output would be seen in Veritech's console output (when running Veritech in a terminal) and in integration test output for dal and sdf tests. Note that `warn` and `error` level logging will still be written out.