### PR TITLE
 Replace hidden schemas (docker hub credential, k8s namespace, k8s deployment) in internal tests (ENG-1363)

### DIFF
--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -38,6 +38,7 @@ mod docker_image;
 mod kubernetes_deployment;
 mod kubernetes_namespace;
 mod systeminit_generic_frame;
+mod test_exclusive_fallout;
 mod test_exclusive_starfield;
 
 const NODE_COLOR_FRAMES: &str = "#FFFFFF";
@@ -234,10 +235,7 @@ pub async fn migrate_for_tests(
         ctx.blocking_commit().await?;
     }
 
-    // Perform migrations on hidden schemas, only if the user asks for them.
-    // TODO(nick): remove the "migrate_all" and replace tests using these schemas with test
-    // exclusive schemas (or if the tests test the builtins themselves and not the system,
-    // ensure there is an equivalent test for the system).
+    // Perform migrations on "hidden" schemas.
     if migrate_all || specific_builtin_schemas.contains("docker hub credential") {
         driver
             .migrate_docker_hub_credential(ctx, "Docker", NODE_COLOR_DOCKER)
@@ -260,6 +258,9 @@ pub async fn migrate_for_tests(
     // Perform migrations on test-exclusive schemas.
     if migrate_all || migrate_test_exclusive || specific_builtin_schemas.contains("starfield") {
         driver.migrate_test_exclusive_starfield(ctx).await?;
+    }
+    if migrate_all || migrate_test_exclusive || specific_builtin_schemas.contains("fallout") {
+        driver.migrate_test_exclusive_fallout(ctx).await?;
     }
 
     Ok(())

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.json
@@ -1,0 +1,13 @@
+{
+  "props": [
+    {
+      "name": "special",
+      "kind": "string"
+    }
+  ],
+  "outputSockets": [
+    {
+      "name": "bethesda"
+    }
+  ]
+}

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.metadata.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "fallout",
+  "menuName": "fallout",
+  "category": "test exclusive",
+  "color": "#ffffff",
+  "componentKind": "standard",
+  "link": null,
+  "description": null
+}

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
@@ -1,6 +1,10 @@
 {
   "props": [
     {
+      "name": "name",
+      "kind": "string"
+    },
+    {
       "name": "freestar",
       "kind": "string"
     },
@@ -27,12 +31,7 @@
   ],
   "inputSockets": [
     {
-      "name": "input"
-    }
-  ],
-  "outputSockets": [
-    {
-      "name": "output"
+      "name": "bethesda"
     }
   ]
 }

--- a/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
@@ -1,0 +1,156 @@
+use crate::func::argument::FuncArgumentKind;
+use crate::schema::variant::definition::{
+    SchemaVariantDefinition, SchemaVariantDefinitionJson, SchemaVariantDefinitionMetadataJson,
+};
+use crate::schema::variant::leaves::LeafInputLocation;
+use crate::schema::variant::leaves::LeafKind;
+use crate::{
+    builtins::schema::MigrationDriver, schema::variant::leaves::LeafInput, ActionKind,
+    ActionPrototype, ActionPrototypeContext, Func, FuncArgument, FuncBackendKind,
+    FuncBackendResponseType, WorkflowPrototype, WorkflowPrototypeContext,
+};
+use crate::{BuiltinsResult, DalContext, SchemaVariant, StandardModel};
+
+const DEFINITION: &str = include_str!("definitions/test_exclusive_fallout.json");
+const DEFINITION_METADATA: &str = include_str!("definitions/test_exclusive_fallout.metadata.json");
+
+impl MigrationDriver {
+    pub async fn migrate_test_exclusive_fallout(&self, ctx: &DalContext) -> BuiltinsResult<()> {
+        let definition: SchemaVariantDefinitionJson = serde_json::from_str(DEFINITION)?;
+        let metadata: SchemaVariantDefinitionMetadataJson =
+            serde_json::from_str(DEFINITION_METADATA)?;
+
+        SchemaVariantDefinition::new_from_structs(ctx, metadata.clone(), definition.clone())
+            .await?;
+
+        let (
+            mut schema,
+            mut schema_variant,
+            _root_prop,
+            _maybe_prop_cache,
+            _explicit_internal_providers,
+            _external_providers,
+        ) = match self
+            .create_schema_and_variant(ctx, metadata, Some(definition))
+            .await?
+        {
+            Some(tuple) => tuple,
+            None => return Ok(()),
+        };
+        schema.set_ui_hidden(ctx, true).await?;
+        let schema_variant_id = *schema_variant.id();
+
+        // Setup the confirmation function.
+        let mut confirmation_func = Func::new(
+            ctx,
+            "test:confirmationFallout",
+            FuncBackendKind::JsAttribute,
+            FuncBackendResponseType::Confirmation,
+        )
+        .await?;
+        let confirmation_func_id = *confirmation_func.id();
+        let code = "async function exists(input) {
+            if (!input.resource?.payload) {
+                return {
+                    success: false,
+                    recommendedActions: [\"create\"]
+                }
+            }
+            return {
+                success: true,
+                recommendedActions: [],
+            }
+        }";
+        confirmation_func
+            .set_code_plaintext(ctx, Some(code))
+            .await?;
+        confirmation_func.set_handler(ctx, Some("exists")).await?;
+        let confirmation_func_argument = FuncArgument::new(
+            ctx,
+            "resource",
+            FuncArgumentKind::String,
+            None,
+            confirmation_func_id,
+        )
+        .await?;
+
+        // Add the leaf for the confirmation.
+        SchemaVariant::add_leaf(
+            ctx,
+            confirmation_func_id,
+            schema_variant_id,
+            None,
+            LeafKind::Confirmation,
+            vec![LeafInput {
+                location: LeafInputLocation::Resource,
+                func_argument_id: *confirmation_func_argument.id(),
+            }],
+        )
+        .await?;
+
+        // Create command and workflow funcs for our workflow and action prototypes.
+        let mut command_func = Func::new(
+            ctx,
+            "test:createCommandFallout",
+            FuncBackendKind::JsCommand,
+            FuncBackendResponseType::Command,
+        )
+        .await?;
+        let code = "async function create() {
+            return { payload: \"poop\", status: \"ok\" };
+        }";
+        command_func.set_code_plaintext(ctx, Some(code)).await?;
+        command_func.set_handler(ctx, Some("create")).await?;
+        let mut workflow_func = Func::new(
+            ctx,
+            "test:createWorkflowFallout",
+            FuncBackendKind::JsWorkflow,
+            FuncBackendResponseType::Workflow,
+        )
+        .await?;
+        let code = "async function create() {
+          return {
+            name: \"test:createWorkflowFallout\",
+            kind: \"conditional\",
+            steps: [
+              {
+                command: \"test:createCommandFallout\",
+              },
+            ],
+          };
+        }";
+        workflow_func.set_code_plaintext(ctx, Some(code)).await?;
+        workflow_func.set_handler(ctx, Some("create")).await?;
+
+        // Create workflow and action prototypes.
+        let workflow_prototype = WorkflowPrototype::new(
+            ctx,
+            *workflow_func.id(),
+            serde_json::Value::Null,
+            WorkflowPrototypeContext {
+                schema_id: *schema.id(),
+                schema_variant_id: *schema_variant.id(),
+                ..Default::default()
+            },
+            "Create Fallout",
+        )
+        .await?;
+        ActionPrototype::new(
+            ctx,
+            *workflow_prototype.id(),
+            "create",
+            ActionKind::Create,
+            ActionPrototypeContext {
+                schema_id: *schema.id(),
+                schema_variant_id,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Finalize the schema variant.
+        schema_variant.finalize(ctx, None).await?;
+
+        Ok(())
+    }
+}

--- a/lib/dal/tests/integration_test/internal/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/internal/component/confirmation.rs
@@ -67,9 +67,11 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
                 "color": "#ffffff",
                 "protected": false
             },
-            "domain": {},
+            "domain": {
+                "name": "component",
+            },
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": false,
                     "recommendedActions": ["create"]
                 }
