### PR TITLE
fix(lang-js): Ensure that JSON is added to the nullables list in lang-js

### DIFF
--- a/bin/lang-js/src/resolver_function.ts
+++ b/bin/lang-js/src/resolver_function.ts
@@ -171,9 +171,10 @@ const nullables: { [key in FuncBackendResponseType]?: boolean } = {
   [FuncBackendResponseType.Array]: true,
   [FuncBackendResponseType.Boolean]: true,
   [FuncBackendResponseType.Integer]: true,
+  [FuncBackendResponseType.Json]: true,
+  [FuncBackendResponseType.Map]: true,
   [FuncBackendResponseType.Object]: true,
   [FuncBackendResponseType.String]: true,
-  [FuncBackendResponseType.Map]: true,
 
   [FuncBackendResponseType.CodeGeneration]: false,
   [FuncBackendResponseType.Qualification]: false,


### PR DESCRIPTION
Without this, attribute functions that bind to an output socket can't be
nullable as their default backend response type is Json
