### PR TITLE
Ensure no component view properties cannot panic (ENG-1318)

### DIFF
--- a/lib/dal/src/component/confirmation/view.rs
+++ b/lib/dal/src/component/confirmation/view.rs
@@ -438,7 +438,7 @@ pub struct Recommendation {
     pub status: RecommendationStatus,
     /// Indicates the ability to "run" the [`Fix`](crate::Fix) associated with the
     /// [recommendation](Self).
-    pub is_runnable: RecommendationIsRunnable,
+    is_runnable: RecommendationIsRunnable,
     /// Gives the [`history view`](crate::fix::FixHistoryView) of the last [`Fix`](crate::Fix) ran.
     /// This will be empty if the [`Recommendation`] had never had a corresponding
     /// [`Fix`](crate::Fix) ran before.
@@ -465,7 +465,7 @@ pub enum RecommendationStatus {
 /// [`ActionPrototype`](crate::ActionPrototype).
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum RecommendationIsRunnable {
+enum RecommendationIsRunnable {
     /// The [`Recommendation`] is ready to be ran.
     Yes,
     /// The [`Recommendation`] is not ready to be ran.

--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -197,7 +197,7 @@ impl ResourceView {
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct ResourceRefreshId {
+pub struct ResourceRefreshedPayload {
     component_id: ComponentId,
 }
 
@@ -208,7 +208,7 @@ impl WsEvent {
     ) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
-            WsPayload::ResourceRefreshed(ResourceRefreshId { component_id }),
+            WsPayload::ResourceRefreshed(ResourceRefreshedPayload { component_id }),
         )
         .await
     }

--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -439,6 +439,12 @@ pub struct FixHistoryView {
     resource: Option<ResourceView>,
 }
 
+impl FixHistoryView {
+    pub fn status(&self) -> FixCompletionStatus {
+        self.status
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct FixReturn {

--- a/lib/dal/src/job/definition/fix.rs
+++ b/lib/dal/src/job/definition/fix.rs
@@ -203,7 +203,7 @@ impl JobConsumer for FixesJob {
         )
         .await?;
 
-        // Always retriggers confirmations, and propagates resource if it changed.
+        // Always re-trigger confirmations, and propagate a resource if it changed.
         ctx.enqueue_blocking_job(DependentValuesUpdate::new(ctx, vec![*attribute_value.id()]))
             .await;
 

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -10,12 +10,10 @@ use veritech_client::OutputStream;
 
 use crate::{
     func::backend::js_workflow::FuncBackendJsWorkflowArgs, func::backend::FuncDispatchContext,
-    func::binding::FuncBindingId, func::execution::FuncExecution,
-    workflow_runner::workflow_runner_state::WorkflowRunnerState, Connections, DalContext,
+    func::binding::FuncBindingId, func::execution::FuncExecution, Connections, DalContext,
     DalContextBuilder, Func, FuncBackendKind, FuncBinding, FuncBindingError,
-    FuncBindingReturnValue, PgPoolError, RequestContext, ResourceView, ServicesContext,
-    StandardModel, StandardModelError, TransactionsError, WsEvent, WsEventError, WsEventResult,
-    WsPayload,
+    FuncBindingReturnValue, PgPoolError, RequestContext, ServicesContext, StandardModel,
+    StandardModelError, TransactionsError, WsEvent, WsEventError, WsEventResult, WsPayload,
 };
 
 #[derive(Error, Debug)]
@@ -512,15 +510,6 @@ pub struct CommandOutput {
     output: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct CommandReturn {
-    run_id: usize,
-    resources: Vec<ResourceView>,
-    runner_state: WorkflowRunnerState,
-    output: Vec<String>,
-}
-
 impl WsEvent {
     pub async fn command_output(
         ctx: &DalContext,
@@ -530,25 +519,6 @@ impl WsEvent {
         WsEvent::new(
             ctx,
             WsPayload::CommandOutput(CommandOutput { run_id, output }),
-        )
-        .await
-    }
-
-    pub async fn command_return(
-        ctx: &DalContext,
-        run_id: usize,
-        resources: Vec<ResourceView>,
-        runner_state: WorkflowRunnerState,
-        output: Vec<String>,
-    ) -> WsEventResult<Self> {
-        WsEvent::new(
-            ctx,
-            WsPayload::CommandReturn(CommandReturn {
-                run_id,
-                resources,
-                runner_state,
-                output,
-            }),
         )
         .await
     }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -6,11 +6,11 @@ use thiserror::Error;
 use crate::component::confirmation::ConfirmationsUpdatedPayload;
 use crate::component::ComponentCreatedPayload;
 use crate::{
-    component::{code::CodeGeneratedPayload, resource::ResourceRefreshId},
+    component::{code::CodeGeneratedPayload, resource::ResourceRefreshedPayload},
     fix::{batch::FixBatchReturn, FixReturn},
     qualification::QualificationCheckPayload,
     status::StatusMessage,
-    workflow::{CommandOutput, CommandReturn},
+    workflow::CommandOutput,
     AttributeValueId, ChangeSetPk, ComponentId, DalContext, PropId, SchemaPk, SocketId,
     StandardModelError, TransactionsError, WorkspacePk,
 };
@@ -43,12 +43,11 @@ pub enum WsPayload {
     ChangeSetWritten(ChangeSetPk),
     ComponentCreated(ComponentCreatedPayload),
     SchemaCreated(SchemaPk),
-    ResourceRefreshed(ResourceRefreshId),
+    ResourceRefreshed(ResourceRefreshedPayload),
     ConfirmationsUpdated(ConfirmationsUpdatedPayload),
     CheckedQualifications(QualificationCheckPayload),
     CommandOutput(CommandOutput),
     CodeGenerated(CodeGeneratedPayload),
-    CommandReturn(CommandReturn),
     FixBatchReturn(FixBatchReturn),
     FixReturn(FixReturn),
     StatusUpdate(StatusMessage),

--- a/lib/dal/tests/integration_test/builtins/aws_region.rs
+++ b/lib/dal/tests/integration_test/builtins/aws_region.rs
@@ -39,7 +39,8 @@ async fn aws_region_field_validation(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // expected
+            .to_value()
+            .expect("could not convert to value") // expected
     );
 
     let validation_statuses = ValidationResolver::find_status(ctx, region_payload.component_id)
@@ -93,7 +94,8 @@ async fn aws_region_field_validation(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // expected
+            .to_value()
+            .expect("could not convert to value") // expected
     );
 
     // TODO(nick): now, ensure we have the right value! Huzzah.
@@ -162,7 +164,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -193,7 +196,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Find the providers we need for connection.
@@ -243,7 +247,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -274,7 +279,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Perform update!
@@ -303,7 +309,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -335,7 +342,8 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }
 
@@ -398,7 +406,8 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -429,7 +438,8 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Find the providers we need for connection.
@@ -479,7 +489,8 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -510,7 +521,8 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Perform update!
@@ -539,7 +551,8 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -571,6 +584,7 @@ async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalConte
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/builtins/coreos_butane.rs
+++ b/lib/dal/tests/integration_test/builtins/coreos_butane.rs
@@ -133,7 +133,8 @@ async fn butane_to_ec2_user_data_is_valid_ignition(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // FIXME(nick): there is a race here where the "generateAwsEc2JSON" function needs to run

--- a/lib/dal/tests/integration_test/builtins/docker_image_intelligence.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_intelligence.rs
@@ -32,7 +32,8 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -50,7 +51,8 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Update the "/root/si/name" value for "bloodscythe", observe that it worked, and observe
@@ -79,7 +81,8 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     assert_eq!(
@@ -98,7 +101,8 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Now, the "/root/si/name" value for "soulrender", observe that it worked, and observe
@@ -127,7 +131,8 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -145,6 +150,7 @@ async fn docker_image_intra_component_update(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/docker_image_to_kubernetes_deployment.rs
@@ -37,7 +37,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -62,7 +63,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Find the providers we need for connection.
@@ -112,7 +114,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -137,7 +140,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Perform update!
@@ -166,7 +170,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     assert_eq!(
@@ -205,7 +210,8 @@ async fn docker_image_to_kubernetes_deployment_inter_component_update(ctx: &mut 
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     let mut cs = ChangeSet::get_by_pk(ctx, &ctx.visibility().change_set_pk)

--- a/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_deployment_intelligence.rs
@@ -121,7 +121,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -139,7 +140,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -186,7 +188,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -211,7 +214,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Connect the fedora docker image to the spongebob deployment.
@@ -251,7 +255,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -269,7 +274,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -329,7 +335,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -354,7 +361,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // After the first update, let's connect alpine to the spongebob deployment.
@@ -432,7 +440,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -450,7 +459,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -521,7 +531,8 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -559,6 +570,7 @@ async fn kubernetes_deployment_intelligence(octx: DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
+++ b/lib/dal/tests/integration_test/builtins/kubernetes_namespace_to_kubernetes_deployment.rs
@@ -68,7 +68,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Find the providers we need for connection.
@@ -149,7 +150,8 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Perform update!
@@ -220,6 +222,7 @@ async fn kubernetes_namespace_to_kubernetes_deployment_inter_component_update(ct
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -615,7 +615,8 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Apply changeset
@@ -663,7 +664,8 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     Component::restore_and_propagate(ctx, nginx_container.component_id)
@@ -703,6 +705,7 @@ async fn create_delete_and_restore_components(ctx: &mut DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/component/validation.rs
+++ b/lib/dal/tests/integration_test/component/validation.rs
@@ -538,7 +538,8 @@ async fn ensure_validations_are_sourced_correctly(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // expected
+            .to_value()
+            .expect("could not convert to value") // expected
     );
 
     // Ensure that we see exactly one expected validation status with exactly one expected

--- a/lib/dal/tests/integration_test/component/view/properties.rs
+++ b/lib/dal/tests/integration_test/component/view/properties.rs
@@ -114,7 +114,10 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
             },
             "domain": {}
         }], // expected
-        component_view_properties.drop_code().to_value() // actual
+        component_view_properties
+            .drop_code()
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // Update the poop field, which will cause the code generation entry to be updated.
@@ -183,6 +186,9 @@ async fn drop_subtree_using_component_view_properties(ctx: &DalContext) {
                 "poop": "canoe"
             }
         }], // expected
-        component_view_properties.drop_code().to_value() // actual
+        component_view_properties
+            .drop_code()
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -44,7 +44,10 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
                 "image": "13700KF",
             },
         }], // expected
-        component_view_properties.drop_qualification().to_value() // actual
+        component_view_properties
+            .drop_qualification()
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     node.set_geometry(ctx, "0", "0", Some("500"), Some("500"))
@@ -68,7 +71,10 @@ async fn create_node_and_check_intra_component_intelligence(ctx: &DalContext) {
                 "image": "13700KF",
             },
         }], // expected
-        component_view_properties.drop_qualification().to_value() // actual
+        component_view_properties
+            .drop_qualification()
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }
 

--- a/lib/dal/tests/integration_test/edge.rs
+++ b/lib/dal/tests/integration_test/edge.rs
@@ -184,7 +184,8 @@ async fn create_delete_and_restore_edges(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // delete the edge
@@ -220,7 +221,8 @@ async fn create_delete_and_restore_edges(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // restore the edge
@@ -257,7 +259,8 @@ async fn create_delete_and_restore_edges(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }
 
@@ -391,7 +394,8 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // delete the nginx connection
@@ -431,7 +435,8 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 
     // delete the nginx connection
@@ -463,6 +468,7 @@ async fn create_multiple_connections_and_delete(ctx: &DalContext) {
             .component_view_properties(ctx)
             .await
             .drop_qualification()
-            .to_value() // actual
+            .to_value()
+            .expect("could not convert to value") // actual
     );
 }

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
@@ -89,7 +89,12 @@ async fn model_and_fix_flow_aws_key_pair(
                 },
             },
         }], // expected
-        key_pair.view(&ctx).await.drop_confirmation().to_value(), // actual
+        key_pair
+            .view(&ctx)
+            .await
+            .drop_confirmation()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -102,7 +107,11 @@ async fn model_and_fix_flow_aws_key_pair(
                 "region": "us-east-2",
             },
         }], // expected
-        region.view(&ctx).await.to_value(), // actual
+        region
+            .view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Apply the change set and get rolling!

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
@@ -243,7 +243,10 @@ async fn model_and_fix_flow_whiskers(
                 },
             },
         }], // expected
