### PR TITLE
have modal capture mousedown events

### DIFF
--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -1,6 +1,6 @@
 <template>
   <TransitionRoot :show="isOpen" appear as="template">
-    <Dialog as="div" class="relative z-50" @close="exitHandler">
+    <Dialog as="div" class="relative z-50" @close="exitHandler" @mousedown.stop>
       <TransitionChild
         as="template"
         enter="duration-300 ease-out"


### PR DESCRIPTION
when the modal is open, it is totally in charge, so I think it makes sense as a general rule to capture the mousedown events. This means you must first dismiss the modal before something else that may be listening for clicks will fire.

specifically this fixes https://github.com/systeminit/si/issues/2606