### PR TITLE
feat(dal,si-pkg,object-tree,sdf): import/export qualifications

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -12,8 +12,8 @@ pub use import::{import_pkg, import_pkg_from_pkg};
 use crate::{
     installed_pkg::InstalledPkgError, prop_tree::PropTreeError,
     schema::variant::definition::SchemaVariantDefinitionError, FuncBackendKind,
-    FuncBackendResponseType, FuncError, PropError, SchemaError, SchemaId, SchemaVariantError,
-    SchemaVariantId, StandardModelError,
+    FuncBackendResponseType, FuncError, FuncId, PropError, SchemaError, SchemaId,
+    SchemaVariantError, SchemaVariantId, StandardModelError,
 };
 
 #[derive(Debug, Error)]
@@ -46,6 +46,8 @@ pub enum PkgError {
     InstalledPkg(#[from] InstalledPkgError),
     #[error("Installed schema id {0} does not exist")]
     InstalledSchemaMissing(SchemaId),
+    #[error("Installed func id {0} does not exist")]
+    InstalledFuncMissing(FuncId),
     #[error("Installed schema variant {0} does not exist")]
     InstalledSchemaVariantMissing(SchemaVariantId),
     #[error("standard model relationship {0} missing belongs_to for {1} with id {2}")]
@@ -58,6 +60,10 @@ pub enum PkgError {
     InvalidFuncBackendKind(FuncBackendKind),
     #[error("Cannot package func with backend response type of {0}")]
     InvalidFuncBackendResponseType(FuncBackendResponseType),
+    #[error("Package asked for a function with the unique id {0} but none could be found")]
+    MissingFuncUniqueId(String),
+    #[error("Func {0} missing from exported funcs")]
+    MissingExportedFunc(FuncId),
 }
 
 impl PkgError {

--- a/lib/dal/src/queries/attribute_prototype/list_protoype_funcs_for_context_and_func_backend_response_type.sql
+++ b/lib/dal/src/queries/attribute_prototype/list_protoype_funcs_for_context_and_func_backend_response_type.sql
@@ -1,0 +1,9 @@
+SELECT DISTINCT ON (funcs.id) 
+  row_to_json(funcs.*) AS object
+FROM attribute_prototypes_v1($1, $2) AS ap
+JOIN funcs_v1($1, $2) as funcs
+  ON funcs.id = ap.func_id
+WHERE in_attribute_context_v1($3, ap)
+  AND ap.attribute_context_prop_id = $4
+  AND funcs.backend_response_type = $5
+ORDER BY funcs.id

--- a/lib/object-tree/src/graph.rs
+++ b/lib/object-tree/src/graph.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use strum::{AsRefStr, EnumString};
 use thiserror::Error;
 
-use crate::Hash;
+use crate::{Hash, HashParseError};
 
 const KEY_VERSION_STR: &str = "version";
 const KEY_NODE_KIND_STR: &str = "node_kind";
@@ -65,6 +65,9 @@ pub enum GraphError {
     /// When a hash value failed to verify an expected value
     #[error("failed to verify hash; expected={0}, computed={1}")]
     Verify(Hash, Hash),
+    /// When a hash is not a valid blake3 hash
+    #[error("transparent")]
+    HashParse(#[from] HashParseError),
 }
 
 impl GraphError {

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -16,7 +16,20 @@
       "hidden": false,
       "link": "https://truth.com",
       "uniqueId": "dadf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf"
+    },
+    {
+      "name": "si:falsey",
+      "displayName": "false",
+      "description": "it returns false, but not really",
+      "handler": "truth",
+      "codeBase64": "ZnVuY3Rpb24gdHJ1dGgoKSB7IHJldHVybiB0cnVlOyB9",
+      "backendKind": "jsAttribute",
+      "responseType": "boolean",
+      "hidden": false,
+      "link": "https://truth.com",
+      "uniqueId": "badf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf"
     }
+
   ],
   "schemas": [
     {
@@ -25,6 +38,14 @@
       "variants": [
         {
           "name": "v0",
+          "qualifications": [
+            {
+              "funcUniqueId": "dadf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf"
+            },
+            {
+              "funcUniqueId": "badf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf"
+            }
+          ],
           "domain": {
             "name": "domain",
             "kind": "object",

--- a/lib/si-pkg/src/node/func.rs
+++ b/lib/si-pkg/src/node/func.rs
@@ -103,7 +103,7 @@ impl ReadBytes for FuncNode {
             Some(Url::parse(&link_str).map_err(GraphError::parse)?)
         };
         let unique_id_str = read_key_value_line(reader, KEY_UNIQUE_ID_STR)?;
-        let unique_id: Hash = Hash::new(unique_id_str.as_bytes());
+        let unique_id: Hash = Hash::from_str(&unique_id_str)?;
 
         Ok(Self {
             name,

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -8,12 +8,20 @@ mod category;
 mod func;
 mod package;
 mod prop;
+mod qualification;
 mod schema;
 mod schema_variant;
+mod schema_variant_child;
 
 pub(crate) use self::{
-    category::CategoryNode, func::FuncNode, package::PackageNode, prop::PropNode,
-    schema::SchemaNode, schema_variant::SchemaVariantNode,
+    category::CategoryNode,
+    func::FuncNode,
+    package::PackageNode,
+    prop::PropNode,
+    qualification::QualificationNode,
+    schema::SchemaNode,
+    schema_variant::SchemaVariantNode,
+    schema_variant_child::{SchemaVariantChild, SchemaVariantChildNode},
 };
 
 const NODE_KIND_CATEGORY: &str = "category";
@@ -21,7 +29,9 @@ const NODE_KIND_PACKAGE: &str = "package";
 const NODE_KIND_PROP: &str = "prop";
 const NODE_KIND_SCHEMA: &str = "schema";
 const NODE_KIND_SCHEMA_VARIANT: &str = "schema_variant";
+const NODE_KIND_SCHEMA_VARIANT_CHILD: &str = "schema_variant_child";
 const NODE_KIND_FUNC: &str = "func";
+const NODE_KIND_QUALIFICATION: &str = "qualification";
 
 const KEY_NODE_KIND_STR: &str = "node_kind";
 
@@ -32,7 +42,9 @@ pub enum PkgNode {
     Prop(PropNode),
     Schema(SchemaNode),
     SchemaVariant(SchemaVariantNode),
+    SchemaVariantChild(SchemaVariantChildNode),
     Func(FuncNode),
+    Qualification(QualificationNode),
 }
 
 impl PkgNode {
@@ -41,7 +53,9 @@ impl PkgNode {
     pub const PROP_KIND_STR: &str = NODE_KIND_PROP;
     pub const SCHEMA_KIND_STR: &str = NODE_KIND_SCHEMA;
     pub const SCHEMA_VARIANT_KIND_STR: &str = NODE_KIND_SCHEMA_VARIANT;
+    pub const SCHEMA_VARIANT_KIND_CHILD_STR: &str = NODE_KIND_SCHEMA_VARIANT_CHILD;
     pub const FUNC_KIND_STR: &str = NODE_KIND_FUNC;
+    pub const QUALIFICATION_KIND_STR: &str = NODE_KIND_QUALIFICATION;
 
     pub fn node_kind_str(&self) -> &'static str {
         match self {
@@ -50,7 +64,9 @@ impl PkgNode {
             Self::Prop(_) => NODE_KIND_PROP,
             Self::Schema(_) => NODE_KIND_SCHEMA,
             Self::SchemaVariant(_) => NODE_KIND_SCHEMA_VARIANT,
+            Self::SchemaVariantChild(_) => NODE_KIND_SCHEMA_VARIANT_CHILD,
             Self::Func(_) => NODE_KIND_FUNC,
+            Self::Qualification(_) => NODE_KIND_QUALIFICATION,
         }
     }
 }
@@ -63,7 +79,9 @@ impl NameStr for PkgNode {
             Self::Prop(node) => node.name(),
             Self::Schema(node) => node.name(),
             Self::SchemaVariant(node) => node.name(),
+            Self::SchemaVariantChild(node) => node.name(),
             Self::Func(node) => node.name(),
+            Self::Qualification(_) => NODE_KIND_QUALIFICATION,
         }
     }
 }
@@ -78,7 +96,9 @@ impl WriteBytes for PkgNode {
             Self::Prop(node) => node.write_bytes(writer)?,
             Self::Schema(node) => node.write_bytes(writer)?,
             Self::SchemaVariant(node) => node.write_bytes(writer)?,
+            Self::SchemaVariantChild(node) => node.write_bytes(writer)?,
             Self::Func(node) => node.write_bytes(writer)?,
+            Self::Qualification(node) => node.write_bytes(writer)?,
         };
 
         Ok(())
@@ -98,7 +118,11 @@ impl ReadBytes for PkgNode {
             NODE_KIND_PROP => Self::Prop(PropNode::read_bytes(reader)?),
             NODE_KIND_SCHEMA => Self::Schema(SchemaNode::read_bytes(reader)?),
             NODE_KIND_SCHEMA_VARIANT => Self::SchemaVariant(SchemaVariantNode::read_bytes(reader)?),
+            NODE_KIND_SCHEMA_VARIANT_CHILD => {
+                Self::SchemaVariantChild(SchemaVariantChildNode::read_bytes(reader)?)
+            }
             NODE_KIND_FUNC => Self::Func(FuncNode::read_bytes(reader)?),
+            NODE_KIND_QUALIFICATION => Self::Qualification(QualificationNode::read_bytes(reader)?),
             invalid_kind => {
                 return Err(GraphError::parse_custom(format!(
                     "invalid package node kind: {invalid_kind}"

--- a/lib/si-pkg/src/node/qualification.rs
+++ b/lib/si-pkg/src/node/qualification.rs
@@ -1,0 +1,54 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, Hash, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+
+use crate::QualificationSpec;
+
+use super::PkgNode;
+
+const FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+
+#[derive(Clone, Debug)]
+pub struct QualificationNode {
+    pub func_unique_id: Hash,
+}
+
+impl WriteBytes for QualificationNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, FUNC_UNIQUE_ID_STR, self.func_unique_id.to_string())?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for QualificationNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let func_unique_id_str = read_key_value_line(reader, FUNC_UNIQUE_ID_STR)?;
+        let func_unique_id = Hash::from_str(&func_unique_id_str)?;
+
+        Ok(Self { func_unique_id })
+    }
+}
+
+impl NodeChild for QualificationSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Leaf,
+            Self::NodeType::Qualification(QualificationNode {
+                func_unique_id: self.func_unique_id,
+            }),
+            vec![],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -6,7 +6,7 @@ use object_tree::{
 };
 use url::Url;
 
-use crate::SchemaVariantSpec;
+use crate::{node::SchemaVariantChild, SchemaVariantSpec};
 
 use super::PkgNode;
 
@@ -75,7 +75,13 @@ impl NodeChild for SchemaVariantSpec {
                 link: self.link.as_ref().cloned(),
                 color: self.color.as_ref().cloned(),
             }),
-            vec![Box::new(self.domain.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>],
+            vec![
+                Box::new(SchemaVariantChild::Domain(self.domain.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(SchemaVariantChild::Qualifications(
+                    self.qualifications.clone(),
+                )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            ],
         )
     }
 }

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -1,0 +1,108 @@
+use std::io::{BufRead, Write};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{PropSpec, QualificationSpec};
+
+use super::PkgNode;
+
+const VARIANT_CHILD_TYPE_DOMAIN: &str = "domain";
+const VARIANT_CHILD_TYPE_QUALIFICATIONS: &str = "qualifications";
+
+const KEY_KIND_STR: &str = "kind";
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SchemaVariantChild {
+    Domain(PropSpec),
+    Qualifications(Vec<QualificationSpec>),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum SchemaVariantChildNode {
+    Domain,
+    Qualifications,
+}
+
+impl SchemaVariantChildNode {
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
+            Self::Qualifications => VARIANT_CHILD_TYPE_QUALIFICATIONS,
+        }
+    }
+}
+
+impl NameStr for SchemaVariantChildNode {
+    fn name(&self) -> &str {
+        match self {
+            Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
+            Self::Qualifications => VARIANT_CHILD_TYPE_QUALIFICATIONS,
+        }
+    }
+}
+
+impl WriteBytes for SchemaVariantChildNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind_str())?;
+        Ok(())
+    }
+}
+
+impl ReadBytes for SchemaVariantChildNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+
+        let node = match kind_str.as_str() {
+            VARIANT_CHILD_TYPE_DOMAIN => Self::Domain,
+            VARIANT_CHILD_TYPE_QUALIFICATIONS => Self::Qualifications,
+            invalid_kind => {
+                return Err(GraphError::parse_custom(format!(
+                    "invalid schema variant child kind: {invalid_kind}"
+                )))
+            }
+        };
+
+        Ok(node)
+    }
+}
+
+impl NodeChild for SchemaVariantChild {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        match self {
+            Self::Domain(domain) => {
+                let domain =
+                    Box::new(domain.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>;
+
+                NodeWithChildren::new(
+                    NodeKind::Tree,
+                    Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::Domain),
+                    vec![domain],
+                )
+            }
+            Self::Qualifications(entries) => {
+                let mut children = Vec::new();
+                for entry in entries {
+                    children
+                        .push(Box::new(entry.clone())
+                            as Box<dyn NodeChild<NodeType = Self::NodeType>>);
+                }
+
+                NodeWithChildren::new(
+                    NodeKind::Tree,
+                    Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::Qualifications),
+                    children,
+                )
+            }
+        }
+    }
+}

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -33,6 +33,20 @@ impl PkgSpec {
     pub fn builder() -> PkgSpecBuilder {
         PkgSpecBuilder::default()
     }
+
+    pub fn func_for_unique_id(&self, unique_id: &FuncUniqueId) -> Option<&FuncSpec> {
+        self.funcs
+            .iter()
+            .find(|func_spec| &func_spec.unique_id == unique_id)
+    }
+
+    pub fn func_for_name(&self, name: impl AsRef<str>) -> Option<&FuncSpec> {
+        let name = name.as_ref();
+
+        self.funcs
+            .iter()
+            .find(|func_spec| func_spec.name.as_str() == name)
+    }
 }
 
 impl PkgSpecBuilder {
@@ -91,6 +105,8 @@ pub enum FuncSpecBackendResponseType {
     Command,
 }
 
+pub type FuncUniqueId = Hash;
+
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[builder(build_fn(error = "SpecError"))]
@@ -111,8 +127,8 @@ pub struct FuncSpec {
     pub response_type: FuncSpecBackendResponseType,
     #[builder(setter(into))]
     pub hidden: bool,
-    #[builder(field(type = "Hash", build = "self.build_func_unique_id()"))]
-    pub unique_id: Hash,
+    #[builder(field(type = "FuncUniqueId", build = "self.build_func_unique_id()"))]
+    pub unique_id: FuncUniqueId,
 
     #[builder(setter(into, strip_option), default)]
     pub link: Option<Url>,
@@ -231,6 +247,9 @@ pub struct SchemaVariantSpec {
 
     #[builder(private, default = "Self::default_domain()")]
     pub domain: PropSpec,
+
+    #[builder(setter(each(name = "qualification"), into), default)]
+    pub qualifications: Vec<QualificationSpec>,
 }
 
 impl SchemaVariantSpec {
@@ -288,6 +307,20 @@ impl SchemaVariantSpecBuilder {
             ),
         };
         self
+    }
+}
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct QualificationSpec {
+    #[builder(setter(into))]
+    pub func_unique_id: FuncUniqueId,
+}
+
+impl QualificationSpec {
+    pub fn builder() -> QualificationSpecBuilder {
+        QualificationSpecBuilder::default()
     }
 }
 


### PR DESCRIPTION
Adds the ability to declare qualifications for a schema variant in a package, and handles importing and exporting them to/from the database.