### PR TITLE
Use solely test exclusive schemas for "internal" integration tests (ENG-1367)

### DIFF
--- a/lib/dal-test/src/helpers/component_bag.rs
+++ b/lib/dal-test/src/helpers/component_bag.rs
@@ -122,6 +122,13 @@ impl ComponentBag {
             .expect("could not find prop")
     }
 
+    /// Generates a new [`ComponentView`] and returns it.
+    pub async fn component_view(&self, ctx: &DalContext) -> ComponentView {
+        ComponentView::new(ctx, self.component_id)
+            .await
+            .expect("cannot get component view")
+    }
+
     /// Generates a new [`ComponentView`] and returns [`ComponentViewProperties`].
     ///
     /// Use this over [`Self::component_view_properties_raw()`] if you'd like to drop certain

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -18,8 +18,9 @@ use crate::socket::SocketError;
 use crate::{
     ActionPrototypeError, AttributeContextBuilderError, AttributePrototypeArgumentError,
     AttributePrototypeError, AttributeReadContext, AttributeValueError, AttributeValueId,
-    DalContext, ExternalProviderId, FuncError, PropError, PropId, SchemaError, SchemaVariantId,
-    StandardModelError, TransactionsError, ValidationPrototypeError, WorkflowPrototypeError,
+    DalContext, ExternalProviderId, FuncError, InternalProviderId, PropError, PropId, SchemaError,
+    SchemaVariantId, StandardModelError, TransactionsError, ValidationPrototypeError,
+    WorkflowPrototypeError,
 };
 
 // Private builtins modules.
@@ -62,7 +63,9 @@ pub enum BuiltinsError {
     InternalProvider(#[from] InternalProviderError),
     #[error("missing attribute prototype for attribute value")]
     MissingAttributePrototypeForAttributeValue,
-    #[error("missing attribute prototype for external provider id: {0}")]
+    #[error("missing attribute prototype for explicit internal provider: {0}")]
+    MissingAttributePrototypeForExplicitInternalProvider(InternalProviderId),
+    #[error("missing attribute prototype for external provider: {0}")]
     MissingAttributePrototypeForExternalProvider(ExternalProviderId),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_fallout.json
@@ -1,13 +1,28 @@
 {
   "props": [
     {
+      "name": "name",
+      "kind": "string"
+    },
+    {
       "name": "special",
       "kind": "string"
+    },
+    {
+      "name": "rads",
+      "kind": "integer"
+    },
+    {
+      "name": "active",
+      "kind": "boolean"
     }
   ],
   "outputSockets": [
     {
       "name": "bethesda"
+    },
+    {
+      "name": "fallout"
     }
   ]
 }

--- a/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
+++ b/lib/dal/src/builtins/schema/definitions/test_exclusive_starfield.json
@@ -9,6 +9,10 @@
       "kind": "string"
     },
     {
+      "name": "attributes",
+      "kind": "string"
+    },
+    {
       "name": "universe",
       "kind": "object",
       "children": [
@@ -22,6 +26,10 @@
               {
                 "name": "sun",
                 "kind": "string"
+              },
+              {
+                "name": "planets",
+                "kind": "integer"
               }
             ]
           }
@@ -32,6 +40,9 @@
   "inputSockets": [
     {
       "name": "bethesda"
+    },
+    {
+      "name": "fallout"
     }
   ]
 }

--- a/lib/dal/src/func/backend/validation.rs
+++ b/lib/dal/src/func/backend/validation.rs
@@ -55,10 +55,14 @@ impl FuncBackend for FuncBackendValidation {
                 },
                 None => Some(value_must_be_present_error),
             },
