### PR TITLE
fix(web,sdf): Ensure exec endpoints always have the latest code ENG-1798

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -167,7 +167,9 @@ const componentTypeOptions = [
 
 const updateAsset = () => {
   if (assetStore.selectedAsset) {
-    assetStore.SAVE_ASSET(assetStore.selectedAsset);
+    assetStore.assetsById[assetStore.selectedAsset.id] =
+      assetStore.selectedAsset;
+    assetStore.SAVE_ASSET(assetStore.selectedAsset.id);
   }
 };
 

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -92,7 +92,7 @@ const onChange = () => {
   if (!selectedAsset.value || selectedAsset.value.code === editingAsset.value) {
     return;
   }
-  assetStore.SAVE_ASSET({
+  assetStore.enqueueAssetSave({
     ...selectedAsset.value,
     code: editingAsset.value,
   });

--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -47,7 +47,7 @@ const props = defineProps({
   typescript: { type: String },
   noLint: Boolean,
   noVim: Boolean,
-  debounceUpdate: { type: Boolean, default: true },
+  debounceUpdate: { type: Boolean, default: false },
 });
 
 const emit = defineEmits<{

--- a/app/web/src/utils/keyedDebouncer.ts
+++ b/app/web/src/utils/keyedDebouncer.ts
@@ -1,0 +1,16 @@
+import { debounce, DebouncedFunc } from "lodash-es";
+
+export default <F extends (...args: Parameters<F>) => ReturnType<F>>(
+  toDebounce: F,
+  waitMs?: number,
+) => {
+  const debounceQueues: {
+    [key: string | number | symbol]: DebouncedFunc<F> | undefined;
+  } = {};
+  return (key: string | number | symbol) => {
+    if (!debounceQueues[key]) {
+      debounceQueues[key] = debounce(toDebounce, waitMs ?? 1000);
+    }
+    return debounceQueues[key];
+  };
+};

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -412,11 +412,23 @@ impl ScenarioHarness {
         &mut self,
         visibility: &Visibility,
         asset_id: SchemaVariantDefinitionId,
+        asset_name: String,
+        menu_name: Option<String>,
+        code: String,
     ) {
         let request = ExecVariantDefRequest {
             id: asset_id,
+            name: asset_name,
+            menu_name,
+            category: "".to_string(),
+            color: "#FFFF00".to_string(),
+            link: Some("https://www.systeminit.com/".to_string()),
+            code,
+            handler: "createAsset".to_string(),
+            description: None,
             visibility: *visibility,
         };
+
         let response: ExecVariantDefResponse = self
             .query_post("/api/variant_def/exec_variant_def", &request)
             .await;

--- a/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
@@ -78,7 +78,13 @@ async fn authoring_flow_asset(
         .await;
 
     harness
-        .publish_asset(ctx.visibility(), asset.asset_id)
+        .publish_asset(
+            ctx.visibility(),
+            asset.asset_id,
+            schema_name.to_string(),
+            None,
+            asset_definition.to_string(),
+        )
         .await;
 
     // Let's add the new schema to our test harness cache


### PR DESCRIPTION
Removes the debounce by default in the CodeEditor, but keeps it in case we feel there's a need for it later. Adds a debounce to the asset code save editor that mimics the one used to debounce func code saves. Also sends the entire asset def through the exec endpoint to ensure we save the latest data immediately prior to executing, ensuring we don't execute out of date code because of the API debounces.

This ensures we always have the latest code in the API requests to exec_variant_def and save_and_exec_func.