### PR TITLE
Clarify which linux distros are supported for local dev and add nightly badge (ENG-1870)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # System Initiative
 
-[![Discord Server](https://img.shields.io/badge/discord-gray?style=flat-square&logo=discord)](https://discord.com/invite/system-init)
-[![Build dashboard](https://img.shields.io/badge/dashboard-gray?style=flat-square&logo=buildkite)](https://buildkite.com/system-initiative)
-[![Build status](https://badge.buildkite.com/ecdbcb0ae243a74976f62a95826ec1fce62707e6fe07e4b973.svg?style=flat-square)](https://buildkite.com/system-initiative/si-merge-main)
+[![Discord Server](https://img.shields.io/badge/discord-gray?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/invite/system-init)
+[![Build dashboard](https://img.shields.io/badge/dashboard-gray?style=for-the-badge&logo=buildkite&logoColor=white)](https://buildkite.com/system-initiative)
+[![Build status](https://img.shields.io/buildkite/ecdbcb0ae243a74976f62a95826ec1fce62707e6fe07e4b973?style=for-the-badge&logo=buildkite&label=build)](https://buildkite.com/system-initiative/si-merge-main)
+[![Nightly status](https://img.shields.io/buildkite/311961055d5366e6b7d0bfb95cc01a513a103e8b39c8a42d33?style=for-the-badge&logo=buildkite&label=nightly)](https://buildkite.com/system-initiative/si-nightly)
+
 
 This is a monolithic repository containing the System Initiative software.
 

--- a/docs/DEVELOPMENT_ENVIRONMENT.md
+++ b/docs/DEVELOPMENT_ENVIRONMENT.md
@@ -27,6 +27,9 @@ Linux (GNU) is officially supported on both x86_64 (amd64) and aarch64 (arm64) a
 [NixOS](https://nixos.org/) is not supported at this time, but may be desired in the future.
 Linux with MUSL instead of GNU is also not currently supported.
 
+In general, GNU-based distros that are roughly [FHS-compliant](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) work.
+Those include, but are not limited to the following: Ubuntu, Fedora, Debian, Arch Linux, and openSUSE.
+
 ### Windows
 
 Using native Windows is not supported at this time, but may be desired in the future.
@@ -91,12 +94,13 @@ For Docker Desktop, the version corresponding to your native architecture should
 WSL2 users should be able to use either Docker Desktop for WSL2 or Docker Engine (i.e. installing and using
 `docker` within the distro and not interacting with the host).
 
+Regardless of platform, you may need to configure credentials in `~/.local/share`.
+
 #### Rancher Desktop
 
-Since [Rancher Desktop](https://rancherdesktop.io/) provides the ability to use the [moby](https://github.com/moby/moby),
+Since [Rancher Desktop](https://rancherdesktop.io/) provides the ability to use [moby](https://github.com/moby/moby),
 you can use it to run and develop the System Initiative software.
 However, it is untested, and you may need to further configuration depending on your platform.
-For example, on WSL2 via Windows, you may need to configure credentials in `~/.local/share`.
 
 ### (Optional) Direnv
 


### PR DESCRIPTION
- Clarify which linux distros are supported for local dev (i.e. the
  roughly FHS-compliant and GNU-based ones)
- Fix "~/.local/share" note for Docker to be generic to all platforms
- Change badges to "for-the-badge" by going to shields.io directly
  instead of through the buildkite-provided badges
- Add nightly badge

<img src="https://media0.giphy.com/media/4N5ddOOJJ7gtKTgNac/giphy.gif"/>