### PR TITLE
feat(si-pkg,sdf): convert SiPkg to PkgSpec for serialization

### DIFF
--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -33,7 +33,7 @@ pub use {
 
 use crate::{
     node::{CategoryNode, PkgNode},
-    spec::{PkgSpec, SpecError},
+    spec::{FuncSpec, PkgSpec, SchemaSpec, SpecError},
 };
 
 #[derive(Debug, Error)]
@@ -326,5 +326,32 @@ impl SiPkgMetadata {
 
     pub fn hash(&self) -> Hash {
         self.hash
+    }
+}
+
+impl TryFrom<SiPkg> for PkgSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkg) -> Result<Self, Self::Error> {
+        let mut builder = PkgSpec::builder();
+
+        let metadata = value.metadata()?;
+
+        builder
+            .name(metadata.name())
+            .description(metadata.description())
+            .version(metadata.version())
+            .created_at(metadata.created_at())
+            .created_by(metadata.created_by());
+
+        for func in value.funcs()? {
+            builder.func(FuncSpec::try_from(func)?);
+        }
+
+        for schema in value.schemas()? {
+            builder.schema(SchemaSpec::try_from(schema)?);
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/attr_func_input.rs
+++ b/lib/si-pkg/src/pkg/attr_func_input.rs
@@ -3,7 +3,10 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, Source};
 
-use crate::node::{AttrFuncInputNode, PkgNode};
+use crate::{
+    node::{AttrFuncInputNode, PkgNode},
+    AttrFuncInputSpec, AttrFuncInputSpecKind,
+};
 
 #[derive(Clone, Debug)]
 pub enum SiPkgAttrFuncInput<'a> {
@@ -89,5 +92,38 @@ impl<'a> SiPkgAttrFuncInput<'a> {
                 source,
             },
         })
+    }
+}
+
+impl<'a> TryFrom<SiPkgAttrFuncInput<'a>> for AttrFuncInputSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgAttrFuncInput<'a>) -> Result<Self, Self::Error> {
+        let mut builder = AttrFuncInputSpec::builder();
+        match value {
+            SiPkgAttrFuncInput::Prop {
+                name, prop_path, ..
+            } => {
+                builder.kind(AttrFuncInputSpecKind::Prop);
+                builder.name(name);
+                builder.prop_path(prop_path);
+            }
+            SiPkgAttrFuncInput::InputSocket {
+                name, socket_name, ..
+            } => {
+                builder.kind(AttrFuncInputSpecKind::InputSocket);
+                builder.name(name);
+                builder.socket_name(socket_name);
+            }
+            SiPkgAttrFuncInput::OutputSocket {
+                name, socket_name, ..
+            } => {
+                builder.kind(AttrFuncInputSpecKind::OutputSocket);
+                builder.name(name);
+                builder.socket_name(socket_name);
+            }
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/command_func.rs
+++ b/lib/si-pkg/src/pkg/command_func.rs
@@ -3,7 +3,10 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, Source};
 
-use crate::{node::PkgNode, spec::FuncUniqueId};
+use crate::{
+    CommandFuncSpec,
+    {node::PkgNode, spec::FuncUniqueId},
+};
 
 #[derive(Clone, Debug)]
 pub struct SiPkgCommandFunc<'a> {
