### PR TITLE
chore: add `--bind-all` flag to `buck2 run dev:up`

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,4 +1,5 @@
 config.define_string_list("to-run", args = True)
+config.define_bool("bind-all")
 cfg = config.parse()
 
 # Define groups of services
@@ -167,11 +168,15 @@ local_resource(
 
 # Locally build and run `web` in dev mode
 web_target = "//app/web:dev"
+serve_cmd = "buck2 run {}".format(web_target)
+if cfg.get("bind-all", False):
+    serve_cmd = serve_cmd + " -- --host 0.0.0.0"
+
 local_resource(
     "web",
     labels = ["frontend"],
     cmd = "buck2 build {}".format(web_target),
-    serve_cmd = "buck2 run {}".format(web_target),
+    serve_cmd = serve_cmd,
     allow_parallel = True,
     resource_deps = [
         "sdf",

--- a/prelude-si/pnpm.bzl
+++ b/prelude-si/pnpm.bzl
@@ -928,7 +928,7 @@ npm_package_path="$1"
 npm_run_command="$2"
 
 cd "$rootpath/$npm_package_path"
-pnpm run --report-summary "$npm_run_command"
+pnpm run --report-summary "$npm_run_command" "$@"
 """, is_executable = True);
     args = cmd_args([script, ctx.attrs.path, ctx.attrs.command])
     args.hidden([ctx.attrs.deps])

--- a/prelude-si/tilt.bzl
+++ b/prelude-si/tilt.bzl
@@ -90,6 +90,8 @@ def _invoke_tilt(ctx: AnalysisContext, subcmd: str) -> list[[DefaultInfo, RunInf
     run_cmd_args = cmd_args([
         "tilt",
         subcmd,
+        "--host",
+        "0.0.0.0",
         "--file",
         tiltfile,
     ])


### PR DESCRIPTION
This change will run Tilt binding to all IPs as well as the `app/web` service.

This means you can run:

```
buck2 run dev:up -- --bind-all
```
