### PR TITLE
fix(si): Ensure that we have a default email in place when using the launcher

### DIFF
--- a/lib/si-cli/src/containers.rs
+++ b/lib/si-cli/src/containers.rs
@@ -3,7 +3,6 @@ use crate::{CliResult, CONTAINER_NAMES};
 use docker_api::models::{ContainerSummary, ImageSummary, PingInfo};
 use docker_api::opts::{
     ContainerFilter, ContainerListOpts, ImageListOpts, ImageRemoveOpts, LogsOpts, PullOpts,
-    RegistryAuth,
 };
 use docker_api::Docker;
 use futures::StreamExt;

--- a/lib/si-cli/src/key_management.rs
+++ b/lib/si-cli/src/key_management.rs
@@ -80,8 +80,13 @@ pub async fn get_credentials() -> CliResult<Credentials> {
 }
 
 pub async fn get_user_email() -> CliResult<String> {
-    let credentials = get_credentials().await?;
+    let data_dir_exists = get_si_data_dir().await;
+    if data_dir_exists.is_err() {
+        // If the data_dir doesn't exist then we should default to sally for now
+        return Ok("sally@systeminit.com".to_string());
+    }
 
+    let credentials = get_credentials().await?;
     if let Some(email) = credentials.si_email {
         Ok(email)
     } else {


### PR DESCRIPTION
There was a chicken and egg scenario that the data_dir we store creds
in may not exist until we write the creds or the keys BUT we were trying
to read the SI email from it

We now default to sally@systeminit.com if it's not found
