### PR TITLE
fix(*): pin rust to 1.71.0 until compile time regression fixed

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.71.0"
 profile = "default"


### PR DESCRIPTION
Rust 1.72.0 introduced compile time regressions for async heavy code:

https://github.com/rust-lang/rust/issues/115283

Reverting to 1.71.0 gets us back to reasonable compile times for sdf. We should stay there until a fix is released.