### PR TITLE
fix(si): Ensure we only stop containers that are actually started

### DIFF
--- a/lib/si-cli/src/cmd/stop.rs
+++ b/lib/si-cli/src/cmd/stop.rs
@@ -32,7 +32,6 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
             .get_existing_container(container_identifier.clone())
             .await?;
         if existing.is_some() {
-            println!("Stopping container {}", container_identifier.clone());
             app.container_engine()
                 .stop_container(existing.unwrap().id.unwrap().to_string())
                 .await?;


### PR DESCRIPTION
When running `si stop` on a system that had stopped containers, we got
an error from docker as follows:

```
Stopping container local-web-1
Error:
   0: docker api: error 304 Not Modified - Not Modified
   1: error 304 Not Modified - Not Modified

Location:
   bin/si/src/main.rs:121
```

This PR now checks that a container is running before attempting to
stop it
