### PR TITLE
fix(web): fix leaf function reactivity after revert

### DIFF
--- a/app/web/src/components/FuncEditor/CodeGenerationDetails.vue
+++ b/app/web/src/components/FuncEditor/CodeGenerationDetails.vue
@@ -73,6 +73,7 @@ watch(
   ([mv, svOpts, componentOpts]) => {
     selectedVariants.value = toOptionValues(svOpts, mv.schemaVariantIds);
     selectedComponents.value = toOptionValues(componentOpts, mv.componentIds);
+    inputs.value = mv.inputs;
   },
   { immediate: true },
 );

--- a/app/web/src/components/FuncEditor/ConfirmationDetails.vue
+++ b/app/web/src/components/FuncEditor/ConfirmationDetails.vue
@@ -80,6 +80,7 @@ watch(
       schemaVariantOptions.value,
       mv.schemaVariantIds,
     );
+    inputs.value = mv.inputs;
   },
   { immediate: true },
 );

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -341,6 +341,7 @@ const revertFuncReqStatus = funcStore.getRequestStatus("REVERT_FUNC");
 const revertFunc = async () => {
   if (!funcId.value) return;
   await funcStore.REVERT_FUNC(funcId.value);
+  await funcStore.FETCH_FUNC_DETAILS(funcId.value);
   resetEditingFunc();
 };
 

--- a/app/web/src/components/FuncEditor/LeafInputs.vue
+++ b/app/web/src/components/FuncEditor/LeafInputs.vue
@@ -32,6 +32,16 @@ const domainSelected = ref(props.modelValue.includes("domain"));
 const resourceSelected = ref(props.modelValue.includes("resource"));
 
 watch(
+  () => props.modelValue,
+  (inputs) => {
+    codeSelected.value = inputs.includes("code");
+    deletedAtSelected.value = inputs.includes("deletedAt");
+    domainSelected.value = inputs.includes("domain");
+    resourceSelected.value = inputs.includes("resource");
+  },
+);
+
+watch(
   [codeSelected, deletedAtSelected, domainSelected, resourceSelected],
   ([code, deletedAt, domain, resource]) => {
     const leafInputLocations: LeafInputLocation[] = [];

--- a/app/web/src/components/FuncEditor/QualificationDetails.vue
+++ b/app/web/src/components/FuncEditor/QualificationDetails.vue
@@ -81,6 +81,7 @@ watch(
   ([mv, svOpts, componentOpts]) => {
     selectedVariants.value = toOptionValues(svOpts, mv.schemaVariantIds);
     selectedComponents.value = toOptionValues(componentOpts, mv.componentIds);
+    inputs.value = mv.inputs;
   },
   { immediate: true },
 );

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -365,9 +365,6 @@ export const useFuncStore = () => {
             method: "post",
             url: "func/revert_func",
             params: { id: funcId, ...visibility },
-            onSuccess: () => {
-              this.FETCH_FUNC_DETAILS(funcId);
-            },
           });
         },
 


### PR DESCRIPTION
Reverting was not waiting for load before refreshing the "draft", and the leaf function input details where not fully reactive to changes from the API request.