### PR TITLE
fix(web): don't add fake fixBatch timestamps

### DIFF
--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -308,13 +308,11 @@ export const useFixesStore = () => {
                         logs: [],
                       },
                       startedAt: `${new Date()}`,
-                      finishedAt: `${new Date()}`,
                     };
                   });
                 }),
                 author: authStore.user?.email ?? "...",
                 startedAt: `${new Date()}`,
-                finishedAt: `${new Date()}`,
               });
             },
           });


### PR DESCRIPTION
We were faking some timestamps before we had real ones, leading to a confusing "finished at" report on the apply history for incomplete jobs.