### PR TITLE
chore(ci-base): pre-verify github.com SSH hosts

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -62,7 +62,11 @@ RUN set -eux; \
     . "$HOME/.nix-profile/etc/profile.d/nix.sh"; \
     nix-env -iA nixpkgs.nixFlakes; \
     grep 'Nix installer' "$HOME/.profile" >>"$HOME/.bashrc"; \
-    git config --global --add safe.directory /workdir
+    \
+    git config --global --add safe.directory /workdir; \
+    mkdir -p "$HOME/.ssh"; \
+    chmod 0700 "$HOME/.ssh"; \
+    ssh-keyscan github.com >>"$HOME/.ssh/known_hosts";
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Without doing this, when performing a Git operation, an interactive prompt may display in the non-interactive environment of a CI job running in a Docker container.