### PR TITLE
feat(dal,cyclone-core,cyclone-server,lang-js): Rename resource value prop to payload

### DIFF
--- a/bin/lang-js/src/command_run.ts
+++ b/bin/lang-js/src/command_run.ts
@@ -23,7 +23,7 @@ export type CommandRunResult =
   | CommandRunResultFailure;
 
 export interface CommandRunResultSuccess extends ResultSuccess {
-  value: unknown;
+  payload: unknown;
   health: "ok" | "warning" | "error";
   message?: string;
 }
@@ -127,7 +127,7 @@ async function execute(
       status: "success",
       executionId,
       error: commandRunResult.error as string | undefined,
-      value: commandRunResult.value,
+      payload: commandRunResult.payload,
       health: commandRunResult.status as "ok" | "warning" | "error",
       message: commandRunResult.message as string | undefined,
     };
@@ -141,13 +141,13 @@ function wrapCode(code: string, handle: string): string {
   const wrapped = `module.exports = function(arg, callback) {
     ${code}
     arg = Array.isArray(arg) ? arg : [arg];
-    const resource = arg[0]?.properties?.resource?.value ?? null;
+    const resource = arg[0]?.properties?.resource?.payload ?? null;
     const returnValue = ${handle}(...arg, callback);
     if (returnValue instanceof Promise) {
       returnValue.then((data) => callback(data))
           .catch((err) => callback({
             status: "error",
-            value: resource,
+            payload: resource,
       	    message: err.message,
 	  }));
     } else {

--- a/lib/cyclone-core/src/command_run.rs
+++ b/lib/cyclone-core/src/command_run.rs
@@ -21,7 +21,7 @@ pub enum ResourceStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CommandRunResultSuccess {
     pub execution_id: String,
-    pub value: Option<serde_json::Value>,
+    pub payload: Option<serde_json::Value>,
     pub status: ResourceStatus,
     pub message: Option<String>,
     // Collects the error if the function throws

--- a/lib/cyclone-server/src/result/command_run.rs
+++ b/lib/cyclone-server/src/result/command_run.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct LangServerCommandRunResultSuccess {
     pub execution_id: String,
     #[serde(default)]
-    pub value: Option<serde_json::Value>,
+    pub payload: Option<serde_json::Value>,
     pub health: ResourceStatus,
     #[serde(default)]
     pub message: Option<String>,
@@ -24,7 +24,7 @@ impl From<LangServerCommandRunResultSuccess> for CommandRunResultSuccess {
             error: value.error,
             status: value.health,
             message: value.message,
-            value: value.value,
+            payload: value.payload,
         }
     }
 }

--- a/lib/dal/src/builtins/func/awsAmiRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsAmiRefreshCommand.ts
@@ -23,7 +23,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: component.properties.resource?.value,
+      payload: component.properties.resource?.payload,
       message: "AMI ${component.properties.domain.ImageId} is invalid (InvalidAMIID.Malformed)",
     }
   }
@@ -33,7 +33,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: component.properties.resource?.value,
+      payload: component.properties.resource?.payload,
       message: `AWS CLI 2 "aws ec2 describe-images" returned non zero exit code (${child.exitCode})`,
     }
   }
@@ -44,10 +44,10 @@ async function refresh(component: Input): Promise<Output> {
     console.log(child.stdout);
     return {
       status: "error",
-      value: component.properties.resource?.value,
+      payload: component.properties.resource?.payload,
       message: `AMI ${component.properties.domain.ImageId} not found in region ${component.properties.domain.region}`,
     }
   }
 
-  return { value: images[0], status: "ok" };
+  return { payload: images[0], status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsEc2CreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsEc2CreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     }
   }
 
@@ -25,5 +25,5 @@ async function create(component: Input): Promise<Output> {
     }
   }
 
-  return { value: JSON.parse(child.stdout), status: "ok" };
+  return { payload: JSON.parse(child.stdout), status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsEc2DeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsEc2DeleteCommand.ts
@@ -1,11 +1,11 @@
 async function deleteResource(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
 
   const instances = Array.isArray(resource) ? resource : [resource];
   const instanceIds = instances.flatMap((i) => i.Instances).map((i) => i.InstanceId).filter((id) => !!id);
   if (!instanceIds || instanceIds.length === 0) return {
     status: "error",
-    value: resource,
+    payload: resource,
     message: "No EC2 instance id found"
   };
 
@@ -23,10 +23,10 @@ async function deleteResource(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Ec2 Instance, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
     };
   }
 
-  return { value: null, status: "ok" };
+  return { payload: null, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsEc2RefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsEc2RefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -11,7 +11,7 @@ async function refresh(component: Input): Promise<Output> {
   const instanceIds = instances.flatMap((i) => i.Instances).map((i) => i.InstanceId).filter((id) => !!id);
   if (!instanceIds || instanceIds.length === 0) return {
     status: "error",
-    value: resource,
+    payload: resource,
     message: "No EC2 instance id found"
   };
 
@@ -38,7 +38,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "EC2 Instance Id is invalid (InvalidInstanceID.Malformed)",
     }
   }
@@ -48,7 +48,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `AWS CLI 2 "aws ec2 describe-instances" returned non zero exit code (${child.exitCode})`,
     }
   }
@@ -80,5 +80,5 @@ async function refresh(component: Input): Promise<Output> {
     }
   }
 
-  return { value: object.Reservations, status, message };
+  return { payload: object.Reservations, status, message };
 }

--- a/lib/dal/src/builtins/func/awsEgressCreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsEgressCreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     }
   }
 
@@ -25,5 +25,5 @@ async function create(component: Input): Promise<Output> {
     }
   }
 
-  return { value: JSON.parse(child.stdout).SecurityGroupRules, status: "ok" };
+  return { payload: JSON.parse(child.stdout).SecurityGroupRules, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsEgressDeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsEgressDeleteCommand.ts
@@ -1,11 +1,11 @@
 async function deleteResource(component: Input): Promise<Output> {
-    const resource = component.properties.resource?.value[0];
+    const resource = component.properties.resource?.payload[0];
 
     if (resource.SecurityGroupRuleId === undefined) {
         console.error("unable to find a valid SecurityGroupRuleID");
         return {
             status: "error",
-            value: resource,
+            payload: resource,
             message: `Unable to delete Egress Rule, unable to find a valid SecurityGroupRuleId`,
         }
     }
@@ -14,7 +14,7 @@ async function deleteResource(component: Input): Promise<Output> {
         console.error("unable to find a valid GroupID");
         return {
             status: "error",
-            value: resource,
+            payload: resource,
             message: `Unable to delete Egress Rule, unable to find a valid GroupID`,
         }
     }
@@ -34,10 +34,10 @@ async function deleteResource(component: Input): Promise<Output> {
         console.error(child.stderr);
         return {
             status: "error",
-            value: resource,
+            payload: resource,
             message: `Unable to delete Egress Rule, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
         }
     }
 
