### PR TITLE
fix(council,pinga) Reduce race conditions around global graph updates and in-flight node processing

### DIFF
--- a/lib/council-server/src/server.rs
+++ b/lib/council-server/src/server.rs
@@ -300,7 +300,7 @@ pub async fn job_processed_a_value(
     for reply_channel in
         complete_graph.mark_node_as_processed(reply_channel, change_set_id, node_id)?
     {
-        info!(%reply_channel, ?node_id, "AttributeValue has been processed by another job");
+        info!(%reply_channel, ?node_id, "AttributeValue has been processed by a job");
         nats.publish(
             reply_channel,
             serde_json::to_vec(&Response::BeenProcessed { node_id }).unwrap(),

--- a/lib/council-server/src/server/graph/node_metadata.rs
+++ b/lib/council-server/src/server/graph/node_metadata.rs
@@ -1,0 +1,143 @@
+use std::{
+    collections::{vec_deque::Iter, HashSet, VecDeque},
+    time::Instant,
+};
+
+use crate::{server::Error, Id};
+
+#[derive(Debug)]
+pub struct NodeMetadata {
+    // This should really be an ordered set, to remove duplicates, but we'll deal with
+    // that later.
+    wanted_by_reply_channels: VecDeque<String>,
+    processing_reply_channel: Option<String>,
+    depends_on_node_ids: HashSet<Id>,
+    processing_started_at: Option<Instant>,
+    last_updated_at: Instant,
+}
+
+impl Default for NodeMetadata {
+    fn default() -> Self {
+        Self {
+            wanted_by_reply_channels: VecDeque::default(),
+            processing_reply_channel: Option::default(),
+            depends_on_node_ids: HashSet::default(),
+            processing_started_at: Option::default(),
+            last_updated_at: Instant::now(),
+        }
+    }
+}
+
+impl NodeMetadata {
+    pub fn add_wanted_by_reply_channel(&mut self, reply_channel: &str) {
+        self.wanted_by_reply_channels
+            .push_back(reply_channel.to_owned());
+        self.last_updated_at = Instant::now();
+    }
+
+    pub fn dependencies_satisfied(&self) -> bool {
+        self.depends_on_node_ids.is_empty()
+    }
+
+    pub fn depends_on(&self, node_id: Id) -> bool {
+        self.depends_on_node_ids.contains(&node_id)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.wanted_by_reply_channels.is_empty() && self.processing_reply_channel.is_none()
+    }
+
+    pub fn is_processing_stale(&self) -> bool {
+        if let Some(processing_started_at) = self.processing_started_at {
+            // If we've been updated more recently than when we last set the reply channel
+            // for the job that should be processing this node, then the information that
+            // job is using to update this node is out of date. We'll need to act as though
+            // we never told that job to process this node in the first place, and have
+            // a job that wants this node process it again with the up to date inputs.
+            return processing_started_at < self.last_updated_at;
+        }
+
+        false
+    }
+
+    pub fn mark_as_processed(
+        &mut self,
+        reply_channel: &str,
+    ) -> Result<(bool, HashSet<String>), Error> {
+        if self.processing_reply_channel().map(|p| &**p) != Some(reply_channel) {
+            return Err(Error::ShouldNotBeProcessingByJob);
+        }
+
+        let processing_reply_channel = self.processing_reply_channel.take();
+
+        if self.is_processing_stale() {
+            self.add_wanted_by_reply_channel(reply_channel);
+
+            return Ok((false, HashSet::new()));
+        }
+
+        if self.dependencies_satisfied() {
+            let mut wanted_by_reply_channels = self.wanted_by_reply_channels();
+            if let Some(processed_by_reply_channel) = processing_reply_channel {
+                wanted_by_reply_channels.insert(processed_by_reply_channel);
+            }
+
+            Ok((true, wanted_by_reply_channels))
+        } else {
+            Ok((false, HashSet::new()))
+        }
+    }
+
+    pub fn merge_metadata(&mut self, reply_channel: String, dependencies: &Vec<Id>) {
+        self.last_updated_at = Instant::now();
+
+        if !self.wanted_by_reply_channels.contains(&reply_channel) {
+            self.wanted_by_reply_channels.push_back(reply_channel);
+        }
+        self.depends_on_node_ids.extend(dependencies);
+    }
+
+    pub fn next_to_process(&mut self) -> Option<String> {
+        if self.depends_on_node_ids.is_empty() && self.processing_reply_channel.is_none() {
+            self.last_updated_at = Instant::now();
+
+            self.processing_reply_channel = self.wanted_by_reply_channels.pop_front();
+            if self.processing_reply_channel.is_some() {
+                self.processing_started_at = Some(Instant::now());
+            } else {
+                self.processing_started_at = None;
+            }
+            return self.processing_reply_channel.clone();
+        }
+        None
+    }
+
+    pub fn processing_reply_channel(&self) -> Option<&String> {
+        self.processing_reply_channel.as_ref()
+    }
+
+    pub fn remove_channel(&mut self, reply_channel: &str) {
+        self.last_updated_at = Instant::now();
+
+        self.wanted_by_reply_channels
+            .retain(|el| el != reply_channel);
+        self.processing_reply_channel = self
+            .processing_reply_channel
+            .take()
+            .filter(|el| el != reply_channel);
+    }
+
+    pub fn remove_dependency(&mut self, node_id: Id) {
+        if self.depends_on_node_ids.remove(&node_id) {
+            self.last_updated_at = Instant::now();
+        };
+    }
+
+    pub fn wanted_by_reply_channels(&self) -> HashSet<String> {
+        HashSet::from_iter(self.wanted_by_reply_channels.iter().cloned())
+    }
+
+    pub fn wanted_by_reply_channels_iter(&self) -> Iter<'_, String> {
+        self.wanted_by_reply_channels.iter()
+    }
+}

--- a/lib/dal/src/status.rs
+++ b/lib/dal/src/status.rs
@@ -276,6 +276,11 @@ impl StatusUpdate {
         value_ids: Vec<AttributeValueId>,
     ) -> StatusUpdateResult<Vec<AttributeValueMetadata>> {
         for value_id in value_ids.iter() {
+            // The value may have been processed by a different job, so it won't have gone through
+            // `set_running_dependent_value_ids` to be removed from the list of queued value ids.
+            self.data.queued_dependent_value_ids.remove(value_id);
+
+            // Value id is done updating (regardless of success), so it's no longer running.
             self.data.running_dependent_value_ids.remove(value_id);
         }
         self.data.completed_dependent_value_ids.extend(&value_ids);


### PR DESCRIPTION
Given two jobs that are interested in partially overlapping graphs:

```
Job A: AV 1 -> AV 2
Job B: AV 3 -> AV 2
```

There is a race condition that will cause AV 2 to have stale information, if Job A submits its graph, and is able to start processing AV 2 before Job B submits its graph, and Job B is able to start and finish processing AV 3 before Job A has finished processing AV 2.

When council checks to see whether all of the things that AV 2 depends on have been processed, there is no record that AV 3 was added (and removed) from the list between when Job A started working on AV 2, and when it finished, which means that it doesn't know that AV 2 should be re-evaluated.

To avoid this, we now keep track of both when we determined that Job A should be the one to process AV 2, and when we modify any of the informataion about AV 2. If we have modified AV 2's information more recently than when we determined that Job A should process it, then we don't consider Job A to have processed the most recent version of AV 2's inputs. We put Job A's reply channel back at the end of the list of reply channels that are interested in AV 2, and mark AV 2 as not currently being processed so it can be picked up as normal when checking for nodes that are ready to be processed. Job A's reply channel is added to the back of the list of reply channels interested in AV 2 to try to more fairly distribute the work of processing nodes that have to be re-processed like this.

To be able to support re-processing nodes like this, we also make it so that a job will not remove a node from its list of nodes it is expecting to be processed until it sees a `BeenProcessed` message from council for that node, even if it is the one that was doing the processing.