### PR TITLE
Replace many to many relationship with column for root prop (ENG-1264)

### DIFF
--- a/lib/dal/src/migrations/U2134__add_root_prop_column_to_schema_variants.sql
+++ b/lib/dal/src/migrations/U2134__add_root_prop_column_to_schema_variants.sql
@@ -1,0 +1,120 @@
+-- NOTE(nick): this migration was originally numbered "U2130", but since "U2132" came in first and PR#2134 was a small
+-- test refactoring PR of mine, I decided to number this migration as "U2134".
+
+-- Add the root prop column to the schema variants table.
+ALTER TABLE schema_variants ADD COLUMN root_prop_id ident;
+
+-- Populate the new column.
+UPDATE schema_variants
+    SET root_prop_id = prop_many_to_many_schema_variants.left_object_id
+    FROM prop_many_to_many_schema_variants
+WHERE  schema_variants.id = prop_many_to_many_schema_variants.right_object_id;
+
+-- Re-create the function. We can do this because the signature did not change.
+CREATE OR REPLACE FUNCTION find_schema_variant_id_for_prop_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    prop_id ident,
+    OUT schema_variant_id ident) AS
+$$
+DECLARE
+    root_prop_id ident;
+BEGIN
+    SELECT find_root_prop_id_v1(
+        this_tenancy,
+        this_visibility,
+        prop_id
+    )
+    INTO STRICT root_prop_id;
+
+    SELECT id
+    INTO STRICT schema_variant_id
+    FROM schema_variants_v1($1, $2) as schema_variants
+    WHERE schema_variants.root_prop_id = root_prop_id;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+-- Re-create the function. We can do this because the signature did not change.
+CREATE OR REPLACE FUNCTION attribute_value_id_for_prop_and_context_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_context jsonb,
+    this_prop_id ident
+)
+    RETURNS ident
+    LANGUAGE SQL
+    STABLE
+    PARALLEL SAFE
+AS
+$$
+SELECT DISTINCT ON (
+    av.attribute_context_prop_id,
+    COALESCE(avbtav.belongs_to_id, ident_nil_v1()),
+    COALESCE(av.key, '')
+    ) av.id
+FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+         LEFT JOIN attribute_value_belongs_to_attribute_value_v1(this_tenancy, this_visibility) AS avbtav
+                   ON av.id = avbtav.object_id
+         INNER JOIN schema_variants_v1(this_tenancy, this_visibility) AS schema_variants
+                    ON av.attribute_context_prop_id = schema_variants.root_prop_id
+WHERE in_attribute_context_v1(this_context, av)
+  -- NOTE(nick): why is this named "this_prop_id"?
+  AND schema_variants.id = this_prop_id
+ORDER BY av.attribute_context_prop_id,
+         COALESCE(avbtav.belongs_to_id, ident_nil_v1()),
+         COALESCE(av.key, ''),
+         av.visibility_change_set_pk DESC,
+         av.visibility_deleted_at DESC NULLS FIRST,
+         av.attribute_context_internal_provider_id DESC,
+         av.attribute_context_external_provider_id DESC,
+         av.attribute_context_component_id DESC
+$$;
+
+-- Create a new view that doesn't use the old table.
+CREATE OR REPLACE VIEW components_with_attributes_v2 AS
+SELECT components.id                                     AS component_id,
+       component_belongs_to_schema.belongs_to_id         AS schema_id,
+       schemas.name                                      AS schema_name,
+       component_belongs_to_schema_variant.belongs_to_id AS schema_variant_id,
+       schema_variants.name                              AS schema_variant_name,
+       schema_variants.root_prop_id                      AS root_prop_id,
+       internal_providers.id                             AS internal_provider_id,
+       attribute_values.id                               AS attribute_value_id,
+       func_binding_return_values.tenancy_workspace_pk,
+       func_binding_return_values.visibility_change_set_pk,
+       func_binding_return_values.visibility_deleted_at,
+       func_binding_return_values.id                     AS func_binding_return_value_id,
+       func_binding_return_values.value                  AS prop_values
+FROM components
+         LEFT JOIN component_belongs_to_schema ON component_belongs_to_schema.object_id = components.id
+         LEFT JOIN component_belongs_to_schema_variant ON component_belongs_to_schema_variant.object_id = components.id
+         LEFT JOIN schemas ON schemas.id = component_belongs_to_schema.belongs_to_id
+         LEFT JOIN schema_variants ON schema_variants.id = component_belongs_to_schema_variant.belongs_to_id
+         LEFT JOIN internal_providers ON internal_providers.prop_id = schema_variants.root_prop_id
+         LEFT JOIN attribute_values
+                   ON attribute_values.attribute_context_internal_provider_id = internal_providers.id AND
+                      attribute_values.attribute_context_component_id = components.id
+         LEFT JOIN func_binding_return_values
+                   ON func_binding_return_values.id = attribute_values.func_binding_return_value_id;
+
+-- NOTE(nick,fletcher): we can perform the more "destructive" actions below because at the time
+-- that this migration was written, users can only run one sdf at a time and must restart the
+-- entire stack. In the future, we will want multiple migrations to ensure this works.
+
+-- Drop and delete all dependencies on "components_with_attributes".
+DROP FUNCTION in_tenancy_and_visible_v1(jsonb,jsonb,components_with_attributes);
+DROP FUNCTION in_tenancy_v1(jsonb,components_with_attributes);
+DROP FUNCTION is_visible_v1(jsonb,components_with_attributes);
+
+-- Now we can drop "components_with_attributes".
+DROP VIEW components_with_attributes;
+
+-- Drop and delete all dependencies on "prop_many_to_many_schema_variants".
+DROP FUNCTION in_tenancy_and_visible_v1(jsonb,jsonb,prop_many_to_many_schema_variants);
+DROP FUNCTION in_tenancy_v1(jsonb,prop_many_to_many_schema_variants);
+DROP FUNCTION is_visible_v1(jsonb,prop_many_to_many_schema_variants);
+DROP FUNCTION prop_many_to_many_schema_variants_v1(jsonb,jsonb);
+DELETE FROM standard_models WHERE standard_models.table_name = 'prop_many_to_many_schema_variants';
+
+-- Now we can drop "prop_many_to_many_schema_variants".
+DROP TABLE prop_many_to_many_schema_variants;

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -33,12 +33,6 @@ impl PropertyEditorSchema {
             .ok_or(PropertyEditorError::SchemaVariantNotFound(
                 schema_variant_id,
             ))?;
-        let root_prop = schema_variant
-            .props(ctx)
-            .await?
-            .into_iter()
-            .next()
-            .ok_or(PropertyEditorError::RootPropNotFound)?;
         let mut props: HashMap<PropertyEditorPropId, PropertyEditorProp> = HashMap::new();
         let mut child_props: HashMap<PropertyEditorPropId, Vec<PropertyEditorPropId>> =
             HashMap::new();
@@ -66,8 +60,11 @@ impl PropertyEditorSchema {
             props.insert(property_editor_prop.id, property_editor_prop);
         }
 
+        let root_prop_id = schema_variant
+            .root_prop_id()
+            .ok_or(PropertyEditorError::RootPropNotFound)?;
         Ok(PropertyEditorSchema {
-            root_prop_id: (*root_prop.id()).into(),
+            root_prop_id: (*root_prop_id).into(),
             props,
             child_props,
         })

--- a/lib/dal/src/queries/change_status/list_added_components.sql
+++ b/lib/dal/src/queries/change_status/list_added_components.sql
@@ -1,7 +1,7 @@
 SELECT DISTINCT ON (component_id) component_id,
                                   components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM components_with_attributes AS components
+FROM components_with_attributes_v2 AS components
 
 -- Find components that are not in HEAD
 WHERE component_id NOT IN (SELECT id

--- a/lib/dal/src/queries/change_status/list_deleted_components.sql
+++ b/lib/dal/src/queries/change_status/list_deleted_components.sql
@@ -1,7 +1,7 @@
 SELECT DISTINCT ON (component_id) component_id,
                                   components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM components_with_attributes AS components
+FROM components_with_attributes_v2 AS components
 
 -- Ensure they are deleted
 WHERE visibility_deleted_at IS NOT NULL

--- a/lib/dal/src/queries/change_status/list_modified_components.sql
+++ b/lib/dal/src/queries/change_status/list_modified_components.sql
@@ -1,7 +1,7 @@
 SELECT DISTINCT ON (component_id) component_id,
                                   components.prop_values -> 'si' ->> 'name' AS component_name
 
-FROM components_with_attributes AS components
+FROM components_with_attributes_v2 AS components
 
          -- Collect all unique component ids
          INNER JOIN (SELECT DISTINCT ON (attribute_context_component_id) attribute_context_component_id

--- a/lib/dal/src/queries/component/find_name.sql
+++ b/lib/dal/src/queries/component/find_name.sql
@@ -15,13 +15,11 @@ WHERE id IN (
                                        JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
                                             ON si_prop.name = 'si'
                                                 AND pbtp.object_id = si_prop.id
-                                                AND pbtp.belongs_to_id IN (
-                                                    SELECT pmtmsv.left_object_id AS root_prop_id
-                                                    FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
-                                                             JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
-                                                                  ON cbtsv.belongs_to_id = pmtmsv.right_object_id
-                                                                      AND cbtsv.object_id = $3
-                                                )
+                                       JOIN schema_variants_v1($1, $2) as schema_variants
+                                            ON pbtp.belongs_to_id = schema_variants.root_prop_id
+                                       JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
+                                            ON cbtsv.belongs_to_id = schema_variants.id
+                                                AND cbtsv.object_id = $3
                           )
     ) AS name_prop
                   ON av.attribute_context_prop_id = name_prop.id
@@ -37,67 +35,3 @@ WHERE id IN (
     ORDER BY av.attribute_context_prop_id,
              av.attribute_context_component_id DESC
 )
-
--- This ends up with an extremely bad query plan to the point where it
--- takes ~10-11 SECONDS to complete, vs the ~12 MILLIseconds that the
--- above version takes.
---
--- SELECT fbrv.value AS component_name
--- FROM component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
--- -- TODO: We could do this as a normal join if we fixed prop_many_to_many_schema_variants to be prop_belongs_to_schema_variant (which matches our current rules/logic)
--- --
--- -- Having the SchemaVariant lets us get the PropId for the "root" Prop.
--- INNER JOIN (
---     SELECT DISTINCT ON (left_object_id)
---         left_object_id AS prop_id,
---         right_object_id AS schema_variant_id
---     FROM prop_many_to_many_schema_variants_v1($1, $2)
--- ) AS root_pmtmsv
---     ON root_pmtmsv.schema_variant_id = cbtsv.belongs_to_id
--- -- Having the "root" PropId lets us get the "si" PropId.
--- INNER JOIN prop_belongs_to_prop_v1($1, $2) AS si_pbtp
---     ON si_pbtp.belongs_to_id = root_pbtsv.prop_id
--- INNER JOIN props_v1($1, $2) AS si_prop
---     ON si_prop.id = si_pbtp.object_id
---         AND si_prop.name = 'si'
--- -- Having the "si" PropId lets us get the "name" PropId.
--- INNER JOIN prop_belongs_to_prop_v1($1, $2) AS name_pbtp
---     ON name_pbtp.belongs_to_id = si_prop.id
--- INNER JOIN props_v1($1, $2) AS name_prop
---     ON name_prop.id = name_pbtp.object_id
---         AND name_prop.name = 'name'
--- INNER JOIN LATERAL (
---     SELECT DISTINCT ON (attribute_context_prop_id)
---         id AS attribute_value_id,
---         func_binding_return_value_id,
---         attribute_context_prop_id,
---         attribute_context_internal_provider_id,
---         attribute_context_external_provider_id,
---         attribute_context_component_id,
---         attribute_context_system_id
---     FROM attribute_values_v1($1, $2) AS av
---     WHERE
---         in_attribute_context_v1(
---             -- We're only interested in the AttributeValue that's directly for the "/root/si/name" Prop
---             -- for a given ComponentId & SystemId. We're not bothering to filter on the Schema &
---             -- SchemaVariant, as a Component can only belong to one SchemaVariant, and a SchemaVariant
---             -- can only belong to one Schema.
---             attribute_context_build_from_parts_v1(
---                 name_prop.id, -- PropId
---                 ident_nil_v1(), -- InternalProviderId
---                 ident_nil_v1(), -- ExternalProviderId
---                 $3, -- ComponentId
---                 $4 -- SystemId
---             ),
---             av
---         )
---         AND attribute_context_prop_id = name_prop.id
---     ORDER BY
---         attribute_context_prop_id,
---         attribute_context_component_id DESC,
---         attribute_context_system_id DESC
--- ) AS name_av
---     ON name_av.attribute_context_prop_id = name_prop.id
--- INNER JOIN func_binding_return_values_v1($1, $2) AS fbrv
---     ON fbrv.id = name_av.func_binding_return_value_id
--- WHERE cbtsv.object_id = $3

--- a/lib/dal/src/queries/component/find_si_child_attribute_value.sql
+++ b/lib/dal/src/queries/component/find_si_child_attribute_value.sql
@@ -11,12 +11,9 @@ JOIN (
        AND si_prop.name = 'si'
   JOIN prop_belongs_to_prop_v1($1, $2) AS si_prop_belongs_to_root_prop
     ON si_prop_belongs_to_root_prop.object_id = si_prop.id
-       AND si_prop_belongs_to_root_prop.belongs_to_id IN 
-  (
-    SELECT pmtmsv.left_object_id AS root_prop_id
-    FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
-    WHERE pmtmsv.right_object_id = $4
-  )
+  JOIN schema_variants_v1($1, $2) AS schema_variants
+    ON si_prop_belongs_to_root_prop.belongs_to_id = schema_variants.root_prop_id
+       AND schema_variants.id = $4
 ) si_child_prop
   ON attribute_values.attribute_context_prop_id = si_child_prop.id
 -- We will also take the "default" type too (corresponds to the attribute

--- a/lib/dal/src/queries/component/list_all_resource_implicit_internal_provider_attribute_values.sql
+++ b/lib/dal/src/queries/component/list_all_resource_implicit_internal_provider_attribute_values.sql
@@ -10,9 +10,7 @@ LEFT JOIN props_v1($1, $2) as props
        AND props.name = 'resource'
 JOIN prop_belongs_to_prop_v1($1, $2) AS prop_belongs_to_prop
     ON prop_belongs_to_prop.object_id = props.id
-       AND prop_belongs_to_prop.belongs_to_id IN (
-           SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
-           FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-           LEFT JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
-               ON component_belongs_to_schema_variant.belongs_to_id = prop_many_to_many_schema_variants.right_object_id
-       )
+JOIN schema_variants_v1($1, $2) AS schema_variants
+    ON schema_variants.root_prop_id = prop_belongs_to_prop.belongs_to_id
+LEFT JOIN component_belongs_to_schema_variant_v1($1, $2) as component_belongs_to_schema_variant
+    ON component_belongs_to_schema_variant.belongs_to_id = schema_variants.id

--- a/lib/dal/src/queries/component/root_child_attribute_value_for_component.sql
+++ b/lib/dal/src/queries/component/root_child_attribute_value_for_component.sql
@@ -7,13 +7,11 @@ FROM attribute_values_v1($1, $2) AS av
              JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
                   ON root_child_prop.name = $3
                       AND pbtp.object_id = root_child_prop.id
-                      AND pbtp.belongs_to_id IN (
-                          SELECT pmtmsv.left_object_id AS root_prop_id
-                          FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
-                                   JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
-                                        ON cbtsv.belongs_to_id = pmtmsv.right_object_id
-                                            AND cbtsv.object_id = $4
-                      )
+             JOIN schema_variants_v1($1, $2) AS schema_variants
+                  ON schema_variants.root_prop_id = pbtp.belongs_to_id
+             JOIN component_belongs_to_schema_variant_v1($1, $2) AS cbtsv
+                  ON cbtsv.belongs_to_id = schema_variants.id
+                      AND cbtsv.object_id = $4
 ) AS root_child_prop
               ON av.attribute_context_prop_id = root_child_prop.id
 

--- a/lib/dal/src/queries/prop/find_root_for_schema_variant.sql
+++ b/lib/dal/src/queries/prop/find_root_for_schema_variant.sql
@@ -1,5 +1,0 @@
-SELECT row_to_json(props.*) as object
-FROM props_v1($1, $2) AS props
-INNER JOIN prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-    ON prop_many_to_many_schema_variants.left_object_id = props.id
-WHERE prop_many_to_many_schema_variants.right_object_id = $3

--- a/lib/dal/src/queries/prop/tree_for_all_schema_variants.sql
+++ b/lib/dal/src/queries/prop/tree_for_all_schema_variants.sql
@@ -31,7 +31,7 @@ WITH RECURSIVE props_tree AS (
         ON parent.prop_id = pbtp2.belongs_to_id
 )
 SELECT
-    pmtmsv.right_object_id AS schema_variant_id,
+    schema_variants.id AS schema_variant_id,
     props_tree.object,
     props_tree.root_id,
     props_tree.prop_id,
@@ -40,8 +40,8 @@ SELECT
     props_tree.path,
     ip.id                  AS internal_provider_id
 FROM props_tree
-JOIN prop_many_to_many_schema_variants_v1($1, $2) pmtmsv
-    ON pmtmsv.left_object_id = props_tree.root_id
+JOIN schema_variants_v1($1, $2) schema_variants
+    ON schema_variants.root_prop_id = props_tree.root_id
 LEFT JOIN internal_providers_v1($1, $2) ip ON props_tree.prop_id = ip.prop_id
 ORDER BY
     schema_variant_id,

--- a/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
+++ b/lib/dal/src/queries/property_editor_schema_for_schema_variant.sql
@@ -14,9 +14,9 @@ WHERE
     props.hidden = FALSE
     AND props.id IN (
         WITH RECURSIVE recursive_props AS (
-            SELECT left_object_id AS prop_id
-            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-            WHERE right_object_id = $3
+            SELECT root_prop_id AS prop_id
+            FROM schema_variants_v1($1, $2) AS schema_variants
+            WHERE schema_variants.id = $3
             UNION ALL
             SELECT pbp.object_id AS prop_id
             FROM prop_belongs_to_prop_v1($1, $2) AS pbp

--- a/lib/dal/src/queries/schema_variant/all_props.sql
+++ b/lib/dal/src/queries/schema_variant/all_props.sql
@@ -2,9 +2,9 @@ SELECT row_to_json(props.*) AS object
 FROM props_v1($1, $2) AS props
 WHERE props.id IN (
     WITH RECURSIVE recursive_props AS (
-        SELECT left_object_id AS prop_id
-        FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-        WHERE right_object_id = $3
+        SELECT root_prop_id AS prop_id
+        FROM schema_variants_v1($1, $2) AS schema_variants
+        WHERE schema_variants.id = $3
         UNION ALL
         SELECT pbp.object_id AS prop_id
         FROM prop_belongs_to_prop_v1($1, $2) AS pbp

--- a/lib/dal/src/queries/schema_variant/all_related_funcs.sql
+++ b/lib/dal/src/queries/schema_variant/all_related_funcs.sql
@@ -7,9 +7,9 @@
  WHERE props.id in
        (WITH RECURSIVE recursive_props
                            AS
-                           (SELECT left_object_id AS prop_id
-                            FROM prop_many_to_many_schema_variants_v1($1, $2) AS pmtmsv
-                            WHERE right_object_id = $3
+                           (SELECT root_prop_id AS prop_id
+                            FROM schema_variants_v1($1, $2) AS schema_variants
+                            WHERE schema_variants.id = $3
                             UNION ALL
                             SELECT pbp.object_id as prop_id
                             FROM prop_belongs_to_prop_v1($1, $2) AS pbp

--- a/lib/dal/src/queries/schema_variant/find_leaf_item_prop.sql
+++ b/lib/dal/src/queries/schema_variant/find_leaf_item_prop.sql
@@ -11,9 +11,7 @@ FROM props_v1($1, $2) AS leaf_item_prop
                                     ON leaf_map_prop.name = $4
                                         AND leaf_map_prop.kind = 'map'
                                         AND prop_belongs_to_prop.object_id = leaf_map_prop.id
-                                        AND prop_belongs_to_prop.belongs_to_id IN (
-                                            SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
-                                            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-                                            WHERE prop_many_to_many_schema_variants.right_object_id = $3
-                                        )
+                               JOIN schema_variants_v1($1, $2) as schema_variants
+                                    ON prop_belongs_to_prop.belongs_to_id = schema_variants.root_prop_id
+                                        AND schema_variants.id = $3
                   )

--- a/lib/dal/src/queries/schema_variant/find_root_child_implicit_internal_provider.sql
+++ b/lib/dal/src/queries/schema_variant/find_root_child_implicit_internal_provider.sql
@@ -5,8 +5,6 @@ FROM internal_providers_v1($1, $2) as internal_providers
                        AND props.name = $4
          JOIN prop_belongs_to_prop_v1($1, $2) AS prop_belongs_to_prop
               ON prop_belongs_to_prop.object_id = props.id
-                  AND prop_belongs_to_prop.belongs_to_id IN (
-                      SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
-                      FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-                      WHERE prop_many_to_many_schema_variants.right_object_id = $3
-                  )
+         JOIN schema_variants_v1($1, $2) AS schema_variants
+              ON prop_belongs_to_prop.belongs_to_id = schema_variants.root_prop_id
+                    AND schema_variants.id = $3

--- a/lib/dal/src/queries/schema_variant/find_root_prop.sql
+++ b/lib/dal/src/queries/schema_variant/find_root_prop.sql
@@ -1,0 +1,5 @@
+SELECT row_to_json(props.*) as object
+FROM props_v1($1, $2) AS props
+         INNER JOIN schema_variants_v1($1, $2) AS schema_variants
+                    ON props.id = schema_variants.root_prop_id
+WHERE schema_variants.id = $3

--- a/lib/dal/src/queries/schema_variant/list_root_si_child_props.sql
+++ b/lib/dal/src/queries/schema_variant/list_root_si_child_props.sql
@@ -7,8 +7,6 @@ FROM props_v1($1, $2) as props
                   AND si_prop.name = 'si'
          JOIN prop_belongs_to_prop_v1($1, $2) AS si_prop_belongs_to_root_prop
               ON si_child_prop_belongs_to_si_prop.belongs_to_id = si_prop_belongs_to_root_prop.object_id
-                  AND si_prop_belongs_to_root_prop.belongs_to_id IN (
-                      SELECT prop_many_to_many_schema_variants.left_object_id AS root_prop_id
-                      FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-                      WHERE prop_many_to_many_schema_variants.right_object_id = $3
-                  )
+         JOIN schema_variants_v1($1, $2) AS schema_variants
+              ON schema_variants.root_prop_id = si_prop_belongs_to_root_prop.belongs_to_id
+                  AND schema_variants.id = $3

--- a/lib/dal/src/queries/validation_prototype/list_for_schema_variant.sql
+++ b/lib/dal/src/queries/validation_prototype/list_for_schema_variant.sql
@@ -4,9 +4,9 @@ INNER JOIN props_v1($1, $2) as props
     ON props.id = validation_prototypes.prop_id
     AND props.id IN (
         WITH RECURSIVE recursive_props AS (
-            SELECT left_object_id AS prop_id
-            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-            WHERE right_object_id = $3
+            SELECT root_prop_id AS prop_id
+            FROM schema_variants_v1($1, $2) AS schema_variants
+            WHERE schema_variants.id = $3
             UNION ALL
             SELECT pbp.object_id AS prop_id
             FROM prop_belongs_to_prop_v1($1, $2) AS pbp

--- a/lib/dal/src/queries/validation_resolver/find_status.sql
+++ b/lib/dal/src/queries/validation_resolver/find_status.sql
@@ -16,9 +16,9 @@ LEFT JOIN func_binding_return_values_v1($1, $2) as func_binding_return_values
 WHERE
     attribute_values.attribute_context_prop_id IN (
         WITH RECURSIVE recursive_props AS (
-            SELECT left_object_id AS prop_id
-            FROM prop_many_to_many_schema_variants_v1($1, $2) AS prop_many_to_many_schema_variants
-            WHERE right_object_id = $4
+            SELECT root_prop_id AS prop_id
+            FROM schema_variants_v1($1, $2) AS schema_variants
+            WHERE schema_variants.id = $4
             UNION ALL
             SELECT pbp.object_id AS prop_id
             FROM prop_belongs_to_prop_v1($1, $2) AS pbp

--- a/lib/dal/tests/integration_test/internal/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/internal/attribute/prototype.rs
@@ -25,13 +25,6 @@ async fn new_attribute_prototype(ctx: &DalContext) {
         .await
         .expect("cannot find default variant");
 
-    let first_prop = default_variant
-        .props(ctx)
-        .await
-        .expect("cannot get props")
-        .pop()
-        .expect("no prop found");
-
     let component = create_component_for_schema(ctx, schema.id()).await;
 
     let func = Func::new(
@@ -57,8 +50,11 @@ async fn new_attribute_prototype(ctx: &DalContext) {
         .await
         .expect("failed to execute func binding");
 
+    let root_prop_id = default_variant
+        .root_prop_id()
+        .expect("no root prop for schema variant");
     let context = AttributeContext::builder()
-        .set_prop_id(*first_prop.id())
+        .set_prop_id(*root_prop_id)
         .set_component_id(*component.id())
         .to_context()
         .expect("cannot create context");

--- a/lib/dal/tests/integration_test/internal/prop.rs
+++ b/lib/dal/tests/integration_test/internal/prop.rs
@@ -1,9 +1,6 @@
 use dal::{DalContext, Prop, PropKind, StandardModel};
 use dal_test::helpers::generate_fake_name;
-use dal_test::{
-    test,
-    test_harness::{create_schema, create_schema_variant},
-};
+use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
@@ -13,35 +10,6 @@ async fn new(ctx: &DalContext) {
         .expect("cannot create prop");
     assert_eq!(prop.name(), "coolness");
     assert_eq!(prop.kind(), &PropKind::String);
-}
-
-#[test]
-async fn schema_variants(ctx: &DalContext) {
-    let schema = create_schema(ctx).await;
-    let schema_variant = create_schema_variant(ctx, *schema.id()).await;
-    let prop = Prop::new(ctx, generate_fake_name(), PropKind::String, None)
-        .await
-        .expect("cannot create prop");
-
-    prop.add_schema_variant(ctx, schema_variant.id())
-        .await
-        .expect("cannot add schema variant");
-
-    let relations = prop
-        .schema_variants(ctx)
-        .await
-        .expect("cannot get schema variants");
-    assert_eq!(relations, vec![schema_variant.clone()]);
-
-    prop.remove_schema_variant(ctx, schema_variant.id())
-        .await
-        .expect("cannot remove schema variant");
-
-    let relations = prop
-        .schema_variants(ctx)
-        .await
-        .expect("cannot get schema variants");
-    assert_eq!(relations, vec![]);
 }
 
 #[test]

--- a/lib/dal/tests/integration_test/internal/standard_model.rs
+++ b/lib/dal/tests/integration_test/internal/standard_model.rs
@@ -1,6 +1,7 @@
+use dal::socket::{SocketEdgeKind, SocketKind};
 use dal::{
-    standard_model, ChangeSet, ChangeSetPk, DalContext, Func, FuncBackendKind, Prop, PropId,
-    PropKind, Schema, SchemaVariant, SchemaVariantId, StandardModel,
+    standard_model, ChangeSet, ChangeSetPk, DalContext, DiagramKind, Func, FuncBackendKind, Schema,
+    SchemaVariant, SchemaVariantId, Socket, SocketArity, SocketId, StandardModel,
 };
 use dal_test::{
     test,
@@ -333,12 +334,28 @@ async fn has_many(ctx: &DalContext) {
 
 #[test]
 async fn associate_many_to_many(ctx: &DalContext) {
-    let prop_one = Prop::new(ctx, "prop_one", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
-    let prop_two = Prop::new(ctx, "prop_two", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
+    let socket_one = Socket::new(
+        ctx,
+        "socket_one",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
+    let socket_two = Socket::new(
+        ctx,
+        "socket_two",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationInput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
 
     let schema = create_schema(ctx).await;
     let schema_variant_one = create_schema_variant(ctx, *schema.id()).await;
@@ -346,16 +363,16 @@ async fn associate_many_to_many(ctx: &DalContext) {
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_two.id(),
     )
     .await
@@ -363,16 +380,16 @@ async fn associate_many_to_many(ctx: &DalContext) {
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
         schema_variant_two.id(),
     )
     .await
@@ -381,9 +398,17 @@ async fn associate_many_to_many(ctx: &DalContext) {
 
 #[test]
 async fn disassociate_many_to_many(ctx: &DalContext) {
-    let prop_one = Prop::new(ctx, "prop_one", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
+    let socket_one = Socket::new(
+        ctx,
+        "socket_one",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
 
     let schema = create_schema(ctx).await;
     let schema_variant_one = create_schema_variant(ctx, *schema.id()).await;
@@ -391,24 +416,24 @@ async fn disassociate_many_to_many(ctx: &DalContext) {
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::disassociate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_two.id(),
     )
     .await
@@ -417,9 +442,17 @@ async fn disassociate_many_to_many(ctx: &DalContext) {
 
 #[test]
 async fn disassociate_all_many_to_many(ctx: &DalContext) {
-    let prop_one = Prop::new(ctx, "prop_one", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
+    let socket_one = Socket::new(
+        ctx,
+        "socket_one",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
 
     let schema = create_schema(ctx).await;
     let schema_variant_one = create_schema_variant(ctx, *schema.id()).await;
@@ -427,24 +460,24 @@ async fn disassociate_all_many_to_many(ctx: &DalContext) {
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::disassociate_all_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
     )
     .await
     .expect("cannot disassociate many to many");
@@ -452,12 +485,28 @@ async fn disassociate_all_many_to_many(ctx: &DalContext) {
 
 #[test]
 async fn many_to_many(ctx: &DalContext) {
-    let prop_one = Prop::new(ctx, "prop_one", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
-    let prop_two = Prop::new(ctx, "prop_two", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
+    let socket_one = Socket::new(
+        ctx,
+        "socket_one",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
+    let socket_two = Socket::new(
+        ctx,
+        "socket_two",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationInput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
 
     let schema = create_schema(ctx).await;
     let schema_variant_one = create_schema_variant(ctx, *schema.id()).await;
@@ -465,44 +514,44 @@ async fn many_to_many(ctx: &DalContext) {
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot associate many to many");
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot associate many to many");
 
     let right_object_id: Option<&SchemaVariantId> = None;
-    let left_object_id: Option<&PropId> = None;
-    let prop_variants: Vec<SchemaVariant> = standard_model::many_to_many(
+    let left_object_id: Option<&SocketId> = None;
+    let socket_variants: Vec<SchemaVariant> = standard_model::many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        "props",
+        "socket_many_to_many_schema_variants",
+        "sockets",
         "schema_variants",
-        Some(prop_one.id()),
+        Some(socket_one.id()),
         right_object_id,
     )
     .await
     .expect("cannot get list of users for group");
-    assert_eq!(prop_variants.len(), 2);
+    assert_eq!(socket_variants.len(), 2);
     assert_eq!(
-        prop_variants
+        socket_variants
             .into_iter()
             .filter(|v| v == &schema_variant_one || v == &schema_variant_two)
             .count(),
@@ -511,81 +560,80 @@ async fn many_to_many(ctx: &DalContext) {
 
     standard_model::disassociate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot disassociate many to many");
 
-    let variant_two_props: Vec<Prop> = standard_model::many_to_many(
+    let variant_two_sockets: Vec<Socket> = standard_model::many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        "props",
+        "socket_many_to_many_schema_variants",
+        "sockets",
         "schema_variants",
         left_object_id,
         Some(schema_variant_two.id()),
     )
     .await
-    .expect("cannot get list of props for variant");
+    .expect("cannot get list of sockets for variant");
     assert_eq!(
-        variant_two_props
+        variant_two_sockets
             .into_iter()
-            .filter(|p| p == &prop_one)
+            .filter(|s| s == &socket_one)
             .count(),
         1
     );
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
         schema_variant_two.id(),
     )
     .await
     .expect("cannot associate many to many");
 
-    let variant_two_props: Vec<Prop> = standard_model::many_to_many(
+    let variant_two_sockets: Vec<Socket> = standard_model::many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        "props",
+        "socket_many_to_many_schema_variants",
+        "sockets",
         "schema_variants",
         left_object_id,
         Some(schema_variant_two.id()),
     )
     .await
-    .expect("cannot get list of props for variant");
-    assert_eq!(variant_two_props.len(), 3);
+    .expect("cannot get list of sockets for variant");
     assert_eq!(
-        variant_two_props
+        variant_two_sockets
             .into_iter()
-            .filter(|p| p == &prop_one || p == &prop_two)
+            .filter(|s| s == &socket_one || s == &socket_two)
             .count(),
         2
     );
 
     standard_model::disassociate_all_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_two.id(),
+        "socket_many_to_many_schema_variants",
+        socket_two.id(),
     )
     .await
     .expect("cannot disassociate many to many");
 
-    let variant_two_props: Vec<Prop> = standard_model::many_to_many(
+    let variant_two_sockets: Vec<Socket> = standard_model::many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        "props",
+        "socket_many_to_many_schema_variants",
+        "sockets",
         "schema_variants",
         left_object_id,
         Some(schema_variant_two.id()),
     )
     .await
-    .expect("cannot get list of groups for user");
+    .expect("cannot get list of sockets for vairant");
     assert_eq!(
-        variant_two_props
+        variant_two_sockets
             .into_iter()
-            .filter(|p| p == &prop_one)
+            .filter(|s| s == &socket_one)
             .count(),
         1
     );
@@ -593,25 +641,33 @@ async fn many_to_many(ctx: &DalContext) {
 
 #[test]
 async fn associate_many_to_many_no_repeat_entries(ctx: &DalContext) {
-    let prop_one = Prop::new(ctx, "prop_one", PropKind::String, None)
-        .await
-        .expect("unable to create prop");
+    let socket_one = Socket::new(
+        ctx,
+        "socket_one",
+        SocketKind::Standalone,
+        &SocketEdgeKind::ConfigurationOutput,
+        &SocketArity::Many,
+        &DiagramKind::Configuration,
+        None,
+    )
+    .await
+    .expect("could not create socket");
 
     let schema = create_schema(ctx).await;
     let schema_variant_one = create_schema_variant(ctx, *schema.id()).await;
 
     standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await
     .expect("cannot associate many to many");
     let result = standard_model::associate_many_to_many(
         ctx,
-        "prop_many_to_many_schema_variants",
-        prop_one.id(),
+        "socket_many_to_many_schema_variants",
+        socket_one.id(),
         schema_variant_one.id(),
     )
     .await;

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -139,10 +139,8 @@ pub enum FuncError {
     FuncExecutionFailed(String),
     #[error("Function execution failed: this function is not connected to any assets, and was not executed")]
     FuncExecutionFailedNoPrototypes,
-    #[error("Could not root prop for child prop {0}")]
-    MissingRootPropForProp(PropId),
-    #[error("Could not find schema variant for root prop {0}")]
-    PropMissingSchemaVariant(PropId),
+    #[error("Could not find schema variant for prop {0}")]
+    SchemaVariantNotFoundForProp(PropId),
 }
 
 pub type FuncResult<T> = Result<T, FuncError>;


### PR DESCRIPTION
Replace "prop_many_to_many_schema_variants" with a "root_prop_id" column
for the "schema_variants" table for two primary reasons:

1) "Many to many" is not the correct relationship since root Props
   cannot be reused for other SchemaVariants.
2) A column using a foreign ID is preferable and more ergonomic than a
   "belongs to" standard model relationship.

The new column is non-nullable and is immutable at the Rust layer. We
are affordaded some grace with the new migration since users only run
one "sdf" instance at a time (as of time of writing) and must restart
the entire stack when upgrading.

<img src="https://media2.giphy.com/media/hZq5XitsxurUBzfWFP/giphy.gif"/>