### PR TITLE
Add initial impl of filtering buck2 targets (ENG-1625)

### DIFF
--- a/bxl/dependent_targets.bxl
+++ b/bxl/dependent_targets.bxl
@@ -1,51 +1,46 @@
 def _dependent_targets_impl(ctx):
-    targets = []
-
-    # Add affected targets if global project files are provided.
-    #
-    # Note: when a global project file is provided, *all* targets are considered affected.
-    if len(ctx.cli_args.global_file) > 0:
-        targets.extend(_dependent_global_file_targets(ctx))
-
-    # Add affected targets for all provided `BUCK` files.
-    #
-    # Note: when a `BUCK` file has been added or modified, all of its targets and associated reverse
-    # dependencies are considered affected.
-    if len(ctx.cli_args.buck_file) > 0:
-        targets.extend(_dependent_buck_file_targets(ctx, ctx.cli_args.buck_file))
-
-    # Add affected targets for all provided prelude files (i.e. `*.bzl` files).
-    #
-    # Note: when a `.bzl` file has been added or modified, all of the `BUCK` files which load this
-    # source and associated reverse dependencies are considered affected.
-    if len(ctx.cli_args.prelude_file) > 0:
-        print("TODO prelude files: {}".format(ctx.cli_args.prelude_file))
-
-    # Add affected targets for all provided deleted files.
-    #
-    # Note: for each deleted file, walk up the directory tree to find the nearest `BUCK` file, and
-    # use each parent `BUCK` file to determine all of its targets and associated reverse
-    # dependencies.
-    if len(ctx.cli_args.deleted_file) > 0:
-        targets.extend(_dependent_deleted_file_targets(ctx))
-
-    # Add affected targets for all provided added or modified files.
-    #
-    # Note: when a source file has been added or modified, all owned targets and associated reverse
-    # dependencies are considered affected.
-    if len(ctx.cli_args.modified_file) > 0:
-        targets.extend(_dependent_modified_file_targets(ctx))
-
-    # Sort targets and reduce to a unique set
-    targets = sorted(map(lambda e: e.label, ctx.uquery().eval(_set_str(targets))))
+    targets = _compute_targets(ctx)
+    filtered = _filter_targets(ctx, targets)
 
     # Print each target string, one per line
