### PR TITLE
feat(dal,si-pkg): pkg up functions on props in the si tree

### DIFF
--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -527,6 +527,27 @@ async fn create_schema_variant(
                 create_socket(ctx, socket, *schema.id(), *schema_variant.id(), func_map).await?;
             }
 
+            for si_prop_func in variant_spec.si_prop_funcs()? {
+                let prop = schema_variant
+                    .find_prop(ctx, &si_prop_func.kind().prop_path())
+                    .await?;
+                create_attribute_function_for_prop(
+                    ctx,
+                    *schema_variant.id(),
+                    AttrFuncInfo {
+                        func_unique_id: si_prop_func.func_unique_id(),
+                        prop_id: *prop.id(),
+                        inputs: si_prop_func
+                            .inputs()?
+                            .iter()
+                            .map(|input| input.to_owned().into())
+                            .collect(),
+                    },
+                    func_map,
+                )
+                .await?;
+            }
+
             for default_value_info in context.default_values.into_inner() {
                 set_default_value(ctx, default_value_info).await?;
             }

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -68,6 +68,7 @@
       "variants": [
         {
           "name": "v0",
+          "siPropFuncs": [],
           "workflows": [],
           "sockets": [],
           "commandFuncs": [],

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -14,9 +14,9 @@ pub use spec::{
     FuncSpecBackendKind, FuncSpecBackendResponseType, FuncUniqueId, LeafFunctionSpec,
     LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, PkgSpec, PkgSpecBuilder, PropSpec,
     PropSpecBuilder, PropSpecKind, PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder,
-    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SocketSpec,
-    SocketSpecArity, SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind, WorkflowSpec,
-    WorkflowSpecBuilder,
+    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SiPropFuncSpec,
+    SiPropFuncSpecBuilder, SiPropFuncSpecKind, SocketSpec, SocketSpecArity, SocketSpecKind,
+    SpecError, ValidationSpec, ValidationSpecKind, WorkflowSpec, WorkflowSpecBuilder,
 };
 
 #[cfg(test)]

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -18,6 +18,7 @@ mod prop_child;
 mod schema;
 mod schema_variant;
 mod schema_variant_child;
+mod si_prop_func;
 mod socket;
 mod validation;
 mod workflow;
@@ -37,6 +38,7 @@ pub(crate) use self::{
     schema::SchemaNode,
     schema_variant::SchemaVariantNode,
     schema_variant_child::{SchemaVariantChild, SchemaVariantChildNode},
+    si_prop_func::SiPropFuncNode,
     socket::SocketNode,
     validation::ValidationNode,
     workflow::WorkflowNode,
@@ -57,6 +59,7 @@ const NODE_KIND_SCHEMA: &str = "schema";
 const NODE_KIND_SCHEMA_VARIANT: &str = "schema_variant";
 const NODE_KIND_SCHEMA_VARIANT_CHILD: &str = "schema_variant_child";
 const NODE_KIND_SOCKET: &str = "socket";
+const NODE_KIND_SI_PROP_FUNC: &str = "si_prop_func";
 const NODE_KIND_VALIDATION: &str = "validation";
 const NODE_KIND_WORKFLOW: &str = "workflow";
 
@@ -79,6 +82,7 @@ pub enum PkgNode {
     SchemaVariant(SchemaVariantNode),
     SchemaVariantChild(SchemaVariantChildNode),
     Socket(SocketNode),
+    SiPropFunc(SiPropFuncNode),
     Validation(ValidationNode),
     Workflow(WorkflowNode),
 }
@@ -99,6 +103,7 @@ impl PkgNode {
     pub const SCHEMA_VARIANT_KIND_STR: &str = NODE_KIND_SCHEMA_VARIANT;
     pub const SCHEMA_VARIANT_KIND_CHILD_STR: &str = NODE_KIND_SCHEMA_VARIANT_CHILD;
     pub const SOCKET_KIND_STR: &str = NODE_KIND_SOCKET;
+    pub const SI_PROP_FUNC_KIND_STR: &str = NODE_KIND_SI_PROP_FUNC;
     pub const VALIDATION_KIND_STR: &str = NODE_KIND_VALIDATION;
     pub const WORKFLOW_KIND_STR: &str = NODE_KIND_WORKFLOW;
 
@@ -119,6 +124,7 @@ impl PkgNode {
             Self::SchemaVariant(_) => NODE_KIND_SCHEMA_VARIANT,
             Self::SchemaVariantChild(_) => NODE_KIND_SCHEMA_VARIANT_CHILD,
             Self::Socket(_) => NODE_KIND_SOCKET,
+            Self::SiPropFunc(_) => NODE_KIND_SI_PROP_FUNC,
             Self::Validation(_) => NODE_KIND_VALIDATION,
             Self::Workflow(_) => NODE_KIND_WORKFLOW,
         }
@@ -143,6 +149,7 @@ impl NameStr for PkgNode {
             Self::SchemaVariant(node) => node.name(),
             Self::SchemaVariantChild(node) => node.name(),
             Self::Socket(node) => node.name(),
+            Self::SiPropFunc(_) => NODE_KIND_SI_PROP_FUNC,
             Self::Validation(_) => NODE_KIND_VALIDATION,
             Self::Workflow(_) => NODE_KIND_WORKFLOW,
         }
@@ -169,6 +176,7 @@ impl WriteBytes for PkgNode {
             Self::SchemaVariant(node) => node.write_bytes(writer)?,
             Self::SchemaVariantChild(node) => node.write_bytes(writer)?,
             Self::Socket(node) => node.write_bytes(writer)?,
+            Self::SiPropFunc(node) => node.write_bytes(writer)?,
             Self::Validation(node) => node.write_bytes(writer)?,
             Self::Workflow(node) => node.write_bytes(writer)?,
         };
@@ -206,6 +214,7 @@ impl ReadBytes for PkgNode {
                 Self::SchemaVariantChild(SchemaVariantChildNode::read_bytes(reader)?)
             }
             NODE_KIND_SOCKET => Self::Socket(SocketNode::read_bytes(reader)?),
+            NODE_KIND_SI_PROP_FUNC => Self::SiPropFunc(SiPropFuncNode::read_bytes(reader)?),
             NODE_KIND_VALIDATION => Self::Validation(ValidationNode::read_bytes(reader)?),
             NODE_KIND_WORKFLOW => Self::Workflow(WorkflowNode::read_bytes(reader)?),
             invalid_kind => {

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -105,6 +105,8 @@ impl NodeChild for SchemaVariantSpec {
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(SchemaVariantChild::Sockets(self.sockets.clone()))
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(SchemaVariantChild::SiPropFuncs(self.si_prop_funcs.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
             ],
         )
     }

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -7,7 +7,8 @@ use object_tree::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CommandFuncSpec, FuncDescriptionSpec, LeafFunctionSpec, PropSpec, SocketSpec, WorkflowSpec,
+    CommandFuncSpec, FuncDescriptionSpec, LeafFunctionSpec, PropSpec, SiPropFuncSpec, SocketSpec,
+    WorkflowSpec,
 };
 
 use super::PkgNode;
@@ -17,6 +18,7 @@ const VARIANT_CHILD_TYPE_DOMAIN: &str = "domain";
 const VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS: &str = "func_descriptions";
 const VARIANT_CHILD_TYPE_LEAF_FUNCTIONS: &str = "leaf_functions";
 const VARIANT_CHILD_TYPE_SOCKETS: &str = "sockets";
+const VARIANT_CHILD_TYPE_SI_PROP_FUNCS: &str = "si_prop_funcs";
 const VARIANT_CHILD_TYPE_WORKFLOWS: &str = "workflows";
 
 const KEY_KIND_STR: &str = "kind";
@@ -29,6 +31,7 @@ pub enum SchemaVariantChild {
     FuncDescriptions(Vec<FuncDescriptionSpec>),
     LeafFunctions(Vec<LeafFunctionSpec>),
     Sockets(Vec<SocketSpec>),
+    SiPropFuncs(Vec<SiPropFuncSpec>),
     Workflows(Vec<WorkflowSpec>),
 }
 
@@ -39,6 +42,7 @@ pub enum SchemaVariantChildNode {
     FuncDescriptions,
     LeafFunctions,
     Sockets,
+    SiPropFuncs,
     Workflows,
 }
 
@@ -50,6 +54,7 @@ impl SchemaVariantChildNode {
             Self::FuncDescriptions => VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
             Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
+            Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
             Self::Workflows => VARIANT_CHILD_TYPE_WORKFLOWS,
         }
     }
@@ -63,6 +68,7 @@ impl NameStr for SchemaVariantChildNode {
             Self::FuncDescriptions => VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
             Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
+            Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
             Self::Workflows => VARIANT_CHILD_TYPE_WORKFLOWS,
         }
     }
@@ -88,6 +94,7 @@ impl ReadBytes for SchemaVariantChildNode {
             VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS => Self::FuncDescriptions,
             VARIANT_CHILD_TYPE_LEAF_FUNCTIONS => Self::LeafFunctions,
             VARIANT_CHILD_TYPE_SOCKETS => Self::Sockets,
+            VARIANT_CHILD_TYPE_SI_PROP_FUNCS => Self::SiPropFuncs,
             VARIANT_CHILD_TYPE_WORKFLOWS => Self::Workflows,
             invalid_kind => {
                 return Err(GraphError::parse_custom(format!(
@@ -154,6 +161,17 @@ impl NodeChild for SchemaVariantChild {
                     .iter()
                     .map(|socket| {
                         Box::new(socket.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::SiPropFuncs(si_prop_funcs) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::SiPropFuncs),
+                si_prop_funcs
+                    .iter()
+                    .map(|si_prop_func| {
+                        Box::new(si_prop_func.clone())
+                            as Box<dyn NodeChild<NodeType = Self::NodeType>>
                     })
                     .collect(),
             ),

--- a/lib/si-pkg/src/node/si_prop_func.rs
+++ b/lib/si-pkg/src/node/si_prop_func.rs
@@ -1,0 +1,74 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
+};
+
+use crate::{FuncUniqueId, SiPropFuncSpec, SiPropFuncSpecKind};
+
+use super::PkgNode;
+
+const KEY_KIND_STR: &str = "kind";
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+
+#[derive(Clone, Debug)]
+pub struct SiPropFuncNode {
+    pub kind: SiPropFuncSpecKind,
+    pub func_unique_id: FuncUniqueId,
+}
+
+impl WriteBytes for SiPropFuncNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind)?;
+        write_key_value_line(
+            writer,
+            KEY_FUNC_UNIQUE_ID_STR,
+            self.func_unique_id.to_string(),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for SiPropFuncNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+        let kind = SiPropFuncSpecKind::from_str(&kind_str).map_err(GraphError::parse)?;
+
+        let func_unique_id_str = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+        let func_unique_id =
+            FuncUniqueId::from_str(&func_unique_id_str).map_err(GraphError::parse)?;
+
+        Ok(Self {
+            kind,
+            func_unique_id,
+        })
+    }
+}
+
+impl NodeChild for SiPropFuncSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::SiPropFunc(SiPropFuncNode {
+                kind: self.kind,
+                func_unique_id: self.func_unique_id,
+            }),
+            self.inputs
+                .iter()
+                .map(|input| {
+                    Box::new(input.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                })
+                .collect(),
+        )
+    }
+}

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -21,6 +21,7 @@ mod func_description;
 mod leaf_function;
 mod prop;
 mod schema;
+mod si_prop_func;
 mod socket;
 mod validation;
 mod variant;
@@ -28,7 +29,7 @@ mod workflow;
 
 pub use {
     attr_func_input::*, command_func::*, func::*, func_description::*, leaf_function::*, prop::*,
-    schema::*, socket::*, validation::*, variant::*, workflow::*,
+    schema::*, si_prop_func::*, socket::*, validation::*, variant::*, workflow::*,
 };
 
 use crate::{

--- a/lib/si-pkg/src/pkg/si_prop_func.rs
+++ b/lib/si-pkg/src/pkg/si_prop_func.rs
@@ -1,0 +1,88 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgError, Source};
+
+use crate::{
+    node::PkgNode, AttrFuncInputSpec, FuncUniqueId, SiPkgAttrFuncInput, SiPropFuncSpec,
+    SiPropFuncSpecKind,
+};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgSiPropFunc<'a> {
+    kind: SiPropFuncSpecKind,
+    func_unique_id: FuncUniqueId,
+    hash: Hash,
+    source: Source<'a>,
+}
+
+impl<'a> SiPkgSiPropFunc<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::SiPropFunc(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::SI_PROP_FUNC_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            kind: node.kind,
+            func_unique_id: node.func_unique_id,
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn kind(&self) -> SiPropFuncSpecKind {
+        self.kind
+    }
+
+    pub fn func_unique_id(&self) -> FuncUniqueId {
+        self.func_unique_id
+    }
+
+    pub fn inputs(&self) -> PkgResult<Vec<SiPkgAttrFuncInput>> {
+        let mut inputs = vec![];
+
+        for idx in self
+            .source
+            .graph
+            .neighbors_directed(self.source.node_idx, Outgoing)
+        {
+            inputs.push(SiPkgAttrFuncInput::from_graph(self.source.graph, idx)?);
+        }
+
+        Ok(inputs)
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgSiPropFunc<'a>> for SiPropFuncSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgSiPropFunc<'a>) -> Result<Self, Self::Error> {
+        let mut builder = SiPropFuncSpec::builder();
+        for input in value.inputs()? {
+            builder.input(AttrFuncInputSpec::try_from(input)?);
+        }
+
+        Ok(builder
+            .kind(value.kind)
+            .func_unique_id(value.func_unique_id)
+            .build()?)
+    }
+}

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use super::{
     PkgResult, SiPkgCommandFunc, SiPkgError, SiPkgFuncDescription, SiPkgLeafFunction, SiPkgProp,
-    SiPkgSocket, SiPkgWorkflow, Source,
+    SiPkgSiPropFunc, SiPkgSocket, SiPkgWorkflow, Source,
 };
 
 use crate::{
@@ -120,6 +120,11 @@ impl<'a> SiPkgSchemaVariant<'a> {
         command_funcs,
         SchemaVariantChildNode::CommandFuncs,
         SiPkgCommandFunc
+    );
+    impl_variant_children_from_graph!(
+        si_prop_funcs,
+        SchemaVariantChildNode::SiPropFuncs,
+        SiPkgSiPropFunc
     );
 
     fn prop_stack_from_source<I>(
@@ -312,6 +317,10 @@ impl<'a> SiPkgSchemaVariant<'a> {
 
         for workflow in self.workflows()? {
             builder.workflow(workflow.try_into()?);
+        }
+
+        for si_prop_func in self.si_prop_funcs()? {
+            builder.si_prop_func(si_prop_func.try_into()?);
         }
 
         Ok(builder.build()?)

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -10,6 +10,7 @@ mod func_description;
 mod leaf_function;
 mod prop;
 mod schema;
+mod si_prop_func;
 mod socket;
 mod validation;
 mod variant;
@@ -17,7 +18,7 @@ mod workflow;
 
 pub use {
     attr_func_input::*, command_func::*, func::*, func_description::*, leaf_function::*, prop::*,
-    schema::*, socket::*, validation::*, variant::*, workflow::*,
+    schema::*, si_prop_func::*, socket::*, validation::*, variant::*, workflow::*,
 };
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]

--- a/lib/si-pkg/src/spec/si_prop_func.rs
+++ b/lib/si-pkg/src/spec/si_prop_func.rs
@@ -1,0 +1,51 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+
+use super::{AttrFuncInputSpec, FuncUniqueId, SpecError};
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    PartialEq,
+    Eq,
+    AsRefStr,
+    Display,
+    EnumIter,
+    EnumString,
+    Copy,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum SiPropFuncSpecKind {
+    Name,
+    Color,
+}
+
+impl SiPropFuncSpecKind {
+    pub fn prop_path(&self) -> Vec<&'static str> {
+        match self {
+            Self::Name => vec!["root", "si", "name"],
+            Self::Color => vec!["root", "si", "color"],
+        }
+    }
+}
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct SiPropFuncSpec {
+    #[builder(setter(into))]
+    pub kind: SiPropFuncSpecKind,
+    #[builder(setter(into))]
+    pub func_unique_id: FuncUniqueId,
+    #[builder(setter(each(name = "input"), into), default)]
+    pub inputs: Vec<AttrFuncInputSpec>,
+}
+
+impl SiPropFuncSpec {
+    pub fn builder() -> SiPropFuncSpecBuilder {
+        SiPropFuncSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use super::{
     CommandFuncSpec, FuncDescriptionSpec, LeafFunctionSpec, PropSpec, PropSpecWidgetKind,
-    SocketSpec, SpecError, WorkflowSpec,
+    SiPropFuncSpec, SocketSpec, SpecError, WorkflowSpec,
 };
 
 #[derive(
@@ -61,6 +61,9 @@ pub struct SchemaVariantSpec {
 
     #[builder(setter(each(name = "socket"), into), default)]
     pub sockets: Vec<SocketSpec>,
+
+    #[builder(setter(each(name = "si_prop_func"), into), default)]
+    pub si_prop_funcs: Vec<SiPropFuncSpec>,
 }
 
 impl SchemaVariantSpec {


### PR DESCRIPTION
Support packaging up functions that set the value of props in the `si` tree. Currently just: `/root/si/name` and `/root/si/color`