### PR TITLE
chore(pg) Increase minimum query execution time to trigger autoexplain

### DIFF
--- a/component/postgres/postgresql-additions.conf
+++ b/component/postgres/postgresql-additions.conf
@@ -12,7 +12,7 @@ log_destination = 'syslog,stderr'
 log_directory = '/var/log/postgresql'
 log_file_mode = 0644
 log_line_prefix = '%m [%p] %q[user=%u,db=%d,app=%a] '
-log_min_duration_statement = 250
+log_min_duration_statement = 1500
 log_lock_waits = on
 log_temp_files = 0
 log_checkpoints = on
@@ -21,7 +21,7 @@ log_disconnections = on
 log_autovacuum_min_duration = 0
 
 auto_explain.log_format = 'json'
-auto_explain.log_min_duration = 250
+auto_explain.log_min_duration = 1500
 auto_explain.log_analyze = on
 auto_explain.log_buffers = on
 auto_explain.log_timing = off


### PR DESCRIPTION
Having a minimum query time of 250 ms is very agressive, and results in triggering a _lot_ of autoexplains during normal usage, and during test runs. Bumping the minimum query time to 1.5 seconds will make the postgres container logs a bit less noisy. We'll still get useful autoexplain output for the worst offenders, and can decrease the minimum execution time to trigger autoexplain again in the future.