### PR TITLE
fix(buck2): allow rustc to use Nix environment when compiling

### DIFF
--- a/prelude/rust/tools/rustc_action.py
+++ b/prelude/rust/tools/rustc_action.py
@@ -228,6 +228,7 @@ async def main() -> int:
         ]
         if k in os.environ
     }
+    nix_env(env)
     if args.env:
         # Unescape previously escaped newlines.
         # Example: \\\\n\\n -> \\\n\n -> \\n\n
@@ -324,6 +325,40 @@ async def main() -> int:
             res = 0
 
     return res
+
+
+NIX_ENV_VARS = [
+    "NIX_BINTOOLS",
+    "NIX_BINTOOLS_FOR_TARGET",
+    "NIX_CC",
+    "NIX_CC_FOR_TARGET",
+    "NIX_CFLAGS_COMPILE",
+    "NIX_CFLAGS_COMPILE_FOR_TARGET",
+    "NIX_COREFOUNDATION_RPATH",
+    "NIX_DONT_SET_RPATH",
+    "NIX_DONT_SET_RPATH_FOR_BUILD",
+    "NIX_ENFORCE_NO_NATIVE",
+    "NIX_HARDENING_ENABLE",
+    "NIX_IGNORE_LD_THROUGH_GCC",
+    "NIX_LDFLAGS",
+    "NIX_LDFLAGS_FOR_TARGET",
+    "NIX_NO_SELF_RPATH",
+]
+NIX_ENV_VAR_PREFIXES = [
+    "NIX_BINTOOLS_WRAPPER_TARGET_HOST_",
+    "NIX_BINTOOLS_WRAPPER_TARGET_TARGET_",
+    "NIX_CC_WRAPPER_TARGET_HOST_",
+    "NIX_CC_WRAPPER_TARGET_TARGET_",
+]
+
+
+def nix_env(env: Dict[str, str]):
+    env.update({k: os.environ[k] for k in NIX_ENV_VARS if k in os.environ})
+    for prefix in NIX_ENV_VAR_PREFIXES:
+        vars_starting_with = dict(
+            filter(lambda pair: pair[0].startswith(prefix),
+                   os.environ.items()))
+        env.update({k: v for k, v in vars_starting_with.items()})
 
 
 sys.exit(asyncio.run(main()))

--- a/third-party/patches/nix_rustc_action.py.patch
+++ b/third-party/patches/nix_rustc_action.py.patch
@@ -1,0 +1,51 @@
+diff --git a/prelude/rust/tools/rustc_action.py b/prelude/rust/tools/rustc_action.py
+index b4b4a0176..bfe952cc7 100755
+--- a/prelude/rust/tools/rustc_action.py
++++ b/prelude/rust/tools/rustc_action.py
+@@ -228,6 +228,7 @@ async def main() -> int:
+         ]
+         if k in os.environ
+     }
++    nix_env(env)
+     if args.env:
+         # Unescape previously escaped newlines.
+         # Example: \\\\n\\n -> \\\n\n -> \\n\n
+@@ -326,4 +327,38 @@ async def main() -> int:
+     return res
+ 
+ 
++NIX_ENV_VARS = [
++    "NIX_BINTOOLS",
++    "NIX_BINTOOLS_FOR_TARGET",
++    "NIX_CC",
++    "NIX_CC_FOR_TARGET",
++    "NIX_CFLAGS_COMPILE",
++    "NIX_CFLAGS_COMPILE_FOR_TARGET",
++    "NIX_COREFOUNDATION_RPATH",
++    "NIX_DONT_SET_RPATH",
++    "NIX_DONT_SET_RPATH_FOR_BUILD",
++    "NIX_ENFORCE_NO_NATIVE",
++    "NIX_HARDENING_ENABLE",
++    "NIX_IGNORE_LD_THROUGH_GCC",
++    "NIX_LDFLAGS",
++    "NIX_LDFLAGS_FOR_TARGET",
++    "NIX_NO_SELF_RPATH",
++]
++NIX_ENV_VAR_PREFIXES = [
++    "NIX_BINTOOLS_WRAPPER_TARGET_HOST_",
++    "NIX_BINTOOLS_WRAPPER_TARGET_TARGET_",
++    "NIX_CC_WRAPPER_TARGET_HOST_",
++    "NIX_CC_WRAPPER_TARGET_TARGET_",
++]
++
++
++def nix_env(env: Dict[str, str]):
++    env.update({k: os.environ[k] for k in NIX_ENV_VARS if k in os.environ})
++    for prefix in NIX_ENV_VAR_PREFIXES:
++        vars_starting_with = dict(
++            filter(lambda pair: pair[0].startswith(prefix),
++                   os.environ.items()))
++        env.update({k: v for k, v in vars_starting_with.items()})
++
++
+ sys.exit(asyncio.run(main()))

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -10,8 +10,6 @@ load("@prelude-si//pnpm:toolchain.bzl", "pnpm_toolchain")
 
 system_cxx_toolchain(
     name = "cxx",
-    linker = "clang",
-    link_flags = ["-v"],
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This change enables our project to build using the Nix environment running on Linux and macOS platforms.

Background
----------

The upstream `rustc_action.py` script which invokes `rustc` filters the environment in an effort to maintain a better sandboxed build. When we build in a Nix environment (currently used for development and shortly in CI), there are several environment variables that cause the correct linking behavior under Nix.

The Nix environment provides wrapper scripts for `clang` and `clang++` which use these environment variables. The `rustc` program is responsible for invoking the linker (by default this tends to be `cc`/`clang`) which means these environment variables need to be present in the `rustc` process so that its children can inherit them.

The Fix
-------

While there were many attempts at a solution to this problem, we went with a "patch the upstream" approach. In other words, the `rustc_action.py` script is what prevents our correct Nix behavior, so we slightly augmented it with support for more environment variables. This script is provided to us via the upstream
`facebookincubator/buck2-prelude` Git repository which we currently vendor using `git subtree`. This means that our "patch" will be wiped out when we re-vendor/update against upstream changes. With this in mind, we provide a `third-party/patches/nix_rustc_action.patch` file which should allow us to patch over upstream updates similar to upstream patching in a packaging system.

<img src="https://media2.giphy.com/media/nFjDu1LjEADh6/giphy.gif"/>