### PR TITLE
fix(make) Do not use hard-coded path to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CI := false
 CI_FROM_REF := main
 CI_TO_REF := HEAD
 FORCE := false
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 LOCAL_PG := $(shell test $$(uname -m) = "arm64" && test $$(uname) = "Darwin" && echo true || echo false)
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Bash is _usually_, but not always, located at `/usr/bin/bash`. The common convention is to use `/usr/bin/env bash` to "find" the bash executable, and every system we're testing/developing/deploying on ensures that `/usr/bin/env` exists, at least partially, for this exact reason.