-    for target in targets:
-        ctx.output.print(target)
+    for target in filtered:
+        ctx.output.print(target.label)
 
 dependent_targets = bxl(
     impl = _dependent_targets_impl,
     cli_args = {
+        "check_doc": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable doc checks.""",
+        ),
+        "check_format": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable format checks.""",
+        ),
+        "check_lint": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable lint checks.""",
+        ),
+        "test_doc": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable doc tests.""",
+        ),
+        "test_integration": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable integration tests.""",
+        ),
+        "test_unit": cli_args.bool(
+            default = False,
+            doc = """Filter targets to testable unit tests.""",
+        ),
+        "release_docker": cli_args.bool(
+            default = False,
+            doc = """Filter targets to releaseable docker images.""",
+        ),
+        "promote_docker": cli_args.bool(
+            default = False,
+            doc = """Filter targets to runnable docker promotions.""",
+        ),
         "global_file": cli_args.list(
             cli_args.string(),
             default = [],
@@ -85,21 +80,87 @@ dependent_targets = bxl(
     },
 )
 
+def _compute_targets(ctx: "bxl_ctx") -> "target_set":
+    targets = utarget_set()
+
+    # Add affected targets if global project files are provided.
+    #
+    # Note: when a global project file is provided, *all* targets are considered affected.
+    if len(ctx.cli_args.global_file) > 0:
+        targets = targets + _dependent_global_file_targets(ctx)
+
+    # Add affected targets for all provided `BUCK` files.
+    #
+    # Note: when a `BUCK` file has been added or modified, all of its targets and associated reverse
+    # dependencies are considered affected.
+    if len(ctx.cli_args.buck_file) > 0:
+        targets = targets + _dependent_buck_file_targets(ctx, ctx.cli_args.buck_file)
+
+    # Add affected targets for all provided prelude files (i.e. `*.bzl` files).
+    #
+    # Note: when a `.bzl` file has been added or modified, all of the `BUCK` files which load this
+    # source and associated reverse dependencies are considered affected.
+    if len(ctx.cli_args.prelude_file) > 0:
+        # TODO(nick,fletcher): we need to figure this out. Use "rbuildfile" maybe?
+        ctx.output.print("TODO prelude files: {}".format(ctx.cli_args.prelude_file))
+
+    # Add affected targets for all provided deleted files.
+    #
+    # Note: for each deleted file, walk up the directory tree to find the nearest `BUCK` file, and
+    # use each parent `BUCK` file to determine all of its targets and associated reverse
+    # dependencies.
+    if len(ctx.cli_args.deleted_file) > 0:
+        targets = targets + _dependent_deleted_file_targets(ctx)
+
+    # Add affected targets for all provided added or modified files.
+    #
+    # Note: when a source file has been added or modified, all owned targets and associated reverse
+    # dependencies are considered affected.
+    if len(ctx.cli_args.modified_file) > 0:
+        targets = targets + _dependent_modified_file_targets(ctx)
+
+    return targets
+
+def _filter_targets(ctx: "bxl_ctx", targets: "target_set") -> "target_set":
+    filtered = utarget_set()
+
+    if ctx.cli_args.check_doc:
+        filtered = filtered + ctx.uquery().attrfilter("name", "check-doc", targets)
+    if ctx.cli_args.check_format:
+        filtered = filtered + ctx.uquery().attrfilter("name", "check-format", targets)
+    if ctx.cli_args.check_lint:
+        filtered = filtered + ctx.uquery().attrfilter("name", "check-lint", targets)
+    if ctx.cli_args.test_doc:
+        filtered = filtered + ctx.uquery().attrfilter("name", "test-doc", targets)
+    if ctx.cli_args.test_integration:
+        filtered = filtered + ctx.uquery().attrfilter("name", "test-integration", targets)
+    if ctx.cli_args.test_unit:
+        filtered = filtered + ctx.uquery().attrfilter("name", "test-unit", targets)
+    if ctx.cli_args.release_docker:
+        filtered = filtered + ctx.uquery().kind("docker_image_release", targets)
+    if ctx.cli_args.promote_docker:
+        # TODO(nick,fletcher): solve how to filter for promote_docker.
+         ctx.output.print("TODO cannot filter promote_docker yet, filtering out everything")
+
+    return filtered
+
 # Computes a list of targets for all targets in the project.
-def _dependent_global_file_targets(ctx: "bxl_ctx") -> [str.type]:
+def _dependent_global_file_targets(ctx: "bxl_ctx") -> "target_set":
     query = "root//..."
     results = ctx.uquery().eval(query)
 
-    return map(lambda e: "{}".format(e.label), results)
+    return results
 
 # Computes a list of targets for all targets affected by given `BUCK` files.
-def _dependent_buck_file_targets(ctx: "bxl_ctx", buck_files: [str.type]) -> [str.type]:
+def _dependent_buck_file_targets(ctx: "bxl_ctx", buck_files: [str.type]) -> "target_set":
     return _rdeps_for_targets(ctx, _buck_files_to_targets(buck_files))
 
 # Computes a list of target strings for all targets affected by given deleted files.
-def _dependent_deleted_file_targets(ctx: "bxl_ctx") -> [str.type]:
+def _dependent_deleted_file_targets(ctx: "bxl_ctx") -> "target_set":
     buck_files = []
     for deleted_file in ctx.cli_args.deleted_file:
+        if ctx.fs.is_file(deleted_file):
+            fail("expected deleted file, but it exists:", deleted_file)
         buck_file = _find_parent_buck_file(ctx, deleted_file)
         if buck_file:
             buck_files.append(buck_file)
@@ -107,30 +168,31 @@ def _dependent_deleted_file_targets(ctx: "bxl_ctx") -> [str.type]:
     return _dependent_buck_file_targets(ctx, buck_files)
 
 # Computes a list of targets for all targets affected by given modified files.
-def _dependent_modified_file_targets(ctx: "bxl_ctx") -> [str.type]:
+def _dependent_modified_file_targets(ctx: "bxl_ctx") -> "target_set":
     modified_files = map(
         lambda e: e if e.startswith("root//") else "root//" + e,
         filter(lambda e: ctx.fs.is_file(e), ctx.cli_args.modified_file),
     )
     query = "owner(%s)"
-    results = ctx.uquery().eval(query, query_args = modified_files)
+    results_set = ctx.uquery().eval(query, query_args = modified_files)
 
-    target_set = {}
-    for values in results.values():
-        for value in map(lambda e: "{}".format(e.label), values):
-            target_set.update({value: True})
+    targets = utarget_set()
 
-    return _rdeps_for_targets(ctx, target_set.keys())
+    for results in results_set.values():
+        targets = targets + results
+
+    return _rdeps_for_targets(ctx, map(lambda e: "{}".format(e.label), targets))
 
 # Computes a list of targets which are reverse dependencies of given targets within a universe.
-def _rdeps_for_targets(ctx: "bxl_ctx", targets: [str.type]) -> [str.type]:
-    query = "rdeps({}, {})".format(
-        _set_str(ctx.cli_args.rdeps_universe),
-        _set_str(targets),
-    )
-    results = ctx.uquery().eval(query)
+def _rdeps_for_targets(ctx: "bxl_ctx", targets: [str.type]) -> "target_set":
+    universe = ctx.unconfigured_targets(_normalized_target_strs(ctx.cli_args.rdeps_universe))
+    targets = ctx.unconfigured_targets(_normalized_target_strs(targets))
 
-    return map(lambda e: "{}".format(e.label), results)
+    results = ctx.uquery().rdeps(
+        universe,
+        targets,
+    )
+    return results
 
 # Returns a file path to the nearest `BUCK` file in parent directories of a given file path.
 def _find_parent_buck_file(ctx: "bxl_ctx", deleted_file: str.type) -> str.type:
@@ -155,6 +217,9 @@ def _set_str(targets: [str.type]) -> str.type:
             )
         )
     )
+
+def _normalized_target_strs(targets: [str.type]) -> [str.type]:
+    return map(lambda e: "root" + e if e.startswith("//") else e, targets)
 
 # Returns a list of target selectors for a given list of `BUCK` files.
 def _buck_files_to_targets(buck_files: [str.type]) -> [str.type]:


### PR DESCRIPTION
- Add initial implementation of filtering buck2 targets, barring "promote_docker"
- Add "check_doc" argument
- Rename "build_docker" argument to "release_docker"
- Assert that deleted targets do not exist on the filesystem within dependent targets evaluation
- Refactor dependent targets evaluation to be split into computed targets and filtered targets

<img src="https://media0.giphy.com/media/tisjPOVIb8mtx2LmGN/giphy.gif"/>