### PR TITLE
fix(web): prevent changeset actions in frontend while fixes are running

### DIFF
--- a/app/web/src/components/AssetPalette2.vue
+++ b/app/web/src/components/AssetPalette2.vue
@@ -49,15 +49,20 @@
               class="select-none border-b-2 dark:border-neutral-600"
             >
               <SiNodeSprite
-                :class="
-                  componentsStore.selectedInsertSchemaId === schema.id
-                    ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
-                    : ''
-                "
                 :color="schema.color"
                 :name="schema.displayName"
-                class="border border-transparent hover:border-action-500 dark:hover:border-action-300 dark:text-white hover:text-action-500 dark:hover:text-action-500 hover:cursor-pointer"
-                @mousedown.left="onSelect(schema.id)"
+                :class="
+                  clsx(
+                    'border border-transparent',
+                    fixesAreRunning
+                      ? 'hover:cursor-progress'
+                      : 'hover:border-action-500 dark:hover:border-action-300 dark:text-white hover:text-action-500 dark:hover:text-action-500 hover:cursor-pointer',
+                    componentsStore.selectedInsertSchemaId === schema.id
+                      ? 'bg-action-100 dark:bg-action-700 border border-action-500 dark:border-action-300'
+                      : '',
+                  )
+                "
+                @mousedown.left="onSelect(schema.id, fixesAreRunning)"
                 @click.right.prevent
               />
             </li>
@@ -83,10 +88,13 @@
 import * as _ from "lodash-es";
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import { Collapsible, Icon, ScrollArea } from "@si/vue-lib/design-system";
+import clsx from "clsx";
 import SiNodeSprite from "@/components/SiNodeSprite.vue";
 import { useComponentsStore, MenuSchema } from "@/store/components.store";
 import NodeSkeleton from "@/components/NodeSkeleton.vue";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
+
+defineProps<{ fixesAreRunning: boolean }>();
 
 const instructionsRef = ref();
 
@@ -134,7 +142,12 @@ const updateMouseNode = (e: MouseEvent) => {
   }
 };
 
-function onSelect(schemaId: string) {
+function onSelect(schemaId: string, fixesAreRunning: boolean) {
+  if (fixesAreRunning) {
+    // Prevent selection while fixes are running
+    return;
+  }
+
   componentsStore.selectedInsertSchemaId = schemaId;
   selecting.value = true;
 }

--- a/app/web/src/components/ChangeSetPanel2.vue
+++ b/app/web/src/components/ChangeSetPanel2.vue
@@ -19,6 +19,7 @@
           variant="ghost"
           icon="git-branch"
           size="sm"
+          :disabled="fixesStore.fixesAreInProgress"
           @click="openCreateModal"
         />
       </div>
@@ -99,11 +100,13 @@ import {
 } from "@si/vue-lib/design-system";
 import { nilId } from "@/utils/nilId";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFixesStore } from "@/store/fixes.store";
 import Wipe from "./Wipe.vue";
 
 const wipeRef = ref<InstanceType<typeof Wipe>>();
 
 const changeSetsStore = useChangeSetsStore();