+            Validation::IntegerIsNotEmpty { value} => match value {
+                Some(_value) => None,
+                None => Some(value_must_be_present_error),
+            },
             Validation::StringIsNotEmpty { value} => match value {
-                Some(value) => match !value.is_empty() {
-                    true => None,
-                    false => Some(value_must_be_present_error),
+                Some(value) => match value.is_empty() {
+                    true => Some(value_must_be_present_error),
+                    false => None,
                 },
                 None => Some(value_must_be_present_error),
             },

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -209,7 +209,7 @@ pub struct GenerateMenuItem {
 
 impl GenerateMenuItem {
     /// Generates raw items and initializes menu items as an empty vec.
-    pub async fn new(ctx: &DalContext) -> NodeMenuResult<Self> {
+    pub async fn new(ctx: &DalContext, include_ui_hidden: bool) -> NodeMenuResult<Self> {
         let mut item_list = Vec::new();
 
         // NOTE(nick): currently, we only generate ui menus for schemas.
@@ -221,7 +221,7 @@ impl GenerateMenuItem {
 
         for ui_menu in ui_menus.into_iter() {
             if let Some(schema) = ui_menu.schema(ctx).await? {
-                if schema.ui_hidden() {
+                if !include_ui_hidden && schema.ui_hidden() {
                     continue;
                 }
                 item_list.push((

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -834,6 +834,9 @@ async fn get_validations_for_prop(
                     spec_builder.upper_bound(upper_bound);
                     spec_builder.lower_bound(lower_bound);
                 }
+                Validation::IntegerIsNotEmpty { .. } => {
+                    spec_builder.kind(ValidationSpecKind::IntegerIsNotEmpty);
+                }
                 Validation::StringHasPrefix { expected, .. } => {
                     spec_builder.kind(ValidationSpecKind::StringHasPrefix);
                     spec_builder.expected_string(expected);

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -751,6 +751,9 @@ async fn create_prop_validation(
             lower_bound,
             upper_bound,
         }),
+        SiPkgValidation::IntegerIsNotEmpty { .. } => {
+            ValidationKind::Builtin(Validation::IntegerIsNotEmpty { value: None })
+        }
         SiPkgValidation::StringEquals { expected, .. } => {
             ValidationKind::Builtin(Validation::StringEquals {
                 value: None,

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -53,6 +53,8 @@ pub enum Validation {
         lower_bound: i64,
         upper_bound: i64,
     },
+    /// Validate that the "value" integer is not empty
+    IntegerIsNotEmpty { value: Option<i64> },
     /// Validate that the "value" string is the same as the expected string.
     StringEquals {
         value: Option<String>,
@@ -79,7 +81,7 @@ pub enum Validation {
     StringIsValidIpAddr { value: Option<String> },
     /// Validate that the "value" string is a Hex Color.
     StringIsHexColor { value: Option<String> },
-    /// Validate that the "value" is not empty
+    /// Validate that the "value" string is not empty
     StringIsNotEmpty { value: Option<String> },
 }
 
@@ -96,6 +98,9 @@ impl Validation {
                 value: Self::value_as_i64(value)?,
                 lower_bound,
                 upper_bound,
+            },
+            Validation::IntegerIsNotEmpty { value: _ } => Validation::IntegerIsNotEmpty {
+                value: Self::value_as_i64(value)?,
             },
             Validation::StringEquals { value: _, expected } => Validation::StringEquals {
                 value: Self::value_as_string(value)?,

--- a/lib/dal/tests/integration_test/internal/node_menu.rs
+++ b/lib/dal/tests/integration_test/internal/node_menu.rs
@@ -1,21 +1,20 @@
 use dal::{node_menu::GenerateMenuItem, DalContext};
-use dal_test::helpers::component_bag::ComponentBagger;
 use dal_test::test;
 
+/// Recommended to run with the following environment variable:
+/// ```shell
+/// SI_TEST_BUILTIN_SCHEMAS=test
+/// ```
 #[test]
 async fn get_node_menu(ctx: &DalContext) {
-    let mut bagger = ComponentBagger::new();
-    let _docker_image_bag = bagger.create_component(ctx, "valorant", "Docker Image");
+    let gmi = GenerateMenuItem::new(ctx, true)
+        .await
+        .expect("cannot get items");
+    let raw_items = gmi.raw_items;
 
-    let gmi = GenerateMenuItem::new(ctx).await.expect("cannot get items");
-    let items = gmi.raw_items;
-
-    let docker_image_item = items.iter().find(|(path, item)| {
+    let item = raw_items.iter().find(|(path, item)| {
         let mut path = path.clone();
-        item.name == "Image" && path.pop().expect("path not found") == "Docker"
+        item.name == "starfield" && path.pop().expect("path not found") == "test exclusive"
     });
-    assert!(
-        docker_image_item.is_some(),
-        "menu must include the docker image item"
-    );
+    assert!(item.is_some());
 }

--- a/lib/dal/tests/integration_test/internal/validation_prototype.rs
+++ b/lib/dal/tests/integration_test/internal/validation_prototype.rs
@@ -1,36 +1,23 @@
 use dal::{
     func::backend::validation::FuncBackendValidationArgs, validation::Validation, DalContext, Func,
-    Prop, Schema, StandardModel, ValidationPrototype, ValidationPrototypeContext,
+    StandardModel, ValidationPrototype, ValidationPrototypeContext,
 };
-use dal_test::{helpers::find_prop_and_parent_by_name, test};
+use dal_test::helpers::component_bag::ComponentBagger;
+use dal_test::test;
 
 #[test]
 async fn new(ctx: &DalContext) {
-    let schema = Schema::find_by_attr(ctx, "name", &"Docker Image".to_string())
-        .await
-        .expect("cannot find docker image")
-        .pop()
-        .expect("no docker image found");
-
-    let default_variant = schema
-        .default_variant(ctx)
-        .await
-        .expect("cannot find default variant");
-
-    let (prop_id, _) =
-        find_prop_and_parent_by_name(ctx, "image", "domain", None, *default_variant.id())
-            .await
-            .expect("could not find prop by name");
-    let prop = Prop::get_by_id(ctx, &prop_id)
-        .await
-        .expect("could not find prop by id")
-        .expect("prop not found by id");
+    let mut bagger = ComponentBagger::new();
+    let component_bag = bagger.create_component(ctx, "starfield", "starfield").await;
+    let prop = component_bag
+        .find_prop(ctx, &["root", "domain", "freestar"])
+        .await;
 
     let func_name = "si:validation".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
-        .expect("Error fetching builtin function");
-    let func = funcs.pop().expect("Missing builtin function si:validation");
+        .expect("error fetching builtin function");
+    let func = funcs.pop().expect("missing builtin function si:validation");
 
     let args = FuncBackendValidationArgs::new(Validation::StringEquals {
         value: Some("".to_string()),
@@ -42,7 +29,7 @@ async fn new(ctx: &DalContext) {
     let _validation_prototype = ValidationPrototype::new(
         ctx,
         *func.id(),
-        serde_json::to_value(&args).expect("Serialization failed"),
+        serde_json::to_value(&args).expect("serialization failed"),
         builder
             .to_context(ctx)
             .await
@@ -54,31 +41,17 @@ async fn new(ctx: &DalContext) {
 
 #[test]
 async fn find_for_prop(ctx: &DalContext) {
-    let schema = Schema::find_by_attr(ctx, "name", &"Docker Image".to_string())
-        .await
-        .expect("cannot find docker image")
-        .pop()
-        .expect("no docker image found");
-
-    let default_variant = schema
-        .default_variant(ctx)
-        .await
-        .expect("cannot find default variant");
-
-    let (prop_id, _) =
-        find_prop_and_parent_by_name(ctx, "image", "domain", None, *default_variant.id())
-            .await
-            .expect("could not find prop by name");
-    let prop = Prop::get_by_id(ctx, &prop_id)
-        .await
-        .expect("could not find prop by id")
-        .expect("prop not found by id");
+    let mut bagger = ComponentBagger::new();
+    let component_bag = bagger.create_component(ctx, "starfield", "starfield").await;
+    let prop = component_bag
+        .find_prop(ctx, &["root", "domain", "freestar"])
+        .await;
 
     let func_name = "si:validation".to_string();
     let mut funcs = Func::find_by_attr(ctx, "name", &func_name)
         .await
         .expect("Error fetching builtin function");
-    let func = funcs.pop().expect("Missing builtin function si:validation");
+    let func = funcs.pop().expect("missing builtin function si:validation");
 
     let first_args = FuncBackendValidationArgs::new(Validation::StringEquals {
         value: Some("".to_string()),

--- a/lib/sdf-server/src/server/service/diagram/get_node_add_menu.rs
+++ b/lib/sdf-server/src/server/service/diagram/get_node_add_menu.rs
@@ -23,7 +23,7 @@ pub async fn get_node_add_menu(
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     // NOTE(nick): return only configuration-related content at the moment.
-    let gmi = GenerateMenuItem::new(&ctx).await?;
+    let gmi = GenerateMenuItem::new(&ctx, false).await?;
     let response = gmi.create_menu_json()?;
 
     Ok(Json(response))

--- a/lib/si-pkg/src/node/validation.rs
+++ b/lib/si-pkg/src/node/validation.rs
@@ -95,7 +95,8 @@ impl WriteBytes for ValidationNode {
                     .map(|id| id.to_string())
                     .unwrap_or("".to_string()),
             )?,
-            ValidationSpecKind::StringIsValidIpAddr
+            ValidationSpecKind::IntegerIsNotEmpty
+            | ValidationSpecKind::StringIsValidIpAddr
             | ValidationSpecKind::StringIsHexColor
             | ValidationSpecKind::StringIsNotEmpty => {}
         }
@@ -152,7 +153,8 @@ impl ReadBytes for ValidationNode {
                 func_unique_id =
                     Some(FuncUniqueId::from_str(&func_unique_id_str).map_err(GraphError::parse)?);
             }
-            ValidationSpecKind::StringIsValidIpAddr
+            ValidationSpecKind::IntegerIsNotEmpty
+            | ValidationSpecKind::StringIsValidIpAddr
             | ValidationSpecKind::StringIsHexColor
             | ValidationSpecKind::StringIsNotEmpty => {}
         }
@@ -183,6 +185,10 @@ impl NodeChild for ValidationSpec {
                     kind: ValidationSpecKind::IntegerIsBetweenTwoIntegers,
                     upper_bound: Some(*upper_bound),
                     lower_bound: Some(*lower_bound),
+                    ..ValidationNode::default()
+                },
+                ValidationSpec::IntegerIsNotEmpty => ValidationNode {
+                    kind: ValidationSpecKind::IntegerIsNotEmpty,
                     ..ValidationNode::default()
                 },
                 ValidationSpec::StringEquals { expected } => ValidationNode {

--- a/lib/si-pkg/src/pkg/validation.rs
+++ b/lib/si-pkg/src/pkg/validation.rs
@@ -13,6 +13,10 @@ pub enum SiPkgValidation<'a> {
         hash: Hash,
         source: Source<'a>,
     },
+    IntegerIsNotEmpty {
+        hash: Hash,
+        source: Source<'a>,
+    },
     StringEquals {
         expected: String,
         hash: Hash,
@@ -79,6 +83,9 @@ impl<'a> SiPkgValidation<'a> {
                     hash,
                     source,
                 }
+            }
+            ValidationSpecKind::IntegerIsNotEmpty => {
+                SiPkgValidation::IntegerIsNotEmpty { hash, source }
             }
             ValidationSpecKind::StringEquals => SiPkgValidation::StringEquals {
                 expected: node
@@ -148,6 +155,9 @@ impl<'a> TryFrom<SiPkgValidation<'a>> for ValidationSpec {
                 builder.kind(ValidationSpecKind::IntegerIsBetweenTwoIntegers);
                 builder.lower_bound(lower_bound);
                 builder.upper_bound(upper_bound);
+            }
+            SiPkgValidation::IntegerIsNotEmpty { .. } => {
+                builder.kind(ValidationSpecKind::IntegerIsNotEmpty);
             }
             SiPkgValidation::StringEquals { expected, .. } => {
                 builder.kind(ValidationSpecKind::StringEquals);

--- a/lib/si-pkg/src/spec/validation.rs
+++ b/lib/si-pkg/src/spec/validation.rs
@@ -13,6 +13,7 @@ pub enum ValidationSpec {
         lower_bound: i64,
         upper_bound: i64,
     },
+    IntegerIsNotEmpty,
     StringEquals {
         expected: String,
     },
@@ -42,6 +43,7 @@ impl ValidationSpec {
 )]
 pub enum ValidationSpecKind {
     IntegerIsBetweenTwoIntegers,
+    IntegerIsNotEmpty,
     StringEquals,
     StringHasPrefix,
     StringInStringArray,
@@ -111,6 +113,7 @@ impl ValidationSpecBuilder {
                             .ok_or(UninitializedFieldError::from("lower_bound"))?,
                     }
                 }
+                ValidationSpecKind::IntegerIsNotEmpty => ValidationSpec::IntegerIsNotEmpty,
                 ValidationSpecKind::StringEquals => ValidationSpec::StringEquals {
                     expected: self
                         .expected_string


### PR DESCRIPTION
## Context

This PR ensures that we solely use test exclusive schemas for "internal" integration tests. This PR **does not** promise to cover every single usage of builtin schemas (e.g. scenario tests or `sdf` tests in general), but it does tackle the primary bulk of them. This should make things easier for packaging folks taking our builtin schemas and moving them to packages.

Tested by executing the following command:
`SI_TEST_BUILTIN_SCHEMAS=test cargo test --package dal --test integration integration_test::internal`.

## Snipped Commit Description

Primary changes:
- Add props and connections to output and input sockets for fallout and starfield schemas
- Add "IntegerIsNotEmpty" validation (used by test exclusive schema(s))

Secondary changes:
- Micro adjust and improve tests as needed (improved helper functions, better lookups, etc.)
- Remove unused helper functions
- Remove unneeded prop finding function

## GIF

<img src="https://media3.giphy.com/media/gFknnphRjemOzAoJsC/giphy.gif"/>