### PR TITLE
fix(dal): commit before applying change-set so jobs finish in correct visibility

### DIFF
--- a/lib/dal/tests/integration_test/internal/component/confirmation.rs
+++ b/lib/dal/tests/integration_test/internal/component/confirmation.rs
@@ -206,6 +206,9 @@ async fn list_confirmations(mut octx: DalContext) {
     let (component, _) = Component::new(ctx, "component", schema_variant_id)
         .await
         .expect("cannot create component");
+    ctx.blocking_commit()
+        .await
+        .expect("could not commit & run jobs");
 
     assert_eq!(new_change_set.pk, ctx.visibility().change_set_pk);
     let mut change_set = ChangeSet::get_by_pk(ctx, &ctx.visibility().change_set_pk)
@@ -263,7 +266,7 @@ async fn list_confirmations(mut octx: DalContext) {
                 "protected": false
             },
             "domain": {
-                "name": "starfield",
+                "name": "component",
             },
             "confirmation": {
                 "test:confirmationStarfield": {
@@ -326,7 +329,7 @@ async fn list_confirmations(mut octx: DalContext) {
                 "protected": false
             },
             "domain": {
-                "name": "starfield",
+                "name": "component",
             },
             "resource": {
                 "logs": [],
@@ -410,7 +413,7 @@ async fn list_confirmations(mut octx: DalContext) {
                 "protected": false
             },
             "domain": {
-                "name": "starfield",
+                "name": "component",
             },
             "resource": {
                 "logs": [],

--- a/lib/si-test-macros/src/expand.rs
+++ b/lib/si-test-macros/src/expand.rs
@@ -528,7 +528,7 @@ pub(crate) trait FnSetupExpander {
                     .wrap_err("failed to build default dal ctx for dal_context_default")?;
                 ctx.update_tenancy(::dal::Tenancy::new(*#nw.workspace.pk()));
                 ::dal_test::helpers::create_change_set_and_update_ctx(&mut ctx).await;
-                ctx.commit()
+                ctx.blocking_commit()
                     .await
                     .wrap_err("failed to commit create_change_set_and_update_ctx")?;
 
@@ -559,7 +559,7 @@ pub(crate) trait FnSetupExpander {
                     .wrap_err("failed to build default dal ctx for dal_context_default_mut")?;
                 ctx.update_tenancy(::dal::Tenancy::new(*#nw.workspace.pk()));
                 ::dal_test::helpers::create_change_set_and_update_ctx(&mut ctx).await;
-                ctx.commit()
+                ctx.blocking_commit()
                     .await
                     .wrap_err("failed to commit create_change_set_and_update_ctx_mut")?;
 


### PR DESCRIPTION
Fixes this: https://buildkite.com/system-initiative/si-merge-queue/builds/126#018992fc-533c-4ca1-b22d-37b4be28b237

As the jobs will execute in the change-set's visibility, but they only block after the change-set is merged, their result may endup in a dead change-set and not on main.

Now we block before merging the change-set so we ensure all data from it has been propagated. This also showed a different race on /root/si/name -> /root/domain/name that we hadn't seen any failure for for some reason.

I'm also blocking all commits in the si-macro-test to ensure nothing is ever leaked if changed, it should be a noop for now and a life saver when not a noop anymore.