+const fixesStore = useFixesStore();
 const openChangeSets = computed(() => changeSetsStore.openChangeSets);
 const selectedChangeSetId = computed(() => changeSetsStore.selectedChangeSetId);
 const selectedChangeSetName = computed(

--- a/app/web/src/components/ComponentOutline/ComponentOutline2.vue
+++ b/app/web/src/components/ComponentOutline/ComponentOutline2.vue
@@ -5,7 +5,11 @@
         <SidebarSubpanelTitle class="border-t-0">
           <div class="flex flex-row grow">
             <span class="mr-auto">Diagram Outline</span>
-            <Icon v-if="fetchComponentsReq.isPending" name="loader" size="sm" />
+            <Icon
+              v-if="fetchComponentsReq.isPending || fixesAreRunning"
+              name="loader"
+              size="sm"
+            />
           </div>
         </SidebarSubpanelTitle>
 
@@ -100,6 +104,8 @@ import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
 
 import ComponentOutlineNode from "./ComponentOutlineNode2.vue";
 import EmptyStateIcon from "../EmptyStateIcon.vue";
+
+defineProps<{ fixesAreRunning: boolean }>();
 
 const outlineRef = ref<HTMLElement>();
 

--- a/app/web/src/components/ProgressBarOverlay.vue
+++ b/app/web/src/components/ProgressBarOverlay.vue
@@ -26,7 +26,7 @@
 
       <div class="ml-xs flex-none">
         <VButton
-          v-if="featureFlagsStore.SINGLE_MODEL_SCREEN"
+          v-if="featureFlagsStore.SINGLE_MODEL_SCREEN && showRefreshButton"
           icon="refresh"
           variant="ghost"
           loadingIcon="refresh-active"
@@ -88,6 +88,7 @@ const props = defineProps({
   // can set to override bar fill
   progressPercent: { type: Number },
   barLabel: { type: String },
+  showRefreshButton: { type: Boolean, default: true },
 });
 
 const computedProgressPercent = computed(() => {

--- a/app/web/src/components/RecommendationProgressOverlay.vue
+++ b/app/web/src/components/RecommendationProgressOverlay.vue
@@ -6,6 +6,7 @@
     :doneCount="fixState.executed"
     :totalCount="fixState.total"
     :barLabel="fixState.mode === 'syncing' ? 'Synced' : 'Applied'"
+    :showRefreshButton="false"
   />
   <GlobalStatusOverlay v-else />
 </template>
@@ -29,9 +30,9 @@ const fixState = computed(() => {
     const executed = fixesStore.completedFixesOnRunningBatch.length;
 
     // Reload confirmations if all recommendations have been applied!
-    let summary = "Applying recommendations...";
+    let summary = "Applying actions...";
     if (total > 0 && total === executed) {
-      summary = "Recommendations applied!";
+      summary = "Finishing up actions...";
       fixesStore.LOAD_CONFIRMATIONS();
     }
 

--- a/app/web/src/components/Workspace/WorkspaceModelAndViewNew.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndViewNew.vue
@@ -6,10 +6,17 @@
     :minSize="250"
   >
     <template #subpanel1>
-      <ComponentOutline class="" @right-click-item="onOutlineRightClick" />
+      <ComponentOutline
+        class=""
+        :fixesAreRunning="fixesAreRunning"
+        @right-click-item="onOutlineRightClick"
+      />
     </template>
     <template #subpanel2>
-      <AssetPalette class="border-t dark:border-neutral-600" />
+      <AssetPalette
+        class="border-t dark:border-neutral-600"
+        :fixesAreRunning="fixesAreRunning"
+      />
     </template>
   </ResizablePanel>
 
@@ -26,7 +33,7 @@
     >
       <ReadOnlyBanner show-refresh-all-button />
     </div-->
-    <GlobalStatusOverlay />
+    <RecommendationProgressOverlay />
     <GenericDiagram
       v-if="diagramNodes"
       ref="diagramRef"
@@ -318,6 +325,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import RecommendationSprite from "@/components/RecommendationSprite2.vue";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
 import { nilId } from "@/utils/nilId";
+import RecommendationProgressOverlay from "@/components/RecommendationProgressOverlay.vue";
 import GenericDiagram from "../GenericDiagram/GenericDiagram.vue";
 import ApplyHistory from "../ApplyHistory.vue";
 import AssetPalette from "../AssetPalette2.vue";
@@ -336,7 +344,6 @@ import {
   HoverElementEvent,
 } from "../GenericDiagram/diagram_types";
 import ComponentOutline from "../ComponentOutline/ComponentOutline2.vue";
-import GlobalStatusOverlay from "../GlobalStatusOverlay.vue";
 import EdgeDetailsPanel from "../EdgeDetailsPanel.vue";
 import MultiSelectDetailsPanel from "../MultiSelectDetailsPanel.vue";
 import ComponentCard from "../ComponentCard.vue";
@@ -345,6 +352,12 @@ import EmptyStateIcon from "../EmptyStateIcon.vue";
 
 const changeSetStore = useChangeSetsStore();
 const fixesStore = useFixesStore();
+
+const fixesAreRunning = computed(
+  () =>
+    fixesStore.fixesAreInProgress ||
+    changeSetStore.getRequestStatus("APPLY_CHANGE_SET2").value.isPending,
+);
 
 const diffs = computed(() => {
   const arr = Object.values(componentsStore.componentsById)
@@ -804,6 +817,7 @@ const typeDisplayName = (action = "delete") => {
 
 const rightClickMenuItems = computed(() => {
   const items: DropdownMenuItemObjectDef[] = [];
+  const disabled = fixesStore.fixesAreInProgress;
   if (selectedEdgeId.value) {
     // single selected edge
     if (selectedEdge.value?.changeStatus === "deleted") {
@@ -811,12 +825,14 @@ const rightClickMenuItems = computed(() => {
         label: "Restore edge",
         icon: "trash-restore",
         onSelect: triggerRestoreSelection,
+        disabled,
       });
     } else {
       items.push({
         label: "Delete edge",
         icon: "trash",
         onSelect: triggerDeleteSelection,
+        disabled,
       });
     }
   } else if (selectedComponentId.value && selectedComponent.value) {
@@ -828,6 +844,7 @@ const rightClickMenuItems = computed(() => {
         }"`,
         icon: "trash-restore",
         onSelect: triggerRestoreSelection,
+        disabled,
       });
     } else {
       items.push({
@@ -836,6 +853,7 @@ const rightClickMenuItems = computed(() => {
         }"`,
         icon: "trash",
         onSelect: triggerDeleteSelection,
+        disabled,
       });
     }
   } else if (selectedComponentIds.value.length) {
@@ -848,6 +866,7 @@ const rightClickMenuItems = computed(() => {
         )}`,
         icon: "trash",
         onSelect: triggerDeleteSelection,
+        disabled,
       });
     }
     if (restorableSelectedComponents.value.length > 0) {
@@ -858,6 +877,7 @@ const rightClickMenuItems = computed(() => {
         )}`,
         icon: "trash-restore",
         onSelect: triggerRestoreSelection,
+        disabled,
       });
     }
   }
@@ -867,6 +887,7 @@ const rightClickMenuItems = computed(() => {
       label: "Refresh resource",
       icon: "refresh",
       onSelect: refreshResourceForSelectedComponent,
+      disabled,
     });
   }
   return items;

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -117,6 +117,7 @@ export const useFixesStore = () => {
         >,
       }),
       getters: {
+        fixesAreInProgress: (state) => !!state.runningFixBatch,
         enabledRecommendations(): Recommendation[] {
           return _.values(this.recommendationsSelection)
             .filter(({ selected }) => selected)

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
@@ -9,6 +9,7 @@
         'flex gap-xs items-center p-xs pr-sm cursor-pointer rounded-sm children:pointer-events-none',
         isFocused && 'bg-action-500',
         !menuCtx.isCheckable.value && !icon && !$slots.icon && 'pl-sm',
+        disabled && 'text-gray-500',
       )
     "
     role="menuitem"


### PR DESCRIPTION
Creating a changeset in the middle of the fix flow causes inconsistency.
This PR prevents this by checking if fixes are running, and if they are
it

   - disables the changeset button
   - prevents dropping assets on the graph
   - disables the right click menu
   - Uses RecommendationProgressOverlay as the global overlay to give
     status updates about actions while in flight

There are probably other paths that could create a changeset or get into
a conflict with the fix run.

A more robust solution is needed that prevents SDF itself from
performing operations that could cause inconsistency during the fix run,
but this should make for a smoother user experience.