### PR TITLE
feat(dal,sdf): generate real types for function inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "base64 0.21.2",
  "buck2-resources",
  "chrono",
+ "convert_case 0.6.0",
  "council-server",
  "dal-test",
  "derive_more",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -19,6 +19,7 @@ rust_library(
         "//third-party/rust:async-trait",
         "//third-party/rust:base64",
         "//third-party/rust:chrono",
+        "//third-party/rust:convert_case",
         "//third-party/rust:derive_more",
         "//third-party/rust:diff",
         "//third-party/rust:dyn-clone",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -11,6 +11,7 @@ async-recursion = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+convert_case = { workspace = true }
 council-server = { path = "../../lib/council-server" }
 derive_more = { workspace = true }
 diff = { workspace = true }

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -150,6 +150,13 @@ impl MigrationDriver {
                     )
                     .domain_prop(
                         PropSpec::builder()
+                            .name("hidden_prop")
+                            .kind(PropKind::String)
+                            .hidden(true)
+                            .build()?,
+                    )
+                    .domain_prop(
+                        PropSpec::builder()
                             .name("freestar")
                             .kind(PropKind::String)
                             .build()?,

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -626,7 +626,7 @@ async fn set_variant_spec_prop_data(
     prop_root: SchemaVariantSpecPropRoot,
     func_specs: &HashMap<FuncId, FuncSpec>,
 ) -> PkgResult<()> {
-    let mut prop_tree = PropTree::new(ctx, true, Some(*variant.id())).await?;
+    let mut prop_tree = PropTree::new(ctx, true, Some(vec![*variant.id()]), None).await?;
     let root_tree_node = prop_tree
         .root_props
         .pop()

--- a/lib/dal/src/queries/prop/tree_for_all_schema_variants.sql
+++ b/lib/dal/src/queries/prop/tree_for_all_schema_variants.sql
@@ -2,49 +2,48 @@
     return a list of all props for all schema variants along with their internal provider ids
     in a manner suitable for constructing a tree from the list
  */
-WITH RECURSIVE props_tree AS (
-    SELECT
-        row_to_json(p.*)  AS object,
-        p.id              AS root_id,
-        p.id              AS prop_id,
-        p.name            AS name,
-        '/'               AS path,
-        ident_nil_v1()    AS parent_id,
-        0::bigint         AS depth
-    FROM props_v1($1, $2) AS p
-    LEFT JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
-        ON p.id = pbtp.object_id
-    WHERE pbtp.belongs_to_id IS NULL
-    UNION ALL
-    SELECT
-        row_to_json(child_props.*)        AS object,
-        parent.root_id                    AS root_id,
-        child_props.id                    AS prop_id,
-        child_props.name                  AS name,
-        parent.path || parent.name || '/' AS path,
-        parent.prop_id                    AS parent_id,
-        parent.depth + 1                  AS depth
-    FROM props_v1($1, $2) AS child_props
-    JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp2
-        ON child_props.id = pbtp2.object_id
-    JOIN props_tree AS parent
-        ON parent.prop_id = pbtp2.belongs_to_id
-)
-SELECT
-    schema_variants.id AS schema_variant_id,
-    props_tree.object,
-    props_tree.root_id,
-    props_tree.prop_id,
-    props_tree.parent_id,
-    props_tree.name,
-    props_tree.path,
-    ip.id                  AS internal_provider_id
+WITH RECURSIVE props_tree AS (SELECT row_to_json(p.*)    AS object,
+                                     p.id                AS root_id,
+                                     p.id                AS prop_id,
+                                     p.name              AS name,
+                                     '/'                 AS path,
+                                     ident_nil_v1()      AS parent_id,
+                                     0::bigint           AS depth,
+                                     p.hidden            AS hidden,
+                                     p.schema_variant_id AS schema_variant_id
+                              FROM props_v1($1, $2) AS p
+                                       LEFT JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
+                                                 ON p.id = pbtp.object_id
+                              WHERE ($3::ident IS NULL AND pbtp.belongs_to_id IS NULL)
+                                 OR pbtp.object_id = $3::ident
+                              UNION ALL
+                              SELECT row_to_json(child_props.*)        AS object,
+                                     parent.root_id                    AS root_id,
+                                     child_props.id                    AS prop_id,
+                                     child_props.name                  AS name,
+                                     parent.path || parent.name || '/' AS path,
+                                     parent.prop_id                    AS parent_id,
+                                     parent.depth + 1                  AS depth,
+                                     child_props.hidden                AS hidden,
+                                     child_props.schema_variant_id     AS schema_variant_id
+                              FROM props_v1($1, $2) AS child_props
+                                       JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp2
+                                            ON child_props.id = pbtp2.object_id
+                                       JOIN props_tree AS parent
+                                            ON parent.prop_id = pbtp2.belongs_to_id)
+SELECT props_tree.object,
+       props_tree.root_id,
+       props_tree.prop_id,
+       props_tree.parent_id,
+       props_tree.name,
+       props_tree.path,
+       props_tree.schema_variant_id,
+       ip.id AS internal_provider_id
 FROM props_tree
-JOIN schema_variants_v1($1, $2) schema_variants
-    ON schema_variants.root_prop_id = props_tree.root_id
-LEFT JOIN internal_providers_v1($1, $2) ip ON props_tree.prop_id = ip.prop_id
-ORDER BY
-    schema_variant_id,
-    root_id,
-    depth,
-    name;
+         LEFT JOIN internal_providers_v1($1, $2) ip ON props_tree.prop_id = ip.prop_id
+WHERE $4 IS TRUE
+   OR props_tree.hidden IS FALSE
+ORDER BY schema_variant_id,
+         root_id,
+         depth,
+         name;

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -127,6 +127,10 @@ impl LeafInputLocation {
         }
     }
 
+    pub fn prop_path(&self) -> Vec<&'static str> {
+        vec!["root", self.arg_name()]
+    }
+
     pub fn maybe_from_arg_name(arg_name: &str) -> Option<Self> {
         Some(match arg_name {
             "domain" => LeafInputLocation::Domain,

--- a/lib/dal/tests/integration_test/internal/mod.rs
+++ b/lib/dal/tests/integration_test/internal/mod.rs
@@ -13,6 +13,7 @@ mod node;
 mod node_menu;
 mod pkg;
 mod prop;
+mod prop_tree;
 mod property_editor;
 mod provider;
 mod schema;

--- a/lib/dal/tests/integration_test/internal/prop_tree.rs
+++ b/lib/dal/tests/integration_test/internal/prop_tree.rs
@@ -1,0 +1,206 @@
+use dal::{
+    prop::PropPath, prop_tree::PropTree, DalContext, Prop, Schema, SchemaVariant, SchemaVariantId,
+    StandardModel,
+};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn all_schema_variants(ctx: &DalContext) {
+    let prop_tree = PropTree::new(ctx, true, None, None)
+        .await
+        .expect("able to fetch prop tree");
+
+    let variant_ids: Vec<SchemaVariantId> = prop_tree
+        .root_props
+        .iter()
+        .map(|node| node.schema_variant_id)
+        .collect();
+
+    let all_variants = SchemaVariant::list(ctx)
+        .await
+        .expect("able to list schema variants");
+
+    assert_eq!(all_variants.len(), variant_ids.len());
+}
+
+#[test]
+async fn one_schema_variant(ctx: &DalContext) {
+    let starfield = Schema::find_by_attr(ctx, "name", &"starfield")
+        .await
+        .expect("get starfield")
+        .pop()
+        .expect("starfield is there");
+
+    let default_variant = starfield
+        .default_variant(ctx)
+        .await
+        .expect("get default variant of starfield");
+
+    let prop_tree = PropTree::new(ctx, false, Some(vec![*default_variant.id()]), None)
+        .await
+        .expect("able to fetch prop tree");
+
+    assert_eq!(1, prop_tree.root_props.len());
+    let root_prop = prop_tree.root_props.get(0).expect("able to get root prop");
+    assert_eq!(*default_variant.id(), root_prop.schema_variant_id);
+
+    let domain = root_prop
+        .children
+        .iter()
+        .find(|node| node.name.as_str() == "domain")
+        .expect("able to find domain");
+
+    assert!(
+        !domain
+            .children
+            .iter()
+            .any(|node| node.name.as_str() == "hidden_prop"),
+        "hidden props remain hidden"
+    );
+
+    let prop_tree = PropTree::new(ctx, true, Some(vec![*default_variant.id()]), None)
+        .await
+        .expect("able to fetch prop tree");
+    let root_prop = prop_tree.root_props.get(0).expect("able to get root prop");
+    let domain = root_prop
+        .children
+        .iter()
+        .find(|node| node.name.as_str() == "domain")
+        .expect("able to find domain");
+
+    assert!(
+        domain
+            .children
+            .iter()
+            .any(|node| node.name.as_str() == "hidden_prop"),
+        "hidden props revealed when asked"
+    );
+}
+
+#[test]
+pub async fn typescript_generation(ctx: &DalContext) {
+    let starfield = Schema::find_by_attr(ctx, "name", &"starfield")
+        .await
+        .expect("get starfield")
+        .pop()
+        .expect("starfield is there");
+
+    let default_variant = starfield
+        .default_variant(ctx)
+        .await
+        .expect("get default variant of starfield");
+
+    let prop_tree = PropTree::new(ctx, true, Some(vec![*default_variant.id()]), None)
+        .await
+        .expect("able to fetch prop tree");
+
+    let mut typescript_iface = prop_tree
+        .ts_types(ctx)
+        .await
+        .expect("able to generate TS interface");
+
+    assert_eq!(1, typescript_iface.len());
+
+    let (type_name, _ts_type) = typescript_iface.pop().expect("has an interface");
+
+    assert_eq!("Starfield_V0_Root", &type_name);
+
+    let si_prop =
+        Prop::find_prop_by_path(ctx, *default_variant.id(), &PropPath::new(["root", "si"]))
+            .await
+            .expect("able to find prop");
+
+    let prop_tree = PropTree::new(
+        ctx,
+        true,
+        Some(vec![*default_variant.id()]),
+        Some(*si_prop.id()),
+    )
+    .await
+    .expect("able to fetch prop tree");
+
+    let mut typescript_iface = prop_tree
+        .ts_types(ctx)
+        .await
+        .expect("able to generate TS interface for root/si");
+
+    let (type_name, ts_type) = typescript_iface.pop().expect("has an interface");
+
+    assert_eq!("Starfield_V0_Si", &type_name);
+
+    assert_eq!(
+        "interface Starfield_V0_Si {
+\"color\": string | null | undefined;
+\"name\": string | null | undefined;
+\"protected\": boolean | null | undefined;
+\"type\": string | null | undefined;
+}",
+        &ts_type
+    );
+
+    // test a single, non object prop type generation
+    let si_prop = Prop::find_prop_by_path(
+        ctx,
+        *default_variant.id(),
+        &PropPath::new(["root", "si", "protected"]),
+    )
+    .await
+    .expect("able to find prop");
+
+    let prop_tree = PropTree::new(
+        ctx,
+        true,
+        Some(vec![*default_variant.id()]),
+        Some(*si_prop.id()),
+    )
+    .await
+    .expect("able to fetch prop tree");
+
+    let mut typescript_iface = prop_tree
+        .ts_types(ctx)
+        .await
+        .expect("able to generate TS interface for root/si");
+
+    let (type_name, ts_type) = typescript_iface.pop().expect("has an interface");
+    assert_eq!("Starfield_V0_Protected", &type_name);
+    assert_eq!(
+        "type Starfield_V0_Protected = boolean | null | undefined;",
+        &ts_type
+    );
+
+    // test a single, non object prop type generation (maps)
+    let si_prop = Prop::find_prop_by_path(
+        ctx,
+        *default_variant.id(),
+        &PropPath::new(["root", "qualification"]),
+    )
+    .await
+    .expect("able to find prop");
+
+    let prop_tree = PropTree::new(
+        ctx,
+        true,
+        Some(vec![*default_variant.id()]),
+        Some(*si_prop.id()),
+    )
+    .await
+    .expect("able to fetch prop tree");
+
+    let mut typescript_iface = prop_tree
+        .ts_types(ctx)
+        .await
+        .expect("able to generate TS interface for root/si");
+
+    let (type_name, ts_type) = typescript_iface.pop().expect("has an interface");
+    eprintln!("{}", &ts_type);
+
+    assert_eq!("Starfield_V0_Qualification", &type_name);
+    assert_eq!(
+        "type Starfield_V0_Qualification = Record<string, {
+\"message\": string | null | undefined;
+\"result\": string | null | undefined;
+}> | null | undefined;",
+        &ts_type
+    );
+}

--- a/lib/sdf-server/src/server/service/func/list_input_sources.rs
+++ b/lib/sdf-server/src/server/service/func/list_input_sources.rs
@@ -117,7 +117,14 @@ pub async fn list_input_sources(
     })
     .collect();
 
-    let props = prop_tree_to_list(&PropTree::new(&ctx, true, request.schema_variant_id).await?);
+    let prop_tree = PropTree::new(
+        &ctx,
+        true,
+        request.schema_variant_id.map(|sv_id| vec![sv_id]),
+        None,
+    )
+    .await?;
+    let props = prop_tree_to_list(&prop_tree);
 
     Ok(Json(ListInputSourcesResponse {
         input_sockets,

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -345,6 +345,7 @@ async fn attribute_view_for_leaf_func(
 
         argument_views.push(AttributePrototypeArgumentView {
             func_argument_id: *func_argument.id(),
+            func_argument_name: func_argument.name().to_owned(),
             id: Some(*proto_arg.id()),
             internal_provider_id: Some(proto_arg.internal_provider_id()),
         });


### PR DESCRIPTION
Generates a typescript type for any prop tree, and returns those types for the inputs to functions when getting a function view. Works for actions, validations, and attribute functions.

NOTE: root.resource.payload is special cased here since the prop is a `string` type but we are storing non-string json values there and expecting non-string json values as input to functions. Either a new PropKind will have to be used for this case, or we can wait for the resource_value work to give us strongly typed resource prop trees.