### PR TITLE
chore(ci-base): add Docker package to image

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -9,8 +9,25 @@ RUN set -eux; \
         ca-certificates \
         curl \
         git \
+        gnupg \
         sudo \
         xz-utils \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg;\
+    chmod a+r /etc/apt/keyrings/docker.gpg; \
+    echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" \
+        | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This ensures that we can build our Docker images from inside this Docker container. We build inside this Docker container because it is ultimately invoked via `buck2` which needs our source tree and the software in the Nix flake. Boom.