### PR TITLE
fix(si): support self update through symbolic links on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,8 +4517,7 @@ dependencies = [
 [[package]]
 name = "self-replace"
 version = "1.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7c919783db74b5995f13506069227e4721d388bea4a8ac3055acac864ac16"
+source = "git+https://github.com/systeminit/self-replace.git?branch=unix-current-exe-read-link#702afa3e3ccc1d683bd7141a56f2dd4459f979f0"
 dependencies = [
  "fastrand",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,6 @@ vfs-tar = { version = "0.4.0", features = ["mmap"] }
 # pending a potential merge and release of
 # https://github.com/softprops/hyperlocal/pull/53
 hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-unix-stream" }
+# pending a potential merge and release of
+# https://github.com/mitsuhiko/self-replace/pull/18
+self-replace = { git = "https://github.com/systeminit/self-replace.git", branch = "unix-current-exe-read-link" }

--- a/lib/si-cli/src/cmd/update.rs
+++ b/lib/si-cli/src/cmd/update.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use flate2::read::GzDecoder;
 use inquire::Confirm;
 use serde::{Deserialize, Serialize};
-use std::{env, io::Cursor};
+use std::{env, fs, io::Cursor};
 use telemetry::prelude::*;
 
 use crate::{key_management::get_user_email, state::AppState, CliResult, SiCliError};
@@ -70,7 +70,10 @@ async fn update_current_binary(url: &str) -> CliResult<()> {
     })
     .await??;
 
-    let current_exe = env::current_exe()?;
+    let mut current_exe = env::current_exe()?;
+    if current_exe.is_symlink() {
+        current_exe = fs::read_link(current_exe)?;
+    }
     let new_binary = tempdir.path().join("si");
 
     println!("Replacing '{}' with new binary", current_exe.display());

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -17,6 +17,13 @@ git_fetch(
     visibility = [],
 )
 
+git_fetch(
+    name = "systeminit/self-replace.git",
+    repo = "https://github.com/systeminit/self-replace.git",
+    rev = "702afa3e3ccc1d683bd7141a56f2dd4459f979f0",
+    visibility = [],
+)
+
 http_archive(
     name = "Inflector-0.11.4.crate",
     sha256 = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3",
@@ -11845,19 +11852,11 @@ alias(
     visibility = ["PUBLIC"],
 )
 
-http_archive(
-    name = "self-replace-1.3.5.crate",
-    sha256 = "a0e7c919783db74b5995f13506069227e4721d388bea4a8ac3055acac864ac16",
-    strip_prefix = "self-replace-1.3.5",
-    urls = ["https://crates.io/api/v1/crates/self-replace/1.3.5/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
     name = "self-replace-1.3.5",
-    srcs = [":self-replace-1.3.5.crate"],
+    srcs = [":systeminit/self-replace.git"],
     crate = "self_replace",
-    crate_root = "self-replace-1.3.5.crate/src/lib.rs",
+    crate_root = "systeminit/self-replace/src/lib.rs",
     edition = "2018",
     platform = {
         "windows-gnu": dict(

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -4048,8 +4048,7 @@ dependencies = [
 [[package]]
 name = "self-replace"
 version = "1.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7c919783db74b5995f13506069227e4721d388bea4a8ac3055acac864ac16"
+source = "git+https://github.com/systeminit/self-replace.git?branch=unix-current-exe-read-link#702afa3e3ccc1d683bd7141a56f2dd4459f979f0"
 dependencies = [
  "fastrand",
  "tempfile",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -123,3 +123,6 @@ vfs-tar = { version = "0.4.0", features = ["mmap"] }
 # pending a potential merge and release of
 # https://github.com/softprops/hyperlocal/pull/53
 hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-unix-stream" }
+# pending a potential merge and release of
+# https://github.com/mitsuhiko/self-replace/pull/18
+self-replace = { git = "https://github.com/systeminit/self-replace.git", branch = "unix-current-exe-read-link" }


### PR DESCRIPTION
When the launcher (i.e. the `si` program) is installed from a non-root user and when they don't have either `$HOME/.local/bin` or `$HOME/bin` currently in their `$PATH`, the launcher is installed to `$HOME/.si/bin/si` and a symlink is created at `/usr/local/bin/si` with a sudo call (that is, the root user owns the symlink as it is a system directory).

Prior to this change, when a self update was attempted (via calling `si update --self) under the scenario above, the new binary would attempt to write itself to a temp file under the *symlink*'s  parent directory of `/usr/local/bin`. This would cause an permissions error that looks like:

```
Downloading new binary
Replacing '/usr/local/bin/si' with new binary
Error:
   0: io: Permission denied (os error 13) at path "/usr/local/bin/.si.__temp__6DqCUt"
   1: Permission denied (os error 13) at path "/usr/local/bin/.si.__temp__6DqCUt"

Location:
   <unknown>

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Additionally, if the non-root user happened to have write permission on `/usr/local/bin`, then the new binary would overwrite the symlink and install itself to `/usr/local/bin/si`, thus eliminating the symlink.

The detection of a symlink and its resolution by calling `std::fs::read_link` is provided via a fix in the upstream [self-replace](https://crates.io/crates/self-replace) crate.

References: mitsuhiko/self-replace#18

<img src="https://media3.giphy.com/media/AIt35N6MJs3qWWk9dL/giphy.gif"/>