### PR TITLE
feat(council,pinga) Track failed nodes in DependentValuesUpdate & propagate sub-graph removal through council

### DIFF
--- a/lib/council-server/src/client.rs
+++ b/lib/council-server/src/client.rs
@@ -65,6 +65,22 @@ impl PubClient {
         Ok(())
     }
 
+    pub async fn failed_processing_value(&self, node_id: Id) -> Result<()> {
+        let message = serde_json::to_vec(&Request::ValueProcessingFailed {
+            change_set_id: self.change_set_id,
+            node_id,
+        })?;
+        self.nats
+            .publish_with_reply_or_headers(
+                &self.pub_channel,
+                Some(&self.reply_channel),
+                None,
+                message,
+            )
+            .await?;
+        Ok(())
+    }
+
     pub async fn bye(self) -> Result<()> {
         let message = serde_json::to_vec(&Request::Bye {
             change_set_id: self.change_set_id,

--- a/lib/council-server/src/lib.rs
+++ b/lib/council-server/src/lib.rs
@@ -65,6 +65,10 @@ pub enum Request {
         change_set_id: Id,
         node_id: Id,
     },
+    ValueProcessingFailed {
+        change_set_id: Id,
+        node_id: Id,
+    },
     Bye {
         change_set_id: Id,
     },
@@ -76,5 +80,6 @@ pub enum Response {
     OkToCreate,
     OkToProcess { node_ids: Vec<Id> },
     BeenProcessed { node_id: Id },
+    Failed { node_id: Id },
     Shutdown,
 }


### PR DESCRIPTION
If an individual `AttributeValue` fails to update for some reason, we don't want the entire `DependentValuesUpdate` job to bomb out. Instead, we want to notify council that we were unable to update that node, so council can remove the sub-graph with the failed node as the root, and notify all jobs that are interested in any of the nodes in the sub-graph that they should no longer be waiting to be told to either start processing any of those nodes, or to be told that another job has handled processing one of the nodes.

By not immediately exiting the `DependentValuesUpdate` job, we are also able to send status updates through to the front end, to let it know that it should no longer consider any of the failed/removed `AttributeValue`s as currently updating.