### PR TITLE
fix(web,sdf): save component type when changed in variant definition

### DIFF
--- a/lib/dal/src/schema/variant/root_prop/component_type.rs
+++ b/lib/dal/src/schema/variant/root_prop/component_type.rs
@@ -25,8 +25,14 @@ use strum::{AsRefStr, Display, EnumIter, EnumString};
 )]
 #[serde(rename_all = "camelCase")]
 pub enum ComponentType {
+    #[serde(alias = "AggregationFrame")]
+    #[strum(serialize = "AggregationFrame", serialize = "aggregationFrame")]
     AggregationFrame,
+    #[serde(alias = "Component")]
+    #[strum(serialize = "Component", serialize = "component")]
     Component,
+    #[serde(alias = "ConfigurationFrame")]
+    #[strum(serialize = "ConfigurationFrame", serialize = "configurationFrame")]
     ConfigurationFrame,
 }
 

--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -144,6 +144,9 @@ pub async fn save_variant_def(
     variant_def
         .set_description(ctx, request.description.clone())
         .await?;
+    variant_def
+        .set_component_type(ctx, request.component_type)
+        .await?;
 
     let mut asset_func = Func::get_by_id(ctx, &variant_def.func_id()).await?.ok_or(
         SchemaVariantDefinitionError::FuncNotFound(variant_def.func_id()),

--- a/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
@@ -3,6 +3,7 @@ use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
 use axum::extract::OriginalUri;
 use axum::Json;
+use dal::ComponentType;
 use dal::{schema::variant::definition::SchemaVariantDefinitionId, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +19,7 @@ pub struct SaveVariantDefRequest {
     pub code: String,
     pub handler: String,
     pub description: Option<String>,
+    pub component_type: ComponentType,
     #[serde(flatten)]
     pub visibility: Visibility,
 }

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -19,9 +19,9 @@ use dal::component::confirmation::view::{ConfirmationView, RecommendationView};
 use dal::schema::variant::definition::SchemaVariantDefinitionId;
 use dal::{
     property_editor::values::PropertyEditorValue, socket::SocketEdgeKind, AttributeValue,
-    AttributeValueId, ComponentId, ComponentView, ComponentViewProperties, DalContext, Diagram,
-    FixBatchId, NodeId, Prop, PropKind, Schema, SchemaId, SchemaVariantId, Socket, StandardModel,
-    Visibility,
+    AttributeValueId, ComponentId, ComponentType, ComponentView, ComponentViewProperties,
+    DalContext, Diagram, FixBatchId, NodeId, Prop, PropKind, Schema, SchemaId, SchemaVariantId,
+    Socket, StandardModel, Visibility,
 };
 use names::{Generator, Name};
 use sdf_server::service::component::refresh::{RefreshRequest, RefreshResponse};
@@ -424,6 +424,7 @@ impl ScenarioHarness {
             color: "#FFFF00".to_string(),
             link: Some("https://www.systeminit.com/".to_string()),
             code,
+            component_type: ComponentType::Component,
             handler: "createAsset".to_string(),
             description: None,
             visibility: *visibility,
@@ -451,6 +452,7 @@ impl ScenarioHarness {
             color: "#FFFF00".to_string(),
             link: Some("https://www.systeminit.com/".to_string()),
             code,
+            component_type: ComponentType::Component,
             handler: "createAsset".to_string(),
             description: None,
             visibility: *visibility,

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -26,9 +26,15 @@ use super::{
 )]
 #[serde(rename_all = "camelCase")]
 pub enum SchemaVariantSpecComponentType {
+    #[serde(alias = "AggregationFrame")]
+    #[strum(serialize = "AggregationFrame", serialize = "aggregationFrame")]
     AggregationFrame,
     #[default]
+    #[serde(alias = "Component")]
+    #[strum(serialize = "Component", serialize = "component")]
     Component,
+    #[serde(alias = "ConfigurationFrame")]
+    #[strum(serialize = "ConfigurationFrame", serialize = "configurationFrame")]
     ConfigurationFrame,
 }
 


### PR DESCRIPTION
The component_type property on the save/exec variant definition requests was being ignored. A bit of a goof here is that the enum is being serialized differently by strum than by serde, so aliases added to handle the different serializations.