### PR TITLE
Execute funcs on write in vim mode (ENG-1326)

### DIFF
--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -15,7 +15,12 @@
         loadFuncDetailsReq.isSuccess && typeof editingFunc === 'string'
       "
     >
-      <CodeEditor v-model="editingFunc" typescript @change="updateFuncCode" />
+      <CodeEditor
+        v-model="editingFunc"
+        typescript
+        @change="updateFuncCode"
+        @vim-mode-write="execFunc"
+      />
     </template>
     <ErrorMessage
       v-else-if="loadFuncDetailsReq.isError"
@@ -68,5 +73,9 @@ watch(
 
 const updateFuncCode = (code: string) => {
   funcStore.updateFuncCode(props.funcId, code);
+};
+
+const execFunc = () => {
+  funcStore.SAVE_AND_EXEC_FUNC(props.funcId);
 };
 </script>


### PR DESCRIPTION
- Execute Funcs "on write" (i.e. ":w") in vim mode
- Ensure that the "Executing" icon transitions between states properly when writing in vim mode
  - This is in the FuncDetails component, and it works out of the box due to how it was already written

<img src="https://media1.giphy.com/media/xT5LMRMUMVHdk5oLHa/giphy.gif"/>