### PR TITLE
Add buck2 uploader and update buck2 to latest (ENG-1484)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,13 +3,11 @@
     "buck2-subflake": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-MCbVKLtQhdTm4idrGFYeTP1T6MIx8cnkeX7Qq/WjJMk=",
+        "narHash": "sha256-X3e6cLHk6ugnlMvc4TiKqzIJDV0ZdPvdVPDP5iizcrE=",
         "path": "nix/buck2",
         "type": "path"
       },
@@ -23,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -41,11 +39,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -74,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684935479,
-        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
+        "lastModified": 1685383865,
+        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
+        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
         "type": "github"
       },
       "original": {
@@ -89,6 +87,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1685383865,
+        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1681358109,
         "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
@@ -108,21 +122,21 @@
       "inputs": {
         "buck2-subflake": "buck2-subflake",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1684981217,
-        "narHash": "sha256-7ZgOsyOfdb7pD/6wHTh8EGnUFzO0GR39pAjb340Tefo=",
+        "lastModified": 1685500416,
+        "narHash": "sha256-P6wLC+P8o9w4XNLZAbZy3BwKkp1xi/+H9dF+7SXDP70=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e64b8ea322c6c84d2810abcfa02afcd66ea20868",
+        "rev": "9651f0beee6e7a9783cc02eac722854851c65ae7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    buck2-subflake = {
-      url = "path:nix/buck2";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    buck2-subflake.url = "path:nix/buck2";
   };
 
   # Flake outputs

--- a/nix/buck2/flake.lock
+++ b/nix/buck2/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684935479,
-        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
+        "lastModified": 1685383865,
+        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
+        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
         "type": "github"
       },
       "original": {

--- a/nix/buck2/flake.nix
+++ b/nix/buck2/flake.nix
@@ -12,8 +12,22 @@
         pkgs = import nixpkgs { inherit system; };
 
         buck2 = pkgs.stdenv.mkDerivation rec {
-          # The primary variable to control the "version" of buck2 that we want from S3.
-          date = "2023-05-24";
+          # The primary variables to control the "version" of buck2 that we want from S3.
+          #
+          # To upload the latest objects and get the hashes needed for this flake, run
+          # "buck2 run //support:upload-latest-buck2". You can run that target again to find the
+          # hashes, even if the objects have already been uploaded.
+          #
+          # For the hashes, default to "aarch64-darwin".
+          date = "2023-05-31";
+          binarySha256 = if system == "x86_64-linux" then
+            "sha256-0MzhwUgBO7BUuwExGx/htm6UOxPr00CKC9edNYqwQoA="
+          else if system == "aarch64-linux" then
+            "sha256-/Fo6IEPx6+5H4/kHxPahGUJlMxSeS5mXWtHfux4PxL4="
+          else if system == "x86_64-darwin" then
+            "sha256-UzhZznPbwzYTNLUhLtW7uNC2F7R6UMSFonDY8StunBc="
+          else
+            "sha256-i2MVcLcrGN3G4tE0aaf/65zBJeLBkSgm8vroQ1EenlA=";
 
           pname = "buck2";
           version = "unstable-${date}";
@@ -28,21 +42,6 @@
             "x86_64-apple-darwin"
           else
             "aarch64-apple-darwin";
-
-          # Default to "aarch64-darwin" for the sha256 value.
-          binarySha256 = if system == "x86_64-linux" then
-            "sha256-TzKQM7P9zdcUx/RAjATlKYML2bzMPSe4wZNw6kupQS8="
-          else if system == "aarch64-linux" then
-            "sha256-De/1MxFs1u8c83a1VltGqXjEwwS+2apSY1IXvX9EaFQ="
-          else if system == "x86_64-darwin" then
-            "sha256-WP+LivDDAlgZ8UBcUadkW6+AxseRqHXGX9rOFykNEz4="
-          else
-            "sha256-tpkfodVXP3C66ZR/NSjMrdyJrqg5h0NYO5l9B0TZFOg=";
-
-          # Uncomment these two variables (and comment the ones of the same name) to update the
-          # sha256 values for each system.
-          # binarySystem = "aarch64-apple-darwin";
-          # binarySha256 = pkgs.lib.fakeSha256;
 
           binary = pkgs.fetchurl {
             url =

--- a/support/BUCK
+++ b/support/BUCK
@@ -1,0 +1,5 @@
+sh_binary(
+    name = "upload-latest-buck2",
+    main = "upload-latest-buck2-and-find-hashes.sh",
+    visibility = ["PUBLIC"],
+)

--- a/support/upload-latest-buck2-and-find-hashes.sh
+++ b/support/upload-latest-buck2-and-find-hashes.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# First, cache the universal date.
+DATE=$(date -u +%F)
+
+function subflake-hashes {
+  PREFETCH_PREFIX="https://buck2-binaries.s3.us-east-2.amazonaws.com/$DATE"
+  AARCH64_DARWIN=$(nix hash to-sri --type sha256 $(nix-prefetch-url $PREFETCH_PREFIX/buck2-aarch64-apple-darwin.zst))
+  AARCH64_LINUX=$(nix hash to-sri --type sha256 $(nix-prefetch-url $PREFETCH_PREFIX/buck2-aarch64-unknown-linux-gnu.zst))
+  X86_64_DARWIN=$(nix hash to-sri --type sha256 $(nix-prefetch-url $PREFETCH_PREFIX/buck2-x86_64-apple-darwin.zst))
+  X86_64_LINUX=$(nix hash to-sri --type sha256 $(nix-prefetch-url $PREFETCH_PREFIX/buck2-x86_64-unknown-linux-gnu.zst))
+  echo "\
+hashes for the subflake:
+
+  x86_64-linux    $X86_64_LINUX
+  aarch64-linux   $AARCH64_LINUX
+  x86_64-darwin   $X86_64_DARWIN
+  aarch64-darwin  $AARCH64_DARWIN
+"
+}
+
+# Check if we need to perform an upload. Find the hashes for the subflake
+# if the objects already exist.
+DATE=$(date -u +%F)
+if aws --region us-east-2 s3 ls "buck2-binaries/$DATE"; then
+  echo "buck2-binaries is up to date: $DATE"
+  subflake-hashes
+  exit 0
+fi
+
+# Download what we need into a temporary directory.
+pushd $(mktemp -d)
+SOURCE_PREFIX="https://github.com/facebook/buck2/releases/download/latest"
+mkdir ${DATE}
+pushd ${DATE}
+wget $SOURCE_PREFIX/buck2-aarch64-apple-darwin.zst
+wget $SOURCE_PREFIX/buck2-aarch64-unknown-linux-gnu.zst
+wget $SOURCE_PREFIX/buck2-x86_64-apple-darwin.zst
+wget $SOURCE_PREFIX/buck2-x86_64-unknown-linux-gnu.zst
+popd
+
+# Upload the files to the bucket.
+aws \
+  --region us-east-2 \
+  s3 mv ${DATE} "s3://buck2-binaries/$DATE/" \
+  --recursive \
+  --acl public-read
+popd
+
+# Find the hashes for the subflake.
+subflake-hashes
+echo "success! now you can update the buck2 subflake to use the new objects with the hashes above"


### PR DESCRIPTION
- Add buck2 uploader script and BUCK target
- Re-introduce "support" directory
- Ensure buck2 does not follow nixpkgs input in core flake (avoids "cannot fetch input" errors with using a relative path)
- Use latest buck2 (2023-05-31)

<img src="https://media2.giphy.com/media/KezkSUnCEUKP0DocQk/giphy.gif"/>