### PR TITLE
build(ci-base): revert Dockerfile to be built on Debian

### DIFF
--- a/component/ci-base/BUCK
+++ b/component/ci-base/BUCK
@@ -12,7 +12,9 @@ docker_image(
         "docker-entrypoint.sh": ".",
     },
     build_args = {
-        "BASE_VERSION": "3",
+        "BASE_VERSION": "12-slim",
+        "USER_UID": "2000",
+        "USER_GID": "2000",
     },
     run_docker_args = [
         "--privileged",

--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -1,18 +1,41 @@
 ARG BASE_VERSION
-FROM alpine:${BASE_VERSION}
+FROM debian:${BASE_VERSION}
 
-# hadolint ignore=DL3018
+ARG USER_UID
+ARG USER_GID
+
+# hadolint ignore=DL3008
 RUN set -eux; \
-    apk add --no-cache \
-        bash \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        busybox \
+        ca-certificates \
         curl \
-        docker \
         git \
+        gnupg \
         sudo \
-        xz \
+        xz-utils \
     ; \
-    addgroup -g 2000 ci; \
-    adduser -h /home/ci -s /bin/bash -G ci -u 2000 -D ci; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg;\
+    chmod a+r /etc/apt/keyrings/docker.gpg; \
+    echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" \
+        | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    useradd --create-home --shell /bin/bash --uid "${USER_UID}" ci; \
     echo 'ci ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/ci; \
     mkdir -p /workdir; \
     chown -R ci:ci /workdir
@@ -37,6 +60,7 @@ RUN set -eux; \
     } >"$HOME/.config/nix/nix.conf"; \
     . "$HOME/.nix-profile/etc/profile.d/nix.sh"; \
     nix-env -iA nixpkgs.nixFlakes; \
+    grep 'Nix installer' "$HOME/.profile" >>"$HOME/.bashrc"; \
     git config --global --add safe.directory /workdir
 
 WORKDIR /workdir


### PR DESCRIPTION
There is a build correctness issue with `bin/lang-js` which results in a binary using a standard Linux distro's ELF interpreter and system libraries. Swapping this image to be based on Alpine Linux (with its musl libc impl) exposed this correctness issue but before we can land a fix, reverting the Dockerfile impl seems like a better approach for now.