### PR TITLE
Add SDF Host and Port flags to SI launcher

### DIFF
--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           if ! [[ "${SI_STAFF}" =~ "$PR_AUTHOR" ]]; then
-            echo "Authored by one of our amazing cmmunity peeps!"
+            echo "Authored by one of our amazing community peeps!"
             echo "requires-community-tag=true" >> $GITHUB_OUTPUT
           else
             echo "Successfully checked the author against the staff list"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@ We contributors to System Initiative:
 * Dan Miller (@jazzdan)
 * Neil Hanlon (@NeilHanlon)
 * Matthew Sanabria (@sudomateo)
+* John Watson (@johnrwatson)

--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -59,6 +59,14 @@ pub(crate) struct Args {
     #[arg(long = "web-port", env = "SI_WEB_PORT", default_value = "8080")]
     pub web_port: u32,
 
+    /// Allows starting the sdf service and binding to a specific IP
+    #[arg(long = "sdf-host", env = "SI_SDF_ADDRESS", default_value = "127.0.0.1")]
+    pub sdf_host: String,
+
+    /// Allows starting the sdf service and binding to a specific port
+    #[arg(long = "sdf-port", env = "SI_SDF_PORT", default_value = "5156")]
+    pub sdf_port: u32,
+
     /// The engine in which to launch System Initiate Containers
     #[arg(value_parser = PossibleValuesParser::new(Engine::variants()))]
     #[arg(long, short, env = "SI_CONTAINER_ENGINE", default_value = "docker")]

--- a/bin/si/src/main.rs
+++ b/bin/si/src/main.rs
@@ -33,6 +33,9 @@ async fn main() -> Result<()> {
     let web_host = args.web_host.clone();
     let web_port = args.web_port;
 
+    let sdf_host = args.sdf_host.clone();
+    let sdf_port = args.sdf_port;
+
     let current_version = VERSION.trim();
 
     debug!(arguments =?args, "parsed cli arguments");
@@ -49,6 +52,8 @@ async fn main() -> Result<()> {
         is_preview,
         web_host,
         web_port,
+        sdf_host,
+        sdf_port,
         args.with_function_debug_logs,
         Arc::from(engine),
     );

--- a/lib/si-cli/src/cmd/start.rs
+++ b/lib/si-cli/src/cmd/start.rs
@@ -342,6 +342,8 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
                 .create_sdf(
                     container_name.clone(),
                     container.clone(),
+                    app.sdf_host(),
+                    app.sdf_port(),
                     si_data_dir.clone(),
                 )
                 .await?;
@@ -383,8 +385,8 @@ async fn invoke(app: &AppState, is_preview: bool) -> CliResult<()> {
                 .create_web(
                     container_name.clone(),
                     container.clone(),
-                    app.web_port(),
                     app.web_host(),
+                    app.web_port(),
                 )
                 .await?;
         }

--- a/lib/si-cli/src/engine.rs
+++ b/lib/si-cli/src/engine.rs
@@ -38,13 +38,20 @@ pub trait ContainerEngine {
         with_debug_logs: bool,
     ) -> CliResult<()>;
     async fn create_pinga(&self, name: String, image: String, data_dir: PathBuf) -> CliResult<()>;
-    async fn create_sdf(&self, name: String, image: String, data_dir: PathBuf) -> CliResult<()>;
+    async fn create_sdf(
+        &self, 
+        name: String, 
+        image: String,
+        host_ip: String,
+        host_port: u32,
+        data_dir: PathBuf,
+    ) -> CliResult<()>;
     async fn create_web(
         &self,
         name: String,
         image: String,
-        host_port: u32,
         host_ip: String,
+        host_port: u32,
     ) -> CliResult<()>;
 }
 

--- a/lib/si-cli/src/engine/docker_engine.rs
+++ b/lib/si-cli/src/engine/docker_engine.rs
@@ -438,7 +438,14 @@ impl ContainerEngine for DockerEngine {
         Ok(())
     }
 
-    async fn create_sdf(&self, name: String, image: String, data_dir: PathBuf) -> CliResult<()> {
+    async fn create_sdf(
+        &self, 
+        name: String, 
+        image: String, 
+        host_ip: String,
+        host_port: u32,
+        data_dir: PathBuf
+    ) -> CliResult<()> {
         let create_opts = ContainerCreateOpts::builder()
             .name(name)
             .image(format!("{0}:stable", image))
@@ -454,7 +461,10 @@ impl ContainerEngine for DockerEngine {
             ])
             .network_mode("bridge")
             .restart_policy("on-failure", 3)
-            .expose(PublishPort::tcp(5156), HostPort::new(5156))
+            .expose(
+                PublishPort::tcp(5156), 
+                HostPort::with_ip(host_port, host_ip),
+            )
             .volumes([
                 format!(
                     "{}:/run/sdf/cyclone_encryption.key:z",
@@ -476,8 +486,8 @@ impl ContainerEngine for DockerEngine {
         &self,
         name: String,
         image: String,
-        host_port: u32,
         host_ip: String,
+        host_port: u32,
     ) -> CliResult<()> {
         let create_opts = ContainerCreateOpts::builder()
             .name(name)

--- a/lib/si-cli/src/engine/podman_engine.rs
+++ b/lib/si-cli/src/engine/podman_engine.rs
@@ -636,7 +636,14 @@ impl ContainerEngine for PodmanEngine {
         Ok(())
     }
 
-    async fn create_sdf(&self, name: String, image: String, data_dir: PathBuf) -> CliResult<()> {
+    async fn create_sdf(
+        &self, 
+        name: String,
+        image: String,
+        host_ip: String,
+        host_port: u32,
+        data_dir: PathBuf
+    ) -> CliResult<()> {
         let create_opts = ContainerCreateOpts::builder()
             .name(name.clone())
             .image(format!("{0}:stable", image.clone()))
@@ -660,8 +667,8 @@ impl ContainerEngine for PodmanEngine {
             ]))
             .portmappings(vec![PortMapping {
                 container_port: Some(5156),
-                host_port: Some(5156),
-                host_ip: None,
+                host_port: Some(host_port.try_into().unwrap()),
+                host_ip: Some(host_ip),
                 protocol: None,
                 range: None,
             }])
@@ -710,8 +717,8 @@ impl ContainerEngine for PodmanEngine {
         &self,
         name: String,
         image: String,
-        host_port: u32,
         host_ip: String,
+        host_port: u32,
     ) -> CliResult<()> {
         let create_opts = ContainerCreateOpts::builder()
             .name(name.clone())

--- a/lib/si-cli/src/state.rs
+++ b/lib/si-cli/src/state.rs
@@ -12,6 +12,8 @@ pub struct AppState {
     is_preview: bool,
     web_host: String,
     web_port: u32,
+    sdf_host: String,
+    sdf_port: u32,
     with_function_debug_logs: bool,
     container_engine: Arc<Box<dyn ContainerEngine>>,
 }
@@ -25,6 +27,8 @@ impl AppState {
         is_preview: bool,
         web_host: String,
         web_port: u32,
+        sdf_host: String,
+        sdf_port: u32,
         with_function_debug_logs: bool,
         container_engine: Arc<Box<dyn ContainerEngine>>,
     ) -> Self {
@@ -35,6 +39,8 @@ impl AppState {
             is_preview,
             web_host,
             web_port,
+            sdf_host,
+            sdf_port,
             with_function_debug_logs,
             container_engine,
         }
@@ -62,6 +68,14 @@ impl AppState {
 
     pub fn web_port(&self) -> u32 {
         self.web_port
+    }
+
+    pub fn sdf_host(&self) -> String {
+        self.sdf_host.clone()
+    }
+
+    pub fn sdf_port(&self) -> u32 {
+        self.sdf_port
     }
 
     pub fn posthog_client(&self) -> &PosthogClient {


### PR DESCRIPTION
**_feat(si): add sdf-host and sdf-port options to si launcher_**
Based on one of the issues mentioned in: https://github.com/systeminit/si/issues/2700 regarding the sdf component being hardcoded to specific interfaces/ports.

Code has been added (in a similar tact to the web-port and web-host flags) to allow these to be configured. These flags are outlined below:
`--sdf-host (CLI) | SI_SDF_ADDRESS  (Shell) | 127.0.0.1 default`
`--sdf-port (CLI) | SI_SDF_PORT (Shell) | 5156 default`

Some tests have been run locally which validates the flags get set correctly. Happy to conduct/provide more test evidence as per requirements of maintainers.

---
**_chore: amended minor typo in community check workflow_**
Amended very minor typo in the community workflow/check