### PR TITLE
feat(object-tree,si-pkg): Support optional nodes in object tree

### DIFF
--- a/lib/si-pkg/src/node/action_func.rs
+++ b/lib/si-pkg/src/node/action_func.rs
@@ -40,7 +40,7 @@ impl WriteBytes for ActionFuncNode {
 }
 
 impl ReadBytes for ActionFuncNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -51,12 +51,12 @@ impl ReadBytes for ActionFuncNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             kind,
             func_unique_id,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/attr_func_input.rs
+++ b/lib/si-pkg/src/node/attr_func_input.rs
@@ -93,7 +93,7 @@ impl WriteBytes for AttrFuncInputNode {
 }
 
 impl ReadBytes for AttrFuncInputNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -102,7 +102,7 @@ impl ReadBytes for AttrFuncInputNode {
 
         let kind = AttrFuncInputSpecKind::from_str(&kind_str).map_err(GraphError::parse)?;
 
-        Ok(match kind {
+        Ok(Some(match kind {
             AttrFuncInputSpecKind::Prop => {
                 let prop_path = read_key_value_line(reader, KEY_PROP_PATH_STR)?;
                 let (unique_id, deleted) = read_common_fields(reader)?;
@@ -133,7 +133,7 @@ impl ReadBytes for AttrFuncInputNode {
                     deleted,
                 }
             }
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/category.rs
+++ b/lib/si-pkg/src/node/category.rs
@@ -61,7 +61,7 @@ impl WriteBytes for CategoryNode {
 }
 
 impl ReadBytes for CategoryNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -72,13 +72,14 @@ impl ReadBytes for CategoryNode {
             CATEGORY_TYPE_FUNCS => Self::Funcs,
             CATEGORY_TYPE_SCHEMAS => Self::Schemas,
             invalid_kind => {
-                return Err(GraphError::parse_custom(format!(
+                dbg!(format!(
                     "invalid package category node kind: {invalid_kind}"
-                )))
+                ));
+                return Ok(None);
             }
         };
 
-        Ok(node)
+        Ok(Some(node))
     }
 }
 

--- a/lib/si-pkg/src/node/change_set.rs
+++ b/lib/si-pkg/src/node/change_set.rs
@@ -46,7 +46,7 @@ impl WriteBytes for ChangeSetNode {
 }
 
 impl ReadBytes for ChangeSetNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -61,11 +61,11 @@ impl ReadBytes for ChangeSetNode {
         let status_str = read_key_value_line(reader, KEY_STATUS)?;
         let status = ChangeSetSpecStatus::from_str(&status_str).map_err(GraphError::parse)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             based_on_change_set,
             status,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/change_set_child.rs
+++ b/lib/si-pkg/src/node/change_set_child.rs
@@ -55,7 +55,7 @@ impl WriteBytes for ChangeSetChildNode {
 }
 
 impl ReadBytes for ChangeSetChildNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -65,13 +65,14 @@ impl ReadBytes for ChangeSetChildNode {
             CHANGE_SET_CHILD_TYPE_FUNCS => Self::Funcs,
             CHANGE_SET_CHILD_TYPE_SCHEMAS => Self::Schemas,
             invalid_kind => {
-                return Err(GraphError::parse_custom(format!(
+                dbg!(format!(
                     "invalid change set child node kind: {invalid_kind}"
-                )))
+                ));
+                return Ok(None);
             }
         };
 
-        Ok(node)
+        Ok(Some(node))
     }
 }
 

--- a/lib/si-pkg/src/node/func.rs
+++ b/lib/si-pkg/src/node/func.rs
@@ -83,7 +83,7 @@ impl WriteBytes for FuncNode {
 }
 
 impl ReadBytes for FuncNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -135,12 +135,12 @@ impl ReadBytes for FuncNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             data,
             unique_id: unique_id.unwrap_or("".into()),
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/func_argument.rs
+++ b/lib/si-pkg/src/node/func_argument.rs
@@ -46,7 +46,7 @@ impl WriteBytes for FuncArgumentNode {
 }
 
 impl ReadBytes for FuncArgumentNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -63,13 +63,13 @@ impl ReadBytes for FuncArgumentNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             kind,
             element_kind,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/leaf_function.rs
+++ b/lib/si-pkg/src/node/leaf_function.rs
@@ -47,7 +47,7 @@ impl WriteBytes for LeafFunctionNode {
 }
 
 impl ReadBytes for LeafFunctionNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -65,7 +65,7 @@ impl ReadBytes for LeafFunctionNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             func_unique_id,
             leaf_kind,
             input_code,
@@ -74,7 +74,7 @@ impl ReadBytes for LeafFunctionNode {
             input_resource,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/map_key_func.rs
+++ b/lib/si-pkg/src/node/map_key_func.rs
@@ -32,17 +32,17 @@ impl WriteBytes for MapKeyFuncNode {
 }
 
 impl ReadBytes for MapKeyFuncNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
         let key = read_key_value_line(reader, KEY_KEY_STR)?;
         let func_unique_id = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             key,
             func_unique_id,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -232,41 +232,46 @@ impl WriteBytes for PkgNode {
 }
 
 impl ReadBytes for PkgNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
         let node_kind_str = read_key_value_line(reader, KEY_NODE_KIND_STR)?;
 
         let node = match node_kind_str.as_str() {
-            NODE_KIND_ACTION_FUNC => Self::ActionFunc(ActionFuncNode::read_bytes(reader)?),
+            NODE_KIND_ACTION_FUNC => ActionFuncNode::read_bytes(reader)?.map(Self::ActionFunc),
             NODE_KIND_ATTR_FUNC_INPUT => {
-                Self::AttrFuncInput(AttrFuncInputNode::read_bytes(reader)?)
+                AttrFuncInputNode::read_bytes(reader)?.map(Self::AttrFuncInput)
             }
-            NODE_KIND_CATEGORY => Self::Category(CategoryNode::read_bytes(reader)?),
-            NODE_KIND_CHANGE_SET => Self::ChangeSet(ChangeSetNode::read_bytes(reader)?),
+            NODE_KIND_CATEGORY => CategoryNode::read_bytes(reader)?.map(Self::Category),
+            NODE_KIND_CHANGE_SET => ChangeSetNode::read_bytes(reader)?.map(Self::ChangeSet),
             NODE_KIND_CHANGE_SET_CHILD => {
-                Self::ChangeSetChild(ChangeSetChildNode::read_bytes(reader)?)
+                ChangeSetChildNode::read_bytes(reader)?.map(Self::ChangeSetChild)
             }
-            NODE_KIND_FUNC => Self::Func(FuncNode::read_bytes(reader)?),
-            NODE_KIND_FUNC_ARGUMENT => Self::FuncArgument(FuncArgumentNode::read_bytes(reader)?),
-            NODE_KIND_LEAF_FUNCTION => Self::LeafFunction(LeafFunctionNode::read_bytes(reader)?),
-            NODE_KIND_MAP_KEY_FUNC => Self::MapKeyFunc(MapKeyFuncNode::read_bytes(reader)?),
-            NODE_KIND_PACKAGE => Self::Package(PackageNode::read_bytes(reader)?),
-            NODE_KIND_PROP => Self::Prop(PropNode::read_bytes(reader)?),
-            NODE_KIND_PROP_CHILD => Self::PropChild(PropChildNode::read_bytes(reader)?),
-            NODE_KIND_SCHEMA => Self::Schema(SchemaNode::read_bytes(reader)?),
-            NODE_KIND_SCHEMA_VARIANT => Self::SchemaVariant(SchemaVariantNode::read_bytes(reader)?),
+            NODE_KIND_FUNC => FuncNode::read_bytes(reader)?.map(Self::Func),
+            NODE_KIND_FUNC_ARGUMENT => {
+                FuncArgumentNode::read_bytes(reader)?.map(Self::FuncArgument)
+            }
+            NODE_KIND_LEAF_FUNCTION => {
+                LeafFunctionNode::read_bytes(reader)?.map(Self::LeafFunction)
+            }
+            NODE_KIND_MAP_KEY_FUNC => MapKeyFuncNode::read_bytes(reader)?.map(Self::MapKeyFunc),
+            NODE_KIND_PACKAGE => PackageNode::read_bytes(reader)?.map(Self::Package),
+            NODE_KIND_PROP => PropNode::read_bytes(reader)?.map(Self::Prop),
+            NODE_KIND_PROP_CHILD => PropChildNode::read_bytes(reader)?.map(Self::PropChild),
+            NODE_KIND_SCHEMA => SchemaNode::read_bytes(reader)?.map(Self::Schema),
+            NODE_KIND_SCHEMA_VARIANT => {
+                SchemaVariantNode::read_bytes(reader)?.map(Self::SchemaVariant)
+            }
             NODE_KIND_SCHEMA_VARIANT_CHILD => {
-                Self::SchemaVariantChild(SchemaVariantChildNode::read_bytes(reader)?)
+                SchemaVariantChildNode::read_bytes(reader)?.map(Self::SchemaVariantChild)
             }
-            NODE_KIND_SOCKET => Self::Socket(SocketNode::read_bytes(reader)?),
-            NODE_KIND_SI_PROP_FUNC => Self::SiPropFunc(SiPropFuncNode::read_bytes(reader)?),
-            NODE_KIND_VALIDATION => Self::Validation(ValidationNode::read_bytes(reader)?),
+            NODE_KIND_SOCKET => SocketNode::read_bytes(reader)?.map(Self::Socket),
+            NODE_KIND_SI_PROP_FUNC => SiPropFuncNode::read_bytes(reader)?.map(Self::SiPropFunc),
+            NODE_KIND_VALIDATION => ValidationNode::read_bytes(reader)?.map(Self::Validation),
             invalid_kind => {
-                return Err(GraphError::parse_custom(format!(
-                    "invalid package node kind: {invalid_kind}"
-                )))
+                dbg!(format!("invalid package node kind: {invalid_kind}"));
+                None
             }
         };
 

--- a/lib/si-pkg/src/node/package.rs
+++ b/lib/si-pkg/src/node/package.rs
@@ -60,7 +60,7 @@ impl WriteBytes for PackageNode {
 }
 
 impl ReadBytes for PackageNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -79,7 +79,7 @@ impl ReadBytes for PackageNode {
         let default_change_set = read_key_value_line_opt(reader, KEY_DEFAULT_CHANGE_SET)?;
         let workspace_pk = read_key_value_line_opt(reader, KEY_WORKSPACE_PK_STR)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             kind,
             name,
             version,
@@ -88,7 +88,7 @@ impl ReadBytes for PackageNode {
             created_by,
             default_change_set,
             workspace_pk,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/prop.rs
+++ b/lib/si-pkg/src/node/prop.rs
@@ -170,7 +170,7 @@ impl WriteBytes for PropNode {
 }
 
 impl ReadBytes for PropNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -265,7 +265,7 @@ impl ReadBytes for PropNode {
             }
         };
 
-        Ok(node)
+        Ok(Some(node))
     }
 }
 

--- a/lib/si-pkg/src/node/prop_child.rs
+++ b/lib/si-pkg/src/node/prop_child.rs
@@ -66,7 +66,7 @@ impl WriteBytes for PropChildNode {
 }
 
 impl ReadBytes for PropChildNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -78,13 +78,12 @@ impl ReadBytes for PropChildNode {
             PROP_CHILD_TYPE_PROPS => Self::Props,
             PROP_CHILD_TYPE_VALIDATIONS => Self::Validations,
             invalid_kind => {
-                return Err(GraphError::parse_custom(format!(
-                    "invalid schema variant child kind: {invalid_kind}"
-                )))
+                dbg!(format!("invalid schema variant child kind: {invalid_kind}"));
+                return Ok(None);
             }
         };
 
-        Ok(node)
+        Ok(Some(node))
     }
 }
 

--- a/lib/si-pkg/src/node/schema.rs
+++ b/lib/si-pkg/src/node/schema.rs
@@ -60,7 +60,7 @@ impl WriteBytes for SchemaNode {
 }
 
 impl ReadBytes for SchemaNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -88,12 +88,12 @@ impl ReadBytes for SchemaNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             data,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -67,7 +67,7 @@ impl WriteBytes for SchemaVariantNode {
 }
 
 impl ReadBytes for SchemaVariantNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -104,12 +104,12 @@ impl ReadBytes for SchemaVariantNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             data,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -76,7 +76,7 @@ impl WriteBytes for SchemaVariantChildNode {
 }
 
 impl ReadBytes for SchemaVariantChildNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -90,13 +90,12 @@ impl ReadBytes for SchemaVariantChildNode {
             VARIANT_CHILD_TYPE_SI_PROP_FUNCS => Self::SiPropFuncs,
             VARIANT_CHILD_TYPE_SOCKETS => Self::Sockets,
             invalid_kind => {
-                return Err(GraphError::parse_custom(format!(
-                    "invalid schema variant child kind: {invalid_kind}"
-                )))
+                dbg!(format!("invalid schema variant child kind: {invalid_kind}"));
+                return Ok(None);
             }
         };
 
-        Ok(node)
+        Ok(Some(node))
     }
 }
 

