### PR TITLE
fix(docker): fix `docker_image_promote` for non-default image name

### DIFF
--- a/prelude-si/macros/docker.bzl
+++ b/prelude-si/macros/docker.bzl
@@ -35,6 +35,6 @@ def docker_image(
 
     _docker_image_promote(
         name = promote_target,
-        image_name = "{}/{}".format(organization, name),
+        image_name = "{}/{}".format(organization, kwargs.get("image_name", name)),
         visibility = visibility,
     )


### PR DESCRIPTION
This fix addresses images where the `docker_image` target name does not match the final Docker image name (which can be set via the `image_name` attribute).