### PR TITLE
fix(web): key save_and_exec request by func id

### DIFF
--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -229,7 +229,10 @@ const revertFunc = async () => {
   resetEditingFunc();
 };
 
-const execFuncReqStatus = funcStore.getRequestStatus("SAVE_AND_EXEC_FUNC");
+const execFuncReqStatus = funcStore.getRequestStatus(
+  "SAVE_AND_EXEC_FUNC",
+  funcId,
+);
 const execFunc = () => {
   if (!funcId) return;
   funcStore.SAVE_AND_EXEC_FUNC(funcId);

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -7,6 +7,7 @@ import { Visibility } from "@/api/sdf/dal/visibility";
 import { FuncVariant } from "@/api/sdf/dal/func";
 
 import { nilId } from "@/utils/nilId";
+import { trackEvent } from "@/utils/tracking";
 import { useChangeSetsStore } from "../change_sets.store";
 import { useRealtimeStore } from "../realtime/realtime.store";
 import { useComponentsStore } from "../components.store";
@@ -18,7 +19,6 @@ import {
   CreateFuncAttributeOptions,
 } from "./types";
 import { useRouterStore } from "../router.store";
-import {trackEvent} from "@/utils/tracking";
 
 export type FuncId = string;
 
@@ -194,6 +194,7 @@ export const useFuncStore = () => {
         return new ApiRequest<SaveFuncResponse>({
           method: "post",
           url: "func/save_and_exec",
+          keyRequestStatusBy: funcId,
           params: { ...func, ...visibility },
           onSuccess: (response) => {
             this.funcDetailsById[funcId].associations = response.associations;


### PR DESCRIPTION
Without this we get the error for the previous function when we switch to a new function