### PR TITLE
Separate recommendations from views (ENG-1327)

### DIFF
--- a/app/web/src/components/RecommendationPicker.vue
+++ b/app/web/src/components/RecommendationPicker.vue
@@ -173,9 +173,7 @@ const allSelected = computed(() => {
   return false;
 });
 
-const recommendations = computed(() =>
-  fixesStore.confirmations.flatMap((c) => c.recommendations),
-);
+const recommendations = computed(() => fixesStore.recommendations);
 
 const statusStore = useStatusStore();
 const fixesStore = useFixesStore();

--- a/lib/dal/src/component/confirmation.rs
+++ b/lib/dal/src/component/confirmation.rs
@@ -1,3 +1,6 @@
+//! This module contains operations related to working with the "/root/confirmation" subtree
+//! in relation to [`Components`](Component).
+
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -5,7 +8,7 @@ use telemetry::prelude::*;
 
 use crate::action_prototype::ActionKind;
 use crate::attribute::value::AttributeValue;
-use crate::component::confirmation::view::{ConfirmationView, PrimaryActionKind};
+use crate::component::confirmation::view::{ConfirmationView, RecommendationView};
 use crate::component::{
     ComponentResult, LIST_ALL_RESOURCE_IMPLICIT_INTERNAL_PROVIDER_ATTRIBUTE_VALUES,
 };
@@ -80,17 +83,18 @@ impl Component {
     }
 
     // TODO(nick): big query potential here.
