### PR TITLE
fix(web): prevents anchor click from hard reloading

### DIFF
--- a/lib/vue-lib/src/design-system/tabs/TabGroup.vue
+++ b/lib/vue-lib/src/design-system/tabs/TabGroup.vue
@@ -68,7 +68,7 @@
                   ),
                 )
               "
-              @click.stop="emit('closeTab', tab.props.slug)"
+              @click.prevent.stop="emit('closeTab', tab.props.slug)"
             >
               <Icon name="x" size="xs" />
             </button>


### PR DESCRIPTION
Prevents the anchor click from propagating when closing a function tab, as it was was forcing a hard reload of the page.