### PR TITLE
fix(si): Infer the container engine based on args being passed

### DIFF
--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -71,6 +71,11 @@ pub(crate) struct Args {
     #[arg(value_parser = PossibleValuesParser::new(Engine::variants()))]
     #[arg(long, short, env = "SI_CONTAINER_ENGINE", default_value = "docker")]
     engine: String,
+    /// A path to a podman.sock file. The default paths checked are `$XDG_RUNTIME_DIR/podman/podman.sock`
+    /// and `/var/run/podman.sock"`. Passing a value here will be an explicit
+    /// usage of that location.
+    #[arg(long, env = "SI_PODMAN_SOCK")]
+    pub podman_sock: Option<String>,
     /// A path to a docker.sock file. The default paths checked are `/var/run/docker.sock`
     /// and `$HOME/.docker/run/docker.sock"`. Passing a value here will be an explicit
     /// usage of that location.
@@ -191,7 +196,7 @@ pub enum Mode {
     Local,
 }
 
-#[derive(Clone, Copy, Debug, Display, EnumString, EnumVariantNames)]
+#[derive(Clone, Copy, Debug, Display, EnumString, EnumVariantNames, PartialEq)]
 pub enum Engine {
     #[strum(serialize = "docker")]
     Docker,


### PR DESCRIPTION
Currently, if a user passes Podman as the engine and a docker-sock
then the CLI will error, We can make an assumption of the engine
based on the param passed and then let the user know we are doing so

```
si --podman-sock /var/run/podman.sock status
WARNING: A `podman_sock` location parameter was passed but no Podman engine was chosen. Continuing with the assumption you meant to choose Podman as the container engine...

Checking for user supplied docker.sock
System Initiative Launcher is in "local" mode
```

```
SI_CONTAINER_ENGINE=podman si --docker-sock /var/run/docker.sock status
WARNING: A `docker_sock` location parameter was passed but no Docker engine was chosen. Continuing with the assumption you meant to choose Docker as the container engine...

Checking for user supplied docker.sock
System Initiative Launcher is in "local" mode
```
