### PR TITLE
fix(sdf): fix nightly ci

### DIFF
--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_whiskers.rs
@@ -424,11 +424,6 @@ async fn model_and_fix_flow_whiskers(
             "domain": {
                 "region": "us-east-2",
             },
-            "qualification": {
-                "si:qualificationAwsRegionHasRegionSet": {
-                    "result": "success",
-                },
-            },
         }], // expected
         region
             .view(&ctx)


### PR DESCRIPTION
Whiskers nightly test was checking for the dropped region qualification and failing.