### PR TITLE
fix(dal): special case si:resourcePayloadToValue

### DIFF
--- a/lib/dal/examples/dal-pkg-import/BUCK
+++ b/lib/dal/examples/dal-pkg-import/BUCK
@@ -12,6 +12,7 @@ rust_binary(
         "//lib/dal:dal",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-data-pg:si-data-pg",
+        "//lib/si-pkg:si-pkg",
         "//lib/veritech-client:veritech-client",
         "//third-party/rust:tokio",
     ],

--- a/lib/dal/examples/dal-pkg-import/main.rs
+++ b/lib/dal/examples/dal-pkg-import/main.rs
@@ -1,12 +1,14 @@
 use std::{env, path::Path, sync::Arc};
 
 use buck2_resources::Buck2Resources;
+use dal::generate_unique_id;
 use dal::{
-    pkg::import_pkg, DalContext, JobQueueProcessor, NatsProcessor, ServicesContext, Tenancy,
-    Workspace,
+    pkg::import_pkg_from_pkg, ChangeSet, DalContext, JobQueueProcessor, NatsProcessor,
+    ServicesContext, Tenancy, Workspace,
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use si_data_pg::{PgPool, PgPoolConfig};
+use si_pkg::SiPkg;
 use veritech_client::{Client as VeritechClient, EncryptionKey};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
@@ -17,11 +19,30 @@ async fn main() -> Result<()> {
     let tar_file = args.nth(1).expect("usage: program <PKG_FILE>");
 
     let mut ctx = ctx().await?;
-    let workspace = Workspace::builtin(&ctx).await?;
+
+    let workspace = match Workspace::find_first_user_workspace(&ctx).await? {
+        Some(workspace) => workspace,
+        None => Workspace::builtin(&ctx).await?,
+    };
+
     ctx.update_tenancy(Tenancy::new(*workspace.pk()));
 
-    println!("--- Importing pkg: {tar_file}");
-    import_pkg(&ctx, Path::new(&tar_file)).await?;
+    let pkg = SiPkg::load_from_file(Path::new(&tar_file)).await?;
+    let metadata = pkg.metadata()?;
+    let change_set_name = format!(
+        "pkg - {} ({}) {}",
+        metadata.name(),
+        metadata.version(),
+        generate_unique_id(4)
+    );
+    let change_set = ChangeSet::new(&ctx, &change_set_name, None).await?;
+    let ctx = ctx.clone_with_new_visibility(ctx.visibility().to_change_set(change_set.pk));
+
+    println!(
+        "--- Importing pkg: {tar_file} into change set \"{change_set_name}\" in workspace \"{}\"",
+        workspace.name()
+    );
+    import_pkg_from_pkg(&ctx, &pkg, &tar_file, None).await?;
 
     println!("--- Committing database transaction");
     ctx.commit().await?;

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -81,8 +81,9 @@ pub async fn import_pkg_from_pkg(
         let unique_id = func_spec.unique_id().to_string();
 
         // This is a hack because the hash of the intrinsics has changed from the version in the
-        // packages
-        if func::is_intrinsic(func_spec.name()) {
+        // packages. We also apply this to si:resourcePayloadToValue since it should be an
+        // intrinsic but is only in our packages
+        if func::is_intrinsic(func_spec.name()) || func_spec.name() == "si:resourcePayloadToValue" {
             let func = if let Some(func) = Func::find_by_name(ctx, func_spec.name()).await? {
                 func
             } else {

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -74,6 +74,14 @@ impl Workspace {
         Ok(object)
     }
 
+    pub async fn find_first_user_workspace(ctx: &DalContext) -> WorkspaceResult<Option<Self>> {
+        let row = ctx.txns().await?.pg().query_opt(
+            "SELECT row_to_json(w.*) AS object FROM workspaces AS w WHERE pk != $1 ORDER BY created_at ASC LIMIT 1", &[&WorkspacePk::NONE],
+        ).await?;
+
+        Ok(standard_model::option_object_from_row(row)?)
+    }
+
     #[instrument(skip_all)]
     pub async fn new(
         ctx: &mut DalContext,


### PR DESCRIPTION
Because new exports will have a different hash with the added values to support workspaces, si:resourcePayloadToValue should temporarily be treated like an intrinsic on import and only imported once.

Also updates the dal-pkg-import tool to use a change set on import.