### PR TITLE
feat(dal,si-pkg): add command prototypes, pkg up command funcs

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -146,6 +146,8 @@ pub async fn migrate(
         }
         None => {
             schema::migrate_for_production(ctx).await?;
+
+            func::migrate_command_prototypes(ctx).await?;
         }
     }
 

--- a/lib/dal/src/command_prototype.rs
+++ b/lib/dal/src/command_prototype.rs
@@ -1,0 +1,186 @@
+use serde::{Deserialize, Serialize};
+use si_data_nats::NatsError;
+use si_data_pg::PgError;
+use std::default::Default;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    func::FuncId, impl_standard_model, pk, standard_model, standard_model_accessor, ComponentId,
+    DalContext, HistoryEventError, SchemaVariantId, StandardModel, StandardModelError, Tenancy,
+    Timestamp, TransactionsError, Visibility,
+};
+
+const FIND_FOR_FUNC: &str = include_str!("queries/command_prototype_find_for_func.sql");
+const FIND_FOR_CONTEXT: &str = include_str!("queries/command_prototype_find_for_context.sql");
+
+#[derive(Error, Debug)]
+pub enum CommandPrototypeError {
+    #[error("error serializing/deserializing json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("nats txn error: {0}")]
+    Nats(#[from] NatsError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
+    #[error("standard model error: {0}")]
+    StandardModelError(#[from] StandardModelError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+}
+
+pub type CommandPrototypeResult<T> = Result<T, CommandPrototypeError>;
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CommandPrototypeContext {
+    pub component_id: ComponentId,
+    pub schema_variant_id: SchemaVariantId,
+}
+
+impl Default for CommandPrototypeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandPrototypeContext {
+    pub fn new() -> Self {
+        Self {
+            component_id: ComponentId::NONE,
+            schema_variant_id: SchemaVariantId::NONE,
+        }
+    }
+
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    pub fn set_component_id(&mut self, component_id: ComponentId) {
+        self.component_id = component_id;
+    }
+
+    pub fn schema_variant_id(&self) -> SchemaVariantId {
+        self.schema_variant_id
+    }
+
+    pub fn set_schema_variant_id(&mut self, schema_variant_id: SchemaVariantId) {
+        self.schema_variant_id = schema_variant_id;
+    }
+}
+
+pk!(CommandPrototypePk);
+pk!(CommandPrototypeId);
+
+impl_standard_model! {
+    model: CommandPrototype,
+    pk: CommandPrototypePk,
+    id: CommandPrototypeId,
+    table_name: "command_prototypes",
+    history_event_label_base: "command_prototype",
+    history_event_message_name: "Command Prototype"
+}
+
+/// A CommandProtoype joins the [`Funcs`](crate::Func) which are used in
+/// (`Workflows`)(crate::Workflow) to the context in which they are executed (schema variant or
+/// component context)
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CommandPrototype {
+    pk: CommandPrototypePk,
+    id: CommandPrototypeId,
+    func_id: FuncId,
+    component_id: ComponentId,
+    schema_variant_id: SchemaVariantId,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+}
+
+impl CommandPrototype {
+    #[instrument(skip_all)]
+    pub async fn new(
+        ctx: &DalContext,
+        func_id: FuncId,
+        CommandPrototypeContext {
+            component_id,
+            schema_variant_id,
+        }: CommandPrototypeContext,
+    ) -> CommandPrototypeResult<Self> {
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_one(
+                "SELECT object FROM command_prototype_create_v1($1, $2, $3, $4, $5)",
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &func_id,
+                    &component_id,
+                    &schema_variant_id,
+                ],
+            )
+            .await?;
+        let object = standard_model::finish_create_from_row(ctx, row).await?;
+        Ok(object)
+    }
+
+    standard_model_accessor!(func_id, Pk(FuncId), CommandPrototypeResult);
+    standard_model_accessor!(
+        schema_variant_id,
+        Pk(SchemaVariantId),
+        CommandPrototypeResult
+    );
+    standard_model_accessor!(component_id, Pk(ComponentId), CommandPrototypeResult);
+
+    pub async fn find_for_func_and_schema_variant(
+        ctx: &DalContext,
+        func_id: FuncId,
+        schema_variant_id: SchemaVariantId,
+    ) -> CommandPrototypeResult<Option<Self>> {
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                FIND_FOR_FUNC,
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &func_id,
+                    &schema_variant_id,
+                ],
+            )
+            .await?;
+
+        Ok(standard_model::object_option_from_row_option(row)?)
+    }
+
+    pub async fn find_for_context(
+        ctx: &DalContext,
+        CommandPrototypeContext {
+            component_id,
+            schema_variant_id,
+        }: CommandPrototypeContext,
+    ) -> CommandPrototypeResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .await?
+            .pg()
+            .query(
+                FIND_FOR_CONTEXT,
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &component_id,
+                    &schema_variant_id,
+                ],
+            )
+            .await?;
+
+        Ok(standard_model::objects_from_rows(rows)?)
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -24,6 +24,7 @@ pub mod builtins;
 pub mod change_set;
 pub mod change_status;
 pub mod code_view;
