### PR TITLE
Add arguments to set host and port for web container

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,22 +2,29 @@
 
 We contributors to System Initiative:
 
-* License all our contributions to the project under the Apache License, Version 2.0
-* Have the legal rights to license our contributions ourselves, or get permission to license them from our employers, clients, or others who may have them
-* Add our names and GitHub handles to this CONTRIBUTORS.md file to create a permanent record that users, distributors, and other contributors can all rely on
+- License all our contributions to the project under the Apache License, Version
+  2.0
+- Have the legal rights to license our contributions ourselves, or get
+  permission to license them from our employers, clients, or others who may have
+  them
+- Add our names and GitHub handles to this CONTRIBUTORS.md file to create a
+  permanent record that users, distributors, and other contributors can all rely
+  on
 
------------
-* Adam Jacob (@adamhjk)
-* Anna Saulwick (@AnnaAtMax)
-* Brit Myers (@britmyerss)
-* Fletcher Nichol (@fnichol)
-* Jacob Helwig (@jhelwig)
-* Mahir Lupinacci (@mahirl)
-* Nick Gerace (@nickgerace)
-* Paul Stack (@stack72)
-* Paulo Cabral (@paulocsanz)
-* Theo Ephraim (@theoephraim)
-* Victor Bustamante (@vbustamante)
-* Wendy Bujalski (@wendybujalski)
-* Zack Hamm (@zacharyhamm)
-* Dan Miller (@jazzdan)
+---
+
+- Adam Jacob (@adamhjk)
+- Anna Saulwick (@AnnaAtMax)
+- Brit Myers (@britmyerss)
+- Fletcher Nichol (@fnichol)
+- Jacob Helwig (@jhelwig)
+- Mahir Lupinacci (@mahirl)
+- Nick Gerace (@nickgerace)
+- Paul Stack (@stack72)
+- Paulo Cabral (@paulocsanz)
+- Theo Ephraim (@theoephraim)
+- Victor Bustamante (@vbustamante)
+- Wendy Bujalski (@wendybujalski)
+- Zack Hamm (@zacharyhamm)
+- Dan Miller (@jazzdan)
+- Neil Hanlon (@NeilHanlon)

