### PR TITLE
auth portal login success redirect

### DIFF
--- a/app/auth-portal/package.json
+++ b/app/auth-portal/package.json
@@ -23,6 +23,7 @@
     "clsx": "^1.2.1",
     "highlight.js": "^11.7.0",
     "less": "^4.1.3",
+    "local-storage-fallback": "^4.1.2",
     "lodash-es": "^4.17.21",
     "pinia": "^2.1.3",
     "posthog-js": "^1.51.4",

--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -3,6 +3,7 @@ import { RouterOptions } from "vite-ssg";
 import { Router } from "vue-router";
 import { nextTick } from "vue";
 import posthog from "posthog-js";
+import storage from "local-storage-fallback";
 import LoginPage from "./pages/LoginPage.vue";
 import LogoutPage from "./pages/LogoutPage.vue";
 import NotFoundPage from "./pages/NotFoundPage.vue";
@@ -50,7 +51,12 @@ export const routerOptions: RouterOptions = {
     {
       path: "/login-success",
       name: "login-success",
-      redirect: { name: "tutorial" },
+      redirect() {
+        // see App.vue for logic saving this redirect location
+        const savedPath = storage.getItem("SI-LOGIN-REDIRECT");
+        storage.removeItem("SI-LOGIN-REDIRECT");
+        return savedPath || { name: "tutorial" };
+      },
     },
     { path: "/:catchAll(.*)", name: "404", component: NotFoundPage },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       less:
         specifier: ^4.1.3
         version: 4.1.3
+      local-storage-fallback:
+        specifier: ^4.1.2
+        version: 4.1.2
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21


### PR DESCRIPTION
saves the requested URL before redirecting to login/TOS/profile completion, and redirects when things are done. This will let us point users at the download/install page, and kick them there correctly after successful login (and other required steps)