### PR TITLE
chore(ci-base): add `openssh-client` to base image for Git tag pushing

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
         curl \
         git \
         gnupg \
+        openssh-client \
         sudo \
         xz-utils \
     ; \


### PR DESCRIPTION
An `ssh` program is required by Git when pushing a Git tag in come of our pipeline activities.

/cc @stack72 