--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -51,13 +51,13 @@ pub(crate) struct Args {
     #[arg(long, short = 'p', default_value = "false")]
     pub is_preview: bool,
     
-    /// Allows starting the service and binding to a specific IP
-    #[arg(long = "host", default_value = "127.0.0.1")]
-    pub bind_host: String,
+    /// Allows starting the web service and binding to a specific IP
+    #[arg(long = "web-host", env = "SI_WEB_ADDRESS", default_value = "127.0.0.1")]
+    pub web_host: String,
 
-    /// Allows starting the service and binding to a specific port
-    #[arg(long = "port", default_value = "8080")]
-    pub bind_port: u32,
+    /// Allows starting the web service and binding to a specific port
+    #[arg(long = "web-port", env = "SI_WEB_PORT", default_value = "8080")]
+    pub web_port: u32,
 
     /// The engine in which to launch System Initiate Containers
     #[arg(value_parser = PossibleValuesParser::new(Engine::variants()))]

--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -50,6 +50,15 @@ pub(crate) struct Args {
     /// Show a preview of what the System Initiative Launcher will do
     #[arg(long, short = 'p', default_value = "false")]
     pub is_preview: bool,
+    
+    /// Allows starting the service and binding to a specific IP
+    #[arg(long = "host", default_value = "127.0.0.1")]
+    pub bind_host: String,
+
+    /// Allows starting the service and binding to a specific port
+    #[arg(long = "port", default_value = "8080")]
+    pub bind_port: u32,
+
     /// The engine in which to launch System Initiate Containers
     #[arg(value_parser = PossibleValuesParser::new(Engine::variants()))]
     #[arg(long, short, env = "SI_CONTAINER_ENGINE", default_value = "docker")]
@@ -94,6 +103,7 @@ pub(crate) struct LaunchArgs {
     /// Allows the launching of the metrics collection endpoint
     #[clap(long)]
     pub metrics: bool,
+    
 }
 
 // #[derive(Debug, clap::Args)]
@@ -120,7 +130,8 @@ pub(crate) struct StatusArgs {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct StartArgs {}
+pub(crate) struct StartArgs {
+}
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct RestartArgs {}

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -29,6 +29,9 @@ async fn main() -> Result<()> {
         "".to_string()
     };
 
+    let bind_host = args.bind_host.clone();
+    let bind_port = args.bind_port;
+
     let current_version = VERSION.trim();
 
     debug!(arguments =?args, "parsed cli arguments");
@@ -68,6 +71,8 @@ async fn main() -> Result<()> {
         Arc::from(current_version),
         Arc::from(mode.to_string()),
         is_preview,
+        bind_host,
+        bind_port,
     );
 
     println!(

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -29,8 +29,8 @@ async fn main() -> Result<()> {
         "".to_string()
     };
 
-    let bind_host = args.bind_host.clone();
-    let bind_port = args.bind_port;
+    let web_host = args.web_host.clone();
+    let web_port = args.web_port;
 
     let current_version = VERSION.trim();
 
@@ -71,8 +71,8 @@ async fn main() -> Result<()> {
         Arc::from(current_version),
         Arc::from(mode.to_string()),
         is_preview,
-        bind_host,
-        bind_port,
+        web_host,
+        web_port,
     );
 
     println!(

--- a/lib/si-cli/src/cmd/launch.rs
+++ b/lib/si-cli/src/cmd/launch.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 impl AppState {
     pub async fn launch(&self, launch_metrics: bool) -> CliResult<()> {
-        invoke(launch_metrics, self.bind_host(), self.bind_port()).await?;
+        invoke(launch_metrics, self.web_host(), self.web_port()).await?;
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "launch-ui"}),
@@ -16,15 +16,15 @@ impl AppState {
     }
 }
 
-async fn invoke(launch_metrics: bool, bind_host: String, bind_port: u32) -> CliResult<()> {
+async fn invoke(launch_metrics: bool, web_host: String, web_port: u32) -> CliResult<()> {
     let path = if launch_metrics {
-        format!("http://{0}:16686", bind_host)
+        "http://localhost:16686"
     } else {
-        format!("http://{0}:{1}", bind_host, bind_port)
+        format!("http://{0}:{1}", web_host, web_port)
     };
 
-    if path == format!("http://{0}:{1}", bind_host, bind_port) {
-        check_web(bind_port).await?;
+    if path == format!("http://{0}:{1}", web_host, web_port) {
+        check_web(web_port).await?;
         check_sdf().await?;
     }
 
@@ -38,8 +38,8 @@ async fn invoke(launch_metrics: bool, bind_host: String, bind_port: u32) -> CliR
     Ok(())
 }
 
-async fn check_web(bind_port: u32) -> CliResult<()> {
-    let path = format!("http://localhost:{0}", bind_port);
+async fn check_web(web_port: u32) -> CliResult<()> {
+    let path = format!("http://localhost:{0}", web_port);
     let resp = reqwest::get(path).await;
     if let Err(_e) = resp {
         return Err(SiCliError::WebPortal());

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -428,8 +428,8 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
                 container_name.clone()
             );
 
-            let host_ip = app.bind_host();
-            let host_port = app.bind_port();
+            let host_ip = app.web_host();
+            let host_port = app.web_port();
 
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -8,7 +8,10 @@ use crate::{CliResult, CONTAINER_NAMES};
 use docker_api::opts::{ContainerCreateOpts, HostPort, PublishPort};
 
 impl AppState {
-    pub async fn start(&self, docker: &DockerClient) -> CliResult<()> {
+    pub async fn start(
+        &self,
+        docker: &DockerClient,
+    ) -> CliResult<()> {
         self.track(
             get_user_email().await?,
             serde_json::json!({"command-name": "start-system"}),
@@ -424,13 +427,17 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
                 container.clone(),
                 container_name.clone()
             );
+
+            let host_ip = app.bind_host();
+            let host_port = app.bind_port();
+
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())
                 .image(format!("{0}:stable", container.clone()))
                 .links(vec!["local-sdf-1:sdf"])
                 .env(["SI_LOG=trace"])
                 .network_mode("bridge")
-                .expose(PublishPort::tcp(8080), HostPort::new(8080))
+                .expose(PublishPort::tcp(8080), HostPort::with_ip(host_port, host_ip))
                 .build();
 
             let container = docker.containers().create(&create_opts).await?;

--- a/lib/si-cli/src/cmd/status.rs
+++ b/lib/si-cli/src/cmd/status.rs
@@ -77,7 +77,7 @@ async fn invoke(app: &AppState, docker: &DockerClient, show_logs: bool, log_line
         }
 
         if container_identifier == "local-web-1" {
-            let web_path = format!("http://{0}:{1}/", app.bind_host(), app.bind_port());
+            let web_path = format!("http://{0}:{1}/", app.web_host(), app.web_port());
             let resp = reqwest::get(web_path).await;
             if resp.is_err() && state == ContainerState::Running {
                 state = ContainerState::Waiting;

--- a/lib/si-cli/src/cmd/status.rs
+++ b/lib/si-cli/src/cmd/status.rs
@@ -21,7 +21,7 @@ impl AppState {
             get_user_email().await?,
             serde_json::json!({"command-name": "system-status"}),
         );
-        invoke(docker, show_logs, log_lines).await?;
+        invoke(self, docker, show_logs, log_lines).await?;
         Ok(())
     }
 }
@@ -40,7 +40,7 @@ enum ContainerState {
     Waiting,
 }
 
-async fn invoke(docker: &DockerClient, show_logs: bool, log_lines: usize) -> CliResult<()> {
+async fn invoke(app: &AppState, docker: &DockerClient, show_logs: bool, log_lines: usize) -> CliResult<()> {
     println!("Checking the status of System Initiative Software");
 
     let mut container_status = Vec::new();
@@ -77,7 +77,7 @@ async fn invoke(docker: &DockerClient, show_logs: bool, log_lines: usize) -> Cli
         }
 
         if container_identifier == "local-web-1" {
-            let web_path = "http://localhost:8080/";
+            let web_path = format!("http://{0}:{1}/", app.bind_host(), app.bind_port());
             let resp = reqwest::get(web_path).await;
             if resp.is_err() && state == ContainerState::Running {
                 state = ContainerState::Waiting;

--- a/lib/si-cli/src/state.rs
+++ b/lib/si-cli/src/state.rs
@@ -9,8 +9,8 @@ pub struct AppState {
     version: Arc<str>,
     mode: Arc<str>,
     is_preview: bool,
-    bind_host: String,
-    bind_port: u32,
+    web_host: String,
+    web_port: u32,
 }
 
 impl AppState {
@@ -19,16 +19,16 @@ impl AppState {
         version: Arc<str>,
         mode: Arc<str>,
         is_preview: bool,
-        bind_host: String,
-        bind_port: u32,
+        web_host: String,
+        web_port: u32,
     ) -> Self {
         Self {
             posthog_client: posthog_client.into(),
             version,
             mode,
             is_preview,
-            bind_host,
-            bind_port,
+            web_host,
+            web_port,
         }
     }
 
@@ -44,12 +44,12 @@ impl AppState {
         self.is_preview
     }
 
-    pub fn bind_host(&self) -> String {
-        self.bind_host.clone()
+    pub fn web_host(&self) -> String {
+        self.web_host.clone()
     }
 
-    pub fn bind_port(&self) -> u32 {
-        self.bind_port
+    pub fn web_port(&self) -> u32 {
+        self.web_port
     }
 
     pub fn posthog_client(&self) -> &PosthogClient {

--- a/lib/si-cli/src/state.rs
+++ b/lib/si-cli/src/state.rs
@@ -9,6 +9,8 @@ pub struct AppState {
     version: Arc<str>,
     mode: Arc<str>,
     is_preview: bool,
+    bind_host: String,
+    bind_port: u32,
 }
 
 impl AppState {
@@ -17,12 +19,16 @@ impl AppState {
         version: Arc<str>,
         mode: Arc<str>,
         is_preview: bool,
+        bind_host: String,
+        bind_port: u32,
     ) -> Self {
         Self {
             posthog_client: posthog_client.into(),
             version,
             mode,
             is_preview,
+            bind_host,
+            bind_port,
         }
     }
 
@@ -36,6 +42,14 @@ impl AppState {
 
     pub fn is_preview(&self) -> bool {
         self.is_preview
+    }
+
+    pub fn bind_host(&self) -> String {
+        self.bind_host.clone()
+    }
+
+    pub fn bind_port(&self) -> u32 {
+        self.bind_port
     }
 
     pub fn posthog_client(&self) -> &PosthogClient {


### PR DESCRIPTION
This change adds the `--host` and `--port` arguments to the `si` command which allow the user to set the host and port for the user-facing web container. This allows a user to run the portal on one machine, but access it from another one (e.g.).

This is (one of) my first rust contribution(s), so I'm more than happy to address any and all issues.

I considered adding this to the Start command's arguments (and state), but figured it rather belonged in the global AppState so it could be used by other commands, e.g., the Restart and Status commands, to show the proper information to the user.

Thank you in advance for your consideration.