### PR TITLE
chore: fix local pg auto detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CI_FROM_REF := main
 CI_TO_REF := HEAD
 FORCE := false
 SHELL := /bin/bash
-LOCAL_PG := $(shell test $$(uname -m) = "arm64" && test $$(uname) = "Darwin" && echo true)
+LOCAL_PG := $(shell test $$(uname -m) = "arm64" && test $$(uname) = "Darwin" && echo true || echo false)
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
the rest of the makefile didnt like an empty var, so we now always set it to `true` or `false`