### PR TITLE
fix(dal): don't update_for_context in delete DalContext

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -758,6 +758,9 @@ impl AttributeValue {
         create_child_proxies: bool,
         propagate_dependent_values: bool,
     ) -> AttributeValueResult<(Option<serde_json::Value>, AttributeValueId)> {
+        // TODO(nick,paulo,zack,jacob): ensure we do not _have_ to do this in the future.
+        let ctx = &ctx.clone_without_deleted_visibility();
+
         let row = ctx.pg_txn().query_one(
             "SELECT new_attribute_value_id FROM attribute_value_update_for_context_raw_v1($1, $2, $3, $4, $5, $6, $7, $8)",
             &[

--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -100,11 +100,6 @@ impl Component {
             return Err(ComponentError::CannotUpdateResourceTreeInChangeSet);
         }
 
-        // No need to update if the cached value is there
-        if self.resource(ctx).await? == result {
-            return Ok(false);
-        }
-
         let resource_attribute_value = Component::root_prop_child_attribute_value_for_component(
             ctx,
             self.id,

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -257,6 +257,13 @@ impl DalContext {
         ));
     }
 
+    /// Clones a new context from this one without deleted visibility.
+    pub fn clone_without_deleted_visibility(&self) -> Self {
+        let mut ctx = self.clone();
+        ctx.update_without_deleted_visibility();
+        ctx
+    }
+
     /// Clones a new context from this one with a new [`Visibility`].
     pub fn clone_with_new_visibility(&self, visibility: Visibility) -> Self {
         let mut new = self.clone();

--- a/lib/dal/src/job/definition/refresh.rs
+++ b/lib/dal/src/job/definition/refresh.rs
@@ -118,6 +118,7 @@ impl JobConsumer for RefreshJob {
     }
 
     async fn run_job(&self, ctx_builder: DalContextBuilder) -> JobConsumerResult<()> {
+        assert!(!self.single_transaction);
         let ctx = ctx_builder
             .build(self.access_builder().build(self.visibility()))
             .await?;


### PR DESCRIPTION
- Raise if children attribute value exists when it shouldn't
- Use standard model functions instead of inlining them
- Unset attribute value belongs to when deleting it