### PR TITLE
fix(dal,sdf-server): don't create duplicate definitions

### DIFF
--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -6,7 +6,7 @@ use telemetry::prelude::*;
 
 use crate::func::argument::{FuncArgument, FuncArgumentId};
 use crate::installed_pkg::InstalledPkg;
-use crate::pkg::import_pkg_from_pkg;
+use crate::pkg::{import_pkg_from_pkg, ImportOptions};
 use crate::{
     func::{
         binding::{FuncBinding, FuncBindingId},
@@ -139,7 +139,16 @@ pub async fn migrate_pkg(
 
     let root_hash = pkg.hash()?.to_string();
     if InstalledPkg::find_by_hash(ctx, &root_hash).await?.is_none() {
-        import_pkg_from_pkg(ctx, &pkg, pkg_filename, schemas).await?;
+        import_pkg_from_pkg(
+            ctx,
+            &pkg,
+            pkg_filename,
+            schemas.map(|schemas| ImportOptions {
+                schemas: Some(schemas),
+                ..Default::default()
+            }),
+        )
+        .await?;
     }
 
     Ok(())

--- a/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
@@ -171,7 +171,10 @@ impl MigrationDriver {
             ctx,
             &fallout_pkg,
             "test:fallout",
-            Some(vec!["fallout".into()]),
+            Some(crate::pkg::ImportOptions {
+                schemas: Some(vec!["fallout".into()]),
+                ..Default::default()
+            }),
         )
         .await?;
 

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -245,7 +245,10 @@ impl MigrationDriver {
             ctx,
             &starfield_pkg,
             "test:starfield",
-            Some(vec!["starfield".into()]),
+            Some(crate::pkg::ImportOptions {
+                schemas: Some(vec!["starfield".into()]),
+                ..Default::default()
+            }),
         )
         .await?;
 

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -6,7 +6,7 @@ mod import;
 
 pub use export::export_pkg;
 pub use export::get_component_type;
-pub use import::{import_pkg, import_pkg_from_pkg};
+pub use import::{import_pkg, import_pkg_from_pkg, ImportOptions};
 
 use si_pkg::{FuncSpecBackendKind, FuncSpecBackendResponseType, SiPkgError, SpecError};
 

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -60,7 +60,16 @@ pub async fn exec_variant_def(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
-    import_pkg_from_pkg(&ctx, &pkg, metadata.clone().name.as_str(), None).await?;
+    import_pkg_from_pkg(
+        &ctx,
+        &pkg,
+        metadata.clone().name.as_str(),
+        Some(dal::pkg::ImportOptions {
+            schemas: None,
+            no_definitions: true,
+        }),
+    )
+    .await?;
 
     track(
         &posthog_client,


### PR DESCRIPTION
When creating an asset from a schema variant definition we shouldn't write a second automatically generated definition to the database.