### PR TITLE
feat(web): hide modules tab behind feature flag

### DIFF
--- a/app/web/src/components/CustomizeTabs.vue
+++ b/app/web/src/components/CustomizeTabs.vue
@@ -9,7 +9,11 @@
     <TabGroupItem slug="functions" label="FUNCTIONS">
       <slot v-if="tabContentSlug === 'functions'" />
     </TabGroupItem>
-    <TabGroupItem slug="packages" label="MODULES">
+    <TabGroupItem
+      v-if="featureFlagsStore.MODULES_TAB"
+      slug="packages"
+      label="MODULES"
+    >
       <slot v-if="tabContentSlug === 'packages'" />
     </TabGroupItem>
   </TabGroup>
@@ -19,9 +23,11 @@
 import { useRouter, useRoute } from "vue-router";
 import { PropType } from "vue";
 import { TabGroup, TabGroupItem } from "@si/vue-lib/design-system";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 
 const router = useRouter();
 const route = useRoute();
+const featureFlagsStore = useFeatureFlagsStore();
 
 defineProps({
   tabContentSlug: {

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -3,17 +3,35 @@ import { addStoreHooks } from "@si/vue-lib/pinia";
 import * as _ from "lodash-es";
 import { posthog } from "@/utils/posthog";
 
+const FLAGS: { [key: string]: { key: string; default: boolean } } = {
+  one_screen_to_rule_them_all: {
+    key: "SINGLE_MODEL_SCREEN",
+    default: false,
+  },
+  modules_tab: {
+    key: "MODULES_TAB",
+    default: false,
+  },
+};
+
+const flagsToState = () =>
+  Object.values(FLAGS).reduce((state, flag) => {
+    state[flag.key] = flag.default;
+    return state;
+  }, {} as { [key: string]: boolean });
+
 export function useFeatureFlagsStore() {
   return addStoreHooks(
     defineStore("feature-flags", {
-      state: () => ({
-        SINGLE_MODEL_SCREEN: false,
-      }),
+      state: () => flagsToState(),
       onActivated() {
         posthog.onFeatureFlags((flags) => {
-          this.SINGLE_MODEL_SCREEN = flags.includes(
-            "one_screen_to_rule_them_all",
-          );
+          for (const flag of flags) {
+            const flagKey = FLAGS[flag]?.key;
+            if (flagKey) {
+              this[flagKey] = true;
+            }
+          }
         });
       },
     }),


### PR DESCRIPTION
adds the MODULES_TAB feature flag to control display of the modules tab on the customize screen.