### PR TITLE
feat(dal,web,sdf-server): Edit and save confirmation descriptions

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -136,7 +136,8 @@ import {
   VButton,
   VormInput,
   RequestStatusMessage,
-  Modal, ErrorMessage,
+  Modal,
+  ErrorMessage,
 } from "@si/vue-lib/design-system";
 import { useAssetStore } from "@/store/asset.store";
 

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -41,10 +41,10 @@ import {
   VButton,
   RequestStatusMessage,
 } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
 import SiSearch from "@/components/SiSearch.vue";
 import { useAssetStore } from "@/store/asset.store";
 import AssetListItem from "./AssetListItem.vue";
-import {useRouter} from "vue-router";
 
 const assetStore = useAssetStore();
 const router = useRouter();
@@ -68,7 +68,7 @@ const newAsset = async () => {
       name: "workspace-lab-assets",
       params: {
         ...router.currentRoute.value.params,
-        'assetId': result.result.data.id,
+        assetId: result.result.data.id,
       },
     });
   }

--- a/app/web/src/components/FuncEditor/ConfirmationDescriptionModal.vue
+++ b/app/web/src/components/FuncEditor/ConfirmationDescriptionModal.vue
@@ -1,0 +1,169 @@
+<template>
+  <Modal
+    ref="descriptionsModalRef"
+    title="Edit Confirmation Descriptions"
+    type="save"
+    save-label="Save descriptions"
+    @save="saveDescriptions"
+  >
+    <Stack spacing="sm">
+      <VormInput
+        v-if="schemaVariants.length > 0"
+        v-model="selectedVariant"
+        label="Asset Type"
+        type="dropdown"
+        class="flex-1"
+        :options="schemaVariants"
+      />
+      <div v-else>No schema variants configured for this confirmation.</div>
+
+      <Stack v-if="editingFuncDescriptions[selectedVariant]" spacing="sm">
+        <VormInput
+          v-model="editingName"
+          label="Name"
+          required
+          placeholder="The name of this confirmation..."
+        />
+        <VormInput
+          v-model="editingProvider"
+          label="Provider"
+          required
+          placeholder="The cloud provider used by this confirmation..."
+        />
+        <VormInput
+          v-model="editingSuccessDescription"
+          label="Success Description"
+          type="textarea"
+          placeholder="The message to display when this confirmation succeeds..."
+        />
+        <VormInput
+          v-model="editingFailureDescription"
+          label="Failure Description"
+          type="textarea"
+          placeholder="The message to display when this confirmation fails..."
+        />
+      </Stack>
+    </Stack>
+  </Modal>
+</template>
+
+<script lang="ts" setup>
+import { computed, toRef, ref, watch } from "vue";
+import { VormInput, Stack, Modal, useModal } from "@si/vue-lib/design-system";
+import { FuncDescriptionView } from "@/store/func/types";
+import { nilId } from "@/utils/nilId";
+
+const props = defineProps<{
+  schemaVariants: { label: string; value: string | number | object }[];
+  modelValue: FuncDescriptionView[];
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: FuncDescriptionView[]): void;
+  (e: "change", v: FuncDescriptionView[]): void;
+}>();
+
+const descriptionsModalRef = ref<InstanceType<typeof Modal>>();
+
+const { open: openModal, close } = useModal(descriptionsModalRef);
+
+const open = () => {
+  openModal();
+};
+
+defineExpose({ open, close });
+
+const schemaVariants = toRef(props, "schemaVariants", []);
+const modelValue = toRef(props, "modelValue", []);
+const selectedVariant = ref<string>(
+  typeof schemaVariants.value?.[0]?.value === "string"
+    ? schemaVariants.value?.[0]?.value ?? ""
+    : "",
+);
+
+const funcDescriptions = computed(() => {
+  const descriptionsBySvId: { [key: string]: FuncDescriptionView } = {};
+
+  for (const sv of schemaVariants.value) {
+    const { label, value } = sv;
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const desc = modelValue.value.find((descView) => {
+      return descView.schemaVariantId === value;
+    }) ?? {
+      id: nilId(),
+      schemaVariantId: value,
+      contents: {
+        Confirmation: {
+          name: label,
+          success_description: "",
+          failure_description: "",
+          provider: "",
+        },
+      },
+    };
+
+    descriptionsBySvId[value] = desc;
+  }
+
+  return descriptionsBySvId;
+});
+
+const editingName = ref<string>("");
+const editingProvider = ref<string>("");
+const editingSuccessDescription = ref<string>("");
+const editingFailureDescription = ref<string>("");
+
+const editingFuncDescriptions = ref(funcDescriptions);
+
+const saveCurrentDescription = (svId: string) => {
+  const description = editingFuncDescriptions.value[svId];
+  if (description) {
+    description.contents.Confirmation = {
+      name: editingName.value,
+      provider: editingProvider.value ?? "",
+      success_description: editingSuccessDescription.value ?? "",
+      failure_description: editingFailureDescription.value ?? "",
+    };
+
+    editingFuncDescriptions.value[svId] = description;
+  }
+};
+
+watch(
+  selectedVariant,
+  (sv, prevSv) => {
+    if (typeof sv !== "string") {
+      return;
+    }
+
+    if (typeof prevSv === "string") {
+      saveCurrentDescription(prevSv);
+    }
+
+    const selectedDescription = editingFuncDescriptions.value[sv];
+    if (!selectedDescription) {
+      return;
+    }
+
+    editingName.value = selectedDescription.contents.Confirmation.name;
+    editingProvider.value =
+      selectedDescription.contents.Confirmation.provider ?? "";
+    editingSuccessDescription.value =
+      selectedDescription.contents.Confirmation.success_description ?? "";
+    editingFailureDescription.value =
+      selectedDescription.contents.Confirmation.failure_description ?? "";
+  },
+  { immediate: true },
+);
+
+const saveDescriptions = () => {
+  saveCurrentDescription(selectedVariant.value);
+  const newDescriptions = Object.values(editingFuncDescriptions.value);
+  emit("update:modelValue", newDescriptions);
+  emit("change", newDescriptions);
+  close();
+};
+</script>

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -14,10 +14,27 @@ export interface CodeGenerationAssociations {
   componentIds: string[];
 }
 
