### PR TITLE
fix(dal,sdf): populate child proxies for qualifications

### DIFF
--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -26,6 +26,7 @@ use crate::{
 use crate::{AttributeValueError, AttributeValueId, FuncBackendResponseType, TransactionsError};
 
 const ALL_ANCESTOR_PROPS: &str = include_str!("queries/prop/all_ancestor_props.sql");
+const FIND_ROOT_PROP_FOR_PROP: &str = include_str!("queries/prop/root_prop_for_prop.sql");
 const FIND_ROOT_FOR_SCHEMA_VARIANT: &str =
     include_str!("queries/prop/find_root_for_schema_variant.sql");
 
@@ -294,6 +295,23 @@ impl Prop {
             )
             .await?;
         Ok(object_option_from_row_option(row)?)
+    }
+
+    pub async fn find_root_prop_for_prop(
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> PropResult<Option<Self>> {
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                FIND_ROOT_PROP_FOR_PROP,
+                &[ctx.tenancy(), ctx.visibility(), &prop_id],
+            )
+            .await?;
+
+        Ok(standard_model::object_option_from_row_option::<Self>(row)?)
     }
 
     /// Returns the given [`Prop`] and all ancestor [`Props`](crate::Prop) back to the root.

--- a/lib/dal/src/queries/prop/root_prop_for_prop.sql
+++ b/lib/dal/src/queries/prop/root_prop_for_prop.sql
@@ -1,0 +1,17 @@
+WITH RECURSIVE recursive_props AS (
+    SELECT
+        $3::ident AS prop_id,
+        0::bigint  AS depth
+    UNION ALL
+    SELECT
+        pbp.belongs_to_id         AS prop_id,
+        recursive_props.depth + 1 AS depth
+    FROM prop_belongs_to_prop_v1($1, $2) AS pbp
+    JOIN recursive_props
+        ON pbp.object_id = recursive_props.prop_id
+)
+SELECT row_to_json(props.*) AS object
+FROM props_v1($1, $2) as props
+INNER JOIN recursive_props rp
+    ON rp.prop_id = props.id
+ORDER BY depth DESC LIMIT 1;

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -1,6 +1,7 @@
 //! This module contains (and is oriented around) the [`RootProp`]. This object is not persisted
 //! to the database.
 
+use strum_macros::{AsRefStr, Display as EnumDisplay, EnumIter, EnumString};
 use telemetry::prelude::*;
 
 use crate::edit_field::widget::WidgetKind;
@@ -17,6 +18,7 @@ pub mod component_type;
 
 /// This enum contains the subtree names for every direct child [`Prop`](crate::Prop) of
 /// [`RootProp`](RootProp). Not all children will be of the same [`PropKind`](crate::PropKind).
+#[derive(AsRefStr, EnumIter, EnumString, EnumDisplay)]
 pub enum RootPropChild {
     /// Corresponds to the "/root/si" subtree.
     Si,

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -138,6 +138,10 @@ pub enum FuncError {
     FuncExecutionFailed(String),
     #[error("Function execution failed: this function is not connected to any assets, and was not executed")]
     FuncExecutionFailedNoPrototypes,
+    #[error("Could not root prop for child prop {0}")]
+    MissingRootPropForProp(PropId),
+    #[error("Could not find schema variant for root prop {0}")]
+    PropMissingSchemaVariant(PropId),
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -140,7 +140,7 @@ async fn save_attr_func_prototypes(
     ctx: &DalContext,
     func: &Func,
     prototypes: Vec<AttributePrototypeView>,
-    remoted_protoype_op: RemovedPrototypeOp,
+    removed_protoype_op: RemovedPrototypeOp,
     key: Option<String>,
 ) -> FuncResult<Option<PropKind>> {
     let mut id_set = HashSet::new();
@@ -230,7 +230,7 @@ async fn save_attr_func_prototypes(
     // TODO: should use a custom query to fetch for *not in* id_set only
     for proto in AttributePrototype::find_for_func(ctx, func.id()).await? {
         if !id_set.contains(proto.id()) {
-            match remoted_protoype_op {
+            match removed_protoype_op {
                 RemovedPrototypeOp::Reset => {
                     reset_prototype_and_value_to_builtin_function(ctx, &proto, proto.context)
                         .await?


### PR DESCRIPTION
When a qualification is executed at the schema variant context, the values it creates have to be propagated into the component context for every component that is an "instance" of that schema variant. We can do this by creating proxy values at the component context that point back to the schema variant level values, and then executing the functions again for those proxy values so that they take the component context input. We're not doing this anywhere automatically for values created by functions run by `update_from_prototype_function` right now, it's only handled via the update/insert_for_context PL/pgSQL functions. I've rigged this up here to do so when a function is executed on the function details panel, but I believe we should rework this so that `update_from_prototype_function` handles the population of child proxy values whenever it's called for automatically. I'm not digging into that yet, since I think it's best done with a new PL/pgSQL function that will require a little more care and testing before we're confident it handles every kind of value.

![image](https://user-images.githubusercontent.com/1928978/231532750-68f93660-389a-417d-910e-f821e5bcf3a8.png)
