### PR TITLE
feat(web): make all customize screens read-only if on head

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -1,5 +1,6 @@
 <template>
   <VButton
+    v-if="!changeSetsStore.headSelected"
     ref="applyButtonRef"
     icon="tools"
     size="sm"

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -1,12 +1,13 @@
 <template>
-  <div>
+  <div class="p-xs">
     <RequestStatusMessage
       v-if="loadAssetReqStatus.isPending"
       :requestStatus="loadAssetReqStatus"
       showLoaderWithoutMessage
     />
-    <div v-else-if="assetStore.selectedAsset && assetId" class="flex flex-col">
+    <div v-else-if="assetStore.selectedAsset && assetId">
       <div
+        v-if="!changeSetsStore.headSelected"
         class="p-sm border-b dark:border-neutral-600 flex flex-row items-center gap-2"
       >
         <VButton
@@ -27,13 +28,12 @@
           @click="cloneAsset"
         />
       </div>
-      <div class="p-2">
+
+      <Stack>
         <ErrorMessage
           v-if="executeAssetReqStatus.isError"
           :requestStatus="executeAssetReqStatus"
         />
-      </div>
-      <div class="p-sm flex flex-col">
         <VormInput
           id="name"
           v-model="assetStore.selectedAsset.name"
@@ -43,8 +43,6 @@
           placeholder="Give this asset a name here..."
           @blur="updateAsset"
         />
-      </div>
-      <div class="p-sm flex flex-col">
         <VormInput
           id="menuName"
           v-model="assetStore.selectedAsset.menuName"
@@ -54,8 +52,6 @@
           placeholder="Optionally, give the asset a shorter name for display here..."
           @blur="updateAsset"
         />
-      </div>
-      <div class="p-sm flex flex-col">
         <VormInput
           id="category"
           v-model="assetStore.selectedAsset.category"
@@ -65,8 +61,6 @@
           placeholder="Pick a category for this asset"
           @blur="updateAsset"
         />
-      </div>
-      <div class="p-sm flex flex-col">
         <VormInput
           id="componentType"
           v-model="assetStore.selectedAsset.componentType"
@@ -76,8 +70,6 @@
           label="Component Type"
           @change="updateAsset"
         />
-      </div>
-      <div class="p-sm flex flex-col">
         <VormInput
           id="description"
           v-model="assetStore.selectedAsset.description"
@@ -87,32 +79,25 @@
           placeholder="Provide a brief description of this asset here..."
           @blur="updateAsset"
         />
-      </div>
-      <div class="p-sm">
-        <label class="pl-[1px] text-sm font-bold" for="color">Color</label>
-        <div class="mt-1 block">
+        <VormInput type="container" label="color" :disabled="disabled">
           <ColorPicker
             id="color"
             v-model="assetStore.selectedAsset.color"
+            :disabled="disabled"
             @change="updateAsset"
           />
-        </div>
-      </div>
-      <div class="p-sm flex flex-col">
+        </VormInput>
+
         <VormInput
           id="link"
           v-model="assetStore.selectedAsset.link"
+          type="url"
           :disabled="disabled"
           label="Documentation Link"
           placeholder="Enter a link to the documentation for this asset here..."
           @blur="updateAsset"
         />
-        <div class="text-md text-action-500 font-bold">
-          <a :href="assetStore.selectedAsset.link" target="_blank">
-            Documentation Link
-          </a>
-        </div>
-      </div>
+      </Stack>
     </div>
     <div
       v-else
@@ -135,15 +120,18 @@ import {
   RequestStatusMessage,
   Modal,
   ErrorMessage,
+  Stack,
 } from "@si/vue-lib/design-system";
 import { useAssetStore } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import ColorPicker from "./ColorPicker.vue";
 
 defineProps<{
   assetId?: string;
 }>();
 
+const changeSetsStore = useChangeSetsStore();
 const assetStore = useAssetStore();
 const funcStore = useFuncStore();
 const loadAssetReqStatus = assetStore.getRequestStatus("LOAD_ASSET");

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -30,7 +30,9 @@
       <CodeEditor
         v-model="editingAsset"
         json
