### PR TITLE
feat(web,sdf): create change-set if on head in most actions

### DIFF
--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -1,5 +1,4 @@
 import Axios, { AxiosRequestConfig, AxiosResponse } from "axios";
-import router from "@/router";
 import { useAuthStore } from "@/store/auth.store";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -53,7 +53,7 @@ export function useChangeSetsStore() {
       actions: {
         async setActiveChangeset(changeSetPk: string) {
           // We need to force refetch changesets since there's a race condition in which redirects
-          // will be triggered but the frontend won't have refreshed the list of changesets 
+          // will be triggered but the frontend won't have refreshed the list of changesets
           if (!this.changeSetsById[changeSetPk]) {
             await this.FETCH_CHANGE_SETS();
           }

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -131,6 +131,7 @@ pub fn routes() -> Router<AppState> {
             post(get_node_add_menu::get_node_add_menu),
         )
         .route("/create_node", post(create_node::create_node))
+        .route("/create_node2", post(create_node::create_node2))
         .route(
             "/set_node_position",
             post(set_node_position::set_node_position),
@@ -140,28 +141,48 @@ pub fn routes() -> Router<AppState> {
             post(create_connection::create_connection),
         )
         .route(
-            "/create_connection_2",
-            post(create_connection::create_connection_2),
+            "/create_connection2",
+            post(create_connection::create_connection2),
         )
         .route(
             "/delete_connection",
             post(delete_connection::delete_connection),
         )
         .route(
+            "/delete_connection2",
+            post(delete_connection::delete_connection2),
+        )
+        .route(
             "/restore_connection",
             post(restore_connection::restore_connection),
+        )
+        .route(
+            "/restore_connection2",
+            post(restore_connection::restore_connection2),
         )
         .route(
             "/delete_component",
             post(delete_component::delete_component),
         )
         .route(
+            "/delete_component2",
+            post(delete_component::delete_component2),
+        )
+        .route(
             "/restore_component",
             post(restore_component::restore_component),
         )
         .route(
+            "/restore_component2",
+            post(restore_component::restore_component2),
+        )
+        .route(
             "/connect_component_to_frame",
             post(connect_component_to_frame::connect_component_to_frame),
+        )
+        .route(
+            "/connect_component_to_frame2",
+            post(connect_component_to_frame::connect_component_to_frame2),
         )
         .route(
             "/list_schema_variants",

--- a/lib/sdf-server/src/server/service/diagram/connect_component_to_frame.rs
+++ b/lib/sdf-server/src/server/service/diagram/connect_component_to_frame.rs
@@ -4,9 +4,9 @@ use dal::edge::{EdgeKind, EdgeObjectId, VertexObjectKind};
 use dal::job::definition::DependentValuesUpdate;
 use dal::socket::{SocketEdgeKind, SocketKind};
 use dal::{
-    node::NodeId, AttributeReadContext, AttributeValue, Component, Connection, DalContext, Edge,
-    EdgeError, ExternalProvider, InternalProvider, InternalProviderId, Node, PropId, StandardModel,
-    Visibility, WsEvent,
+    node::NodeId, AttributeReadContext, AttributeValue, ChangeSet, ChangeSetPk, Component,
+    Connection, DalContext, Edge, EdgeError, ExternalProvider, InternalProvider,
+    InternalProviderId, Node, PropId, StandardModel, Visibility, WsEvent,
 };
 use dal::{ComponentType, Socket};
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,8 @@ pub struct CreateFrameConnectionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CreateFrameConnectionResponse {
     pub connection: Connection,
+    #[serde(rename = "_forceChangesetPk")] // TODO(victor) find a way to return this as a header
+    pub force_changeset_pk: Option<ChangeSetPk>,
 }
 
 /// Create a [`Connection`](dal::Connection) with a _to_ [`Socket`](dal::Socket) and
@@ -116,7 +118,10 @@ pub async fn connect_component_to_frame(
 
     ctx.commit().await?;
 
-    Ok(Json(CreateFrameConnectionResponse { connection }))
+    Ok(Json(CreateFrameConnectionResponse {
+        connection,
+        force_changeset_pk: None,
+    }))
 }
 
 // Create all valid connections between parent and child sockets
@@ -298,4 +303,112 @@ pub async fn connect_component_sockets_to_frame(
     }
 
     Ok(())
+}
+
+/// Create a [`Connection`](dal::Connection) with a _to_ [`Socket`](dal::Socket) and
+/// [`Node`](dal::Node) and a _from_ [`Socket`](dal::Socket) and [`Node`](dal::Node).
+/// Creating a change set if on head.
+pub async fn connect_component_to_frame2(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<CreateFrameConnectionRequest>,
+) -> DiagramResult<Json<CreateFrameConnectionResponse>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    // Connect children to parent through frame edge
+    let from_socket = Socket::find_frame_socket_for_node(
+        &ctx,
+        request.child_node_id,
+        SocketEdgeKind::ConfigurationOutput,
+    )
+    .await?;
+    let to_socket = Socket::find_frame_socket_for_node(
+        &ctx,
+        request.parent_node_id,
+        SocketEdgeKind::ConfigurationInput,
+    )
+    .await?;
+
+    let connection = Connection::new(
+        &ctx,
+        request.child_node_id,
+        *from_socket.id(),
+        request.parent_node_id,
+        *to_socket.id(),
+        EdgeKind::Symbolic,
+    )
+    .await?;
+
+    connect_component_sockets_to_frame(&ctx, request.parent_node_id, request.child_node_id).await?;
+
+    let child_comp = Node::get_by_id(&ctx, &request.child_node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(request.child_node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?;
+
+    let child_schema = child_comp
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    let parent_comp = Node::get_by_id(&ctx, &request.parent_node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(request.parent_node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?;
+
+    let parent_schema = parent_comp
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "component_connected_to_frame",
+        serde_json::json!({
+                    "parent_component_id": parent_comp.id(),
+                    "parent_component_schema_name": parent_schema.name(),
+                    "parent_socket_id": to_socket.id(),
+                    "parent_socket_name": to_socket.name(),
+                    "child_component_id": child_comp.id(),
+                    "child_component_schema_name": child_schema.name(),
+                    "child_socket_id": from_socket.id(),
+                    "child_socket_name": from_socket.name(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateFrameConnectionResponse {
+        connection,
+        force_changeset_pk,
+    }))
 }

--- a/lib/sdf-server/src/server/service/diagram/create_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_connection.rs
@@ -141,7 +141,8 @@ pub async fn create_connection(
 
 /// Create a [`Connection`](dal::Connection) with a _to_ [`Socket`](dal::Socket) and
 /// [`Node`](dal::Node) and a _from_ [`Socket`](dal::Socket) and [`Node`](dal::Node).
-pub async fn create_connection_2(
+/// Creating change set if on head
+pub async fn create_connection2(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     PosthogClient(posthog_client): PosthogClient,

--- a/lib/sdf-server/src/server/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_component.rs
@@ -1,6 +1,6 @@
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{Component, ComponentId, StandardModel, Visibility, WsEvent};
+use dal::{ChangeSet, ChangeSetPk, Component, ComponentId, StandardModel, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 use super::{DiagramError, DiagramResult};
@@ -17,8 +17,9 @@ pub struct DeleteComponentRequest {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct DeleteComponentResponse {
-    pub success: bool,
+pub struct ForceChangeSet {
+    #[serde(rename = "_forceChangesetPk")] // TODO(victor) find a way to return this as a header
+    pub force_changeset_pk: Option<ChangeSetPk>,
 }
 
 /// Delete a [`Component`](dal::Component) via its componentId.
@@ -28,7 +29,7 @@ pub async fn delete_component(
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Json(request): Json<DeleteComponentRequest>,
-) -> DiagramResult<Json<DeleteComponentResponse>> {
+) -> DiagramResult<Json<ForceChangeSet>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let mut comp = Component::get_by_id(&ctx, &request.component_id)
@@ -60,5 +61,65 @@ pub async fn delete_component(
 
     ctx.commit().await?;
 
-    Ok(Json(DeleteComponentResponse { success: true }))
+    Ok(Json(ForceChangeSet {
+        force_changeset_pk: None,
+    }))
+}
+
+/// Delete a [`Component`](dal::Component) via its componentId. Creates change-set if on head
+pub async fn delete_component2(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<DeleteComponentRequest>,
+) -> DiagramResult<Json<ForceChangeSet>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    let mut comp = Component::get_by_id(&ctx, &request.component_id)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?;
+
+    let comp_schema = comp
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    comp.delete_and_propagate(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "delete_component",
+        serde_json::json!({
+            "component_id": request.component_id,
+            "component_schema_name": comp_schema.name(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(ForceChangeSet { force_changeset_pk }))
 }

--- a/lib/sdf-server/src/server/service/diagram/delete_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_connection.rs
@@ -1,7 +1,7 @@
 use axum::extract::OriginalUri;
 use axum::Json;
 use dal::edge::EdgeId;
-use dal::{Connection, Edge, Node, Socket, Visibility, WsEvent};
+use dal::{ChangeSet, ChangeSetPk, Connection, Edge, Node, Socket, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;
@@ -88,4 +88,99 @@ pub async fn delete_connection(
     ctx.commit().await?;
 
     Ok(())
+}
+
+/// Delete a [`Connection`](dal::Connection) via its EdgeId. Creating change-set if on head.
+pub async fn delete_connection2(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<DeleteConnectionRequest>,
+) -> DiagramResult<Json<ForceChangeSet>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    let edge = Edge::get_by_id(&ctx, &request.edge_id)
+        .await?
+        .ok_or(DiagramError::EdgeNotFound)?;
+
+    let conn = Connection::from_edge(&edge);
+    let from_component_schema = Node::get_by_id(&ctx, &conn.source.node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(conn.source.node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    let from_socket = Socket::get_by_id(&ctx, &conn.source.socket_id)
+        .await?
+        .ok_or(DiagramError::SocketNotFound)?;
+
+    let to_component_schema = Node::get_by_id(&ctx, &conn.destination.node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(conn.destination.node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    let to_socket = Socket::get_by_id(&ctx, &conn.destination.socket_id)
+        .await?
+        .ok_or(DiagramError::SocketNotFound)?;
+
+    Connection::delete_for_edge(&ctx, request.edge_id).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "delete_connection",
+        serde_json::json!({
+            "from_node_id": conn.source.node_id,
+            "from_node_schema_name": from_component_schema.name(),
+            "from_socket_id": conn.source.socket_id,
+            "from_socket_name": &from_socket.name(),
+            "to_node_id": conn.destination.node_id,
+            "to_node_schema_name": to_component_schema.name(),
+            "to_socket_id": conn.destination.socket_id,
+            "to_socket_name":  &to_socket.name(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(ForceChangeSet { force_changeset_pk }))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ForceChangeSet {
+    #[serde(rename = "_forceChangesetPk")] // TODO(victor) find a way to return this as a header
+    pub force_changeset_pk: Option<ChangeSetPk>,
 }

--- a/lib/sdf-server/src/server/service/diagram/restore_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/restore_component.rs
@@ -1,6 +1,6 @@
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{Component, ComponentId, Visibility, WsEvent};
+use dal::{ChangeSet, ChangeSetPk, Component, ComponentId, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;
@@ -63,4 +63,75 @@ pub async fn restore_component(
     ctx.commit().await?;
 
     Ok(())
+}
+
+/// Delete a [`Component`](dal::Component) via its componentId. Creating change set if on head.
+pub async fn restore_component2(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<RestoreComponentRequest>,
+) -> DiagramResult<Json<ForceChangeSet>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    Component::restore_and_propagate(&ctx, request.component_id).await?;
+
+    let (component, schema) = {
+        let ctx_with_deleted = &ctx.clone_with_delete_visibility();
+
+        let component = Component::get_by_id(ctx_with_deleted, &request.component_id)
+            .await?
+            .ok_or(DiagramError::ComponentNotFound)?;
+
+        let schema = component
+            .schema(&ctx)
+            .await?
+            .ok_or(DiagramError::SchemaNotFound)?;
+
+        (component, schema)
+    };
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "restore_component",
+        serde_json::json!({
+                    "component_id": component.id(),
+                    "component_schema_name": schema.name(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(ForceChangeSet { force_changeset_pk }))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ForceChangeSet {
+    #[serde(rename = "_forceChangesetPk")] // TODO(victor) find a way to return this as a header
+    pub force_changeset_pk: Option<ChangeSetPk>,
 }

--- a/lib/sdf-server/src/server/service/diagram/restore_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/restore_connection.rs
@@ -1,7 +1,7 @@
 use axum::extract::OriginalUri;
 use axum::Json;
 use dal::edge::EdgeId;
-use dal::{Connection, Edge, Node, Socket, Visibility, WsEvent};
+use dal::{ChangeSet, ChangeSetPk, Connection, Edge, Node, Socket, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;
@@ -88,4 +88,99 @@ pub async fn restore_connection(
     ctx.commit().await?;
 
     Ok(())
+}
+
+/// Delete a [`Connection`](dal::Connection) via its EdgeId. Creates change-set if on head.
+pub async fn restore_connection2(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<UndeleteConnectionRequest>,
+) -> DiagramResult<Json<ForceChangeSet>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    Connection::restore_for_edge(&ctx, request.edge_id).await?;
+
+    let edge = Edge::get_by_id(&ctx, &request.edge_id)
+        .await?
+        .ok_or(DiagramError::EdgeNotFound)?;
+
+    let conn = Connection::from_edge(&edge);
+    let from_component_schema = Node::get_by_id(&ctx, &conn.source.node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(conn.source.node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    let from_socket = Socket::get_by_id(&ctx, &conn.source.socket_id)
+        .await?
+        .ok_or(DiagramError::SocketNotFound)?;
+
+    let to_component_schema = Node::get_by_id(&ctx, &conn.destination.node_id)
+        .await?
+        .ok_or(DiagramError::NodeNotFound(conn.destination.node_id))?
+        .component(&ctx)
+        .await?
+        .ok_or(DiagramError::ComponentNotFound)?
+        .schema(&ctx)
+        .await?
+        .ok_or(DiagramError::SchemaNotFound)?;
+
+    let to_socket = Socket::get_by_id(&ctx, &conn.destination.socket_id)
+        .await?
+        .ok_or(DiagramError::SocketNotFound)?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "restore_connection",
+        serde_json::json!({
+            "from_node_id": conn.source.node_id,
+            "from_node_schema_name": from_component_schema.name(),
+            "from_socket_id": conn.source.socket_id,
+            "from_socket_name": &from_socket.name(),
+            "to_node_id": conn.destination.node_id,
+            "to_node_schema_name": to_component_schema.name(),
+            "to_socket_id": conn.destination.socket_id,
+            "to_socket_name":  &to_socket.name(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(ForceChangeSet { force_changeset_pk }))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ForceChangeSet {
+    #[serde(rename = "_forceChangesetPk")] // TODO(victor) find a way to return this as a header
+    pub force_changeset_pk: Option<ChangeSetPk>,
 }

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -26,9 +26,7 @@ use dal::{
 use names::{Generator, Name};
 use sdf_server::service::component::refresh::{RefreshRequest, RefreshResponse};
 use sdf_server::service::dev::{AuthorSingleSchemaRequest, AuthorSingleSchemaResponse};
-use sdf_server::service::diagram::delete_component::{
-    DeleteComponentRequest, DeleteComponentResponse,
-};
+use sdf_server::service::diagram::delete_component::{DeleteComponentRequest, ForceChangeSet};
 use sdf_server::service::diagram::get_diagram::GetDiagramRequest;
 use sdf_server::service::variant_definition::create_variant_def::{
     CreateVariantDefRequest, CreateVariantDefResponse,
@@ -489,10 +487,9 @@ impl ScenarioHarness {
             component_id,
             visibility: *ctx.visibility(),
         };
-        let response: DeleteComponentResponse = self
+        let _response: ForceChangeSet = self
             .query_post("/api/diagram/delete_component", &request)
             .await;
-        assert!(response.success)
     }
 
     pub async fn author_single_schema_with_default_variant(


### PR DESCRIPTION
Converted most update backend routes to create a change-set if on head. This uncovered a major problem with this approach though. Which is a race-condition. If you take two actions fast while on head each action will happen in a different change-set. The only way to avoid this is either "freezing" the screen if some update action is happening while on head, which will unfreeze when the new change set pk is returned, but this may turn out really awkward for the user as making the unresponsiveness / breakage of flow clear and ergonomic is hard.

Since this does not affect the regular screen I'm ok with merging and then we can translate the routes to the approach that is decided. Reverting this PR is simple enough.

The other option is moving the control of the change set pk back to the front-end. Which has problems with how we detect change-sets as it requires a route update, and it may be a dead-end but it would give us total control over those races. Since JS single-threaded concurrency allows us to intercept all actions.

Restoration actions technically should not be triggearable on head, ignoring them in this refactor felt awkward as it could show incorrect data on the screen, so I decided to support them out of the box. They should not appear, and if one day we decide to show them it will work out of the box, if not it won't change a thing.

I will give this problem some more thought, maybe there is something I'm missing (or that was discussed last week).