### PR TITLE
feat(web): Secret store with only browser local data

### DIFF
--- a/app/web/src/components/AddSecretForm.vue
+++ b/app/web/src/components/AddSecretForm.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="overflow-y-auto flex flex-col gap-sm w-full h-full p-sm">
+    <!--  TODO: Add form validation  -->
     <VormInput v-model="secretFormData.name" type="text" label="Name">
       <template #instructions>
         <div class="text-neutral-700 dark:text-neutral-400 italic">
@@ -12,15 +13,36 @@
       type="textarea"
       label="Description"
     />
+    <VButton
+      size="sm"
+      tone="action"
+      loadingText="Storing Secret"
+      label="Store Secret"
+      @click="saveSecret"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { VormInput } from "@si/vue-lib/design-system";
+import { VormInput, VButton } from "@si/vue-lib/design-system";
 import { reactive } from "vue";
+import { SecretDefinitionId, useSecretsStore } from "@/store/secrets.store";
+
+const props = defineProps<{ definitionId: SecretDefinitionId }>();
+
+const secretsStore = useSecretsStore();
 
 const secretFormData = reactive({
   name: "",
   description: "",
 });
+
+const saveSecret = () => {
+  secretsStore.SAVE_SECRET(
+    props.definitionId,
+    secretFormData.name,
+    {},
+    secretFormData.description,
+  );
+};
 </script>

--- a/app/web/src/components/ComponentOutline/StatusIconWithPopover.vue
+++ b/app/web/src/components/ComponentOutline/StatusIconWithPopover.vue
@@ -3,7 +3,7 @@
     :class="
       clsx(
         'p-2xs rounded',
-        popoverRef && popoverRef.isOpen
+        popoverRef?.isOpen
           ? 'bg-action-300 dark:bg-action-400'
           : 'hover:bg-action-200 dark:hover:bg-action-300',
       )
@@ -16,9 +16,7 @@
       :type="type"
       :status="status"
       :size="size"
-      :tone="
-        isHovered || (popoverRef && popoverRef.isOpen) ? 'shade' : undefined
-      "
+      :tone="isHovered || popoverRef?.isOpen ? 'shade' : undefined"
     />
     <Popover
       ref="popoverRef"

--- a/app/web/src/components/CustomizeTabs.vue
+++ b/app/web/src/components/CustomizeTabs.vue
@@ -16,6 +16,13 @@
     >
       <slot v-if="tabContentSlug === 'packages'" />
     </TabGroupItem>
+    <TabGroupItem
+      v-if="featureFlagsStore.SECRETS"
+      slug="secrets"
+      label="SECRETS"
+    >
+      <slot v-if="tabContentSlug === 'secrets'" />
+    </TabGroupItem>
   </TabGroup>
 </template>
 
@@ -31,7 +38,7 @@ const featureFlagsStore = useFeatureFlagsStore();
 
 defineProps({
   tabContentSlug: {
-    type: String as PropType<"assets" | "functions" | "packages">,
+    type: String as PropType<"assets" | "functions" | "packages" | "secrets">,
     required: true,
   },
 });

--- a/app/web/src/components/PropertyEditor.vue
+++ b/app/web/src/components/PropertyEditor.vue
@@ -29,7 +29,7 @@
     >
       <VButton label="Add Secret" @click="(e) => popoverRef.open(e)" />
       <Popover ref="popoverRef" anchorDirectionX="left" anchorAlignY="bottom">
-        <SecretsList definitionName="AWS Credential" />
+        <SecretsList definitionId="Mocks" />
       </Popover>
     </div>
     <!-- temporary code for testing secrets popover -->

--- a/app/web/src/components/SecretsList.vue
+++ b/app/web/src/components/SecretsList.vue
@@ -13,7 +13,7 @@
         <div
           class="uppercase font-bold text-md pb-xs text-shade-100 dark:text-shade-0"
         >
-          Secret: {{ definitionName }}
+          Secret: {{ definitionId }}
         </div>
         <div class="text-xs italic text-neutral-600 dark:text-neutral-500">
           <template v-if="addingSecret">
@@ -39,18 +39,18 @@
       />
     </div>
 
