### PR TITLE
chore(rust) Switch rust-toolchain to TOML format

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,4 @@
-stable
+[toolchain]
+channel = "stable"
+profile = "default"
+components = [ "rust-analyzer" ]


### PR DESCRIPTION
The TOML format allows us a bit more fine-grained control over the version of rust that is used, beyond which channel it is pulled from.