### PR TITLE
chore(tests) Always output the DB name used for each test

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -354,6 +354,12 @@ impl TestContextBuilder {
         } else {
             info!(dbname = %dbname, "test-specific database already exists");
         }
+        // This is ugly, but we pretty much always want to know which test DB is used for
+        // any given test when it fails, and the logging/tracing macros aren't captured
+        // (or displayed) during tests, while `println!(...)` will be captured the same as
+        // "normal" test output, meaning it respects --nocapture and being displayed for
+        // failing tests.
+        println!("Test database: {}", &dbname);
 
         // Return new PG pool that uess the new datatbase
         new_pg_pool_config.dbname = dbname;


### PR DESCRIPTION
This is ugly, but we pretty much always want to know which test DB is used for any given test when it fails, and the logging/tracing macros aren't captured (or displayed) during tests, while `println!(...)` will be captured the same as "normal" test output, meaning it respects `--nocapture` and being displayed for failing tests.