### PR TITLE
feat(si): self-update binary from latest release 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4626,6 +4626,7 @@ dependencies = [
  "serde",
  "serde_json",
  "si-posthog",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -34,9 +34,15 @@ async fn main() -> Result<()> {
         )
     );
 
-    if let Some(_update) = update::find().await? {
-        if !matches!(args.command, Commands::Update(_)) {
-            println!("Update found, please run `si update` to install it\n");
+    if !matches!(args.command, Commands::Update(_)) {
+        match update::find().await {
+            Ok(Some(_)) => {
+                println!("Update found, please run `si update` to install it\n");
+            }
+            Ok(None) => {}
+            Err(err) => {
+                println!("Unable to retrieve updates: {err}");
+            }
         }
     }
 

--- a/lib/si-cli/BUCK
+++ b/lib/si-cli/BUCK
@@ -17,6 +17,7 @@ rust_library(
         "//third-party/rust:tokio",
         "//third-party/rust:reqwest",
         "//third-party/rust:thiserror",
+        "//third-party/rust:tempfile",
         "//lib/si-posthog-rs:si-posthog",
         "//third-party/rust:serde_json",
     ],

--- a/lib/si-cli/Cargo.toml
+++ b/lib/si-cli/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 reqwest = { workspace = true }
+tempfile = { workspace = true }

--- a/lib/si-cli/src/lib.rs
+++ b/lib/si-cli/src/lib.rs
@@ -29,8 +29,12 @@ pub enum SiCliError {
     IncorrectInstallMode(String),
     #[error("aborting installation")]
     Installation,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
     #[error("reqwest: {0}")]
     Reqwest(#[from] reqwest::Error),
+    #[error("unable to download update, status = {0}")]
+    UnableToDownloadUpdate(u16),
 }
 
 pub type CliResult<T> = Result<T, SiCliError>;


### PR DESCRIPTION
Right now the binaries are coming from this private repo, so only authenticated sessions can download it. Which means the updater can't download it, for now it just shows you the link so you can manually download the new version.

But the self-updater is implemented and tested, it just needs to be uncommented after the binary becomes public.

We may decide to add a layer to provide the binaries without authentication through our API to enable this before open sourcing, which is simple to do, or we may wait until we go public.

But the auth-api isn't deployed and the actual si cli is not there, so we don't need to rush to make this work right now, it's easy to make it work when needed and it may avoid work since the requirements will change soon.