### PR TITLE
build(buck2): make "check" targets testable for cargo rules

### DIFF
--- a/prelude-si/cargo.bzl
+++ b/prelude-si/cargo.bzl
@@ -1,4 +1,21 @@
-def cargo_clippy_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+load(
+    "@prelude//decls/common.bzl",
+    "buck",
+)
+load(
+    "@prelude//test/inject_test_run_info.bzl",
+    "inject_test_run_info",
+)
+load(
+    "@prelude//tests:re_utils.bzl",
+    "get_re_executor_from_props",
+)
+
+def cargo_clippy_impl(ctx: "context") -> [[
+    DefaultInfo.type,
+    RunInfo.type,
+    ExternalRunnerTestInfo.type,
+]]:
     run_cmd_args = cmd_args([
         "cargo",
         "clippy",
@@ -12,23 +29,58 @@ def cargo_clippy_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
 
     args_file = ctx.actions.write("cargo-clippy-args.txt", run_cmd_args)
 
-    return [
-        DefaultInfo(
-            default_output = args_file,
+    # Setup a RE executor based on the `remote_execution` param.
+    re_executor = get_re_executor_from_props(ctx.attrs.remote_execution)
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "cargo",
+            command = [run_cmd_args],
+            env = ctx.attrs.env,
+            labels = ctx.attrs.labels,
+            contacts = ctx.attrs.contacts,
+            default_executor = re_executor,
+            # We implicitly make this test via the project root, instead of
+            # the cell root (e.g. fbcode root).
+            run_from_project_root = re_executor != None,
+            use_project_relative_paths = re_executor != None,
         ),
-        RunInfo(
-            args = run_cmd_args,
-        ),
+    ) + [
+        DefaultInfo(default_output = args_file),
     ]
 
-cargo_clippy = rule(impl = cargo_clippy_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_clippy = rule(
+    impl = cargo_clippy_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Set environment variables for this rule's invocation of cargo. The environment
+            variable values may include macros which are expanded.""",
+        ),
+        "labels": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "contacts": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "remote_execution": buck.re_opts_for_tests_arg(),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+    },
+)
 
 def cargo_clippy_fix_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
     run_cmd_args = cmd_args([
@@ -56,16 +108,23 @@ def cargo_clippy_fix_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
         ),
     ]
 
-cargo_clippy_fix = rule(impl = cargo_clippy_fix_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_clippy_fix = rule(
+    impl = cargo_clippy_fix_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+    },
+)
 
-def cargo_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+def cargo_check_impl(ctx: "context") -> [[
+    DefaultInfo.type,
+    RunInfo.type,
+    ExternalRunnerTestInfo.type,
+]]:
     run_cmd_args = cmd_args([
         "cargo",
         "check",
@@ -78,23 +137,58 @@ def cargo_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
 
     args_file = ctx.actions.write("cargo-check-args.txt", run_cmd_args)
 
-    return [
-        DefaultInfo(
-            default_output = args_file,
+    # Setup a RE executor based on the `remote_execution` param.
+    re_executor = get_re_executor_from_props(ctx.attrs.remote_execution)
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "cargo",
+            command = [run_cmd_args],
+            env = ctx.attrs.env,
+            labels = ctx.attrs.labels,
+            contacts = ctx.attrs.contacts,
+            default_executor = re_executor,
+            # We implicitly make this test via the project root, instead of
+            # the cell root (e.g. fbcode root).
+            run_from_project_root = re_executor != None,
+            use_project_relative_paths = re_executor != None,
         ),
-        RunInfo(
-            args = run_cmd_args,
-        ),
+    ) + [
+        DefaultInfo(default_output = args_file),
     ]
 
-cargo_check = rule(impl = cargo_check_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_check = rule(
+    impl = cargo_check_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Set environment variables for this rule's invocation of cargo. The environment
+            variable values may include macros which are expanded.""",
+        ),
+        "labels": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "contacts": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "remote_execution": buck.re_opts_for_tests_arg(),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+    },
+)
 
 def cargo_doc_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
     run_cmd_args = cmd_args([
@@ -117,16 +211,23 @@ def cargo_doc_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
         ),
     ]
 
-cargo_doc = rule(impl = cargo_doc_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_doc = rule(
+    impl = cargo_doc_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+    },
+)
 
-def cargo_doc_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+def cargo_doc_check_impl(ctx: "context") -> [[
+    DefaultInfo.type,
+    RunInfo.type,
+    ExternalRunnerTestInfo.type,
+]]:
     run_cmd_args = cmd_args([
         "cargo",
         "doc",
@@ -151,23 +252,58 @@ def cargo_doc_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
     )
     run_cmd_args = cmd_args([script]).hidden(ctx.attrs.srcs)
 
-    return [
-        DefaultInfo(
-            default_output = args_file,
+    # Setup a RE executor based on the `remote_execution` param.
+    re_executor = get_re_executor_from_props(ctx.attrs.remote_execution)
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "cargo",
+            command = [run_cmd_args],
+            env = ctx.attrs.env,
+            labels = ctx.attrs.labels,
+            contacts = ctx.attrs.contacts,
+            default_executor = re_executor,
+            # We implicitly make this test via the project root, instead of
+            # the cell root (e.g. fbcode root).
+            run_from_project_root = re_executor != None,
+            use_project_relative_paths = re_executor != None,
         ),
-        RunInfo(
-            args = run_cmd_args,
-        ),
+    ) + [
+        DefaultInfo(default_output = args_file),
     ]
 
-cargo_doc_check = rule(impl = cargo_doc_check_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_doc_check = rule(
+    impl = cargo_doc_check_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Set environment variables for this rule's invocation of cargo. The environment
+            variable values may include macros which are expanded.""",
+        ),
+        "labels": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "contacts": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "remote_execution": buck.re_opts_for_tests_arg(),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+    },
+)
 
 def cargo_fmt_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
     run_cmd_args = cmd_args([
@@ -190,16 +326,23 @@ def cargo_fmt_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
         ),
     ]
 
-cargo_fmt = rule(impl = cargo_fmt_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_fmt = rule(
+    impl = cargo_fmt_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+    },
+)
 
-def cargo_fmt_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+def cargo_fmt_check_impl(ctx: "context") -> [[
+    DefaultInfo.type,
+    RunInfo.type,
+    ExternalRunnerTestInfo.type,
+]]:
     run_cmd_args = cmd_args([
         "cargo",
         "fmt",
@@ -212,20 +355,55 @@ def cargo_fmt_check_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
 
     args_file = ctx.actions.write("cargo-fmt-args.txt", run_cmd_args)
 
-    return [
-        DefaultInfo(
-            default_output = args_file,
+    # Setup a RE executor based on the `remote_execution` param.
+    re_executor = get_re_executor_from_props(ctx.attrs.remote_execution)
+
+    return inject_test_run_info(
+        ctx,
+        ExternalRunnerTestInfo(
+            type = "cargo",
+            command = [run_cmd_args],
+            env = ctx.attrs.env,
+            labels = ctx.attrs.labels,
+            contacts = ctx.attrs.contacts,
+            default_executor = re_executor,
+            # We implicitly make this test via the project root, instead of
+            # the cell root (e.g. fbcode root).
+            run_from_project_root = re_executor != None,
+            use_project_relative_paths = re_executor != None,
         ),
-        RunInfo(
-            args = run_cmd_args,
-        ),
+    ) + [
+        DefaultInfo(default_output = args_file),
     ]
 
-cargo_fmt_check = rule(impl = cargo_fmt_check_impl, attrs = {
-    "crate": attrs.string(),
-    "srcs": attrs.list(
-        attrs.source(),
-        default = [],
-        doc = """The set of Rust source files in the crate."""
-    ),
-})
+cargo_fmt_check = rule(
+    impl = cargo_fmt_check_impl,
+    attrs = {
+        "crate": attrs.string(),
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """The set of Rust source files in the crate."""
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Set environment variables for this rule's invocation of cargo. The environment
+            variable values may include macros which are expanded.""",
+        ),
+        "labels": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "contacts": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "remote_execution": buck.re_opts_for_tests_arg(),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+    },
+)


### PR DESCRIPTION
This change makes the following rules testable (in addition to being runnable):

- `cargo_clippy`
- `cargo_check`
- `cargo_doc_check`
- `cargo_fmt_check`

Note that since all of these rules are running Cargo subcommands, they are will all block on each other concurrently due to the Cargo workspace lock. Future work should be able to move these rules away from directly running Cargo subcommands and should break these back into "share-nothing" targets.

<img src="https://media2.giphy.com/media/l0Iy8wR3vSemtX8xG/giphy.gif"/>