### PR TITLE
chore(build): Ensure CLion uses shell commands rather than makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ buck-out
 third-party/vendor
 third-party/target
 third-party/.cargo
+
+# direnv
+.direnv

--- a/.run/Prepare.run.xml
+++ b/.run/Prepare.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Prepare" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="prepare" workingDirectory="$PROJECT_DIR$">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Prepare" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make prepare" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run Council.run.xml
+++ b/.run/Run Council.run.xml
@@ -1,8 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Council" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="run//bin/council" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Run Council" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make run//bin/council" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run Pinga.run.xml
+++ b/.run/Run Pinga.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Pinga" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="run//bin/pinga" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Run Pinga" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make run//bin/pinga" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run SDF.run.xml
+++ b/.run/Run SDF.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run SDF" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="run//bin/sdf" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Run SDF" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make run//bin/sdf" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run SI.run.xml
+++ b/.run/Run SI.run.xml
@@ -1,9 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run SI" type="CompoundRunConfigurationType">
-    <toRun name="Run Pinga" type="MAKEFILE_TARGET_RUN_CONFIGURATION" />
-    <toRun name="Run SDF" type="MAKEFILE_TARGET_RUN_CONFIGURATION" />
-    <toRun name="Run Veritech" type="MAKEFILE_TARGET_RUN_CONFIGURATION" />
-    <toRun name="Run Web" type="MAKEFILE_TARGET_RUN_CONFIGURATION" />
+    <toRun name="Run Council" type="ShConfigurationType" />
+    <toRun name="Run Pinga" type="ShConfigurationType" />
+    <toRun name="Run SDF" type="ShConfigurationType" />
+    <toRun name="Run Veritech" type="ShConfigurationType" />
+    <toRun name="Run Web" type="ShConfigurationType" />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run Veritech.run.xml
+++ b/.run/Run Veritech.run.xml
@@ -1,10 +1,16 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Veritech" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="run//bin/veritech" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs>
-        <env name="DEBUG" value="*" />
-      </envs>
-    </makefile>
+  <configuration default="false" name="Run Veritech" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make run//bin/veritech" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs>
+      <env name="DEBUG" value="*" />
+    </envs>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Run Web.run.xml
+++ b/.run/Run Web.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Web" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="run//app/web" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Run Web" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make run//app/web" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Teardown.run.xml
+++ b/.run/Teardown.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Teardown" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="down" workingDirectory="$PROJECT_DIR$" arguments="">
-      <envs />
-    </makefile>
+  <configuration default="false" name="Teardown" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="make down" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
The default setup in clion is to use /usr/bin/make. When using nix,
this will ignore the make in the nix flake and will instead use the
system version of make

This commit changes the run configurations to use a raw shell command
similar to what non-clion users will use e.g

```
make run//bin/council
```
