### PR TITLE
Add ability to toggle vim mode (ENG-1317)

### DIFF
--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -95,6 +95,7 @@ import DockerLogo from "~icons/mdi/docker";
 import KubernetesLogo from "~icons/carbon/kubernetes";
 import DiscordLogo from "~icons/carbon/logo-discord";
 import GithubLogo from "~icons/carbon/logo-github";
+import VimLogo from "~icons/raphael/vim";
 
 // carbon
 import Hashtag from "~icons/carbon/hashtag";
@@ -200,6 +201,7 @@ export const LOGO_ICONS = Object.freeze({
   // others - not used in providers currently
   "logo-discord": DiscordLogo,
   "logo-github": GithubLogo,
+  "logo-vim": VimLogo,
 });
 
 /*


### PR DESCRIPTION
- Add ability to toggle vim mode for CodeEditor instances
  - Vim mode ability was not added for CodeViewer instances since it is more likely that CodeViewer goes the way of the dinosaur and CodeEditor takes its place in the near future
- Use local storage to cache a vim mode preference (i.e. use across multiple CodeEditor instances and upon browser restart)

<img src="https://media0.giphy.com/media/l1J9LMNeWISnddECA/giphy.gif"/>