### PR TITLE
fix(web): fix exec_asset request status handling in details panel

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -149,7 +149,7 @@ import { nilId } from "@/utils/nilId";
 import { useComponentsStore } from "@/store/components.store";
 import ColorPicker from "./ColorPicker.vue";
 
-defineProps<{
+const props = defineProps<{
   assetId?: string;
 }>();
 
@@ -157,7 +157,14 @@ const changeSetsStore = useChangeSetsStore();
 const componentsStore = useComponentsStore();
 const assetStore = useAssetStore();
 const funcStore = useFuncStore();
-const loadAssetReqStatus = assetStore.getRequestStatus("LOAD_ASSET");
+const loadAssetReqStatus = assetStore.getRequestStatus(
+  "LOAD_ASSET",
+  props.assetId,
+);
+const executeAssetReqStatus = assetStore.getRequestStatus(
+  "EXEC_ASSET",
+  props.assetId,
+);
 const executeAssetModalRef = ref();
 const assetModalTitle = ref("New Asset Created");
 
@@ -206,7 +213,7 @@ const executeAsset = async () => {
   if (assetStore.selectedAssetId) {
     const result = await assetStore.EXEC_ASSET(assetStore.selectedAssetId);
     if (result.result.success) {
-      executeAssetModalRef.value.open();
+      executeAssetModalRef.value?.open();
       const { schemaVariantId } = result.result.data;
       if (schemaVariantId !== nilId()) {
         assetStore.setSchemaVariantIdForAsset(
@@ -221,11 +228,6 @@ const executeAsset = async () => {
     }
   }
 };
-
-const executeAssetReqStatus = assetStore.getRequestStatus(
-  "EXEC_ASSET",
-  assetStore.selectedAsset?.id,
-);
 
 const cloneAsset = async () => {
   if (assetStore.selectedAsset?.id) {

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -48,7 +48,9 @@
           singleModelScreen
           @detached="onDetach"
         />
-        <AssetDetailsPanel v-else :assetId="assetId" />
+        <!-- the key here is to force remounting so we get the proper asset
+        request statuses -->
+        <AssetDetailsPanel v-else :key="assetId" :assetId="assetId" />
       </template>
       <div
         v-else
@@ -58,7 +60,11 @@
       </div>
     </div>
     <template v-else>
-      <AssetDetailsPanel v-if="assetId && !funcId" :assetId="assetId" />
+      <AssetDetailsPanel
+        v-if="assetId && !funcId"
+        :key="assetId"
+        :assetId="assetId"
+      />
       <FuncDetails
         v-else-if="assetId && funcId"
         :funcId="funcId"

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -314,6 +314,7 @@ export const useAssetStore = () => {
           >({
             method: "post",
             url: "/variant_def/exec_variant_def",
+            keyRequestStatusBy: assetId,
             params: {
               ...visibility,
               ..._.omit(asset, [


### PR DESCRIPTION
Request was not keyed by id, and the key provided was not refreshing on asset change.