### PR TITLE
Shorten dev setup section and put nix installer first (ENG-1490)

### DIFF
--- a/app/auth-portal/src/content/tutorial/02-dev_setup.md
+++ b/app/auth-portal/src/content/tutorial/02-dev_setup.md
@@ -6,8 +6,9 @@ hideWorkspaceLink: true
 ## Run a development instance of System Initiative
 
 First things first - let’s set you up with a System Initiative development environment. You will need to check the
-source code out from GitHub, ensure your system has `nix` installed with its environment set up fully, start our
-ancillary services in  Docker containers, and finally, compile and execute the various System Initiative services.
+source code out from GitHub, ensure your system has `nix` installed with its environment set up fully (*we highly
+recommend using the [Zero to Nix](https://zero-to-nix.com/start/install) installer over the  official installer*), start
+our ancillary services in Docker containers, and finally, compile and execute the various System Initiative services.
 
 *Note - If you’re running this in a VM, you’ll want to run through this all as a non-root user with sudo access. On a
 personal machine, this will likely be the case already.*
@@ -16,44 +17,28 @@ personal machine, this will likely be the case already.*
 
 To run a development build of System Initiative and complete this tutorial, you will need to have our development
 dependencies installed.
-Let's start by choosing a compatible platform.
+The following  platforms are supported: macOS, Linux (GNU), [WSL2](https://learn.microsoft.com/en-us/windows/wsl/)
+(Windows 10/11) on either `x86_64 (amd64)` or `aarch64 (arm64)`.
 
-The following platforms are supported:
-
-| Architecture    | Operating System                                                                           |
-|-----------------|--------------------------------------------------------------------------------------------|
-| x86_64 (amd64)  | macOS, Linux (GNU), [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) (Windows 10/11) |
-| aarch64 (arm64) | macOS, Linux (GNU), [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) (Windows 10/11) |
-
- **Platform Notes:**
- - Using macOS `aarch64 (arm64)` requires on Rosetta 2 (install it with `softwareupdate --install-rosetta`)
- - [NixOS](https://nixos.org/) will not likely work at this time (though, this may be desired in the future)
- - [SELinux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) will likely need to be set to `permissive` mode or configured to work with `nix`
- - Linux with MUSL instead of GNU *might* work, but it is untested
+**Platform Notes:**
+- Using macOS `aarch64 (arm64)` requires on Rosetta 2 (install it with `softwareupdate --install-rosetta`)
+- macOS users: you may need to run `xcode-select --install` before proceeding
+- Linux users: [SELinux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) will likely need to be set to `permissive` mode or 
+  configured to work with `nix`
 
 ### Install development dependencies
 
 Once a platform is chosen, we can install the dependencies for using the flake.
 _This section will install software on your computer and mutate your running environment!_
 
-- `nix` with flakes enabled
+- `nix` with flakes enabled (enabled by defualt when using the recommended
+  [Zero to Nix](https://zero-to-nix.com/start/install) installer)
 - `docker` from [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [Docker Engine](https://docs.docker.com/engine/)
+  corresponding to your native architecture (WSL2 users can use either Docker Desktop for WSL2 or Docker Engine inside
+  WSL2)
 - (optional, but recommended) [`direnv`](https://direnv.net) version `>= 2.30` hooked into your shell
 
-For `nix`, we highly recommend using the [Zero to Nix](https://zero-to-nix.com/start/install) installer over the
-official installer; one reason being that the former will enable flakes by default.
-
-For `docker`, the Docker Desktop version corresponding to your native architecture should be used on macOS.
-WSL2 users should be able to use either Docker Desktop for WSL2 or Docker Engine inside the WSL2 VM.
-Native Linux or Linux VM users might be able to use `podman` a drop in replacement for `docker`, though this is untested.
-
-For `direnv`, we recommend using it for both ease of running commands and editor integration.
-You can install it with [your package manager of choice](https://direnv.net/docs/installation.html), but at least
-version `2.30.x` must be used for the flake integration to work properly.
-If you're unsure which installation method to use or your package manager does not provide a compatible version, you
-can use `nix` itself (e.g. `nix profile install nixpkgs#direnv`).
-
-With `nix` and `docker` set up, you will have (at least) the following available:
+With `nix` and `docker` set up, you will have (at least) the following available in the flake environment:
 
 * automake
 * make
@@ -80,6 +65,11 @@ If `direnv` is installed and [hooked into your shell](https://direnv.net/docs/ho
 the repository and `nix` will boostrap the environment for you using the flake.
 Otherwise, you can execute `nix develop` to enter the environment, `nix develop --command <command>` to
 execute a command, or use the environment in whatever way your prefer.
+
+You can install it with [your package manager of choice](https://direnv.net/docs/installation.html), but at least
+version `2.30.x` must be used for the flake integration to work properly.
+If you're unsure which installation method to use or your package manager does not provide a compatible version, you
+can use `nix` itself (e.g. `nix profile install nixpkgs#direnv`).
 
 ### Configure dependencies
 


### PR DESCRIPTION
- Short dev setup section, but retain the longer form section in the README (it is okay for the tutorial to be more opinionated here)
- Put the nix installer link at the first mention of nix (ensuring that users use our recommendation installation method)

<img src="https://media0.giphy.com/media/3ornjZLITGcFQVRbxK/giphy.gif"/>