### PR TITLE
add `--keep-images` flag to delete subcommand

### DIFF
--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -132,7 +132,11 @@ pub(crate) struct StopArgs {}
 pub(crate) struct CheckArgs {}
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct DeleteArgs {}
+pub(crate) struct DeleteArgs {
+    /// Keep containers so you don't have to redownload them every time
+    #[clap(long, env = "SI_KEEP_IMAGES_ON_DELETE")]
+    pub keep_images: bool,
+}
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct UpdateArgs {

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -128,8 +128,8 @@ async fn main() -> Result<()> {
         Commands::Configure(args) => {
             state.configure(args.force_reconfigure).await?;
         }
-        Commands::Delete(_args) => {
-            state.delete(&docker).await?;
+        Commands::Delete(args) => {
+            state.delete(&docker, args.keep_images).await?;
         }
         Commands::Restart(_args) => {
             state.restart(&docker).await?;


### PR DESCRIPTION
When iterating on bits which launch containers as part of the launcher, the stop/delete/start routine to refresh the containers can take a long time when downloading the images each time. This change adds a flag and associated environment variable (`SI_KEEP_IMAGES_ON_DELETE=(true|false)`) to skip image cleanup when deleting the containers.

n.b. this change does not provide a way to clean up the images afterwards, except to start them with `si start` and re-run `si delete`, or cleaning them manually (e.g., with docker image prune)

Original (default) behavior:

```
╰─➤ SI_KEEP_IMAGES_ON_DELETE=false SI_LOG=info buck2 run //bin/si -- delete
Build ID: e9421082-36e0-4cfe-b0ae-997cd6c2e8a3
Network: Up: 0 B  Down: 0 B
Jobs completed: 3. Time elapsed: 0.0s.
System Initiative Launcher is in "local" mode


Launcher update found, please run `si update` to install it

Deleting container: local-jaeger-1 (7668e9c9e0605dc9e2fda5d07aa4166405f0cf78f63b1e2c2327214948ce185b)
Removing image: systeminit/jaeger:stable
Deleting container: local-postgres-1 (07e6e4b24cedff95aa0b5407dbb47d7efc5aebd0f9dc80547da30b74d2f9fbdc)
Removing image: systeminit/postgres:stable
Deleting container: local-nats-1 (58e0f7610d89df7ade95c8bc99d369e3be35da37dac727c37d5836537cf2e776)
Removing image: systeminit/nats:stable
Deleting container: local-otelcol-1 (1dbaf608462d36c5ef5f26741b1e8fd00f5df1596aa68aa69364ff436fe8e81c)
Removing image: systeminit/otelcol:stable
Deleting container: local-council-1 (67523a0855250069bb2e950bfc0bb2905c981ab1465323b5aa8a9096e6d78497)
Removing image: systeminit/council:stable
Deleting container: local-veritech-1 (f3a8162013c351bdad67ad1af2d0a946b2fa0edf9d2d93fc7d4ed603c418b3a5)
Removing image: systeminit/veritech:stable
Deleting container: local-pinga-1 (aa70723528a1d1e4e48d5047b2398d0a9678e325412297dc6f2513ca50972467)
Removing image: systeminit/pinga:stable
Deleting container: local-sdf-1 (1b11017e4abbf42c7c1de99a694347c2ba03f3068ab68bf54da91baa7f26cc0c)
Removing image: systeminit/sdf:stable
Deleting container: local-web-1 (89f8622c0329b9870cbc95165712946b8222e94cb0cd3f3ffbdd026204db9cd2)
Removing image: systeminit/web:stable
```

New (optional) behavior:

```
╰─➤ SI_KEEP_IMAGES_ON_DELETE=true SI_LOG=info buck2 run //bin/si -- delete
Build ID: a6606f83-0d3f-4d42-ba13-4b3d7781ea8f
Network: Up: 0 B  Down: 0 B
Jobs completed: 3. Time elapsed: 0.0s.
System Initiative Launcher is in "local" mode


Launcher update found, please run `si update` to install it

Deleting container: local-jaeger-1 (8b9bcc791e94dcfd44bbeb91f3a30846846da0af28a89fdb2b977b943878e1b4)
Deleting container: local-postgres-1 (a0c9a8c918c64cd29263f8ae475736c0f76f9bd75fa82ea8b271b20c3b3456ab)
Deleting container: local-nats-1 (67066b6731ac0d2e239c8115abc4af6773cf6c9dc6ab6ba307ecf14deab42d10)
Deleting container: local-otelcol-1 (99309cc6b850797fd8eabcc419387c21ddef7d4f774453f1abf3405d0047d275)
Deleting container: local-council-1 (c613ea87e662e6bdde65bfc3a572851501f3c9a47b65c1e7856e4227bfb7bf2a)
Deleting container: local-veritech-1 (d53ac8ee66385798199036f929fa23d8bfc3f4f2a75fc4efcc78b753770bfdfe)
Deleting container: local-pinga-1 (a3fd71960adc469a7d4a08f80b8cfdf97a534a7137c4915264147c033d41bb9c)
Deleting container: local-sdf-1 (d7da7a72f2ff5d110dc02bbf7f6aa553414e428fa0b62e28001d0799057de18e)
Deleting container: local-web-1 (f94879a60fb8092849c7d7d56a46ea78bd99cacdc7e5b40c73f2430b8daddc7a)

```