### PR TITLE
feat(module-index,web): filter workspace backups by user pk

### DIFF
--- a/app/web/src/components/modules/ModuleListPanel.vue
+++ b/app/web/src/components/modules/ModuleListPanel.vue
@@ -91,7 +91,7 @@ const exportModalRef = ref<InstanceType<typeof Modal>>();
 const textSearch = ref("");
 
 async function triggerSearch() {
-  await moduleStore.SEARCH_REMOTE_MODULES();
+  await moduleStore.SEARCH_REMOTE_MODULES({ su: true });
 }
 
 onMounted(triggerSearch);

--- a/app/web/src/store/module.store.ts
+++ b/app/web/src/store/module.store.ts
@@ -202,7 +202,11 @@ export const useModuleStore = () => {
           });
         },
 
-        async SEARCH_REMOTE_MODULES(params?: { name?: string; kind?: string }) {
+        async SEARCH_REMOTE_MODULES(params?: {
+          name?: string;
+          kind?: string;
+          su?: boolean;
+        }) {
           return new ModuleIndexApiRequest<{
             modules: (RemoteModuleSummary & {
               latestHash: ModuleHash;

--- a/bin/module-index/Dockerfile
+++ b/bin/module-index/Dockerfile
@@ -39,5 +39,5 @@ EXPOSE 5157/tcp
 ENTRYPOINT [ \
   "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/module-index", \
   "--jwt-public-key", "/run/module-index/prod.jwt_signing_public_key.pem", \
-  "--restrict-listing", "--disable-opentelemetry" \
+   "--disable-opentelemetry" \
 ]

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -80,9 +80,6 @@ pub(crate) struct Args {
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
-
-    #[arg(long, env)]
-    pub(crate) restrict_listing: bool,
 }
 
 impl TryFrom<Args> for Config {
@@ -129,9 +126,6 @@ impl TryFrom<Args> for Config {
             }
             if let Some(jwt_public_key) = args.jwt_public_key {
                 config_map.set("jwt_signing_public_key_path", jwt_public_key);
-            }
-            if args.restrict_listing {
-                config_map.set("restrict_listing", true);
             }
 
             // if let Some(migration_mode) = args.migration_mode {

--- a/lib/module-index-server/src/app_state.rs
+++ b/lib/module-index-server/src/app_state.rs
@@ -25,7 +25,6 @@ pub struct AppState {
     posthog_client: PosthogClient,
     aws_creds: AwsCredentials,
     s3_config: S3Config,
-    restrict_listing: bool,
     token_emails: Arc<Mutex<HashMap<String, String>>>,
 
     shutdown_broadcast: ShutdownBroadcast,
@@ -44,7 +43,6 @@ impl AppState {
         posthog_client: PosthogClient,
         aws_creds: AwsCredentials,
         s3_config: S3Config,
-        restrict_listing: bool,
         shutdown_broadcast_tx: broadcast::Sender<()>,
         tmp_shutdown_tx: mpsc::Sender<ShutdownSource>,
     ) -> Self {
@@ -54,7 +52,6 @@ impl AppState {
             posthog_client,
             aws_creds,
             s3_config,
-            restrict_listing,
             shutdown_broadcast: ShutdownBroadcast(shutdown_broadcast_tx),
             token_emails: Arc::new(Mutex::new(HashMap::new())),
             _tmp_shutdown_tx: Arc::new(tmp_shutdown_tx),
@@ -88,9 +85,5 @@ impl AppState {
     /// Clones the ArcMutex that holds a hashmap between auth tokens and emails
     pub fn token_emails(&self) -> Arc<Mutex<HashMap<String, String>>> {
         self.token_emails.clone()
-    }
-
-    pub fn restrict_listing(&self) -> bool {
-        self.restrict_listing
     }
 }

--- a/lib/module-index-server/src/config.rs
+++ b/lib/module-index-server/src/config.rs
@@ -55,9 +55,6 @@ pub struct Config {
     #[builder(default = "PosthogConfig::default()")]
     posthog: PosthogConfig,
 
-    #[builder(default = "false")]
-    restrict_listing: bool,
-
     s3: S3Config,
 }
 
@@ -99,11 +96,6 @@ impl Config {
     pub fn s3(&self) -> &S3Config {
         &self.s3
     }
-
-    /// Whether to restrict module listing to SystemInit accounts
-    pub fn restrict_listing(&self) -> bool {
-        self.restrict_listing
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -120,8 +112,6 @@ pub struct ConfigFile {
     pub posthog: PosthogConfig,
     #[serde(default)]
     pub s3: S3Config,
-    #[serde(default)]
-    pub restrict_listing: bool,
 }
 
 impl Default for ConfigFile {
@@ -139,7 +129,6 @@ impl Default for ConfigFile {
             jwt_signing_public_key_path: default_jwt_signing_public_key_path(),
             posthog: Default::default(),
             s3: Default::default(),
-            restrict_listing: Default::default(),
         }
     }
 }
@@ -161,7 +150,6 @@ impl TryFrom<ConfigFile> for Config {
         config.jwt_signing_public_key_path(value.jwt_signing_public_key_path.try_into()?);
         config.posthog(value.posthog);
         config.s3(value.s3);
-        config.restrict_listing(value.restrict_listing);
         config.build().map_err(Into::into)
     }
 }

--- a/lib/module-index-server/src/routes/reject_module_route.rs
+++ b/lib/module-index-server/src/routes/reject_module_route.rs
@@ -55,9 +55,7 @@ pub async fn reject_module(
     State(state): State<AppState>,
     mut multipart: Multipart,
 ) -> Result<Json<Option<ModuleDetailsResponse>>, RejectModuleError> {
-    if dbg!(state.restrict_listing())
-        && !dbg!(is_systeminit_auth_token(&auth_token, state.token_emails()).await?)
-    {
+    if !is_systeminit_auth_token(&auth_token, state.token_emails()).await? {
         return Ok(Json(None));
     }
 

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use si_pkg::{SiPkg, SiPkgError, SiPkgKind};
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::{
     extract::{Authorization, DbConnection, ExtractedS3Bucket},
@@ -57,7 +56,7 @@ impl IntoResponse for UpsertModuleError {
 
 // #[debug_handler]
 pub async fn upsert_module_route(
-    Authorization { .. }: Authorization,
+    Authorization { user_claim, .. }: Authorization,
     ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     mut multipart: Multipart,
@@ -99,8 +98,7 @@ pub async fn upsert_module_route(
     let new_module = si_module::ActiveModel {
         name: Set(module_metadata.name().to_owned()),
         description: Set(Some(module_metadata.description().to_owned())),
-        // owner_user_id: Set(claim.user_pk.to_string()),
-        owner_user_id: Set(Ulid::new().to_string()),
+        owner_user_id: Set(user_claim.user_pk.to_string()),
         owner_display_name: Set(Some(module_metadata.created_by().to_owned())),
         latest_hash: Set(module_metadata.hash().to_string()),
         // maybe use db's `CLOCK_TIMESTAMP()`?

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -100,7 +100,6 @@ impl Server<(), ()> {
             posthog_client,
             aws_creds,
             config.s3().clone(),
-            config.restrict_listing(),
         )?;
 
         info!(
@@ -215,7 +214,6 @@ pub fn build_service(
     posthog_client: PosthogClient,
     aws_creds: AwsCredentials,
     s3_config: S3Config,
-    restrict_listing: bool,
 ) -> Result<(Router, oneshot::Receiver<()>, broadcast::Receiver<()>)> {
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
     let (shutdown_broadcast_tx, shutdown_broadcast_rx) = broadcast::channel(1);
@@ -226,7 +224,6 @@ pub fn build_service(
         posthog_client,
         aws_creds,
         s3_config,
-        restrict_listing,
         shutdown_broadcast_tx.clone(),
         shutdown_tx,
     );


### PR DESCRIPTION
Module uploads were getting a random user id. Updated to store the user claim pk from the auth token as the user id. This allows us to filter workspace backups by user.

Removes "restrict-listing" and adds a "su" flag to list modules which will list modules for all users / allow module rejection if user token matches a systeminit.com user token.