### PR TITLE
Make dashboard and discord logos white on badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # System Initiative
 
-[![Discord Server](https://img.shields.io/badge/discord-gray?style=for-the-badge&logo=discord)](https://discord.com/invite/system-init)
-[![Build dashboard](https://img.shields.io/badge/dashboard-gray?style=for-the-badge&logo=buildkite)](https://buildkite.com/system-initiative)
+[![Discord Server](https://img.shields.io/badge/discord-gray?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/invite/system-init)
+[![Build dashboard](https://img.shields.io/badge/dashboard-gray?style=for-the-badge&logo=buildkite&logoColor=white)](https://buildkite.com/system-initiative)
 [![Build status](https://img.shields.io/buildkite/ecdbcb0ae243a74976f62a95826ec1fce62707e6fe07e4b973?style=for-the-badge&logo=buildkite&label=build)](https://buildkite.com/system-initiative/si-merge-main)
 [![Nightly status](https://img.shields.io/buildkite/311961055d5366e6b7d0bfb95cc01a513a103e8b39c8a42d33?style=for-the-badge&logo=buildkite&label=nightly)](https://buildkite.com/system-initiative/si-nightly)
-
 
 This is a monolithic repository containing the System Initiative software.
 


### PR DESCRIPTION
For readability the logos for the dashboard and discord badges are now white. This was supposed to be the PR linked below, but due to performance degradation from external services, the amended commit was not picked up.

Previous PR: https://github.com/systeminit/si/pull/2621

<img src="https://media4.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif"/>