### PR TITLE
feat(auth-portal): Removed calendly user interview ask

### DIFF
--- a/app/auth-portal/src/content/tutorial/08-next_steps.md
+++ b/app/auth-portal/src/content/tutorial/08-next_steps.md
@@ -20,10 +20,6 @@ We love feedback and engaging with users on their experience using System Initia
 
 [Let's talk on Discord](https://discord.com/invite/system-init).
 
-### Schedule an interview
-
-We’d love to schedule a half-hour Zoom with you. Please schedule time with Adam Jacob (CEO), Mark Dennard (Director of UX), and Anna Saulwick (Director of Product) [via our Calendly](https://calendly.com/d/2gm-dhd-xvq/system-initiative-feedback-session).
-
 ### Collaborate
 
 We're excited for DevOps builders to get involved and start modeling and building systems in System Initiative, so please join us on Discord, talk about the Assets you want to see, and start making stuff with us! 


### PR DESCRIPTION
 Removed calendly user interview ask from tutorial part 8: Next steps. 

Talked to Mark and Adam about this. 