### PR TITLE
feat: initial dev experience, powered by Tilt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,12 @@ indent_size = 4
 tab_width = 4
 max_line_length = 100
 
+[Tiltfile]
+indent_style = space
+indent_size = 4
+tab_width = 4
+max_line_length = 100
+
 [Dockerfile]
 indent_style = space
 indent_size = 4

--- a/dev/BUCK
+++ b/dev/BUCK
@@ -1,0 +1,42 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "alias",
+    "tilt_docker_compose_stop",
+    "tilt_down",
+    "tilt_up",
+)
+
+python_bootstrap_binary(
+    name = "healthcheck",
+    main = "healthcheck.py",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "dev",
+    actual = ":up",
+)
+
+# Bring up the full set of services for development
+tilt_up(
+    name = "up",
+)
+
+# Bring up only platform services such as PostgreSQL, NATS, etc.
+tilt_up(
+    name = "platform",
+    args = [
+        "platform"
+    ],
+)
+
+# Stop any remaining/running services while attempting to preserve persistent state
+tilt_docker_compose_stop(
+    name = "stop",
+    docker_compose_file = "docker-compose.platform.yml",
+)
+
+# Bring down any remaining/running services
+tilt_down(
+    name = "down",
+)

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,0 +1,171 @@
+config.define_string_list("to-run", args = True)
+cfg = config.parse()
+
+# Define groups of services
+groups = {
+    "platform": [
+        "jaeger",
+        "nats",
+        "otelcol",
+        "postgres",
+    ],
+    "backend": [
+        "council",
+        "pinga",
+        "veritech",
+        "sdf",
+    ],
+    "frontend": [
+        "web",
+    ],
+}
+# Add "all" group as a sorted set of all services
+_all = {}
+for group_values in groups.values():
+    for value in group_values:
+        _all.update({ value: True })
+groups.update({ "all": sorted(_all.keys()) })
+
+# Parse the CLI args to enable group names and/or individual service names
+enabled_resources = []
+for arg in cfg.get("to-run", []):
+    if arg in groups:
+        enabled_resources += groups[arg]
+    else:
+        enabled_resources.append(arg)
+config.set_enabled_resources(enabled_resources)
+
+# Default trigger mode to manual so that (importantly) backend services don't rebuild/restart
+# automatically. This is opt-in in the Tilt UI in the `Mode` column
+trigger_mode = TRIGGER_MODE_MANUAL
+
+def _buck2_dep_inputs(target):
+    cmd = [
+        "buck2",
+        "uquery",
+        "\"inputs(deps('{}'))\"".format(target),
+    ]
+    file_paths = str(local(" ".join(cmd))).splitlines()
+
+    return file_paths
+
+# From the Tilt docs:
+#
+# > By default, Tilt will not let you develop against a remote cluster.
+#
+# The implication appears to be that if Tilt finds a configured Kubernetes setup on your system
+# **and** it's a remote cluster, despite the fact that we are not using any Kubernetes features or
+# capabilities, it will still try to connect and fail. Instead, we're going to disable this check
+# and continue.
+#
+# - https://docs.tilt.dev/choosing_clusters.html#remote
+# - https://docs.tilt.dev/api.html#api.allow_k8s_contexts
+allow_k8s_contexts(k8s_context())
+
+# Use Docker Compose to provide the platform services
+docker_compose("./docker-compose.platform.yml")
+compose_services = ["jaeger", "nats", "otelcol", "postgres"]
+for service in compose_services:
+    dc_resource(service, labels = ["platform"])
+
+# Locally build and run `council`
+council_target = "//bin/council:council"
+local_resource(
+    "council",
+    labels = ["backend"],
+    cmd = "buck2 build {}".format(council_target),
+    serve_cmd = "buck2 run {}".format(council_target),
+    allow_parallel = True,
+    resource_deps = [
+        "nats",
+        "otelcol",
+    ],
+    deps = _buck2_dep_inputs(council_target),
+    trigger_mode = trigger_mode,
+)
+
+# Locally build and run `pinga`
+pinga_target = "//bin/pinga:pinga"
+local_resource(
+    "pinga",
+    labels = ["backend"],
+    cmd = "buck2 build {}".format(pinga_target),
+    serve_cmd = "buck2 run {}".format(pinga_target),
+    allow_parallel = True,
+    resource_deps = [
+        "council",
+        "nats",
+        "otelcol",
+        "veritech",
+    ],
+    deps = _buck2_dep_inputs(pinga_target),
+    trigger_mode = trigger_mode,
+)
+
+# Locally build and run `veritech`
+veritech_target = "//bin/veritech:veritech"
+local_resource(
+    "veritech",
+    labels = ["backend"],
+    cmd = "buck2 build {}".format(veritech_target),
+    serve_cmd = "buck2 run {}".format(veritech_target),
+    allow_parallel = True,
+    resource_deps = [
+        "nats",
+        "otelcol",
+    ],
+    deps = _buck2_dep_inputs(veritech_target),
+    trigger_mode = trigger_mode,
+)
+
+# Locally build and run `sdf`
+sdf_target = "//bin/sdf:sdf"
+local_resource(
+    "sdf",
+    labels = ["backend"],
+    cmd = "buck2 build {}".format(sdf_target),
+    serve_cmd = "buck2 run {}".format(sdf_target),
+    allow_parallel = True,
+    resource_deps = [
+        "nats",
+        "otelcol",
+        "pinga",
+        "postgres",
+        "veritech",
+    ],
+    deps = _buck2_dep_inputs(sdf_target),
+    trigger_mode = trigger_mode,
+    readiness_probe = probe(
+        period_secs  = 5,
+        http_get = http_get_action(
+            port = 5156,
+            path = "/api/"
+        ),
+    ),
+    links = [
+        "localhost:5156",
+    ],
+)
+
+# Locally build and run `web` in dev mode
+web_target = "//app/web:dev"
+local_resource(
+    "web",
+    labels = ["frontend"],
+    cmd = "buck2 build {}".format(web_target),
+    serve_cmd = "buck2 run {}".format(web_target),
+    allow_parallel = True,
+    resource_deps = [
+        "sdf",
+    ],
+    readiness_probe = probe(
+        period_secs  = 5,
+        http_get = http_get_action(
+            port = 8080,
+        ),
+    ),
+    links = [
+        link("http://127.0.0.1:8080", "web"),
+        link("https://auth.systeminit.com", "auth"),
+    ],
+)

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -1,0 +1,37 @@
+---
+version: "3"
+
+services:
+  postgres:
+    image: systeminit/postgres:stable
+    environment:
+      - "POSTGRES_PASSWORD=bugbear"
+      - "PGPASSWORD=bugbear"
+      - "POSTGRES_USER=si"
+      - "POSTGRES_DB=si"
+      - "POSTGRES_MULTIPLE_DBS=si_test,si_test_dal,si_test_sdf_server,si_auth,si_module_index"
+    ports:
+      - "5432:5432"
+
+  nats:
+    image: systeminit/nats:stable
+    command:
+      - "--config"
+      - "nats-server.conf"
+      - "-DVV"
+    ports:
+      - "4222:4222"
+
+  jaeger:
+    image: systeminit/jaeger:stable
+    ports:
+      - "5317:4317"
+      - "16686:16686"
+
+  otelcol:
+    image: systeminit/otelcol:stable
+    ports:
+      - "4317:4317"
+      - "55679:55679"
+    depends_on:
+      - jaeger

