### PR TITLE
feat(module-index): use whoami req to restrict module listing by email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-api-client"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "remain",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "telemetry",
+ "thiserror",
+ "tokio",
+ "ulid",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2706,7 @@ dependencies = [
 name = "module-index-server"
 version = "0.1.0"
 dependencies = [
+ "auth-api-client",
  "axum",
  "base64 0.21.2",
  "buck2-resources",
@@ -2718,6 +2735,7 @@ dependencies = [
  "tower",
  "tower-http",
  "ulid",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "bin/sdf",
     "bin/si",
     "bin/veritech",
+    "lib/auth-api-client",
     "lib/buck2-resources",
     "lib/bytes-lines-codec",
     "lib/config-file",

--- a/bin/module-index/Dockerfile
+++ b/bin/module-index/Dockerfile
@@ -34,9 +34,10 @@ COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/local-bin/* /usr/local/bin/
 COPY --from=builder /workdir/config/keys/prod.jwt_signing_public_key.pem /run/module-index
 
-EXPOSE 5156/tcp
+EXPOSE 5157/tcp
 
 ENTRYPOINT [ \
   "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/module-index", \
   "--jwt-public-key", "/run/module-index/prod.jwt_signing_public_key.pem" \
+  "--restrict-listing" \
 ]

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -80,6 +80,9 @@ pub(crate) struct Args {
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
+
+    #[arg(long, env)]
+    pub(crate) restrict_listing: bool,
 }
 
 impl TryFrom<Args> for Config {

--- a/lib/auth-api-client/BUCK
+++ b/lib/auth-api-client/BUCK
@@ -1,0 +1,20 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "auth-api-client",
+    deps = [
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:chrono",
+        "//third-party/rust:remain",
+        "//third-party/rust:reqwest",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+        "//third-party/rust:ulid",
+        "//third-party/rust:url",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/auth-api-client/Cargo.toml
+++ b/lib/auth-api-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "auth-api-client"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = { workspace = true }
+remain = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+ulid = { workspace = true }
+url = { workspace = true }

--- a/lib/auth-api-client/src/client.rs
+++ b/lib/auth-api-client/src/client.rs
@@ -1,0 +1,42 @@
+use crate::types::{AuthApiClientError, AuthApiResult, WhoamiResponse};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Clone)]
+pub struct AuthApiClient {
+    base_url: Url,
+    auth_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UserWrap {
+    user: WhoamiResponse,
+}
+
+impl AuthApiClient {
+    pub fn new(base_url: Url, auth_token: &str) -> Self {
+        Self {
+            base_url,
+            auth_token: auth_token.into(),
+        }
+    }
+
+    pub async fn whoami(&self) -> AuthApiResult<WhoamiResponse> {
+        let token_no_bearer = self
+            .auth_token
+            .strip_prefix("Bearer ")
+            .ok_or(AuthApiClientError::AuthTokenNotBearer)?;
+
+        let whoami_url = self.base_url.join("whoami")?;
+        let whoami_response = reqwest::Client::new()
+            .get(whoami_url)
+            .header("Cookie", format!("si-auth={}", &token_no_bearer))
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let whoami = whoami_response.json::<UserWrap>().await?.user;
+
+        Ok(whoami)
+    }
+}

--- a/lib/auth-api-client/src/lib.rs
+++ b/lib/auth-api-client/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod client;
+pub mod types;
+
+pub const PROD_AUTH_API_ENDPOINT: &str = "https://auth-api.systeminit.com";

--- a/lib/auth-api-client/src/types.rs
+++ b/lib/auth-api-client/src/types.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use ulid::Ulid;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AuthApiClientError {
+    #[error("Auth token is not in Bearer format")]
+    AuthTokenNotBearer,
+    #[error("Request error: {0}")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+    #[error("Request error: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("Upload error: {0}")]
+    Upload(String),
+    #[error("Url parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+}
+
+pub type AuthApiResult<T> = Result<T, AuthApiClientError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WhoamiResponse {
+    pub id: Ulid,
+    pub auth0_id: String,
+    pub auth0_details: serde_json::Value,
+    pub nickname: String,
+    pub email: String,
+    pub email_verified: bool,
+    pub first_name: String,
+    pub last_name: String,
+    pub picture_url: String,
+    pub discord_username: String,
+    pub github_username: String,
+    pub onboarding_details: serde_json::Value,
+    pub agreed_tos_version: String,
+    pub needs_tos_update: bool,
+}

--- a/lib/module-index-server/BUCK
+++ b/lib/module-index-server/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "module-index-server",
     deps = [
+        "//lib/auth-api-client:auth-api-client",
         "//lib/buck2-resources:buck2-resources",
         "//lib/module-index-client:module-index-client",
         "//lib/si-data-pg:si-data-pg",
@@ -31,6 +32,7 @@ rust_library(
         "//third-party/rust:tower",
         "//third-party/rust:tower-http",
         "//third-party/rust:ulid",
+        "//third-party/rust:url",
     ],
     srcs = glob([
         "src/**/*.rs",

--- a/lib/module-index-server/Cargo.toml
+++ b/lib/module-index-server/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 axum = { workspace = true }
+auth-api-client = { path = "../../lib/auth-api-client" }
 base64 = { workspace = true }
 buck2-resources = { path = "../../lib/buck2-resources" }
 chrono = { workspace = true }
@@ -34,3 +35,4 @@ tokio-stream = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 ulid = { workspace = true }
+url = { workspace = true }

--- a/lib/module-index-server/src/config.rs
+++ b/lib/module-index-server/src/config.rs
@@ -55,6 +55,9 @@ pub struct Config {
     #[builder(default = "PosthogConfig::default()")]
     posthog: PosthogConfig,
 
+    #[builder(default = "false")]
+    restrict_listing: bool,
+
     s3: S3Config,
 }
 
@@ -95,6 +98,11 @@ impl Config {
     #[must_use]
     pub fn s3(&self) -> &S3Config {
         &self.s3
+    }
+
+    /// Whether to restrict module listing to SystemInit accounts
+    pub fn restrict_listing(&self) -> bool {
+        self.restrict_listing
     }
 }
 

--- a/lib/module-index-server/src/lib.rs
+++ b/lib/module-index-server/src/lib.rs
@@ -6,6 +6,7 @@ mod models;
 mod routes;
 mod s3;
 pub mod server;
+mod whoami;
 
 pub use crate::{
     config::{

--- a/lib/module-index-server/src/routes/download_module_route.rs
+++ b/lib/module-index-server/src/routes/download_module_route.rs
@@ -42,7 +42,7 @@ impl IntoResponse for DownloadModuleError {
 
 pub async fn download_module_route(
     Path(module_id): Path<ModuleId>,
-    Authorization(_claim): Authorization,
+    Authorization { .. }: Authorization,
     ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
 ) -> Result<Redirect, DownloadModuleError> {

--- a/lib/module-index-server/src/routes/get_module_details_route.rs
+++ b/lib/module-index-server/src/routes/get_module_details_route.rs
@@ -47,7 +47,7 @@ pub struct GetModuleDetailsRequest {
 
 pub async fn get_module_details_route(
     Path(module_id): Path<ModuleId>,
-    Authorization(_claim): Authorization,
+    Authorization { .. }: Authorization,
     DbConnection(txn): DbConnection,
     Query(_request): Query<GetModuleDetailsRequest>,
 ) -> Result<Json<Value>, GetModuleDetailsError> {

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -57,7 +57,7 @@ impl IntoResponse for UpsertModuleError {
 
 // #[debug_handler]
 pub async fn upsert_module_route(
-    Authorization(_claim): Authorization,
+    Authorization { .. }: Authorization,
     ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     mut multipart: Multipart,

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -100,6 +100,7 @@ impl Server<(), ()> {
             posthog_client,
             aws_creds,
             config.s3().clone(),
+            config.restrict_listing(),
         )?;
 
         info!(
@@ -214,6 +215,7 @@ pub fn build_service(
     posthog_client: PosthogClient,
     aws_creds: AwsCredentials,
     s3_config: S3Config,
+    restrict_listing: bool,
 ) -> Result<(Router, oneshot::Receiver<()>, broadcast::Receiver<()>)> {
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
     let (shutdown_broadcast_tx, shutdown_broadcast_rx) = broadcast::channel(1);
@@ -224,6 +226,7 @@ pub fn build_service(
         posthog_client,
         aws_creds,
         s3_config,
+        restrict_listing,
         shutdown_broadcast_tx.clone(),
         shutdown_tx,
     );

--- a/lib/module-index-server/src/whoami.rs
+++ b/lib/module-index-server/src/whoami.rs
@@ -1,0 +1,51 @@
+use auth_api_client::{client::AuthApiClient, types::AuthApiClientError};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use thiserror::Error;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum WhoamiError {
+    #[error("auth api error: {0}")]
+    AuthApiClient(#[from] AuthApiClientError),
+    #[error("Url parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+}
+
+type WhoamiResult<T> = Result<T, WhoamiError>;
+
+pub async fn get_email_for_auth_token(
+    token: &str,
+    token_map: Arc<Mutex<HashMap<String, String>>>,
+) -> WhoamiResult<String> {
+    let mut token_map = token_map.lock().await;
+
+    match token_map.get(token) {
+        Some(email) => Ok(email.into()),
+        None => {
+            let auth_api_client =
+                AuthApiClient::new(auth_api_client::PROD_AUTH_API_ENDPOINT.try_into()?, token);
+
+            let whoami = auth_api_client.whoami().await?;
+
+            token_map.insert(token.into(), whoami.email.clone());
+
+            Ok(whoami.email)
+        }
+    }
+}
+
+pub fn is_systeminit_email(email: &str) -> bool {
+    email.to_lowercase().ends_with("@systeminit.com")
+}
+
+pub async fn is_systeminit_auth_token(
+    token: &str,
+    token_map: Arc<Mutex<HashMap<String, String>>>,
+) -> WhoamiResult<bool> {
+    Ok(is_systeminit_email(
+        &get_email_for_auth_token(token, token_map).await?,
+    ))
+}


### PR DESCRIPTION
Adds an arc-mutex guarded hashmap to the module index app state to cache emails by the provided auth token. In the future we may want to just directly connect to the deployed sdf's database and lookup the email in the users table.