### PR TITLE
feat(dal,sdf): support builtin schema variant migrations

### DIFF
--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -77,7 +77,7 @@ impl SocketView {
             .filter_map(|socket| {
                 (!socket.ui_hidden()).then(|| Self {
                     id: socket.id().to_string(),
-                    label: socket.name().to_owned(),
+                    label: socket.human_name().unwrap_or(socket.name()).to_owned(),
                     ty: socket.name().to_owned(),
                     // Note: it's not clear if this mapping is correct, and there is no backend support for bidirectional sockets for now
                     direction: match socket.edge_kind() {

--- a/lib/dal/src/migrations/U2132__builtin_schema_variant_migrations.sql
+++ b/lib/dal/src/migrations/U2132__builtin_schema_variant_migrations.sql
@@ -1,0 +1,5 @@
+CREATE UNIQUE INDEX schema_names ON schemas (name, tenancy_workspace_pk, visibility_change_set_pk);
+
+ALTER TABLE schema_variants ADD COLUMN ui_hidden BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE sockets ADD COLUMN human_name text;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -166,6 +166,7 @@ pub struct SchemaVariant {
     #[serde(flatten)]
     visibility: Visibility,
 
+    ui_hidden: bool,
     name: String,
     link: Option<String>,
     // NOTE(nick): we may want to replace this with a better solution. We use this to ensure
@@ -393,6 +394,7 @@ impl SchemaVariant {
         Ok(())
     }
 
+    standard_model_accessor!(ui_hidden, bool, SchemaVariantResult);
     standard_model_accessor!(name, String, SchemaVariantResult);
     standard_model_accessor!(link, Option<String>, SchemaVariantResult);
     standard_model_accessor!(finalized_once, bool, SchemaVariantResult);

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -431,6 +431,7 @@ impl SchemaVariant {
         ctx: &DalContext,
         schema_variant_definition_metadata: SchemaVariantDefinitionMetadataJson,
         schema_variant_definition: SchemaVariantDefinitionJson,
+        variant_name: &str,
     ) -> SchemaVariantResult<(
         Self,
         RootProp,
@@ -438,8 +439,6 @@ impl SchemaVariant {
         Vec<InternalProvider>,
         Vec<ExternalProvider>,
     )> {
-        let variant_name = "v0".to_string();
-
         let schema_name = schema_variant_definition_metadata.name.clone();
 
         let schema_id = match Schema::find_by_name(ctx, &schema_name).await {

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -106,6 +106,7 @@ pub struct Socket {
     pk: SocketPk,
     id: SocketId,
     name: String,
+    human_name: Option<String>,
     kind: SocketKind,
     edge_kind: SocketEdgeKind,
     diagram_kind: DiagramKind,
@@ -173,6 +174,7 @@ impl Socket {
         Ok(object)
     }
 
+    standard_model_accessor!(human_name, Option<String>, SocketResult);
     standard_model_accessor!(name, String, SocketResult);
     standard_model_accessor!(kind, Enum(SocketKind), SocketResult);
     standard_model_accessor!(edge_kind, Enum(SocketEdgeKind), SocketResult);

--- a/lib/sdf-server/src/server/service/diagram/list_schema_variants.rs
+++ b/lib/sdf-server/src/server/service/diagram/list_schema_variants.rs
@@ -74,6 +74,10 @@ pub async fn list_schema_variants(
 
     let mut variants_view = Vec::with_capacity(variants.len());
     for variant in variants {
+        if variant.ui_hidden() {
+            continue;
+        }
+
         let schema = variant
             .schema(&ctx)
             .await?

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -62,7 +62,7 @@ pub async fn exec_variant_def(
     })?;
 
     let (mut schema_variant, _, _, _, _) =
-        SchemaVariant::new_with_definition(&ctx, metadata, definition)
+        SchemaVariant::new_with_definition(&ctx, metadata, definition, "v0")
             .await
             .map_err(|e| {
                 SchemaVariantDefinitionError::CouldNotCreateSchemaVariantFromDefinition(


### PR DESCRIPTION
- Find or create schema
- Create schema variant with custom name and make it default
- Enable hiding outdated schema variants from the ui menu
- Have human_name and name in sockets, so new versions of schema variants don't connect to old versions while having the same display name (if not supported)