### PR TITLE
fix(web): coalesce confirmationStatus to neutral

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -325,12 +325,12 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               typeIcon: component?.icon || "logo-si",
               statusIcons: _.compact([
                 qualificationStatusToIconMap[qualificationStatus ?? "failure"],
-                confirmationStatusToIconMap[
-                  confirmationStatus ?? "failure"
-                ] ?? {
-                  icon: "minus",
-                  tone: "neutral",
-                },
+                confirmationStatus
+                  ? confirmationStatusToIconMap[confirmationStatus]
+                  : {
+                      icon: "minus",
+                      tone: "neutral",
+                    },
               ]),
             };
           });


### PR DESCRIPTION
Chose the wrong default if confirmationStatus is undefined. Ensure we choose neutral if there is no status (meaning no confirmation/resource).