### PR TITLE
chore(rust) Configure .editorconfig for Rust files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,12 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.rs]
+indent_style = space
+tab_width = 4
+insert_final_newline = true
+end_of_line = lf
+
 [*.sh]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
The previous .editorconfig was defaulting `*.rs` files to use the "global" config, which does not match the style currently used across our Rust files.