### PR TITLE
Pinga concurrency limits

### DIFF
--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -13,7 +13,7 @@ pub use dal::CycloneKeyPair;
 pub use si_settings::{StandardConfig, StandardConfigFile};
 use ulid::Ulid;
 
-const DEFAULT_CONCURRENCY_LIMIT: usize = 50;
+const DEFAULT_CONCURRENCY_LIMIT: usize = 5;
 
 #[remain::sorted]
 #[derive(Debug, Error)]


### PR DESCRIPTION
# bug(pinga) Set concurrency limit from layer loaded config

Previously, we weren't respecting the concurrency limit read in from the layer loaded config, which means that we were always using the internally set default concurrency limit. By paying attention to what the layerd load finds, we can now set the concurrency limit through the `SI_PINGA__CONCURRENCY_LIMIT` environment variable.

# chore(pinga) Drastically reduce the default concurrency limit

The default concurrency limit of 50 was apparently dangerously close to running into exhausting the number of connections in the `PgPool` on macOS, where the default pool size (based on detected CPU core count) is significantly lower than the default pool size we've been seeing on our Linux-based development machines.

This lowers the default concurrency down to something that should be "safe" on the most common development environments we expect to see.

On systems where the `PgPool` size is significantly higher, and where system resources generally allow for it, a larger concurrency limit can be opted in to by setting the environment variable `SI_PINGA__CONCURRENCY_LIMIT` to something higher. (This can be done automically by adding it to the `.env`, and `direnv` will handle loading/updating the env var.)
