### PR TITLE
chore(nix): add openssh to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
             pkg-config
             postgresql_14
             protobuf
+            openssh
             (rustToolchain.override {
               # This really should be augmenting the extensions, instead of
               # completely overriding them, but since we're not setting up


### PR DESCRIPTION
Until we remove the LD_LIBRARY_PATH change for OpenSSL we need to grab SSH from nix as well to support git-over-ssh