### PR TITLE
feat(si): Enable the use of debug logs for veritech SI container

### DIFF
--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -68,6 +68,9 @@ pub(crate) struct Args {
     /// usage of that location.
     #[arg(long, env = "SI_DOCKER_SOCK")]
     pub docker_sock: Option<String>,
+    /// Enable debug logs for function executions via veritech
+    #[clap(long)]
+    pub with_function_debug_logs: bool,
     #[command(subcommand)]
     pub(crate) command: Commands,
 }

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<()> {
         is_preview,
         web_host,
         web_port,
+        args.with_function_debug_logs,
     );
 
     println!(

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -272,6 +272,9 @@ async fn invoke(app: &AppState, docker: &DockerClient, is_preview: bool) -> CliR
                 "SI_VERITECH__NATS__URL=nats".to_string(),
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317".to_string(),
             ];
+            if app.with_function_debug_logs() {
+                env_vars.push("SI_LOG=debug".to_string());
+            }
             env_vars.append(&mut veritech_credentials);
             let create_opts = ContainerCreateOpts::builder()
                 .name(container_name.clone())

--- a/lib/si-cli/src/state.rs
+++ b/lib/si-cli/src/state.rs
@@ -11,6 +11,7 @@ pub struct AppState {
     is_preview: bool,
     web_host: String,
     web_port: u32,
+    with_function_debug_logs: bool,
 }
 
 impl AppState {
@@ -21,6 +22,7 @@ impl AppState {
         is_preview: bool,
         web_host: String,
         web_port: u32,
+        with_function_debug_logs: bool,
     ) -> Self {
         Self {
             posthog_client: posthog_client.into(),
@@ -29,6 +31,7 @@ impl AppState {
             is_preview,
             web_host,
             web_port,
+            with_function_debug_logs,
         }
     }
 
@@ -38,6 +41,10 @@ impl AppState {
 
     pub fn mode(&self) -> &str {
         self.mode.deref()
+    }
+
+    pub fn with_function_debug_logs(&self) -> bool {
+        self.with_function_debug_logs
     }
 
     pub fn is_preview(&self) -> bool {


### PR DESCRIPTION
```
si --with-function-debug-logs start
```
