### PR TITLE
Add ability to author test-exclusive `Schemas` and add "starfield" test-exclusive `Schema` (ENG-1348)

### DIFF
--- a/bin/gen-var-defs/src/main.rs
+++ b/bin/gen-var-defs/src/main.rs
@@ -68,7 +68,7 @@ async fn get_definitions_for_schema_name(
     SchemaVariantDefinitionMetadataJson,
     SchemaVariantDefinitionJson,
 )> {
-    let schema = Schema::schema_for_name(ctx, schema_name).await?;
+    let schema = Schema::find_by_name(ctx, schema_name).await?;
     let default_variant = schema.default_variant(ctx).await?;
 
     let metadata_json = SchemaVariantDefinitionMetadataJson::from_schema_and_variant(

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
@@ -1,0 +1,12 @@
+{
+  "inputSockets": [
+    {
+      "name": "input"
+    }
+  ],
+  "outputSockets": [
+    {
+      "name": "output"
+    }
+  ]
+}

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.metadata.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "starfield",
+  "menuName": "starfield",
+  "category": "test exclusive",
+  "color": "#ffffff",
+  "componentKind": "standard",
+  "link": null,
+  "description": null
+}

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -1,0 +1,157 @@
+use crate::func::argument::FuncArgumentKind;
+use crate::schema::variant::definition::{
+    SchemaVariantDefinition, SchemaVariantDefinitionJson, SchemaVariantDefinitionMetadataJson,
+};
+use crate::schema::variant::leaves::LeafInputLocation;
+use crate::schema::variant::leaves::LeafKind;
+use crate::{
+    builtins::schema::MigrationDriver, schema::variant::leaves::LeafInput, ActionKind,
+    ActionPrototype, ActionPrototypeContext, Func, FuncArgument, FuncBackendKind,
+    FuncBackendResponseType, WorkflowPrototype, WorkflowPrototypeContext,
+};
+use crate::{BuiltinsResult, DalContext, SchemaVariant, StandardModel};
+
+const DEFINITION: &str = include_str!("definitions/test_exclusive_starfield.json");
+const DEFINITION_METADATA: &str =
+    include_str!("definitions/test_exclusive_starfield.metadata.json");
+
+impl MigrationDriver {
+    pub async fn migrate_test_exclusive_starfield(&self, ctx: &DalContext) -> BuiltinsResult<()> {
+        let definition: SchemaVariantDefinitionJson = serde_json::from_str(DEFINITION)?;
+        let metadata: SchemaVariantDefinitionMetadataJson =
+            serde_json::from_str(DEFINITION_METADATA)?;
+
+        SchemaVariantDefinition::new_from_structs(ctx, metadata.clone(), definition.clone())
+            .await?;
+
+        let (
+            mut schema,
+            mut schema_variant,
+            _root_prop,
+            _maybe_prop_cache,
+            _explicit_internal_providers,
+            _external_providers,
+        ) = match self
+            .create_schema_and_variant(ctx, metadata, Some(definition))
+            .await?
+        {
+            Some(tuple) => tuple,
+            None => return Ok(()),
+        };
+        schema.set_ui_hidden(ctx, true).await?;
+        let schema_variant_id = *schema_variant.id();
+
+        // Setup the confirmation function.
+        let mut confirmation_func = Func::new(
+            ctx,
+            "test:confirmation",
+            FuncBackendKind::JsAttribute,
+            FuncBackendResponseType::Confirmation,
+        )
+        .await?;
+        let confirmation_func_id = *confirmation_func.id();
+        let code = "async function exists(input) {
+            if (!input.resource?.value) {
+                return {
+                    success: false,
+                    recommendedActions: [\"create\"]
+                }
+            }
+            return {
+                success: true,
+                recommendedActions: [],
+            }
+        }";
+        confirmation_func
+            .set_code_plaintext(ctx, Some(code))
+            .await?;
+        confirmation_func.set_handler(ctx, Some("exists")).await?;
+        let confirmation_func_argument = FuncArgument::new(
+            ctx,
+            "resource",
+            FuncArgumentKind::String,
+            None,
+            confirmation_func_id,
+        )
+        .await?;
+
+        // Add the leaf for the confirmation.
+        SchemaVariant::add_leaf(
+            ctx,
+            confirmation_func_id,
+            schema_variant_id,
+            None,
+            LeafKind::Confirmation,
+            vec![LeafInput {
+                location: LeafInputLocation::Resource,
+                func_argument_id: *confirmation_func_argument.id(),
+            }],
+        )
+        .await?;
+
+        // Create command and workflow funcs for our workflow and action prototypes.
+        let mut command_func = Func::new(
+            ctx,
+            "test:createCommand",
+            FuncBackendKind::JsCommand,
+            FuncBackendResponseType::Command,
+        )
+        .await?;
+        let code = "async function create() {
+            return { value: \"poop\", status: \"ok\" };
+        }";
+        command_func.set_code_plaintext(ctx, Some(code)).await?;
+        command_func.set_handler(ctx, Some("create")).await?;
+        let mut workflow_func = Func::new(
+            ctx,
+            "test:createWorkflow",
+            FuncBackendKind::JsWorkflow,
+            FuncBackendResponseType::Workflow,
+        )
+        .await?;
+        let code = "async function create() {
+          return {
+            name: \"test:createWorkflow\",
+            kind: \"conditional\",
+            steps: [
+              {
+                command: \"test:createCommand\",
+              },
+            ],
+          };
+        }";
+        workflow_func.set_code_plaintext(ctx, Some(code)).await?;
+        workflow_func.set_handler(ctx, Some("create")).await?;
+
+        // Create workflow and action prototypes.
+        let workflow_prototype = WorkflowPrototype::new(
+            ctx,
+            *workflow_func.id(),
+            serde_json::Value::Null,
+            WorkflowPrototypeContext {
+                schema_id: *schema.id(),
+                schema_variant_id: *schema_variant.id(),
+                ..Default::default()
+            },
+            "create",
+        )
+        .await?;
+        ActionPrototype::new(
+            ctx,
+            *workflow_prototype.id(),
+            "create",
+            ActionKind::Create,
+            ActionPrototypeContext {
+                schema_id: *schema.id(),
+                schema_variant_id,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Finalize the schema variant.
+        schema_variant.finalize(ctx, None).await?;
+
+        Ok(())
+    }
+}

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -194,7 +194,7 @@ impl Schema {
         }
     }
 
-    pub async fn schema_for_name(ctx: &DalContext, name: impl AsRef<str>) -> SchemaResult<Schema> {
+    pub async fn find_by_name(ctx: &DalContext, name: impl AsRef<str>) -> SchemaResult<Schema> {
         let name = name.as_ref();
         let schemas = Schema::find_by_attr(ctx, "name", &name).await?;
         schemas

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -442,7 +442,7 @@ impl SchemaVariant {
 
         let schema_name = schema_variant_definition_metadata.name.clone();
 
-        let schema_id = match Schema::schema_for_name(ctx, &schema_name).await {
+        let schema_id = match Schema::find_by_name(ctx, &schema_name).await {
             Ok(schema) => *schema.id(),
             Err(SchemaError::NotFoundByName(_)) => {
                 let schema = Schema::new(ctx, &schema_name, &ComponentKind::Standard)

--- a/lib/sdf-server/src/server/service/variant_definition/clone_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/clone_variant_def.rs
@@ -43,7 +43,7 @@ pub async fn create_variant_def(
     let mut name;
     loop {
         name = format!("{} Clone {}", variant_def.name(), generate_unique_id(4));
-        match Schema::schema_for_name(&ctx, &name).await {
+        match Schema::find_by_name(&ctx, &name).await {
             Ok(_) => continue,
             Err(SchemaError::NotFoundByName(_)) | Err(SchemaError::NoDefaultVariant(_)) => break,
             Err(e) => {


### PR DESCRIPTION
## Description

This PR provides the ability to author test-exclusive `Schemas` as well as provides the first test-exclusive `Schema`, "starfield".

> _The ability and the first implementation using said ability were supposed to be included as two separate commits, but I accidentally squashed them. We'll do it live!_

##  Why the need for test-exclusive `Schemas`?

For integration tests, `sdf` tests and "scenario" tests alike, the complexity of `Schemas` and `SchemaVariants` have dramatically increased over time. Test authors are currently faced with two choices: author a slim `Schema` and `SchemaVariant` in-line or use a "builtin", like "Docker Image".

**The problem with the former choice:** do this across enough tests, and we will be creating hundreds of slightly different `Schemas` and `SchemaVariants`. Not only is there high potential for structural drift, but creating all those objects on a "per-test" basis does not help with CI bottlenecks.

**The problem with the latter choice:** we need to be explicit about when we are testing SI vs. testing a "builtin" that is used within SI. It is totally fine to create an integration test that checks if connecting an "AWS Region" `Component` to an "AWS AMI" `Component` performs as expected. However, that test should exist _independently_  of a test that isn't reliant on those `Schemas`.

**The solution:** test-exclusive `Schemas`. Migrate once, use them infinite times, and you're off to the races. Available for tests exclusively and not for production use.

## What's next?

This PR is the beginning and exists to not only resolve ENG-1348, but also to help in resolving ENG-1341. The latter issue involves removing the dependency of "Kubernetes Namespace", "Kubernetes Deployment", and "Docker Hub Credential" from integration tests that do not test them directly (i.e. tests that do not have an existing generic SI test for the functionality they are testing).

In order to remove those dependencies, we need to either create in-line objects or use test-exclusive `Schemas`. Test-exclusive `Schemas` are the better choice.

## Why was the `confirmation` integration test module chosen?

There's leaves, functions, actions and workflows involved without a massive `Prop` tree. In addition, both tests in the module were using the same copy/pasted Rust block to construct a `Schema` and `SchemaVariant`. Those reasons and more made the module a great candidate to showcase how a test-exclusive `Schema` works.

## Commit Description

```
Primary:
- Add "starfield" test-exclusive schema and use in the two existing "confirmation" integration tests
- Add ability to author more test-exclusive schemas
  - Further separated production migration logic from test migration logic to avoid footguns
  - Renamed "SchemaBuiltinOption" to "SelectedTestBuiltinSchemas" to not only clarify purpose, but also to match the environment variable name, "SI_TEST_BUILTIN_SCHEMAS" more closely
- Ensure "SelectedTestBuiltinSchemas" is only provided when running tests and not in production
- Deduce test-exclusive schemas based on the "SelectedTestBuiltinSchemas" enum variant (currently, an unused bool)

Misc:
- Rename "Schema::schema_for_name" to "Schema::find_by_name" to match existing convention in the codebase
```

## GIF

<img src="https://media1.giphy.com/media/gpotOLrL0Ebb5kvRHb/giphy-downsized-medium.gif"/>