### PR TITLE
chore(sdf-tests): avoid stale data in sdf tests

### DIFF
--- a/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
@@ -24,7 +24,7 @@ async fn authoring_flow_asset(
 
     // Create the asset
     let asset = harness
-        .create_asset(&ctx, schema_name.to_string(), None)
+        .create_asset(ctx.visibility(), schema_name.to_string(), None)
         .await;
     assert!(asset.asset_id.is_some());
 
@@ -37,7 +37,7 @@ async fn authoring_flow_asset(
             .setValueFrom(new ValueFromBuilder().setKind("prop").setPropPath(["root", "si", "name"]).build())
             .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
             .build();
-    
+
         const portsProp = new PropBuilder()
             .setKind("array")
             .setName("ExposedPorts")
@@ -47,18 +47,18 @@ async fn authoring_flow_asset(
                         .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
                         .build())
             .build();
-    
+
         const portsSocket = new SocketDefinitionBuilder()
             .setName("Exposed Ports")
             .setArity("many")
             .build();
-    
+
         const credentialSocket = new SocketDefinitionBuilder()
             .setName("Docker Hub Credential")
             .setArity("many")
             .build();
-    
-    
+
+
         return new AssetBuilder()
             .addProp(imageProp)
             .addProp(portsProp)
@@ -69,7 +69,7 @@ async fn authoring_flow_asset(
 
     harness
         .update_asset(
-            &ctx,
+            ctx.visibility(),
             asset.asset_id,
             schema_name.to_string(),
             None,
@@ -77,12 +77,16 @@ async fn authoring_flow_asset(
         )
         .await;
 
-    harness.publish_asset(&ctx, asset.asset_id).await;
+    harness
+        .publish_asset(ctx.visibility(), asset.asset_id)
+        .await;
 
     // Let's add the new schema to our test harness cache
     harness.add_schemas(&ctx, &[schema_name]).await;
 
-    let my_asset = harness.create_node(&ctx, schema_name, None).await;
+    let my_asset = harness
+        .create_node(ctx.visibility(), schema_name, None)
+        .await;
 
     // Update the name of the asset
     harness

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_aws_key_pair.rs
@@ -28,9 +28,9 @@ async fn model_and_fix_flow_aws_key_pair(
         .await;
 
     // Create all AWS components.
-    let region = harness.create_node(&ctx, "Region", None).await;
+    let region = harness.create_node(ctx.visibility(), "Region", None).await;
     let key_pair = harness
-        .create_node(&ctx, "Key Pair", Some(region.node_id))
+        .create_node(ctx.visibility(), "Key Pair", Some(region.node_id))
         .await;
 
     // Update property editor values.
@@ -120,7 +120,7 @@ async fn model_and_fix_flow_aws_key_pair(
         .await;
 
     // Check the confirmations and ensure they look as we expect.
-    let (confirmations, mut recommendations) = harness.list_confirmations(&mut ctx).await;
+    let (confirmations, mut recommendations) = harness.list_confirmations(ctx.visibility()).await;
     assert_eq!(
         1,                   // expected
         confirmations.len()  // actual
@@ -131,7 +131,7 @@ async fn model_and_fix_flow_aws_key_pair(
     // Run the fix for the confirmation.
     let fix_batch_id = harness
         .run_fixes(
-            &mut ctx,
+            ctx.visibility(),
             vec![FixRunRequest {
                 attribute_value_id: recommendation.confirmation_attribute_value_id,
                 component_id: recommendation.component_id,
@@ -141,7 +141,7 @@ async fn model_and_fix_flow_aws_key_pair(
         .await;
 
     // Check that the fix succeeded.
-    let mut fix_batch_history_views = harness.list_fixes(&mut ctx).await;
+    let mut fix_batch_history_views = harness.list_fixes(ctx.visibility()).await;
     let fix_batch_history_view = fix_batch_history_views.pop().expect("no fix batches found");
     assert!(fix_batch_history_views.is_empty());
     assert_eq!(

--- a/lib/sdf-server/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_flow_fedora_coreos_ignition.rs
@@ -37,12 +37,14 @@ async fn model_flow_fedora_coreos_ignition(
     harness.create_change_set_and_update_ctx(&mut ctx, "").await;
 
     // Create all components.
-    let region = harness.create_node(&ctx, "Region", None).await;
+    let region = harness.create_node(ctx.visibility(), "Region", None).await;
     let ec2 = harness
-        .create_node(&ctx, "EC2 Instance", Some(region.node_id))
+        .create_node(ctx.visibility(), "EC2 Instance", Some(region.node_id))
         .await;
-    let docker = harness.create_node(&ctx, "Docker Image", None).await;
-    let butane = harness.create_node(&ctx, "Butane", None).await;
+    let docker = harness
+        .create_node(ctx.visibility(), "Docker Image", None)
+        .await;
+    let butane = harness.create_node(ctx.visibility(), "Butane", None).await;
 
     // Make all connections.
     harness


### PR DESCRIPTION
- Minimize usage of context in sdf helpers to help debugging its usage
- Blocking commit when the database is accessed directly through the DAL API in sdf tests, to ensure no data is stale anywhere
- Add a few dbgs to the nightly test to have more info if it fails again