### PR TITLE
Update issue templates to point to Discord where needed (ENG-1812)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this report! Please give us as much context in the form below to help us solve this.
+
+        If you have a question or topic of conversation that does not fit our issue template(s), reach out to us [on Discord](https://discord.com/invite/system-init).
   - type: textarea
     id: what-happened
     attributes:
@@ -26,9 +28,10 @@ body:
       label: Operating system
       description: 'The operating system you are running System Initiative on'
       options:
-        - Linux / Unix
+        - Linux
         - macOS
-        - windows
+        - Windows via WSL2
+        - Other (please specify)
     validations:
       required: true
   - type: dropdown
@@ -37,8 +40,9 @@ body:
       label: Architecture
       description: 'The OS architecture you are running System Initiative on'
       options:
-        - am64d / x86_64
-        - arm64 / aarch64
+        - x86_64 / amd64
+        - aarch64 / arm64
+        - Other (please specify)
     validations:
       required: true
   - type: dropdown
@@ -51,6 +55,7 @@ body:
         - Chrome
         - Safari
         - Microsoft Edge
+        - Other (please specify)
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this feature request! Please fill the form below.
+
+        If you have a question or topic of conversation that does not fit our issue template(s), reach out to us [on Discord](https://discord.com/invite/system-init).
   - type: textarea
     id: is-it-a-problem
     attributes:


### PR DESCRIPTION
- Update issue templates to point to Discord where needed
- Fix arch error for amd64 and re-order for bug template
- Add "Other" option for arch, os, and browser (since folks may file issues for officially unsupported or new platforms)
- Remove Unix option
- Replace Windows option with WSL2 option

<img src="https://media1.giphy.com/media/LSX49vHf7JHGyGjrC0/giphy.gif"/>