### PR TITLE
feat(veritech): consume provided AWS/Docker creds in Docker container

### DIFF
--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -1,6 +1,7 @@
 load(
     "@prelude-si//:macros.bzl",
     "docker_image",
+    "export_file",
     "rust_binary",
 )
 
@@ -23,12 +24,17 @@ rust_binary(
     visibility = ["PUBLIC"],
 )
 
+export_file(
+    name = "docker-entrypoint.sh",
+)
+
 docker_image(
     name = "image",
     image_name = "veritech",
     flake_lock = "//:flake.lock",
     build_deps = [
         "//bin/veritech:veritech",
+        "//bin/veritech:docker-entrypoint.sh",
         "//bin/cyclone:cyclone",
         "//bin/lang-js:bin",
     ]

--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -21,6 +21,11 @@ RUN cp -R $(nix-store --query --requisites result/) /tmp/nix-store-closure
 # hadolint ignore=SC2046
 RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
 
+# Add wrapper/entrypoint for `$BIN` to exec `.$BIN`
+RUN set -eux; \
+    mv -v "/tmp/local-bin/$BIN" "/tmp/local-bin/.$BIN"; \
+    cp -pv /workdir/bin/$BIN/docker-entrypoint.sh "/tmp/local-bin/$BIN";
+
 ###########################################################################
 # Builder Stage: cyclone
 ###########################################################################

--- a/bin/veritech/docker-entrypoint.sh
+++ b/bin/veritech/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# shellcheck disable=SC3043
+set -eu
+
+main() {
+  write_aws_credentials
+  write_docker_credentials
+
+  exec /usr/local/bin/.veritech "$@"
+}
+
+write_aws_credentials() {
+  ensure_env_var AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID:-}"
+  ensure_env_var AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY:-}"
+
+  mkdir -p "$HOME/.aws"
+  chmod 0755 "$HOME/.aws"
+  cat <<-EOF >"$HOME/.aws/credentials"
+	[default]
+	aws_access_key_id = ${AWS_ACCESS_KEY_ID:-}
+	aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY:-}
+	EOF
+  chmod 0600 "$HOME/.aws/credentials"
+
+  # Remove environment variables from veritech's environment
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+}
+
+write_docker_credentials() {
+  ensure_env_var DOCKER_AUTHENTICATION "${DOCKER_AUTHENTICATION:-}"
+
+  local auth_key="https://index.docker.io/v1/"
+
+  mkdir -p "$HOME/.docker"
+  chmod 0700 "$HOME/.docker"
+  cat <<-EOF >"$HOME/.docker/config.json"
+	{"auths":{"$auth_key":{"auth":"${DOCKER_AUTHENTICATION:-}"}}}
+	EOF
+  chmod 0600 "$HOME/.docker/config.json"
+
+  # Remove environment variables from veritech's environment
+  unset DOCKER_AUTHENTICATION
+}
+
+ensure_env_var() {
+  local name="$1"
+  local value="$2"
+
+  if [ -z "$value" ]; then
+    echo "xxx" >&2
+    echo "xxx Missing required environment variable: '$name', aborting" >&2
+    echo "xxx" >&2
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This change adds 3 new required environment variables to be set when running the `systeminit/veritech` image:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `DOCKER_AUTHENTICATION`

A shimmed entrypoint/wrapper script is installed in the Docker image as `/usr/local/bin/veritech` (in the source tree as
`bin/veritech/docker-entrypoint.sh`) which will ensure these 3 environment variables are set (i.e. non-empty) and will create 2 configuration files for the `app` user--who runs the Veritech service:

- `$HOME/.aws/credentials`
- `$HOME/.docker/config.json`

These files are created and injected with the above environment variable credentials, then the real Veritech binary is exec'd at `/usr/local/bin/.veritech`, passing along any arguments.

If any environment variables are not set, the entrypoint/wrapper script will exit non-zero, causing the container to abort running with an appropriate error message about the required missing environment variable.

Note that this entrypoint/shim is only present in the built Docker image and *not* present in any Nix built package, raw binary produced via Buck2, etc.