-        ami.view(&ctx).await.to_value(), // actual
+        ami.view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -274,7 +277,12 @@ async fn model_and_fix_flow_whiskers(
                 },
             },
         }], // expected
-        key_pair.view(&ctx).await.drop_confirmation().to_value(), // actual
+        key_pair
+            .view(&ctx)
+            .await
+            .drop_confirmation()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -309,7 +317,8 @@ async fn model_and_fix_flow_whiskers(
             .view(&ctx)
             .await
             .drop_confirmation()
-            .to_value(), // actual
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Check Ingress, EC2 Instance and Region.
@@ -348,7 +357,12 @@ async fn model_and_fix_flow_whiskers(
                 },
             },
         }], // expected
-        ingress.view(&ctx).await.drop_confirmation().to_value(), // actual
+        ingress
+            .view(&ctx)
+            .await
+            .drop_confirmation()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -381,7 +395,11 @@ async fn model_and_fix_flow_whiskers(
                 },
             },
         }], // expected
-        ec2.view(&ctx).await.drop_confirmation().to_value(), // actual
+        ec2.view(&ctx)
+            .await
+            .drop_confirmation()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -394,7 +412,11 @@ async fn model_and_fix_flow_whiskers(
                 "region": "us-east-2",
             },
         }], // expected
