### PR TITLE
fix(web): Fix detach button for attribute functions by ensuring ref is available

### DIFF
--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -58,6 +58,7 @@
             @click="openModal(proto.id)"
           />
           <VButton
+            v-if="!schemaVariantId"
             :disabled="disabled"
             variant="transparent"
             tone="destructive"

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -200,11 +200,30 @@
               @change="updateFunc"
             />
           </Collapsible>
+
+          <Collapsible
+            v-if="
+              editingFunc.variant === FuncVariant.Attribute && schemaVariantId
+            "
+            label="Binding"
+            defaultOpen
+          >
+            <AttributeBindings
+              v-if="
+                editingFunc.associations &&
+                editingFunc.associations.type === 'attribute'
+              "
+              ref="detachRef"
+              v-model="editingFunc.associations"
+              :schemaVariantId="schemaVariantId"
+              @change="updateFunc"
+            />
+          </Collapsible>
         </ScrollArea>
       </TabGroupItem>
 
       <TabGroupItem
-        v-if="editingFunc.variant === FuncVariant.Attribute"
+        v-if="editingFunc.variant === FuncVariant.Attribute && !schemaVariantId"
         label="Bindings"
         slug="bindings"
       >


### PR DESCRIPTION
In the asset editor context, this moves the binding list to the func details instead of on another panel, so that the ref will be defined.