### PR TITLE
chore(dal): avoid rerunning confirmations when not needed

### DIFF
--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -271,7 +271,5 @@ async fn finish_batch(ctx: &DalContext, id: FixBatchId) -> JobConsumerResult<()>
         .await?
         .publish_on_commit(ctx)
         .await?;
-
-    Component::run_all_confirmations(ctx).await?;
     Ok(())
 }


### PR DESCRIPTION
It's not clear why, but this makes the system less stable (some data sometimes doesn't seem propagated properly).

This theoretically is the correct fix, we already trigger dependent values update (therefore confirmations) for every /root/resource that gets a fix run for, successfully or not. So confirmations are rerunning more than they should. Except that this change seems to break stuff, which might be a dumb mistake somewhere or it may signify a deeper issue.

I'm leaving this open so I can debug this properly whenever I get time, because this fix has been injected in a couple of PRs making the changes to the PR hard to debug as the cause for the bugs weren't clear. So instead of doing that I can just come back here, set the system up and see what's up.