### PR TITLE
feat(auth-portal): embed survey, alias user to email

### DIFF
--- a/app/auth-portal/src/content/tutorial/03-deploy_containerized_app.md
+++ b/app/auth-portal/src/content/tutorial/03-deploy_containerized_app.md
@@ -245,7 +245,7 @@ that we have not yet configured the `/domain/InstanceType` attribute.
 
 ![Needs an Instance Type](tutorial-img/03-deploy_containerized_app/needs_an_instance_type.png)
 
-Go to the `domain/ImageId` attribute in the details panel, and set it to `t3.micro`. You should see the 'All Fields Are
+Go to the `domain/InstanceType` attribute in the details panel, and set it to `t3.micro`. You should see the 'All Fields Are
 Valid' qualification turn green and the remaining warnings are related to the Key Pair and Security Group not existing
 yet (which is fine - it will soon enough!) Close the status bar, and let's get this show on the road.
 

--- a/app/auth-portal/src/content/tutorial/05-model_survey.md
+++ b/app/auth-portal/src/content/tutorial/05-model_survey.md
@@ -1,5 +1,16 @@
 ---
-title: "Survey: Modeling"
+title: "Survey: Deployment"
 ---
 
-Lorem ipsem survey money
+## Survey: Deployment
+
+We have a few questions we would like you to answer about your experience. Please fill in the form below, using the
+__same email address you signed up with__. 
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdC363eoal2uE0VlgOOpIuB8TuCey5lCcMqpp3k3w7203pDgw/viewform?embedded=true" 
+        width="640" 
+        height="1800" frameborder="0" marginheight="0" marginwidth="0">
+  Loading Survey...
+</iframe>
+
+Make sure you submit the form in the embed. Once we've received your response, you can continue to the next step!

--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -6,6 +6,8 @@ import LogoutPage from "./pages/LogoutPage.vue";
 import NotFoundPage from "./pages/NotFoundPage.vue";
 import DashboardPage from "./pages/DashboardPage.vue";
 import ProfilePage from "./pages/ProfilePage.vue";
+import {nextTick} from "vue";
+import posthog from "posthog-js";
 
 // normally we'd initialze a router directly, but instead we pass the options to ViteSSG
 export const routerOptions: RouterOptions = {
@@ -57,5 +59,11 @@ export function initRouterGuards(router: Router) {
     if (!to.name || !_.isString(to.name)) return;
     if (["login", "logout", "404"].includes(to.name)) return;
     // TODO: might want to do something here...?
+  });
+
+  router.afterEach((to) => {
+    nextTick(() => {
+      posthog.capture("$pageview", {$current_url: to.fullPath});
+    }).catch((e) => console.log("Failed to caputre posthog pageview", e));
   });
 }

--- a/app/auth-portal/src/store/auth.store.ts
+++ b/app/auth-portal/src/store/auth.store.ts
@@ -53,6 +53,9 @@ export const useAuthStore = defineStore("auth", {
         onSuccess: (response) => {
           this.user = response.user;
           posthog.identify(this.user.id);
+          if (this.user.email) {
+            posthog.alias(this.user.id, this.user.email);
+          }
         },
         onFail(e) {
           /* eslint-disable-next-line no-console */


### PR DESCRIPTION
This embeds the survey in the tutorial, and automatically aliases the user to their email address. It also ensures we capture pageviews for routes in the auth portal.