### PR TITLE
feat(web, auth) oss tracking, various fixes

### DIFF
--- a/app/auth-portal/src/App.vue
+++ b/app/auth-portal/src/App.vue
@@ -291,6 +291,7 @@ watch([checkAuthReq, route], () => {
     if (
       ![
         "login",
+        "signup",
         "404",
         "legal",
         // allow viewing tutorial without login if VITE_PREVIEW_TUTORIAL set in env

--- a/app/auth-portal/src/components/WorkspaceLinkWidget.vue
+++ b/app/auth-portal/src/components/WorkspaceLinkWidget.vue
@@ -11,6 +11,7 @@
         'cursor-pointer',
       )
     "
+    @mousedown="tracker.trackEvent('workspace_launcher_widget_click')"
   >
     <Icon v-if="!compact" name="laptop" size="lg" />
     <Stack spacing="xs">
@@ -107,6 +108,7 @@ import { useWorkspacesStore, WorkspaceId } from "@/store/workspaces.store";
 import { useOnboardingStore } from "@/store/onboarding.store";
 
 import { API_HTTP_URL } from "@/store/api";
+import { tracker } from "@/lib/posthog";
 
 const props = defineProps({
   workspaceId: { type: String as PropType<WorkspaceId> },

--- a/app/auth-portal/src/pages/DownloadPage.vue
+++ b/app/auth-portal/src/pages/DownloadPage.vue
@@ -62,7 +62,10 @@
       >
         Copy and paste the following command into your terminal and execute it:
       </p>
-      <RichText class="py-sm">
+      <RichText
+        class="py-sm"
+        @mousedown="tracker.trackEvent('copy_install_script')"
+      >
         <pre><code class="language-shell">$ curl -sSf https://auth.systeminit.com/install.sh | sh</code></pre>
       </RichText>
       <div class="font-bold text-xl">Manual Installation</div>
@@ -102,6 +105,12 @@
             class="flex flex-row items-center text-action-500 font-bold cursor-pointer"
             :href="asset.url"
             target="_blank"
+            @mousedown="
+              tracker.trackEvent('binary_download_click', {
+                version: selectedVersion,
+                platform: selectedPlatform,
+              })
+            "
           >
             <!-- TODO(wendy) - download link goes here -->
             <div>Download</div>
@@ -123,6 +132,7 @@
           class="flex flex-row items-center text-action-500 font-bold cursor-pointer"
           :href="`https://github.com/systeminit/si/releases/tag/${selectedVersion}`"
           target="_blank"
+          @mousedown="tracker.trackEvent('changelog_click')"
         >
           <!-- TODO(wendy) - changelog link goes here -->
           <div>Github</div>
@@ -140,6 +150,7 @@ import clsx from "clsx";
 import { computed, onBeforeMount, ref } from "vue";
 import { Icon, VormInput, RichText } from "@si/vue-lib/design-system";
 import { Asset, useGithubStore } from "@/store/github.store";
+import { tracker } from "@/lib/posthog";
 import { useFeatureFlagsStore } from "../store/feature_flags.store";
 
 const featureFlagsStore = useFeatureFlagsStore();

--- a/app/auth-portal/src/pages/LoginPage.vue
+++ b/app/auth-portal/src/pages/LoginPage.vue
@@ -2,37 +2,41 @@
   <RichText class="text-center">
     <h2>Welcome to System Initiative</h2>
     <p>
-      Please click the button to log in or to signup if you don't have an SI
-      account.
+      You are being redirected to Auth0 to complete login/signup. If you are not
+      automatically redirected, please
+      <a :href="AUTHORIZE_URL">click here</a> to continue.
     </p>
 
-    <p class="italic">
+    <!-- <p class="italic">
       <template v-if="countDownSeconds === 0">Redirecting...</template>
       <template v-else>
         You will be automatically redirected in {{ countDownSeconds }}
         {{ countDownSeconds === 1 ? "second" : "seconds" }}
       </template>
-    </p>
-    <VButton :href="LOGIN_URL" size="lg">Log in or Sign up!</VButton>
+    </p> -->
   </RichText>
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, onMounted, ref } from "vue";
-import { useRouter } from "vue-router";
-import { RichText, VButton } from "@si/vue-lib/design-system";
+import { onBeforeMount, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { RichText } from "@si/vue-lib/design-system";
 import { useHead } from "@vueuse/head";
 import { useAuthStore } from "@/store/auth.store";
 
-const API_URL = import.meta.env.VITE_AUTH_API_URL;
-const LOGIN_URL = `${API_URL}/auth/login`;
-
 const authStore = useAuthStore();
 const router = useRouter();
+const route = useRoute();
 
-const countDownSeconds = ref(5);
+const IS_SIGNUP = route.name === "signup";
 
-useHead({ title: "Login" });
+const API_URL = import.meta.env.VITE_AUTH_API_URL;
+// if on /signup we add an extra hint to tell auth0 to start on signup
+const AUTHORIZE_URL = `${API_URL}/auth/login${IS_SIGNUP ? "?signup=1" : ""}`;
+
+// const countDownSeconds = ref(0);
+
+useHead({ title: IS_SIGNUP ? "Sign Up" : "Login" });
 
 onBeforeMount(async () => {
   if (authStore.userIsLoggedIn) {
@@ -41,14 +45,14 @@ onBeforeMount(async () => {
 });
 
 onMounted(() => {
-  setInterval(() => {
-    // in case redirecting fails or takes longer, dont want the timer to go negative
-    if (countDownSeconds.value === 0) return;
-
-    countDownSeconds.value--;
-    if (countDownSeconds.value === 0) {
-      window.location.replace(LOGIN_URL);
-    }
-  }, 1000);
+  window.location.replace(AUTHORIZE_URL);
+  // setInterval(() => {
+  //   // in case redirecting fails or takes longer, dont want the timer to go negative
+  //   if (countDownSeconds.value === 0) return;
+  //   countDownSeconds.value--;
+  //   if (countDownSeconds.value === 0) {
+  //     window.location.replace(AUTHORIZE_URL);
+  //   }
+  // }, 1000);
 });
 </script>

--- a/app/auth-portal/src/pages/LogoutPage.vue
+++ b/app/auth-portal/src/pages/LogoutPage.vue
@@ -15,8 +15,7 @@ const router = useRouter();
 onMounted(async () => {
   if (authStore.userIsLoggedIn) {
     await authStore.logout();
-  } else {
-    await router.push({ name: "login" });
   }
+  window.location.href = "https://www.systeminit.com";
 });
 </script>

--- a/app/auth-portal/src/pages/ProfilePage.vue
+++ b/app/auth-portal/src/pages/ProfilePage.vue
@@ -347,9 +347,7 @@ async function tellUsMoreHandler(skip: boolean) {
   if (validationMethods.hasError()) return;
 
   if (!skip) {
-    tracker.trackEvent("tell_us_more_answers", {
-      stepTwoData,
-    });
+    tracker.trackEvent("tell_us_more_answers", stepTwoData);
   }
 
   const completeProfileReq = await authStore.COMPLETE_PROFILE(

--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -16,6 +16,7 @@ export const routerOptions: RouterOptions = {
   routes: [
     { path: "/", name: "home", redirect: { name: "login" } },
     { path: "/login", name: "login", component: LoginPage },
+    { path: "/signup", name: "signup", component: LoginPage },
     { path: "/logout", name: "logout", component: LogoutPage },
     {
       // public legal page, optionally can jump to specific doc
@@ -67,7 +68,7 @@ export const routerOptions: RouterOptions = {
 export function initRouterGuards(router: Router) {
   router.beforeEach((from, to) => {
     if (!to.name || !_.isString(to.name)) return;
-    if (["login", "logout", "404"].includes(to.name)) return;
+    if (["login", "signup", "logout", "404"].includes(to.name)) return;
     // TODO: might want to do something here...?
   });
 

--- a/app/web/src/pages/NotFound.vue
+++ b/app/web/src/pages/NotFound.vue
@@ -10,11 +10,3 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-
-export default defineComponent({
-  name: "NotFoundPage",
-});
-</script>

--- a/app/web/src/pages/OopsPage.vue
+++ b/app/web/src/pages/OopsPage.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="flex flex-col items-center justify-center h-screen bg-black">
+    <meta name="robots" content="noindex" />
+    <div class="text-center">
+      <RichText>
+        <p class="text-5xl text-white">Oops!</p>
+        <p class="text-xl text-white my-md">
+          Looks like something went wrong with your system.
+        </p>
+        <p class="text-xl text-white richtext">
+          Please try restarting your SI stack and then
+          <a href="/">click here</a>
+        </p>
+      </RichText>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RichText } from "@si/vue-lib/design-system";
+</script>

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -145,6 +145,13 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/pages/auth/LogoutPage.vue"), // just need something here for TS, but guard always redirects
   },
 
+  {
+    path: "/oops",
+    name: "oops",
+    meta: { public: true },
+    component: () => import("@/pages/OopsPage.vue"),
+  },
+
   // 404
   {
     path: "/:catchAll(.*)",

--- a/app/web/src/utils/posthog.ts
+++ b/app/web/src/utils/posthog.ts
@@ -4,6 +4,8 @@ if (import.meta.env.VITE_POSTHOG_PUBLIC_KEY) {
   posthog.init(import.meta.env.VITE_POSTHOG_PUBLIC_KEY, {
     api_host: import.meta.env.VITE_POSTHOG_API_HOST,
   });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (window) (window as any).posthog = posthog;
 }
 
 export { posthog };

--- a/bin/auth-api/src/routes/auth.routes.ts
+++ b/bin/auth-api/src/routes/auth.routes.ts
@@ -16,7 +16,9 @@ router.get("/auth/login", async (ctx) => {
   // TODO: can read from querystring info about where request originated
   // so that we can shoot later directly back to the right place, skipping auth portal
 
-  const { randomState, url } = getAuth0LoginUrl();
+  // passing in a querystring signup=1 will show auth0's signup page instead of login
+  // it's almost exactly the same, but one less step if using a password
+  const { randomState, url } = getAuth0LoginUrl(!!ctx.request.query.signup);
 
   // save our auth request in the cache using our random state
   await setCache(

--- a/bin/auth-api/src/routes/github.routes.ts
+++ b/bin/auth-api/src/routes/github.routes.ts
@@ -46,9 +46,8 @@ const loadReleases = async (): Promise<Release[]> => {
         return req.data;
       }, (err) => {
         throw new ApiError(
-          err.response.statusText,
-          "GITHUB_LIST_RELEASES_FAILURE",
-          err.response.data.message,
+          'Conflict',
+          `Fetching relases from github failed: ${err.response.statusText} - ${err.response.data.message}`,
         );
       });
 
@@ -98,9 +97,8 @@ router.get("/github/releases/latest", async (ctx) => {
   const latest = (await loadReleases())[0];
   if (!latest) {
     throw new ApiError(
-      "NotFound",
-      "GITHUB_LATEST_RELEASE_NOT_FOUND",
-      "not found",
+      "Conflict",
+      "Could not find the latest release on Github",
     );
   }
 

--- a/bin/auth-api/src/services/auth0.service.ts
+++ b/bin/auth-api/src/services/auth0.service.ts
@@ -21,7 +21,7 @@ const auth0Api = Axios.create({
 
 export type Auth0UserData = Auth0.UserData;
 
-export function getAuth0LoginUrl() {
+export function getAuth0LoginUrl(signup = false) {
   // lots of ways to generate this, but... nanoid is pretty good and already url-safe
   const randomState = nanoid(16);
 
@@ -31,6 +31,7 @@ export function getAuth0LoginUrl() {
     redirect_uri: LOGIN_CALLBACK_URL,
     state: randomState,
     scope: "openid profile email",
+    ...signup && { screen_hint: 'signup' },
     // `connection=CONNECTION` // not quite sure
     // prompt=none // for silent authentication - https://auth0.com/docs/authenticate/login/configure-silent-authentication
     // audience -- can be used to specify which "api" we are connecting to?

--- a/lib/vue-lib/src/design-system/general/RichText.vue
+++ b/lib/vue-lib/src/design-system/general/RichText.vue
@@ -111,7 +111,10 @@ function adjustLinks() {
   if (!containerRef.value) return;
   const linkEls = containerRef.value.querySelectorAll("a");
   linkEls.forEach((linkEl) => {
-    linkEl.setAttribute("target", "_blank");
+    const url = linkEl.getAttribute("href");
+    if (url && !url.startsWith("#")) {
+      linkEl.setAttribute("target", "_blank");
+    }
   });
 }
 


### PR DESCRIPTION
- adds some handling so we can direct users directly to auth0 signup vs login
- removes the countdown on the login page in auth portal
- logout now directs user to systeminit.com instead of auth portal login page
- fix issues to allow anchor links in <RichText> blocks
- add oops page and detect weird nginx 404 timeouts?
- add various tracking events