### PR TITLE
fix(si-data-pg,si-data-nats): ensure txn spans follow from accurate span

### DIFF
--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -20,8 +20,9 @@ pub use tracing;
 pub mod prelude {
     pub use super::{FormattedSpanKind, SpanExt, SpanKind};
     pub use tracing::{
-        self, debug, debug_span, error, event, field::Empty, info, info_span, instrument, span,
-        trace, trace_span, warn, Instrument, Level, Span,
+        self, debug, debug_span, enabled, error, event, event_enabled, field::Empty, info,
+        info_span, instrument, span, span_enabled, trace, trace_span, warn, Instrument, Level,
+        Span,
     };
 }
 


### PR DESCRIPTION
This change appears to be the underlying cause of both the "mutex poison" and write lock contention scenarios that our team has observed when fully enabling the OpenTelemetry tracing layer.

Background
----------

In both our Postgres and NATS wrapping crates (i.e. `si-data-pg` and `si-data-nats` respectively) we would propagate the tracing span of the method that started the transaction. For example, in the `si-data-pg` create, to start a transaction from our client you can call:

```rust
let pool = PgPool::new(PgPoolConfig::default).await?;
let client = pool.get().await?;

let txn = client.transaction().await?;
```

Inside of our `InstrumentedTransaction` there is a reference to the span for `pub async fn transaction(&mut self) -> Result<...>` which is the "parent" of the transaction. Then, when we run queries, for example:

```rust
let rows = txn.query("SELECT 1", &[]).await?;
```

...the span for `pub async fn query(&self, ...) -> Result<...>` would record that is "follows from" the parent transaction span. In this way we can associate all queries and operations to their specific transaction. Note that it's not that these methods are child spans of the transaction--they are actually child spans of the function that invoked them. Rather, there is a looser association with the tranaction that is extremely valuable when inspecting the traces visually.

This idea of attaching spans to another span with a "follow from" relationship has been in the codebase for some time now (literally years), however there's likely always been a problem lurking.

The Issue
---------

The problem is that in our "parent span", we call `Span::current()` in order to find the span that we are in. Then we use this span value and pass it into our transaction wrapper type which is now the "parent span" which all other methods follow from.

After a very close reading of docs for `Span::current()`, it states:

> Returns a handle to the span considered by the Subscriber to be the
> current span.
>
> If the subscriber indicates that it does not track the current span,
> or that the thread from which this function is called is not currently
> inside a span, the returned span will be disabled.

"... [C]onsidered by the Subscriber" is the key bit of information.

In our data crates we don't want to see logging of every query, transaction commit, etc. by default and so all function instrumentation (i.e. the macro which sets up spans around our functions) are set to `level = "debug"`.

When the log level is at a higher level--like `Level::INFO` which is often the assumed default--these spans will be disabled and skipped as they are at a lower level of verbosity. So when `Span::current()` is called, the span that is returned is often a function higher up in the call stack that is importantly *not* our currently function running on the stack (i.e. it might not be the span for `pub async fn transaction(...) -> Result<...>`).

So, when multiple low level spans are created, like that for a few `txn.query()` method calls, their "parent span" was being set to the nearest info level span, often a much longer running span. And so, if 2 of these `query()` methods were started and importantly on different transactions, they would share the same span parent and would therefore require the lock on that parent span to get its metadata to record their own info.

This is what I believe we were seeing being manifested with a mutex poison on macOS systems and a write lock contention on Linux systems. In enabling the OpenTelemetry layer, its `Subscriber` implementation was influencing the `Span::current()` determination and on closing spans required more span metadata lock access to record its metadata before transmitting OpenTelemetry span data on the internal Tracer (the part of OpenTelemetry that sends data to a collector).

The Solution
------------

Turned out to be not very difficult. In these "parent transaction" methods where before we called `Span::current()`, instead we are using the return of a `tracing::span_enabled!()` macro to help us decide whether to call `Span::current()` (to get the real, immediate span), or to call `Span::none()` which returns a span which has no ID--but importantly can still be used by the downstream code to call `.follows_from()` on.

To ensure that `Span::current()` is getting our immediate function span which was using a `#[instrumented(level = "debug")]` macro, we can check `span_enabled!(Level::DEBUG)`. Then, to ensure that the debug log level is set for our crate specifically, we add `target: "si_data_pg"`, so for the Postgres crate this works out to something like:

```rust
let span = if span_enabled!(target: "si_data_pg", Level::DEBUG) {
    Span::current()
} else {
    Span::none()
};
```

Finally, because this is rather verbose and because we need this code in the function directly, this code is wrapped in a
`current_span_for_debug!()` macro in each crate.

In my testing so far I can boot our system with every service running with an active OpenTelemetry layer--in both the standard/default log levels and with debug logging broadly and specifically for the `si-data-pg`/`si-data-nats` crates.

A future change will re-enable all OpenTelemetry by default, but I would prefer to test this change much more vigorously ;)

<img src="https://media4.giphy.com/media/lShSxBDYoOCQQ1YHla/giphy.gif"/>