### PR TITLE
feat(auth-api,si): check for container updates

### DIFF
--- a/bin/auth-api/.env
+++ b/bin/auth-api/.env
@@ -27,5 +27,5 @@ AUTH0_CLIENT_SECRET=fill-in-real-key  # must set in .env.local to run auth api l
 POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
 POSTHOG_API_HOST=https://e.systeminit.com
 
-GH_TOKEN=fill-in-real-token
+GH_TOKEN=fill-in-real-token  # must set in .env.local to run auth api locally
 GH_DOMAIN=api.github.com

--- a/bin/auth-api/src/routes/github.routes.ts
+++ b/bin/auth-api/src/routes/github.routes.ts
@@ -24,14 +24,14 @@ interface Release {
   publishedAt: string;
 }
 
-let cachedAt: Date | null = null;
+let releaseCachedAt: Date | null = null;
 let releases: Release[] | null = null;
-let loading: boolean = false;
+let loadingReleases: boolean = false;
 
-router.get("/github/releases", async (ctx) => {
-  const seconds = Math.abs(Date.now() - (cachedAt?.getTime() ?? 0));
-  if ((seconds > 180 * 1000 || !releases) && !loading) {
-    loading = true;
+const loadReleases = async (): Promise<Release[]> => {
+  const seconds = Math.abs(Date.now() - (releaseCachedAt?.getTime() ?? 0));
+  if ((seconds > 180 * 1000 || !releases) && !loadingReleases) {
+    loadingReleases = true;
 
     try {
       const data = await tryCatch(async () => {
@@ -77,7 +77,7 @@ router.get("/github/releases", async (ctx) => {
         releasesTemp.push(release);
       }
 
-      cachedAt = new Date();
+      releaseCachedAt = new Date();
       releases = releasesTemp;
     } catch (err) {
       if (releases) {
@@ -87,9 +87,110 @@ router.get("/github/releases", async (ctx) => {
       }
       throw err;
     } finally {
-      loading = false;
+      loadingReleases = false;
     }
   }
 
-  ctx.body = releases ?? [];
+  return releases ?? [];
+};
+
+router.get("/github/releases/latest", async (ctx) => {
+  const latest = (await loadReleases())[0];
+  if (!latest) {
+    throw new ApiError(
+      "NotFound",
+      "GITHUB_LATEST_RELEASE_NOT_FOUND",
+      "not found",
+    );
+  }
+
+  ctx.body = latest;
+});
+
+router.get("/github/releases", async (ctx) => {
+  ctx.body = await loadReleases();
+});
+
+interface GithubTag {
+  ref: string;
+  node_id: string;
+  url: string;
+  object: {
+    sha: string;
+    type: string;
+    url: string;
+  };
+}
+
+interface LatestContainer {
+  namespace: string;
+  repository: string;
+  name: string;
+  gitSha: string;
+  digest: string;
+}
+
+let containersCachedAt: Date | null = null;
+let containers: LatestContainer[] | null = null;
+let loadingContainers: boolean = false;
+
+router.get("/github/containers/latest", async (ctx) => {
+  const seconds = Math.abs(Date.now() - (containersCachedAt?.getTime() ?? 0));
+  if ((seconds > 180 * 1000 || !containers) && !loadingContainers) {
+    loadingContainers = true;
+
+    try {
+      const data: GithubTag[] = await tryCatch(async () => {
+        const req = await ghApi.get("/repos/systeminit/si/git/refs/tags", {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${process.env.GH_TOKEN}`,
+            "X-Github-Api-Version": "2022-11-28",
+          },
+        });
+
+        return req.data;
+      }, (err) => {
+        throw new ApiError(
+          err.response.statusText,
+          "GITHUB_LIST_TAGS_FAILURE",
+          err.response.data.message,
+        );
+      });
+
+      const prefixes = ["sdf", "veritech", "pinga", "council", "module-index", "web", "otelcol", "jaeger", "nats", "postgres"];
+      const latestContainers = [];
+      for (const tag of data) {
+        for (const prefix of prefixes) {
+          const start = `refs/tags/${prefix}/sha256-`;
+          if (tag.ref.startsWith(start)) {
+            const digest = tag.ref.replace(start, "");
+            latestContainers.push({
+              namespace: "systeminit",
+              repository: prefix,
+              name: `${prefix}/sha256-${digest}`,
+              gitSha: tag.object.sha,
+              digest,
+            });
+            break;
+          }
+        }
+      }
+
+      containersCachedAt = new Date();
+      containers = latestContainers;
+    } catch (err) {
+      if (containers) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        ctx.body = containers;
+        return;
+      }
+      throw err;
+    } finally {
+      loadingContainers = false;
+    }
+  }
+
+  ctx.body = containers ?? [];
 });

--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -131,8 +131,11 @@ pub(crate) struct DeleteArgs {}
 #[derive(Debug, clap::Args)]
 pub(crate) struct UpdateArgs {
     /// Skip the confirmation check as part of the update command
-    #[clap(short, long)]
-    pub skip_check: bool,
+    #[clap(short = 'y', long)]
+    pub skip_confirmation: bool,
+    /// Skip the containers update as part of the update command
+    #[clap(name = "self", short, long)]
+    pub binary: bool,
 }
 
 #[derive(Debug, clap::Args)]

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -45,10 +45,16 @@ async fn main() -> Result<()> {
 
     if !matches!(args.command, Commands::Update(_)) {
         match update::find(VERSION, auth_api_host.as_deref()).await {
-            Ok(Some(_)) => {
-                println!("Update found, please run `si update` to install it\n");
+            Ok(update) => {
+                if update.si.is_some() {
+                    println!("Launcher update found, please run `si update` to install it");
+                }
+
+                if !update.containers.is_empty() {
+                    println!("Containers update found, please run `si update` to install them");
+                }
+                println!();
             }
-            Ok(None) => {}
             Err(err) => {
                 println!("Unable to retrieve updates: {err}");
             }
@@ -92,7 +98,8 @@ async fn main() -> Result<()> {
                 auth_api_host.as_deref(),
                 &ph_client,
                 mode.to_string(),
-                args.skip_check,
+                args.skip_confirmation,
+                args.binary,
             )
             .await?;
         }

--- a/lib/si-cli/src/cmd/update.rs
+++ b/lib/si-cli/src/cmd/update.rs
@@ -26,24 +26,62 @@ pub struct Release {
     pub published_at: String,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LatestContainer {
+    pub namespace: String,
+    pub repository: String,
+    pub name: String,
+    pub git_sha: String,
+    pub digest: String,
+}
+
+#[derive(Debug)]
+pub struct Update {
+    pub containers: Vec<LatestContainer>,
+    pub si: Option<Release>,
+}
+
 static HOST: &str = "https://auth-api.systeminit.com";
 
-pub async fn find(current_version: &str, host: Option<&str>) -> CliResult<Option<Release>> {
+pub async fn find(current_version: &str, host: Option<&str>) -> CliResult<Update> {
     let host = if let Some(host) = host { host } else { HOST };
 
-    let req = reqwest::get(format!("{host}/github/releases")).await?;
+    let req = reqwest::get(format!("{host}/github/containers/latest")).await?;
     if req.status().as_u16() != 200 {
-        println!("API returned an expected status code: {}", req.status());
-        return Ok(None);
+        return Err(SiCliError::UnableToFetchContainersUpdate(
+            req.status().as_u16(),
+        ));
     }
 
-    let releases: Vec<Release> = req.json().await?;
-    if let Some(release) = releases.first() {
-        if release.version != current_version {
-            return Ok(Some(release.clone()));
+    let current_containers = get_container_details().await?;
+
+    let mut containers = Vec::new();
+    let latest_containers: Vec<LatestContainer> = req.json().await?;
+    'outer: for latest in latest_containers {
+        for current in &current_containers {
+            if current.git_sha == latest.git_sha {
+                containers.push(latest);
+                continue 'outer;
+            }
         }
+
+        // If we don't have the container locally we should fetch it
+        containers.push(latest);
     }
-    Ok(None)
+
+    let req = reqwest::get(format!("{host}/github/releases/latest")).await?;
+    if req.status().as_u16() != 200 {
+        return Err(SiCliError::UnableToFetchSiUpdate(req.status().as_u16()));
+    }
+
+    let mut si = None;
+    let release: Release = req.json().await?;
+    if release.version != current_version {
+        si = Some(release);
+    }
+
+    Ok(Update { containers, si })
 }
 
 pub async fn update_current_binary(url: &str) -> CliResult<()> {
@@ -71,7 +109,6 @@ pub async fn update_current_binary(url: &str) -> CliResult<()> {
     tokio::fs::write(tempfile.path(), bytes).await?;
 
     println!("Overwriting current binary");
-    dbg!(&current_exe);
     tokio::fs::rename(tempfile.path(), current_exe).await?;
 
     println!("Binary updated!");
@@ -84,7 +121,8 @@ pub async fn invoke(
     host: Option<&str>,
     posthog_client: &PosthogClient,
     mode: String,
-    skip_check: bool,
+    skip_confirmation: bool,
+    only_binary: bool,
 ) -> CliResult<()> {
     let _ = posthog_client.capture(
         "si-command",
@@ -99,43 +137,72 @@ pub async fn invoke(
     let our_os = "Darwin";
 
     let update = find(current_version, host).await?;
-    if let Some(update) = &update {
-        let version = &update.version;
-        println!("Update found: from {current_version} to {version}\n",);
+    if !only_binary {
+        for image in &update.containers {
+            println!(
+                "Container update found for {}/{}",
+                image.namespace, image.repository
+            );
+        }
     }
 
-    let ans = if let Some(update) = update {
-        if skip_check {
-            Ok((true, update))
+    if let Some(update) = &update.si {
+        let version = &update.version;
+        println!("Launcher update found: from {current_version} to {version}",);
+    }
+
+    let ans = if update.si.is_some() || (!only_binary && !update.containers.is_empty()) {
+        if skip_confirmation {
+            Ok(true)
         } else {
-            println!("{}", "Updating the launcher will destroy your data!".red());
-            Confirm::new("Are you sure you want to update this launcher?")
-                .with_default(false)
-                .prompt()
-                .map(|ans| (ans, update))
+            let mut prompt = "Are you sure you want to update".to_owned();
+            if update.si.is_some() {
+                prompt.push_str(" the binary");
+                if !update.containers.is_empty() {
+                    prompt.push_str(" and");
+                }
+            }
+
+            if !only_binary && !update.containers.is_empty() {
+                println!(
+                    "\n{}",
+                    "Updating the containers will destroy your data!".red()
+                );
+                prompt.push_str(" the containers listed above");
+            }
+
+            prompt.push('?');
+
+            Confirm::new(&prompt).with_default(false).prompt()
         }
     } else {
+        println!("No updates found!");
         return Ok(());
     };
 
     match ans {
-        Ok((true, update)) => {
+        Ok(true) => {
             println!("\nThat's awesome! Let's do this");
-            // Note: we can't download from here because the repo is private, we should
-            // automate the download + replace of the current binary after we go public
-            // (or start caching the binaries in auth api)
-            for asset in &update.assets {
-                if asset.name.to_lowercase().contains(&our_os.to_lowercase()) {
-                    println!("Download the new version here: {}\n", asset.url);
-                    // update_current_binary(&asset.url).await?;
+
+            if !only_binary {
+                dbg!(update.containers);
+            }
+
+            if let Some(update) = &update.si {
+                // Note: we can't download from here because the repo is private, we should
+                // automate the download + replace of the current binary after we go public
+                // (or start caching the binaries in auth api)
+                for asset in &update.assets {
+                    if asset.name.to_lowercase().contains(&our_os.to_lowercase()) {
+                        println!("Download the new version here: {}\n", asset.url);
+                        // update_current_binary(&asset.url).await?;
+                    }
                 }
             }
         }
-        Ok((false, _)) => println!("See ya later ;)"),
+        Ok(false) => println!("See ya later ;)"),
         Err(err) => println!("Error: Try again later!: {err}"),
     }
-
-    let _ = get_container_details().await?;
 
     Ok(())
 }

--- a/lib/si-cli/src/containers.rs
+++ b/lib/si-cli/src/containers.rs
@@ -11,8 +11,8 @@ use std::string::ToString;
 #[derive(Debug)]
 pub struct DockerReleaseInfo {
     pub git_sha: String,
-    pub created_data: String,
-    pub image_name: String,
+    pub created_at: String,
+    pub image: String,
 }
 
 pub(crate) async fn downloaded_systeminit_containers_list() -> Result<Vec<ImageSummary>, SiCliError>
@@ -45,12 +45,12 @@ pub(crate) async fn get_container_details() -> CliResult<Vec<DockerReleaseInfo>>
                 .get("org.opencontainers.image.revision")
                 .unwrap()
                 .to_string(),
-            created_data: container
+            created_at: container
                 .labels
                 .get("org.opencontainers.image.created")
                 .unwrap()
                 .to_string(),
-            image_name: container.labels.get("name").unwrap().to_string(),
+            image: container.labels.get("name").unwrap().to_string(),
         })
     }
 

--- a/lib/si-cli/src/lib.rs
+++ b/lib/si-cli/src/lib.rs
@@ -35,6 +35,10 @@ pub enum SiCliError {
     Reqwest(#[from] reqwest::Error),
     #[error("unable to download update, status = {0}")]
     UnableToDownloadUpdate(u16),
+    #[error("unable to fetch containers update, status = {0}")]
+    UnableToFetchContainersUpdate(u16),
+    #[error("unable to fetch si update, status = {0}")]
+    UnableToFetchSiUpdate(u16),
 }
 
 pub type CliResult<T> = Result<T, SiCliError>;


### PR DESCRIPTION
- Fetch latest containers metadata from github tags tied to a commit
- Compare that metadata with the metadata from the locally running containers
- Suggest an update if there are new containers
- Doesn't actually update, it's the next step
- Add --self to avoid downloading container updates

- Create API to get only the latest si binary release