-    return {value: null, status: "ok"};
+    return {payload: null, status: "ok"};
 }

--- a/lib/dal/src/builtins/func/awsEgressRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsEgressRefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -12,7 +12,7 @@ async function refresh(component: Input): Promise<Output> {
     if (groupId !== undefined && groupId !== rule.GroupId) {
       return {
         status: "error",
-        value: resource,
+        payload: resource,
         message: "Egress references multiple group ids",
       }
     }
@@ -42,7 +42,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Security Group Id is invalid (InvalidGroupId.Malformed)",
     }
   }
@@ -52,7 +52,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `AWS CLI 2 "aws ec2 describe-security-groups" returned non zero exit code (${child.exitCode})`,
     }
   }
@@ -66,7 +66,7 @@ async function refresh(component: Input): Promise<Output> {
 
         for (const range of IpPermission.IpRanges) {
           if (range.CidrIp === rule.CidrIpv4) {
-            return { value: resource, status: "ok" };
+            return { payload: resource, status: "ok" };
           }
         }
       }

--- a/lib/dal/src/builtins/func/awsEipCreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsEipCreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     };
   }
 
@@ -27,5 +27,5 @@ async function create(component: Input): Promise<Output> {
     };
   }
 
-  return { value: JSON.parse(child.stdout), status: "ok" };
+  return { payload: JSON.parse(child.stdout), status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsEipDeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsEipDeleteCommand.ts
@@ -1,5 +1,5 @@
 async function deleteResource(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   // Now, delete the EIP.
   const child = await siExec.waitUntilEnd("aws", [
     "ec2",
@@ -14,10 +14,11 @@ async function deleteResource(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Elastic IP, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
     };
   }
 
-  return { value: null, status: "ok" };
+  return { payload: null, status: "ok" };
 }
+``

--- a/lib/dal/src/builtins/func/awsEipRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsEipRefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -20,7 +20,7 @@ async function refresh(component: Input): Promise<Output> {
     console.log(`EIP Allocation ID: ${resource.AllocationId}`);
     console.error(child.stderr);
     return {
-      value: resource,
+      payload: resource,
       status: "error",
       message: `AWS CLI 2 "aws ec2 describe-addresses" returned non zero exit code (${child.exitCode})`,
     };
@@ -28,5 +28,5 @@ async function refresh(component: Input): Promise<Output> {
 
   const object = JSON.parse(child.stdout);
 
-  return { value: object.Addresses[0], status: "ok" };
+  return { payload: object.Addresses[0], status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsIngressCreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsIngressCreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     }
   }
 
@@ -25,5 +25,5 @@ async function create(component: Input): Promise<Output> {
     }
   }
 
-  return { value: JSON.parse(child.stdout).SecurityGroupRules, status: "ok" };
+  return { payload: JSON.parse(child.stdout).SecurityGroupRules, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsIngressDeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsIngressDeleteCommand.ts
@@ -1,11 +1,11 @@
 async function deleteResource(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value[0];
+  const resource = component.properties.resource?.payload[0];
 
   if (resource.SecurityGroupRuleId === undefined) {
     console.error("unable to find a valid SecurityGroupRuleID");
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Ingress Rule, unable to find a valid SecurityGroupRuleId`,
     }
   }
@@ -14,7 +14,7 @@ async function deleteResource(component: Input): Promise<Output> {
     console.error("unable to find a valid GroupID");
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Ingress Rule, unable to find a valid GroupID`,
     }
   }
@@ -35,10 +35,10 @@ async function deleteResource(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Ingress Rule, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
     }
   }
 
-  return { value: null, status: "ok" };
+  return { payload: null, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsIngressRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsIngressRefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -13,7 +13,7 @@ async function refresh(component: Input): Promise<Output> {
       console.log(resource);
       return {
         status: "error",
-        value: resource,
+        payload: resource,
         message: "Ingress references multiple group ids",
       }
     }
@@ -43,7 +43,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Security Group Id is invalid (InvalidGroupId.Malformed)",
     }
   }
@@ -53,7 +53,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `AWS CLI 2 "aws ec2 describe-security-groups" returned non zero exit code (${child.exitCode})`,
     }
   }
