### PR TITLE
chore(web) update import/export terminology

### DIFF
--- a/app/web/src/components/WorkspaceExportModal.vue
+++ b/app/web/src/components/WorkspaceExportModal.vue
@@ -9,7 +9,7 @@
       <template v-if="exportReqStatus.isSuccess">
         <p>Success!</p>
         <p>
-          You can now restore your workspace to this backup by going to
+          You can now import this workspace by going to
           <br />
           workspace settings (gear in top right) > "Import Workspace"
         </p>
@@ -18,9 +18,8 @@
       </template>
       <template v-else>
         <p>
-          You are about to export a backup of this workspace to the cloud. You
-          will then be able to import / restore this backup on this or another
-          running instance of SI.
+          You are about to export this workspace to the cloud. You will then be
+          able to import it on this or another running instance of SI.
         </p>
 
         <p>Click the button below to continue:</p>
@@ -30,7 +29,7 @@
           :requestStatus="exportReqStatus"
           loadingText="Exporting your workspace..."
           @click="continueHandler"
-          >Export a backup of this workspace</VButton
+          >Export this workspace</VButton
         >
       </template>
     </Stack>

--- a/app/web/src/components/WorkspaceImportModal.vue
+++ b/app/web/src/components/WorkspaceImportModal.vue
@@ -9,7 +9,7 @@
     <Stack>
       <template v-if="importReqStatus.isPending">
         <LoadingMessage>
-          Restoring your workspace from a backup!
+          Importing your workspace!
           <template #moreContent>
             <p class="italic font-sm">
               Please do not refresh while this in progress.
@@ -18,19 +18,19 @@
         </LoadingMessage>
       </template>
       <template v-else-if="importReqStatus.isSuccess">
-        <p>Your workspace has been restored!</p>
+        <p>Your workspace has been imported!</p>
         <p>To see your changes, please reload your browser</p>
         <VButton icon="refresh" @click="refreshHandler">Reload</VButton>
       </template>
       <template v-else>
         <p>
-          You are about to restore from a workspace backup. Please note that all
-          data currently in the local workspace will be overwritten and replaced
-          with the contents of the backup.
+          You are about to import a workspace. Please note that all data
+          currently in the local workspace will be overwritten and replaced with
+          the contents of this workspace.
         </p>
         <p>
-          To continue, please select the backup / export you would like to
-          restore from, and confirm the loss of local data:
+          To continue, please select the workspace you would like to import, and
+          confirm the loss of local data:
         </p>
 
         <ErrorMessage :requestStatus="loadExportsReqStatus" />
@@ -39,10 +39,10 @@
           <VormInput
             v-model="selectedExportId"
             type="dropdown"
-            label="Select an export to restore from"
-            placeholder="- Select an export -"
+            label="Select workspace"
+            placeholder="- Select a workspace -"
             required
-            requiredMessage="Select an export to continue"
+            requiredMessage="Select a workspace to continue"
           >
             <VormInputOption
               v-for="item in exportsList"
@@ -54,10 +54,10 @@
           </VormInput>
         </template>
         <template v-else-if="loadExportsReqStatus.isPending">
-          <VormInput type="container" label="Select an export to restore from">
+          <VormInput type="container" label="Select workspace">
             <Inline alignY="center">
               <Icon name="loader" />
-              <div>Loading your exports</div>
+              <div>Loading your workspace exports</div>
             </Inline>
           </VormInput>
         </template>
@@ -77,7 +77,7 @@
           :disabled="!loadExportsReqStatus.isSuccess || validationState.isError"
           :requestStatus="importReqStatus"
           @click="continueHandler"
-          >Restore from backup</VButton
+          >Import workspace</VButton
         >
       </template>
     </Stack>


### PR DESCRIPTION
I got rid of the "backup" and "restore" terminology in favour of sticking with "export" and "import"

I will say it still feels quite awkward as export/import work well as the verbs but I feel there is a missing noun, for example "backup" or "snapshot"...  "Workspace export" feels like a bit of a mouthful and using just "workspace" doesnt quite feel right as you are not importing a "workspace" you are importing a fixed snapshot of a workspace.