--- a/dev/healthcheck.py
+++ b/dev/healthcheck.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Detects and reports the max number of open files allowed per process.
+"""
+import argparse
+import subprocess
+import shutil
+import sys
+
+MIN_OPENFILES_VALUE = 1024
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    remediations = 0
+
+    section("Running health check on system for developing in the SI project")
+
+    docker_cmd = detect_docker_command()
+    remediations += docker_cmd
+    if docker_cmd == 0:
+        remediations += detect_docker_engine()
+        remediations += detect_docker_compose()
+    remediations += detect_nix_bash()
+    remediations += detect_openfiles_soft_limit()
+
+    blank()
+    if remediations > 0:
+        section(f"Health check complete with _{remediations}_ "
+                "suggested remediation(s)")
+    else:
+        section(f"Health check complete with **no** suggested remediations.")
+
+    # If there are remediations, exit non-zero so scripts can detect that the
+    # current setup may not be healthy
+    return remediations
+
+
+def detect_docker_command() -> int:
+    result = detect_command("docker")
+    return result
+
+
+def detect_docker_engine() -> int:
+    result = subprocess.run(["docker", "info"], capture_output=True)
+    if result.returncode == 0:
+        info("Detected running Docker Engine")
+        return 0
+    else:
+        warn("Failed to detect running Docker Engine")
+        indent("Output from `docker info` stderr:")
+        indent("-----")
+        for line in result.stderr.splitlines():
+            indent(line.decode("ascii"))
+        indent("-----")
+        indent("Ensure that the Docker Engine is running and try again")
+        return 1
+
+
+def detect_docker_compose() -> int:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "version",
+        ],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        info("Detected Docker Compose is installed")
+        return 0
+    else:
+        warn("Failed to detect Docker Compose installation")
+        indent("Output from `docker compose version` stderr:")
+        indent("-----")
+        for line in result.stderr.splitlines():
+            indent(line.decode("ascii"))
+        indent("-----")
+        indent("Ensure that the Docker Compose is running and try again")
+        return 1
+
+
+def detect_nix_bash() -> int:
+    cmd = "bash"
+    result = shutil.which(cmd)
+    if result and result.startswith("/nix/store/"):
+        info(f"Found `{cmd}` in Nix environment")
+        return 0
+    elif result:
+        warn(f"Failed to find `{cmd}` in Nix environment (cmd={result})")
+        indent("Ensure that your direnv setup is correct or that you have ran "
+               "`nix develop`")
+        return 1
+    else:
+        warn(f"Failed to find `{cmd}` in Nix environment or on system")
+        indent("Ensure that your direnv setup is correct or that you have ran "
+               "`nix develop`")
+        return 1
+
+
+def detect_openfiles_soft_limit() -> int:
+    soft_limit = current_openfiles_soft_limit()
+
+    if soft_limit < MIN_OPENFILES_VALUE:
+        new = MIN_OPENFILES_VALUE
+        warn("Low value for max open files soft limit detected in "
+             f"current shell (current={soft_limit})")
+        blank()
+        indent("To set a value for this shell session **only** run:")
+        indent(f"ulimit -Sn {new}", amount=2)
+        blank()
+        indent(
+            "To make a **permanent** change for all new shell sessions run:")
+        indent(f"echo 'ulimit -Sn {new}' >>\"$HOME/.profile\"", amount=2)
+        return 1
+    else:
+        info("Reasonable value for max open files soft limit detected in "
+             f"current shell (current={soft_limit})")
+        return 0
+
+
+def detect_command(cmd: str) -> int:
+    result = shutil.which(cmd)
+    if result:
+        info(f"Detected `{cmd}` command (cmd={result})")
+        return 0
+    else:
+        warn(f"Failed to find `{cmd}` on PATH and is required for development")
+        return 1
+
+
+def current_openfiles_soft_limit() -> int:
+    result = subprocess.run(
+        ["bash", "-c", "ulimit -Sn"],
+        capture_output=True,
+    )
+    result.check_returncode()
+    return int(result.stdout.strip().decode("ascii"))
+
+
+def section(msg: str):
+    print(f"--- {msg}")
+
+
+def info(msg: str):
+    print(f"  - {msg}")
+
+
+def warn(msg: str):
+    print(f"  x {msg}")
+
+
+def indent(msg: str, amount=1):
+    print("{:>{width}}{}".format("", msg, width=amount * 4))
+
+
+def blank():
+    print("")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
             postgresql_14
             protobuf
             reindeer
+            tilt
 
             (rustToolchain.override {
               # This really should be augmenting the extensions, instead of

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -43,3 +43,13 @@ load(
 rust_binary = _rust_binary
 rust_library = _rust_library
 rust_test = _rust_test
+
+load(
+    "@prelude-si//macros:tilt.bzl",
+    _tilt_docker_compose_stop = "tilt_docker_compose_stop",
+    _tilt_down = "tilt_down",
+    _tilt_up = "tilt_up",
+)
+tilt_docker_compose_stop = _tilt_docker_compose_stop
+tilt_down = _tilt_down
+tilt_up = _tilt_up

--- a/prelude-si/macros/tilt.bzl
+++ b/prelude-si/macros/tilt.bzl
@@ -1,0 +1,30 @@
+load(
+    "@prelude-si//:tilt.bzl",
+    _tilt_docker_compose_stop = "tilt_docker_compose_stop",
+    _tilt_down = "tilt_down",
+    _tilt_up = "tilt_up",
+)
+
+def tilt_docker_compose_stop(
+        visibility = ["PUBLIC"],
+        **kwargs):
+    _tilt_docker_compose_stop(
+        visibility = visibility,
+        **kwargs,
+    )
+
+def tilt_down(
+        visibility = ["PUBLIC"],
+        **kwargs):
+    _tilt_down(
+        visibility = visibility,
+        **kwargs,
+    )
+
+def tilt_up(
+        visibility = ["PUBLIC"],
+        **kwargs):
+    _tilt_up(
+        visibility = visibility,
+        **kwargs,
+    )

--- a/prelude-si/tilt.bzl
+++ b/prelude-si/tilt.bzl
@@ -1,0 +1,105 @@
+def tilt_up_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+    return _invoke_tilt(ctx, "up")
+
+tilt_up = rule(
+    impl = tilt_up_impl,
+    attrs = {
+        "tiltfile": attrs.string(
+            default = "Tiltfile",
+            doc = """The Tiltfile to run.""",
+        ),
+        "args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Additional arguments passed as <Tiltfile args>.""",
+        ),
+        "tilt_args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Additional arguments passed as `tilt` arguments.""",
+        ),
+    },
+)
+
+def tilt_down_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+    return _invoke_tilt(ctx, "down")
+
+tilt_down = rule(
+    impl = tilt_down_impl,
+    attrs = {
+        "tiltfile": attrs.string(
+            default = "Tiltfile",
+            doc = """The Tiltfile to run.""",
+        ),
+        "args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Additional arguments passed as <Tiltfile args>.""",
+        ),
+        "tilt_args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Additional arguments passed as `tilt` arguments.""",
+        ),
+    },
+)
+
+def tilt_docker_compose_stop_impl(ctx: "context") -> [[DefaultInfo.type, RunInfo.type]]:
+    docker_compose_file = "{}/{}".format(
+        ctx.label.package,
+        ctx.attrs.docker_compose_file,
+    )
+
+    run_cmd_args = cmd_args([
+        "docker",
+        "compose",
+        "--file",
+        docker_compose_file,
+        "stop",
+    ])
+    run_cmd_args.add(ctx.attrs.services)
+
+    args_file = ctx.actions.write("docker-compose-args.txt", run_cmd_args)
+
+    return [
+        DefaultInfo(default_output = args_file),
+        RunInfo(run_cmd_args),
+    ]
+
+tilt_docker_compose_stop = rule(
+    impl = tilt_docker_compose_stop_impl,
+    attrs = {
+        "docker_compose_file": attrs.string(
+            default = "docker-compose.yml",
+            doc = """The Tiltfile to run.""",
+        ),
+        "services": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Stop specific services.""",
+        ),
+    },
+)
+
+def _invoke_tilt(ctx: "context", subcmd: str.type) -> [[DefaultInfo.type, RunInfo.type]]:
+    tiltfile = "{}/{}".format(
+        ctx.label.package,
+        ctx.attrs.tiltfile,
+    )
+
+    run_cmd_args = cmd_args([
+        "tilt",
+        subcmd,
+        "--file",
+        tiltfile,
+    ])
+    run_cmd_args.add(ctx.attrs.tilt_args)
+    run_cmd_args.add("--")
+    run_cmd_args.add(ctx.attrs.args)
+
+    args_file = ctx.actions.write("tilt-args.txt", run_cmd_args)
+
+    return [
+        DefaultInfo(default_output = args_file),
+        RunInfo(run_cmd_args),
+    ]


### PR DESCRIPTION
This change adds a new tool into the development stack (managed by Nix so no new steps for developers) called [Tilt](https://tilt.dev/). We are using it in a particular way to suit our current workflow, namely to run the supporting services (here called "platform" services) with Docker Compose and run our own services directly on the host by compiling them using the Buck2 build system.

Usage
=====

A new root-level directory called `dev` contains a Buck2 package with runnable targets to manage a development environment.

Check Health of System
----------------------

Before starting a development environment, you can run a health check which will attempt to verify some basic system information, such as a running Docker Engine instance, reasonable max open file limits, etc. The health check is run with:

```sh
buck2 run dev:healthcheck
```

Start a Development Environment
-------------------------------

To start a development environment which runs all supporting platform services and System Initiative services run the following:

```sh
buck2 run dev:up
```

Internally a `Tiltfile` is used in combination with a Docker Compose file to provide a fully running stack of System Initiative. As the output of `tilt` suggests, hitting the space bar will open a web UI which allows you to control the running environment, follow some or all streams of output, and more. To see a stream of all the services' output, hitting the `s` key will redirect all output to the console rather than a web UI.

To stop all locally running System Initiative services, type `ctrl+c` back in the terminal. Note that this will leave the platform services running (such as PostgreSQL, NATS, the OpenTelemetry collector, etc.).

**Note** that for convenience, there is an alias for this command which is `buck2 run dev`.

Stop Platform Services to Run Later
-----------------------------------

If you wish to preserve the state of your database for later development without wiping it, you can run the following:

```sh
buck2 run dev:stop
```

Internally this will issue a `docker compose ... stop` rather than attempting to tear down the platform services.

Resume A Running Environment
----------------------------

The resume an environment that might be stopped, partially or entirely built, you can run re-run:

```sh
buck2 run dev:up
```

Run a Platform-Only Environment
-------------------------------

If you only require platform services running to run integration tests or to run a subset of System Initiative services manually, you can run only the platform services with:

```sh
buck2 run dev:platform
```

Tear Down Development Environment
---------------------------------

The stop all services and delete all persisted data, run the following:

```sh
buck2 run dev:down
```

<img src="https://media0.giphy.com/media/4uKGppPmeVBCzwfnMK/giphy.gif"/>