### PR TITLE
fix(dal): use correct attr value id in remove_proxies_v1

### DIFF
--- a/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
+++ b/lib/dal/src/migrations/U0589__attribute_value_update_for_context_in_db.sql
@@ -1586,7 +1586,7 @@ BEGIN
                 'attribute_value_belongs_to_attribute_value',
                 this_tenancy,
                 this_visibility,
-                tmp_attribute_value_id
+                found_proxy.id 
             );
             PERFORM delete_by_id_v1('attribute_values',
                                     this_tenancy,


### PR DESCRIPTION
Looks like the unset logic was copied from some code below and only one id changed to match found_proxy.id. Fixes qualification execution at schema variant level on func screen.