### PR TITLE
feat(web): Make the Assets tab the default in the customize screen

### DIFF
--- a/app/web/src/components/CustomizeTabs.vue
+++ b/app/web/src/components/CustomizeTabs.vue
@@ -4,14 +4,14 @@
       :start-selected-tab-slug="tabContentSlug"
       @update:selected-tab="onTabChange"
     >
+      <TabGroupItem slug="assets" label="ASSETS">
+        <slot v-if="tabContentSlug === 'assets'" />
+      </TabGroupItem>
       <TabGroupItem slug="functions" label="FUNCTIONS">
         <slot v-if="tabContentSlug === 'functions'" />
       </TabGroupItem>
       <TabGroupItem slug="packages" label="MODULES">
         <slot v-if="tabContentSlug === 'packages'" />
-      </TabGroupItem>
-      <TabGroupItem slug="assets" label="ASSETS">
-        <slot v-if="tabContentSlug === 'assets'" />
       </TabGroupItem>
     </TabGroup>
   </div>
@@ -27,7 +27,7 @@ const route = useRoute();
 
 defineProps({
   tabContentSlug: {
-    type: String as PropType<"functions" | "packages" | "assets">,
+    type: String as PropType<"assets" | "functions" | "packages">,
     required: true,
   },
 });

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -69,11 +69,18 @@ const routes: RouteRecordRaw[] = [
           import("@/components/Workspace/WorkspaceCustomizeIndex.vue"),
         redirect(to) {
           return {
-            name: "workspace-lab-functions",
+            name: "workspace-lab-assets",
             params: to.params,
           };
         },
         children: [
+          {
+            path: "a/:assetId?",
+            name: "workspace-lab-assets",
+            props: true,
+            component: () =>
+                import("@/components/Workspace/WorkspaceCustomizeAssets.vue"),
+          },
           {
             path: "f/:funcId?",
             name: "workspace-lab-functions",
@@ -85,13 +92,6 @@ const routes: RouteRecordRaw[] = [
             name: "workspace-lab-packages",
             component: () =>
               import("@/components/Workspace/WorkspaceCustomizePackages.vue"),
-          },
-          {
-            path: "a/:assetId?",
-            name: "workspace-lab-assets",
-            props: true,
-            component: () =>
-              import("@/components/Workspace/WorkspaceCustomizeAssets.vue"),
           },
         ],
       },


### PR DESCRIPTION
<img width="386" alt="Screenshot 2023-06-07 at 21 26 49" src="https://github.com/systeminit/si/assets/227823/c9a6306b-553a-4d84-a188-5356ecd71c5e">
