### PR TITLE
fix(dal,web): fix status updates when loading recommendations/running…

### DIFF
--- a/app/web/src/components/ApplyHistory.vue
+++ b/app/web/src/components/ApplyHistory.vue
@@ -99,10 +99,7 @@
                 :default-open="false"
               >
                 <template #label>
-                  <StatusIndicatorIcon
-                    type="resource"
-                    :status="fix.resource.status"
-                  />
+                  <StatusIndicatorIcon type="fix" :status="fix.status" />
                   <div class="flex flex-col">
                     <div class="font-bold pl-xs">
                       {{ `${formatTitle(fix.action)} ${fix.schemaName}` }}
@@ -111,8 +108,9 @@
                 </template>
                 <template #default>
                   <div class="p-2 dark:text-neutral-50 text-neutral-900">
+                    <div v-if="!fix.resource">Fix is pending.</div>
                     <CodeViewer
-                      v-if="fix.resource.data"
+                      v-else-if="fix.resource.data"
                       :code="JSON.stringify(fix.resource.data, null, 2)"
                       class="dark:text-neutral-50 text-neutral-900"
                     >
@@ -197,7 +195,7 @@ import FixDetails from "./FixDetails.vue";
 
 const fixesStore = useFixesStore();
 
-const fixBatches = computed(() => _.reverse(fixesStore.allFinishedFixBatches));
+const fixBatches = computed(() => _.reverse(fixesStore.fixBatches));
 
 const formatTitle = (title: string) => {
   return title

--- a/app/web/src/components/RecommendationPicker.vue
+++ b/app/web/src/components/RecommendationPicker.vue
@@ -73,7 +73,11 @@
               <span class="pl-1">{{ destructionRecommendations.length }}</span>
             </div>
             <Icon
-              v-if="confirmationsInFlight || fixesStore.populatingFixes"
+              v-if="
+                confirmationsInFlight ||
+                fixesStore.populatingFixes ||
+                fixesStore.runningFixBatch
+              "
               name="loader"
               size="md"
               class="text-action-500 dark:text-action-100"
@@ -149,6 +153,7 @@ import {
 } from "@si/vue-lib/design-system";
 import SiSearch from "@/components/SiSearch.vue";
 import { useFixesStore } from "@/store/fixes.store";
+import { useStatusStore } from "@/store/status.store";
 import RecommendationSprite from "@/components/RecommendationSprite.vue";
 
 const selectAll = (checked: boolean) => {
@@ -172,6 +177,7 @@ const recommendations = computed(() =>
   fixesStore.confirmations.flatMap((c) => c.recommendations),
 );
 
+const statusStore = useStatusStore();
 const fixesStore = useFixesStore();
 const creationRecommendations = computed(() =>
   recommendations.value.filter((r) => r.actionKind === "create"),
@@ -212,10 +218,9 @@ const confirmationsInFlight = computed(() => {
 const disableApply = computed(
   () =>
     selectedRecommendations.value.length < 1 ||
+    statusStore.globalStatus.isUpdating ||
     fixesStore.populatingFixes ||
-    (fixesStore.runningFixBatch !== undefined &&
-      fixesStore.completedFixesOnRunningBatch.length <
-        fixesStore.fixesOnRunningBatch.length),
+    fixesStore.runningFixBatch !== undefined,
 );
 
 const currentTime = ref(new Date());

--- a/app/web/src/components/RecommendationProgressOverlay.vue
+++ b/app/web/src/components/RecommendationProgressOverlay.vue
@@ -1,17 +1,20 @@
 <template>
   <ProgressBarOverlay
+    v-if="fixesStore.runningFixBatch"
     :title="fixState.summary"
     :detail="fixState.highlightedSummary"
     :done-count="fixState.executed"
     :total-count="fixState.total"
     :bar-label="fixState.mode === 'syncing' ? 'Synced' : 'Applied'"
   />
+  <GlobalStatusOverlay v-else />
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { useFixesStore } from "@/store/fixes.store";
 import ProgressBarOverlay from "@/components/ProgressBarOverlay.vue";
+import GlobalStatusOverlay from "@/components/GlobalStatusOverlay.vue";
 
 const fixesStore = useFixesStore();
 const loadConfirmationsReqStatus =
@@ -54,7 +57,7 @@ const fixState = computed(() => {
     let summary = "Determining recommendations for updated model...";
     let highlightedSummary = "";
     if (rate === 1) {
-      summary = "Model is up to date";
+      summary = "Recommendations are up to date.";
       const { length } = fixesStore.unstartedRecommendations;
       if (length !== 0) {
         highlightedSummary = `${length} recommendation${

--- a/app/web/src/components/StatusBarTabs/Fixes/FixHistoryPanel.vue
+++ b/app/web/src/components/StatusBarTabs/Fixes/FixHistoryPanel.vue
@@ -75,7 +75,7 @@
           >
             <StatusIndicatorIcon
               type="resource"
-              :status="fix.resource.status"
+              :status="fix.resource?.status ?? 'unknown'"
             />
             <div class="font-bold pl-xs line-clamp-2">
               {{ `${formatTitle(fix.action)} ${fix.schemaName}` }}
@@ -83,7 +83,10 @@
           </div>
         </div>
       </div>
-      <div v-if="selectedFixInfo" class="bg-shade-100 grow p-4">
+      <div
+        v-if="selectedFixInfo && selectedFixInfo.resource"
+        class="bg-shade-100 grow p-4"
+      >
         <CodeViewer
           :code="
             selectedFixInfo.resource.data

--- a/app/web/src/components/StatusIndicatorIcon.vue
+++ b/app/web/src/components/StatusIndicatorIcon.vue
@@ -25,7 +25,7 @@ const CONFIG = {
   fix: {
     success: { iconName: "check2", tone: "success" },
     failure: { iconName: "alert-triangle", tone: "destructive" },
-    unstarted: { iconName: "help-circle", tone: "neutral" },
+    unstarted: { iconName: "loader", tone: "neutral" },
     running: { iconName: "loader", tone: "action" },
   },
   resource: {

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -13,6 +13,11 @@ function nilId(): string {
 }
 
 export type FixStatus = "success" | "failure" | "running" | "unstarted";
+export type RecommendationStatus =
+  | "success"
+  | "failure"
+  | "running"
+  | "unstarted";
 export type RecommendationIsRunnable = "yes" | "no" | "running";
 export type ActionKind = "create" | "other" | "destroy";
 
@@ -42,7 +47,7 @@ export type Recommendation = {
   recommendedAction: string;
   provider: string;
   actionKind: ActionKind;
-  status: FixStatus; // TODO(Wendy) - this should be replaced with a reference to the lastFixRun
+  status: RecommendationStatus; // TODO(Wendy) - this should be replaced with a reference to the lastFixRun
   lastFix?: Fix; // TODO(nick,wendy): delete status if we don't need it
   isRunnable: RecommendationIsRunnable;
 };
@@ -58,7 +63,7 @@ export type Fix = {
   componentId: ComponentId;
   attributeValueId: AttributeValueId;
   provider?: string;
-  resource: Resource;
+  resource?: Resource | null;
   startedAt?: string;
   finishedAt?: string;
 };
@@ -324,7 +329,6 @@ export const useFixesStore = () => {
           {
             eventType: "ConfirmationsUpdated",
             callback: (_update) => {
-              this.runningFixBatch = undefined;
               this.LOAD_CONFIRMATIONS();
               this.LOAD_FIX_BATCHES();
             },
@@ -370,6 +374,7 @@ export const useFixesStore = () => {
           {
             eventType: "FixBatchReturn",
             callback: (update) => {
+              this.runningFixBatch = undefined;
               const batch = this.fixBatches.find((b) => b.id === update.id);
               if (!batch) {
                 this.LOAD_CONFIRMATIONS();

--- a/lib/dal/src/fix/batch.rs
+++ b/lib/dal/src/fix/batch.rs
@@ -103,7 +103,7 @@ impl FixBatch {
                         // If we see failures, we should still continue to see if there's an error.
                         batch_completion_status = FixCompletionStatus::Failure
                     }
-                    FixCompletionStatus::Error => {
+                    FixCompletionStatus::Error | FixCompletionStatus::Unstarted => {
                         // Only break on an error since errors take precedence over failures.
                         batch_completion_status = FixCompletionStatus::Error;
                         break;

--- a/lib/sdf-server/src/server/service/fix/list.rs
+++ b/lib/sdf-server/src/server/service/fix/list.rs
@@ -48,7 +48,7 @@ pub async fn list(
             batch_timed_out = true;
             Some(FixCompletionStatus::Failure)
         } else {
-            None
+            Some(FixCompletionStatus::Unstarted)
         };
 
         let mut fix_views = Vec::new();


### PR DESCRIPTION
… fixes

Adds an "unstarted" state to individual fixes and the fix batch, corresponding to the unstarted recommendation state and starts using it again in the fix store. Returns incomplete fixes in fix/list with the unstarted state and a null resource to get live updates working and fixes a bug where we "finished" the batch on the frontend and loaded only finished fixes while the batch was still running.

Also resolves ENG-1276 by adding the global status update bar to the fix screen. It shows if recommendations are not running. And we show the loader now if fixes are actually running.

Co-Authored-By: theo@systeminit.com