@@ -110,14 +112,16 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
                 "color": "#ffffff",
                 "protected": false
             },
-            "domain": {},
+            "domain": {
+                "name": "component"
+            },
             "resource": {
                 "logs": [],
-                "payload": "poop",
-                "status": "ok"
+                "status": "ok",
+                "payload": "poop"
             },
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": true,
                     "recommendedActions": []
                 }
@@ -158,13 +162,15 @@ async fn add_and_run_confirmations(mut octx: DalContext) {
                 "color": "#ffffff",
                 "protected": false
             },
-            "domain": {},
+            "domain": {
+                "name": "component"
+            },
             "resource": {
                 "logs": [],
                 "status": "ok"
             },
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": false,
                     "recommendedActions": ["create"]
                 }
@@ -256,7 +262,7 @@ async fn list_confirmations(mut octx: DalContext) {
             },
             "domain": {},
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": false,
                     "recommendedActions": ["create"]
                 }
@@ -299,7 +305,7 @@ async fn list_confirmations(mut octx: DalContext) {
         .expect("could not list confirmations");
     let confirmation = confirmations.pop().expect("views are empty");
     assert!(confirmations.is_empty());
-    assert_eq!(confirmation.status, ConfirmationStatus::Success);
+    assert_eq!(ConfirmationStatus::Success, confirmation.status);
     assert!(recommendations.is_empty());
 
     // Observe that the confirmation worked after "creation".
@@ -321,7 +327,7 @@ async fn list_confirmations(mut octx: DalContext) {
                 "status": "ok"
             },
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": true,
                     "recommendedActions": []
                 }
