### PR TITLE
fix(si): Change the si binary to not expose unnecessary ports

### DIFF
--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -67,8 +67,6 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())
                 .image(format!("{0}:stable", container.clone()))
-                .expose(PublishPort::tcp(4317), HostPort::new(4317))
-                .expose(PublishPort::tcp(55679), HostPort::new(55679))
                 .links(["local-jaeger-1:jaeger"])
                 .build();
 
@@ -108,7 +106,6 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())
                 .image(format!("{0}:stable", container.clone()))
-                .expose(PublishPort::tcp(5317), HostPort::new(5317))
                 .expose(PublishPort::tcp(16686), HostPort::new(16686))
                 .build();
 
@@ -148,7 +145,6 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())
                 .image(format!("{0}:stable", container.clone()))
-                .expose(PublishPort::tcp(4222), HostPort::new(4222))
                 .command(vec!["--config", "nats-server.conf", "-DVV"])
                 .build();
 
@@ -188,7 +184,6 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())
                 .image(format!("{0}:stable", container.clone()))
-                .expose(PublishPort::tcp(5432), HostPort::new(5432))
                 .env(vec![
                     "POSTGRES_PASSWORD=bugbear",
                     "PGPASSWORD=bugbear",


### PR DESCRIPTION
We don't need to expose specific ports - we only need ports for
web, sdf and jaeger

```
docker ps -a
CONTAINER ID   IMAGE                        COMMAND                  CREATED         STATUS         PORTS                                                                               NAMES
78392dab00d2   systeminit/web:stable        "/usr/local/bin/web"     2 minutes ago   Up 2 minutes   0.0.0.0:8080->8080/tcp                                                              local-web-1
a2826dff3cd7   systeminit/sdf:stable        "/sbin/runuser -u ap…"   2 minutes ago   Up 2 minutes   0.0.0.0:5156->5156/tcp                                                              local-sdf-1
18fefe7fca44   systeminit/pinga:stable      "/sbin/runuser -u ap…"   2 minutes ago   Up 2 minutes                                                                                       local-pinga-1
9cc11241dda6   systeminit/veritech:stable   "/sbin/runuser -u ap…"   2 minutes ago   Up 2 minutes                                                                                       local-veritech-1
030ae10f3500   systeminit/council:stable    "/sbin/runuser -u ap…"   2 minutes ago   Up 2 minutes                                                                                       local-council-1
301115117c3c   systeminit/otelcol:stable    "/bin/otelcol --conf…"   2 minutes ago   Up 2 minutes                                                                                       local-otelcol-1
4dd0154acd67   systeminit/nats:stable       "/nats-server --conf…"   2 minutes ago   Up 2 minutes   4222/tcp, 6222/tcp, 8222/tcp                                                        local-nats-1
92f9a12e9c68   systeminit/postgres:stable   "/usr/local/bin/entr…"   2 minutes ago   Up 2 minutes   5432/tcp                                                                            local-postgres-1
e61ae1bbae8e   systeminit/jaeger:stable     "/go/bin/all-in-one-…"   2 minutes ago   Up 2 minutes   5775/udp, 5778/tcp, 14250/tcp, 6831-6832/udp, 14268/tcp, 0.0.0.0:16686->16686/tcp   local-jaeger-1
```
