### PR TITLE
workspace export/import UI

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -3,7 +3,6 @@
     <RequestStatusMessage
       v-if="loadAssetReqStatus.isPending"
       :requestStatus="loadAssetReqStatus"
-      showLoaderWithoutMessage
     />
     <ScrollArea v-else-if="assetStore.selectedAsset && assetId">
       <template #top>

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -2,7 +2,6 @@
   <RequestStatusMessage
     v-if="loadAssetReqStatus.isPending"
     :requestStatus="loadAssetReqStatus"
-    showLoaderWithoutMessage
   />
   <ScrollArea
     v-else-if="assetId && selectedAsset"

--- a/app/web/src/components/AssetFuncAttachModal.vue
+++ b/app/web/src/components/AssetFuncAttachModal.vue
@@ -80,10 +80,7 @@
           Select an existing function to attach it to this asset
         </div>
         <div v-if="loadFuncDetailsReq?.value.isPending">
-          <RequestStatusMessage
-            :requestStatus="loadFuncDetailsReq.value"
-            showLoaderWithoutMessage
-          />
+          <RequestStatusMessage :requestStatus="loadFuncDetailsReq.value" />
         </div>
         <CodeEditor
           v-if="loadFuncDetailsReq && !loadFuncDetailsReq?.value.isPending"

--- a/app/web/src/components/AssetFuncListPanel.vue
+++ b/app/web/src/components/AssetFuncListPanel.vue
@@ -3,7 +3,6 @@
     <RequestStatusMessage
       v-if="loadAssetReqStatus.isPending"
       :requestStatus="loadAssetReqStatus"
-      showLoaderWithoutMessage
     />
     <ScrollArea>
       <template #top>

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -10,8 +10,9 @@
       (loadFuncDetailsReqStatus.isPending && !storeFuncDetails) ||
       !loadFuncDetailsReqStatus.isRequested
     "
-    >Loading function "{{ selectedFuncSummary?.name }}"</LoadingMessage
   >
+    Loading function "{{ selectedFuncSummary?.name }}"
+  </LoadingMessage>
   <div
     v-else-if="selectedFuncId && editingFunc"
     :class="

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -27,7 +27,7 @@
       v-else-if="loadFuncDetailsReq.isError"
       :requestStatus="loadFuncDetailsReq"
     />
-    <LoadingMessage v-else noMessage />
+    <LoadingMessage v-else />
   </div>
 </template>
 

--- a/app/web/src/components/WorkspaceExportModal.vue
+++ b/app/web/src/components/WorkspaceExportModal.vue
@@ -1,0 +1,63 @@
+<template>
+  <Modal
+    ref="modalRef"
+    title="Export Workspace"
+    size="lg"
+    @closeComplete="closeHandler"
+  >
+    <Stack>
+      <template v-if="exportReqStatus.isSuccess">
+        <p>Success!</p>
+        <p>
+          You can now restore your workspace to this backup by going to
+          <br />
+          workspace settings (gear in top right) > "Import Workspace"
+        </p>
+
+        <VButton icon="check" @click="close">Close this window</VButton>
+      </template>
+      <template v-else>
+        <p>
+          You are about to export a backup of this workspace to the cloud. You
+          will then be able to import / restore this backup on this or another
+          running instance of SI.
+        </p>
+
+        <p>Click the button below to continue:</p>
+
+        <VButton
+          icon="cloud-upload"
+          :requestStatus="exportReqStatus"
+          loadingText="Exporting your workspace..."
+          @click="continueHandler"
+          >Export a backup of this workspace</VButton
+        >
+      </template>
+    </Stack>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { Modal, Stack, VButton, useModal } from "@si/vue-lib/design-system";
+import { ref } from "vue";
+import { useWorkspacesStore } from "@/store/workspaces.store";
+
+const workspacesStore = useWorkspacesStore();
+const exportReqStatus = workspacesStore.getRequestStatus("EXPORT_WORKSPACE");
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const { open: openModal, close } = useModal(modalRef);
+
+function open() {
+  openModal();
+}
+
+function continueHandler() {
+  workspacesStore.EXPORT_WORKSPACE();
+}
+function closeHandler() {
+  workspacesStore.clearRequestStatus("EXPORT_WORKSPACE");
+}
+
+defineExpose({ open, close });
+</script>

