### PR TITLE
fix(dal): sort qualifications by title

### DIFF
--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -41,6 +41,7 @@ impl Component {
         let all_fields_valid_qualification_view =
             Self::all_fields_valid_qualification(ctx, component_id).await?;
         let mut results: Vec<QualificationView> = vec![all_fields_valid_qualification_view];
+        let mut qualification_views = vec![];
 
         // Prepare to assemble qualification views and access the "/root/qualification" prop tree.
         // We will use its implicit internal provider id and its corresponding prop id to do so.
@@ -124,9 +125,13 @@ impl Component {
             )
             .await?
             {
-                results.push(qual_view);
+                qualification_views.push(qual_view);
             }
         }
+
+        qualification_views.sort();
+        // We want the "all fields valid" to always be first
+        results.extend(qualification_views);
 
         WsEvent::checked_qualifications(ctx, component_id)
             .await?

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -151,6 +151,18 @@ pub struct QualificationView {
     pub qualification_name: String,
 }
 
+impl PartialOrd for QualificationView {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.title.partial_cmp(&other.title)
+    }
+}
+
+impl Ord for QualificationView {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.title.cmp(&other.title)
+    }
+}
+
 impl QualificationView {
     pub async fn new(
         ctx: &DalContext,


### PR DESCRIPTION
Using a hashmap for entries means they can appear in different orders, especially if we get sv level and component level quals. Sort them by title.