### PR TITLE
feat(sdf) Allow automatic creation & upload of "Workspace Backup" module on change set apply

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -140,6 +140,7 @@ impl ChangeSet {
             // Before retuning, run all confirmations now that we are on head.
             Component::run_all_confirmations(ctx).await?;
         }
+
         Ok(())
     }
 

--- a/lib/object-tree/src/tar/write.rs
+++ b/lib/object-tree/src/tar/write.rs
@@ -90,7 +90,7 @@ fn write_tar_entry(
     tar_entry_header.set_size(entry.len().try_into()?);
     tar_entry_header.set_cksum();
 
-    tar_builder.append(&dbg!(tar_entry_header), entry)?;
+    tar_builder.append(&tar_entry_header, entry)?;
 
     Ok(())
 }

--- a/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
@@ -1,11 +1,12 @@
 use super::ChangeSetResult;
-use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient, RawAccessToken};
 use crate::server::service::change_set::ChangeSetError;
 use crate::server::tracking::track;
 use axum::extract::OriginalUri;
 use axum::Json;
 use dal::{ChangeSet, ChangeSetPk};
 use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -22,6 +23,7 @@ pub struct ApplyChangeSetResponse {
 pub async fn apply_change_set(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
+    RawAccessToken(raw_access_token): RawAccessToken,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Json(request): Json<ApplyChangeSetRequest>,
@@ -44,6 +46,14 @@ pub async fn apply_change_set(
     );
 
     ctx.commit().await?;
+
+    tokio::task::spawn(
+        super::upload_workspace_backup_module(
+            builder.build(request_ctx.build_head()).await?,
+            raw_access_token,
+        )
+        .instrument(info_span!("Workspace backup module upload")),
+    );
 
     Ok(Json(ApplyChangeSetResponse { change_set }))
 }

--- a/lib/sdf-server/src/server/service/change_set/apply_change_set2.rs
+++ b/lib/sdf-server/src/server/service/change_set/apply_change_set2.rs
@@ -1,5 +1,5 @@
 use super::ChangeSetResult;
-use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient, RawAccessToken};
 use crate::server::service::change_set::ChangeSetError;
 use crate::server::tracking::track;
 use axum::extract::OriginalUri;
@@ -10,6 +10,8 @@ use dal::{
     HistoryActor, StandardModel, User,
 };
 use serde::{Deserialize, Serialize};
+//use telemetry::tracing::{info_span, Instrument, log::warn};
+use telemetry::prelude::*;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +37,7 @@ pub struct ApplyChangeSetResponse {
 pub async fn apply_change_set(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
+    RawAccessToken(raw_access_token): RawAccessToken,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Json(request): Json<ApplyChangeSetRequest>,
@@ -104,6 +107,16 @@ pub async fn apply_change_set(
     }
 
     ctx.commit().await?;
+
+    // If anything fails with uploading the workspace backup module, just log it. We shouldn't
+    // have the change set apply itself fail because of this.
+    tokio::task::spawn(
+        super::upload_workspace_backup_module(
+            builder.build(request_ctx.build_head()).await?,
+            raw_access_token,
+        )
+        .instrument(info_span!("Workspace backup module upload")),
+    );
 
     Ok(Json(ApplyChangeSetResponse { change_set }))
 }


### PR DESCRIPTION
Whenever a change set is applied, we want to create a module that contains all of the schemas/schema variants/functions/anything else a module can contain, and automatically upload it to the module index. This makes it a bit easier for people to work with things while the the system is in a high state of flux, and generally makes it easier to have a backup of any customizations that are made.

For now, this is gated behind running SDF with the `SI__SDF__ENABLE_WORKSPACE_BACKUP_MODULE_UPLOAD` environment variable set (to any value). Generating the backup module itself takes ~9-10 seconds, and until we move this into a background job, taking that on to every change set application is a bit painful. We'll need to figure out how to auth the background job to the module index appropriately (As the user that did the apply? As a "system" user? Something else?) before we can move the module creation/upload to an async background job.