### PR TITLE
chore(nix) Set up LD_LIBRARY_PATH in development shell environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
             kubeval
             libtool
             lld
-	    openssl
+            openssl
             gnumake
             protobuf
             skopeo
@@ -62,9 +62,21 @@
             nodePackages.typescript-language-server
 
           ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
-	    libiconv
-	    pkgs.darwin.apple_sdk.frameworks.Security
-	  ]);
+            libiconv
+            pkgs.darwin.apple_sdk.frameworks.Security
+          ]);
+          # This is awful, but necessary (until we find a better way) to
+          # be able to `cargo run` anything that compiles against
+          # openssl. Without this, ld is unable to find libssl.so.3 and
+          # libcrypto.so.3.
+          #
+          # If we were packaging this up as a flake, instead of only
+          # using nix for the development environment, we'd be using
+          # wrapProgram with something like
+          # `--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl ]}`
+          # to make sure the things we're compiling are always using the
+          # version of openssl they were compiled against.
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
         };
       });
     };


### PR DESCRIPTION
This is awful, but necessary (until we find a better way) to be able to `cargo run` anything that compiles against openssl. Without this, `ld` is unable to find `libssl.so.3` and `libcrypto.so.3`.

If we were packaging this up as a flake, instead of only using nix for the development environment, we'd be using wrapProgram with something like `--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl ]}` to make sure the things we're compiling are always using the version of openssl they were compiled against. Unless we find an even less hacky way of ensuring the compiled binary is able to find the openssl library it was compiled against in a nix environment.