### PR TITLE
fix(web): turn on noUncheckedIndexedAccess and fix fallout

### DIFF
--- a/app/web/src/components/ApplyHistory.vue
+++ b/app/web/src/components/ApplyHistory.vue
@@ -200,7 +200,7 @@ const fixBatches = computed(() => _.reverse(fixesStore.fixBatches));
 const formatTitle = (title: string) => {
   return title
     .split(" ")
-    .map((t) => t[0].toUpperCase() + t.slice(1).toLowerCase())
+    .map((t) => `${t[0]?.toUpperCase()}${t.slice(1).toLowerCase()}`)
     .join(" ");
 };
 </script>

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -129,24 +129,32 @@ const executeAssetModalRef = ref();
 const assetModalTitle = ref("New Asset Created");
 
 const updateAsset = () => {
-  assetStore.SAVE_ASSET(assetStore.selectedAsset);
+  if (assetStore.selectedAsset) {
+    assetStore.SAVE_ASSET(assetStore.selectedAsset);
+  }
 };
 
-const disabled = computed(() => assetStore.selectedAsset.variantExists);
+const disabled = computed(
+  () => assetStore.selectedAsset?.variantExists ?? false,
+);
 
 defineProps<{
   assetId?: string;
 }>();
 
 const executeAsset = async () => {
-  await assetStore.EXEC_ASSET(assetStore.selectedAsset.id);
-  executeAssetModalRef.value.open();
+  if (assetStore.selectedAsset?.id) {
+    await assetStore.EXEC_ASSET(assetStore.selectedAsset.id);
+    executeAssetModalRef.value.open();
+  }
 };
 
 const cloneAsset = async () => {
-  const result = await assetStore.CLONE_ASSET(assetStore.selectedAsset.id);
-  if (result.result.success) {
-    assetStore.SELECT_ASSET(result.result.data.id);
+  if (assetStore.selectedAsset?.id) {
+    const result = await assetStore.CLONE_ASSET(assetStore.selectedAsset.id);
+    if (result.result.success) {
+      assetStore.SELECT_ASSET(result.result.data.id);
+    }
   }
 };
 </script>

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -82,7 +82,10 @@ watch(
 );
 
 const onChange = () => {
-  if (selectedAsset.value.definition === editingAsset.value) {
+  if (
+    !selectedAsset.value ||
+    selectedAsset.value.definition === editingAsset.value
+  ) {
     return;
   }
   selectedAsset.value.definition = editingAsset.value;

--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full">
+  <div v-if="selectedComponent" class="flex flex-col h-full">
     <!-- <div class="p-xs border-b dark:border-neutral-600">
       <Inline align-y="center">
         <Icon size="md" name="plug" class="shrink-0 mr-2xs" />
@@ -182,6 +182,8 @@ const refreshing = computed(() => {
 });
 
 const onClickRefreshButton = () => {
-  componentsStore.REFRESH_RESOURCE_INFO(selectedComponent.value.id);
+  if (selectedComponent.value) {
+    componentsStore.REFRESH_RESOURCE_INFO(selectedComponent.value.id);
+  }
 };
 </script>

--- a/app/web/src/components/ComponentDetailsResource.vue
+++ b/app/web/src/components/ComponentDetailsResource.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="selectedComponent">
     <CodeViewer
       v-if="selectedComponent.resource.data !== null"
       :code="

--- a/app/web/src/components/ComponentOutline/ComponentOutline.vue
+++ b/app/web/src/components/ComponentOutline/ComponentOutline.vue
@@ -187,7 +187,9 @@ const onKeyDown = (e: KeyboardEvent) => {
       toSelectIndex = 0;
     }
     const toSelect = componentIds[toSelectIndex];
-    componentsStore.setSelectedComponentId(toSelect);
+    if (toSelect) {
+      componentsStore.setSelectedComponentId(toSelect);
+    }
   }
 };
 </script>

--- a/app/web/src/components/ComponentOutline/ComponentOutlineNode.vue
+++ b/app/web/src/components/ComponentOutline/ComponentOutlineNode.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="component-outline-node" :data-component-id="componentId">
+  <div
+    v-if="component"
+    class="component-outline-node"
+    :data-component-id="componentId"
+  >
     <!-- component info -->
     <div
       :class="
@@ -79,7 +83,7 @@
               icon="refresh"
               size="xs"
               variant="ghost"
-              @click="componentsStore.REFRESH_RESOURCE_INFO(component.id)"
+              @click="componentsStore.REFRESH_RESOURCE_INFO(component!.id)"
             />
           </div>
 
@@ -165,7 +169,7 @@ const isSelected = computed(() =>
 
 const enableGroupToggle = computed(
   () =>
-    component.value.isGroup &&
+    component.value?.isGroup &&
     childComponents.value.length &&
     !filterModeActive.value,
 );
@@ -194,13 +198,13 @@ function onHoverEnd() {
 }
 
 const parentBreadcrumbsText = computed(() => {
-  if (!component.value.parentId) return;
+  if (!component.value?.parentId) return;
 
   const parentIds =
     componentsStore.parentIdPathByComponentId[component.value.id];
   return _.map(
     parentIds,
-    (parentId) => componentsStore.componentsById[parentId].displayName,
+    (parentId) => componentsStore.componentsById[parentId]?.displayName,
   ).join(" > ");
 });
 </script>

--- a/app/web/src/components/EdgeCard.vue
+++ b/app/web/src/components/EdgeCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="fromComponent && toComponent">
     <ComponentCard :component-id="fromComponent.id" />
     <div class="_connection-label text-xs italic">
       <!-- currently output and input socket always have the same label/name -->
@@ -25,20 +25,26 @@ const componentsStore = useComponentsStore();
 
 const edge = computed(() => componentsStore.edgesById[props.edgeId]);
 
-const fromComponent = computed(
-  () => componentsStore.componentsByNodeId[edge.value.fromNodeId],
+const fromComponent = computed(() =>
+  edge.value?.fromNodeId
+    ? componentsStore.componentsByNodeId[edge.value.fromNodeId]
+    : undefined,
 );
-const fromSchema = computed(
-  () => componentsStore.schemaVariantsById[fromComponent.value.schemaVariantId],
+const fromSchema = computed(() =>
+  fromComponent.value?.schemaVariantId
+    ? componentsStore.schemaVariantsById[fromComponent.value.schemaVariantId]
+    : undefined,
 );
 const fromSocket = computed(() =>
   _.find(
-    fromSchema.value.outputSockets,
+    fromSchema.value?.outputSockets ?? [],
     (s) => s.id === edge.value?.fromSocketId,
   ),
 );
-const toComponent = computed(
-  () => componentsStore.componentsByNodeId[edge.value?.toNodeId],
+const toComponent = computed(() =>
+  edge.value?.toNodeId
+    ? componentsStore.componentsByNodeId[edge.value.toNodeId]
+    : undefined,
 );
 // const toSchema = computed(
 //   () => componentsStore.schemaVariantsById[toComponent.value.schemaVariantId],

--- a/app/web/src/components/EdgeDetailsPanel.vue
+++ b/app/web/src/components/EdgeDetailsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full">
+  <div v-if="selectedEdge" class="flex flex-col h-full">
     <div class="p-xs border-b dark:border-neutral-600">
       <Inline align-y="center">
         <Icon size="md" name="plug" class="shrink-0 mr-2xs" />

--- a/app/web/src/components/GenericDiagram/DiagramGroup.vue
+++ b/app/web/src/components/GenericDiagram/DiagramGroup.vue
@@ -419,9 +419,9 @@ const connectedEdgesBySocketKey = computed(() => {
   const lookup: Record<DiagramElementUniqueKey, DiagramEdgeData[]> = {};
   _.each(props.connectedEdges, (edge) => {
     lookup[edge.fromSocketKey] ||= [];
-    lookup[edge.fromSocketKey].push(edge);
+    lookup[edge.fromSocketKey]!.push(edge);
     lookup[edge.toSocketKey] ||= [];
-    lookup[edge.toSocketKey].push(edge);
+    lookup[edge.toSocketKey]!.push(edge);
   });
   return lookup;
 });

--- a/app/web/src/components/GenericDiagram/DiagramNode.vue
+++ b/app/web/src/components/GenericDiagram/DiagramNode.vue
@@ -323,9 +323,9 @@ const connectedEdgesBySocketKey = computed(() => {
   const lookup: Record<DiagramElementUniqueKey, DiagramEdgeData[]> = {};
   _.each(props.connectedEdges, (edge) => {
     lookup[edge.fromSocketKey] ||= [];
-    lookup[edge.fromSocketKey].push(edge);
+    lookup[edge.fromSocketKey]!.push(edge);
     lookup[edge.toSocketKey] ||= [];
-    lookup[edge.toSocketKey].push(edge);
+    lookup[edge.toSocketKey]!.push(edge);
   });
   return lookup;
 });

--- a/app/web/src/components/GenericDiagram/diagram_types.ts
+++ b/app/web/src/components/GenericDiagram/diagram_types.ts
@@ -27,6 +27,7 @@ export type DiagramElementTypes = "node" | "socket" | "edge";
 export type DiagramElementUniqueKey = string;
 
 export abstract class DiagramElementData {
+  abstract get def(): DiagramNodeDef | DiagramSocketDef | DiagramEdgeDef;
   abstract get uniqueKey(): DiagramElementUniqueKey;
 }
 
@@ -103,7 +104,7 @@ export class DiagramEdgeData extends DiagramElementData {
   // helpers to get the unique key of the node and sockets this edge is connected to
   get fromNodeKey() {
     const comp = useComponentsStore().componentsByNodeId[this.def.fromNodeId];
-    if (comp.isGroup) {
+    if (comp?.isGroup) {
       return DiagramGroupData.generateUniqueKey(this.def.fromNodeId);
     }
     return DiagramNodeData.generateUniqueKey(this.def.fromNodeId);
@@ -111,7 +112,7 @@ export class DiagramEdgeData extends DiagramElementData {
 
   get toNodeKey() {
     const comp = useComponentsStore().componentsByNodeId[this.def.toNodeId];
-    if (comp.isGroup) {
+    if (comp?.isGroup) {
       return DiagramGroupData.generateUniqueKey(this.def.toNodeId);
     }
     return DiagramNodeData.generateUniqueKey(this.def.toNodeId);
@@ -119,7 +120,7 @@ export class DiagramEdgeData extends DiagramElementData {
 
   get fromSocketKey() {
     const comp = useComponentsStore().componentsByNodeId[this.def.fromNodeId];
-    if (comp.isGroup) {
+    if (comp?.isGroup) {
       return DiagramSocketData.generateUniqueKey(
         DiagramGroupData.generateUniqueKey(this.def.fromNodeId),
         this.def.fromSocketId,
@@ -133,7 +134,7 @@ export class DiagramEdgeData extends DiagramElementData {
 
   get toSocketKey() {
     const comp = useComponentsStore().componentsByNodeId[this.def.toNodeId];
-    if (comp.isGroup) {
+    if (comp?.isGroup) {
       return DiagramSocketData.generateUniqueKey(
         DiagramGroupData.generateUniqueKey(this.def.toNodeId),
         this.def.toSocketId,

--- a/app/web/src/components/PackageDetailsPanel.vue
+++ b/app/web/src/components/PackageDetailsPanel.vue
@@ -44,7 +44,9 @@ const selectedPackageListItem = computed(
 
 const installPackage = async () => {
   disableInstallButton.value = true;
-  await packageStore.INSTALL_PACKAGE(selectedPackageListItem.value);
+  if (selectedPackageListItem.value) {
+    await packageStore.INSTALL_PACKAGE(selectedPackageListItem.value);
+  }
   disableInstallButton.value = false;
 };
 </script>

--- a/app/web/src/components/PackageDisplay.vue
+++ b/app/web/src/components/PackageDisplay.vue
@@ -112,7 +112,7 @@ const selectedPackageListItem = computed(
 watch(
   () => packageStore.urlSelectedPackageSlug,
   (selectedPackageName) => {
-    if (selectedPackageName) {
+    if (selectedPackageName && selectedPackageListItem.value) {
       packageStore.GET_PACKAGE(selectedPackageListItem.value);
     }
   },

--- a/app/web/src/components/PropertyEditor.vue
+++ b/app/web/src/components/PropertyEditor.vue
@@ -7,7 +7,7 @@
     >
       <PropertyWidget
         v-if="schemasByPropId[pv.propId]"
-        :schema-prop="schemasByPropId[pv.propId]"
+        :schema-prop="schemasByPropId[pv.propId]!"
         :prop-value="pv"
         :path="paths[pv.id]"
         :collapsed-paths="collapsed"
@@ -213,7 +213,9 @@ const determineOrder = (
 ): PropertyEditorValue[] => {
   for (const childValueId of childValueIds) {
     const child = values.value.values[childValueId];
-    order.push(child);
+    if (child) {
+      order.push(child);
+    }
     const childValuesList = values.value.childValues[childValueId];
     if (childValuesList) {
       determineOrder(order, childValuesList);

--- a/app/web/src/components/SelectMenu.vue
+++ b/app/web/src/components/SelectMenu.vue
@@ -129,9 +129,9 @@ const selectedLabel = computed<string>(() => {
       case 0:
         return props.noneSelectedLabel ?? "select an option...";
       case 1:
-        return selectedOptions.value[0].label;
+        return selectedOptions.value[0]?.label ?? "label missing";
       default:
-        return `${selectedOptions.value[0].label} (+${
+        return `${selectedOptions.value[0]?.label} (+${
           selectedOptions.value.length - 1
         })`;
     }

--- a/app/web/src/components/SiPackageListItem.vue
+++ b/app/web/src/components/SiPackageListItem.vue
@@ -1,5 +1,6 @@
 <template>
   <RouterLink
+    v-if="packageInfo"
     class="flex flex-row items-center gap-2.5 py-4 pr-4 pl-8 text-xs relative border border-transparent dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300"
     :class="
       isSelected
@@ -34,6 +35,6 @@ const packageInfo = computed(
   () => packageStore.packageListByName[props.packageId],
 );
 const isSelected = computed(
-  () => packageInfo.value.name === packageStore.urlSelectedPackageSlug,
+  () => packageInfo.value?.name === packageStore.urlSelectedPackageSlug,
 );
 </script>

--- a/app/web/src/components/StatusBarTabs/Changes/ChangesTabPanel.vue
+++ b/app/web/src/components/StatusBarTabs/Changes/ChangesTabPanel.vue
@@ -10,7 +10,7 @@
       <template #icon="{ component }">
         <StatusIndicatorIcon
           type="change"
-          :status="componentsById[component.id].changeStatus"
+          :status="componentsById[component.id]?.changeStatus"
         />
       </template>
     </StatusBarTabPanelComponentList>
@@ -59,8 +59,8 @@
               <CodeViewer
                 font-size="13px"
                 class="text-neutral-50 mx-2"
-                :code="selectedComponentDiff.diffs[0].code"
-                :code-language="selectedComponentDiff.diffs[0].language"
+                :code="selectedComponentDiff.diffs[0]?.code"
+                :code-language="selectedComponentDiff.diffs[0]?.language"
               >
                 <template #title>
                   <span class="text-lg">Diff</span>

--- a/app/web/src/components/StatusBarTabs/Confirmations/ConfirmationsResourceList.vue
+++ b/app/web/src/components/StatusBarTabs/Confirmations/ConfirmationsResourceList.vue
@@ -24,7 +24,7 @@
         @click="onSelectResource(componentId)"
       >
         <span class="shrink min-w-0 truncate mr-3">
-          {{ componentsStore.componentsById[componentId].displayName }}
+          {{ componentsStore.componentsById[componentId]?.displayName }}
         </span>
         <StatusIndicatorIcon
           type="confirmation"

--- a/app/web/src/components/StatusBarTabs/Fixes/FixHistoryPanel.vue
+++ b/app/web/src/components/StatusBarTabs/Fixes/FixHistoryPanel.vue
@@ -180,7 +180,7 @@ const sortOptions: SortOption[] = [
   { value: "r", title: "Newest" },
   { value: "o", title: "Oldest" },
 ];
-const selectedSort = ref<SortOption>(sortOptions[0]);
+const selectedSort = ref<SortOption | undefined>(sortOptions[0]);
 const selectedFixBatchId = ref<string | null>(null);
 const selectedFix = ref<SelectedFix | null>(null);
 const selectFixBatch = (id: string) => {
@@ -204,7 +204,7 @@ const fixBatchesWithFixes = computed(() =>
   })),
 );
 const fixListDisplay = computed(() => {
-  if (selectedSort.value.value === "r") {
+  if (selectedSort.value?.value === "r") {
     return [...fixBatchesWithFixes.value].reverse();
   } else return fixBatchesWithFixes.value;
 });
@@ -228,7 +228,7 @@ const selectedFixInfo = computed(() => {
 const formatTitle = (title: string) => {
   return title
     .split(" ")
-    .map((t) => t[0].toUpperCase() + t.slice(1).toLowerCase())
+    .map((t) => `${t[0]?.toUpperCase()}${t.slice(1).toLowerCase()}`)
     .join(" ");
 };
 </script>

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -217,13 +217,13 @@ const diagramEdges = computed(() => {
     edge.isInvisible = false;
 
     const toNodeParentId =
-      componentsStore.componentsByNodeId[edge.toNodeId].parentNodeId;
+      componentsStore.componentsByNodeId[edge.toNodeId]?.parentNodeId;
 
     if (toNodeParentId) {
       const toNodeParentComp =
         componentsStore.componentsByNodeId[toNodeParentId];
 
-      if (toNodeParentComp.nodeType === "aggregationFrame") {
+      if (toNodeParentComp?.nodeType === "aggregationFrame") {
         if (edge.fromNodeId === toNodeParentComp.nodeId) {
           edge.isInvisible ||= true;
         }
@@ -231,12 +231,12 @@ const diagramEdges = computed(() => {
     }
 
     const fromNodeParentId =
-      componentsStore.componentsByNodeId[edge.fromNodeId].parentNodeId;
+      componentsStore.componentsByNodeId[edge.fromNodeId]?.parentNodeId;
 
     if (fromNodeParentId) {
       const fromParentComp =
         componentsStore.componentsByNodeId[fromNodeParentId];
-      if (fromParentComp.nodeType === "aggregationFrame") {
+      if (fromParentComp?.nodeType === "aggregationFrame") {
         if (edge.toNodeId === fromParentComp.nodeId) {
           edge.isInvisible ||= true;
         }
@@ -477,12 +477,12 @@ async function triggerRestoreSelection() {
     const parentIds = _.compact(
       _.map(
         selectedComponentIds.value,
-        (id) => componentsStore.componentsById[id].parentId,
+        (id) => componentsStore.componentsById[id]?.parentId,
       ),
     );
 
     const hasDeletedParent = parentIds.find(
-      (id) => !_.isNil(componentsStore.componentsById[id].deletedInfo),
+      (id) => !_.isNil(componentsStore.componentsById[id]?.deletedInfo),
     );
 
     if (hasDeletedParent) {
@@ -501,10 +501,12 @@ async function triggerRestoreSelection() {
 function getDiagramElementKeyForComponentId(componentId?: ComponentId | null) {
   if (!componentId) return;
   const component = componentsStore.componentsById[componentId];
-  if (component.isGroup) {
-    return DiagramGroupData.generateUniqueKey(component.nodeId);
+  if (component) {
+    if (component.isGroup) {
+      return DiagramGroupData.generateUniqueKey(component.nodeId);
+    }
+    return DiagramNodeData.generateUniqueKey(component.nodeId);
   }
-  return DiagramNodeData.generateUniqueKey(component.nodeId);
 }
 
 function getDiagramElementKeyForEdgeId(edgeId?: EdgeId | null) {
@@ -569,10 +571,10 @@ watch(
 function onGroupElements({ group, elements }: GroupEvent) {
   if (group.def.nodeType === "aggregationFrame") {
     const groupSchemaId =
-      componentsStore.componentsByNodeId[group.def.id].schemaVariantId;
+      componentsStore.componentsByNodeId[group.def.id]?.schemaVariantId;
     elements = _.filter(elements, (e) => {
       const elementSchemaId =
-        componentsStore.componentsByNodeId[e.def.id].schemaVariantId;
+        componentsStore.componentsByNodeId[e.def.id]?.schemaVariantId;
 
       return elementSchemaId === groupSchemaId;
     });
@@ -593,7 +595,7 @@ function onOutlineRightClick(e: MouseEvent) {
 }
 
 const typeDisplayName = (action = "delete") => {
-  if (selectedComponentId.value) {
+  if (selectedComponentId.value && selectedComponent.value) {
     if (selectedComponent.value.nodeType === "component") return "Component";
     else return "Frame";
   } else if (selectedComponentIds.value.length) {
@@ -617,7 +619,7 @@ const rightClickMenuItems = computed(() => {
   if (!isViewMode.value) {
     if (selectedEdgeId.value) {
       // single selected edge
-      if (selectedEdge.value.changeStatus === "deleted") {
+      if (selectedEdge.value?.changeStatus === "deleted") {
         items.push({
           label: "Restore edge",
           icon: "trash-restore",
@@ -630,7 +632,7 @@ const rightClickMenuItems = computed(() => {
           onSelect: triggerDeleteSelection,
         });
       }
-    } else if (selectedComponentId.value) {
+    } else if (selectedComponentId.value && selectedComponent.value) {
       // single selected component
       if (selectedComponent.value.changeStatus === "deleted") {
         items.push({
@@ -673,7 +675,7 @@ const rightClickMenuItems = computed(() => {
       }
     }
   }
-  if (selectedComponentId.value && selectedComponent.value.resource.data) {
+  if (selectedComponent.value?.resource.data) {
     items.push({
       label: "Refresh resource",
       icon: "refresh",
@@ -684,6 +686,8 @@ const rightClickMenuItems = computed(() => {
 });
 
 const refreshResourceForSelectedComponent = () => {
-  componentsStore.REFRESH_RESOURCE_INFO(selectedComponent.value.id);
+  if (selectedComponent.value?.id) {
+    componentsStore.REFRESH_RESOURCE_INFO(selectedComponent.value.id);
+  }
 };
 </script>

--- a/app/web/src/pages/HomePage.vue
+++ b/app/web/src/pages/HomePage.vue
@@ -41,9 +41,14 @@ const workspacesReqStatus = workspacesStore.getRequestStatus(
 function autoSelectWorkspace() {
   if (workspaces.value.length !== 1) return;
 
+  const workspacePk = workspaces.value[0]?.pk;
+  if (!workspacePk) {
+    return;
+  }
+
   router.push({
     name: "workspace-single",
-    params: { workspacePk: workspaces.value[0].pk },
+    params: { workspacePk },
   });
 }
 

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -60,7 +60,7 @@ export const useAssetStore = () => {
       }),
       getters: {
         assets: (state) => _.values(state.assetsById),
-        selectedAsset(): Asset {
+        selectedAsset(): Asset | undefined {
           return this.assetsById[this.selectedAssetId || 0];
         },
       },

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -110,7 +110,7 @@ export function useChangeSetsStore() {
           // returning `false` means we cannot auto select
           if (!this.openChangeSets.length) return false; // no open change sets
           if (this.openChangeSets.length === 1)
-            return this.openChangeSets[0].pk; // only 1 change set - will auto select it
+            return this.openChangeSets[0]?.pk; // only 1 change set - will auto select it
           // TODO: add logic to for auto-selecting when multiple change sets open
           // - select one created by you
           // - track last selected in localstorage and select that one...
@@ -159,7 +159,11 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetApplied",
             callback: (id) => {
-              this.changeSetsById[id].status = ChangeSetStatus.Applied;
+              const changeSet = this.changeSetsById[id];
+              if (changeSet) {
+                changeSet.status = ChangeSetStatus.Applied;
+                this.changeSetsById[id] = changeSet;
+              }
             },
           },
           {

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -135,19 +135,21 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
 
               for (const propKey in response.props) {
                 const prop = response.props[propKey];
-                const isHidden =
-                  prop.name === "type" &&
-                  this.selectedComponent.schemaName === "Generic Frame";
-                const isReadonly =
-                  prop.name === "type" &&
-                  this.selectedComponent.childNodeIds !== undefined &&
-                  this.selectedComponent.childNodeIds.length > 0;
+                if (prop) {
+                  const isHidden =
+                    prop.name === "type" &&
+                    this.selectedComponent.schemaName === "Generic Frame";
+                  const isReadonly =
+                    prop.name === "type" &&
+                    this.selectedComponent.childNodeIds !== undefined &&
+                    this.selectedComponent.childNodeIds.length > 0;
 
-                props[propKey] = {
-                  ...prop,
-                  isHidden,
-                  isReadonly,
-                };
+                  props[propKey] = {
+                    ...prop,
+                    isHidden,
+                    isReadonly,
+                  };
+                }
               }
 
               this.schema = { ...response, props };

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -110,9 +110,10 @@ export const useFixesStore = () => {
         confirmationsByComponentId(): Record<ComponentId, Confirmation[]> {
           const obj: Record<ComponentId, Confirmation[]> = {};
           for (const confirmation of this.confirmations) {
-            if (!obj[confirmation.componentId])
+            if (!obj[confirmation.componentId]) {
               obj[confirmation.componentId] = [];
-            obj[confirmation.componentId].push(confirmation);
+            }
+            obj[confirmation.componentId]!.push(confirmation);
           }
           return obj;
         },

--- a/app/web/src/store/package.store.ts
+++ b/app/web/src/store/package.store.ts
@@ -89,7 +89,7 @@ export const usePackageStore = () => {
         packageList: (state) => _.values(state.packageListByName),
         packagesBySlug: (state) =>
           _.keyBy(_.values(state.packageListByName), (p) => p.name),
-        selectedPackageListItem(): PackageListItem {
+        selectedPackageListItem(): PackageListItem | undefined {
           return this.packagesBySlug[this.urlSelectedPackageSlug ?? ""];
         },
         selectedPackage(): Package | undefined {
@@ -121,8 +121,16 @@ export const usePackageStore = () => {
             url: "/pkg/install_pkg",
             params: { name: pkg.name, ...visibility },
             onSuccess: (_response) => {
-              this.packagesByName[pkg.name].installed = true;
-              this.packageListByName[pkg.name].installed = true;
+              const pkgItem = this.packagesByName[pkg.name];
+              if (pkgItem) {
+                pkgItem.installed = true;
+                this.packagesByName[pkg.name] = pkgItem;
+              }
+              const pkgListItem = this.packageListByName[pkg.name];
+              if (pkgListItem) {
+                pkgListItem.installed = true;
+                this.packageListByName[pkg.name] = pkgListItem;
+              }
             },
           });
         },

--- a/app/web/src/store/qualifications.store.ts
+++ b/app/web/src/store/qualifications.store.ts
@@ -49,7 +49,7 @@ export const useQualificationsStore = () => {
         },
         qualificationStatusWithRollupsByComponentId(): Record<
           ComponentId,
-          QualificationStatus
+          QualificationStatus | undefined
         > {
           const componentsStore = useComponentsStore();
 
@@ -139,7 +139,7 @@ export const useQualificationsStore = () => {
           // Do not fetch qualifications for a deleted component
           const componentsStore = useComponentsStore();
           const component = componentsStore.componentsById[componentId];
-          if (component.changeStatus === "deleted") return;
+          if (component?.changeStatus === "deleted") return;
 
           return new ApiRequest<Qualification[]>({
             url: "component/list_qualifications",

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -139,11 +139,13 @@ export const useRealtimeStore = defineStore("realtime", () => {
 
   function destroySingleSubscription(id: SubscriptionId) {
     const sub = subscriptions[id];
-    topicSubscriptionCounter[sub.topic]--;
-    if (topicSubscriptionCounter[sub.topic] === 0) {
-      // TODO: send topic unsubscribe message to server
+    if (sub) {
+      topicSubscriptionCounter[sub.topic]--;
+      if (topicSubscriptionCounter[sub.topic] === 0) {
+        // TODO: send topic unsubscribe message to server
+      }
+      delete subscriptions[sub.id];
     }
-    delete subscriptions[sub.id];
   }
 
   // TODO: add optional arg to unsubscribe to specific event types, topics, or by subscription id

--- a/app/web/src/utils/input_validations.ts
+++ b/app/web/src/utils/input_validations.ts
@@ -63,7 +63,7 @@ export const usePropertyEditorValidations = (
         const error = validation.value.errors[x];
         results.push({
           id: `${x}`,
-          message: error.message,
+          message: error?.message ?? "",
           check: () => false,
         });
       }

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@si/tsconfig/tsconfig.browser.json",
   "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [

--- a/lib/eslint-config/.eslintrc.base.js
+++ b/lib/eslint-config/.eslintrc.base.js
@@ -57,6 +57,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/return-await": 0,
+    "@typescript-eslint/no-non-null-assertion": "warn",
 
     // other -----------------------------------------------------
     "no-undef": 0, // handled by typescript, which is better aware of global types

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -226,16 +226,17 @@ export type IconNames =
   | IconNameAliases
   | SpinnableIconNames;
 
-export function getIconByName(name: string) {
+export function getIconByName(name: string): string | undefined {
   /* eslint-disable @typescript-eslint/no-explicit-any */
 
   const nameWithoutModifiers = name.split("--")[0];
-
-  const icon =
-    (SPINNABLE_ICONS as any)[nameWithoutModifiers] ||
-    (ICONS as any)[nameWithoutModifiers] ||
-    (LOGO_ICONS as any)[nameWithoutModifiers] ||
-    (ICONS as any)[(ICON_NAME_ALIASES as any)[nameWithoutModifiers]] ||
-    ICONS["help-circle"];
-  return icon as string;
+  if (nameWithoutModifiers) {
+    const icon =
+      (SPINNABLE_ICONS as any)?.[nameWithoutModifiers] ||
+      (ICONS as any)?.[nameWithoutModifiers] ||
+      (LOGO_ICONS as any)?.[nameWithoutModifiers] ||
+      (ICONS as any)[(ICON_NAME_ALIASES as any)?.[nameWithoutModifiers]] ||
+      ICONS["help-circle"];
+    return icon;
+  }
 }

--- a/lib/vue-lib/src/design-system/layout/Stack.vue
+++ b/lib/vue-lib/src/design-system/layout/Stack.vue
@@ -37,7 +37,7 @@ const Stack = (
   const wrappedChildren = [] as VNode[];
   const children = getSlotChildren(context.slots.default);
   for (let i = 0; i < children.length; i++) {
-    wrappedChildren.push(children[i]);
+    wrappedChildren.push(children[i]!);
     if (props.dividers && i < children.length - 1) {
       wrappedChildren.push(h(Divider));
     }

--- a/lib/vue-lib/src/design-system/tabs/TabGroup.vue
+++ b/lib/vue-lib/src/design-system/tabs/TabGroup.vue
@@ -108,16 +108,16 @@
       </div>
 
       <!-- Here we actually render the tab content of the current tab -->
-      <template v-if="selectedTabSlug && tabs[selectedTabSlug]">
+      <template v-if="selectedTab">
         <!-- extra slots to make it easy to have non-scrolling content above/below scrolling area -->
-        <div v-if="tabs[selectedTabSlug].slots.top">
-          <component :is="tabs[selectedTabSlug].slots.top" />
+        <div v-if="selectedTab.slots.top">
+          <component :is="selectedTab.slots.top" />
         </div>
         <div class="overflow-auto flex-grow relative">
-          <component :is="tabs[selectedTabSlug].slots.default" />
+          <component :is="selectedTab.slots.default" />
         </div>
-        <div v-if="tabs[selectedTabSlug].slots.bottom">
-          <component :is="tabs[selectedTabSlug].slots.bottom" />
+        <div v-if="selectedTab.slots.bottom">
+          <component :is="selectedTab.slots.bottom" />
         </div>
       </template>
     </template>
@@ -195,9 +195,12 @@ const isNoTabs = computed(() => !_.keys(tabs).length);
 const tabs = reactive({} as Record<string, TabGroupItemDefinition>);
 const orderedTabSlugs = ref<string[]>([]);
 const orderedTabs = computed(() =>
-  _.map(orderedTabSlugs.value, (slug) => tabs[slug]),
+  _.map(orderedTabSlugs.value, (slug) => tabs[slug]).filter((tab) => !!tab) as
+  TabGroupItemDefinition[],
 );
 const selectedTabSlug = ref<string>();
+const selectedTab = computed(() => selectedTabSlug.value ?
+tabs[selectedTabSlug.value] : undefined)
 
 function registerTab(slug: string, component: TabGroupItemDefinition) {
   tabs[slug] = component;


### PR DESCRIPTION
We were running into occasional crashes because of accessing props on undefined objects. I've turned on the noUncheckedIndexedAccess flag for typescript and hunted down all the places that tsc complained about.

Most of this will be quick to review but I'd appreciate a close eye on the Diagram and Edge changes that are a little more significant.