-        region.view(&ctx).await.to_value(), // actual
+        region
+            .view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Finally, check Docker Image and Butane.
@@ -412,7 +434,12 @@ async fn model_and_fix_flow_whiskers(
                 ],
             },
         }], // expected
-        docker.view(&ctx).await.drop_qualification().to_value(), // actual
+        docker
+            .view(&ctx)
+            .await
+            .drop_qualification()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Evaluate Docker Image qualification(s) separately as they may contain a timestamp. Technically,
@@ -461,7 +488,11 @@ async fn model_and_fix_flow_whiskers(
                 },
             },
         }], // expected
-        butane.view(&ctx).await.to_value(), // actual
+        butane
+            .view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Apply the change set and get rolling!

--- a/lib/sdf-server/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
@@ -130,7 +130,8 @@ async fn model_flow_fedora_coreos_ignition(
             .drop_confirmation()
             .drop_code()
             .drop_qualification()
-            .to_value(), // actual
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -165,7 +166,11 @@ async fn model_flow_fedora_coreos_ignition(
                 },
             },
         }], // expected
-        butane.view(&ctx).await.to_value(), // actual
+        butane
+            .view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -178,7 +183,11 @@ async fn model_flow_fedora_coreos_ignition(
                 "region": "us-east-2",
             },
         }], // expected
