### PR TITLE
fix(sdf-server): Ensure standard name for Asset scaffold funcs

### DIFF
--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -126,6 +126,7 @@ impl IntoResponse for SchemaVariantDefinitionError {
 pub async fn save_variant_def(
     ctx: &DalContext,
     request: &SaveVariantDefRequest,
+    updated_func_name: Option<String>,
 ) -> SchemaVariantDefinitionResult<()> {
     let mut variant_def = SchemaVariantDefinition::get_by_id(ctx, &request.id)
         .await?
@@ -155,6 +156,10 @@ pub async fn save_variant_def(
         .set_code_plaintext(ctx, Some(&request.code))
         .await?;
     asset_func.set_handler(ctx, Some(&request.handler)).await?;
+
+    if let Some(updated_name) = updated_func_name {
+        asset_func.set_name(ctx, updated_name).await?;
+    }
 
     Ok(())
 }

--- a/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
@@ -39,7 +39,7 @@ pub async fn save_variant_def(
 ) -> SchemaVariantDefinitionResult<Json<SaveVariantDefResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    super::save_variant_def(&ctx, &request).await?;
+    super::save_variant_def(&ctx, &request, None).await?;
 
     track(
         &posthog_client,


### PR DESCRIPTION
When an asset is scaffolded via the UI, we give the func a name like
`new asset 2703`. When we package the asset, it doesn't make sense
to include a func with that name. Therefore, when the exec_variant_def
is called, we now generate the func name as:

myTestFuncScaffold_202308222128

We are camelcasing the assetname, adding `Scaffold` to it and appending
the date in year month day hour minute format. We need to ensure that funcs
are unique and generating to minute should be unique enough
