### PR TITLE
chore(nix) Clean up flake.nix format using flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,24 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -17,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680802968,
-        "narHash": "sha256-McgCkc9FYRnyjZlaDH+kkXCd/3Ze8id20c88k8NNXAY=",
+        "lastModified": 1681217261,
+        "narHash": "sha256-RbxCHWN3Vhyv/WEsXcJlDwF7bpvZ9NxDjfSouQxXEKo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d82b65d4dc1f29d435b97b3b16f953530c8012da",
+        "rev": "3fb8eedc450286d5092e4953118212fa21091b3b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -49,26 +67,42 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1680747499,
-        "narHash": "sha256-E9rcxSTsqRqNd4SD+D/4aqm3qfFyVw0S9YseCks7h+c=",
+        "lastModified": 1681265948,
+        "narHash": "sha256-wYS5dR1fRoU6VtoKScz1OUS/dmart7hfI0G71qkJcwc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8ad3b5ee01a2074b54274216ff2cf0ab844a7426",
+        "rev": "b10a42fe6bb0b6d1b335c1f137419ebf754b2b59",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,68 +3,61 @@
 
   # Flake inputs
   inputs = {
-    # Unstable nixpkgs to get pnpm
-    nixpkgs.url = "github:NixOS/nixpkgs/master"; # also valid: "nixpkgs"
-    rust-overlay.url = "github:oxalica/rust-overlay"; # A helper for Rust + Nix
+    # rust-overlay is designed to work with nixos-unstable
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs, rust-overlay }:
-    let
-      # Overlays enable you to customize the Nixpkgs attribute set
-      overlays = [
-        # Makes a `rust-bin` attribute available in Nixpkgs
-        (import rust-overlay)
-        # Provides a `rustToolchain` attribute for Nixpkgs that we can use to 
-        # create a Rust environment
-        (self: super: {
-          rustToolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain;
-        })
-      ];
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [
+          (import rust-overlay)
 
-      # Helper to provide system-specific attributes
-      nameValuePair = name: value: { inherit name value; };
-      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
-      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forAllSystems = f: genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit overlays system; };
-      });
-    in
-    {
-      # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          buildInputs = (with pkgs; [
-            rustToolchain
-
+          (self: super: {
+            rustToolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+          })
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell {
+          buildInputs = [
             automake
-            awscli
             bash
-            butane
             coreutils
             docker-compose
             gcc
             git
-            pgcli
-            postgresql_14
-            kubeval
+            gnumake
+            jq
             libtool
             lld
-            openssl
-            gnumake
-            protobuf
-            skopeo
-            jq
             nodejs-18_x
             nodePackages.pnpm
             nodePackages.typescript
             nodePackages.typescript-language-server
-
-          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
+            openssl
+            pgcli
+            postgresql_14
+            protobuf
+            rustToolchain
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
             libiconv
-            pkgs.darwin.apple_sdk.frameworks.Security
-          ]);
+            darwin.apple_sdk.frameworks.Security
+          ];
+          depsTargetTarget = [
+            awscli
+            butane
+            kubeval
+            nodejs-18_x
+            skopeo
+          ];
           # This is awful, but necessary (until we find a better way) to
           # be able to `cargo run` anything that compiles against
           # openssl. Without this, ld is unable to find libssl.so.3 and
@@ -78,6 +71,6 @@
           # version of openssl they were compiled against.
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
         };
-      });
-    };
+      }
+    );
 }


### PR DESCRIPTION
The idea is that this should be a bit easier to understand what's going on compared to the previous version, and lend itself a bit more to being used for more than _just_ the development environment.