### PR TITLE
chore: extract common crate deps to use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bce8d450891e3b36f85a2230cec441fddd60e0c455b61b15bb3ffba955ca85"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -891,7 +900,6 @@ dependencies = [
  "si-pkg",
  "sodiumoxide",
  "strum",
- "strum_macros",
  "telemetry",
  "tempfile",
  "thiserror",
@@ -1546,7 +1554,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -1982,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libm"
@@ -2021,9 +2029,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -2377,9 +2385,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2409,9 +2417,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
  "cc",
  "libc",
@@ -3084,13 +3092,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.0",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.0",
 ]
 
 [[package]]
@@ -3099,7 +3107,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3107,6 +3115,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
 
 [[package]]
 name = "reqwest"
@@ -3215,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags",
  "errno",
@@ -3357,7 +3371,6 @@ dependencies = [
  "si-std",
  "sodiumoxide",
  "strum",
- "strum_macros",
  "telemetry",
  "thiserror",
  "tokio",
@@ -3645,7 +3658,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
  "thiserror",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,27 @@ members = [
 [patch.crates-io]
 # pending a potential merge and release of https://github.com/softprops/hyperlocal/pull/53
 hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-unix-stream" }
+
+[workspace.dependencies]
+async-trait = { version = "0.1.68" }
+axum = { version = "0.6.16", features = ["macros", "ws"] }
+base64 = { version = "0.21.0" }
+chrono = { version = "0.4.24", features = ["serde"] }
+clap = { version = "4.2.4", features = ["derive", "color", "env", "wrap_help"] }
+color-eyre = { version = "0.6.2" }
+derive_builder = { version = "0.12.0" }
+futures = { version = "0.3.28" }
+petgraph = { version = "0.6.3", features = ["serde-1"] }
+serde = { version = "1.0.160", features = ["derive", "rc"] }
+serde_json = { version = "1.0.96", features = ["preserve_order"] }
+sodiumoxide = { version = "0.2.7" }
+strum = { version = "0.24.1", features = ["derive"] }
+thiserror = { version = "1.0.24" }
+tokio = { version = "1.27.0", features = ["full"] }
+ulid = { version = "1.0.0", features = ["serde"] }
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.69"
+version = "0.1.0"
+publish = false

--- a/bin/council/Cargo.toml
+++ b/bin/council/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "council"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "council"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 council-server = { path = "../../lib/council-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "cyclone"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "cyclone"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 cyclone-server = { path = "../../lib/cyclone-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }

--- a/bin/gen-var-defs/Cargo.toml
+++ b/bin/gen-var-defs/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name = "gen-var-defs"
-version = "0.1.0"
-edition = "2021"
-publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-async-trait = "0.1.51"
-clap = { version = "4.1.6", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+async-trait = { workspace = true }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 convert_case = "0.6.0"
 dal = { path = "../../lib/dal" }
-derive_builder = { version = "0.12" }
-futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+derive_builder = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-settings = { path = "../../lib/si-settings" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/bin/pinga/Cargo.toml
+++ b/bin/pinga/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "pinga"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "pinga"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 pinga-server = { path = "../../lib/pinga-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }

--- a/bin/sdf/Cargo.toml
+++ b/bin/sdf/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "sdf"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "sdf"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 sdf-server = { path = "../../lib/sdf-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }

--- a/bin/veritech/Cargo.toml
+++ b/bin/veritech/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "veritech"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "veritech"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }
 veritech-server = { path = "../../lib/veritech-server" }

--- a/lib/bytes-lines-codec/Cargo.toml
+++ b/lib/bytes-lines-codec/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "bytes-lines-codec"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 bytes = "1.1.0"
@@ -10,7 +11,7 @@ tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.29"
 
 [dev-dependencies]
-futures = "0.3.17"
-serde = { version = "1.0.130", features = ["derive"] }
-tokio = { version = "1.12.0", features = ["full"] }
+futures = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
 tokio-serde = { version = "0.8.0", features = ["json"] }

--- a/lib/config-file/Cargo.toml
+++ b/lib/config-file/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "config-file"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [features]
 default = []
@@ -28,13 +28,13 @@ layered-yaml = ["layered", "yaml", "config/yaml"]
 config = { version = "0.13.1", default-features = false, optional = true }
 directories = "5.0"
 pathdiff = "0.2.1"
-serde = { version = "1.0.136", optional = true }
-serde_json = { version = "1.0.79", optional = true }
+serde = { version = "1.0.160", optional = true }
+serde_json = { version = "1.0.96", optional = true }
 serde_toml = { package = "toml", version = "0.7", optional = true }
 serde_yaml = { version = "0.9.10", optional = true }
-thiserror = "1.0.30"
-tokio = { version = "1.17.0", features = ["fs", "io-util"], optional = true }
+thiserror = { workspace = true }
+tokio = { version = "1.27.0", features = ["fs", "io-util"], optional = true }
 tracing = "0.1"
 
 [dev-dependencies]
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { workspace = true }

--- a/lib/council-server/Cargo.toml
+++ b/lib/council-server/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "council-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-derive_builder = { version = "0.12" }
-futures = "0.3.13"
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+derive_builder = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-settings = { path = "../../lib/si-settings" }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = "1.0.24"
-tokio = { version = "1.12.0", features = ["full"] }
-ulid = { version = "1", features = ["serde"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+ulid = { workspace = true }

--- a/lib/cyclone-client/Cargo.toml
+++ b/lib/cyclone-client/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "cyclone-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 cyclone-core = { path = "../../lib/cyclone-core" }
-async-trait = { version = "0.1.51" }
-futures = { version = "0.3.17" }
+async-trait = { workspace = true }
+futures = { workspace = true }
 futures-lite = { version = "1.12.0" }
 http = { version = "0.2.5" }
 hyper = { version = "0.14", features = ["client", "http1", "runtime", "server"] }
 hyperlocal = { version = "0.8.0", default-features = false, features = ["client"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-tungstenite = { version = "0.18" }
 
 [dev-dependencies]
-base64 = { version = "0.21" }
+base64 = { workspace = true }
 cyclone-server = { path = "../../lib/cyclone-server" }
-sodiumoxide = { version = "0.2.6" }
+sodiumoxide = { workspace = true }
 tempfile = { version = "3.2.0" }
 test-log = { version = "0.2.10", default-features = false, features = ["trace"] }
 tracing = { version = "0.1" }

--- a/lib/cyclone-core/Cargo.toml
+++ b/lib/cyclone-core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "cyclone-core"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-base64 = { version = "0.21" }
+base64 = { workspace = true }
 nix = { version = "0.26" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
-sodiumoxide = { version = "0.2.6" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sodiumoxide = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "cyclone-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-async-trait = { version = "0.1.51" }
-axum = { version = "0.6.12", features = ["macros", "ws"] }
-base64 = { version = "0.21" }
+async-trait = { workspace = true }
+axum = { workspace = true }
+base64 = { workspace = true }
 bytes-lines-codec = { path = "../bytes-lines-codec" }
-chrono = { version = "0.4.19" }
+chrono = { workspace = true }
 cyclone-core = { path = "../../lib/cyclone-core" }
-derive_builder = { version = "0.12" }
-futures = { version = "0.3.17" }
+derive_builder = { workspace = true }
+futures = { workspace = true }
 hyper = { version = "0.14", features = ["client", "http1", "runtime", "server"] }
 pin-project-lite = { version = "0.2.7" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-settings = { path = "../../lib/si-settings" }
-sodiumoxide = { version = "0.2.6" }
+sodiumoxide = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-serde = { version = "0.8.0", features = ["json"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tower = { version = "0.4.8" }

--- a/lib/dal-test/Cargo.toml
+++ b/lib/dal-test/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
 name = "dal-test"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-color-eyre = { version = "0.6.1" }
+color-eyre = { workspace = true }
+council-server = { path = "../../lib/council-server" }
 dal = { path = "../../lib/dal" }
+jwt-simple = "0.11.0"
 lazy_static = "1.4.0"
 names = { version = "0.14.0", default-features = false }
 pinga-server = { path = "../../lib/pinga-server" }
-serde = { version = "1.0.123", features = ["rc", "derive"] }
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-std = { path = "../../lib/si-std" }
 si-test-macros = { path = "../../lib/si-test-macros" }
-sodiumoxide = "0.2.6"
+sodiumoxide = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 tempfile = "3.2.0"
-thiserror = "1.0.24"
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 veritech-client = { path = "../../lib/veritech-client" }
 veritech-server = { path = "../../lib/veritech-server" }
-council-server = { path = "../../lib/council-server" }
-jwt-simple = "0.11.0"

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "dal"
-version = "0.1.0"
-authors = ["Adam Jacob <adam@systeminit.com>"]
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-recursion = "1.0.0"
-async-trait = "0.1.51"
-base64 = "0.21"
-chrono = { version = "0.4.19", features = ["serde"] }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
 council-server = { path = "../../lib/council-server" }
 derive_more = "0.99.16"
 diff = "0.1"
 dyn-clone = "1.0.6"
-futures = "0.3.13"
+futures = { workspace = true }
 hex = "0.4.3"
 iftree = "1.0.3"
 jwt-simple = "0.11.0"
@@ -24,26 +23,25 @@ nats-subscriber = { path = "../../lib/nats-subscriber" }
 object-tree = { path = "../../lib/object-tree" }
 once_cell = "1.15.0"
 paste = "1.0"
-petgraph = { version = "0.6.2", features = ["serde-1"] }
+petgraph = { workspace = true }
 postgres-types = { version = "0.2.2", features = ["derive"] }
 rand = "0.8.3"
 refinery = "0.8.4"
 regex = "1.5.4"
-serde = { version = "1.0.123", features = ["rc", "derive"] }
+serde = { workspace = true }
 serde-aux = "4.0.0"
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde_json = { workspace = true }
 serde_with = "2.0.0"
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-pkg = { path = "../../lib/si-pkg" }
-sodiumoxide = "0.2.6"
-strum = "0.24.0"
-strum_macros = "0.24.0"
+sodiumoxide = { workspace = true }
+strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = "1.0.24"
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-stream = "0.1.3"
-ulid = { version = "1", features = ["serde"] }
+ulid = { workspace = true }
 url = "2.2.2"
 veritech-client = { path = "../../lib/veritech-client" }
 which = "4.3.0"

--- a/lib/dal/src/action_prototype.rs
+++ b/lib/dal/src/action_prototype.rs
@@ -1,7 +1,7 @@
 use std::default::Default;
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display};
+use strum::{AsRefStr, Display};
 use thiserror::Error;
 
 use si_data_nats::NatsError;

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
-use strum_macros::{Display, EnumString};
+use strum::{Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/change_status.rs
+++ b/lib/dal/src/change_status.rs
@@ -3,7 +3,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use si_data_pg::{PgError, PgRow};
-use strum_macros::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/code_view.rs
+++ b/lib/dal/src/code_view.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display};
+use strum::{AsRefStr, Display};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
 use std::num::{ParseFloatError, ParseIntError};
-use strum_macros::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 use telemetry::prelude::debug;
 use thiserror::Error;
 

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 
 use crate::change_status::ChangeStatus;
 use crate::diagram::DiagramResult;

--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::ResourceStatus;

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -1,7 +1,7 @@
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::mpsc;

--- a/lib/dal/src/func/description.rs
+++ b/lib/dal/src/func/description.rs
@@ -11,7 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 
 use crate::{

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -2,6 +2,7 @@ use crate::{Tenancy, TransactionsError};
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
+use strum::{Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::mpsc::Receiver;
@@ -39,17 +40,7 @@ pub type FuncExecutionResult<T> = Result<T, FuncExecutionError>;
 pk!(FuncExecutionPk);
 
 // Are these the right states? -- Adam
-#[derive(
-    Deserialize,
-    Serialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    strum_macros::EnumString,
-    strum_macros::Display,
-    Copy,
-)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, EnumString, Display, Copy)]
 pub enum FuncExecutionState {
     Create,
     Dispatch,

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -1,6 +1,6 @@
 use crate::{Tenancy, TransactionsError};
 use serde::{Deserialize, Serialize};
-use strum_macros::Display as StrumDisplay;
+use strum::Display as StrumDisplay;
 use thiserror::Error;
 
 use si_data_nats::NatsError;

--- a/lib/dal/src/installed_pkg/asset.rs
+++ b/lib/dal/src/installed_pkg/asset.rs
@@ -6,7 +6,7 @@ use crate::{
     impl_standard_model, pk, standard_model, standard_model_accessor, DalContext, FuncId, SchemaId,
     SchemaVariantId, StandardModel, Tenancy, Timestamp, Visibility,
 };
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 
 const LIST_FOR_KIND_AND_HASH: &str =
     include_str!("../queries/installed_pkg/list_asset_for_kind_and_hash.sql");

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use si_data_nats::{NatsClient, NatsError};
 use si_data_pg::{PgError, PgPool, PgPoolError};
-use strum_macros::{Display, EnumString, EnumVariantNames};
+use strum::{Display, EnumString, EnumVariantNames};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::time;

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
 use std::collections::{HashMap, HashSet};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -63,10 +64,10 @@ pk!(NodeId);
     Clone,
     PartialEq,
     Eq,
-    strum_macros::Display,
-    strum_macros::EnumString,
-    strum_macros::AsRefStr,
-    strum_macros::EnumIter,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
 )]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use strum_macros::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 
 use crate::property_editor::{PropertyEditorError, PropertyEditorPropId, PropertyEditorResult};
 use crate::{

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -2,7 +2,7 @@
 //! subtrees for a [`SchemaVariant`](crate::SchemaVariant). In this domain, a "leaf" is considered
 //! to an entry of a immediate child [`map`](crate::PropKind::Map) underneath "/root".
 
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 use crate::func::argument::{FuncArgumentId, FuncArgumentKind};
 use crate::schema::variant::{SchemaVariantError, SchemaVariantResult};

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -1,7 +1,7 @@
 //! This module contains (and is oriented around) the [`RootProp`]. This object is not persisted
 //! to the database.
 
-use strum_macros::{AsRefStr, Display as EnumDisplay, EnumIter, EnumString};
+use strum::{AsRefStr, Display as EnumDisplay, EnumIter, EnumString};
 use telemetry::prelude::*;
 
 use crate::func::backend::validation::FuncBackendValidationArgs;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -9,7 +9,7 @@ use sodiumoxide::crypto::{
     box_::{PublicKey, SecretKey},
     sealedbox,
 };
-use strum_macros::{AsRefStr, Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::SensitiveContainer;

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -5,7 +5,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::{PgError, PgRow};
 use std::fmt::Debug;
-use strum_macros::AsRefStr;
+use strum::AsRefStr;
 use telemetry::prelude::*;
 use thiserror::Error;
 

--- a/lib/dal/src/workflow.rs
+++ b/lib/dal/src/workflow.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, collections::HashSet, sync::Arc};
 
 use async_recursion::async_recursion;
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::mpsc;

--- a/lib/dal/src/workflow_runner/workflow_runner_state.rs
+++ b/lib/dal/src/workflow_runner/workflow_runner_state.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 
 use crate::standard_model::option_object_from_row;

--- a/lib/deadpool-cyclone/Cargo.toml
+++ b/lib/deadpool-cyclone/Cargo.toml
@@ -1,29 +1,28 @@
 [package]
 name = "deadpool-cyclone"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { version = "0.1.51" }
+async-trait = { workspace = true }
 cyclone-client = { path = "../cyclone-client" }
 cyclone-core = { path = "../cyclone-core" }
 deadpool = { version = "0.9.0", features = ["rt_tokio_1"] }
-derive_builder = { version = "0.12" }
-futures = { version = "0.3.17" }
+derive_builder = { workspace = true }
+futures = { workspace = true }
 nix = { version = "0.26" }
 tempfile = { version = "3.2.0" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { version = "0.1" }
 
 [dev-dependencies]
-serde = "1.0.130"
-serde_json = "1.0.68"
-tokio = { version = "1.12.0", features = ["full"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio-test = "0.4.2"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/lib/nats-subscriber/Cargo.toml
+++ b/lib/nats-subscriber/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "nats-subscriber"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-futures = "0.3.27"
+futures = { workspace = true }
 futures-lite = { version = "1.12.0" }
 pin-project-lite = { version = "0.2.9" }
-serde = { version = "1.0.158", features = ["derive"] }
-serde_json = { version = "1.0.94", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = "1.0.40"
-tokio = { version = "1.26.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/object-tree/Cargo.toml
+++ b/lib/object-tree/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "object-tree"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 blake3 = "1.3.3"
-petgraph = { version = "0.6.2", features = ["serde-1"] }
-serde = { version = "1.0.152", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+petgraph = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
 tar = "0.4.38"
 tempfile = "3.3.0"
-thiserror = "1.0.38"
-tokio = { version = "1.25.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 vfs = "0.9.0"
 vfs-tar = { version = "0.4.0", features = ["mmap"] }

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "pinga-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 dal = { path = "../../lib/dal" }
-derive_builder = { version = "0.12" }
-futures = "0.3"
+derive_builder = { workspace = true }
+futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-settings = { path = "../../lib/si-settings" }
 stream-cancel = "0.8.1"
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-stream = "0.1.12"
-ulid = { version = "1.0.0", features = ["serde"] }
+ulid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "sdf-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-async-trait = "0.1.51"
-axum = { version = "0.6.12", features = ["macros", "ws"] }
+async-trait = { workspace = true }
+axum = { workspace = true }
 axum-macros = { version = "0.3", optional = true } # enable: cargo build --features axum-macro
-base64 = "0.21"
-chrono = { version = "0.4.19", features = ["serde"] }
+base64 = { workspace = true }
+chrono = { workspace = true }
 convert_case = "0.6.0"
 dal = { path = "../dal" }
-derive_builder = { version = "0.12" }
-futures = { version = "0.3.17" }
+derive_builder = { workspace = true }
+futures = { workspace = true }
 hyper = { version = "0.14", features = ["http1", "runtime", "server"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.26" }
 pathdiff = "0.2.1"
 rand = "0.8"
 reqwest = { version = "0.11.14", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = "2.0.0"
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
@@ -30,19 +30,18 @@ si-pkg = { path = "../../lib/si-pkg"}
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 si-posthog-rs = { path = "../../lib/si-posthog-rs" }
-sodiumoxide = "0.2.7"
-strum = "0.24.0"
-strum_macros = "0.24.0"
+sodiumoxide = { workspace = true }
+strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-tungstenite = "0.18"
 tower = { version = "0.4.10" }
 tower-http = { version = "0.4", features = ["cors", "trace"] }
 veritech-client = { path = "../../lib/veritech-client" }
 
 [build-dependencies]
-thiserror = { version = "1.0" }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }

--- a/lib/si-data-nats/Cargo.toml
+++ b/lib/si-data-nats/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "si-data-nats"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 crossbeam-channel = { version = "0.5.1" }
-futures = { version = "0.3.17" }
+futures = { workspace = true }
 nats-client = { package = "nats", version = "0.24.0" }
-serde = { version = "1.0.123", features = ["derive"] }
-serde_json = { version = "1.0.64" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = "1.0.24"
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 nkeys = "0.2.0"

--- a/lib/si-data-pg/Cargo.toml
+++ b/lib/si-data-pg/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 bytes = { version = "1.0.1" }
 deadpool = { version = "0.9.3" }
 deadpool-postgres = { version = "0.10.2" }
-futures = { version = "0.3.17" }
+futures = { workspace = true }
 num_cpus = { version = "1.13.0" }
 ouroboros = { version = "0.15.4" }
 refinery = { version = "0.8.4", features = ["tokio-postgres"] }
-serde = { version = "1.0.123", features = ["derive"] }
+serde = { workspace = true }
 si-std = { path = "../../lib/si-std" }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = "1.0.24"
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-postgres = { version = "0.7.0", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "si-pkg"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.23", features = ["serde"] }
-derive_builder = "0.12.0"
+chrono = { workspace = true }
+derive_builder = { workspace = true }
 object-tree = { path = "../../lib/object-tree" }
-petgraph = { version = "0.6.2", features = ["serde-1"] }
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93"
-strum = { version = "0.24.1", features = ["derive"] }
-strum_macros = "0.24.3"
-thiserror = "1.0.38"
+petgraph = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-serde_json = "1.0.93"
-tokio = { version = "1.25.0", features = ["rt", "macros", "full"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/lib/si-pkg/src/spec/func.rs
+++ b/lib/si-pkg/src/spec/func.rs
@@ -1,7 +1,7 @@
 use derive_builder::Builder;
 use object_tree::Hash;
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use url::Url;
 
 use super::SpecError;

--- a/lib/si-pkg/src/spec/leaf_function.rs
+++ b/lib/si-pkg/src/spec/leaf_function.rs
@@ -1,6 +1,6 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 
 use super::{FuncUniqueId, SpecError};
 

--- a/lib/si-pkg/src/spec/validation.rs
+++ b/lib/si-pkg/src/spec/validation.rs
@@ -1,6 +1,6 @@
 use derive_builder::UninitializedFieldError;
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumIter, EnumString};
+use strum::{Display, EnumIter, EnumString};
 
 use object_tree::Hash;
 

--- a/lib/si-posthog-rs/Cargo.toml
+++ b/lib/si-posthog-rs/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "si-posthog-rs"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-derive_builder = "0.12.0"
+derive_builder = { workspace = true }
 reqwest = { version = "0.11", features = ["json"] }
-serde = { version = "1.0.123", features = ["rc", "derive"] }
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0.24" }
-tokio = { version = "1", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/si-settings/Cargo.toml
+++ b/lib/si-settings/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "si-settings"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 config-file = { path = "../../lib/config-file", features = ["layered-toml"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 serde_with = "2.0.0"
-sodiumoxide = "0.2"
-thiserror = "1.0"
+sodiumoxide = { workspace = true }
+thiserror = { workspace = true }

--- a/lib/si-std/Cargo.toml
+++ b/lib/si-std/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "si-std"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 # NOTE: dependencies should be extremely minimal or very broadly re-used
 # amongst a potential large number of component crates
 [dependencies]
-serde = { version = "1.0.123", features = ["derive"] }
+serde = { workspace = true }

--- a/lib/si-test-macros/Cargo.toml
+++ b/lib/si-test-macros/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "si-test-macros"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [lib]
 proc-macro = true

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "telemetry-application"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-derive_builder = { version = "0.12" }
+derive_builder = { workspace = true }
 opentelemetry-otlp = { version = "0.11.0" }
 opentelemetry-semantic-conventions = { version = "0.10.0" }
+telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing-opentelemetry = { version = "0.18.0" }
 tracing-subscriber = { version = "0.3.11", features = ['env-filter', 'std'] }
-
-telemetry = { path = "../../lib/telemetry-rs" }
-
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["rt", "signal", "sync"] }

--- a/lib/telemetry-rs/Cargo.toml
+++ b/lib/telemetry-rs/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "telemetry"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-async-trait = { version = "0.1.51" }
+async-trait = { workspace = true }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio", "trace"] }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["rt", "signal", "sync"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { version = "0.1" }

--- a/lib/veritech-client/Cargo.toml
+++ b/lib/veritech-client/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "veritech-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cyclone-core = { path = "../../lib/cyclone-core" }
-futures = { version = "0.3.17" }
+futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
-serde = "1.0.123"
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 veritech-core = { path = "../../lib/veritech-core" }
 
 [dev-dependencies]
-base64 = "0.21"
+base64 = { workspace = true }
 indoc = "2.0"
 test-log = { version = "0.2.7", default-features = false, features = ["trace"] }
 tracing = { version = "0.1" }

--- a/lib/veritech-core/Cargo.toml
+++ b/lib/veritech-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "veritech-core"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "veritech-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-chrono = "0.4.24"
+chrono = { workspace = true }
 deadpool-cyclone = { path = "../../lib/deadpool-cyclone" }
-derive_builder = { version = "0.12" }
-futures = { version = "0.3.17" }
+derive_builder = { workspace = true }
+futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
-serde = "1.0.123"
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-settings = { path = "../../lib/si-settings" }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.2.0", features = ["full"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 veritech-core = { path = "../../lib/veritech-core" }


### PR DESCRIPTION
This change refactors some of the Rust crate dependency management to use a Cargo feature called [workspace dependencies]. It may make it easier to maintain the versions of critical and common crate dependencies in a more centralized location. While not every crate should be maintained in this way, the common crates are often rather obvious, such as tokio, serde, etc.

Additionally, this change also uses a similar features called [workspace packages]. This should make maintaining certain package level properties such as `rust-version`, `edition` and `published` in a more consistent way.

[workspace dependencies]: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
[workspace packages]: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

<img src="https://media3.giphy.com/media/11JTxkrmq4bGE0/giphy.gif"/>