@@ -67,7 +67,7 @@ async function refresh(component: Input): Promise<Output> {
 
         for (const range of IpPermission.IpRanges) {
           if (range.CidrIp === rule.CidrIpv4) {
-            return { value: resource, status: "ok" };
+            return { payload: resource, status: "ok" };
           }
         }
       }

--- a/lib/dal/src/builtins/func/awsKeyPairCreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsKeyPairCreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     }
   }
 
@@ -25,5 +25,5 @@ async function create(component: Input): Promise<Output> {
     }
   }
 
-  return { value: JSON.parse(child.stdout), status: "ok" };
+  return { payload: JSON.parse(child.stdout), status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsKeyPairDeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsKeyPairDeleteCommand.ts
@@ -1,5 +1,5 @@
 async function deleteResource(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   // Now, delete the Ec2 Instance.
   const child = await siExec.waitUntilEnd("aws", [
     "ec2",
@@ -14,10 +14,10 @@ async function deleteResource(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `Unable to delete Key Pair, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
     };
   }
 
-  return { value: null, status: "ok" };
+  return { payload: null, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsKeyPairRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsKeyPairRefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -30,7 +30,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Key Pair Id is invalid (InvalidParameterValue)",
     }
   }
@@ -39,7 +39,7 @@ async function refresh(component: Input): Promise<Output> {
     console.log(`Key Pair Id: ${resource.KeyPairId}`);
     console.error(child.stderr);
     return {
-      value: resource,
+      payload: resource,
       status: "error",
       message: `AWS CLI 2 "aws ec2 describe-key-pairs" returned non zero exit code (${child.exitCode})`,
     }
@@ -52,7 +52,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stdout);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Key Pair not found in payload returned by AWS, but it should be there",
     }
   }
@@ -61,5 +61,5 @@ async function refresh(component: Input): Promise<Output> {
   // Key sync does not include secret key, so copy it from existing resource
   keyPair.KeyMaterial = resource.KeyMaterial;
 
-  return { value: keyPair, status: "ok" };
+  return { payload: keyPair, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsRegionRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsRegionRefreshCommand.ts
@@ -1,3 +1,3 @@
 async function refresh(component: Input): Promise<Output> {
-  return { value: { region: component.properties.domain.region }, status: "ok" };
+  return { payload: { region: component.properties.domain.region }, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.ts
+++ b/lib/dal/src/builtins/func/awsSecurityGroupCreateCommand.ts
@@ -1,9 +1,9 @@
 async function create(component: Input): Promise<Output> {
-  if (component.properties.resource?.value) {
+  if (component.properties.resource?.payload) {
     return {
       status: "error",
       message: "Resource already exists",
-      value: component.properties.resource.value,
+      payload: component.properties.resource.payload,
     }
   }
 
@@ -25,5 +25,5 @@ async function create(component: Input): Promise<Output> {
     }
   }
 
-  return { value: JSON.parse(child.stdout), status: "ok" };
+  return { payload: JSON.parse(child.stdout), status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsSecurityGroupDeleteCommand.ts
+++ b/lib/dal/src/builtins/func/awsSecurityGroupDeleteCommand.ts
@@ -1,5 +1,5 @@
 async function deleteResource(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   // Now, delete the security group.
   const child = await siExec.waitUntilEnd("aws", [
     "ec2",
@@ -15,17 +15,17 @@ async function deleteResource(component: Input): Promise<Output> {
     if (child.stderr.includes("DependencyViolation")) {
       return {
         status: "error",
-        value: resource,
+        payload: resource,
         message: `Unable to delete Security Group while it is in use: ${child.exitCode}`,
       }
     } else {
       return {
         status: "error",
-        value: resource,
+        payload: resource,
         message: `Unable to delete Security Group, AWS CLI 2 exited with non zero code: ${child.exitCode}`,
       }
     }
   }
 
-  return { value: null, status: "ok" };
+  return { payload: null, status: "ok" };
 }

--- a/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.ts
+++ b/lib/dal/src/builtins/func/awsSecurityGroupIdFromResource.ts
@@ -1,3 +1,3 @@
 async function parse(properties: Input): Promise<Output> {
-  return properties.resource?.value?.GroupId;
+  return properties.resource?.payload?.GroupId;
 }

--- a/lib/dal/src/builtins/func/awsSecurityGroupRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/awsSecurityGroupRefreshCommand.ts
@@ -1,5 +1,5 @@
 async function refresh(component: Input): Promise<Output> {
-  const resource = component.properties.resource?.value;
+  const resource = component.properties.resource?.payload;
   if (!resource) {
     return {
       status: component.properties.resource?.status ?? "ok",
@@ -30,7 +30,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Security Group Id is invalid (InvalidGroupId.Malformed)",
     }
   }
@@ -40,7 +40,7 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stderr);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: `AWS CLI 2 "aws ec2 describe-security-groups" returned non zero exit code (${child.exitCode})`,
     }
   }
@@ -52,10 +52,10 @@ async function refresh(component: Input): Promise<Output> {
     console.error(child.stdout);
     return {
       status: "error",
-      value: resource,
+      payload: resource,
       message: "Security Group not found in payload returned by AWS, but it should be there",
     }
   }
 
-  return { value: object.SecurityGroups[0], status: "ok" };
+  return { payload: object.SecurityGroups[0], status: "ok" };
 }

--- a/lib/dal/src/builtins/func/confirmationResourceExists.ts
+++ b/lib/dal/src/builtins/func/confirmationResourceExists.ts
@@ -1,5 +1,5 @@
 async function exists(input: Input): Promise<Output> {
-  if (!input.resource?.value) {
+  if (!input.resource?.payload) {
     return {
       success: false,
       recommendedActions: ["create"]

--- a/lib/dal/src/builtins/func/confirmationResourceNeedsDeletion.ts
+++ b/lib/dal/src/builtins/func/confirmationResourceNeedsDeletion.ts
@@ -1,5 +1,5 @@
 async function exists(input: Input): Promise<Output> {
-  if (input.resource?.value && input.deleted_at) {
+  if (input.resource?.payload && input.deleted_at) {
     return {
       success: false,
       recommendedActions: ["delete"]

--- a/lib/dal/src/builtins/func/dockerImageRefreshCommand.ts
+++ b/lib/dal/src/builtins/func/dockerImageRefreshCommand.ts
@@ -5,9 +5,9 @@ async function refresh(component: Input): Promise<Output> {
     return {
       status: "error",
       message: "Unable to refresh docker image",
-      value: component.properties.resource?.value,
+      payload: component.properties.resource?.payload,
     }
   }
 
-  return { value: JSON.parse(child.stdout), status: "ok" };
+  return { payload: JSON.parse(child.stdout), status: "ok" };
 }

--- a/lib/dal/src/builtins/func/leroLeroStanza1Command.ts
+++ b/lib/dal/src/builtins/func/leroLeroStanza1Command.ts
@@ -6,5 +6,5 @@ async function firstStanza() {
   console.log("I really like Fulana, but Sicrana is the one who wants me");
   console.log("Because in love, whoever loses almost always wins");
   console.log("Such a strange thing, avoid it if you can\n");
-  return { value: "first stanza return value", status: "ok" };
+  return { payload: "first stanza return value", status: "ok" };
 }

--- a/lib/dal/src/builtins/func/leroLeroStanza7Command.ts
+++ b/lib/dal/src/builtins/func/leroLeroStanza7Command.ts
@@ -5,5 +5,5 @@ async function seventhStanza() {
   console.log("A good goatling is the one that screams the most wherever the thrush sings");
   console.log("I don't believe in my fate's bad luck");
   console.log("Preying Tico-Tico, nobody takes my cornmeal\n");
-  return { value: "seventh stanza return value", status: "ok" };
+  return { payload: "seventh stanza return value", status: "ok" };
 }

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -51,7 +51,7 @@ impl MigrationDriver {
         .await?;
         let confirmation_func_id = *confirmation_func.id();
         let code = "async function exists(input) {
-            if (!input.resource?.value) {
+            if (!input.resource?.payload) {
                 return {
                     success: false,
                     recommendedActions: [\"create\"]
@@ -98,7 +98,7 @@ impl MigrationDriver {
         )
         .await?;
         let code = "async function create() {
-            return { value: \"poop\", status: \"ok\" };
+            return { payload: \"poop\", status: \"ok\" };
         }";
         command_func.set_code_plaintext(ctx, Some(code)).await?;
         command_func.set_handler(ctx, Some("create")).await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1048,7 +1048,7 @@ impl Component {
             _ => None,
         };
 
-        let has_resource = self.resource(ctx).await?.value.is_some();
+        let has_resource = self.resource(ctx).await?.payload.is_some();
         let rows = ctx
             .txns()
             .await?

--- a/lib/dal/src/component/resource.rs
+++ b/lib/dal/src/component/resource.rs
@@ -188,7 +188,7 @@ pub struct ResourceView {
 impl ResourceView {
     pub fn new(result: CommandRunResult) -> Self {
         Self {
-            data: result.value,
+            data: result.payload,
             message: result.message,
             status: result.status,
             logs: result.logs,

--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -358,7 +358,7 @@ impl Fix {
         } else if batch_timed_out {
             Some(CommandRunResult {
                 status: ResourceStatus::Error,
-                value: None,
+                payload: None,
                 message: Some("Execution timed-out".to_owned()),
                 // TODO: add proper logs here
                 logs: vec![],

--- a/lib/dal/src/func/backend/js_command.rs
+++ b/lib/dal/src/func/backend/js_command.rs
@@ -78,7 +78,7 @@ pub struct CommandRunResult {
     pub status: ResourceStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub value: Option<serde_json::Value>,
+    pub payload: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub message: Option<String>,
@@ -93,7 +93,7 @@ impl ExtractPayload for CommandRunResultSuccess {
 
     fn extract(self) -> FuncBackendResult<Self::Payload> {
         Ok(CommandRunResult {
-            value: self.value,
+            payload: self.payload,
             status: self.status,
             message: self.message.or(self.error),
             logs: Default::default(),

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -432,16 +432,16 @@ impl SchemaVariant {
         .await?;
         resource_logs_log_prop.set_hidden(ctx, true).await?;
 
-        let mut resource_value_prop = Prop::new(
+        let mut resource_payload_prop = Prop::new(
             ctx,
-            "value",
+            "payload",
             PropKind::String,
             None,
             schema_variant_id,
             Some(resource_prop_id),
         )
         .await?;
-        resource_value_prop.set_hidden(ctx, true).await?;
+        resource_payload_prop.set_hidden(ctx, true).await?;
 
         let mut resource_last_synced_prop = Prop::new(
             ctx,

--- a/lib/dal/src/workflow_runner.rs
+++ b/lib/dal/src/workflow_runner.rs
@@ -345,7 +345,7 @@ impl WorkflowRunner {
                     .await?
                     .ok_or(WorkflowRunnerError::ComponentNotFound(component_id))?;
 
-                if component.needs_destroy() && result.value.is_none() {
+                if component.needs_destroy() && result.payload.is_none() {
                     component
                         .set_needs_destroy(deleted_ctx, false)
                         .await

--- a/lib/dal/tests/integration_test/internal/component.rs
+++ b/lib/dal/tests/integration_test/internal/component.rs
@@ -418,7 +418,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             ctx,
             CommandRunResult {
                 status: ResourceStatus::Ok,
-                value: Some(serde_json::json!["quantum"]),
+                payload: Some(serde_json::json!["quantum"]),
                 logs: Default::default(),
                 message: Default::default(),
                 last_synced: Default::default(),
@@ -449,7 +449,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             "domain": {},
             "resource": {
                 "logs": [],
-                "value": "quantum",
+                "payload": "quantum",
                 "status": "ok",
             }
         }], // expected
@@ -465,7 +465,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             "domain": {
                 "u12a": {
                     "logs": [],
-                    "value": "quantum",
+                    "payload": "quantum",
                     "status": "ok",
                 }
             }
@@ -497,7 +497,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             "domain": {},
             "resource": {
                 "logs": [],
-                "value": "quantum",
+                "payload": "quantum",
                 "status": "ok",
             }
         }], // expected
@@ -513,7 +513,7 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             "domain": {
                 "u12a": {
                     "logs": [],
-                    "value": "quantum",
+                    "payload": "quantum",
                     "status": "ok",
                 }
             }

--- a/lib/dal/tests/integration_test/internal/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/internal/component/confirmation.rs
@@ -84,7 +84,7 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
             ctx,
             CommandRunResult {
                 status: ResourceStatus::Ok,
-                value: Some(serde_json::json!["poop"]),
+                payload: Some(serde_json::json!["poop"]),
                 message: None,
                 logs: vec![],
                 last_synced: Default::default(),
@@ -113,7 +113,7 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
             "domain": {},
             "resource": {
                 "logs": [],
-                "value": "poop",
+                "payload": "poop",
                 "status": "ok"
             },
             "confirmation": {
@@ -132,7 +132,7 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
             ctx,
             CommandRunResult {
                 status: ResourceStatus::Ok,
-                value: None,
+                payload: None,
                 message: None,
                 logs: vec![],
                 last_synced: Default::default(),
@@ -318,7 +318,6 @@ async fn list_confirmations(mut octx: DalContext) {
             "domain": {},
             "resource": {
                 "logs": [],
-                "value": "poop",
                 "status": "ok"
             },
             "confirmation": {
@@ -342,7 +341,7 @@ async fn list_confirmations(mut octx: DalContext) {
             ctx,
             CommandRunResult {
                 status: ResourceStatus::Ok,
-                value: None,
+                payload: None,
                 message: None,
                 logs: vec![],
                 last_synced: Default::default(),

--- a/lib/dal/tests/integration_test/internal/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/internal/workflow_runner.rs
@@ -179,7 +179,7 @@ async fn run(ctx: &mut DalContext) {
         .resource(ctx)
         .await
         .expect("unable to fetch resource")
-        .value
+        .payload
         .is_none());
 
     // Apply the change set.
@@ -228,6 +228,6 @@ async fn run(ctx: &mut DalContext) {
         .resource(ctx)
         .await
         .expect("unable to fetch resource")
-        .value
+        .payload
         .is_some());
 }


### PR DESCRIPTION
The premise of this change is that the payload will now be the raw
data that comes back from the raw lang-js function execution

This allows us to be able to transform the raw payload into a resource
prop tree

Co-authored-by: Victor Bustamante <victor@systeminit.com>
