### PR TITLE
feat(web,sdf,auth-api) recover more gracefully from a reset database

### DIFF
--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -1,14 +1,26 @@
 <!-- eslint-disable vue/no-multiple-template-root -->
 <template>
   <div class="font-sans">
-    <RealtimeConnectionStatus />
-    <router-view :key="selectedWorkspace?.pk" />
-    <Teleport to="body">
-      <canvas
-        id="confetti"
-        class="fixed w-full h-full top-0 left-0 pointer-events-none z-100"
-      ></canvas>
-    </Teleport>
+    <template
+      v-if="
+        route.name !== 'auth-connect' &&
+        (!restoreAuthReqStatus.isRequested ||
+          restoreAuthReqStatus.isPending ||
+          reconnectAuthReqStatus.isPending)
+      "
+    >
+      <p>restoring auth...</p>
+    </template>
+    <template v-else>
+      <RealtimeConnectionStatus />
+      <router-view :key="selectedWorkspace?.pk" />
+      <Teleport to="body">
+        <canvas
+          id="confetti"
+          class="fixed w-full h-full top-0 left-0 pointer-events-none z-100"
+        ></canvas>
+      </Teleport>
+    </template>
   </div>
 </template>
 
@@ -21,6 +33,7 @@ import { useThemeContainer } from "@si/vue-lib/design-system";
 import SiLogoUrlLight from "@si/vue-lib/brand-assets/si-logo-symbol-white-bg.svg?url";
 import SiLogoUrlDark from "@si/vue-lib/brand-assets/si-logo-symbol-black-bg.svg?url";
 import { useHead } from "@vueuse/head";
+import { useRoute } from "vue-router";
 import { useCustomFontsLoadedProvider } from "./utils/useFontLoaded";
 import { useAuthStore } from "./store/auth.store";
 import { useWorkspacesStore } from "./store/workspaces.store";
@@ -58,6 +71,10 @@ useHead(
 // this token will be automatically injected into API requests
 const authStore = useAuthStore();
 authStore.initFromStorage().then();
+const restoreAuthReqStatus = authStore.getRequestStatus("RESTORE_AUTH");
+const reconnectAuthReqStatus = authStore.getRequestStatus("AUTH_RECONNECT");
+
+const route = useRoute();
 
 const workspacesStore = useWorkspacesStore();
 const selectedWorkspace = computed(() => workspacesStore.selectedWorkspace);

--- a/app/web/src/api/sdf/dal/user.ts
+++ b/app/web/src/api/sdf/dal/user.ts
@@ -1,8 +1,9 @@
-import { StandardModel } from "@/api/sdf/dal/standard_model";
-
-export interface User extends StandardModel {
+export interface User {
+  pk: string;
   name: string;
   email: string;
   // TODO should be camelcase, but changing backend is annoying
   picture_url?: string;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
 }

--- a/app/web/src/api/sdf/dal/workspace.ts
+++ b/app/web/src/api/sdf/dal/workspace.ts
@@ -1,4 +1,6 @@
 export interface Workspace {
   pk: string;
   name: string;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
 }

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -54,7 +54,9 @@ export const useRealtimeStore = defineStore("realtime", () => {
 
   // boolean tracking whether we are expecting connection to be active
   // currently only logic is if user is logged in
-  const connectionShouldBeEnabled = computed(() => authStore.userIsLoggedIn);
+  const connectionShouldBeEnabled = computed(
+    () => authStore.userIsLoggedInAndInitialized,
+  );
 
   // trigger connect / close as necessary
   watch(

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -51,7 +51,7 @@ export const useWorkspacesStore = addStoreHooks(
     onActivated() {
       const authStore = useAuthStore();
       watch(
-        () => authStore.userIsLoggedIn,
+        () => authStore.userIsLoggedInAndInitialized,
         (loggedIn) => {
           if (loggedIn) this.FETCH_USER_WORKSPACES();
         },

--- a/bin/auth-api/src/custom-state.ts
+++ b/bin/auth-api/src/custom-state.ts
@@ -1,5 +1,6 @@
 import Router from '@koa/router';
 import Koa from 'koa';
+import { Workspace } from '@prisma/client';
 import { UserWithTosStatus } from "./services/users.service";
 
 // types for the things we add to our koa ctx
@@ -8,7 +9,7 @@ export type CustomAppContext = {
 export type CustomAppState = {
   clientIp: string,
   authUser?: UserWithTosStatus,
-  // workspace?: Workspace
+  authWorkspace?: Workspace,
 };
 
 export type CustomRouteContext = Koa.ParameterizedContext<

--- a/bin/auth-api/src/routes/workspace.routes.ts
+++ b/bin/auth-api/src/routes/workspace.routes.ts
@@ -96,3 +96,17 @@ router.post("/complete-auth-connect", async (ctx) => {
     token,
   };
 });
+
+router.get("/auth-reconnect", async (ctx) => {
+  if (!ctx.state.authUser) {
+    throw new ApiError('Unauthorized', 'You must be logged in');
+  }
+  if (!ctx.state.authWorkspace) {
+    throw new ApiError('Unauthorized', 'You must pass a workspace-scoped auth token to use this endpoint');
+  }
+
+  ctx.body = {
+    user: ctx.state.authUser,
+    workspace: ctx.state.authWorkspace,
+  };
+});


### PR DESCRIPTION
this change helps us recover more gracefully from the database being empty - a situation that is now very common due to the way our launcher is setup and how we trash our containers.

The user remains logged in with a valid token, but the workspace (and user) do not exist in this freshly migrated db yet. Previously that initialization happened only in the handoff between the auth system and sdf.

Now instead we have an additional endpoint which can use the existing auth token and just handle this re-initialization. Note that we could do it on every reload (rather than just fetching from sdf which we do now) but this would add extra overhead to that call. So instead we first try to reestablish auth with sdf only, and then if we detect the situation of the workspace not existing, we reach out to the auth api to try to reinitialize it.

This means the flow is now that the user will be thrust back into an empty workspace again without any explanation, which I believe may feel a bit jarring. If we don't like how it feels, we can interject an additional screen which explains what is going on, and gives them the opportunity to log out, restore from a backup, etc...

NOTE - needs a little cleanup before merging