### PR TITLE
feat(module-index,sdf,web): support workspace backups in module-index

### DIFF
--- a/app/web/src/components/WorkspaceExportModal.vue
+++ b/app/web/src/components/WorkspaceExportModal.vue
@@ -39,10 +39,11 @@
 <script setup lang="ts">
 import { Modal, Stack, VButton, useModal } from "@si/vue-lib/design-system";
 import { ref } from "vue";
-import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useModuleStore } from "@/store/module.store";
 
-const workspacesStore = useWorkspacesStore();
-const exportReqStatus = workspacesStore.getRequestStatus("EXPORT_WORKSPACE");
+const moduleStore = useModuleStore();
+
+const exportReqStatus = moduleStore.getRequestStatus("EXPORT_WORKSPACE");
 
 const modalRef = ref<InstanceType<typeof Modal>>();
 const { open: openModal, close } = useModal(modalRef);
@@ -52,10 +53,10 @@ function open() {
 }
 
 function continueHandler() {
-  workspacesStore.EXPORT_WORKSPACE();
+  moduleStore.EXPORT_WORKSPACE();
 }
 function closeHandler() {
-  workspacesStore.clearRequestStatus("EXPORT_WORKSPACE");
+  moduleStore.clearRequestStatus("EXPORT_WORKSPACE");
 }
 
 defineExpose({ open, close });

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -37,6 +37,7 @@ export const useWorkspacesStore = addStoreHooks(
         );
       },
     },
+
     actions: {
       async FETCH_USER_WORKSPACES() {
         return new ApiRequest<{
@@ -54,41 +55,8 @@ export const useWorkspacesStore = addStoreHooks(
           },
         });
       },
-
-      async EXPORT_WORKSPACE() {
-        return new ApiRequest({
-          // using placeholder url to just make a request
-          url: "/session/load_workspace",
-          _delay: 3000,
-          onSuccess: (response) => {},
-        });
-      },
-      async FETCH_WORKSPACE_EXPORTS() {
-        return new ApiRequest({
-          // using placeholder url to just make a request
-          url: "/session/load_workspace",
-          _delay: 1500,
-          onSuccess: (response) => {
-            this.workspaceExports = [
-              { id: "a", createdAt: "2023-08-30T11:22:33Z" },
-              { id: "b", createdAt: "2023-08-26T08:04:11Z" },
-              { id: "c", createdAt: "2023-08-25T18:19:20Z" },
-              { id: "d", createdAt: "2023-08-25T14:15:16Z" },
-            ];
-          },
-        });
-      },
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      async IMPORT_WORKSPACE(exportId: WorkspaceExportId) {
-        return new ApiRequest({
-          // using placeholder url to just make a request
-          url: "/session/load_workspace",
-          _delay: 5000,
-          // params: { id: exportId },
-          onSuccess: (response) => {},
-        });
-      },
     },
+
     onActivated() {
       const authStore = useAuthStore();
       watch(

--- a/lib/module-index-server/src/migrations/U0004__modules_kind.sql
+++ b/lib/module-index-server/src/migrations/U0004__modules_kind.sql
@@ -1,0 +1,3 @@
+ALTER TABLE modules
+    ADD kind text NOT NULL DEFAULT 'module';
+

--- a/lib/module-index-server/src/models/si_module.rs
+++ b/lib/module-index-server/src/models/si_module.rs
@@ -4,7 +4,77 @@ use sea_orm::{
     TryGetError,
 };
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use ulid::Ulid;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ModuleKind {
+    Module,
+    WorkspaceBackup,
+}
+
+impl ModuleKind {
+    pub fn to_db_kind(&self) -> String {
+        match self {
+            ModuleKind::Module => "module".into(),
+            ModuleKind::WorkspaceBackup => "workspaceBackup".into(),
+        }
+    }
+}
+
+impl FromStr for ModuleKind {
+    type Err = sea_query::ValueTypeErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "module" => ModuleKind::Module,
+            "workspaceBackup" => ModuleKind::WorkspaceBackup,
+            _ => return Err(sea_query::ValueTypeErr),
+        })
+    }
+}
+
+impl From<ModuleKind> for sea_orm::Value {
+    fn from(value: ModuleKind) -> Self {
+        value.to_db_kind().into()
+    }
+}
+
+impl sea_query::ValueType for ModuleKind {
+    fn try_from(v: Value) -> Result<Self, sea_query::ValueTypeErr> {
+        match v {
+            Value::String(Some(x)) => Ok(ModuleKind::from_str(x.as_str())?),
+            _ => Err(sea_query::ValueTypeErr),
+        }
+    }
+
+    fn type_name() -> String {
+        stringify!(ModuleId).to_owned()
+    }
+
+    fn array_type() -> sea_orm::sea_query::ArrayType {
+        sea_orm::sea_query::ArrayType::String
+    }
+
+    fn column_type() -> sea_query::ColumnType {
+        sea_query::ColumnType::String(None)
+    }
+}
+
+impl sea_orm::TryGetable for ModuleKind {
+    fn try_get_by<I: sea_orm::ColIdx>(res: &QueryResult, idx: I) -> Result<Self, TryGetError> {
+        let json_str: String = res.try_get_by(idx).map_err(TryGetError::DbErr)?;
+
+        ModuleKind::from_str(&json_str).map_err(|e| {
+            TryGetError::DbErr(DbErr::TryIntoErr {
+                from: "database module kind",
+                into: "ModuleKind",
+                source: Box::new(e),
+            })
+        })
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,6 +94,7 @@ pub struct Model {
     pub created_at: DateTimeWithTimeZone,
     pub rejected_at: Option<DateTimeWithTimeZone>,
     pub rejected_by_display_name: Option<String>,
+    pub kind: ModuleKind,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/lib/module-index-server/src/routes/list_modules_route.rs
+++ b/lib/module-index-server/src/routes/list_modules_route.rs
@@ -41,6 +41,7 @@ impl IntoResponse for ListModulesError {
 #[serde(rename_all = "camelCase")]
 pub struct ListModulesRequest {
     pub name: Option<String>,
+    pub kind: Option<si_module::ModuleKind>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -66,7 +67,11 @@ pub async fn list_module_route(
         return Ok(Json(ListModulesResponse { modules: vec![] }));
     }
 
-    let query = query.filter(si_module::Column::RejectedAt.is_null());
+    let kind = request.kind.unwrap_or(si_module::ModuleKind::Module);
+
+    let query = query
+        .filter(si_module::Column::RejectedAt.is_null())
+        .filter(si_module::Column::Kind.eq(kind.to_db_kind()));
 
     // filters
     let query = if let Some(name_filter) = request.name {

--- a/lib/module-index-server/src/routes/reject_module_route.rs
+++ b/lib/module-index-server/src/routes/reject_module_route.rs
@@ -90,6 +90,7 @@ pub async fn reject_module(
             Utc.fix(),
         ))),
         rejected_by_display_name: Set(Some(data)),
+        kind: Set(module.kind),
     };
 
     let updated_module: si_module::Model = dbg!(active_module.update(&txn).await)?;


### PR DESCRIPTION
Adds a column to the modules table in module index to filter modules by kind ('module', or 'workspaceBackup'). 

Supports listing workspaceBackups in the UX and adds the stub to the workspace import route (will be 404 until that PR lands).