### PR TITLE
chore(si-data-nats) Make crossbeam select error log at debug level

### DIFF
--- a/lib/si-data-nats/src/subscription.rs
+++ b/lib/si-data-nats/src/subscription.rs
@@ -237,7 +237,7 @@ impl Subscription {
                                 // and return None, so instead we're at least going to log this
                                 // event in case it causes more trouble. Silent errors are the root
                                 // of many long nights on call :(
-                                info!(
+                                debug!(
                                     error = ?err,
                                     concat!(
                                         "crossbeam select error on next message, returning None. ",


### PR DESCRIPTION
This message gets logged a fair amount in relatively "normal" circumstances, and ends up being a bit noisy, especially in the pinga output. We should investigate it further at some point, but unless it proves to be an issue, logging at the info level is a bit excessive.