### PR TITLE
chore(nix) Add clang to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           buildInputs = [
             automake
             bash
+            clang
             coreutils
             docker-compose
             gcc


### PR DESCRIPTION
clang++ is used to compille some of the crates we depend on, and the clang nixpkg provides it.