### PR TITLE
feat(dal,sdf-server): ENG-1699 remove orphaned objects

### DIFF
--- a/lib/dal/src/queries/attribute_prototype/list_for_schema_variant.sql
+++ b/lib/dal/src/queries/attribute_prototype/list_for_schema_variant.sql
@@ -1,0 +1,12 @@
+SELECT row_to_json(aps.*) AS object
+FROM attribute_prototypes_v1($1, $2) AS aps
+WHERE
+  aps.attribute_context_prop_id IN
+    (SELECT id FROM props_v1($1, $2) AS props WHERE props.schema_variant_id = $3)
+  OR
+  aps.attribute_context_internal_provider_id IN
+    (SELECT id FROM internal_providers_v1($1, $2) AS ips WHERE ips.schema_variant_id = $3)
+  OR
+  aps.attribute_context_external_provider_id IN
+    (SELECT id FROM external_providers_v1($1, $2) AS eps WHERE eps.schema_variant_id = $3)
+ORDER BY aps.id DESC

--- a/lib/dal/src/queries/schema_variant/all_props.sql
+++ b/lib/dal/src/queries/schema_variant/all_props.sql
@@ -1,15 +1,3 @@
 SELECT row_to_json(props.*) AS object
 FROM props_v1($1, $2) AS props
-WHERE props.id IN (
-    WITH RECURSIVE recursive_props AS (
-        SELECT root_prop_id AS prop_id
-        FROM schema_variants_v1($1, $2) AS schema_variants
-        WHERE schema_variants.id = $3
-        UNION ALL
-        SELECT pbp.object_id AS prop_id
-        FROM prop_belongs_to_prop_v1($1, $2) AS pbp
-        JOIN recursive_props ON pbp.belongs_to_id = recursive_props.prop_id
-    )
-    SELECT prop_id
-    FROM recursive_props
-)
+WHERE props.schema_variant_id = $3;

--- a/lib/dal/tests/integration_test/internal/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/internal/attribute/prototype.rs
@@ -363,7 +363,7 @@ async fn remove_least_specific(ctx: &DalContext) {
         .expect("could not list attribute prototypes for context");
 
     for prototype in prototypes {
-        let result = AttributePrototype::remove(ctx, prototype.id()).await;
+        let result = AttributePrototype::remove(ctx, prototype.id(), false).await;
         if let Err(AttributePrototypeError::LeastSpecificContextPrototypeRemovalNotAllowed(id)) =
             result
         {
@@ -441,7 +441,7 @@ async fn remove_component_specific(ctx: &DalContext) {
 
     for prototype in prototypes {
         // Ensure that performing remove on base prototypes on props results in failure.
-        assert!(AttributePrototype::remove(ctx, prototype.id())
+        assert!(AttributePrototype::remove(ctx, prototype.id(), false)
             .await
             .is_err());
 
@@ -511,9 +511,11 @@ async fn remove_component_specific(ctx: &DalContext) {
             }
 
             // Perform removal on the prototype.
-            assert!(AttributePrototype::remove(ctx, updated_prototype.id())
-                .await
-                .is_ok());
+            assert!(
+                AttributePrototype::remove(ctx, updated_prototype.id(), false)
+                    .await
+                    .is_ok()
+            );
 
             ctx.blocking_commit()
                 .await

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -274,7 +274,9 @@ async fn save_attr_func_prototypes(
                     reset_prototype_and_value_to_intrinsic_function(ctx, &proto, proto.context)
                         .await?
                 }
-                RemovedPrototypeOp::Delete => AttributePrototype::remove(ctx, proto.id()).await?,
+                RemovedPrototypeOp::Delete => {
+                    AttributePrototype::remove(ctx, proto.id(), false).await?
+                }
             }
         }
     }

--- a/lib/sdf-server/src/server/service/variant_definition/get_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/get_variant_def.rs
@@ -7,9 +7,8 @@ use axum::extract::OriginalUri;
 use axum::{extract::Query, Json};
 use dal::{
     schema::variant::definition::{SchemaVariantDefinition, SchemaVariantDefinitionId},
-    ComponentType, Func, StandardModel, Timestamp, Visibility,
+    ComponentType, Func, SchemaVariant, SchemaVariantId, StandardModel, Timestamp, Visibility,
 };
-use dal::{SchemaVariant, SchemaVariantId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -81,6 +80,7 @@ pub async fn get_variant_def(
         ))?;
 
     let variant_id = variant_def.schema_variant_id().copied();
+
     let (has_components, has_attr_funcs) = is_variant_def_locked(&ctx, &variant_def).await?;
     let asset_func = Func::get_by_id(&ctx, &variant_def.func_id()).await?.ok_or(
         SchemaVariantDefinitionError::FuncNotFound(variant_def.func_id()),


### PR DESCRIPTION
Removes objects that will be "orphaned" when the schema variant is deleted when updating an asset's structure.