### PR TITLE
fix(buck2): declare `build_deps` on `docker_image` as `dep` type

### DIFF
--- a/prelude-si/docker.bzl
+++ b/prelude-si/docker.bzl
@@ -50,7 +50,7 @@ docker_image = rule(
             doc = """Mapping of sources files to the relative directory in a Dockerfile context..""",
         ),
         "build_deps": attrs.list(
-            attrs.string(),
+            attrs.dep(),
             default = [],
             doc = """Buck2 targets that could be built in an image.""",
         ),
@@ -219,7 +219,7 @@ def docker_build_context(ctx: "context") -> DockerBuildContext.type:
         cmd.add(cmd_args(src, format = "{}=" + rel_path))
     for dep in ctx.attrs.build_deps or []:
         cmd.add("--dep")
-        cmd.add(dep)
+        cmd.add(dep.label.raw_target())
     cmd.add(context_tree.as_output())
 
     ctx.actions.run(cmd, category = "docker_build_context")

--- a/prelude-si/docker/docker_build_context_srcs_from_deps.bxl
+++ b/prelude-si/docker/docker_build_context_srcs_from_deps.bxl
@@ -60,7 +60,9 @@ docker_build_context_srcs_from_deps = bxl(
 )
 
 def _normalize_target_str(dep: str.type) -> str.type:
-    if dep.startswith("//"):
+    if dep.startswith("root//"):
+        return dep
+    elif dep.startswith("//"):
         return "root" + dep
     else:
         return "root//{}".format(dep)


### PR DESCRIPTION
This change fixes an issue when our CI/CD system computes "work to do" in the `si/merge-queue` pipeline. Prior to this change the `build_deps` attribute on the `docker_image` Buck2 rule was type `string`, primarily as these values were being passed further down for more processing via a BXL and Python script.

The issue arises when we compute dependent work on source file changes, say `bin/council/src/main.rs` which should be pulled into `//bin/council:image` via the `//bin/council:council` target. As our attribute type here was `string`, Buck2 doesn't know we want to consider this as an input to the image. In this case we don't need the inputs *built*, only declared so that later when we ask the question "what are all reverse deps that are impacted with this source change", we get our Docker image builds as one of the targets. Changing the attribute type to `dep` allows Buck2 to track this in its graph.

<img src="https://media4.giphy.com/media/l0IylOPCNkiqOgMyA/giphy.gif"/>