-    <AddSecretForm v-if="addingSecret" />
+    <AddSecretForm v-if="addingSecret" definitionId="definitionId" />
     <div v-else class="overflow-y-auto flex flex-col h-full">
-      <template v-if="mockData.length > 0">
+      <template v-if="secrets.length > 0">
         <SecretCard
-          v-for="secret in mockData"
+          v-for="secret in secrets"
           :key="secret.id"
           :secret="secret"
         />
       </template>
       <div v-else class="flex flex-row items-center grow">
         <div class="text-center w-full">
-          No secrets of this defintion found.
+          No secrets of this definition found.
         </div>
       </div>
     </div>
@@ -59,16 +59,19 @@
 
 <script setup lang="ts">
 import { VButton } from "@si/vue-lib/design-system";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import clsx from "clsx";
-import { Secret } from "@/store/secrets.store";
-import { ActorAndTimestamp } from "@/store/components.store";
+import { useSecretsStore, SecretDefinitionId } from "@/store/secrets.store";
 import SecretCard from "./SecretCard.vue";
 import AddSecretForm from "./AddSecretForm.vue";
 
-const props = defineProps({
-  definitionName: { type: String, required: true },
-});
+const props = defineProps<{ definitionId: SecretDefinitionId }>();
+
+const secretsStore = useSecretsStore();
+
+const secrets = computed(
+  () => secretsStore.secretsByDefinitionId[props.definitionId] ?? [],
+);
 
 const addingSecret = ref(false);
 
@@ -79,72 +82,4 @@ const showAddSecretForm = () => {
 const cancelAddSecretForm = () => {
   addingSecret.value = false;
 };
-
-const mockData = [
-  {
-    id: "mock secret id 1",
-    definition: props.definitionName,
-    name: "Mock Secret Name 1",
-    description:
-      "this is the description of the secret written by the user it can be very long and they can just put as much content as they want Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa  qui officia deserunt mollit anim id est laborum",
-    createdInfo: {
-      actor: { kind: "user", label: "wendywildshape" },
-      timestamp: new Date().toDateString(),
-    } as ActorAndTimestamp,
-  },
-  {
-    id: "mock secret id 2",
-    definition: props.definitionName,
-    name: "Mock Secret Name 2 here this name is very long omg testing long names is important!",
-    description: "this is a shorter description",
-    createdInfo: {
-      actor: { kind: "user", label: "cooldood420" },
-      timestamp: new Date("12/20/2021").toDateString(),
-    } as ActorAndTimestamp,
-  },
-  {
-    id: "mock secret id 3",
-    definition: props.definitionName,
-    name: "Mock Secret Name 3",
-    description: "",
-    createdInfo: {
-      actor: {
-        kind: "user",
-        label: "whateverpersonlongusernamewowthatisreallylongidkwaytoolong",
-      },
-      timestamp: new Date("01/01/2023").toDateString(),
-    } as ActorAndTimestamp,
-  },
-  {
-    id: "mock secret id 4",
-    definition: props.definitionName,
-    name: "Mock Secret Name 4",
-    description: "this one is cool",
-    createdInfo: {
-      actor: { kind: "user", label: "angiecat" },
-      timestamp: new Date().toDateString(),
-    } as ActorAndTimestamp,
-  },
-  {
-    id: "mock secret id 5",
-    definition: props.definitionName,
-    name: "Mock Secret Name 5",
-    description: "",
-    createdInfo: {
-      actor: { kind: "user", label: "gabycat" },
-      timestamp: new Date().toDateString(),
-    } as ActorAndTimestamp,
-  },
-  {
-    id: "mock secret id 6",
-    definition: props.definitionName,
-    name: "THE FINAL MOCK SECRET",
-    description:
-      "with a description that fits on two lines but is not long enough to be truncated at all",
-    createdInfo: {
-      actor: { kind: "system", label: "System Initiative" },
-      timestamp: new Date().toDateString(),
-    } as ActorAndTimestamp,
-  },
-] as Secret[];
 </script>

--- a/app/web/src/components/Workspace/WorkspaceCustomizeSecrets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeSecrets.vue
@@ -1,0 +1,69 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
+<template>
+  <ResizablePanel rememberSizeKey="func-picker" side="left" :minSize="300">
+    <div class="flex flex-col h-full">
+      <div class="relative flex-grow">
+        <CustomizeTabs tabContentSlug="secrets">
+          <AddSecretForm definitionId="Mocks" class="h-auto" />
+          <ul class="m-xs">
+            <li v-for="(definition, index) in secretDefinitions" :key="index">
+              <span>{{ definition }}</span>
+              <ul class="ml-md flex flex-col gap-1">
+                <li
+                  v-for="secret in secretsStore.secretsByDefinitionId[
+                    definition
+                  ]"
+                  :key="secret.id"
+                  class="text-sm"
+                >
+                  <b>{{ secret.name }}</b>
+                  <i class="text-xs text-neutral-500">
+                    by {{ secret.createdInfo.actor.label }}
+                  </i>
+                  <VButton
+                    class="ml-2"
+                    size="xs"
+                    tone="neutral"
+                    icon="x-circle"
+                    @click="secretsStore.DELETE_SECRET(secret.id)"
+                  />
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </CustomizeTabs>
+      </div>
+    </div>
+  </ResizablePanel>
+  <div
+    class="grow overflow-hidden bg-shade-0 dark:bg-neutral-800 dark:text-shade-0 font-semi-bold flex flex-col relative"
+  >
+    <div class="inset-0 p-sm absolute overflow-auto">SECRETS ENTRIES LIST</div>
+  </div>
+  <ResizablePanel rememberSizeKey="func-details" side="right" :minSize="200">
+    <div v-if="FF_SECRETS" class="flex flex-col h-full items-center">
+      <ApplyChangeSetButton class="w-10/12 mx-auto my-4" />
+      <SidebarSubpanelTitle>Secret Details</SidebarSubpanelTitle>
+      WIP
+    </div>
+  </ResizablePanel>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { computed } from "vue";
+import { ResizablePanel, VButton } from "@si/vue-lib/design-system";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
+import ApplyChangeSetButton from "@/components/ApplyChangeSetButton.vue";
+import { useSecretsStore } from "@/store/secrets.store";
+import AddSecretForm from "@/components/AddSecretForm.vue";
+import CustomizeTabs from "../CustomizeTabs.vue";
+
+const secretsStore = useSecretsStore();
+const featureFlagsStore = useFeatureFlagsStore();
+
+const FF_SECRETS = computed(() => featureFlagsStore.SECRETS);
+
+const secretDefinitions = computed(() => secretsStore.definitions);
+</script>

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -92,6 +92,12 @@ const routes: RouteRecordRaw[] = [
             component: () =>
               import("@/components/Workspace/WorkspaceCustomizePackages.vue"),
           },
