### PR TITLE
Remove arithmetic and indexing panics (ENG-1861)

### DIFF
--- a/lib/object-tree/src/lib.rs
+++ b/lib/object-tree/src/lib.rs
@@ -61,6 +61,8 @@
 
 #![warn(
     clippy::unwrap_in_result,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
     clippy::unwrap_used,
     clippy::panic,
     clippy::missing_panics_doc,


### PR DESCRIPTION
This is a follow-up to https://github.com/systeminit/si/pull/2579.
This PR enables clippy lints for catching two kinds of panics: arithmetic overflow errors and slice indexing panics.
<img src="https://media1.giphy.com/media/jIw2JjXd7On9UpGu0V/giphy.gif"/>