+pub mod command_prototype;
 pub mod component;
 pub mod context;
 pub mod cyclone_key_pair;
@@ -94,6 +95,9 @@ pub use attribute::{
 pub use builtins::{BuiltinsError, BuiltinsResult};
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetPk, ChangeSetStatus};
 pub use code_view::{CodeLanguage, CodeView};
+pub use command_prototype::{
+    CommandPrototype, CommandPrototypeContext, CommandPrototypeError, CommandPrototypeId,
+};
 pub use component::{
     resource::ResourceView, status::ComponentStatus, status::HistoryActorTimestamp, Component,
     ComponentError, ComponentId, ComponentView, ComponentViewProperties,

--- a/lib/dal/src/migrations/U2160__command_prototypes.sql
+++ b/lib/dal/src/migrations/U2160__command_prototypes.sql
@@ -1,0 +1,56 @@
+CREATE TABLE command_prototypes
+(
+    pk                          ident primary key default ident_create_v1(),
+    id                          ident not null default ident_create_v1(),
+    tenancy_workspace_pk        ident,
+    visibility_change_set_pk    ident                   NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    func_id                     ident                   NOT NULL,
+    component_id                ident                   NOT NULL,
+    schema_variant_id           ident                   NOT NULL
+);
+
+CREATE UNIQUE INDEX unique_commmand_prototypes_for_schema_variants_and_components
+    ON command_prototypes (func_id,
+                            component_id,
+                            schema_variant_id,
+                            tenancy_workspace_pk,
+                            visibility_change_set_pk);
+SELECT standard_model_table_constraints_v1('command_prototypes');
+
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('command_prototypes', 'model', 'command_prototype', 'Command Prototype');
+
+CREATE OR REPLACE FUNCTION command_prototype_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_func_id ident,
+    this_component_id ident,
+    this_schema_variant_id ident,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           command_prototypes%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO command_prototypes (tenancy_workspace_pk,
+                                     visibility_change_set_pk,
+                                     func_id,
+                                     component_id,
+                                     schema_variant_id)
+    VALUES (this_tenancy_record.tenancy_workspace_pk,
+            this_visibility_record.visibility_change_set_pk,
+            this_func_id,
+            this_component_id,
+            this_schema_variant_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -21,10 +21,10 @@ use crate::{
     socket::SocketError,
     ActionPrototypeError, AttributeContextBuilderError, AttributePrototypeArgumentError,
     AttributePrototypeArgumentId, AttributePrototypeError, AttributePrototypeId,
-    AttributeValueError, ExternalProviderError, ExternalProviderId, FuncBackendKind,
-    FuncBackendResponseType, FuncError, FuncId, InternalProviderError, InternalProviderId,
-    PropError, PropId, SchemaError, SchemaId, SchemaVariantError, SchemaVariantId,
-    StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
+    AttributeValueError, CommandPrototypeError, ExternalProviderError, ExternalProviderId,
+    FuncBackendKind, FuncBackendResponseType, FuncError, FuncId, InternalProviderError,
+    InternalProviderId, PropError, PropId, SchemaError, SchemaId, SchemaVariantError,
+    SchemaVariantId, StandardModelError, ValidationPrototypeError, WorkflowPrototypeError,
 };
 
 #[derive(Debug, Error)]
@@ -140,6 +140,8 @@ pub enum PkgError {
     MissingInternalProviderForSocketName(String),
     #[error("Cannot find installed prop {0}")]
     MissingProp(PropId),
+    #[error(transparent)]
+    CommandPrototype(#[from] CommandPrototypeError),
 }
 
 impl PkgError {

--- a/lib/dal/src/queries/command_prototype_find_for_context.sql
+++ b/lib/dal/src/queries/command_prototype_find_for_context.sql
@@ -1,0 +1,4 @@
+SELECT row_to_json(command_protoypes.*) AS object
+FROM command_prototypes_v1($1, $2) AS command_protoypes 
+WHERE component_id=$3
+  AND schema_variant_id=$4;

--- a/lib/dal/src/queries/command_prototype_find_for_func.sql
+++ b/lib/dal/src/queries/command_prototype_find_for_func.sql
@@ -1,0 +1,3 @@
+SELECT row_to_json(command_protoypes.*) AS object
+FROM command_prototypes_v1($1, $2) AS command_protoypes 
+WHERE func_id = $3 and schema_variant_id=$4;

--- a/lib/dal/src/queries/schema_variant/all_related_funcs.sql
+++ b/lib/dal/src/queries/schema_variant/all_related_funcs.sql
@@ -61,5 +61,15 @@ UNION ALL
           JOIN funcs_v1($1, $2) funcs
                ON funcs.id = wp.func_id
  WHERE wp.schema_variant_id = $3
+   AND wp.component_id = ident_nil_v1()
    AND funcs.code_sha256 != '0')
 
+UNION ALL
+
+(SELECT row_to_json(funcs.*) AS object 
+  FROM command_prototypes_v1($1, $2) cprotos
+          JOIN funcs_v1($1, $2) funcs
+              ON funcs.id = cprotos.func_id
+  WHERE cprotos.schema_variant_id = $3
+    AND cprotos.component_id = ident_nil_v1()
+    AND funcs.code_sha256 != '0')

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -69,6 +69,7 @@
           "name": "v0",
           "workflows": [],
           "sockets": [],
+          "commandFuncs": [],
           "componentType": "component",
           "funcDescriptions": [],
           "leafFunctions": [

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -3,18 +3,19 @@ mod pkg;
 mod spec;
 
 pub use pkg::{
-    SiPkg, SiPkgAction, SiPkgAttrFuncInput, SiPkgAttrFuncInputView, SiPkgError, SiPkgFunc,
-    SiPkgFuncDescription, SiPkgLeafFunction, SiPkgMetadata, SiPkgProp, SiPkgSchema,
+    SiPkg, SiPkgAction, SiPkgAttrFuncInput, SiPkgAttrFuncInputView, SiPkgCommandFunc, SiPkgError,
+    SiPkgFunc, SiPkgFuncDescription, SiPkgLeafFunction, SiPkgMetadata, SiPkgProp, SiPkgSchema,
     SiPkgSchemaVariant, SiPkgSocket, SiPkgValidation, SiPkgWorkflow,
 };
 pub use spec::{
     ActionSpec, ActionSpecBuilder, ActionSpecKind, AttrFuncInputSpec, AttrFuncInputSpecKind,
-    FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder, FuncDescriptionSpec,
-    FuncDescriptionSpecBuilder, FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType,
-    FuncUniqueId, LeafFunctionSpec, LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, PkgSpec,
-    PkgSpecBuilder, PropSpec, PropSpecBuilder, PropSpecKind, SchemaSpec, SchemaSpecBuilder,
-    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SocketSpec,
-    SocketSpecArity, SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind, WorkflowSpec,
+    CommandFuncSpec, CommandFuncSpecBuilder, FuncArgumentKind, FuncArgumentSpec,
+    FuncArgumentSpecBuilder, FuncDescriptionSpec, FuncDescriptionSpecBuilder, FuncSpec,
+    FuncSpecBackendKind, FuncSpecBackendResponseType, FuncUniqueId, LeafFunctionSpec,
+    LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, PkgSpec, PkgSpecBuilder, PropSpec,
+    PropSpecBuilder, PropSpecKind, SchemaSpec, SchemaSpecBuilder, SchemaVariantSpec,
+    SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SocketSpec, SocketSpecArity,
+    SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind, WorkflowSpec,
     WorkflowSpecBuilder,
 };
 

--- a/lib/si-pkg/src/node/command_func.rs
+++ b/lib/si-pkg/src/node/command_func.rs
@@ -1,0 +1,59 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
+};
+
+use crate::{CommandFuncSpec, FuncUniqueId};
+
+use super::PkgNode;
+
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+
+#[derive(Clone, Debug)]
+pub struct CommandFuncNode {
+    pub func_unique_id: FuncUniqueId,
+}
+
+impl WriteBytes for CommandFuncNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(
+            writer,
+            KEY_FUNC_UNIQUE_ID_STR,
+            self.func_unique_id.to_string(),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for CommandFuncNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let func_unique_id_str = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+        let func_unique_id =
+            FuncUniqueId::from_str(&func_unique_id_str).map_err(GraphError::parse)?;
+
+        Ok(Self { func_unique_id })
+    }
+}
+
+impl NodeChild for CommandFuncSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Leaf,
+            Self::NodeType::CommandFunc(CommandFuncNode {
+                func_unique_id: self.func_unique_id,
+            }),
+            vec![],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -7,6 +7,7 @@ use object_tree::{
 mod action;
 mod attr_func_input;
 mod category;
+mod command_func;
 mod func;
 mod func_argument;
 mod func_description;
@@ -25,6 +26,7 @@ pub(crate) use self::{
     action::ActionNode,
     attr_func_input::AttrFuncInputNode,
     category::CategoryNode,
+    command_func::CommandFuncNode,
     func::FuncNode,
     func_argument::FuncArgumentNode,
     func_description::FuncDescriptionNode,
@@ -43,6 +45,7 @@ pub(crate) use self::{
 const NODE_KIND_ACTION: &str = "action";
 const NODE_KIND_ATTR_FUNC_INPUT: &str = "attr_func_input";
 const NODE_KIND_CATEGORY: &str = "category";
+const NODE_KIND_COMMAND_FUNC: &str = "command_func";
 const NODE_KIND_FUNC: &str = "func";
 const NODE_KIND_FUNC_ARGUMENT: &str = "func_argument";
 const NODE_KIND_FUNC_DESCRIPTION: &str = "func_description";
@@ -62,6 +65,7 @@ const KEY_NODE_KIND_STR: &str = "node_kind";
 #[derive(Clone, Debug)]
 pub enum PkgNode {
     Action(ActionNode),
+    CommandFunc(CommandFuncNode),
     AttrFuncInput(AttrFuncInputNode),
     Category(CategoryNode),
     Func(FuncNode),
@@ -83,6 +87,7 @@ impl PkgNode {
     pub const ACTION_KIND_STR: &str = NODE_KIND_ACTION;
     pub const ATTR_FUNC_INPUT_KIND_STR: &str = NODE_KIND_ATTR_FUNC_INPUT;
     pub const CATEGORY_KIND_STR: &str = NODE_KIND_CATEGORY;
+    pub const COMMAND_FUNC_KIND_STR: &str = NODE_KIND_COMMAND_FUNC;
     pub const FUNC_KIND_STR: &str = NODE_KIND_FUNC;
     pub const FUNC_ARGUMENT_KIND_STR: &str = NODE_KIND_FUNC_ARGUMENT;
     pub const FUNC_DESCRIPTION_KIND_STR: &str = NODE_KIND_FUNC_DESCRIPTION;
@@ -102,6 +107,7 @@ impl PkgNode {
             Self::Action(_) => NODE_KIND_ACTION,
             Self::AttrFuncInput(_) => NODE_KIND_ATTR_FUNC_INPUT,
             Self::Category(_) => NODE_KIND_CATEGORY,
+            Self::CommandFunc(_) => NODE_KIND_COMMAND_FUNC,
             Self::Func(_) => NODE_KIND_FUNC,
             Self::FuncArgument(_) => NODE_KIND_FUNC_ARGUMENT,
             Self::FuncDescription(_) => NODE_KIND_FUNC_DESCRIPTION,
@@ -125,6 +131,7 @@ impl NameStr for PkgNode {
             Self::Action(node) => node.name(),
             Self::AttrFuncInput(node) => node.name(),
             Self::Category(node) => node.name(),
+            Self::CommandFunc(_) => NODE_KIND_COMMAND_FUNC,
             Self::Func(node) => node.name(),
             Self::FuncArgument(node) => node.name(),
             Self::FuncDescription(_) => NODE_KIND_FUNC_DESCRIPTION,
@@ -150,6 +157,7 @@ impl WriteBytes for PkgNode {
             Self::Action(node) => node.write_bytes(writer)?,
             Self::AttrFuncInput(node) => node.write_bytes(writer)?,
             Self::Category(node) => node.write_bytes(writer)?,
+            Self::CommandFunc(node) => node.write_bytes(writer)?,
             Self::Func(node) => node.write_bytes(writer)?,
             Self::FuncArgument(node) => node.write_bytes(writer)?,
             Self::FuncDescription(node) => node.write_bytes(writer)?,
@@ -182,6 +190,7 @@ impl ReadBytes for PkgNode {
                 Self::AttrFuncInput(AttrFuncInputNode::read_bytes(reader)?)
             }
             NODE_KIND_CATEGORY => Self::Category(CategoryNode::read_bytes(reader)?),
+            NODE_KIND_COMMAND_FUNC => Self::CommandFunc(CommandFuncNode::read_bytes(reader)?),
             NODE_KIND_FUNC => Self::Func(FuncNode::read_bytes(reader)?),
             NODE_KIND_FUNC_ARGUMENT => Self::FuncArgument(FuncArgumentNode::read_bytes(reader)?),
             NODE_KIND_FUNC_DESCRIPTION => {

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -91,6 +91,8 @@ impl NodeChild for SchemaVariantSpec {
                 component_type: self.component_type,
             }),
             vec![
+                Box::new(SchemaVariantChild::CommandFuncs(self.command_funcs.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(SchemaVariantChild::Domain(self.domain.clone()))
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(SchemaVariantChild::LeafFunctions(

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -15,6 +15,7 @@ use petgraph::prelude::*;
 use thiserror::Error;
 
 mod attr_func_input;
+mod command_func;
 mod func;
 mod func_description;
 mod leaf_function;
@@ -26,8 +27,8 @@ mod variant;
 mod workflow;
 
 pub use {
-    attr_func_input::*, func::*, func_description::*, leaf_function::*, prop::*, schema::*,
-    socket::*, validation::*, variant::*, workflow::*,
+    attr_func_input::*, command_func::*, func::*, func_description::*, leaf_function::*, prop::*,
+    schema::*, socket::*, validation::*, variant::*, workflow::*,
 };
 
 use crate::{

--- a/lib/si-pkg/src/pkg/command_func.rs
+++ b/lib/si-pkg/src/pkg/command_func.rs
@@ -1,0 +1,49 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgError, Source};
+
+use crate::{node::PkgNode, spec::FuncUniqueId};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgCommandFunc<'a> {
+    func_unique_id: FuncUniqueId,
+    hash: Hash,
+    source: Source<'a>,
+}
+
+impl<'a> SiPkgCommandFunc<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::CommandFunc(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::COMMAND_FUNC_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            func_unique_id: node.func_unique_id,
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn func_unique_id(&self) -> FuncUniqueId {
+        self.func_unique_id
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -5,8 +5,8 @@ use std::future::Future;
 use url::Url;
 
 use super::{
-    PkgResult, SiPkgError, SiPkgFuncDescription, SiPkgLeafFunction, SiPkgProp, SiPkgSocket,
-    SiPkgWorkflow, Source,
+    PkgResult, SiPkgCommandFunc, SiPkgError, SiPkgFuncDescription, SiPkgLeafFunction, SiPkgProp,
+    SiPkgSocket, SiPkgWorkflow, Source,
 };
 
 use crate::{
@@ -112,6 +112,11 @@ impl<'a> SiPkgSchemaVariant<'a> {
         leaf_functions,
         SchemaVariantChildNode::LeafFunctions,
         SiPkgLeafFunction
+    );
+    impl_variant_children_from_graph!(
+        command_funcs,
+        SchemaVariantChildNode::CommandFuncs,
+        SiPkgCommandFunc
     );
 
     fn prop_stack_from_source<I>(

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 mod attr_func_input;
+mod command_func;
 mod func;
 mod func_description;
 mod leaf_function;
@@ -15,8 +16,8 @@ mod variant;
 mod workflow;
 
 pub use {
-    attr_func_input::*, func::*, func_description::*, leaf_function::*, prop::*, schema::*,
-    socket::*, validation::*, variant::*, workflow::*,
+    attr_func_input::*, command_func::*, func::*, func_description::*, leaf_function::*, prop::*,
+    schema::*, socket::*, validation::*, variant::*, workflow::*,
 };
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]

--- a/lib/si-pkg/src/spec/command_func.rs
+++ b/lib/si-pkg/src/spec/command_func.rs
@@ -1,0 +1,18 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use super::{FuncUniqueId, SpecError};
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct CommandFuncSpec {
+    #[builder(setter(into))]
+    pub func_unique_id: FuncUniqueId,
+}
+
+impl CommandFuncSpec {
+    pub fn builder() -> CommandFuncSpecBuilder {
+        CommandFuncSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use url::Url;
 
-use super::{FuncDescriptionSpec, LeafFunctionSpec, PropSpec, SocketSpec, SpecError, WorkflowSpec};
+use super::{
+    CommandFuncSpec, FuncDescriptionSpec, LeafFunctionSpec, PropSpec, SocketSpec, SpecError,
+    WorkflowSpec,
+};
 
 #[derive(
     Debug,
@@ -43,6 +46,9 @@ pub struct SchemaVariantSpec {
 
     #[builder(private, default = "Self::default_domain()")]
     pub domain: PropSpec,
+
+    #[builder(setter(each(name = "command_func"), into), default)]
+    pub command_funcs: Vec<CommandFuncSpec>,
 
     #[builder(setter(each(name = "leaf_function"), into), default)]
     pub leaf_functions: Vec<LeafFunctionSpec>,


### PR DESCRIPTION
Adds a table `command_prototypes` that pairs command functions with a context (`component_id`, `schema_variant_id`). Creates missing command prototypes automatically when migrating, and uses them to export and import the command functions to/from an SiPkg.

These `command_prototypes` are currently only used in the package flow, but will be part of the command func editing interface, and could be used to provide a form of type safety for workflow functions (if a workflow function returns a command function name that has no prototype for that schema variant / component, we can tell the user that it's wrong).