+          {
+            path: "s/:secretKind?",
+            name: "workspace-lab-secrets",
+            component: () =>
+              import("@/components/Workspace/WorkspaceCustomizeSecrets.vue"),
+          },
         ],
       },
       {

--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -1,25 +1,161 @@
+import { addStoreHooks } from "@si/vue-lib/pinia";
+import { defineStore } from "pinia";
+import * as _ from "lodash-es";
+
+import { useAuthStore } from "@/store/auth.store";
 import { ActorAndTimestamp } from "./components.store";
 
 export type SecretId = string;
-export type DefinitionId = string;
+export type SecretDefinitionId = string;
 
 export type Secret = {
   id: SecretId;
-  definition: DefinitionId;
+  definition: SecretDefinitionId;
   name: string;
-  description: string;
+  description?: string;
   createdInfo: ActorAndTimestamp;
-  updatedInfo: ActorAndTimestamp;
+  updatedInfo?: ActorAndTimestamp;
 };
 
-// backend endpoint
-// give me all secrets organized by definition id
-// create a secret of the given defintion id with the given encrypted payload
+export function useSecretsStore() {
+  return addStoreHooks(
+    defineStore("secrets", {
+      state: () => ({
+        secrets: {} as Secret[],
+      }),
+      getters: {
+        secretsByDefinitionId: (state) =>
+          _.groupBy(state.secrets, (s) => s.definition),
+        definitions(): SecretDefinitionId[] {
+          return _.keys(this.secretsByDefinitionId);
+        },
+      },
+      actions: {
+        SAVE_SECRET(
+          definition: SecretDefinitionId,
+          name: string,
+          value: Record<string, string>,
+          description?: string,
+        ) {
+          const id = Math.floor(Math.random() * 899999 + 100000).toString();
 
-// store functions
-// give me all secrets of one definition id
-// create a secret of the given defintion id (this includes encrypting the secret itself and sending it to the backend)
+          const { id: userId, name: userName } = useAuthStore().user ?? {
+            id: "-1",
+            name: "Anonymous",
+          };
 
-// next turn of the crank -
-// delete a secret
-// replace a secret
+          this.secrets.push({
+            id,
+            definition,
+            name,
+            description,
+            createdInfo: {
+              actor: { kind: "user", label: userName, id: userId },
+              timestamp: Date(),
+            },
+          });
+        },
+        DELETE_SECRET(id: SecretId) {
+          this.secrets = this.secrets.filter((s) => s.id !== id);
+        },
+      },
+      onActivated() {
+        this.secrets = [
+          {
+            id: "001",
+            definition: "AWS",
+            name: "Production",
+            createdInfo: {
+              actor: { kind: "user", label: "SI Sally", id: "001" },
+              timestamp: Date(),
+            },
+          },
+          {
+            id: "002",
+            definition: "AWS",
+            name: "Staging",
+            createdInfo: {
+              actor: { kind: "user", label: "SI Steve", id: "002" },
+              timestamp: Date(),
+            },
+          },
+          {
+            id: "003",
+            definition: "Azure",
+            name: "Production",
+            createdInfo: {
+              actor: { kind: "user", label: "SI Sally", id: "001" },
+              timestamp: Date(),
+            },
+          },
+          {
+            id: "mock secret id 1",
+            definition: "Mocks",
+            name: "Mock Secret Name 1",
+            description:
+              "this is the description of the secret written by the user it can be very long and they can just put as much content as they want Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa  qui officia deserunt mollit anim id est laborum",
+            createdInfo: {
+              actor: { kind: "user", label: "wendywildshape" },
+              timestamp: new Date().toDateString(),
+            } as ActorAndTimestamp,
+          },
+          {
+            id: "mock secret id 2",
+            definition: "Mocks",
+            name: "Mock Secret Name 2 here this name is very long omg testing long names is important!",
+            description: "this is a shorter description",
+            createdInfo: {
+              actor: { kind: "user", label: "cooldood420" },
+              timestamp: new Date("12/20/2021").toDateString(),
+            } as ActorAndTimestamp,
+          },
+          {
+            id: "mock secret id 3",
+            definition: "Mocks",
+            name: "Mock Secret Name 3",
+            description: "",
+            createdInfo: {
+              actor: {
+                kind: "user",
+                label:
+                  "whateverpersonlongusernamewowthatisreallylongidkwaytoolong",
+              },
+              timestamp: new Date("01/01/2023").toDateString(),
+            } as ActorAndTimestamp,
+          },
+          {
+            id: "mock secret id 4",
+            definition: "Mocks",
+            name: "Mock Secret Name 4",
+            description: "this one is cool",
+            createdInfo: {
+              actor: { kind: "user", label: "angiecat" },
+              timestamp: new Date().toDateString(),
+            } as ActorAndTimestamp,
+          },
+          {
+            id: "mock secret id 5",
+            definition: "Mocks",
+            name: "Mock Secret Name 5",
+            description: "",
+            createdInfo: {
+              actor: { kind: "user", label: "gabycat" },
+              timestamp: new Date().toDateString(),
+            } as ActorAndTimestamp,
+          },
+          {
+            id: "mock secret id 6",
+            definition: "Mocks",
+            name: "THE FINAL MOCK SECRET",
+            description:
+              "with a description that fits on two lines but is not long enough to be truncated at all",
+            createdInfo: {
+              actor: { kind: "system", label: "System Initiative" },
+              timestamp: new Date().toDateString(),
+            } as ActorAndTimestamp,
+          },
+        ];
+      },
+    }),
+  )();
+}


### PR DESCRIPTION
Functional version of secrets store with add and delete functionality, not hooked up to back end yet

Also implements a global secrets panel on the customize screen. On this iteration,  this is for development purposes only 

<img width="504" alt="image" src="https://github.com/systeminit/si/assets/6564471/803cc874-2cc2-4b3d-b52b-28b87e31d935">
