### PR TITLE
chore(web): fix reactivity issues in code editor

### DIFF
--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -47,7 +47,7 @@ let view: EditorView;
 const modelValue = toRef(props, "modelValue", "");
 const disabled = toRef(props, "disabled", false);
 const useJson = toRef(props, "json", false);
-const useTypescript = toRef(props, "typescript", null);
+const typescript = toRef(props, "typescript", null);
 const currentCode = ref<string>(modelValue.value ?? "");
 
 watch(
@@ -78,6 +78,7 @@ const language = new Compartment();
 const readOnly = new Compartment();
 const themeCompartment = new Compartment();
 const lintCompartment = new Compartment();
+const autocompleteCompartment = new Compartment();
 const styleExtensionCompartment = new Compartment();
 const vimCompartment = new Compartment();
 
@@ -134,11 +135,12 @@ const mountEditor = async () => {
 
   const extensions = [basicSetup];
 
-  if (useTypescript.value) {
+  if (typescript.value) {
     const { lintSource, autocomplete } = await createTypescriptSource(
-      useTypescript.value,
+      typescript.value,
     );
-    extensions.push(autocomplete);
+
+    extensions.push(autocompleteCompartment.of(autocomplete));
     extensions.push(lintCompartment.of(linter(lintSource)));
     extensions.push(lintGutter());
     extensions.push(language.of(javascript()));

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -179,8 +179,9 @@ export const useFuncStore = () => {
             func.associations = response.associations;
             func.isRevertible = response.isRevertible;
             this.funcDetailsById[func.id] = func;
+
             // Forces a reload if the types have changed (reloads typescript compiler)
-            if (response.types !== func.types) {
+            if (func.types !== response.types) {
               this.FETCH_FUNC_DETAILS(func.id);
             }
           },
@@ -252,10 +253,13 @@ export const useFuncStore = () => {
           storage.getItem(LOCAL_STORAGE_FUNC_IDS_KEY) ?? ""
         ).split(",") as FuncId[];
         // Filter out cached ids that don't correspond to funcs anymore
-        this.openFuncIds = _.intersection(
+        const newOpenFuncIds = _.intersection(
           localStorageFuncIds,
           _.keys(this.funcsById),
         );
+        if (!_.isEqual(newOpenFuncIds, this.openFuncIds)) {
+          this.openFuncIds = newOpenFuncIds;
+        }
 
         // if we have a url selected function, make sure it exists in the list of open funcs
         if (this.urlSelectedFuncId) {


### PR DESCRIPTION
Avoid changing prop array pointer when code is edited. This fixes the constant reload of the code editor.

Also hotfixes handling of types changing, by reloading the screen. But it doesn't break usability that much. It should be fixed properly by reloading ts lang server and retriggering autocomplete/linting, but it's too much work to unblock the tutorial without much benefit.

It should be done in a subsequent PR