### PR TITLE
fix: update `Cargo.lock` from `bin/si` deps updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4476,7 +4476,10 @@ dependencies = [
  "inquire",
  "open",
  "rand",
+ "serde_json",
+ "si-posthog",
  "strum",
+ "telemetry-application",
  "tokio",
 ]
 


### PR DESCRIPTION
The root `Cargo.lock` was out of date when running rust-analyzer tooling, likely due to depedency updates to the `bin/si` component a few days ago. Now that Buck2 builds our project this lock file is only used for Cargo-style building and other editor/LSP tooling.