### PR TITLE
feat(sdf-server): if there are no prototypes to run, error out

### DIFF
--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -134,8 +134,10 @@ pub enum FuncError {
     UnexpectedFuncVariantCreatingAttributeFunc(FuncVariant),
     #[error("cannot bind func to different prop kinds")]
     FuncDestinationPropKindMismatch,
-    #[error("Function Execution Failed: {0}")]
+    #[error("Function execution failed: {0}")]
     FuncExecutionFailed(String),
+    #[error("Function execution failed: this function is not connected to any assets, and was not executed")]
+    FuncExecutionFailedNoPrototypes,
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;

--- a/lib/sdf-server/src/server/service/func/exec_func.rs
+++ b/lib/sdf-server/src/server/service/func/exec_func.rs
@@ -26,6 +26,10 @@ pub struct ExecFuncResponse {
 
 async fn update_values_for_func(ctx: &DalContext, func: &Func) -> FuncResult<()> {
     let prototypes = AttributePrototype::find_for_func(ctx, func.id()).await?;
+    if prototypes.is_empty() {
+        return Err(FuncError::FuncExecutionFailedNoPrototypes);
+    }
+
     for proto in prototypes {
         let mut values = proto.attribute_values(ctx).await?;
         let value_ids = values


### PR DESCRIPTION
When an attribute function has no prototypes, we won't execute it, but the user doesn't know that. Error out to tell them.