### PR TITLE
fix(lang-js): build all deps for running lang-js in dev with Veritech

### DIFF
--- a/prelude-si/pnpm/BUCK
+++ b/prelude-si/pnpm/BUCK
@@ -16,6 +16,10 @@ export_file(
 )
 
 export_file(
+    name = "build_typescript_runnable_dist_bin.py",
+)
+
+export_file(
     name = "build_workspace_node_modules.py",
 )
 

--- a/prelude-si/pnpm/build_typescript_runnable_dist_bin.py
+++ b/prelude-si/pnpm/build_typescript_runnable_dist_bin.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Builds an isolated dist tree containing a pruned sub-package and all
+production node_modules.
+"""
+import argparse
+import os
+import shutil
+import stat
+import tempfile
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cd-path",
+        required=True,
+        help="Path to runnable dist tree root",
+    )
+    parser.add_argument(
+        "--rel-path",
+        required=True,
+        help="Path to program under tree root",
+    )
+    parser.add_argument(
+        "out_path",
+        help="Path to output",
+    )
+
+    args = parser.parse_args()
+
+    abs_cd_path = os.path.abspath(args.cd_path)
+
+    binary_content = [
+        "#!/usr/bin/env sh",
+        "set -eu",
+        f"cd {abs_cd_path}",
+        f"exec ./{args.rel_path} \"$@\"",
+    ]
+
+    with open(args.out_path, "w") as f:
+        f.write("\n".join(binary_content) + "\n")
+
+    os.chmod(
+        args.out_path,
+        stat.S_IRUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH,
+    )

--- a/prelude-si/pnpm/toolchain.bzl
+++ b/prelude-si/pnpm/toolchain.bzl
@@ -2,6 +2,7 @@ PnpmToolchainInfo = provider(fields = [
     "build_npm_bin",
     "build_package_node_modules",
     "build_pkg_bin",
+    "build_typescript_runnable_dist_bin",
     "build_workspace_node_modules",
     "exec_cmd",
     "package_build_context",
@@ -20,6 +21,7 @@ def pnpm_toolchain_impl(ctx) -> [[DefaultInfo.type, PnpmToolchainInfo.type]]:
             build_package_node_modules = ctx.attrs._build_package_node_modules,
             build_pkg_bin = ctx.attrs._build_pkg_bin,
             build_workspace_node_modules = ctx.attrs._build_workspace_node_modules,
+            build_typescript_runnable_dist_bin = ctx.attrs._build_typescript_runnable_dist_bin,
             exec_cmd = ctx.attrs._exec_cmd,
             package_build_context = ctx.attrs._package_build_context,
             package_dist_context = ctx.attrs._package_dist_context,
@@ -38,6 +40,9 @@ pnpm_toolchain = rule(
         ),
         "_build_pkg_bin": attrs.dep(
             default = "prelude-si//pnpm:build_pkg_bin.py",
+        ),
+        "_build_typescript_runnable_dist_bin": attrs.dep(
+            default = "prelude-si//pnpm:build_typescript_runnable_dist_bin.py",
         ),
         "_build_workspace_node_modules": attrs.dep(
             default = "prelude-si//pnpm:build_workspace_node_modules.py",


### PR DESCRIPTION
This change fixes a Buck2 build issue when running `bin/veritech` under Tilt using the `buck2 run dev` developer workflow. Prior to this change, a Buck2 target depdency of `root//bin/lang-js:lang-js` (which is a `typescript_runnable_dist` type rule) was not always being built and finally depended upon by the `root/bin/lang-js:bin` target (which is a `typescript_runnable_dist_bin` type rule). Unfortunetly as our implementation moved away from using `pkg`, this whole setup has become more complex with 3 slightly different scenarios/solutions needing to have been accounted for: the developer workflow, test execution, and Docker image building.