### PR TITLE
feat(web,si-pkg): package up validations

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -13,11 +13,14 @@ use crate::{
     func::argument::FuncArgumentError, installed_pkg::InstalledPkgError, prop_tree::PropTreeError,
     schema::variant::definition::SchemaVariantDefinitionError, FuncBackendKind,
     FuncBackendResponseType, FuncError, FuncId, PropError, SchemaError, SchemaId,
-    SchemaVariantError, SchemaVariantId, StandardModelError,
+    SchemaVariantError, SchemaVariantId, StandardModelError, ValidationPrototypeError,
 };
 
 #[derive(Debug, Error)]
 pub enum PkgError {
+    #[error("json serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+
     #[error(transparent)]
     Pkg(#[from] SiPkgError),
     #[error(transparent)]
@@ -68,6 +71,8 @@ pub enum PkgError {
     MissingExportedFunc(FuncId),
     #[error("Leaf Function {0} has invalid argument {1}")]
     InvalidLeafArgument(FuncId, String),
+    #[error("Validation Creation Error: {0}")]
+    Validation(#[from] ValidationPrototypeError),
 }
 
 impl PkgError {

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -13,6 +13,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::{
+    func::backend::validation::FuncBackendValidationArgs, DalContext, FuncId, PropId, SchemaId,
+    SchemaVariantId,
+};
+
 pub mod prototype;
 pub mod resolver;
 
@@ -174,4 +179,40 @@ impl ValidationErrorKind {
             Self::JsValidation => "JsValidation",
         }
     }
+}
+
+pub enum ValidationKind {
+    Builtin(Validation),
+    Custom(FuncId),
+}
+
+pub async fn create_validation(
+    ctx: &DalContext,
+    validation_kind: ValidationKind,
+    builtin_func_id: FuncId,
+    prop_id: PropId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+) -> prototype::ValidationPrototypeResult<prototype::ValidationPrototype> {
+    let (validation_func_id, validation_args) = match validation_kind {
+        ValidationKind::Builtin(validation) => (
+            builtin_func_id,
+            serde_json::to_value(FuncBackendValidationArgs::new(validation))?,
+        ),
+
+        ValidationKind::Custom(func_id) => (func_id, serde_json::json!(null)),
+    };
+    let mut builder = prototype::context::ValidationPrototypeContext::builder();
+    builder
+        .set_prop_id(prop_id)
+        .set_schema_id(schema_id)
+        .set_schema_variant_id(schema_variant_id);
+
+    prototype::ValidationPrototype::new(
+        ctx,
+        validation_func_id,
+        validation_args,
+        builder.to_context(ctx).await?,
+    )
+    .await
 }

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -9,6 +9,7 @@ derive_builder = "0.12.0"
 object-tree = { path = "../../lib/object-tree" }
 petgraph = { version = "0.6.2", features = ["serde-1"] }
 serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"
 strum = { version = "0.24.1", features = ["derive"] }
 strum_macros = "0.24.3"
 thiserror = "1.0.38"

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -90,7 +90,12 @@
             "entries": [
               {
                 "name": "apiVersion",
-                "kind": "string"
+                "kind": "string",
+                "validations": [{
+                  "kind": "integerIsBetweenTwoIntegers",
+                  "upper_bound": 31337,
+                  "lower_bound": 2600 
+                }]
               },
               {
                 "name": "kind",

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -4,12 +4,14 @@ mod spec;
 
 pub use pkg::{
     SiPkg, SiPkgError, SiPkgFunc, SiPkgMetadata, SiPkgProp, SiPkgSchema, SiPkgSchemaVariant,
+    SiPkgValidation,
 };
 pub use spec::{
     FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder, FuncSpec, FuncSpecBackendKind,
     FuncSpecBackendResponseType, LeafFunctionSpec, LeafFunctionSpecBuilder, LeafInputLocation,
     LeafKind, PkgSpec, PkgSpecBuilder, PropSpec, PropSpecBuilder, PropSpecKind, SchemaSpec,
-    SchemaSpecBuilder, SchemaVariantSpec, SchemaVariantSpecBuilder, SpecError,
+    SchemaSpecBuilder, SchemaVariantSpec, SchemaVariantSpecBuilder, SpecError, ValidationSpec,
+    ValidationSpecKind,
 };
 
 #[cfg(test)]
@@ -105,7 +107,7 @@ mod tests {
             .funcs_by_unique_id()
             .expect("cannot get funcs by unique id");
 
-        let leaf_funcs = variant.leaf_functions().await.expect("get leaf funcs");
+        let leaf_funcs = variant.leaf_functions().expect("get leaf funcs");
         assert_eq!(3, leaf_funcs.len());
 
         for func in leaf_funcs {
@@ -138,5 +140,7 @@ mod tests {
 
         // k8s deployments are really complex!
         assert_eq!(123, props.lock().await.len());
+
+        let _ = dbg!(props.lock().await);
     }
 }

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -10,9 +10,11 @@ mod func_argument;
 mod leaf_function;
 mod package;
 mod prop;
+mod prop_child;
 mod schema;
 mod schema_variant;
 mod schema_variant_child;
+mod validation;
 
 pub(crate) use self::{
     category::CategoryNode,
@@ -21,20 +23,24 @@ pub(crate) use self::{
     leaf_function::LeafFunctionNode,
     package::PackageNode,
     prop::PropNode,
+    prop_child::PropChildNode,
     schema::SchemaNode,
     schema_variant::SchemaVariantNode,
     schema_variant_child::{SchemaVariantChild, SchemaVariantChildNode},
+    validation::ValidationNode,
 };
 
 const NODE_KIND_CATEGORY: &str = "category";
 const NODE_KIND_PACKAGE: &str = "package";
 const NODE_KIND_PROP: &str = "prop";
+const NODE_KIND_PROP_CHILD: &str = "prop_child";
 const NODE_KIND_SCHEMA: &str = "schema";
 const NODE_KIND_SCHEMA_VARIANT: &str = "schema_variant";
 const NODE_KIND_SCHEMA_VARIANT_CHILD: &str = "schema_variant_child";
 const NODE_KIND_FUNC: &str = "func";
 const NODE_KIND_FUNC_ARGUMENT: &str = "func_argument";
 const NODE_KIND_LEAF_FUNCTION: &str = "leaf_function";
+const NODE_KIND_VALIDATION: &str = "validation";
 
 const KEY_NODE_KIND_STR: &str = "node_kind";
 
@@ -43,18 +49,21 @@ pub enum PkgNode {
     Category(CategoryNode),
     Package(PackageNode),
     Prop(PropNode),
+    PropChild(PropChildNode),
     Schema(SchemaNode),
     SchemaVariant(SchemaVariantNode),
     SchemaVariantChild(SchemaVariantChildNode),
     Func(FuncNode),
     FuncArgument(FuncArgumentNode),
     LeafFunction(LeafFunctionNode),
+    Validation(ValidationNode),
 }
 
 impl PkgNode {
     pub const CATEGORY_KIND_STR: &str = NODE_KIND_CATEGORY;
     pub const PACKAGE_KIND_STR: &str = NODE_KIND_PACKAGE;
     pub const PROP_KIND_STR: &str = NODE_KIND_PROP;
+    pub const PROP_CHILD_KIND_STR: &str = NODE_KIND_PROP_CHILD;
     pub const SCHEMA_KIND_STR: &str = NODE_KIND_SCHEMA;
     pub const SCHEMA_VARIANT_KIND_STR: &str = NODE_KIND_SCHEMA_VARIANT;
     pub const SCHEMA_VARIANT_KIND_CHILD_STR: &str = NODE_KIND_SCHEMA_VARIANT_CHILD;
@@ -67,12 +76,14 @@ impl PkgNode {
             Self::Category(_) => NODE_KIND_CATEGORY,
             Self::Package(_) => NODE_KIND_PACKAGE,
             Self::Prop(_) => NODE_KIND_PROP,
+            Self::PropChild(_) => NODE_KIND_PROP_CHILD,
             Self::Schema(_) => NODE_KIND_SCHEMA,
             Self::SchemaVariant(_) => NODE_KIND_SCHEMA_VARIANT,
             Self::SchemaVariantChild(_) => NODE_KIND_SCHEMA_VARIANT_CHILD,
             Self::Func(_) => NODE_KIND_FUNC,
             Self::FuncArgument(_) => NODE_KIND_FUNC_ARGUMENT,
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
+            Self::Validation(_) => NODE_KIND_VALIDATION,
         }
     }
 }
@@ -83,12 +94,14 @@ impl NameStr for PkgNode {
             Self::Category(node) => node.name(),
             Self::Package(node) => node.name(),
             Self::Prop(node) => node.name(),
+            Self::PropChild(node) => node.name(),
             Self::Schema(node) => node.name(),
             Self::SchemaVariant(node) => node.name(),
             Self::SchemaVariantChild(node) => node.name(),
             Self::Func(node) => node.name(),
             Self::FuncArgument(node) => node.name(),
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
+            Self::Validation(_) => NODE_KIND_VALIDATION,
         }
     }
 }
@@ -101,12 +114,14 @@ impl WriteBytes for PkgNode {
             Self::Category(node) => node.write_bytes(writer)?,
             Self::Package(node) => node.write_bytes(writer)?,
             Self::Prop(node) => node.write_bytes(writer)?,
+            Self::PropChild(node) => node.write_bytes(writer)?,
             Self::Schema(node) => node.write_bytes(writer)?,
             Self::SchemaVariant(node) => node.write_bytes(writer)?,
             Self::SchemaVariantChild(node) => node.write_bytes(writer)?,
             Self::Func(node) => node.write_bytes(writer)?,
             Self::FuncArgument(node) => node.write_bytes(writer)?,
             Self::LeafFunction(node) => node.write_bytes(writer)?,
+            Self::Validation(node) => node.write_bytes(writer)?,
         };
 
         Ok(())
@@ -124,6 +139,7 @@ impl ReadBytes for PkgNode {
             NODE_KIND_CATEGORY => Self::Category(CategoryNode::read_bytes(reader)?),
             NODE_KIND_PACKAGE => Self::Package(PackageNode::read_bytes(reader)?),
             NODE_KIND_PROP => Self::Prop(PropNode::read_bytes(reader)?),
+            NODE_KIND_PROP_CHILD => Self::PropChild(PropChildNode::read_bytes(reader)?),
             NODE_KIND_SCHEMA => Self::Schema(SchemaNode::read_bytes(reader)?),
             NODE_KIND_SCHEMA_VARIANT => Self::SchemaVariant(SchemaVariantNode::read_bytes(reader)?),
             NODE_KIND_SCHEMA_VARIANT_CHILD => {
@@ -132,6 +148,7 @@ impl ReadBytes for PkgNode {
             NODE_KIND_FUNC => Self::Func(FuncNode::read_bytes(reader)?),
             NODE_KIND_FUNC_ARGUMENT => Self::FuncArgument(FuncArgumentNode::read_bytes(reader)?),
             NODE_KIND_LEAF_FUNCTION => Self::LeafFunction(LeafFunctionNode::read_bytes(reader)?),
+            NODE_KIND_VALIDATION => Self::Validation(ValidationNode::read_bytes(reader)?),
             invalid_kind => {
                 return Err(GraphError::parse_custom(format!(
                     "invalid package node kind: {invalid_kind}"

--- a/lib/si-pkg/src/node/prop_child.rs
+++ b/lib/si-pkg/src/node/prop_child.rs
@@ -1,0 +1,113 @@
+use std::io::{BufRead, Write};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{PropSpec, ValidationSpec};
+
+use super::PkgNode;
+
+const PROP_CHILD_TYPE_PROPS: &str = "props";
+const PROP_CHILD_TYPE_VALIDATIONS: &str = "validations";
+
+const KEY_KIND_STR: &str = "kind";
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PropChild {
+    Props(Vec<PropSpec>),
+    Validations(Vec<ValidationSpec>),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum PropChildNode {
+    Props,
+    Validations,
+}
+
+impl PropChildNode {
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Props => PROP_CHILD_TYPE_PROPS,
+            Self::Validations => PROP_CHILD_TYPE_VALIDATIONS,
+        }
+    }
+}
+
+impl NameStr for PropChildNode {
+    fn name(&self) -> &str {
+        match self {
+            Self::Props => PROP_CHILD_TYPE_PROPS,
+            Self::Validations => PROP_CHILD_TYPE_VALIDATIONS,
+        }
+    }
+}
+
+impl WriteBytes for PropChildNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind_str())?;
+        Ok(())
+    }
+}
+
+impl ReadBytes for PropChildNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+
+        let node = match kind_str.as_str() {
+            PROP_CHILD_TYPE_PROPS => Self::Props,
+            PROP_CHILD_TYPE_VALIDATIONS => Self::Validations,
+            invalid_kind => {
+                return Err(GraphError::parse_custom(format!(
+                    "invalid schema variant child kind: {invalid_kind}"
+                )))
+            }
+        };
+
+        Ok(node)
+    }
+}
+
+impl NodeChild for PropChild {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        match self {
+            Self::Props(props) => {
+                let props = props
+                    .iter()
+                    .map(|prop| {
+                        Box::new(prop.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect();
+
+                NodeWithChildren::new(
+                    NodeKind::Tree,
+                    Self::NodeType::PropChild(PropChildNode::Props),
+                    props,
+                )
+            }
+            Self::Validations(validations) => {
+                let validations = validations
+                    .iter()
+                    .map(|validation| {
+                        Box::new(validation.clone())
+                            as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect();
+
+                NodeWithChildren::new(
+                    NodeKind::Tree,
+                    Self::NodeType::PropChild(PropChildNode::Validations),
+                    validations,
+                )
+            }
+        }
+    }
+}

--- a/lib/si-pkg/src/node/validation.rs
+++ b/lib/si-pkg/src/node/validation.rs
@@ -1,0 +1,227 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, Hash, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+
+use crate::{ValidationSpec, ValidationSpecKind};
+
+use super::PkgNode;
+
+const KEY_KIND_STR: &str = "kind";
+const KEY_UPPER_BOUND_STR: &str = "upper_bound";
+const KEY_LOWER_BOUND_STR: &str = "lower_bound";
+const KEY_EXPECTED_STRING_STR: &str = "expected_string";
+const KEY_EXPECTED_STRING_ARRAY_STR: &str = "expected_string_array";
+const KEY_DISPLAY_EXPECTED_STR: &str = "display_expected";
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+
+#[derive(Clone, Debug)]
+pub struct ValidationNode {
+    pub kind: ValidationSpecKind,
+    pub upper_bound: Option<i64>,
+    pub lower_bound: Option<i64>,
+    pub expected_string: Option<String>,
+    pub expected_string_array: Option<Vec<String>>,
+    pub display_expected: Option<bool>,
+    pub func_unique_id: Option<Hash>,
+}
+
+impl Default for ValidationNode {
+    fn default() -> Self {
+        Self {
+            kind: ValidationSpecKind::CustomValidation,
+            upper_bound: None,
+            lower_bound: None,
+            expected_string: None,
+            expected_string_array: None,
+            display_expected: None,
+            func_unique_id: None,
+        }
+    }
+}
+
+impl WriteBytes for ValidationNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind)?;
+
+        match self.kind {
+            ValidationSpecKind::IntegerIsBetweenTwoIntegers => {
+                write_key_value_line(
+                    writer,
+                    KEY_UPPER_BOUND_STR,
+                    self.upper_bound
+                        .map(|i| i.to_string())
+                        .unwrap_or("".to_string()),
+                )?;
+                write_key_value_line(
+                    writer,
+                    KEY_LOWER_BOUND_STR,
+                    self.lower_bound
+                        .map(|i| i.to_string())
+                        .unwrap_or("".to_string()),
+                )?;
+            }
+            ValidationSpecKind::StringEquals | ValidationSpecKind::StringHasPrefix => {
+                write_key_value_line(
+                    writer,
+                    KEY_EXPECTED_STRING_STR,
+                    self.expected_string.clone().unwrap_or("".to_string()),
+                )?
+            }
+            ValidationSpecKind::StringInStringArray => {
+                write_key_value_line(
+                    writer,
+                    KEY_EXPECTED_STRING_ARRAY_STR,
+                    serde_json::to_string(&self.expected_string_array.clone().unwrap_or(vec![]))
+                        .map_err(GraphError::parse)?,
+                )?;
+                write_key_value_line(
+                    writer,
+                    KEY_DISPLAY_EXPECTED_STR,
+                    self.display_expected
+                        .map(|display_expected| display_expected.to_string())
+                        .unwrap_or("".to_string()),
+                )?
+            }
+            ValidationSpecKind::CustomValidation => write_key_value_line(
+                writer,
+                KEY_FUNC_UNIQUE_ID_STR,
+                self.func_unique_id
+                    .map(|id| id.to_string())
+                    .unwrap_or("".to_string()),
+            )?,
+            ValidationSpecKind::StringIsValidIpAddr
+            | ValidationSpecKind::StringIsHexColor
+            | ValidationSpecKind::StringIsNotEmpty => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for ValidationNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+        let kind = ValidationSpecKind::from_str(&kind_str).map_err(GraphError::parse)?;
+        let mut upper_bound = None;
+        let mut lower_bound = None;
+        let mut expected_string = None;
+        let mut expected_string_array = None;
+        let mut display_expected = None;
+        let mut func_unique_id = None;
+
+        match kind {
+            ValidationSpecKind::IntegerIsBetweenTwoIntegers => {
+                let upper_bound_str = read_key_value_line(reader, KEY_UPPER_BOUND_STR)?;
+                upper_bound = Some(i64::from_str(&upper_bound_str).map_err(GraphError::parse)?);
+
+                let lower_bound_str = read_key_value_line(reader, KEY_LOWER_BOUND_STR)?;
+                lower_bound = Some(i64::from_str(&lower_bound_str).map_err(GraphError::parse)?);
+            }
+            ValidationSpecKind::StringEquals | ValidationSpecKind::StringHasPrefix => {
+                let expected_string_str = read_key_value_line(reader, KEY_EXPECTED_STRING_STR)?;
+                if !expected_string_str.is_empty() {
+                    expected_string = Some(expected_string_str);
+                }
+            }
+            ValidationSpecKind::StringInStringArray => {
+                let expected_string_array_str =
+                    read_key_value_line(reader, KEY_EXPECTED_STRING_ARRAY_STR)?;
+                let expected_string_array_json: Vec<String> =
+                    serde_json::from_str(&expected_string_array_str).map_err(GraphError::parse)?;
+                if !expected_string_array_json.is_empty() {
+                    expected_string_array = Some(expected_string_array_json);
+                }
+
+                let display_expected_str = read_key_value_line(reader, KEY_DISPLAY_EXPECTED_STR)?;
+                if !display_expected_str.is_empty() {
+                    display_expected =
+                        Some(bool::from_str(&display_expected_str).map_err(GraphError::parse)?);
+                }
+            }
+            ValidationSpecKind::CustomValidation => {
+                let func_unique_id_str = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+                func_unique_id = Some(Hash::from_str(&func_unique_id_str)?);
+            }
+            ValidationSpecKind::StringIsValidIpAddr
+            | ValidationSpecKind::StringIsHexColor
+            | ValidationSpecKind::StringIsNotEmpty => {}
+        }
+
+        Ok(Self {
+            kind,
+            lower_bound,
+            upper_bound,
+            expected_string,
+            expected_string_array,
+            display_expected,
+            func_unique_id,
+        })
+    }
+}
+
+impl NodeChild for ValidationSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Leaf,
+            Self::NodeType::Validation(match self {
+                ValidationSpec::IntegerIsBetweenTwoIntegers {
+                    lower_bound,
+                    upper_bound,
+                } => ValidationNode {
+                    kind: ValidationSpecKind::IntegerIsBetweenTwoIntegers,
+                    upper_bound: Some(*upper_bound),
+                    lower_bound: Some(*lower_bound),
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringEquals { expected } => ValidationNode {
+                    kind: ValidationSpecKind::StringEquals,
+                    expected_string: Some(expected.clone()),
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringHasPrefix { expected } => ValidationNode {
+                    kind: ValidationSpecKind::StringHasPrefix,
+                    expected_string: Some(expected.clone()),
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringInStringArray {
+                    expected,
+                    display_expected,
+                } => ValidationNode {
+                    kind: ValidationSpecKind::StringInStringArray,
+                    expected_string_array: Some(expected.clone()),
+                    display_expected: Some(*display_expected),
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringIsValidIpAddr => ValidationNode {
+                    kind: ValidationSpecKind::StringIsValidIpAddr,
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringIsHexColor => ValidationNode {
+                    kind: ValidationSpecKind::StringIsHexColor,
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::StringIsNotEmpty => ValidationNode {
+                    kind: ValidationSpecKind::StringIsNotEmpty,
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::CustomValidation { func_unique_id } => ValidationNode {
+                    kind: ValidationSpecKind::CustomValidation,
+                    func_unique_id: Some(*func_unique_id),
+                    ..ValidationNode::default()
+                },
+            }),
+            vec![],
+        )
+    }
+}


### PR DESCRIPTION
Adds a child enum to the package prop node, so we can have both child props of props and validations as children of props. This will also allow us to add attribute functions to props.