### PR TITLE
feat(si-pkg): generate unique ids for funcs on spec build

### DIFF
--- a/lib/dal/tests/integration_test/pkg.rs
+++ b/lib/dal/tests/integration_test/pkg.rs
@@ -77,6 +77,34 @@ async fn test_install_pkg(ctx: &DalContext) {
         .build()
         .expect("build func spec");
 
+    let func_spec_2 = FuncSpec::builder()
+        .name("si:truthy")
+        .display_name("truth")
+        .description("it returns true")
+        .handler("truth")
+        .code_base64(&code_base64)
+        .backend_kind(FuncSpecBackendKind::JsAttribute)
+        .response_type(FuncSpecBackendResponseType::Boolean)
+        .hidden(false)
+        .build()
+        .expect("build func spec");
+
+    let func_spec_3 = FuncSpec::builder()
+        .name("si:truthy")
+        .display_name("truth")
+        .description("it returns true, but this time with a different description")
+        .handler("truth")
+        .code_base64(&code_base64)
+        .backend_kind(FuncSpecBackendKind::JsAttribute)
+        .response_type(FuncSpecBackendResponseType::Boolean)
+        .hidden(false)
+        .build()
+        .expect("build func spec");
+
+    // Ensure unique ids are stable and change with properties changing
+    assert_eq!(func_spec.unique_id, func_spec_2.unique_id);
+    assert_ne!(func_spec.unique_id, func_spec_3.unique_id);
+
     let spec_a = PkgSpec::builder()
         .name("The White Visitation")
         .version("0.1")

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -14,7 +14,8 @@
       "backendKind": "jsAttribute",
       "responseType": "boolean",
       "hidden": false,
-      "link": "https://truth.com"
+      "link": "https://truth.com",
+      "uniqueId": "dadf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf"
     }
   ],
   "schemas": [


### PR DESCRIPTION
Using a hash over the data of a function, generate a unique id for the func so we can use it during import and export to refer to functions in the package tree.