### PR TITLE
fix(cyclone-server,veritech-server): Reducing the logging of shutdown events

### DIFF
--- a/lib/cyclone-server/src/server.rs
+++ b/lib/cyclone-server/src/server.rs
@@ -180,11 +180,11 @@ fn prepare_graceful_shutdown(
 
         tokio::select! {
             _ = sigterm_stream.recv() => {
-                info!("received SIGTERM signal, performing graceful shutdown");
+                trace!("received SIGTERM signal, performing graceful shutdown");
                 send_graceful_shutdown(graceful_shutdown_tx);
             }
             source = shutdown_rx.recv() => {
-                info!(
+                trace!(
                     "received internal shutdown, performing graceful shutdown; source={:?}",
                     source,
                 );

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -858,11 +858,11 @@ fn prepare_graceful_shutdown(
 
         tokio::select! {
             _ = sigterm_stream.recv() => {
-                info!("received SIGTERM signal, performing graceful shutdown");
+                trace!("received SIGTERM signal, performing graceful shutdown");
                 send_graceful_shutdown(graceful_shutdown_tx, shutdown_broadcast_tx);
             }
             source = shutdown_rx.recv() => {
-                info!(
+                trace!(
                     "received internal shutdown, performing graceful shutdown; source={:?}",
                     source,
                 );


### PR DESCRIPTION
Currently the veritech process throws 100s of these (due to cyclone)

```
023-09-26T11:21:12.380324Z  INFO ThreadId(03) cyclone_server::server: received internal shutdown, performing graceful shutdown; source=Some(LimitRequest)
```

I have moved this to a trace level event