### PR TITLE
feat(object-tree,si-pkg): support multiline values

### DIFF
--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -1,7 +1,7 @@
 {
   "name": "complex",
   "version": "12.11.0",
-  "description": "complex things",
+  "description": "complex\nthings\nwith\nmultiple\nlines",
   "createdAt": "2023-02-28T00:19:25Z",
   "createdBy": "fnichol",
   "funcs": [

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -61,6 +61,7 @@ mod tests {
     #[tokio::test]
     async fn pkg_fs_round_trip() {
         let spec: PkgSpec = serde_json::from_str(PACKAGE_JSON).unwrap();
+        let description = spec.description.to_owned();
         let pkg = SiPkg::load_from_spec(spec).expect("failed to load spec");
 
         let tempdir = tempdir().expect("failed to create tempdir");
@@ -72,6 +73,11 @@ mod tests {
         let read_pkg = SiPkg::load_from_dir(tempdir.path())
             .await
             .expect("failed to load pkg from dir");
+
+        assert_eq!(
+            description,
+            read_pkg.metadata().expect("get metadata").description()
+        );
 
         let funcs = read_pkg.funcs().expect("failed to get funcs");
         assert_eq!(2, funcs.len());


### PR DESCRIPTION
Object tree assumed that key value pairs could be contained to a single line. We could support multiline values by encoding them in base64, or, the alternative proposed here, we can encode the length as part of the key. Now the key=value format is:

`key:len=value\n`. 