### PR TITLE
chore(web): amended placeholders for asset creation

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -46,7 +46,7 @@
           type="text"
           :disabled="disabled"
           label="Name"
-          placeholder="Give this asset a name here..."
+          placeholder="(mandatory) Provide the asset a name"
           @blur="updateAsset"
         />
         <VormInput
@@ -55,7 +55,7 @@
           type="text"
           :disabled="disabled"
           label="Display name"
-          placeholder="Optionally, give the asset a shorter name for display here..."
+          placeholder="(optional) Provide the asset a shorter display name"
           @blur="updateAsset"
         />
         <VormInput
@@ -64,7 +64,7 @@
           type="text"
           :disabled="disabled"
           label="Entrypoint"
-          placeholder="Optionally, give the asset a shorter name for display here..."
+          placeholder="(mandatory) Provide the function entrypoint to the asset"
           @blur="updateAsset"
         />
         <VormInput
@@ -73,7 +73,7 @@
           type="text"
           :disabled="disabled"
           label="Category"
-          placeholder="Pick a category for this asset"
+          placeholder="(mandatory) Provide a category for the asset"
           @blur="updateAsset"
         />
         <VormInput
@@ -91,7 +91,7 @@
           type="textarea"
           :disabled="disabled"
           label="Description"
-          placeholder="Provide a brief description of this asset here..."
+          placeholder="(optional) Provide a brief description of the asset"
           @blur="updateAsset"
         />
         <VormInput type="container" label="color" :disabled="disabled">
@@ -109,7 +109,7 @@
           type="url"
           :disabled="disabled"
           label="Documentation Link"
-          placeholder="Enter a link to the documentation for this asset here..."
+          placeholder="(optional) Provide a documentation link for the asset"
           @blur="updateAsset"
         />
       </Stack>


### PR DESCRIPTION
Minor adjustments to asset creation screen to more accurately determine whether fields are mandatory or not.

There is a follow on task to then actually enforce this within the .js/vue. On this commit the POST to SDF will still occur but will still result in a 422 (unprocessable entity).

* UI adjustments can be seen below *

<img width="434" alt="Screenshot 2023-09-22 at 14 28 24" src="https://github.com/systeminit/si/assets/47694061/684ef1e5-5536-4e58-aadc-7a572bd798f4">


