### PR TITLE
fix(si): determine Docker socket location on macOS

### DIFF
--- a/lib/si-cli/src/cmd/delete.rs
+++ b/lib/si-cli/src/cmd/delete.rs
@@ -1,24 +1,21 @@
-use crate::containers::{cleanup_image, delete_container, get_existing_container};
+use crate::containers::DockerClient;
 use crate::key_management::get_user_email;
 use crate::state::AppState;
 use crate::{CliResult, CONTAINER_NAMES};
-use docker_api::Docker;
 
 impl AppState {
-    pub async fn delete(&self) -> CliResult<()> {
+    pub async fn delete(&self, docker: &DockerClient) -> CliResult<()> {
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "delete-system"}),
         );
-        invoke(self, self.is_preview()).await?;
+        invoke(self, docker, self.is_preview()).await?;
         Ok(())
     }
 }
 
-async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
-    app.check(true).await?;
-
-    let docker = Docker::unix("//var/run/docker.sock");
+async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliResult<()> {
+    app.check(docker, true).await?;
 
     if is_preview {
         println!("Deleted the following containers and associated images:");
@@ -30,10 +27,14 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             println!("{}", container_name);
             continue;
         }
-        let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+        let container_summary = docker
+            .get_existing_container(container_name.clone())
+            .await?;
         if let Some(container_summary) = container_summary {
-            delete_container(&docker, container_summary, container_name.clone()).await?;
-            cleanup_image(&docker, name.to_string()).await?;
+            docker
+                .delete_container(container_summary, container_name.clone())
+                .await?;
+            docker.cleanup_image(name.to_string()).await?;
         }
     }
 

--- a/lib/si-cli/src/cmd/install.rs
+++ b/lib/si-cli/src/cmd/install.rs
@@ -1,21 +1,21 @@
-use crate::containers::{download_missing_containers, missing_containers};
+use crate::containers::DockerClient;
 use crate::key_management::get_user_email;
 use crate::state::AppState;
 use crate::CliResult;
 
 impl AppState {
-    pub async fn install(&self) -> CliResult<()> {
+    pub async fn install(&self, docker: &DockerClient) -> CliResult<()> {
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "install"}),
         );
-        invoke(self.is_preview()).await?;
+        invoke(docker, self.is_preview()).await?;
         Ok(())
     }
 }
 
-async fn invoke(is_preview: bool) -> CliResult<()> {
-    let missing_containers = missing_containers().await?;
+async fn invoke(docker: &DockerClient, is_preview: bool) -> CliResult<()> {
+    let missing_containers = docker.missing_containers().await?;
     if missing_containers.is_empty() {
         println!("All containers downloaded\n");
         return Ok(());
@@ -30,7 +30,9 @@ async fn invoke(is_preview: bool) -> CliResult<()> {
     }
 
     println!("Downloading the containers required to run System Initiative");
-    download_missing_containers(missing_containers).await?;
+    docker
+        .download_missing_containers(missing_containers)
+        .await?;
 
     Ok(())
 }

--- a/lib/si-cli/src/cmd/restart.rs
+++ b/lib/si-cli/src/cmd/restart.rs
@@ -1,21 +1,22 @@
+use crate::containers::DockerClient;
 use crate::key_management::get_user_email;
 use crate::state::AppState;
 use crate::CliResult;
 
 impl AppState {
-    pub async fn restart(&self) -> CliResult<()> {
+    pub async fn restart(&self, docker: &DockerClient) -> CliResult<()> {
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "restart-system"}),
         );
-        invoke(self).await?;
+        invoke(self, docker).await?;
         Ok(())
     }
 }
 
