### PR TITLE
chore(dev_env) Use direnv to load nix devShell out of the box

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# Also load things from .env for developer-specific environment variables.
+dotenv
+
+# Use the default devShell from the flake.nix
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ target
 kubeconfig.yml
 vendor/automerge
 *.ignore
-/.envrc
+/.env
 /support/dev/k8s/**/*.env
 /support/dev/k8s/**/dockerconfig.json
 /support/dev/k8s/**/web-htpasswd


### PR DESCRIPTION
This .envrc will load any environment variables that are defined in `.env` (which is ignored by git), and can be used to set up any developer-specific API keys, or other needed environment variables. It will also automatically load the default `devShell` defined in the `flake.nix` to pull in all the dependencies that the repo requires.