### PR TITLE
fix(nix) Remove git/ssh from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,6 @@
             coreutils
             docker-compose
             gcc
-            git
             gnumake
             jq
             libtool
@@ -72,7 +71,6 @@
             pkg-config
             postgresql_14
             protobuf
-            openssh
             (rustToolchain.override {
               # This really should be augmenting the extensions, instead of
               # completely overriding them, but since we're not setting up


### PR DESCRIPTION
While git is currently needed to build the sdf service, having it in the flake causes issues on (at least) macOS. We also needed to pull in (open)ssh to get around a linking issue when using the repo cloned over `ssh://`. When (open)ssh is pulled in, it can't handle when people have used the `UseKeychain` directive that the ssh shipped on macOS uses.

Neither of these issues appear when the repo has been cloned via `https://`, but we don't want to force everyone to have to use `https://` to clone the repo. This does mean that we won't be able to build things in a "pure" environment, however we're likely changing how things are going to be built, and would need to handle that anyway.