-        region.view(&ctx).await.to_value(), // actual
+        region
+            .view(&ctx)
+            .await
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
     assert_eq!(
         serde_json::json![{
@@ -195,7 +204,12 @@ async fn model_flow_fedora_coreos_ignition(
                 ],
             },
         }], // expected
-        docker.view(&ctx).await.drop_qualification().to_value(), // actual
+        docker
+            .view(&ctx)
+            .await
+            .drop_qualification()
+            .to_value()
+            .expect("could not convert to value"), // actual
     );
 
     // Evaluate Docker Image qualification(s) separately as they may contain a timestamp.


### PR DESCRIPTION
## Commit Description

```
Primary:
- Add the ability to drop "/root/resource/last_synced" from
  ComponentViewProperties
- Ensure no ComponentViewProperites methods can panic
  - Looks like this was leftover from when it was moved to "lib/dal"

Secondary:
- Use "last_fix" status for Recommendations in tests
  - We may use these in the future if RecommendationStatus and/or
    RecommendationIsRunnable is removed from the codebase
- Convert RecommendationIsRunnable to be a private enum and remove
  usages barring Recommendation assembly
  - It will likely be removed or significantly refactored
- Delete unused Workflow-related WsEvent
- Little grammatical fixes
```

## GIF

<img src="https://media2.giphy.com/media/jIw2JjXd7On9UpGu0V/giphy.gif"/>