### PR TITLE
fix(buck2): when computing dependent targets, use `attrregexfilter`

### DIFF
--- a/bxl/dependent_targets.bxl
+++ b/bxl/dependent_targets.bxl
@@ -139,25 +139,25 @@ def _filter_targets(ctx: "bxl_ctx", targets: "target_set") -> "target_set":
 
     if ctx.cli_args.check_doc:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "check-doc", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^check-doc(-.+)?$", targets)
     if ctx.cli_args.check_format:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "check-format", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^check-format(-.+)?$", targets)
     if ctx.cli_args.check_lint:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "check-lint", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^check-lint(-.+)?$", targets)
     if ctx.cli_args.check_type:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "check-type", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^check-type(-.+)?$", targets)
     if ctx.cli_args.test_doc:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "test-doc", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^test-doc(-.+)?$", targets)
     if ctx.cli_args.test_integration:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "test-integration", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^test-integration(-.+)?$", targets)
     if ctx.cli_args.test_unit:
         has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter("name", "test-unit", targets)
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^test-unit(-.+)?$", targets)
     if ctx.cli_args.release_docker:
         has_filtered = True
         filtered = filtered + ctx.uquery().kind("docker_image_release", targets)


### PR DESCRIPTION
This change fixes the dependent targets calculation used in CI/CD to look for target names *starting with* the appropriate phase names such as `check-format`, `check-lint`, etc.

Prior to this change, only an exact target name match of `check-format` would return a result. As we start to use more `test_suite` groups to group up similar tests to run under one convenient target we have started to generate such target names as `check-format-rust-bin` or `check-lint-rust-unit`. It appears as though the `test_suite` Buck2 rule type does *not* form a dependency  relationship with its inputs and therefore the rolled up target names such as `check-format` or `check-lint` were not being selected to run in a pipeline.

<img src="https://media2.giphy.com/media/pPi9aBHsop5gqMOvHC/giphy.gif"/>