-async fn invoke(app: &AppState) -> CliResult<()> {
-    app.stop().await?;
-    app.start().await?;
+async fn invoke(app: &AppState, docker: &DockerClient) -> CliResult<()> {
+    app.stop(docker).await?;
+    app.start(docker).await?;
 
     Ok(())
 }

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -1,4 +1,4 @@
-use crate::containers::get_existing_container;
+use crate::containers::DockerClient;
 use crate::key_management::{
     ensure_encryption_keys, ensure_jwt_public_signing_key, format_credentials_for_veritech,
     get_si_data_dir, get_user_email,
@@ -6,25 +6,22 @@ use crate::key_management::{
 use crate::state::AppState;
 use crate::{CliResult, CONTAINER_NAMES};
 use docker_api::opts::{ContainerCreateOpts, HostPort, PublishPort};
-use docker_api::Docker;
 
 impl AppState {
-    pub async fn start(&self) -> CliResult<()> {
+    pub async fn start(&self, docker: &DockerClient) -> CliResult<()> {
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "start-system"}),
         );
-        invoke(self, self.is_preview()).await?;
+        invoke(self, docker, self.is_preview()).await?;
         Ok(())
     }
 }
 
-async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
+async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliResult<()> {
     app.configure(false).await?;
-    app.check(false).await?;
-    app.install().await?;
-
-    let docker = Docker::unix("//var/run/docker.sock");
+    app.check(docker, false).await?;
+    app.install(docker).await?;
 
     if is_preview {
         println!("Started the following containers:");
@@ -38,7 +35,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
         let container = format!("systeminit/{0}", name);
         let container_name = format!("local-{0}-1", name);
         if container == "systeminit/otelcol" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -77,7 +76,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/jaeger" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -115,7 +116,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/nats" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -153,7 +156,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/postgres" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -196,7 +201,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/council" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -237,7 +244,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/veritech" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -282,7 +291,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/pinga" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -330,7 +341,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/sdf" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here
@@ -388,7 +401,9 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             container.start().await?;
         }
         if container == "systeminit/web" {
-            let container_summary = get_existing_container(&docker, container_name.clone()).await?;
+            let container_summary = docker
+                .get_existing_container(container_name.clone())
+                .await?;
             if let Some(existing) = container_summary {
                 // it means we have an existing container
                 // If it's running, we have nothing to do here

--- a/lib/si-cli/src/containers.rs
+++ b/lib/si-cli/src/containers.rs
@@ -1,6 +1,6 @@
 use crate::SiCliError;
 use crate::{CliResult, CONTAINER_NAMES};
-use docker_api::models::{ContainerSummary, ImageSummary};
+use docker_api::models::{ContainerSummary, ImageSummary, PingInfo};
 use docker_api::opts::{
     ContainerFilter, ContainerListOpts, ImageListOpts, ImageRemoveOpts, LogsOpts, PullOpts,
     RegistryAuth,
@@ -9,7 +9,9 @@ use docker_api::Docker;
 use futures::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::cmp::min;
+use std::path::Path;
 use std::string::ToString;
+use telemetry::prelude::*;
 
 #[derive(Debug)]
 pub struct DockerReleaseInfo {
@@ -18,226 +20,257 @@ pub struct DockerReleaseInfo {
     pub image: String,
 }
 
-pub(crate) async fn downloaded_systeminit_containers_list() -> Result<Vec<ImageSummary>, SiCliError>
-{
-    let docker = Docker::unix("//var/run/docker.sock");
-    let opts = ImageListOpts::builder().all(true).build();
-    let mut containers = docker.images().list(&opts).await?;
-
-    let containers: Vec<ImageSummary> = containers
-        .drain(..)
-        .filter(|c| {
-            c.repo_tags
-                .iter()
-                .any(|t| t.starts_with("systeminit/") && t.ends_with(":stable"))
-        })
-        .collect();
-
-    Ok(containers)
+#[derive(Clone, Debug)]
+pub struct DockerClient {
+    docker: Docker,
 }
 
-pub(crate) async fn get_container_details() -> CliResult<Vec<DockerReleaseInfo>> {
-    let mut release_info: Vec<DockerReleaseInfo> = Vec::new();
-    let containers = downloaded_systeminit_containers_list().await?;
-    for container in containers {
-        // Each of the containers we use will 100% have these labels so it's fine to unwrap them
-        // it's not the ideal and we can find a better way to deal with the option but it works
-        release_info.push(DockerReleaseInfo {
-            git_sha: container
-                .labels
-                .get("org.opencontainers.image.revision")
-                .unwrap()
-                .to_string(),
-            created_at: container
-                .labels
-                .get("org.opencontainers.image.created")
-                .unwrap()
-                .to_string(),
-            image: container.labels.get("name").unwrap().to_string(),
-        })
-    }
-
-    Ok(release_info)
-}
-
-pub(crate) async fn missing_containers() -> Result<Vec<String>, SiCliError> {
-    let mut missing_containers = Vec::new();
-    let containers = downloaded_systeminit_containers_list().await?;
-
-    for name in CONTAINER_NAMES.iter() {
-        let required_container = format!("systeminit/{0}", name);
-        if !containers.iter().any(|c| {
-            c.repo_tags
-                .iter()
-                .all(|t| t.contains(required_container.as_str()))
-        }) {
-            missing_containers.push(required_container.to_string());
+impl DockerClient {
+    pub fn unix(socket_path: impl AsRef<Path>) -> Self {
+        debug!(
+            socket_path = %socket_path.as_ref().display(),
+            "configuring Docker with unix socket"
+        );
+        Self {
+            docker: Docker::unix(socket_path),
         }
     }
 
-    Ok(missing_containers)
-}
+    pub(crate) fn containers(&self) -> docker_api::Containers {
+        self.docker.containers()
+    }
 
-pub(crate) async fn download_missing_containers(missing_containers: Vec<String>) -> CliResult<()> {
-    let m = MultiProgress::new();
-    let sty = ProgressStyle::with_template(
-        "{spinner:.red} [{elapsed_precise}] [{wide_bar:.yellow/blue}]",
-    )
-    .unwrap()
-    .progress_chars("#>-");
+    pub(crate) async fn ping(&self) -> CliResult<PingInfo> {
+        self.docker.ping().await.map_err(Into::into)
+    }
 
-    let total_size = 100123123;
+    pub(crate) async fn downloaded_systeminit_containers_list(
+        &self,
+    ) -> Result<Vec<ImageSummary>, SiCliError> {
+        let opts = ImageListOpts::builder().all(true).build();
+        let mut containers = self.docker.images().list(&opts).await?;
 
-    println!("Found {0} missing containers", missing_containers.len());
+        let containers: Vec<ImageSummary> = containers
+            .drain(..)
+            .filter(|c| {
+                c.repo_tags
+                    .iter()
+                    .any(|t| t.starts_with("systeminit/") && t.ends_with(":stable"))
+            })
+            .collect();
 
-    let mut spawned = Vec::new();
-    for missing_container in missing_containers {
-        let pb = m.add(ProgressBar::new(total_size));
-        pb.set_style(sty.clone());
+        Ok(containers)
+    }
 
-        let mut message = "Downloading ".to_owned();
-        message.push_str(missing_container.as_str());
+    pub(crate) async fn get_container_details(&self) -> CliResult<Vec<DockerReleaseInfo>> {
+        let mut release_info: Vec<DockerReleaseInfo> = Vec::new();
+        let containers = self.downloaded_systeminit_containers_list().await?;
+        for container in containers {
+            // Each of the containers we use will 100% have these labels so it's fine to unwrap them
+            // it's not the ideal and we can find a better way to deal with the option but it works
+            release_info.push(DockerReleaseInfo {
+                git_sha: container
+                    .labels
+                    .get("org.opencontainers.image.revision")
+                    .unwrap()
+                    .to_string(),
+                created_at: container
+                    .labels
+                    .get("org.opencontainers.image.created")
+                    .unwrap()
+                    .to_string(),
+                image: container.labels.get("name").unwrap().to_string(),
+            })
+        }
 
-        let h1 = tokio::spawn(async move {
-            let docker = Docker::unix("//var/run/docker.sock");
-            let mut downloaded = 0;
+        Ok(release_info)
+    }
 
-            let auth = RegistryAuth::builder()
-                .username("stack72")
-                .password("dckr_pat_dHhJ3jhygqHx2gCCZqchywQEvDQ")
-                .build();
-            let pull_opts = PullOpts::builder()
-                .image(missing_container)
-                .tag("stable")
-                .auth(auth)
-                .build();
-            let images = docker.images();
-            let mut stream = images.pull(&pull_opts);
-            while let Some(pull_result) = stream.next().await {
-                match pull_result {
-                    Ok(docker_api::models::ImageBuildChunk::PullStatus {
-                        progress_detail, ..
-                    }) => {
-                        if let Some(progress_detail) = progress_detail {
-                            let new = min(
-                                downloaded + progress_detail.current.unwrap_or(0),
-                                total_size,
-                            );
-                            downloaded = progress_detail.current.unwrap_or(0);
-                            pb.set_position(new);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(e) => eprintln!("{e}"),
-                }
+    pub(crate) async fn missing_containers(&self) -> Result<Vec<String>, SiCliError> {
+        let mut missing_containers = Vec::new();
+        let containers = self.downloaded_systeminit_containers_list().await?;
+
+        for name in CONTAINER_NAMES.iter() {
+            let required_container = format!("systeminit/{0}", name);
+            if !containers.iter().any(|c| {
+                c.repo_tags
+                    .iter()
+                    .all(|t| t.contains(required_container.as_str()))
+            }) {
+                missing_containers.push(required_container.to_string());
             }
-        });
-
-        m.println(message).unwrap();
-
-        spawned.push(h1);
-    }
-
-    for spawn in spawned {
-        spawn.await.unwrap();
-    }
-
-    m.println("All containers successfully downloaded").unwrap();
-    m.clear().unwrap();
-
-    Ok(())
-}
-
-pub(crate) async fn delete_container(
-    docker: &Docker,
-    container_summary: ContainerSummary,
-    name: String,
-) -> CliResult<()> {
-    println!(
-        "Deleting container: {} ({})",
-        name,
-        container_summary.id.as_ref().unwrap()
-    );
-    let container = docker
-        .containers()
-        .get(container_summary.id.as_ref().unwrap());
-    container.delete().await?;
-    Ok(())
-}
-
-pub(crate) async fn get_existing_container(
-    docker: &Docker,
-    name: String,
-) -> CliResult<Option<ContainerSummary>> {
-    let filter = ContainerFilter::Name(name.clone());
-    let list_opts = ContainerListOpts::builder()
-        .filter([filter])
-        .all(true)
-        .build();
-
-    let mut containers = docker.containers().list(&list_opts).await?;
-    Ok(containers.pop())
-}
-
-pub(crate) async fn cleanup_image(docker: &Docker, name: String) -> CliResult<()> {
-    let image_name = format!("systeminit/{0}:stable", name);
-    let opts = ImageRemoveOpts::builder()
-        .force(true)
-        .noprune(false)
-        .build();
-
-    if (docker.images().get(image_name.clone()).inspect().await).is_ok() {
-        println!("Removing image: {0}", image_name.clone());
-        docker
-            .images()
-            .get(image_name.clone())
-            .remove(&opts)
-            .await?;
-    };
-
-    Ok(())
-}
-
-pub(crate) async fn get_container_logs(
-    docker: &Docker,
-    name: String,
-    log_lines: usize,
-) -> CliResult<bool> {
-    let filter = ContainerFilter::Name(name.clone());
-    let list_opts = ContainerListOpts::builder()
-        .filter([filter])
-        .all(true)
-        .build();
-    let containers = docker.containers().list(&list_opts).await?;
-    if !containers.is_empty() {
-        let existing_id = containers.first().unwrap().id.as_ref().unwrap();
-        let state = containers.first().unwrap().state.as_ref().unwrap();
-
-        if *state == "running" {
-            let logs_opts = LogsOpts::builder()
-                .n_lines(log_lines)
-                .stdout(true)
-                .stderr(true)
-                .build();
-            let container = docker.containers().get(existing_id);
-            let logs_stream = container.logs(&logs_opts);
-            let logs: Vec<_> = logs_stream
-                .map(|chunk| match chunk {
-                    Ok(chunk) => chunk.to_vec(),
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                        vec![]
-                    }
-                })
-                .collect::<Vec<_>>()
-                .await
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
-            println!("{}", String::from_utf8_lossy(&logs));
-            return Ok(true);
         }
+
+        Ok(missing_containers)
     }
 
-    Ok(false)
+    pub(crate) async fn download_missing_containers(
+        &self,
+        missing_containers: Vec<String>,
+    ) -> CliResult<()> {
+        let m = MultiProgress::new();
+        let sty = ProgressStyle::with_template(
+            "{spinner:.red} [{elapsed_precise}] [{wide_bar:.yellow/blue}]",
+        )
+        .unwrap()
+        .progress_chars("#>-");
+
+        let total_size = 100123123;
+
+        println!("Found {0} missing containers", missing_containers.len());
+
+        let mut spawned = Vec::new();
+        for missing_container in missing_containers {
+            let pb = m.add(ProgressBar::new(total_size));
+            pb.set_style(sty.clone());
+
+            let mut message = "Downloading ".to_owned();
+            message.push_str(missing_container.as_str());
+
+            let docker = self.docker.clone();
+
+            let h1 = tokio::spawn(async move {
+                let mut downloaded = 0;
+
+                let auth = RegistryAuth::builder()
+                    .username("stack72")
+                    .password("dckr_pat_dHhJ3jhygqHx2gCCZqchywQEvDQ")
+                    .build();
+                let pull_opts = PullOpts::builder()
+                    .image(missing_container)
+                    .tag("stable")
+                    .auth(auth)
+                    .build();
+                let images = docker.images();
+                let mut stream = images.pull(&pull_opts);
+                while let Some(pull_result) = stream.next().await {
+                    match pull_result {
+                        Ok(docker_api::models::ImageBuildChunk::PullStatus {
+                            progress_detail,
+                            ..
+                        }) => {
+                            if let Some(progress_detail) = progress_detail {
+                                let new = min(
+                                    downloaded + progress_detail.current.unwrap_or(0),
+                                    total_size,
+                                );
+                                downloaded = progress_detail.current.unwrap_or(0);
+                                pb.set_position(new);
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(e) => eprintln!("{e}"),
+                    }
+                }
+            });
+
+            m.println(message).unwrap();
+
+            spawned.push(h1);
+        }
+
+        for spawn in spawned {
+            spawn.await.unwrap();
+        }
+
+        m.println("All containers successfully downloaded").unwrap();
+        m.clear().unwrap();
+
+        Ok(())
+    }
+
+    pub(crate) async fn delete_container(
+        &self,
+        container_summary: ContainerSummary,
+        name: String,
+    ) -> CliResult<()> {
+        println!(
+            "Deleting container: {} ({})",
+            name,
+            container_summary.id.as_ref().unwrap()
+        );
+        let container = self
+            .docker
+            .containers()
+            .get(container_summary.id.as_ref().unwrap());
+        container.delete().await?;
+        Ok(())
+    }
+
+    pub(crate) async fn get_existing_container(
+        &self,
+        name: String,
+    ) -> CliResult<Option<ContainerSummary>> {
+        let filter = ContainerFilter::Name(name.clone());
+        let list_opts = ContainerListOpts::builder()
+            .filter([filter])
+            .all(true)
+            .build();
+
+        let mut containers = self.docker.containers().list(&list_opts).await?;
+        Ok(containers.pop())
+    }
+
+    pub(crate) async fn cleanup_image(&self, name: String) -> CliResult<()> {
+        let image_name = format!("systeminit/{0}:stable", name);
+        let opts = ImageRemoveOpts::builder()
+            .force(true)
+            .noprune(false)
+            .build();
+
+        if (self.docker.images().get(image_name.clone()).inspect().await).is_ok() {
+            println!("Removing image: {0}", image_name.clone());
+            self.docker
+                .images()
+                .get(image_name.clone())
+                .remove(&opts)
+                .await?;
+        };
+
+        Ok(())
+    }
+
+    pub(crate) async fn get_container_logs(
+        &self,
+        name: String,
+        log_lines: usize,
+    ) -> CliResult<bool> {
+        let filter = ContainerFilter::Name(name.clone());
+        let list_opts = ContainerListOpts::builder()
+            .filter([filter])
+            .all(true)
+            .build();
+        let containers = self.docker.containers().list(&list_opts).await?;
+        if !containers.is_empty() {
+            let existing_id = containers.first().unwrap().id.as_ref().unwrap();
+            let state = containers.first().unwrap().state.as_ref().unwrap();
+
+            if *state == "running" {
+                let logs_opts = LogsOpts::builder()
+                    .n_lines(log_lines)
+                    .stdout(true)
+                    .stderr(true)
+                    .build();
+                let container = self.docker.containers().get(existing_id);
+                let logs_stream = container.logs(&logs_opts);
+                let logs: Vec<_> = logs_stream
+                    .map(|chunk| match chunk {
+                        Ok(chunk) => chunk.to_vec(),
+                        Err(e) => {
+                            eprintln!("Error: {e}");
+                            vec![]
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                println!("{}", String::from_utf8_lossy(&logs));
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
 }

--- a/lib/si-cli/src/lib.rs
+++ b/lib/si-cli/src/lib.rs
@@ -6,6 +6,8 @@ mod containers;
 mod key_management;
 pub mod state;
 
+pub use containers::DockerClient;
+
 pub const CONTAINER_NAMES: &[&str] = &[
     "jaeger", "postgres", "nats", "otelcol", "council", "veritech", "pinga", "sdf", "web",
 ];


### PR DESCRIPTION
This change refactors how the various Docker clients are configured in `lib/si-cli` by moving container (currently only Docker) related functions into a `DockerClient` type as methods. A first-pass refactoring extracts the hardcoded paths of `//var/run/docker.sock` into one location, early in the launcher's `main()` function.

As Docker Desktop on macOS doesn't necessarily mount the Docker socket at `/var/run/docker.sock`, the socket is first looked for in `$HOME/.docker/run/docker.sock` before falling back on the system location. If neither is found, then an error message is displayed, indicating a suitable Docker socket was not found.