-    pub async fn list_confirmations(ctx: &DalContext) -> ComponentResult<Vec<ConfirmationView>> {
+    pub async fn list_confirmations(
+        ctx: &DalContext,
+    ) -> ComponentResult<(Vec<ConfirmationView>, Vec<RecommendationView>)> {
         let sorted_node_ids =
             Node::list_topologically_sorted_configuration_nodes_with_stable_ordering(ctx, false)
                 .await?;
 
-        // Go through all sorted nodes, assemble confirmations and order them by primary action
-        // kind.
-        let mut delete_results = Vec::new();
-        let mut create_results = Vec::new();
-        let mut other_results = Vec::new();
-        let mut no_recommendation_results = Vec::new();
+        // Prepare to sort confirmations and recommendations.
+        let mut destroy_recommendations = Vec::new();
+        let mut create_recommendations = Vec::new();
+        let mut other_recommendations = Vec::new();
+        let mut confirmations = Vec::new();
 
         let ctx_with_deleted = &ctx.clone_with_delete_visibility();
         for sorted_node_id in sorted_node_ids {
@@ -105,42 +109,51 @@ impl Component {
             if component.visibility.deleted_at.is_some() && !component.needs_destroy() {
                 continue;
             }
-            if let Some((component_specific_confirmations, primary_action_kind)) =
-                Self::list_confirmations_for_component(ctx, *component.id()).await?
-            {
-                match primary_action_kind {
-                    PrimaryActionKind::HasRecommendations(action_kind) => match action_kind {
-                        ActionKind::Create => {
-                            create_results.extend(component_specific_confirmations)
-                        }
-                        ActionKind::Other => other_results.extend(component_specific_confirmations),
-                        ActionKind::Destroy => {
-                            delete_results.extend(component_specific_confirmations)
-                        }
-                    },
-                    PrimaryActionKind::NoRecommendations => {
-                        no_recommendation_results.extend(component_specific_confirmations)
+
+            let (confirmations_component_specific, recommendations_component_specific) =
+                Self::list_confirmations_for_component(ctx, *component.id()).await?;
+
+            for recommendation_component_specific in recommendations_component_specific {
+                match recommendation_component_specific.action_kind {
+                    ActionKind::Create => {
+                        create_recommendations.push(recommendation_component_specific)
+                    }
+                    ActionKind::Other => {
+                        other_recommendations.push(recommendation_component_specific)
+                    }
+                    ActionKind::Destroy => {
+                        destroy_recommendations.push(recommendation_component_specific)
                     }
                 }
             }
+
+            if !confirmations_component_specific.is_empty() {
+                confirmations.extend(confirmations_component_specific);
+            }
         }
 
-        // We need to invert the order of the delete results before we create the final results.
-        // The final results are in the following order: destroy, create, other and "no
-        // recommendations" based on a topological sort of the nodes.
-        let mut results = Vec::new();
-        delete_results.reverse();
-        results.extend(delete_results);
-        results.extend(create_results);
-        results.extend(other_results);
-        results.extend(no_recommendation_results);
-        Ok(results)
+        // We need to invert the order of the delete recommendations before we create the final
+        // recommendations list. The final recommendations are in the following order: destroy,
+        // create, and other based on a topological sort of the nodes.
+        let mut recommendations = Vec::new();
+        destroy_recommendations.reverse();
+        recommendations.extend(destroy_recommendations);
+        recommendations.extend(create_recommendations);
+        recommendations.extend(other_recommendations);
+
+        // Finally, sort the confirmations to ensure that they are in stable order. We'll use the
+        // component id and title.
+        confirmations.sort_by_key(|v| (v.component_id, v.title.clone()));
+
+        Ok((confirmations, recommendations))
     }
 
+    /// List [`ConfirmationViews`](ConfirmationView) and [`RecommendationViews`](RecommendationView)
+    /// for a given [`ComponentId`](Component).
     async fn list_confirmations_for_component(
         ctx: &DalContext,
         component_id: ComponentId,
-    ) -> ComponentResult<Option<(Vec<ConfirmationView>, PrimaryActionKind)>> {
+    ) -> ComponentResult<(Vec<ConfirmationView>, Vec<RecommendationView>)> {
         let schema_variant_id = Self::schema_variant_id(ctx, component_id).await?;
         let schema_id = Self::schema_id(ctx, component_id).await?;
         let schema_name = Schema::get_by_id(ctx, &schema_id)
@@ -168,7 +181,7 @@ impl Component {
             Some(all_confirmations_raw) => {
                 let deserialized_value: HashMap<String, ConfirmationEntry> =
                     serde_json::from_value(all_confirmations_raw)?;
-                let view = ConfirmationView::assemble_for_component(
+                let (confirmations, recommendations) = ConfirmationView::assemble_for_component(
                     ctx,
                     component_id,
                     &deserialized_value,
@@ -180,9 +193,9 @@ impl Component {
                 )
                 .await
                 .map_err(|e| ComponentError::ConfirmationView(e.to_string()))?;
-                Ok(Some(view))
+                Ok((confirmations, recommendations))
             }
-            None => Ok(None),
+            None => Ok((vec![], vec![])),
         }
     }
 

--- a/lib/dal/src/tasks/status_receiver.rs
+++ b/lib/dal/src/tasks/status_receiver.rs
@@ -164,12 +164,9 @@ impl StatusReceiver {
 
         let code_generation_attribute_values: HashSet<AttributeValueId> =
             Component::all_code_generation_attribute_values(&ctx).await?;
-        let confirmation_attribute_values: HashSet<AttributeValueId> = HashSet::from_iter(
-            Component::list_confirmations(&ctx)
-                .await?
-                .into_iter()
-                .map(|cv| cv.attribute_value_id),
-        );
+        let (confirmation_views, _) = Component::list_confirmations(&ctx).await?;
+        let confirmation_attribute_values: HashSet<AttributeValueId> =
+            HashSet::from_iter(confirmation_views.iter().map(|cv| cv.attribute_value_id));
 
         // Flatten the dependency graph into a single vec.
         let mut flattened_dependent_graph: Vec<&AttributeValueId> =

--- a/lib/dal/tests/integration_test/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/component/confirmation.rs
@@ -478,18 +478,17 @@ async fn list_confirmations(mut octx: DalContext) {
     ctx.update_visibility(Visibility::new_head(false));
 
     // List confirmations.
-    let mut views = Component::list_confirmations(ctx)
+    let (confirmations, mut recommendations) = Component::list_confirmations(ctx)
         .await
         .expect("could not list confirmations");
-    let mut view = views.pop().expect("views are empty");
-    assert!(views.is_empty());
-    let recommendation = view
-        .recommendations
-        .pop()
-        .expect("recommendations are empty");
+    assert_eq!(
+        1,                   // expected
+        confirmations.len()  // actual
+    );
+    let recommendation = recommendations.pop().expect("recommendations are empty");
 
     // Check that there is only one recommendation and that it looks as expected.
-    assert!(view.recommendations.is_empty());
+    assert!(recommendations.is_empty());
     assert_eq!(
         "create",                           // expected
         &recommendation.recommended_action  // actual
@@ -546,13 +545,13 @@ async fn list_confirmations(mut octx: DalContext) {
 
     // Ensure that our confirmations views look as intended. We should have exactly zero
     // recommendations!
-    let mut views = Component::list_confirmations(ctx)
+    let (mut confirmations, recommendations) = Component::list_confirmations(ctx)
         .await
         .expect("could not list confirmations");
-    let view = views.pop().expect("views are empty");
-    assert!(views.is_empty());
-    assert_eq!(view.status, ConfirmationStatus::Success);
-    assert!(view.recommendations.is_empty());
+    let confirmation = confirmations.pop().expect("views are empty");
+    assert!(confirmations.is_empty());
+    assert_eq!(confirmation.status, ConfirmationStatus::Success);
+    assert!(recommendations.is_empty());
 
     // Observe that the confirmation worked after "creation".
     let component_view = ComponentView::new(ctx, *component.id())
@@ -604,18 +603,17 @@ async fn list_confirmations(mut octx: DalContext) {
         .expect("could not set resource");
 
     // List confirmations.
-    let mut views = Component::list_confirmations(ctx)
+    let (confirmations, mut recommendations) = Component::list_confirmations(ctx)
         .await
         .expect("could not list confirmations");
-    let mut view = views.pop().expect("views are empty");
-    assert!(views.is_empty());
-    let recommendation = view
-        .recommendations
-        .pop()
-        .expect("recommendations are empty");
+    assert_eq!(
+        1,                   // expected
+        confirmations.len()  // actual
+    );
+    let recommendation = recommendations.pop().expect("recommendations are empty");
 
     // Check that there is only one recommendation and that it looks as expected.
-    assert!(view.recommendations.is_empty());
+    assert!(recommendations.is_empty());
     assert_eq!(
         "create",                           // expected
         &recommendation.recommended_action  // actual

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -14,7 +14,7 @@ mod model_flow_fedora_coreos_ignition;
 
 use axum::http::Method;
 use axum::Router;
-use dal::component::confirmation::view::ConfirmationView;
+use dal::component::confirmation::view::{ConfirmationView, RecommendationView};
 use dal::{
     property_editor::values::PropertyEditorValue, socket::SocketEdgeKind, AttributeValue,
     AttributeValueId, ComponentId, ComponentView, ComponentViewProperties, DalContext, Diagram,
@@ -465,13 +465,16 @@ impl ScenarioHarness {
         assert!(response.success);
     }
 
-    pub async fn list_confirmations(&self, ctx: &mut DalContext) -> Vec<ConfirmationView> {
+    pub async fn list_confirmations(
+        &self,
+        ctx: &mut DalContext,
+    ) -> (Vec<ConfirmationView>, Vec<RecommendationView>) {
         let request = ConfirmationsRequest {
             visibility: *ctx.visibility(),
         };
         let response: ConfirmationsResponse =
             self.query_get("/api/fix/confirmations", &request).await;
-        response
+        (response.confirmations, response.recommendations)
     }
 
     pub async fn run_fixes(&self, ctx: &mut DalContext, fixes: Vec<FixRunRequest>) -> FixBatchId {

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
@@ -120,14 +120,13 @@ async fn model_and_fix_flow_aws_key_pair(
         .await;
 
     // Check the confirmations and ensure they look as we expect.
-    let mut confirmations = harness.list_confirmations(&mut ctx).await;
-    let mut confirmation = confirmations.pop().expect("no confirmations found");
-    assert!(confirmations.is_empty());
-    let recommendation = confirmation
-        .recommendations
-        .pop()
-        .expect("no recommendations found");
-    assert!(confirmation.recommendations.is_empty());
+    let (confirmations, mut recommendations) = harness.list_confirmations(&mut ctx).await;
+    assert_eq!(
+        1,                   // expected
+        confirmations.len()  // actual
+    );
+    let recommendation = recommendations.pop().expect("no recommendations found");
+    assert!(recommendations.is_empty());
 
     // Run the fix for the confirmation.
     let fix_batch_id = harness


### PR DESCRIPTION
- Separate recommendations from confirmation views
- Allow confirmations to return recommendations of different kinds (unblocks the "re-create" logic where a confirmation can return two recommends: one of kind "destroy" followed y another of kind "create")

<img src="https://media0.giphy.com/media/3og0IzQgXVbrsipxi8/giphy.gif"/>