### PR TITLE
fix(si): When si delete has been run ensure that the containers are stopped

### DIFF
--- a/lib/si-cli/src/cmd/delete.rs
+++ b/lib/si-cli/src/cmd/delete.rs
@@ -15,6 +15,7 @@ impl AppState {
 
 async fn invoke(app: &AppState, is_preview: bool, keep_images: bool) -> CliResult<()> {
     app.check(true).await?;
+    app.stop().await?;
 
     if is_preview {
         println!("Deleted the following containers and associated images:");


### PR DESCRIPTION
This stops the following from happening:

```
Deleting container: local-jaeger-1 (fb9df0409d90e4cfa68392c47ed09eb688453115e22d1d4ce79b151f9b2cd87f)
Error:
   0: docker api: error 409 Conflict - You cannot remove a running container fb9df0409d90e4cfa68392c47ed09eb688453115e22d1d4ce79b151f9b2cd87f. Stop the container before attempting removal or force remove
   1: error 409 Conflict - You cannot remove a running container fb9df0409d90e4cfa68392c47ed09eb688453115e22d1d4ce79b151f9b2cd87f. Stop the container before attempting removal or force remove
```

Related to #2700
