### PR TITLE
Remove openssl & LD_LIBRARY_PATH override from nix environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,6 @@
             nodePackagesWithPinnedNode.pnpm
             nodePackagesWithPinnedNode.typescript
             nodePackagesWithPinnedNode.typescript-language-server
-            openssl
             pgcli
             pkg-config
             postgresql_14
@@ -95,18 +94,6 @@
             # investigation with veritech on NixOS is recommended.
             pinnedNode
           ];
-          # This is awful, but necessary (until we find a better way) to
-          # be able to `cargo run` anything that compiles against
-          # openssl. Without this, ld is unable to find libssl.so.3 and
-          # libcrypto.so.3.
-          #
-          # If we were packaging this up as a flake, instead of only
-          # using nix for the development environment, we'd be using
-          # wrapProgram with something like
-          # `--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl ]}`
-          # to make sure the things we're compiling are always using the
-          # version of openssl they were compiled against.
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
         };
       });
 }


### PR DESCRIPTION
Now that we don't have a dependency on the `openssl-sys` crate, we no longer need to pull in `openssl`, and override the `LD_LIBRARY_PATH` to get our compiled binaries to be able to find the `openssl` libraries.

**NOTE**: This depends on @fnichol's #2185 PR.