### PR TITLE
fix(si): Ensure we pass :Z to the sdf container mounts

### DIFF
--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -381,11 +381,11 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
                 .expose(PublishPort::tcp(5156), HostPort::new(5156))
                 .volumes([
                     format!(
-                        "{}:/run/sdf/cyclone_encryption.key",
+                        "{}:/run/sdf/cyclone_encryption.key:Z",
                         si_data_dir.join("cyclone_encryption.key").display()
                     ),
                     format!(
-                        "{}:/run/sdf/jwt_signing_public_key.pem",
+                        "{}:/run/sdf/jwt_signing_public_key.pem:Z",
                         si_data_dir.join("jwt_signing_public_key.pem").display()
                     ),
                 ])


### PR DESCRIPTION
Fixes: #2627

:Z indicates the bind mount is private which is required for systems
with selinux enabled

I tested this on a non-selinux enabled system and all works as expected