--- a/app/web/src/components/WorkspaceImportModal.vue
+++ b/app/web/src/components/WorkspaceImportModal.vue
@@ -1,0 +1,143 @@
+<template>
+  <Modal
+    ref="modalRef"
+    title="Import Workspace"
+    size="xl"
+    :noExit="blockExit"
+    noAutoFocus
+  >
+    <Stack>
+      <template v-if="importReqStatus.isPending">
+        <LoadingMessage>
+          Restoring your workspace from a backup!
+          <template #moreContent>
+            <p class="italic font-sm">
+              Please do not refresh while this in progress.
+            </p>
+          </template>
+        </LoadingMessage>
+      </template>
+      <template v-else-if="importReqStatus.isSuccess">
+        <p>Your workspace has been restored!</p>
+        <p>To see your changes, please reload your browser</p>
+        <VButton icon="refresh" @click="refreshHandler">Reload</VButton>
+      </template>
+      <template v-else>
+        <p>
+          You are about to restore from a workspace backup. Please note that all
+          data currently in the local workspace will be overwritten and replaced
+          with the contents of the backup.
+        </p>
+        <p>
+          To continue, please select the backup / export you would like to
+          restore from, and confirm the loss of local data:
+        </p>
+
+        <ErrorMessage :requestStatus="loadExportsReqStatus" />
+
+        <template v-if="loadExportsReqStatus.isSuccess">
+          <VormInput
+            v-model="selectedExportId"
+            type="dropdown"
+            label="Select an export to restore from"
+            placeholder="- Select an export -"
+            required
+            requiredMessage="Select an export to continue"
+          >
+            <VormInputOption
+              v-for="item in exportsList"
+              :key="item.id"
+              :value="item.id"
+            >
+              {{ item.createdAt }}
+            </VormInputOption>
+          </VormInput>
+        </template>
+        <template v-else-if="loadExportsReqStatus.isPending">
+          <VormInput type="container" label="Select an export to restore from">
+            <Inline alignY="center">
+              <Icon name="loader" />
+              <div>Loading your exports</div>
+            </Inline>
+          </VormInput>
+        </template>
+
+        <VormInput
+          v-model="confirmedDataLoss"
+          type="checkbox"
+          noLabel
+          required
+          requiredMessage="You must check this box to continue"
+        >
+          I understand my local workspace data will be overwritten
+        </VormInput>
+
+        <VButton
+          icon="cloud-download"
+          :disabled="!loadExportsReqStatus.isSuccess || validationState.isError"
+          :requestStatus="importReqStatus"
+          @click="continueHandler"
+          >Restore from backup</VButton
+        >
+      </template>
+    </Stack>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import * as _ from "lodash-es";
+import {
+  ErrorMessage,
+  Icon,
+  Inline,
+  LoadingMessage,
+  Modal,
+  Stack,
+  VButton,
+  VormInput,
+  VormInputOption,
+  useModal,
+  useValidatedInputGroup,
+} from "@si/vue-lib/design-system";
+import { computed, ref } from "vue";
+import { useWorkspacesStore } from "@/store/workspaces.store";
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const { open: openModal, close } = useModal(modalRef);
+
+const { validationState, validationMethods } = useValidatedInputGroup();
+
+const workspacesStore = useWorkspacesStore();
+const loadExportsReqStatus = workspacesStore.getRequestStatus(
+  "FETCH_WORKSPACE_EXPORTS",
+);
+const importReqStatus = workspacesStore.getRequestStatus("IMPORT_WORKSPACE");
+
+const exportsList = computed(() => workspacesStore.workspaceExports);
+
+const selectedExportId = ref<string>();
+const confirmedDataLoss = ref(false);
+
+function open() {
+  selectedExportId.value = undefined;
+  confirmedDataLoss.value = false;
+  workspacesStore.FETCH_WORKSPACE_EXPORTS();
+  openModal();
+}
+
+async function continueHandler() {
+  if (validationMethods.hasError()) return;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await workspacesStore.IMPORT_WORKSPACE(selectedExportId.value!);
+}
+
+function refreshHandler() {
+  window.location.reload();
+}
+
+const blockExit = computed(
+  () => importReqStatus.value.isPending || importReqStatus.value.isSuccess,
+);
+
+defineExpose({ open, close });
+</script>