--- a/lib/si-pkg/src/node/si_prop_func.rs
+++ b/lib/si-pkg/src/node/si_prop_func.rs
@@ -38,7 +38,7 @@ impl WriteBytes for SiPropFuncNode {
 }
 
 impl ReadBytes for SiPropFuncNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -49,12 +49,12 @@ impl ReadBytes for SiPropFuncNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             kind,
             func_unique_id,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/socket.rs
+++ b/lib/si-pkg/src/node/socket.rs
@@ -63,7 +63,7 @@ impl WriteBytes for SocketNode {
 }
 
 impl ReadBytes for SocketNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -98,11 +98,11 @@ impl ReadBytes for SocketNode {
 
         let unique_id = read_unique_id(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             name,
             data,
             unique_id,
-        })
+        }))
     }
 }
 

--- a/lib/si-pkg/src/node/validation.rs
+++ b/lib/si-pkg/src/node/validation.rs
@@ -113,7 +113,7 @@ impl WriteBytes for ValidationNode {
 }
 
 impl ReadBytes for ValidationNode {
-    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Self, GraphError>
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
     where
         Self: std::marker::Sized,
     {
@@ -166,7 +166,7 @@ impl ReadBytes for ValidationNode {
 
         let (unique_id, deleted) = read_common_fields(reader)?;
 
-        Ok(Self {
+        Ok(Some(Self {
             kind,
             lower_bound,
             upper_bound,
@@ -176,7 +176,7 @@ impl ReadBytes for ValidationNode {
             func_unique_id,
             unique_id,
             deleted,
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
We removed a node child kind (FuncDescriptions), but this breaks old modules that have func descriptions in them. We still want to be able to read those modules and we want the ability to make changes like this to the package format in the future without invalidating the old modules. This makes the read_bytes trait in object-tree return an Option, so if a node is not one we want to read any more, we can skip it (and its children!), while preserving the rest of the module.