### PR TITLE
Use overlay to get pnpm 8.1.1  (ENG-1320)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680104040,
-        "narHash": "sha256-3872pbvC2EVI8MulLHwaZXoxC/XqPpuQi9sYoh1zDXY=",
+        "lastModified": 1680734714,
+        "narHash": "sha256-AXjZmC/Rklrw6mYJNRZ/254OAf1gfX+9JRFuXGRLEYE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d359333fbe3308ec82a7f379829fff843cddabb",
+        "rev": "c2f2239d92f2e7c853ff5b48701d179fec2ea7d4",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1680056830,
-        "narHash": "sha256-WB4KD8oLSxAAtmXYSzwVwQusC2Gy5vTEln1uTt0GI2k=",
+        "lastModified": 1680660688,
+        "narHash": "sha256-XeQTCxWBR0Ai1VMzI5ZXYpA2lu1F8FzZKjw8RtByZOg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c8d8d05b8100d451243b614d950fa3f966c1fcc2",
+        "rev": "2f40052be98347b479c820c00fb2fc1d87b3aa28",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,22 @@
       overlays = [
         # Makes a `rust-bin` attribute available in Nixpkgs
         (import rust-overlay)
+
         # Provides a `rustToolchain` attribute for Nixpkgs that we can use to 
         # create a Rust environment
         (self: super: {
           rustToolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+        })
+
+        # Override attributes from nixpkgs so that we can get a newer pnpm package
+        (self: super: {
+          si-overlay.pnpm = super.nodePackages.pnpm.override(oldAttrs: rec {
+            version = "8.1.1";
+            src = super.fetchurl {
+              url = "https://registry.npmjs.org/pnpm/-/pnpm-8.1.1.tgz";
+              sha512 = "XLzcc4O8YrqfQ1+qjPtHGDFcdUeno2Zk+kuuSc9CagIiY8y4uhnqQ2B7jW8tgwQDNmehewGZuqrAoskgCkbTnw==";
+            };
+          });
         })
       ];
 
@@ -37,6 +49,7 @@
           # The Nix packages provided in the environment
           buildInputs = (with pkgs; [
             rustToolchain
+            si-overlay.pnpm
 
             automake
             awscli
@@ -54,15 +67,14 @@
             protobuf
             skopeo
             jq
-            nodejs-16_x
-            nodePackages.pnpm
+            nodejs-18_x
+
             nodePackages.typescript
             nodePackages.typescript-language-server
-
           ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
-	    libiconv
-	    pkgs.darwin.apple_sdk.frameworks.Security
-	  ]);
+            libiconv
+            pkgs.darwin.apple_sdk.frameworks.Security
+          ]);
         };
       });
     };


### PR DESCRIPTION
## Description

This PR adds an overlay to override attributes to get a newer version of `pnpm`.

In the meantime, there is an existing PR upstream to upgrade the `pnpm` package, but since it is a major semantic version update, I am waiting for the unofficial(?) maintainer of the package to take a look: https://github.com/NixOS/nixpkgs/pull/224851

## GIF

<img src="https://media2.giphy.com/media/jYmGmDK3rKdkk/giphy.gif"/>