@@ -45,5 +48,15 @@ impl<'a> SiPkgCommandFunc<'a> {
 
     pub fn source(&self) -> &Source<'a> {
         &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgCommandFunc<'a>> for CommandFuncSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgCommandFunc<'a>) -> Result<Self, Self::Error> {
+        Ok(CommandFuncSpec::builder()
+            .func_unique_id(value.func_unique_id)
+            .build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/func_description.rs
+++ b/lib/si-pkg/src/pkg/func_description.rs
@@ -3,7 +3,10 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, Source};
 
-use crate::{node::PkgNode, spec::FuncUniqueId};
+use crate::{
+    FuncDescriptionSpec,
+    {node::PkgNode, spec::FuncUniqueId},
+};
 
 #[derive(Clone, Debug)]
 pub struct SiPkgFuncDescription<'a> {
@@ -51,5 +54,16 @@ impl<'a> SiPkgFuncDescription<'a> {
 
     pub fn source(&self) -> &Source<'a> {
         &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgFuncDescription<'a>> for FuncDescriptionSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgFuncDescription<'a>) -> Result<Self, Self::Error> {
+        Ok(FuncDescriptionSpec::builder()
+            .func_unique_id(value.func_unique_id)
+            .contents(value.contents)
+            .build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/leaf_function.rs
+++ b/lib/si-pkg/src/pkg/leaf_function.rs
@@ -6,6 +6,7 @@ use super::{PkgResult, SiPkgError, Source};
 use crate::{
     node::PkgNode,
     spec::{FuncUniqueId, LeafInputLocation, LeafKind},
+    LeafFunctionSpec,
 };
 
 #[derive(Clone, Debug)]
@@ -74,5 +75,17 @@ impl<'a> SiPkgLeafFunction<'a> {
 
     pub fn source(&self) -> &Source<'a> {
         &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgLeafFunction<'a>> for LeafFunctionSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgLeafFunction<'a>) -> Result<Self, Self::Error> {
+        Ok(LeafFunctionSpec::builder()
+            .leaf_kind(value.leaf_kind)
+            .func_unique_id(value.func_unique_id)
+            .inputs(value.inputs)
+            .build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/schema.rs
+++ b/lib/si-pkg/src/pkg/schema.rs
@@ -3,7 +3,7 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, SiPkgSchemaVariant, Source};
 
-use crate::node::PkgNode;
+use crate::{node::PkgNode, SchemaSpec, SchemaVariantSpec};
 
 #[derive(Clone, Debug)]
 pub struct SiPkgSchema<'a> {
@@ -73,5 +73,24 @@ impl<'a> SiPkgSchema<'a> {
 
     pub fn hash(&self) -> Hash {
         self.hash
+    }
+}
+
+impl<'a> TryFrom<SiPkgSchema<'a>> for SchemaSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgSchema<'a>) -> Result<Self, Self::Error> {
+        let mut builder = SchemaSpec::builder();
+
+        builder.name(value.name()).category(value.category());
+        if let Some(category_name) = value.category_name() {
+            builder.category_name(category_name);
+        }
+
+        for variant in value.variants()? {
+            builder.variant(SchemaVariantSpec::try_from(variant)?);
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/socket.rs
+++ b/lib/si-pkg/src/pkg/socket.rs
@@ -3,10 +3,7 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgAttrFuncInput, SiPkgError, Source};
 
-use crate::{
-    node::PkgNode,
-    spec::{FuncUniqueId, SocketSpecArity, SocketSpecKind},
-};
+use crate::{node::PkgNode, FuncUniqueId, SocketSpec, SocketSpecArity, SocketSpecKind};
 
 #[derive(Clone, Debug)]
 pub struct SiPkgSocket<'a> {
@@ -81,5 +78,25 @@ impl<'a> SiPkgSocket<'a> {
 
     pub fn source(&self) -> &Source<'a> {
         &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgSocket<'a>> for SocketSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgSocket<'a>) -> Result<Self, Self::Error> {
+        let mut builder = SocketSpec::builder();
+
+        builder
+            .kind(value.kind)
+            .name(value.name())
+            .func_unique_id(value.func_unique_id)
+            .arity(value.arity);
+
+        for input in value.inputs()? {
+            builder.input(input.try_into()?);
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/validation.rs
+++ b/lib/si-pkg/src/pkg/validation.rs
@@ -3,7 +3,7 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, Source};
 
-use crate::{node::PkgNode, spec::ValidationSpecKind};
+use crate::{node::PkgNode, ValidationSpec, ValidationSpecKind};
 
 #[derive(Clone, Debug)]
 pub enum SiPkgValidation<'a> {
@@ -130,5 +130,57 @@ impl<'a> SiPkgValidation<'a> {
                 }
             }
         })
+    }
+}
+
+impl<'a> TryFrom<SiPkgValidation<'a>> for ValidationSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgValidation<'a>) -> Result<Self, Self::Error> {
+        let mut builder = ValidationSpec::builder();
+
+        match value {
+            SiPkgValidation::IntegerIsBetweenTwoIntegers {
+                lower_bound,
+                upper_bound,
+                ..
+            } => {
+                builder.kind(ValidationSpecKind::IntegerIsBetweenTwoIntegers);
+                builder.lower_bound(lower_bound);
+                builder.upper_bound(upper_bound);
+            }
+            SiPkgValidation::StringEquals { expected, .. } => {
+                builder.kind(ValidationSpecKind::StringEquals);
+                builder.expected_string(expected);
+            }
+            SiPkgValidation::StringHasPrefix { expected, .. } => {
+                builder.kind(ValidationSpecKind::StringHasPrefix);
+                builder.expected_string(expected);
+            }
+            SiPkgValidation::CustomValidation { func_unique_id, .. } => {
+                builder.kind(ValidationSpecKind::CustomValidation);
+                builder.func_unique_id(func_unique_id);
+            }
+            SiPkgValidation::StringInStringArray {
+                expected,
+                display_expected,
+                ..
+            } => {
+                builder.kind(ValidationSpecKind::StringInStringArray);
+                builder.expected_string_array(expected);
+                builder.display_expected(display_expected);
+            }
+            SiPkgValidation::StringIsValidIpAddr { .. } => {
+                builder.kind(ValidationSpecKind::StringIsValidIpAddr);
+            }
+            SiPkgValidation::StringIsHexColor { .. } => {
+                builder.kind(ValidationSpecKind::StringIsHexColor);
+            }
+            SiPkgValidation::StringIsNotEmpty { .. } => {
+                builder.kind(ValidationSpecKind::StringIsNotEmpty);
+            }
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -11,7 +11,7 @@ use super::{
 
 use crate::{
     node::{PkgNode, PropChildNode, SchemaVariantChildNode},
-    SchemaVariantSpecComponentType,
+    SchemaVariantSpec, SchemaVariantSpecComponentType,
 };
 
 #[derive(Clone, Debug)]
@@ -216,5 +216,43 @@ impl<'a> SiPkgSchemaVariant<'a> {
 
     pub fn hash(&self) -> Hash {
         self.hash
+    }
+}
+
+impl<'a> TryFrom<SiPkgSchemaVariant<'a>> for SchemaVariantSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgSchemaVariant<'a>) -> Result<Self, Self::Error> {
+        let mut builder = SchemaVariantSpec::builder();
+
+        builder
+            .name(value.name())
+            .component_type(value.component_type);
+
+        if let Some(link) = value.link() {
+            builder.link(link.to_owned());
+        }
+
+        if let Some(color) = value.color() {
+            builder.color(color);
+        }
+
+        for command_func in value.command_funcs()? {
+            builder.command_func(command_func.try_into()?);
+        }
+
+        for func_description in value.func_descriptions()? {
+            builder.func_description(func_description.try_into()?);
+        }
+
+        for socket in value.sockets()? {
+            builder.socket(socket.try_into()?);
+        }
+
+        for workflow in value.workflows()? {
+            builder.workflow(workflow.try_into()?);
+        }
+
+        Ok(builder.build()?)
     }
 }

