### PR TITLE
chore(sdf): vendor `pkgs/*.sipkg` in sdf Docker image

### DIFF
--- a/bin/sdf/BUCK
+++ b/bin/sdf/BUCK
@@ -26,5 +26,8 @@ docker_image(
     name = "image",
     image_name = "sdf",
     flake_lock = "//:flake.lock",
-    build_deps = ["//bin/sdf:sdf"]
+    build_deps = [
+        "//bin/sdf:sdf",
+        "//pkgs:pkgs",
+    ]
 )

--- a/bin/sdf/Dockerfile
+++ b/bin/sdf/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
 WORKDIR /run/$BIN
 COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/local-bin/* /usr/local/bin/
+COPY --from=builder /workdir/pkgs/*.sipkg /run/sdf/pkgs/
 
 EXPOSE 5156/tcp
 


### PR DESCRIPTION
Note that this is temporary until our module-index/sdf boot story is more fleshed out. For now, sdf will find the pkgs (i.e. modules) it's expecting.

Not too hard in the end, right?

<img src="https://media2.giphy.com/media/eLvhchyvNNOuLbOtYP/giphy.gif"/>