### PR TITLE
Remove component code loading text (ENG-1335)

### DIFF
--- a/app/web/src/components/StatusBarTabs/Changes/ChangesTabPanel.vue
+++ b/app/web/src/components/StatusBarTabs/Changes/ChangesTabPanel.vue
@@ -25,10 +25,7 @@
     </div>
 
     <div v-else class="w-full h-full flex flex-col bg-shade-100">
-      <template v-if="diffReqStatus.isPending"
-        >Loading component code...</template
-      >
-      <template v-else-if="diffReqStatus.isError">
+      <template v-if="diffReqStatus.isError">
         <ErrorMessage :request-status="diffReqStatus" />
       </template>
       <template v-else-if="diffReqStatus.isSuccess && selectedComponentDiff">


### PR DESCRIPTION
The loading text was unformatted and was primarily for debugging. It can be a bit distracting and does not match the style of the rest of the app. Moreover, it always flashes on screen before code is displayed.

<img src="https://media4.giphy.com/media/11ASZtb7vdJagM/giphy.gif"/>