### PR TITLE
feat(dal, si-pkg): Support multiple prop trees in pkg

### DIFF
--- a/lib/dal/tests/integration_test/internal/pkg.rs
+++ b/lib/dal/tests/integration_test/internal/pkg.rs
@@ -47,14 +47,14 @@ async fn test_install_pkg(ctx: &DalContext) {
             SchemaVariantSpec::builder()
                 .name("Pig Bodine")
                 .color("baddad")
-                .prop(
+                .domain_prop(
                     PropSpec::builder()
                         .name("ImpolexG")
                         .kind(PropSpecKind::String)
                         .build()
                         .expect("able to make prop spec"),
                 )
-                .prop(
+                .domain_prop(
                     PropSpec::builder()
                         .name("TheZone")
                         .kind(PropSpecKind::String)
@@ -108,7 +108,7 @@ async fn test_install_pkg(ctx: &DalContext) {
                         .build()
                         .expect("able to make output socket"),
                 )
-                .prop(
+                .domain_prop(
                     PropSpec::builder()
                         .name("distress_jess")
                         .kind(PropSpecKind::Number)
@@ -123,7 +123,7 @@ async fn test_install_pkg(ctx: &DalContext) {
                         .build()
                         .expect("able to make prop spec"),
                 )
-                .prop(
+                .domain_prop(
                     PropSpec::builder()
                         .name("sixes_and_sevens")
                         .kind(PropSpecKind::Number)

--- a/lib/si-pkg/examples/si-pkg-json-to-fs.rs
+++ b/lib/si-pkg/examples/si-pkg-json-to-fs.rs
@@ -1,6 +1,6 @@
 use std::{env::args, fs};
 
-use si_pkg::{PkgSpec, SiPkg, SiPkgError, SiPkgProp};
+use si_pkg::{PkgSpec, SchemaVariantSpecPropRoot, SiPkg, SiPkgError, SiPkgProp};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,7 +22,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dbg!(&schema);
 
     for variant in schema.variants()? {
-        variant.visit_prop_tree(process_prop, None, &()).await?;
+        variant
+            .visit_prop_tree(SchemaVariantSpecPropRoot::Domain, process_prop, None, &())
+            .await?;
     }
 
     println!("--- Done.");

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -91,6 +91,11 @@
               "inputs": ["domain"]
             }
           ],
+          "resourceValue": {
+            "name": "value",
+            "kind": "object",
+            "entries": []
+          },
           "domain": {
             "name": "domain",
             "kind": "object",

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -14,9 +14,10 @@ pub use spec::{
     FuncSpecBackendKind, FuncSpecBackendResponseType, FuncUniqueId, LeafFunctionSpec,
     LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, PkgSpec, PkgSpecBuilder, PropSpec,
     PropSpecBuilder, PropSpecKind, PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder,
-    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SiPropFuncSpec,
-    SiPropFuncSpecBuilder, SiPropFuncSpecKind, SocketSpec, SocketSpecArity, SocketSpecKind,
-    SpecError, ValidationSpec, ValidationSpecKind, WorkflowSpec, WorkflowSpecBuilder,
+    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType,
+    SchemaVariantSpecPropRoot, SiPropFuncSpec, SiPropFuncSpecBuilder, SiPropFuncSpecKind,
+    SocketSpec, SocketSpecArity, SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind,
+    WorkflowSpec, WorkflowSpecBuilder,
 };
 
 #[cfg(test)]
@@ -139,7 +140,12 @@ mod tests {
         // Ensure we get the props
         let props: Mutex<Vec<String>> = Mutex::new(Vec::new());
         variant
-            .visit_prop_tree(prop_visitor, None, &props)
+            .visit_prop_tree(
+                SchemaVariantSpecPropRoot::Domain,
+                prop_visitor,
+                None,
+                &props,
+            )
             .await
             .expect("able to visit prop tree");
 

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -95,6 +95,9 @@ impl NodeChild for SchemaVariantSpec {
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(SchemaVariantChild::Domain(self.domain.clone()))
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(SchemaVariantChild::ResourceValue(
+                    self.resource_value.clone(),
+                )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(SchemaVariantChild::LeafFunctions(
                     self.leaf_functions.clone(),
                 )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -17,8 +17,9 @@ const VARIANT_CHILD_TYPE_COMMAND_FUNCS: &str = "command_funcs";
 const VARIANT_CHILD_TYPE_DOMAIN: &str = "domain";
 const VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS: &str = "func_descriptions";
 const VARIANT_CHILD_TYPE_LEAF_FUNCTIONS: &str = "leaf_functions";
-const VARIANT_CHILD_TYPE_SOCKETS: &str = "sockets";
+const VARIANT_CHILD_TYPE_RESOURCE_VALUE: &str = "resource_value";
 const VARIANT_CHILD_TYPE_SI_PROP_FUNCS: &str = "si_prop_funcs";
+const VARIANT_CHILD_TYPE_SOCKETS: &str = "sockets";
 const VARIANT_CHILD_TYPE_WORKFLOWS: &str = "workflows";
 
 const KEY_KIND_STR: &str = "kind";
@@ -30,8 +31,9 @@ pub enum SchemaVariantChild {
     Domain(PropSpec),
     FuncDescriptions(Vec<FuncDescriptionSpec>),
     LeafFunctions(Vec<LeafFunctionSpec>),
-    Sockets(Vec<SocketSpec>),
+    ResourceValue(PropSpec),
     SiPropFuncs(Vec<SiPropFuncSpec>),
+    Sockets(Vec<SocketSpec>),
     Workflows(Vec<WorkflowSpec>),
 }
 
@@ -41,8 +43,9 @@ pub enum SchemaVariantChildNode {
     Domain,
     FuncDescriptions,
     LeafFunctions,
-    Sockets,
+    ResourceValue,
     SiPropFuncs,
+    Sockets,
     Workflows,
 }
 
@@ -53,8 +56,9 @@ impl SchemaVariantChildNode {
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::FuncDescriptions => VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
-            Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
+            Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
             Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
+            Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
             Self::Workflows => VARIANT_CHILD_TYPE_WORKFLOWS,
         }
     }
@@ -67,8 +71,9 @@ impl NameStr for SchemaVariantChildNode {
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::FuncDescriptions => VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
-            Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
+            Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
             Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
+            Self::Sockets => VARIANT_CHILD_TYPE_SOCKETS,
             Self::Workflows => VARIANT_CHILD_TYPE_WORKFLOWS,
         }
     }
@@ -93,8 +98,9 @@ impl ReadBytes for SchemaVariantChildNode {
             VARIANT_CHILD_TYPE_DOMAIN => Self::Domain,
             VARIANT_CHILD_TYPE_FUNC_DESCRIPTIONS => Self::FuncDescriptions,
             VARIANT_CHILD_TYPE_LEAF_FUNCTIONS => Self::LeafFunctions,
-            VARIANT_CHILD_TYPE_SOCKETS => Self::Sockets,
+            VARIANT_CHILD_TYPE_RESOURCE_VALUE => Self::ResourceValue,
             VARIANT_CHILD_TYPE_SI_PROP_FUNCS => Self::SiPropFuncs,
+            VARIANT_CHILD_TYPE_SOCKETS => Self::Sockets,
             VARIANT_CHILD_TYPE_WORKFLOWS => Self::Workflows,
             invalid_kind => {
                 return Err(GraphError::parse_custom(format!(
@@ -131,6 +137,16 @@ impl NodeChild for SchemaVariantChild {
                     NodeKind::Tree,
                     Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::Domain),
                     vec![domain],
+                )
+            }
+            Self::ResourceValue(resource_value) => {
+                let resource_value = Box::new(resource_value.clone())
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>;
+
+                NodeWithChildren::new(
+                    NodeKind::Tree,
+                    Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::ResourceValue),
+                    vec![resource_value],
                 )
             }
             Self::FuncDescriptions(descriptions) => NodeWithChildren::new(

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -34,17 +34,17 @@ pub use {
 
 use crate::{
     node::{CategoryNode, PkgNode},
-    spec::{FuncSpec, PkgSpec, SpecError},
+    spec::{FuncSpec, PkgSpec, SchemaVariantSpecPropRoot, SpecError},
 };
 
 #[derive(Debug, Error)]
 pub enum SiPkgError {
     #[error("Package missing required category: {0}")]
     CategoryNotFound(&'static str),
-    #[error("could not find pkg node domain prop for variant with hash={0}")]
-    DomainPropNotFound(Hash),
+    #[error("could not find pkg node root prop {0} for variant with hash={1}")]
+    PropRootNotFound(SchemaVariantSpecPropRoot, Hash),
     #[error("found multiple pkg node domain props for variant with hash={0}")]
-    DomainPropMultipleFound(Hash),
+    PropRootMultipleFound(SchemaVariantSpecPropRoot, Hash),
     #[error(transparent)]
     Fs(#[from] FsError),
     #[error(transparent)]

--- a/lib/si-pkg/src/spec/si_prop_func.rs
+++ b/lib/si-pkg/src/spec/si_prop_func.rs
@@ -4,6 +4,10 @@ use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 
 use super::{AttrFuncInputSpec, FuncUniqueId, SpecError};
 
+/// SiPropFuncs track custom functions for for props created for all schema variants and not part
+/// of the domain tree (which varies for each variant). Currently these are the props under the
+/// /root/si Object and also some props in the resource Object that are also invariant across
+/// schema variants but which can have custom functions
 #[derive(
     Debug,
     Serialize,
@@ -21,6 +25,7 @@ use super::{AttrFuncInputSpec, FuncUniqueId, SpecError};
 pub enum SiPropFuncSpecKind {
     Name,
     Color,
+    ResourcePayload,
 }
 
 impl SiPropFuncSpecKind {
@@ -28,6 +33,7 @@ impl SiPropFuncSpecKind {
         match self {
             Self::Name => vec!["root", "si", "name"],
             Self::Color => vec!["root", "si", "color"],
+            Self::ResourcePayload => vec!["root", "resource", "payload"],
         }
     }
 }


### PR DESCRIPTION
Packages up the prop tree under /root/resource/value *if* it exists and creates the tree if the value prop exists on the schema variant after SchemaVariant::new. Also captures the function if any set on the /root/resource/payload prop.