### PR TITLE
Remove make-related deps (ENG-1697)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,17 +51,6 @@
             reindeer
             rust-toolchain
             tilt
-
-            # TODO(fnichol): we can remove these remaining packages when the
-            # Make workflow is dropped
-            automake
-            coreutils
-            gcc
-            gnumake
-            libtool
-            pkg-config
-            postgresql_14
-
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
Now, we are solely using buck2 and tilt. All Makefile-related content has been removed.

This PR depends on #2393.

<img src="https://media4.giphy.com/media/l0MYMV4Bf5zmV4TWE/giphy.gif"/>