### PR TITLE
fix(web): Make component outline title always visible

### DIFF
--- a/app/web/src/components/ComponentOutline/ComponentOutline2.vue
+++ b/app/web/src/components/ComponentOutline/ComponentOutline2.vue
@@ -1,13 +1,17 @@
 <template>
   <div ref="outlineRef" class="flex flex-col">
     <ScrollArea>
-      <template v-if="rootComponents.length" #top>
-        <SidebarSubpanelTitle class="border-t-0"
-          >Diagram Outline
+      <template #top>
+        <SidebarSubpanelTitle class="border-t-0">
+          Diagram Outline
         </SidebarSubpanelTitle>
 
         <!-- search bar - dont need to show if no components -->
-        <SiSearch auto-search @search="onSearchUpdated" />
+        <SiSearch
+          v-if="rootComponents.length"
+          auto-search
+          @search="onSearchUpdated"
+        />
       </template>
 
       <RequestStatusMessage


### PR DESCRIPTION
<img width="1283" alt="image" src="https://github.com/systeminit/si/assets/6564471/5a8af5ae-9963-4533-91bb-05770a5a4d95">
