### PR TITLE
feat(web,sdf): contrib button on asset screen

### DIFF
--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -7,11 +7,19 @@
     />
     <template #top>
       <div
-        v-if="!changeSetsStore.headSelected"
         class="w-full p-2 border-b dark:border-neutral-600 flex gap-1 flex-row-reverse"
       >
         <VButton
-          label="Author New Asset"
+          v-if="featureFlagsStore.CONTRIBUTE_BUTTON"
+          label="Contribute"
+          tone="action"
+          icon="cloud-upload"
+          size="sm"
+          @click="contributeAsset"
+        />
+        <VButton
+          v-if="!changeSetsStore.headSelected"
+          label="New Asset"
           tone="action"
           icon="plus"
           size="sm"
@@ -45,6 +53,13 @@
         </Collapsible>
       </ul>
     </template>
+    <ModuleExportModal
+      ref="contributeAssetModalRef"
+      title="Contribute Assets"
+      label="Contribute"
+      :preSelectedSchemaVariantId="assetStore.selectedAsset?.schemaVariantId"
+      autoVersion
+    />
   </ScrollArea>
 </template>
 
@@ -61,13 +76,17 @@ import { useRouter } from "vue-router";
 import SiSearch from "@/components/SiSearch.vue";
 import { AssetListEntry, useAssetStore } from "@/store/asset.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import AssetListItem from "./AssetListItem.vue";
+import ModuleExportModal from "./modules/ModuleExportModal.vue";
 
 const changeSetsStore = useChangeSetsStore();
 const assetStore = useAssetStore();
+const featureFlagsStore = useFeatureFlagsStore();
 const { assetList } = storeToRefs(assetStore);
 const router = useRouter();
 const loadAssetsReqStatus = assetStore.getRequestStatus("LOAD_ASSET_LIST");
+const contributeAssetModalRef = ref<InstanceType<typeof ModuleExportModal>>();
 
 const props = defineProps({
   assetId: { type: String },
@@ -120,5 +139,9 @@ const newAsset = async () => {
       },
     });
   }
+};
+
+const contributeAsset = () => {
+  contributeAssetModalRef.value?.open();
 };
 </script>

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -3,22 +3,30 @@ import { addStoreHooks } from "@si/vue-lib/pinia";
 import * as _ from "lodash-es";
 import { posthog } from "@/utils/posthog";
 
-const FLAGS: { [key: string]: { key: string; default: boolean } } = {
+type FlagStoreKey = "SINGLE_MODEL_SCREEN" | "MODULES_TAB" | "CONTRIBUTE_BUTTON";
+
+// The key to this object is the flag name on PostHog, the "storeKey" property is the
+// key used when accessing it from the Pinia feature flag store
+const FLAGS: { [key: string]: { storeKey: FlagStoreKey; default: boolean } } = {
   one_screen_to_rule_them_all: {
-    key: "SINGLE_MODEL_SCREEN",
+    storeKey: "SINGLE_MODEL_SCREEN",
     default: false,
   },
   modules_tab: {
-    key: "MODULES_TAB",
+    storeKey: "MODULES_TAB",
+    default: false,
+  },
+  contribute_button: {
+    storeKey: "CONTRIBUTE_BUTTON",
     default: false,
   },
 };
 
 const flagsToState = () =>
   Object.values(FLAGS).reduce((state, flag) => {
-    state[flag.key] = flag.default;
+    state[flag.storeKey] = flag.default;
     return state;
-  }, {} as { [key: string]: boolean });
+  }, {} as { [key in FlagStoreKey]: boolean });
 
 export function useFeatureFlagsStore() {
   return addStoreHooks(
@@ -27,7 +35,7 @@ export function useFeatureFlagsStore() {
       onActivated() {
         posthog.onFeatureFlags((flags) => {
           for (const flag of flags) {
-            const flagKey = FLAGS[flag]?.key;
+            const flagKey = FLAGS[flag]?.storeKey;
             if (flagKey) {
               this[flagKey] = true;
             }

--- a/lib/sdf-server/src/server/service/pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg.rs
@@ -7,7 +7,7 @@ use axum::{
 use convert_case::{Case, Casing};
 use dal::{
     installed_pkg::InstalledPkgError, pkg::PkgError as DalPkgError, DalContextBuilder,
-    StandardModelError, TenancyError, TransactionsError, WsEventError,
+    StandardModelError, TenancyError, TransactionsError, UserError, WsEventError,
 };
 use serde::{Deserialize, Serialize};
 use si_pkg::{SiPkg, SiPkgError};
@@ -76,6 +76,8 @@ pub enum PkgError {
     Tenancy(#[from] TenancyError),
     #[error("Unable to parse URL: {0}")]
     Url(#[from] url::ParseError),
+    #[error("transparent")]
+    User(#[from] UserError),
     #[error("could not publish websocket event: {0}")]
     WsEvent(#[from] WsEventError),
 }

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -9,6 +9,7 @@ import SlashForward from "~icons/mdi/slash-forward";
 import Check from "~icons/heroicons/check-20-solid";
 import CheckCircle from "~icons/heroicons/check-circle-20-solid";
 import CheckSquare from "./custom-icons/check-square.svg?raw";
+import CloudUpload from "~icons/heroicons-solid/cloud-upload";
 
 import AlertCircle from "~icons/heroicons/exclamation-circle-20-solid";
 import AlertSquare from "./custom-icons/exclamation-square.svg?raw";
@@ -125,6 +126,7 @@ export const ICONS = Object.freeze({
   check2: Check2,
   "clipboard-copy": ClipboardCopy,
   clock: Clock,
+  "cloud-upload": CloudUpload,
   component: Cube,
   create: Create,
   "credit-card": CreditCard,


### PR DESCRIPTION
Button is hidden behind a flag currently (until we have the production index up):
  - Autoselects the currently selected asset in the export module
  - Autogenerates the version as a timestamp.
  - Uses the HistoryActor to set the package author correctly.
  - Sends a posthog event `export_pkg` with metadata and the package hash (which can be used to construct the s3 object url)