### PR TITLE
fix(web): Catch axios errors in CachedAppNotification

### DIFF
--- a/app/web/src/components/CachedAppNotification.vue
+++ b/app/web/src/components/CachedAppNotification.vue
@@ -28,12 +28,12 @@ async function check() {
   const manifestUrl = `${
     window.location.origin
   }/manifest.json?timestamp=${Date.now()}`;
-  const res = await axios(manifestUrl, {
-    headers: { "Cache-Control": "no-cache" },
-  });
 
   try {
-    if (res.status !== 200) throw new Error("server offline");
+    const res = await axios(manifestUrl, {
+      headers: { "Cache-Control": "no-cache" },
+    });
+
     const latestAppFileWithHash = res.data["index.html"].file;
 
     const latestHash = latestAppFileWithHash.match(APP_FILENAME_REGEX)?.[1];


### PR DESCRIPTION
We're fetching manifest.json on an interval, but axios throws an error on 404 which happens in dev mode since we won't have a build or a manifest.json. This quiets those errors while keeping the behavior intact when run from the container/nginx build. The interval will be killed if manifest.json 404s so we only fetch it once in dev mode.