### PR TITLE
fix(si): Ensure that we can recreate a new veritech container

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -73,6 +73,7 @@ A-si-discord-bot:
   - .prettierrc.js
 A-si:
   - bin/si/**/*
+  - lib/si-cli/**/*
 
 #
 # System Initiative libs (i.e. crates/packages/libraries)

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -254,10 +254,9 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
                     continue;
                 }
 
-                println!("Starting existing {0}", container_name.clone());
+                println!("Deleting existing container {0}", container_name.clone());
                 let non_running_container = docker.containers().get(existing.id.as_ref().unwrap());
-                non_running_container.start().await?;
-                continue;
+                non_running_container.delete().await?;
             }
 
             if is_preview {


### PR DESCRIPTION
Fixes: #2609

When the credentials are incorrect, we want to be able to stop
and then restart the container to get the new credentials passed
to the container