-        :disabled="!!selectedAsset.defaultVariantId"
+        :disabled="
+          !!selectedAsset.defaultVariantId || changeSetsStore.headSelected
+        "
         @change="onChange"
       />
     </div>
@@ -46,6 +48,7 @@ import { ref, watch, computed } from "vue";
 import { Timestamp, RequestStatusMessage } from "@si/vue-lib/design-system";
 import { useAssetStore, assetDisplayName } from "@/store/asset.store";
 import SiChip from "@/components/SiChip.vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import CodeEditor from "./CodeEditor.vue";
 import NodeSkeleton from "./NodeSkeleton.vue";
 
@@ -53,6 +56,7 @@ const props = defineProps<{
   assetId?: string;
 }>();
 
+const changeSetsStore = useChangeSetsStore();
 const assetStore = useAssetStore();
 const selectedAsset = computed(() =>
   props.assetId ? assetStore.assetsById[props.assetId] : undefined,

--- a/app/web/src/components/AssetFuncListPanel.vue
+++ b/app/web/src/components/AssetFuncListPanel.vue
@@ -11,7 +11,7 @@
           <div class="flex flex-row items-center justify-between">
             <span class="pt-1">Asset Functions</span>
             <AssetFuncAttachDropdown
-              v-if="assetStore.selectedAssetId"
+              v-if="assetStore.selectedAssetId && !changeSetsStore.headSelected"
               :disabled="
                 !assetStore.assetsById[assetStore.selectedAssetId]
                   ?.defaultVariantId
@@ -83,12 +83,14 @@ import { useAssetStore } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
 import SiFuncListItem from "@/components/SiFuncListItem.vue";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import FuncSkeleton from "./FuncSkeleton.vue";
 import AssetFuncAttachModal from "./AssetFuncAttachModal.vue";
 import AssetFuncAttachDropdown from "./AssetFuncAttachDropdown.vue";
 
 const props = defineProps<{ assetId?: string }>();
 
+const changeSetsStore = useChangeSetsStore();
 const assetStore = useAssetStore();
 const funcStore = useFuncStore();
 

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -7,6 +7,7 @@
     />
     <template #top>
       <div
+        v-if="!changeSetsStore.headSelected"
         class="w-full p-2 border-b dark:border-neutral-600 flex gap-1 flex-row-reverse"
       >
         <VButton
@@ -21,7 +22,8 @@
       <div
         class="w-full text-neutral-400 dark:text-neutral-300 text-sm text-center p-2 border-b dark:border-neutral-600"
       >
-        Select an asset to view or edit it.
+        Select an asset to view
+        {{ !changeSetsStore.headSelected ? "or edit" : "" }} it.
       </div>
     </template>
     <template v-if="assetStore.assetList.length > 0">
@@ -58,8 +60,10 @@ import {
 import { useRouter } from "vue-router";
 import SiSearch from "@/components/SiSearch.vue";
 import { AssetListEntry, useAssetStore } from "@/store/asset.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import AssetListItem from "./AssetListItem.vue";
 
+const changeSetsStore = useChangeSetsStore();
 const assetStore = useAssetStore();
 const { assetList } = storeToRefs(assetStore);
 const router = useRouter();

--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="w-full h-full ph-no-capture">
-    <div v-if="!noVim" class="absolute right-xs top-xs">
+    <div v-if="!noVim" class="absolute right-xs top-xs flex gap-xs">
       <VButton
+        v-if="disabled"
+        size="xs"
+        tone="warning"
+        icon="read-only"
+        variant="ghost"
+        class="pointer-events-none"
+      >
+        Read-only
+      </VButton>
+      <VButton
+        v-else
         size="xs"
         :tone="vimEnabled ? 'success' : 'neutral'"
         icon="logo-vim"

--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="!schemaVariantId"
+      v-if="!schemaVariantId && !changeSetsStore.headSelected"
       class="w-full flex p-2 gap-1 border-b dark:border-neutral-600"
     >
       <VButton
@@ -46,7 +46,10 @@
             <h2 class="pb-2 text-sm">{{ arg.prop }}</h2>
           </li>
         </ul>
-        <div class="w-full flex p-2 gap-1 border-b dark:border-neutral-600">
+        <div
+          v-if="!changeSetsStore.headSelected"
+          class="w-full flex p-2 gap-1 border-b dark:border-neutral-600"
+        >
           <VButton
             :disabled="disabled"
             tone="neutral"
@@ -87,8 +90,10 @@ import {
 import { FuncArgument } from "@/api/sdf/dal/func";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { nilId } from "@/utils/nilId";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import AttributeBindingsModal from "./AttributeBindingsModal.vue";
 
+const changeSetsStore = useChangeSetsStore();
 const funcStore = useFuncStore();
 
 const props = defineProps<{

--- a/app/web/src/components/FuncEditor/FuncArguments.vue
+++ b/app/web/src/components/FuncEditor/FuncArguments.vue
@@ -3,7 +3,7 @@
     <h1 class="text-neutral-400 dark:text-neutral-300 text-sm">
       Add the names of the arguments to this function and their types.
     </h1>
-    <Inline alignY="center">
+    <Inline v-if="!changeSetsStore.headSelected" alignY="center">
       <VormInput
         id="newArg"
         v-model="newArg.name"
@@ -45,7 +45,7 @@
         <VButton
           label="Delete"
           tone="destructive"
-          :disabled="disabled"
+          :disabled="disabled || changeSetsStore.headSelected"
           @click="deleteArgument(arg.name)"
         />
       </Inline>
@@ -60,7 +60,9 @@ import { FuncArgument, FuncArgumentKind } from "@/api/sdf/dal/func";
 import SelectMenu, { Option } from "@/components/SelectMenu.vue";
 import { AttributeAssociations } from "@/store/func/types";
 import { nilId } from "@/utils/nilId";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 
+const changeSetsStore = useChangeSetsStore();
 const generateKindOptions = () => {
   const options: Option[] = [];
   for (const kind in FuncArgumentKind) {

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -24,7 +24,7 @@
     <TabGroup rememberSelectedTabKey="func_details">
       <TabGroupItem label="Properties" slug="properties">
         <ScrollArea>
-          <template #top>
+          <template v-if="!changeSetsStore.headSelected" #top>
             <Stack>
               <div
                 class="w-full flex p-2 gap-1 border-b dark:border-neutral-600"
@@ -88,7 +88,7 @@
           </template>
 
           <Collapsible label="Attributes" defaultOpen>
-            <div class="p-3 flex flex-col gap-2">
+            <Stack class="p-3">
               <h1 class="text-neutral-400 dark:text-neutral-300 text-sm">
                 Give this function a Name, Entrypoint and brief description
                 below.
@@ -121,7 +121,7 @@
                 label="Description"
                 @blur="updateFunc"
               />
-            </div>
+            </Stack>
           </Collapsible>
           <ActionDetails
             v-if="
@@ -130,6 +130,7 @@
             "
             ref="detachRef"
             v-model="editingFunc.associations"
+            :disabled="changeSetsStore.headSelected"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"
           />
@@ -139,6 +140,7 @@
               editingFunc.associations.type === 'codeGeneration'
             "
             v-model="editingFunc.associations"
+            :disabled="changeSetsStore.headSelected"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"
           />
@@ -149,6 +151,7 @@
             "
             ref="detachRef"
             v-model="editingFunc.associations"
+            :disabled="changeSetsStore.headSelected"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"
           />
@@ -159,6 +162,7 @@
             "
             ref="detachRef"
             v-model="editingFunc.associations"
+            :disabled="changeSetsStore.headSelected"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"
           />
@@ -169,6 +173,7 @@
             "
             ref="detachRef"
             v-model="editingFunc.associations"
+            :disabled="changeSetsStore.headSelected"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"
           />
@@ -230,10 +235,12 @@ import {
   Stack,
   ErrorMessage,
   ScrollArea,
+  useDisabledBySelfOrParent,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { FuncVariant, FuncArgument } from "@/api/sdf/dal/func";
 import { useFuncStore, FuncId } from "@/store/func/funcs.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import FuncArguments from "./FuncArguments.vue";
 import ActionDetails from "./ActionDetails.vue";
 import AttributeBindings from "./AttributeBindings.vue";
@@ -358,4 +365,11 @@ const detachFunc = async () => {
     }
   }
 };
+
+const changeSetsStore = useChangeSetsStore();
+
+useDisabledBySelfOrParent(
+  computed(() => changeSetsStore.headSelected),
+  true,
+);
 </script>

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -18,6 +18,7 @@
       <CodeEditor
         v-model="editingFunc"
         :typescript="selectedFuncDetails?.types"
+        :disabled="changeSetsStore.headSelected"
         @change="updateFuncCode"
         @vim-mode-write="execFunc"
       />
@@ -36,11 +37,13 @@ import { storeToRefs } from "pinia";
 import { LoadingMessage, ErrorMessage } from "@si/vue-lib/design-system";
 import { FuncId, useFuncStore } from "@/store/func/funcs.store";
 import CodeEditor from "@/components/CodeEditor.vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 
 const props = defineProps({
   funcId: { type: String as PropType<FuncId>, required: true },
 });
 
+const changeSetsStore = useChangeSetsStore();
 const funcStore = useFuncStore();
 const { selectedFuncSummary, selectedFuncDetails } = storeToRefs(funcStore);
 

--- a/app/web/src/components/FuncEditor/FuncListPanel.vue
+++ b/app/web/src/components/FuncEditor/FuncListPanel.vue
@@ -8,6 +8,7 @@
     <ScrollArea v-if="funcList.length">
       <template #top>
         <div
+          v-if="!changeSetsStore.headSelected"
           class="w-full p-2 border-b dark:border-neutral-600 flex gap-1 flex-row-reverse"
         >
           <NewFuncDropdown
@@ -28,7 +29,8 @@
         <div
           class="w-full text-neutral-400 dark:text-neutral-300 text-sm text-center p-2 border-b dark:border-neutral-600"
         >
-          Select a function to view or edit it.
+          Select a function to view
+          {{ !changeSetsStore.headSelected ? "or edit" : "" }} it.
         </div>
       </template>
 
@@ -80,7 +82,9 @@ import NewFuncDropdown from "@/components/NewFuncDropdown.vue";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useRouteToFunc } from "@/utils/useRouteToFunc";
 import FuncSkeleton from "@/components/FuncSkeleton.vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 
+const changeSetsStore = useChangeSetsStore();
 const routeToFunc = useRouteToFunc();
 const funcStore = useFuncStore();
 const loadFuncsReqStatus = funcStore.getRequestStatus("FETCH_FUNC_LIST");

--- a/app/web/src/components/SelectMenu.vue
+++ b/app/web/src/components/SelectMenu.vue
@@ -1,5 +1,9 @@
 <template>
-  <Listbox v-model="selectedOptions" :disabled="disabled" as="div">
+  <Listbox
+    v-model="selectedOptions"
+    :disabled="disabledBySelfOrParent"
+    as="div"
+  >
     <div class="relative">
       <ListboxButton
         class="cursor-default relative w-full rounded-[0.1875rem] border border-neutral-300 bg-shade-0 py-1.5 pl-3 pr-10 text-left text-neutral-900 shadow-sm hover:border-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-action-500 focus:ring-offset-2 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-50"
@@ -67,14 +71,14 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, toRefs } from "vue";
 import {
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
 } from "@headlessui/vue";
-import { Icon } from "@si/vue-lib/design-system";
+import { Icon, useDisabledBySelfOrParent } from "@si/vue-lib/design-system";
 
 export interface Option {
   label: string;
@@ -89,6 +93,10 @@ const props = defineProps<{
   noneSelectedLabel?: string; // this is only valid in the multiple select case
   disabled?: boolean;
 }>();
+
+const { disabled } = toRefs(props);
+
+const disabledBySelfOrParent = useDisabledBySelfOrParent(disabled);
 
 const isSelected = (option: Option, selected: boolean) =>
   selected ||

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -41,7 +41,7 @@
   <SiPanel rememberSizeKey="func-details" side="right" :minSize="200">
     <div
       v-if="FF_SINGLE_MODEL_SCREEN"
-      class="absolute w-full flex flex-col h-full items-center"
+      class="absolute w-full flex flex-col h-full"
     >
       <ApplyChangeSetButton class="w-10/12 m-4" :recommendations="[]" />
       <SidebarSubpanelTitle v-if="assetId && !funcId"

--- a/app/web/src/components/Workspace/WorkspaceCustomizeIndex.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeIndex.vue
@@ -1,24 +1,5 @@
 <template>
-  <div
-    v-if="FF_SINGLE_MODEL_SCREEN && changeset === null"
-    class="relative bg-black w-full h-full flex items-center justify-center text-3xl text-neutral-400"
-  >
-    Not available on head, create a changeset through the
-    <Icon name="git-branch" size="lg" class="inline-block align-middle mx-3" />
-    button above to use the customize screen
-  </div>
-  <RouterView v-else />
+  <RouterView />
 </template>
 
-<script lang="ts" setup>
-import { Icon } from "@si/vue-lib/design-system";
-import { computed } from "vue";
-import { useChangeSetsStore } from "@/store/change_sets.store";
-import { useFeatureFlagsStore } from "@/store/feature_flags.store";
-
-const featureFlagsStore = useFeatureFlagsStore();
-const FF_SINGLE_MODEL_SCREEN = computed(
-  () => featureFlagsStore.SINGLE_MODEL_SCREEN,
-);
-const changeset = useChangeSetsStore().selectedChangeSet;
-</script>
+<script lang="ts" setup></script>

--- a/app/web/src/components/modules/ModuleListPanel.vue
+++ b/app/web/src/components/modules/ModuleListPanel.vue
@@ -2,6 +2,7 @@
   <ScrollArea>
     <template #top>
       <div
+        v-if="!changeSetsStore.headSelected"
         class="p-xs border-b dark:border-neutral-600 flex gap-1 flex-row-reverse"
       >
         <VButton
@@ -76,9 +77,11 @@ import {
 } from "@si/vue-lib/design-system";
 import SiSearch from "@/components/SiSearch.vue";
 import { useModuleStore } from "@/store/module.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import ModuleListItem from "./ModuleListItem.vue";
 import ModuleExportModal from "./ModuleExportModal.vue";
 
+const changeSetsStore = useChangeSetsStore();
 const moduleStore = useModuleStore();
 const loadLocalModulesReqStatus =
   moduleStore.getRequestStatus("LOAD_LOCAL_MODULES");

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -42,6 +42,7 @@ export function useChangeSetsStore() {
           state.selectedChangeSetId
             ? state.changeSetsById[state.selectedChangeSetId] ?? null
             : null,
+        headSelected: (state) => state.selectedChangeSetId === changeSetIdNil(),
 
         selectedChangeSetWritten: (state) =>
           state.selectedChangeSetId

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -445,6 +445,8 @@ const optionsFromProps = computed((): OptionsAsArray => {
     if (!_.isObject(props.options[0])) {
       return _.map(props.options, (value) => ({
         value,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         label: value.toString(),
       }));
     }
@@ -687,7 +689,7 @@ defineExpose({
     --bg-color: @colors-neutral-100;
 
     &.--theme-dark {
-      --text-color: @colors-neutral-500;
+      --text-color: @colors-neutral-400;
       --text-color-muted: @colors-neutral-500;
       --bg-color: @colors-neutral-900;
     }

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -51,6 +51,7 @@ import EyeOff from "~icons/heroicons-solid/eye-off";
 import ClipboardCopy from "~icons/heroicons-solid/clipboard-copy";
 import Refresh from "~icons/heroicons-solid/refresh";
 import Pencil from "~icons/heroicons-outline/pencil";
+import PencilOff from "~icons/material-symbols/edit-off-outline";
 import Cube from "~icons/heroicons-outline/cube";
 import Clock from "~icons/heroicons-solid/clock";
 import ExclamationCircle from "~icons/heroicons-solid/exclamation-circle";
@@ -160,6 +161,7 @@ export const ICONS = Object.freeze({
   plug: Plug,
   plus: Plus,
   "plus-circle": PlusCircle,
+  "read-only": PencilOff,
   refresh: Refresh,
   "refresh-active": Refresh,
   resize: Resize,


### PR DESCRIPTION
the whole customize UI needs a ton of cleanup, so I dont want to invest too much time, but at least this is a first pass at making things read-only if you are on head.

Long-term, it may make sense to swap disabled inputs for a different view that is just displaying the info in the most legible way possible, but until things are very stable, disabled inputs should work just fine.