### PR TITLE
chore(buck2) Ignore BUCK files inside of third-party dependencies

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -14,4 +14,4 @@ buck = none
 target_platform_detector_spec = target:root//...->prelude//platforms:default
 
 [project]
-ignore = .git
+ignore = .git, third-party/rust/.cargo/**/BUCK, third-party/rust/vendor/**/BUCK


### PR DESCRIPTION
At least one of our Rust third-party dependencies uses buck2 itself to build & release. Unfortunately, this file is not compatible with our buck2 config, and we are not using it to build that dependency. When doing `buck2 targets //...`, we run into an error when it is trying to parse the `BUCK` files under `third-party/rust/.cargo`, and `third-party/rust/vendor`.

Since we're never using those `BUCK` files, we are now ignoring any `BUCK` files under those paths, and removing the possibility of them breaking our setup accidentally.