### PR TITLE
[WIP] Add a Dockerfile for the si cli

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ We contributors to System Initiative:
 * Zack Hamm (@zacharyhamm)
 * Dan Miller (@jazzdan)
 * Neil Hanlon (@NeilHanlon)
+* Tensibai Zhaoying (@Tensibai)

--- a/bin/si/Dockerfile
+++ b/bin/si/Dockerfile
@@ -1,0 +1,6 @@
+FROM bitnami/minideb:latest
+
+RUN install_packages curl ca-certificates
+RUN curl -sSfL https://auth.systeminit.com/install.sh | sh
+
+ENTRYPOINT [ "/usr/local/bin/si" ]


### PR DESCRIPTION
A first attempt at creating a docker image for the si cli so I could run it on Ubuntu20 where the glibc is a bit too old (3.21).

Running as root, it works using the following command line `docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /root/.local/share/:/root/.local/share/ -it si:latest <command>`

In bash adding an alias `alias si='docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /root/.local/share/:/root/.local/share/ -it si:latest'` works well.

I wasn't sure where to document it, so opening this PR as first step to discuss it.