### PR TITLE
build(third-party): update `third-party/rust/Cargo.lock`

### DIFF
--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -3559,7 +3559,7 @@ dependencies = [
  "sodiumoxide",
  "stream-cancel",
  "strum",
- "syn 2.0.15",
+ "syn 2.0.16",
  "tar",
  "tempfile",
  "test-log",


### PR DESCRIPTION
I suspect the lock file wasn't updated in the Rust dependencies PR, resulting in a small churn when I ran `reindeer --third-party-dir third-party/rust vendor`.