### PR TITLE
feat(si): Ensure that the SI binary can update it's containers

### DIFF
--- a/bin/auth-api/src/routes/github.routes.ts
+++ b/bin/auth-api/src/routes/github.routes.ts
@@ -1,4 +1,4 @@
-// import _ from 'lodash';
+import _ from 'lodash';
 import Axios from "axios";
 import { tryCatch } from "../lib/try-catch";
 import { ApiError } from "../lib/api-error";
@@ -110,7 +110,6 @@ router.get("/github/releases", async (ctx) => {
   ctx.body = await loadReleases();
 });
 
-/*
 interface GithubTag {
   ref: string;
   node_id: string;
@@ -132,13 +131,12 @@ interface LatestContainer {
 let containersCachedAt: Date | null = null;
 let containers: LatestContainer[] | null = null;
 let loadingContainers: boolean = false;
-*/
 
 router.get("/github/containers/latest", async (ctx) => {
-  ctx.body = [];
+  // ctx.body = [];
 
   // TODO: re-enable container updates when we fix the tags
-  /*
+
   const seconds = Math.abs(Date.now() - (containersCachedAt?.getTime() ?? 0));
   if ((seconds > 180 * 1000 || !containers) && !loadingContainers) {
     loadingContainers = true;
@@ -201,5 +199,4 @@ router.get("/github/containers/latest", async (ctx) => {
   }
 
   ctx.body = containers ?? [];
-  */
 });

--- a/lib/si-cli/src/cmd/update.rs
+++ b/lib/si-cli/src/cmd/update.rs
@@ -138,7 +138,7 @@ impl AppState {
                     continue;
                 }
 
-                if current.git_sha != latest.git_sha {
+                if current.version != latest.digest {
                     containers.push(latest);
                 }
                 continue 'outer;

--- a/lib/si-cli/src/containers.rs
+++ b/lib/si-cli/src/containers.rs
@@ -18,6 +18,7 @@ pub struct DockerReleaseInfo {
     pub git_sha: String,
     pub created_at: String,
     pub image: String,
+    pub version: String,
 }
 
 #[derive(Clone, Debug)]
@@ -72,6 +73,11 @@ impl DockerClient {
                 git_sha: container
                     .labels
                     .get("org.opencontainers.image.revision")
+                    .unwrap()
+                    .to_string(),
+                version: container
+                    .labels
+                    .get("org.opencontainers.image.version")
                     .unwrap()
                     .to_string(),
                 created_at: container


### PR DESCRIPTION
- fix(auth-api): Reenable the container updates from the github releases API
- fix(si): Ensure we are comparing the container version vs release digest from the auth-api for updates

there is an order of operations here - we need to release the SI binary *first* to get the good update behaviour in place then we can launch the auth-api