--- a/app/web/src/components/layout/navbar/Navbar.vue
+++ b/app/web/src/components/layout/navbar/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="bg-neutral-900 text-white relative border-b border-shade-100 shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] z-100"
+    class="bg-neutral-900 text-white relative border-b border-shade-100 shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] z-90"
   >
     <div class="pl-sm">
       <div class="flex items-center h-16">

--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -6,6 +6,8 @@
 
     <SiThemeSwitcher />
 
+    <WorkspaceSettingsMenu v-if="featureFlagsStore.WORKSPACE_BACKUPS" />
+
     <NavbarButton tooltipText="Profile">
       <template #default="{ open, hovered }">
         <div class="flex-row flex text-white items-center">
@@ -41,8 +43,12 @@
 import { Icon, DropdownMenuItem } from "@si/vue-lib/design-system";
 import SiArrow from "@/components/SiArrow.vue";
 import { useAuthStore } from "@/store/auth.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import SiThemeSwitcher from "./NavbarThemeSwitcher.vue";
 import NavbarButton from "./NavbarButton.vue";
+import WorkspaceSettingsMenu from "./WorkspaceSettingsMenu.vue";
+
+const featureFlagsStore = useFeatureFlagsStore();
 
 const copyURL = () => {
   navigator.clipboard.writeText(window.location.href);

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -1,0 +1,33 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
+<template>
+  <NavbarButton tooltipText="Workspace Settings">
+    <Icon name="settings" />
+
+    <template #dropdownContent>
+      <DropdownMenuItem
+        icon="cloud-upload"
+        label="Export Workspace"
+        @click="exportModalRef?.open()"
+      />
+      <DropdownMenuItem
+        icon="cloud-download"
+        label="Import Workspace"
+        @click="importModalRef?.open()"
+      />
+    </template>
+  </NavbarButton>
+
+  <WorkspaceImportModal ref="importModalRef" />
+  <WorkspaceExportModal ref="exportModalRef" />
+</template>
+
+<script setup lang="ts">
+import { DropdownMenuItem, Icon } from "@si/vue-lib/design-system";
+import { ref } from "vue";
+import WorkspaceImportModal from "@/components/WorkspaceImportModal.vue";
+import WorkspaceExportModal from "@/components/WorkspaceExportModal.vue";
+import NavbarButton from "./NavbarButton.vue";
+
+const importModalRef = ref<InstanceType<typeof WorkspaceImportModal>>();
+const exportModalRef = ref<InstanceType<typeof WorkspaceExportModal>>();
+</script>

--- a/app/web/src/components/modules/ModuleDetailsPanel.vue
+++ b/app/web/src/components/modules/ModuleDetailsPanel.vue
@@ -2,7 +2,6 @@
   <RequestStatusMessage
     v-if="localDetailsReq.isPending"
     :requestStatus="localDetailsReq"
-    showLoaderWithoutMessage
   />
   <div v-else-if="localDetails" class="flex flex-col">
     <div

--- a/app/web/src/pages/WorkspaceSinglePage.vue
+++ b/app/web/src/pages/WorkspaceSinglePage.vue
@@ -40,7 +40,7 @@
           class="text-center text-2xl z-100 absolute w-full h-full bg-black bg-opacity-50 flex flex-row justify-center items-center"
         >
           <div class="bg-black text-white w-1/5 rounded-lg">
-            <LoadingMessage message="Creating Change Set..." />
+            <LoadingMessage>Creating Change Set...</LoadingMessage>
           </div>
         </div>
         <div class="w-full h-full flex flex-row relative overflow-hidden">

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -1,45 +1,37 @@
 import { defineStore } from "pinia";
-import { addStoreHooks } from "@si/vue-lib/pinia";
 import * as _ from "lodash-es";
+import { addStoreHooks } from "@si/vue-lib/pinia";
 import { posthog } from "@/utils/posthog";
 
-type FlagStoreKey = "CONTRIBUTE_BUTTON" | "MODULES_TAB" | "SECRETS";
-
-// The key to this object is the flag name on PostHog, the "storeKey" property is the
-// key used when accessing it from the Pinia feature flag store
-const FLAGS: { [key: string]: { storeKey: FlagStoreKey; default: boolean } } = {
-  modules_tab: {
-    storeKey: "MODULES_TAB",
-    default: false,
-  },
-  contribute_button: {
-    storeKey: "CONTRIBUTE_BUTTON",
-    default: false,
-  },
-  secrets: {
-    storeKey: "SECRETS",
-    default: false,
-  },
+// translation from store key to posthog feature flag name
+const FLAG_MAPPING = {
+  // STORE_FLAG_NAME: "posthogFlagName",
+  MODULES_TAB: "modules_tab",
+  CONTRIBUTE_BUTTON: "contribute_button",
+  SECRETS: "secrets",
+  WORKSPACE_BACKUPS: "workspaceBackups",
 };
 
-const flagsToState = () =>
-  Object.values(FLAGS).reduce((state, flag) => {
-    state[flag.storeKey] = flag.default;
-    return state;
-  }, {} as { [key in FlagStoreKey]: boolean });
+type FeatureFlags = keyof typeof FLAG_MAPPING;
+const PH_TO_STORE_FLAG_LOOKUP = _.invert(FLAG_MAPPING) as Record<
+  string,
+  FeatureFlags
+>;
 
 export function useFeatureFlagsStore() {
   return addStoreHooks(
     defineStore("feature-flags", {
-      state: () => flagsToState(),
+      // all flags default to false
+      state: () => _.mapValues(FLAG_MAPPING, () => false),
       onActivated() {
-        posthog.onFeatureFlags((flags) => {
-          for (const flag of flags) {
-            const flagKey = FLAGS[flag]?.storeKey;
-            if (flagKey) {
-              this[flagKey] = true;
+        posthog.onFeatureFlags((phFlags) => {
+          // reset local flags from posthog data
+          _.each(phFlags, (phFlag) => {
+            const storeFlagKey = PH_TO_STORE_FLAG_LOOKUP[phFlag];
+            if (storeFlagKey) {
+              this[storeFlagKey as FeatureFlags] = true;
             }
-          }
+          });
         });
       },
     }),

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -8,10 +8,17 @@ import { useRouterStore } from "./router.store";
 
 type WorkspacePk = string;
 
+type WorkspaceExportId = string;
+type WorkspaceExportSummary = {
+  id: WorkspaceExportId;
+  createdAt: IsoDateString;
+};
+
 export const useWorkspacesStore = addStoreHooks(
   defineStore("workspaces", {
     state: () => ({
       workspacesByPk: {} as Record<WorkspacePk, Workspace>,
+      workspaceExports: [] as WorkspaceExportSummary[],
     }),
     getters: {
       allWorkspaces: (state) => _.values(state.workspacesByPk),
@@ -45,6 +52,40 @@ export const useWorkspacesStore = addStoreHooks(
             // NOTE - we could cache this stuff in localstorage too to avoid showing loading state
             // but this is a small optimization to make later...
           },
+        });
+      },
+
+      async EXPORT_WORKSPACE() {
+        return new ApiRequest({
+          // using placeholder url to just make a request
+          url: "/session/load_workspace",
+          _delay: 3000,
+          onSuccess: (response) => {},
+        });
+      },
+      async FETCH_WORKSPACE_EXPORTS() {
+        return new ApiRequest({
+          // using placeholder url to just make a request
+          url: "/session/load_workspace",
+          _delay: 1500,
+          onSuccess: (response) => {
+            this.workspaceExports = [
+              { id: "a", createdAt: "2023-08-30T11:22:33Z" },
+              { id: "b", createdAt: "2023-08-26T08:04:11Z" },
+              { id: "c", createdAt: "2023-08-25T18:19:20Z" },
+              { id: "d", createdAt: "2023-08-25T14:15:16Z" },
+            ];
+          },
+        });
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      async IMPORT_WORKSPACE(exportId: WorkspaceExportId) {
+        return new ApiRequest({
+          // using placeholder url to just make a request
+          url: "/session/load_workspace",
+          _delay: 5000,
+          // params: { id: exportId },
+          onSuccess: (response) => {},
         });
       },
     },

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -44,7 +44,6 @@ you can pass in options as props too */
               modelValue === null && !placeholderSelectable
                 ? '--placeholder-selected'
                 : '',
-              { sm: '', md: 'vorm-input__input-medium' }[props.size],
             ]"
             :disabled="disabledBySelfOrParent"
             :value="valueForSelectField"
@@ -360,6 +359,7 @@ const computedClasses = computed(() => ({
   "--focused": isFocus.value,
   "--disabled": disabledBySelfOrParent.value,
   [`--type-${props.type}`]: true,
+  [`--size-${props.size}`]: true,
   [`--theme-${theme.value}`]: true,
 }));
 
@@ -722,15 +722,17 @@ defineExpose({
   border: 1px solid var(--border-color);
   border-radius: 3px;
   transition: border-color 0.15s;
-  padding: 4px 10px;
+  padding: 4px 12px;
   color: var(--text-color);
   font: inherit;
   background-color: var(--bg-color);
-  line-height: 2;
 
-  &.vorm-input__input-medium {
+  .vorm-input.--size-sm & {
+    padding: 4px 10px;
+    height: 32px;
+  }
+  .vorm-input.--size-md & {
     padding: 8px 12px;
-    height: 40px;
   }
 
   &:hover {
@@ -744,9 +746,7 @@ defineExpose({
 
   select& {
     -webkit-appearance: none;
-    padding-top: 0;
-    padding-bottom: 0;
-    padding-right: 28px; // to make space for dropdown arrow
+    padding-right: 28px !important; // to make space for dropdown arrow
 
     // dropdown arrow on right
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40' fill='%23666'><polygon points='10,15 30,15 20,25'/></svg>");
@@ -899,9 +899,7 @@ defineExpose({
     display: block;
     width: 24px;
     height: 24px;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    margin-right: 8px;
+    margin-right: 12px;
     flex-shrink: 0;
     cursor: pointer;
 

--- a/lib/vue-lib/src/design-system/general/LoadingMessage.vue
+++ b/lib/vue-lib/src/design-system/general/LoadingMessage.vue
@@ -1,30 +1,25 @@
 <template>
   <div
-    v-if="computedMessage || $slots.default || noMessage"
+    v-if="requestStatus === undefined || requestStatus.isPending"
     class="w-full flex flex-col items-center gap-4 p-xl"
   >
     <Icon name="loader" size="2xl" />
-    <h2>
-      <slot>{{ computedMessage }}</slot>
+    <h2 v-if="message || $slots.default" class="text-lg">
+      <slot>{{ message }}</slot>
     </h2>
+    <div v-if="$slots.moreContent">
+      <slot name="moreContent" />
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType } from "vue";
+import { PropType } from "vue";
 import { ApiRequestStatus } from "../../pinia";
 import { Icon } from "..";
 
 const props = defineProps({
-  noMessage: { type: Boolean, default: false },
   message: { type: String },
-  requestMessage: { type: String },
   requestStatus: { type: Object as PropType<ApiRequestStatus> },
-});
-
-const computedMessage = computed(() => {
-  if (props.message) return props.message;
-  else if (props.requestStatus?.isPending) return props.requestMessage;
-  else return undefined;
 });
 </script>

--- a/lib/vue-lib/src/design-system/general/RequestStatusMessage.vue
+++ b/lib/vue-lib/src/design-system/general/RequestStatusMessage.vue
@@ -1,10 +1,6 @@
 <template>
   <div>
-    <LoadingMessage
-      :requestStatus="requestStatus"
-      :requestMessage="loadingMessage"
-      :noMessage="showLoaderWithoutMessage"
-    />
+    <LoadingMessage :requestStatus="requestStatus" :message="loadingMessage" />
     <ErrorMessage :requestStatus="requestStatus" />
   </div>
 </template>
@@ -16,7 +12,6 @@ import LoadingMessage from "./LoadingMessage.vue";
 import { ApiRequestStatus } from "../../pinia";
 
 defineProps({
-  showLoaderWithoutMessage: { type: Boolean, default: false },
   loadingMessage: { type: String },
   requestStatus: { type: Object as PropType<ApiRequestStatus> },
 });

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -9,7 +9,8 @@ import SlashForward from "~icons/mdi/slash-forward";
 import Check from "~icons/heroicons/check-20-solid";
 import CheckCircle from "~icons/heroicons/check-circle-20-solid";
 import CheckSquare from "./custom-icons/check-square.svg?raw";
-import CloudUpload from "~icons/heroicons-solid/cloud-upload";
+import CloudUpload from "~icons/mdi/cloud-upload";
+import CloudDownload from "~icons/mdi/cloud-download";
 
 import AlertCircle from "~icons/heroicons/exclamation-circle-20-solid";
 import AlertSquare from "./custom-icons/exclamation-square.svg?raw";
@@ -35,6 +36,7 @@ import Play from "~icons/ion/play-sharp";
 import Arrow from "~icons/heroicons-solid/arrow-up";
 import Chevron from "~icons/heroicons-solid/chevron-up";
 
+import Gear from "~icons/heroicons-solid/cog-8-tooth";
 import Save from "~icons/heroicons-solid/save";
 import Download from "~icons/heroicons-solid/download";
 import Trash from "~icons/heroicons-solid/trash";
@@ -128,6 +130,7 @@ export const ICONS = Object.freeze({
   check2: Check2,
   "clipboard-copy": ClipboardCopy,
   clock: Clock,
+  "cloud-download": CloudDownload,
   "cloud-upload": CloudUpload,
   component: Cube,
   create: Create,
@@ -172,6 +175,7 @@ export const ICONS = Object.freeze({
   save: Save,
   search: Search,
   selector: Selector,
+  settings: Gear,
   show: Eye,
   slash: SlashForward,
   sun: Sun,

--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -1,6 +1,16 @@
 <template>
-  <TransitionRoot :show="isOpen" appear as="template">
-    <Dialog as="div" class="relative z-50" @close="exitHandler" @mousedown.stop>
+  <TransitionRoot
+    :show="isOpen"
+    appear
+    as="template"
+    @afterLeave="emit('closeComplete')"
+  >
+    <Dialog
+      as="div"
+      class="relative z-100"
+      @close="exitHandler"
+      @mousedown.stop
+    >
       <TransitionChild
         as="template"
         enter="duration-300 ease-out"
@@ -134,6 +144,7 @@ const props = defineProps({
     default: "Create",
     required: false,
   },
+  noAutoFocus: Boolean,
 });
 
 // make modal a new "theme container" but by passing no value, we reset the theme back to the root theme
@@ -144,7 +155,9 @@ const isOpen = ref(props.beginOpen);
 function open() {
   hideFocusTrap.value = false;
   isOpen.value = true;
-  setTimeout(fixAutoFocusElement);
+  if (!props.noAutoFocus) {
+    setTimeout(fixAutoFocusElement);
+  }
 }
 function close() {
   emit("close");
@@ -185,8 +198,9 @@ function exitHandler() {
 const saveLabel = toRef(props, "saveLabel", "Create");
 
 const emit = defineEmits<{
-  (e: "close"): void;
-  (e: "save"): void;
+  close: [];
+  closeComplete: [];
+  save: [];
 }>();
 
 defineExpose({ open, close, isOpen });


### PR DESCRIPTION
adds a workspace settings cog, along with import/export modals. Currently mocking the requests with fake delays...

Some intermediate loading states as well, but these screenshots show the flow. Playing with the terms "backup" and "restore" a bit now, as this more accurately describes the flow as we will be implementing them for now. I suspect in the future that backup/restore may be some options within the broader category of export/import - ie you may be able to export/import subsets of a workspace without losing your local data, rather than only all or nothing.


new workspace settings menu
<img width="271" alt="image" src="https://github.com/systeminit/si/assets/1158956/a73abf26-44d4-4965-8e90-d4ab7b705bf3">

export modal
<img width="542" alt="image" src="https://github.com/systeminit/si/assets/1158956/f4c24ee9-fdc9-4bb6-8ee1-39cf27d63579">
<img width="542" alt="image" src="https://github.com/systeminit/si/assets/1158956/50d4d014-8536-46e1-b81c-750171d0dca2">

import modal
<img width="604" alt="image" src="https://github.com/systeminit/si/assets/1158956/64888ad6-ac94-48c4-b10c-445374b5a3a1">
<img width="604" alt="image" src="https://github.com/systeminit/si/assets/1158956/0821dd5c-c4c8-4640-b512-9693e77dd0d1">

