### PR TITLE
chore(ci): only create GitHub release drafts

### DIFF
--- a/.ci/publish-binary.py
+++ b/.ci/publish-binary.py
@@ -82,7 +82,7 @@ def create_github_release(tag: str, assets: List[str], verbose: bool):
         "gh",
         "release",
         "create",
-        "--latest",
+        "--draft",
         "--generate-notes",
         tag,
     ] + assets


### PR DESCRIPTION
The CI pipeline will takes these draft releases and update them to full releases (and set the latest flag) in the `si/merge-main` pipeline.