### PR TITLE
chore(rust): remove rust analyzer requirement

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "stable"
 profile = "default"
-components = [ "rust-analyzer" ]


### PR DESCRIPTION
Rust analyzer is not supported on all platforms, like WSL2. Requiring it means those platforms can't compile anything