+export interface ConfirmationFuncDescriptionContents {
+  name: string;
+  success_description?: string;
+  failure_description?: string;
+  provider?: string;
+}
+
+export interface FuncDescriptionContents {
+  Confirmation: ConfirmationFuncDescriptionContents;
+}
+
+export interface FuncDescriptionView {
+  schemaVariantId: string;
+  contents: FuncDescriptionContents;
+}
+
 export interface ConfirmationAssociations {
   type: "confirmation";
   schemaVariantIds: string[];
   componentIds: string[];
+  descriptions: FuncDescriptionView[];
 }
 
 export interface QualificationAssociations {

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -170,8 +170,8 @@ async fn build_func_description_specs(
 
     for func_description in FuncDescription::list_for_schema_variant(ctx, variant_id).await? {
         let func_spec = func_specs
-            .get(&func_description.func_id())
-            .ok_or(PkgError::MissingExportedFunc(func_description.func_id()))?;
+            .get(func_description.func_id())
+            .ok_or(PkgError::MissingExportedFunc(*func_description.func_id()))?;
 
         specs.push(
             FuncDescriptionSpec::builder()

--- a/lib/dal/tests/integration_test/internal/func/description.rs
+++ b/lib/dal/tests/integration_test/internal/func/description.rs
@@ -24,15 +24,15 @@ async fn new(ctx: &DalContext) {
         .await
         .expect("could not create description");
 
-    assert_eq!(func_id, description.func_id());
-    assert_eq!(*schema_variant.id(), description.schema_variant_id());
+    assert_eq!(func_id, *description.func_id());
+    assert_eq!(schema_variant.id(), description.schema_variant_id());
     assert_eq!(
         contents,
         description
             .deserialized_contents()
             .expect("could not deserialize contents")
     );
-    assert_eq!(contents.response_type(), description.response_type());
+    assert_eq!(contents.response_type(), *description.response_type());
     assert_eq!(contents.response_type(), response_type);
 }
 

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -4,11 +4,11 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use super::ValidationPrototypeView;
 use super::{
     AttributePrototypeArgumentView, AttributePrototypeView, FuncArgumentView, FuncAssociations,
     FuncError, FuncResult,
 };
+use super::{FuncDescriptionView, ValidationPrototypeView};
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
 use dal::{
@@ -21,7 +21,7 @@ use dal::{
     DalContext, Func, FuncBackendKind, FuncBinding, FuncId, InternalProviderId, Prop,
     SchemaVariantId, StandardModel, Visibility, WsEvent,
 };
-use dal::{FuncBackendResponseType, PropKind, SchemaVariant, ValidationPrototype};
+use dal::{FuncBackendResponseType, FuncDescription, PropKind, SchemaVariant, ValidationPrototype};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -327,6 +327,45 @@ async fn attribute_view_for_leaf_func(
     Ok(prototype_view)
 }
 
+async fn save_func_descriptions(
+    ctx: &DalContext,
+    func: &Func,
+    descriptions: Vec<FuncDescriptionView>,
+) -> FuncResult<()> {
+    let mut id_set = HashSet::new();
+
+    for desc in descriptions {
+        match FuncDescription::find_for_func_and_schema_variant(
+            ctx,
+            *func.id(),
+            desc.schema_variant_id,
+        )
+        .await?
+        {
+            Some(mut func_desc) => {
+                func_desc
+                    .set_deserialized_contents(ctx, desc.contents)
+                    .await?;
+                id_set.insert(*func_desc.id());
+            }
+            None => {
+                let new_func_desc =
+                    FuncDescription::new(ctx, *func.id(), desc.schema_variant_id, desc.contents)
+                        .await?;
+                id_set.insert(*new_func_desc.id());
+            }
+        }
+    }
+
+    for mut desc in FuncDescription::list_for_func(ctx, *func.id()).await? {
+        if !id_set.contains(desc.id()) {
+            desc.delete_by_id(ctx).await?;
+        }
+    }
+
+    Ok(())
+}
+
 async fn save_leaf_prototypes(
     ctx: &DalContext,
     func: &Func,
@@ -575,6 +614,7 @@ pub async fn do_save_func(
                 if let Some(FuncAssociations::Confirmation {
                     schema_variant_ids,
                     component_ids,
+                    descriptions,
                 }) = request.associations
                 {
                     save_leaf_prototypes(
@@ -585,6 +625,8 @@ pub async fn do_save_func(
                         LeafKind::Confirmation,
                     )
                     .await?;
+
+                    save_func_descriptions(ctx, &func, descriptions).await?;
                 }
             }
             FuncBackendResponseType::Qualification => {
@@ -685,6 +727,7 @@ pub async fn save_func<'a>(
         | Some(FuncAssociations::Confirmation {
             component_ids,
             schema_variant_ids,
+            ..
         }) => (component_ids, schema_variant_ids),
         _ => (vec![], vec![]),
     };


### PR DESCRIPTION
Allows editing the "FuncDescription" table for confirmations, so you can set the "success" and "failure" descriptions. 