### PR TITLE
chore(dal,sdf-server): use PropPath type to remove manual joins and splits by PROP_PATH_SEPARATOR

### DIFF
--- a/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
@@ -77,7 +77,7 @@ impl MigrationDriver {
                                 AttrFuncInputSpec::builder()
                                     .kind(AttrFuncInputSpecKind::Prop)
                                     .name("identity")
-                                    .prop_path(PropPath::new(&["root", "si", "name"]))
+                                    .prop_path(PropPath::new(["root", "si", "name"]))
                                     .build()?,
                             )
                             .build()?,
@@ -122,7 +122,7 @@ impl MigrationDriver {
                                 AttrFuncInputSpec::builder()
                                     .name("identity")
                                     .kind(AttrFuncInputSpecKind::Prop)
-                                    .prop_path(PropPath::new(&["root", "domain", "special"]))
+                                    .prop_path(PropPath::new(["root", "domain", "special"]))
                                     .build()?,
                             )
                             .build()?,
@@ -136,7 +136,7 @@ impl MigrationDriver {
                                 AttrFuncInputSpec::builder()
                                     .name("identity")
                                     .kind(AttrFuncInputSpecKind::Prop)
-                                    .prop_path(PropPath::new(&["root"]))
+                                    .prop_path(PropPath::new(["root"]))
                                     .build()?,
                             )
                             .build()?,

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -128,7 +128,7 @@ impl MigrationDriver {
                                 AttrFuncInputSpec::builder()
                                     .kind(AttrFuncInputSpecKind::Prop)
                                     .name("identity")
-                                    .prop_path(PropPath::new(&["root", "si", "name"]))
+                                    .prop_path(PropPath::new(["root", "si", "name"]))
                                     .build()?,
                             )
                             .build()?,

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -862,7 +862,8 @@ async fn create_attribute_function(
 
         match input {
             SiPkgAttrFuncInputView::Prop { prop_path, .. } => {
-                let prop = Prop::find_prop_by_raw_path(ctx, schema_variant_id, &prop_path).await?;
+                let prop =
+                    Prop::find_prop_by_path(ctx, schema_variant_id, &prop_path.into()).await?;
                 let prop_ip = InternalProvider::find_for_prop(ctx, *prop.id())
                     .await?
                     .ok_or(PkgError::MissingInternalProviderForProp(*prop.id()))?;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::attribute::context::AttributeContextBuilder;
 use crate::func::binding_return_value::FuncBindingReturnValueError;
-use crate::prop::PROP_PATH_SEPARATOR;
+use crate::prop::PropPath;
 use crate::provider::internal::InternalProviderError;
 use crate::schema::variant::definition::SchemaVariantDefinitionError;
 use crate::schema::variant::root_prop::component_type::ComponentType;
@@ -743,9 +743,7 @@ impl SchemaVariant {
         schema_variant_id: SchemaVariantId,
         path: &[&str],
     ) -> SchemaVariantResult<Prop> {
-        let path = path.join(PROP_PATH_SEPARATOR);
-
-        match Prop::find_prop_by_raw_path(ctx, schema_variant_id, &path).await {
+        match Prop::find_prop_by_path(ctx, schema_variant_id, &PropPath::new(path)).await {
             Ok(prop) => Ok(prop),
             Err(PropError::NotFoundAtPath(path, visiblity)) => Err(
                 SchemaVariantError::PropNotFoundAtPath(schema_variant_id, path, visiblity),

--- a/lib/sdf-server/src/server/service/component/resource_domain_diff.rs
+++ b/lib/sdf-server/src/server/service/component/resource_domain_diff.rs
@@ -2,7 +2,6 @@ use axum::{extract::Query, Json};
 use dal::func::backend::js_reconciliation::{
     ReconciliationDiff, ReconciliationDiffDomain, ReconciliationResult,
 };
-use dal::prop::PROP_PATH_SEPARATOR;
 use dal::{
     AttributeReadContext, AttributeValue, AttributeView, Component, ComponentId,
     ExternalProviderId, Func, FuncBinding, FuncError, InternalProviderId, Prop,
@@ -132,7 +131,7 @@ pub async fn get_diff(
                 // TODO: Should we treat unset as equal or not?
                 if diff_value.diff {
                     diff.insert(
-                        prop.path().clone().replace(PROP_PATH_SEPARATOR, "/"),
+                        prop.path().with_replaced_sep("/"),
                         ReconciliationDiff {
                             normalized_resource: diff_value.new_value,
                             resource: resource_prop_view.value().clone(),
@@ -144,7 +143,7 @@ pub async fn get_diff(
                     );
                 }
             } else {
-                warn!("Prop {} does not have diff functions set, therefore can't be diffed with prop {domain_prop_id:?}", prop.path());
+                warn!("Prop {} does not have diff functions set, therefore can't be diffed with prop {domain_prop_id:?}", prop.path().as_str());
             }
         }
 


### PR DESCRIPTION
We're doing a lot of joining/splitting by PROP_PATH_SEPARATOR in various places. This should make using PropPaths split by the vertical tab more ergonomic. Could probably be reworked to use fewer allocations.