### PR TITLE
feat(dal,si-pkg): support prop default values for scalars

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -138,6 +138,8 @@ pub enum PkgError {
     MissingInternalProviderForProp(PropId),
     #[error("Cannot find InternalProvider for Socket named {0}")]
     MissingInternalProviderForSocketName(String),
+    #[error("Cannot find installed prop {0}")]
+    MissingProp(PropId),
 }
 
 impl PkgError {

--- a/lib/object-tree/src/graph.rs
+++ b/lib/object-tree/src/graph.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use strum::{AsRefStr, EnumString};
 use thiserror::Error;
 
-use crate::{Hash, HashParseError};
+use crate::Hash;
 
 const KEY_VERSION_STR: &str = "version";
 const KEY_NODE_KIND_STR: &str = "node_kind";
@@ -65,9 +65,6 @@ pub enum GraphError {
     /// When a hash value failed to verify an expected value
     #[error("failed to verify hash; expected={0}, computed={1}")]
     Verify(Hash, Hash),
-    /// When a hash is not a valid blake3 hash
-    #[error("transparent")]
-    HashParse(#[from] HashParseError),
 }
 
 impl GraphError {

--- a/lib/si-pkg/src/node/func.rs
+++ b/lib/si-pkg/src/node/func.rs
@@ -1,12 +1,17 @@
-use super::PkgNode;
-use crate::spec::{FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType};
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+use url::Url;
+
 use object_tree::{
-    read_key_value_line, write_key_value_line, GraphError, Hash, NameStr, NodeChild, NodeKind,
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
     NodeWithChildren, ReadBytes, WriteBytes,
 };
-use std::io::{BufRead, Write};
-use std::str::FromStr;
-use url::Url;
+
+use crate::spec::{FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncUniqueId};
+
+use super::PkgNode;
 
 const KEY_NAME_STR: &str = "name";
 const KEY_DISPLAY_NAME_STR: &str = "display_name";
@@ -30,7 +35,7 @@ pub struct FuncNode {
     pub response_type: FuncSpecBackendResponseType,
     pub hidden: bool,
     pub link: Option<Url>,
-    pub unique_id: Hash,
+    pub unique_id: FuncUniqueId,
 }
 
 impl NameStr for FuncNode {
@@ -103,7 +108,7 @@ impl ReadBytes for FuncNode {
             Some(Url::parse(&link_str).map_err(GraphError::parse)?)
         };
         let unique_id_str = read_key_value_line(reader, KEY_UNIQUE_ID_STR)?;
-        let unique_id: Hash = Hash::from_str(&unique_id_str)?;
+        let unique_id = FuncUniqueId::from_str(&unique_id_str).map_err(GraphError::parse)?;
 
         Ok(Self {
             name,

--- a/lib/si-pkg/src/node/validation.rs
+++ b/lib/si-pkg/src/node/validation.rs
@@ -4,11 +4,11 @@ use std::{
 };
 
 use object_tree::{
-    read_key_value_line, write_key_value_line, GraphError, Hash, NodeChild, NodeKind,
-    NodeWithChildren, ReadBytes, WriteBytes,
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
 };
 
-use crate::{ValidationSpec, ValidationSpecKind};
+use crate::{FuncUniqueId, ValidationSpec, ValidationSpecKind};
 
 use super::PkgNode;
 
@@ -28,7 +28,7 @@ pub struct ValidationNode {
     pub expected_string: Option<String>,
     pub expected_string_array: Option<Vec<String>>,
     pub display_expected: Option<bool>,
-    pub func_unique_id: Option<Hash>,
+    pub func_unique_id: Option<FuncUniqueId>,
 }
 
 impl Default for ValidationNode {
@@ -149,7 +149,8 @@ impl ReadBytes for ValidationNode {
             }
             ValidationSpecKind::CustomValidation => {
                 let func_unique_id_str = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
-                func_unique_id = Some(Hash::from_str(&func_unique_id_str)?);
+                func_unique_id =
+                    Some(FuncUniqueId::from_str(&func_unique_id_str).map_err(GraphError::parse)?);
             }
             ValidationSpecKind::StringIsValidIpAddr
             | ValidationSpecKind::StringIsHexColor

--- a/lib/si-pkg/src/pkg/prop.rs
+++ b/lib/si-pkg/src/pkg/prop.rs
@@ -12,36 +12,42 @@ use crate::{
 pub enum SiPkgProp<'a> {
     String {
         name: String,
+        default_value: Option<String>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
     },
     Number {
         name: String,
+        default_value: Option<i64>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
     },
     Boolean {
         name: String,
+        default_value: Option<bool>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
     },
     Map {
         name: String,
+        default_value: Option<serde_json::Value>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
     },
     Array {
         name: String,
+        default_value: Option<serde_json::Value>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
     },
     Object {
         name: String,
+        default_value: Option<serde_json::Value>,
         func_unique_id: Option<FuncUniqueId>,
         hash: Hash,
         source: Source<'a>,
@@ -111,54 +117,66 @@ impl<'a> SiPkgProp<'a> {
         Ok(match prop_node {
             PropNode::String {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::String {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,
             },
             PropNode::Integer {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::Number {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,
             },
             PropNode::Boolean {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::Boolean {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,
             },
             PropNode::Map {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::Map {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,
             },
             PropNode::Array {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::Array {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,
             },
             PropNode::Object {
                 name,
+                default_value,
                 func_unique_id,
             } => Self::Object {
                 name,
+                default_value,
                 func_unique_id,
                 hash,
                 source,

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -38,6 +38,7 @@ impl SchemaVariantSpecBuilder {
     fn default_domain() -> PropSpec {
         PropSpec::Object {
             validations: None,
+            default_value: None,
             name: "domain".to_string(),
             entries: vec![],
             func_unique_id: None,


### PR DESCRIPTION
Grabs values set at the schema variant prop context as the default values when exporting and sets them as default value when importing. Currently only handles default scalar values (no maps, arrays or entire objects). 