### PR TITLE
feat(si-cli): replace running binary when updating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4657,12 +4657,14 @@ dependencies = [
 name = "si-cli"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.2",
  "color-eyre",
  "colored",
  "comfy-table",
  "console",
  "directories",
  "docker-api",
+ "flate2",
  "futures",
  "indicatif",
  "inquire",
@@ -4674,6 +4676,7 @@ dependencies = [
  "serde_json",
  "si-posthog",
  "sodiumoxide",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }
 vfs = "0.9.0"
 vfs-tar = { version = "0.4.0", features = ["mmap"] }
+flate2 = "1.0.26"
 
 [patch.crates-io]
 # pending a potential merge and release of

--- a/lib/si-cli/BUCK
+++ b/lib/si-cli/BUCK
@@ -16,6 +16,8 @@ rust_library(
         "//third-party/rust:open",
         "//third-party/rust:rand",
         "//third-party/rust:remain",
+        "//third-party/rust:tar",
+        "//third-party/rust:flate2",
         "//third-party/rust:serde",
         "//third-party/rust:tokio",
         "//third-party/rust:toml",

--- a/lib/si-cli/Cargo.toml
+++ b/lib/si-cli/Cargo.toml
@@ -28,3 +28,5 @@ sodiumoxide = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 colored = { workspace = true }
+tar = { workspace = true }
+flate2 = { workspace = true }

--- a/lib/si-cli/src/lib.rs
+++ b/lib/si-cli/src/lib.rs
@@ -26,6 +26,8 @@ pub enum SiCliError {
     Installation,
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+    #[error("join: {0}")]
+    Join(#[from] tokio::task::JoinError),
     #[error("Unable to find local data dir. Expected format `$HOME/.local/share` or `$HOME/Library/Application Support`")]
     MissingDataDir(),
     #[error("reqwest: {0}")]

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -4066,6 +4066,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "flate2",
+    actual = ":flate2-1.0.26",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "flate2-1.0.26.crate",
     sha256 = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743",
@@ -13389,6 +13395,7 @@ cargo.rust_binary(
         ":directories-5.0.1",
         ":docker-api-0.14.0",
         ":dyn-clone-1.0.11",
+        ":flate2-1.0.26",
         ":futures-0.3.28",
         ":futures-lite-1.13.0",
         ":futures-util-0.3.28",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -4623,6 +4623,7 @@ dependencies = [
  "directories",
  "docker-api",
  "dyn-clone",
+ "flate2",
  "futures",
  "futures-lite",
  "futures-util",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -114,6 +114,7 @@ url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }
 vfs = "0.9.0"
 vfs-tar = { version = "0.4.0", features = ["mmap"] }
+flate2 = "1.0.26"
 
 # Local patches - typically Git references
 [patch.crates-io]


### PR DESCRIPTION
After we open source we should remove the line with the TODO

Since our repo is private we can't download from it, so we created a mirror public repo with the releases.