### PR TITLE
build: build bin/pinga with buck2

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -6,6 +6,11 @@ alias(
 )
 
 alias(
+    name = "pinga",
+    actual = "//bin/pinga:pinga",
+)
+
+alias(
     name = "sdf",
     actual = "//bin/sdf:sdf",
 )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ serde_url_params = "0.2.1"
 serde_with = "3.0.0"
 serde_yaml = "0.9.21"
 sodiumoxide = "0.2.7"
+stream-cancel = "0.8.1"
 strum = { version = "0.24.1", features = ["derive"] }
 tar = "0.4.38"
 tempfile = "3.5.0"

--- a/bin/pinga/BUCK
+++ b/bin/pinga/BUCK
@@ -1,0 +1,16 @@
+rust_binary(
+    name = "pinga",
+    edition = "2021",
+    deps = [
+        "//lib/pinga-server:pinga-server",
+        "//lib/telemetry-application-rs:telemetry-application",
+        "//third-party/rust:clap",
+        "//third-party/rust:color-eyre",
+        "//third-party/rust:tokio",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+    resources = {
+        "dev.encryption.key": "//lib/cyclone-server:dev.encryption.key",
+    },
+    visibility = ["PUBLIC"],
+)

--- a/bin/pinga/Cargo.toml
+++ b/bin/pinga/Cargo.toml
@@ -10,8 +10,8 @@ name = "pinga"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0.14", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = { version = "0.6.1" }
+clap = { workspace = true }
+color-eyre = { workspace = true }
 pinga-server = { path = "../../lib/pinga-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { workspace = true }

--- a/lib/pinga-server/BUCK
+++ b/lib/pinga-server/BUCK
@@ -1,0 +1,26 @@
+rust_library(
+    name = "pinga-server",
+    edition = "2021",
+    deps = [
+        "//lib/dal:dal",
+        "//lib/nats-subscriber:nats-subscriber",
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/si-data-pg:si-data-pg",
+        "//lib/si-settings:si-settings",
+        "//lib/telemetry-rs:telemetry",
+        "//lib/veritech-client:veritech-client",
+        "//third-party/rust:derive_builder",
+        "//third-party/rust:futures",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:stream-cancel",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-stream",
+        "//third-party/rust:ulid",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+    visibility = ["PUBLIC"],
+)

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -7,18 +7,18 @@ publish = false
 
 [dependencies]
 dal = { path = "../../lib/dal" }
-derive_builder = { version = "0.12" }
-futures = "0.3"
+derive_builder = { workspace = true }
+futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-settings = { path = "../../lib/si-settings" }
-stream-cancel = "0.8.1"
+stream-cancel = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
-thiserror = { version = "1.0" }
-tokio = { version = "1.12.0", features = ["full"] }
-tokio-stream = "0.1.12"
-ulid = { version = "1.0.0", features = ["serde"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+ulid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
@@ -12,7 +15,7 @@ pub use dal::CycloneKeyPair;
 pub use si_settings::{StandardConfig, StandardConfigFile};
 use ulid::Ulid;
 
-const CONCURRENCY_DEFAULT: usize = 50;
+const DEFAULT_CONCURRENCY_LIMIT: usize = 50;
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -20,8 +23,16 @@ pub enum ConfigError {
     Builder(#[from] ConfigBuilderError),
     #[error(transparent)]
     CanonicalFile(#[from] CanonicalFileError),
+    #[error("error configuring for development")]
+    Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
     #[error(transparent)]
     Settings(#[from] si_settings::SettingsError),
+}
+
+impl ConfigError {
+    fn development(err: impl std::error::Error + 'static + Sync + Send) -> Self {
+        Self::Development(Box::new(err))
+    }
 }
 
 type Result<T> = std::result::Result<T, ConfigError>;
@@ -36,7 +47,7 @@ pub struct Config {
 
     cyclone_encryption_key_path: CanonicalFile,
 
-    #[builder(default = "CONCURRENCY_DEFAULT")]
+    #[builder(default = "default_concurrency_limit()")]
     concurrency: usize,
 
     #[builder(default = "random_instance_id()")]
@@ -84,37 +95,25 @@ impl Config {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConfigFile {
+    #[serde(default)]
     pg: PgPoolConfig,
+    #[serde(default)]
     nats: NatsConfig,
+    #[serde(default = "default_cyclone_encryption_key_path")]
     cyclone_encryption_key_path: String,
+    #[serde(default = "default_concurrency_limit")]
     concurrency_limit: usize,
+    #[serde(default = "random_instance_id")]
     instance_id: String,
 }
 
 impl Default for ConfigFile {
     fn default() -> Self {
-        let mut cyclone_encryption_key_path = "/run/pinga/cyclone_encryption.key".to_string();
-
-        // TODO(fnichol): okay, this goes away/changes when we determine where the key would be by
-        // default, etc.
-        if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
-            // In development we just take the keys cyclone is using (it needs both public and secret)
-            // The dal integration tests will also need it
-            cyclone_encryption_key_path = Path::new(&dir)
-                .join("../../lib/cyclone-server/src/dev.encryption.key")
-                .to_string_lossy()
-                .to_string();
-            warn!(
-                cyclone_encryption_key_path = cyclone_encryption_key_path.as_str(),
-                "detected cargo run, setting *default* key paths from sources"
-            );
-        }
-
         Self {
             pg: Default::default(),
             nats: Default::default(),
-            cyclone_encryption_key_path,
-            concurrency_limit: CONCURRENCY_DEFAULT,
+            cyclone_encryption_key_path: default_cyclone_encryption_key_path(),
+            concurrency_limit: default_concurrency_limit(),
             instance_id: random_instance_id(),
         }
     }
@@ -127,7 +126,9 @@ impl StandardConfigFile for ConfigFile {
 impl TryFrom<ConfigFile> for Config {
     type Error = ConfigError;
 
-    fn try_from(value: ConfigFile) -> Result<Self> {
+    fn try_from(mut value: ConfigFile) -> Result<Self> {
+        detect_and_configure_development(&mut value)?;
+
         let mut config = Config::builder();
         config.pg_pool(value.pg);
         config.nats(value.nats);
@@ -139,4 +140,160 @@ impl TryFrom<ConfigFile> for Config {
 
 fn random_instance_id() -> String {
     Ulid::new().to_string()
+}
+
+fn default_cyclone_encryption_key_path() -> String {
+    "/run/pinga/cyclone_encryption.key".to_string()
+}
+
+fn default_concurrency_limit() -> usize {
+    DEFAULT_CONCURRENCY_LIMIT
+}
+
+fn detect_and_configure_development(
+    config: &mut ConfigFile,
+) -> std::result::Result<(), ConfigError> {
+    if std::env::var("BUCK_RUN_BUILD_ID").is_ok() {
+        buck2_development(config)
+    } else if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        cargo_development(dir, config)
+    } else {
+        Ok(())
+    }
+}
+
+fn buck2_development(config: &mut ConfigFile) -> std::result::Result<(), ConfigError> {
+    let resources = Buck2Resources::read()?;
+
+    let cyclone_encryption_key_path = resources
+        .get("bin/pinga/dev.encryption.key")?
+        .to_string_lossy()
+        .to_string();
+
+    warn!(
+        cyclone_encryption_key_path = cyclone_encryption_key_path.as_str(),
+        "detected development run",
+    );
+
+    config.cyclone_encryption_key_path = cyclone_encryption_key_path;
+
+    Ok(())
+}
+
+fn cargo_development(dir: String, config: &mut ConfigFile) -> std::result::Result<(), ConfigError> {
+    let cyclone_encryption_key_path = Path::new(&dir)
+        .join("../../lib/cyclone-server/src/dev.encryption.key")
+        .to_string_lossy()
+        .to_string();
+
+    warn!(
+        cyclone_encryption_key_path = cyclone_encryption_key_path.as_str(),
+        "detected development run",
+    );
+
+    config.cyclone_encryption_key_path = cyclone_encryption_key_path;
+
+    Ok(())
+}
+
+// TODO(fnichol): extract Buck2 resource code into small common crate
+#[derive(Debug, Error)]
+enum Buck2ResourcesError {
+    #[error("failed canonicalize path: `{path}`")]
+    Canonicalize {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+    #[error("failed to look up our own executable path")]
+    NoCurrentExe { source: std::io::Error },
+    #[error("executable doesn't have a filename: `{executable_path}`")]
+    NoFileName { executable_path: PathBuf },
+    #[error("failed to find parent directory of executable: `{executable_path}`")]
+    NoParentDir { executable_path: PathBuf },
+    #[error("no resource named `{name}` found in manifest file: `{manifest_path}`")]
+    NoSuchResource {
+        name: String,
+        manifest_path: PathBuf,
+    },
+    #[error("Failed to parse manifest file: `{manifest_path}`")]
+    ParsingFailed {
+        manifest_path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("Failed to read manifest file: `{manifest_path}`")]
+    ReadFailed {
+        manifest_path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+// TODO(fnichol): extract Buck2 resource code into small common crate
+struct Buck2Resources {
+    inner: HashMap<String, PathBuf>,
+    parent_dir: PathBuf,
+    manifest_path: PathBuf,
+}
+
+impl Buck2Resources {
+    fn read() -> std::result::Result<Self, ConfigError> {
+        let executable_path = std::env::current_exe().map_err(|source| {
+            ConfigError::development(Buck2ResourcesError::NoCurrentExe { source })
+        })?;
+        let parent_dir = match executable_path.parent() {
+            Some(p) => p,
+            None => {
+                return Err(ConfigError::development(Buck2ResourcesError::NoParentDir {
+                    executable_path,
+                }))
+            }
+        };
+        let file_name = match executable_path.file_name() {
+            Some(f) => f,
+            None => {
+                return Err(ConfigError::development(Buck2ResourcesError::NoFileName {
+                    executable_path,
+                }))
+            }
+        };
+        let manifest_path =
+            parent_dir.join(format!("{}.resources.json", file_name.to_string_lossy()));
+        let manifest_string = match std::fs::read_to_string(&manifest_path) {
+            Ok(s) => s,
+            Err(source) => {
+                return Err(ConfigError::development(Buck2ResourcesError::ReadFailed {
+                    manifest_path,
+                    source,
+                }))
+            }
+        };
+        let inner: HashMap<String, PathBuf> =
+            serde_json::from_str(&manifest_string).map_err(|source| {
+                ConfigError::development(Buck2ResourcesError::ParsingFailed {
+                    manifest_path: manifest_path.clone(),
+                    source,
+                })
+            })?;
+
+        Ok(Self {
+            inner,
+            parent_dir: parent_dir.to_path_buf(),
+            manifest_path,
+        })
+    }
+
+    fn get(&self, name: impl AsRef<str>) -> std::result::Result<PathBuf, ConfigError> {
+        let rel_path = self.inner.get(name.as_ref()).ok_or_else(|| {
+            ConfigError::development(Buck2ResourcesError::NoSuchResource {
+                name: name.as_ref().to_string(),
+                manifest_path: self.manifest_path.clone(),
+            })
+        })?;
+
+        let path = self.parent_dir.join(rel_path);
+        let path = path.canonicalize().map_err(|source| {
+            ConfigError::development(Buck2ResourcesError::Canonicalize { source, path })
+        })?;
+
+        Ok(path)
+    }
 }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -12893,6 +12893,31 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "stream-cancel",
+    actual = ":stream-cancel-0.8.1",
+    visibility = ["PUBLIC"],
+)
+
+cargo.rust_library(
+    name = "stream-cancel-0.8.1",
+    srcs = [
+        "vendor/stream-cancel-0.8.1/src/combinator.rs",
+        "vendor/stream-cancel-0.8.1/src/lib.rs",
+        "vendor/stream-cancel-0.8.1/src/wrapper.rs",
+    ],
+    crate = "stream_cancel",
+    crate_root = "vendor/stream-cancel-0.8.1/src/lib.rs",
+    edition = "2018",
+    rustc_flags = ["--cap-lints=allow"],
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.28",
+        ":pin-project-1.0.12",
+        ":tokio-1.28.0",
+    ],
+)
+
 cargo.rust_library(
     name = "stringprep-0.1.2",
     srcs = [
@@ -13412,6 +13437,7 @@ cargo.rust_binary(
         ":serde_with-3.0.0",
         ":serde_yaml-0.9.21",
         ":sodiumoxide-0.2.7",
+        ":stream-cancel-0.8.1",
         ":strum-0.24.1",
         ":tar-0.4.38",
         ":tempfile-3.5.0",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -3406,6 +3406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stream-cancel"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,6 +3612,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sodiumoxide",
+ "stream-cancel",
  "strum",
  "tar",
  "tempfile",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -77,6 +77,7 @@ serde_url_params = "0.2.1"
 serde_with = "3.0.0"
 serde_yaml = "0.9.21"
 sodiumoxide = "0.2.7"
+stream-cancel = "0.8.1"
 strum = { version = "0.24.1", features = ["derive"] }
 tar = "0.4.38"
 tempfile = "3.5.0"


### PR DESCRIPTION
This change adds Buck2 build and run support to `bin/pinga` so that a developer can run the following:

```sh
buck2 run //bin/pinga
```