### PR TITLE
feat(auth-api): support sdf tokens in auth-api

### DIFF
--- a/bin/auth-api/src/services/auth.service.ts
+++ b/bin/auth-api/src/services/auth.service.ts
@@ -29,7 +29,16 @@ export function createAuthToken(userId: string) {
 }
 
 export async function decodeAuthToken(token: string) {
-  return verifyJWT(token) as AuthTokenData & JwtPayload;
+  const verified = verifyJWT(token);
+  if (typeof verified !== "string" && "user_pk" in verified) {
+    return {
+      userId: verified.user_pk,
+      ...verified,
+      user_pk: undefined,
+    } as AuthTokenData & JwtPayload;
+  } else {
+    return verified as AuthTokenData & JwtPayload;
+  }
 }
 
 // Auth tokens used for communication between the user's browser and SDF


### PR DESCRIPTION
We need to make requests to the auth-api from the backend as well as the frontend. Since we can't re-encode the signed JWT, we only have the one we've acquired from the auth-api server. This change supports using tokens in the sdf format for requests to the auth api as well as the default token format.