### PR TITLE
flake.nix updates for dev environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,13 @@
             pkg-config
             postgresql_14
             protobuf
-            rustToolchain
+            (rustToolchain.override {
+              # This really should be augmenting the extensions, instead of
+              # completely overriding them, but since we're not setting up
+              # any extensions in our rust-toolchain file, it should be
+              # fine for now.
+              extensions = [ "rust-src" "rust-analyzer" ];
+            })
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
* chore(nix) Add pkg-config as a build dependency

  This is required for crates to be able to find things like libssl.

* chore(nix) Ensure rust-src & rust-analyzer components are available in a dev shell

  We don't want/need these components when building the various services,
  but they are extremely nice to have when doing development.
