### PR TITLE
docs: use buck2 targets to list targets

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ We contributors to System Initiative:
 * Victor Bustamante (@vbustamante)
 * Wendy Bujalski (@wendybujalski)
 * Zack Hamm (@zacharyhamm)
+* Dan Miller (@jazzdan)

--- a/docs/RUNNING_RUST_TESTS.md
+++ b/docs/RUNNING_RUST_TESTS.md
@@ -24,7 +24,7 @@ buck2 test <crate>:test
 To see all options, use `buck2 targets` with a `:` character at the end.
 
 ```bash
-buck2 test <crate>:
+buck2 targets <crate>:
 ```
 
 ## Running Individual Tests


### PR DESCRIPTION
My guess is this was a copy paste error?