--- a/lib/si-pkg/src/pkg/workflow.rs
+++ b/lib/si-pkg/src/pkg/workflow.rs
@@ -3,7 +3,7 @@ use petgraph::prelude::*;
 
 use super::{PkgResult, SiPkgError, Source};
 
-use crate::{node::PkgNode, ActionSpecKind};
+use crate::{node::PkgNode, ActionSpec, ActionSpecKind, WorkflowSpec};
 
 #[derive(Clone, Debug)]
 pub struct SiPkgWorkflow<'a> {
@@ -70,6 +70,24 @@ impl<'a> SiPkgWorkflow<'a> {
     }
 }
 
+impl<'a> TryFrom<SiPkgWorkflow<'a>> for WorkflowSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgWorkflow<'a>) -> Result<Self, Self::Error> {
+        let mut builder = WorkflowSpec::builder();
+
+        builder
+            .title(value.title())
+            .func_unique_id(value.func_unique_id);
+
+        for action in value.actions()? {
+            builder.action(action.try_into()?);
+        }
+
+        Ok(builder.build()?)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SiPkgAction<'a> {
     kind: ActionSpecKind,
@@ -119,5 +137,16 @@ impl<'a> SiPkgAction<'a> {
 
     pub fn source(&self) -> &Source<'a> {
         &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgAction<'a>> for ActionSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgAction<'a>) -> Result<Self, Self::Error> {
+        Ok(ActionSpec::builder()
+            .kind(value.kind)
+            .name(value.name)
+            .build()?)
     }
 }

--- a/lib/si-pkg/src/spec/schema.rs
+++ b/lib/si-pkg/src/spec/schema.rs
@@ -23,16 +23,6 @@ impl SchemaSpec {
     pub fn builder() -> SchemaSpecBuilder {
         SchemaSpecBuilder::default()
     }
-
-    #[allow(unused_mut)]
-    pub fn try_variant<I>(&mut self, item: I) -> Result<&mut Self, I::Error>
-    where
-        I: TryInto<SchemaVariantSpec>,
-    {
-        let converted: SchemaVariantSpec = item.try_into()?;
-        self.variants.extend(Some(converted));
-        Ok(self)
-    }
 }
 
 impl TryFrom<SchemaSpecBuilder> for SchemaSpec {


### PR DESCRIPTION
Captures all data from the package as a PkgSpec *except* the prop tree, which will come in a follow up.