### PR TITLE
chore(dev): Enable debug logs by default in Veritech

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -126,7 +126,7 @@ local_resource(
     "veritech",
     labels = ["backend"],
     cmd = "buck2 build {}".format(veritech_target),
-    serve_cmd = "buck2 run {}".format(veritech_target),
+    serve_cmd = "SI_LOG=debug buck2 run {}".format(veritech_target),
     allow_parallel = True,
     resource_deps = [
         "nats",


### PR DESCRIPTION
Setting the `SI_LOG=debug` for the veritech tilt service

<img width="1125" alt="Screenshot 2023-09-18 at 18 44 19" src="https://github.com/systeminit/si/assets/227823/83fff05b-2906-4fc2-9dbe-c53f3c2a6003">
