### PR TITLE
feat(si-pkg): Add ChangeSet node to SiPkg

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -48,7 +48,7 @@ pub enum ChangeSetError {
 pub type ChangeSetResult<T> = Result<T, ChangeSetError>;
 
 #[remain::sorted]
-#[derive(Deserialize, Serialize, Debug, Display, EnumString, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Display, EnumString, PartialEq, Eq, Clone)]
 pub enum ChangeSetStatus {
     Abandoned,
     Applied,

--- a/lib/si-pkg/pkg-workspace.json
+++ b/lib/si-pkg/pkg-workspace.json
@@ -5,6 +5,16 @@
   "description": "complex\nthings\nwith\nmultiple\nlines\n\n\n",
   "createdAt": "2023-08-28T00:19:25Z",
   "createdBy": "zacharyhamm",
-  "funcs": [],
-  "schemas": []
+  "defaultChangeSet": "head",
+  "changeSets": [
+    {
+      "name": "head",
+      "status": "Open"
+    },
+    {
+      "name": "Change set 1",
+      "based_on_change_set": "head",
+      "status": "Applied"
+    }
+  ]
 }

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -9,14 +9,15 @@ pub use pkg::{
 };
 pub use spec::{
     ActionFuncSpec, ActionFuncSpecBuilder, ActionFuncSpecKind, AttrFuncInputSpec,
-    AttrFuncInputSpecKind, FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder,
-    FuncDescriptionSpec, FuncDescriptionSpecBuilder, FuncSpec, FuncSpecBackendKind,
-    FuncSpecBackendResponseType, FuncUniqueId, LeafFunctionSpec, LeafFunctionSpecBuilder,
-    LeafInputLocation, LeafKind, MapKeyFuncSpec, MapKeyFuncSpecBuilder, PkgSpec, PkgSpecBuilder,
-    PropSpec, PropSpecBuilder, PropSpecKind, PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder,
-    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType,
-    SchemaVariantSpecPropRoot, SiPropFuncSpec, SiPropFuncSpecBuilder, SiPropFuncSpecKind,
-    SocketSpec, SocketSpecArity, SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind,
+    AttrFuncInputSpecKind, ChangeSetSpec, ChangeSetSpecBuilder, ChangeSetSpecStatus,
+    FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder, FuncDescriptionSpec,
+    FuncDescriptionSpecBuilder, FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType,
+    FuncUniqueId, LeafFunctionSpec, LeafFunctionSpecBuilder, LeafInputLocation, LeafKind,
+    MapKeyFuncSpec, MapKeyFuncSpecBuilder, PkgSpec, PkgSpecBuilder, PropSpec, PropSpecBuilder,
+    PropSpecKind, PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder, SchemaVariantSpec,
+    SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SchemaVariantSpecPropRoot,
+    SiPropFuncSpec, SiPropFuncSpecBuilder, SiPropFuncSpecKind, SocketSpec, SocketSpecArity,
+    SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind,
 };
 
 #[cfg(test)]
@@ -67,21 +68,20 @@ mod tests {
         let pkg_data = pkg.write_to_bytes().expect("failed to serialize pkg");
 
         let read_pkg = SiPkg::load_from_bytes(pkg_data).expect("failed to load pkg from bytes");
+        let metadata = read_pkg.metadata().expect("Get metadata (WorkspaceBackup)");
+
+        assert_eq!(description, metadata.description());
+
+        assert_eq!(SiPkgKind::WorkspaceBackup, metadata.kind());
+
+        assert_eq!(Some("head"), metadata.default_change_set());
+
+        let change_sets = read_pkg.change_sets().expect("able to get change_sets");
+        assert_eq!(2, change_sets.len());
 
         assert_eq!(
-            description,
-            read_pkg
-                .metadata()
-                .expect("get metadata (WorkspaceBackup)")
-                .description()
-        );
-
-        assert_eq!(
-            SiPkgKind::WorkspaceBackup,
-            read_pkg
-                .metadata()
-                .expect("get metadata for kind (WorkspaceBackup)")
-                .kind()
+            "head",
+            change_sets.get(0).expect("get first change set").name()
         );
     }
 

--- a/lib/si-pkg/src/node/change_set.rs
+++ b/lib/si-pkg/src/node/change_set.rs
@@ -1,0 +1,91 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+
+use super::PkgNode;
+use crate::{
+    node::ChangeSetChild,
+    spec::{ChangeSetSpec, ChangeSetSpecStatus},
+};
+
+const KEY_NAME_STR: &str = "name";
+const KEY_BASED_ON_CHANGE_SET: &str = "based_on_change_set";
+const KEY_STATUS: &str = "status";
+
+#[derive(Clone, Debug)]
+pub struct ChangeSetNode {
+    pub name: String,
+    pub based_on_change_set: Option<String>,
+    pub status: ChangeSetSpecStatus,
+}
+
+impl NameStr for ChangeSetNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl WriteBytes for ChangeSetNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_NAME_STR, self.name())?;
+        write_key_value_line(
+            writer,
+            KEY_BASED_ON_CHANGE_SET,
+            self.based_on_change_set.as_deref().unwrap_or(""),
+        )?;
+        write_key_value_line(writer, KEY_STATUS, self.status)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for ChangeSetNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let name = read_key_value_line(reader, KEY_NAME_STR)?;
+        let based_on_change_set_str = read_key_value_line(reader, KEY_BASED_ON_CHANGE_SET)?;
+        let based_on_change_set = if based_on_change_set_str.is_empty() {
+            None
+        } else {
+            Some(based_on_change_set_str.to_owned())
+        };
+
+        let status_str = read_key_value_line(reader, KEY_STATUS)?;
+        let status = ChangeSetSpecStatus::from_str(&status_str).map_err(GraphError::parse)?;
+
+        Ok(Self {
+            name,
+            based_on_change_set,
+            status,
+        })
+    }
+}
+
+impl NodeChild for ChangeSetSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::ChangeSet(ChangeSetNode {
+                name: self.name.to_owned(),
+                status: self.status,
+                based_on_change_set: self.based_on_change_set.to_owned(),
+            }),
+            vec![
+                Box::new(ChangeSetChild::Schemas(self.schemas.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(ChangeSetChild::Funcs(self.funcs.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            ],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -7,6 +7,8 @@ use object_tree::{
 mod action_func;
 mod attr_func_input;
 mod category;
+mod change_set;
+mod change_set_child;
 mod func;
 mod func_argument;
 mod func_description;
@@ -26,6 +28,8 @@ pub(crate) use self::{
     action_func::ActionFuncNode,
     attr_func_input::AttrFuncInputNode,
     category::CategoryNode,
+    change_set::ChangeSetNode,
+    change_set_child::{ChangeSetChild, ChangeSetChildNode},
     func::FuncNode,
     func_argument::FuncArgumentNode,
     func_description::FuncDescriptionNode,
@@ -45,6 +49,8 @@ pub(crate) use self::{
 const NODE_KIND_ACTION_FUNC: &str = "action_func";
 const NODE_KIND_ATTR_FUNC_INPUT: &str = "attr_func_input";
 const NODE_KIND_CATEGORY: &str = "category";
+const NODE_KIND_CHANGE_SET: &str = "change_set";
+const NODE_KIND_CHANGE_SET_CHILD: &str = "change_set_child";
 const NODE_KIND_FUNC: &str = "func";
 const NODE_KIND_FUNC_ARGUMENT: &str = "func_argument";
 const NODE_KIND_FUNC_DESCRIPTION: &str = "func_description";
@@ -68,6 +74,8 @@ pub enum PkgNode {
     ActionFunc(ActionFuncNode),
     AttrFuncInput(AttrFuncInputNode),
     Category(CategoryNode),
+    ChangeSet(ChangeSetNode),
+    ChangeSetChild(ChangeSetChildNode),
     Func(FuncNode),
     FuncArgument(FuncArgumentNode),
     FuncDescription(FuncDescriptionNode),
@@ -88,6 +96,8 @@ impl PkgNode {
     pub const ACTION_FUNC_KIND_STR: &str = NODE_KIND_ACTION_FUNC;
     pub const ATTR_FUNC_INPUT_KIND_STR: &str = NODE_KIND_ATTR_FUNC_INPUT;
     pub const CATEGORY_KIND_STR: &str = NODE_KIND_CATEGORY;
+    pub const CHANGE_SET_KIND_STR: &str = NODE_KIND_CHANGE_SET;
+    pub const CHANGE_SET_CHILD_KIND_STR: &str = NODE_KIND_CHANGE_SET_CHILD;
     pub const FUNC_KIND_STR: &str = NODE_KIND_FUNC;
     pub const FUNC_ARGUMENT_KIND_STR: &str = NODE_KIND_FUNC_ARGUMENT;
     pub const FUNC_DESCRIPTION_KIND_STR: &str = NODE_KIND_FUNC_DESCRIPTION;
@@ -107,6 +117,8 @@ impl PkgNode {
         match self {
             Self::AttrFuncInput(_) => NODE_KIND_ATTR_FUNC_INPUT,
             Self::Category(_) => NODE_KIND_CATEGORY,
+            Self::ChangeSet(_) => NODE_KIND_CHANGE_SET,
+            Self::ChangeSetChild(_) => NODE_KIND_CHANGE_SET_CHILD,
             Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
             Self::Func(_) => NODE_KIND_FUNC,
             Self::FuncArgument(_) => NODE_KIND_FUNC_ARGUMENT,
@@ -131,6 +143,8 @@ impl NameStr for PkgNode {
         match self {
             Self::AttrFuncInput(node) => node.name(),
             Self::Category(node) => node.name(),
+            Self::ChangeSet(node) => node.name(),
+            Self::ChangeSetChild(node) => node.name(),
             Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
             Self::Func(node) => node.name(),
             Self::FuncArgument(node) => node.name(),
@@ -157,6 +171,8 @@ impl WriteBytes for PkgNode {
         match self {
             Self::AttrFuncInput(node) => node.write_bytes(writer)?,
             Self::Category(node) => node.write_bytes(writer)?,
+            Self::ChangeSet(node) => node.write_bytes(writer)?,
+            Self::ChangeSetChild(node) => node.write_bytes(writer)?,
             Self::ActionFunc(node) => node.write_bytes(writer)?,
             Self::Func(node) => node.write_bytes(writer)?,
             Self::FuncArgument(node) => node.write_bytes(writer)?,
@@ -191,6 +207,10 @@ impl ReadBytes for PkgNode {
                 Self::AttrFuncInput(AttrFuncInputNode::read_bytes(reader)?)
             }
             NODE_KIND_CATEGORY => Self::Category(CategoryNode::read_bytes(reader)?),
+            NODE_KIND_CHANGE_SET => Self::ChangeSet(ChangeSetNode::read_bytes(reader)?),
+            NODE_KIND_CHANGE_SET_CHILD => {
+                Self::ChangeSetChild(ChangeSetChildNode::read_bytes(reader)?)
+            }
             NODE_KIND_FUNC => Self::Func(FuncNode::read_bytes(reader)?),
             NODE_KIND_FUNC_ARGUMENT => Self::FuncArgument(FuncArgumentNode::read_bytes(reader)?),
             NODE_KIND_FUNC_DESCRIPTION => {

--- a/lib/si-pkg/src/pkg/change_set.rs
+++ b/lib/si-pkg/src/pkg/change_set.rs
@@ -1,0 +1,98 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgError, SiPkgSchema, Source};
+use crate::SiPkgFunc;
+use crate::{
+    node::{ChangeSetChildNode, PkgNode},
+    ChangeSetSpecStatus,
+};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgChangeSet<'a> {
+    name: String,
+    based_on_change_set: Option<String>,
+    status: ChangeSetSpecStatus,
+
+    hash: Hash,
+
+    source: Source<'a>,
+}
+
+macro_rules! impl_change_set_children_from_graph {
+    ($fn_name:ident, ChangeSetChildNode::$child_node:ident, $pkg_type:ident) => {
+        pub fn $fn_name(&self) -> PkgResult<Vec<$pkg_type>> {
+            let mut entries = vec![];
+            if let Some(child_idxs) = self
+                .source
+                .graph
+                .neighbors_directed(self.source.node_idx, Outgoing)
+                .find(|node_idx| {
+                    matches!(
+                        &self.source.graph[*node_idx].inner(),
+                        PkgNode::ChangeSetChild(ChangeSetChildNode::$child_node)
+                    )
+                })
+            {
+                let child_node_idxs: Vec<_> = self
+                    .source
+                    .graph
+                    .neighbors_directed(child_idxs, Outgoing)
+                    .collect();
+
+                for child_idx in child_node_idxs {
+                    entries.push($pkg_type::from_graph(self.source.graph, child_idx)?);
+                }
+            }
+
+            Ok(entries)
+        }
+    };
+}
+
+impl<'a> SiPkgChangeSet<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let change_set_hashed_node = &graph[node_idx];
+        let change_set_node = match change_set_hashed_node.inner() {
+            PkgNode::ChangeSet(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::CHANGE_SET_KIND_STR,
+                    unexpected.node_kind_str(),
+                ));
+            }
+        };
+
+        let change_set = Self {
+            name: change_set_node.name,
+            status: change_set_node.status,
+            based_on_change_set: change_set_node.based_on_change_set,
+            hash: change_set_hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        };
+
+        Ok(change_set)
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    pub fn status(&self) -> ChangeSetSpecStatus {
+        self.status
+    }
+
+    pub fn based_on_change_set(&self) -> Option<&str> {
+        self.based_on_change_set.as_deref()
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    impl_change_set_children_from_graph!(funcs, ChangeSetChildNode::Funcs, SiPkgFunc);
+    impl_change_set_children_from_graph!(schemas, ChangeSetChildNode::Schemas, SiPkgSchema);
+}

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 mod action_func;
 mod attr_func_input;
+mod change_set;
 mod func;
 mod func_description;
 mod leaf_function;
@@ -17,8 +18,9 @@ mod validation;
 mod variant;
 
 pub use {
-    action_func::*, attr_func_input::*, func::*, func_description::*, leaf_function::*,
-    map_key_func::*, prop::*, schema::*, si_prop_func::*, socket::*, validation::*, variant::*,
+    action_func::*, attr_func_input::*, change_set::*, func::*, func_description::*,
+    leaf_function::*, map_key_func::*, prop::*, schema::*, si_prop_func::*, socket::*,
+    validation::*, variant::*,
 };
 
 use super::SiPkgKind;
@@ -39,12 +41,21 @@ pub struct PkgSpec {
     pub created_at: DateTime<Utc>,
     #[builder(setter(into))]
     pub created_by: String,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub default_change_set: Option<String>,
 
     #[builder(setter(each(name = "schema", into)), default)]
+    #[serde(default)]
     pub schemas: Vec<SchemaSpec>,
 
     #[builder(setter(each(name = "func", into)), default)]
+    #[serde(default)]
     pub funcs: Vec<FuncSpec>,
+
+    #[builder(setter(each(name = "change_set", into)), default)]
+    #[serde(default)]
+    pub change_sets: Vec<ChangeSetSpec>,
 }
 
 impl PkgSpec {

--- a/lib/si-pkg/src/spec/change_set.rs
+++ b/lib/si-pkg/src/spec/change_set.rs
@@ -1,0 +1,42 @@
+use super::{FuncSpec, SchemaSpec, SpecError};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
+
+#[remain::sorted]
+#[derive(Deserialize, Serialize, Debug, Display, EnumString, PartialEq, Eq, Clone, Copy)]
+pub enum ChangeSetSpecStatus {
+    Abandoned,
+    Applied,
+    Closed,
+    Failed,
+    Open,
+}
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct ChangeSetSpec {
+    #[builder(setter(into))]
+    pub name: String,
+
+    #[builder(setter(into))]
+    pub based_on_change_set: Option<String>,
+
+    #[builder(setter(into))]
+    pub status: ChangeSetSpecStatus,
+
+    #[builder(setter(each(name = "schema", into)), default)]
+    #[serde(default)]
+    pub schemas: Vec<SchemaSpec>,
+
+    #[builder(setter(each(name = "func", into)), default)]
+    #[serde(default)]
+    pub funcs: Vec<FuncSpec>,
+}
+
+impl ChangeSetSpec {
+    pub fn builder() -> ChangeSetSpecBuilder {
+        ChangeSetSpecBuilder::default()
+    }
+}


### PR DESCRIPTION
Adds a new package "category" for change sets. Adds the idea of a "default_change_set" to the SiPkg. ChangeSets are a name, a status and a pointer to the change set that they are "based on", along with child nodes for functions and schemas. In the future they will also include Components (with Node Positions), and Edges.