### PR TITLE
build(pnpm): explicitly list workspace members

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,8 +461,6 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
-  bin/council: {}
-
   bin/lang-js:
     dependencies:
       '@typescript/vfs':
@@ -541,12 +539,6 @@ importers:
       ts-jest:
         specifier: ^27.1.4
         version: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@4.9.5)
-
-  bin/pinga: {}
-
-  bin/sdf: {}
-
-  bin/veritech: {}
 
   lib/eslint-config:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,10 @@
+---
 packages:
-  # frontend
-  - 'app/*'
-
-  # backend
-  - 'bin/*'
-  - 'lib/*'
-
-  - '!bin/si-discord-bot' # TODO - fix this
+  - app/auth-portal
+  - app/web
+  - bin/auth-api
+  - bin/lang-js
+  - lib/eslint-config
+  - lib/ts-lib
+  - lib/tsconfig
+  - lib/vue-lib


### PR DESCRIPTION
This change completely removes references to Rust crate components such as `bin/council` from the pnpm lock file. Prior to this change, several symlinks were still being created under `node_modules/` containing a `BUCK` file, and thus causing Buck2 to attempt to build a related package.