@@ -403,7 +409,7 @@ async fn list_confirmations(mut octx: DalContext) {
                 "status": "ok"
             },
             "confirmation": {
-                "test:confirmation": {
+                "test:confirmationStarfield": {
                     "success": false,
                     "recommendedActions": ["create"]
                 }

--- a/lib/dal/tests/integration_test/internal/workflow_runner.rs
+++ b/lib/dal/tests/integration_test/internal/workflow_runner.rs
@@ -154,18 +154,16 @@ async fn fail(ctx: &mut DalContext) {
 
 #[test]
 async fn run(ctx: &mut DalContext) {
-    let title = "Refresh Docker Image";
+    let title = "Refresh Starfield";
     let prototype = WorkflowPrototype::find_by_attr(ctx, "title", &title)
         .await
         .expect("unable to find workflow by attr")
         .pop()
-        .expect("unable to find docker image resource refresh workflow prototype");
+        .expect("unable to find refresh workflow prototype");
 
-    let schema = Schema::find_by_attr(ctx, "name", &"Docker Image")
+    let schema = Schema::find_by_name(ctx, "starfield")
         .await
-        .expect("unable to find docker image schema")
-        .pop()
-        .expect("unable to find docker image");
+        .expect("unable to find schema");
     let (component, _) =
         Component::new_for_default_variant_from_schema(ctx, "systeminit/whiskers", *schema.id())
             .await


### PR DESCRIPTION
Primary:
- Replace hidden schemas (Docker Hub Credential, Kubernetes Namespace
  and Kubernetes Deployment) from "internal" integration tests with test
  exclusive schemas
- Add fallout test exclusive schema to aid with replacement
- Extend starfield test exclusive schema for more test scenarios

Secondary:
- Add assembler for component payload objects (meant to replace the
  builtin harness)

<img src="https://media4.giphy.com/media/1iQmrsdzAiqYOX1n3a/giphy.gif"/>