### PR TITLE
fix(web): editor should take up as much height as it can

### DIFF
--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -1,8 +1,6 @@
 <template>
-  <div
-    class="w-full h-full border-neutral-300 dark:border-neutral-600 border-x p-2"
-  >
-    <div class="absolute right-[14px] top-[14px]">
+  <div class="w-full h-full">
+    <div class="absolute right-xs top-xs">
       <VButton2
         size="xs"
         :tone="vimEnabled ? 'success' : 'neutral'"
@@ -10,12 +8,7 @@
         @click="vimEnabled = !vimEnabled"
       />
     </div>
-    <div
-      ref="editorMount"
-      class="border border-neutral-300 dark:border-neutral-600"
-      @keyup.stop
-      @keydown.stop
-    />
+    <div ref="editorMount" class="h-full" @keyup.stop @keydown.stop />
   </div>
 </template>
 
@@ -94,6 +87,7 @@ const codeMirrorTheme = computed(() =>
 const styleExtension = computed(() => {
   const activeLineHighlight = appTheme.value === "dark" ? "#7c6f64" : "#e0dee9";
   return EditorView.theme({
+    "&": { height: "100%" },
     ".cm-scroller": { overflow: "auto" },
     ".cm-vim-panel, .cm-vim-panel input": {
       padding: "0px 10px",

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div
+    class="h-full border border-t-0 border-neutral-300 dark:border-neutral-600"
+  >
     <div
       v-if="loadFuncDetailsReq.isPending && !editingFunc"
       class="w-full flex flex-col items-center gap-4 p-xl"

--- a/app/web/src/components/Workspace/WorkspaceCustomizeFunctions.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeFunctions.vue
@@ -12,7 +12,7 @@
   <div
     class="grow overflow-hidden bg-shade-0 dark:bg-neutral-800 dark:text-shade-0 text-lg font-semi-bold flex flex-col relative"
   >
-    <div class="left-2 right-2 top-2 bottom-0 absolute">
+    <div class="left-2 right-2 top-2 bottom-2 absolute">
       <FuncEditorTabs />
     </div>
   </div>


### PR DESCRIPTION
A bit of polish that seems very necessary now that we have a vim mode-line. Get that editor height all the way to the end of the tab.