### PR TITLE
feat(dal,sdf,web): Workspace Backup of schema variants and functions

### DIFF
--- a/lib/dal/examples/dal-pkg-import/main.rs
+++ b/lib/dal/examples/dal-pkg-import/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         "--- Importing pkg: {tar_file} into change set \"{change_set_name}\" in workspace \"{}\"",
         workspace.name()
     );
-    import_pkg_from_pkg(&ctx, &pkg, &tar_file, None).await?;
+    import_pkg_from_pkg(&ctx, &pkg, None).await?;
 
     println!("--- Committing database transaction");
     ctx.commit().await?;

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -56,14 +56,14 @@ static FUNC_BUILTIN_BY_PATH: once_cell::sync::Lazy<std::collections::HashMap<&st
 
 pub async fn migrate_intrinsics(ctx: &DalContext) -> BuiltinsResult<()> {
     let intrinsics_pkg_spec = IntrinsicFunc::pkg_spec()?;
-    let name = intrinsics_pkg_spec.name.to_owned();
+    let _name = intrinsics_pkg_spec.name.to_owned();
     let intrinsics_pkg = SiPkg::load_from_spec(intrinsics_pkg_spec)?;
 
     if InstalledPkg::find_by_hash(ctx, &intrinsics_pkg.hash()?.to_string())
         .await?
         .is_none()
     {
-        import_pkg_from_pkg(ctx, &intrinsics_pkg, &name, None).await?;
+        import_pkg_from_pkg(ctx, &intrinsics_pkg, None).await?;
         ctx.blocking_commit().await?;
     }
 

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -153,7 +153,6 @@ pub async fn migrate_pkg(
         import_pkg_from_pkg(
             ctx,
             &pkg,
-            pkg_filename,
             schemas.map(|schemas| ImportOptions {
                 schemas: Some(schemas),
                 ..Default::default()

--- a/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_fallout.rs
@@ -211,7 +211,6 @@ impl MigrationDriver {
         import_pkg_from_pkg(
             ctx,
             &fallout_pkg,
-            "test:fallout",
             Some(crate::pkg::ImportOptions {
                 schemas: Some(vec!["fallout".into()]),
                 ..Default::default()

--- a/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_starfield.rs
@@ -307,7 +307,6 @@ impl MigrationDriver {
         import_pkg_from_pkg(
             ctx,
             &starfield_pkg,
-            "test:starfield",
             Some(crate::pkg::ImportOptions {
                 schemas: Some(vec!["starfield".into()]),
                 ..Default::default()

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -48,6 +48,8 @@ pub enum FuncError {
     /// Could not find the identity [`Func`].
     #[error("identity func not found")]
     IdentityFuncNotFound,
+    #[error("intrinsic parse error: {0} is not an intrinsic")]
+    IntrinsicParse(String),
     #[error("intrinsic spec creation error {0}")]
     IntrinsicSpecCreation(String),
     #[error("nats txn error: {0}")]

--- a/lib/dal/src/func/intrinsics.rs
+++ b/lib/dal/src/func/intrinsics.rs
@@ -139,4 +139,21 @@ impl IntrinsicFunc {
             Self::Validation => "si:validation",
         }
     }
+
+    pub fn maybe_from_str(s: &str) -> Option<Self> {
+        Some(match s {
+            "si:identity" => Self::Identity,
+            "si:setArray" => Self::SetArray,
+            "si:setBoolean" => Self::SetBoolean,
+            "si:setInteger" => Self::SetInteger,
+            "si:setMap" => Self::SetMap,
+            "si:setObject" => Self::SetObject,
+            "si:setString" => Self::SetString,
+            "si:unset" => Self::Unset,
+            "si:validation" => Self::Validation,
+            _ => {
+                return None;
+            }
+        })
+    }
 }

--- a/lib/dal/src/migrations/U2310__clear_workspace.sql
+++ b/lib/dal/src/migrations/U2310__clear_workspace.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE FUNCTION clear_workspace_v1(tenancy_to_clear jsonb)
+RETURNS VOID AS
+$$
+DECLARE
+  standard_model  standard_models%ROWTYPE;
+  tenancy_record  tenancy_record_v1;
+  this_table_name regclass;
+BEGIN
+  FOR standard_model IN SELECT * FROM standard_models
+    LOOP
+      this_table_name := standard_model.table_name::regclass;
+      EXECUTE format(
+        'DELETE FROM %1$I WHERE in_tenancy_v1(%2$L, %1$I.tenancy_workspace_pk)',
+        this_table_name,
+        tenancy_to_clear
+      );
+    END LOOP;
+
+    EXECUTE format(
+      'DELETE FROM change_sets WHERE in_tenancy_v1(%1$L, change_sets.tenancy_workspace_pk)',
+      tenancy_to_clear
+    );
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -24,6 +24,7 @@ use crate::{
     ExternalProviderId, FuncBackendKind, FuncBackendResponseType, FuncError, FuncId,
     InternalProviderError, InternalProviderId, PropError, PropId, PropKind, SchemaError, SchemaId,
     SchemaVariantError, SchemaVariantId, StandardModelError, ValidationPrototypeError,
+    WorkspaceError, WorkspacePk,
 };
 
 #[remain::sorted]
@@ -117,8 +118,12 @@ pub enum PkgError {
     MissingItemPropForMapProp(PropId),
     #[error("Cannot find installed prop {0}")]
     MissingProp(PropId),
+    #[error("Cannot find root prop for variant {0}")]
+    MissingRootProp(SchemaVariantId),
     #[error("Cannot find schema_variant_definition {0}")]
     MissingSchemaVariantDefinition(SchemaVariantId),
+    #[error("Unique id missing for node in workspace backup: {0}")]
+    MissingUniqueIdForNode(String),
     #[error("Package with that hash already installed: {0}")]
     PackageAlreadyInstalled(String),
     #[error(transparent)]
@@ -152,9 +157,21 @@ pub enum PkgError {
     #[error("standard model relationship {0} found multiple belongs_to for {1} with id {2}")]
     StandardModelMultipleBelongsTo(&'static str, &'static str, String),
     #[error(transparent)]
+    UlidDecode(#[from] ulid::DecodeError),
+    #[error(transparent)]
     UrlParse(#[from] ParseError),
     #[error("Validation creation error: {0}")]
     Validation(#[from] ValidationPrototypeError),
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
+    #[error("Cannot find default change set \"{0}\" in workspace backup")]
+    WorkspaceBackupNoDefaultChangeSet(String),
+    #[error("Workspace backup missing workspace name")]
+    WorkspaceNameNotInBackup,
+    #[error("Workspace not found: {0}")]
+    WorkspaceNotFound(WorkspacePk),
+    #[error("Workspace backup missing workspace pk")]
+    WorkspacePkNotInBackup,
 }
 
 impl PkgError {

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1,20 +1,25 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path, str::FromStr};
 use telemetry::prelude::*;
 use tokio::sync::Mutex;
 
 use si_pkg::{
     SchemaVariantSpecPropRoot, SiPkg, SiPkgActionFunc, SiPkgAttrFuncInputView, SiPkgError,
-    SiPkgFunc, SiPkgLeafFunction, SiPkgProp, SiPkgSchema, SiPkgSchemaVariant, SiPkgSocket,
-    SiPkgValidation, SocketSpecKind,
+    SiPkgFunc, SiPkgFuncArgument, SiPkgFuncData, SiPkgKind, SiPkgLeafFunction, SiPkgMetadata,
+    SiPkgProp, SiPkgPropData, SiPkgSchema, SiPkgSchemaData, SiPkgSchemaVariant, SiPkgSocket,
+    SiPkgSocketData, SocketSpecKind, ValidationSpec,
 };
 
 use crate::{
     component::ComponentKind,
-    func::{self, binding::FuncBinding, binding_return_value::FuncBindingReturnValue},
+    func::{
+        self, argument::FuncArgumentKind, backend::validation::FuncBackendValidationArgs,
+        binding::FuncBinding, binding_return_value::FuncBindingReturnValue,
+    },
     installed_pkg::{
         InstalledPkg, InstalledPkgAsset, InstalledPkgAssetKind, InstalledPkgAssetTyped,
         InstalledPkgId,
     },
+    prop::PropPath,
     schema::{
         variant::{
             definition::{SchemaVariantDefinition, SchemaVariantDefinitionJson},
@@ -22,75 +27,122 @@ use crate::{
         },
         SchemaUiMenu,
     },
-    validation::{create_validation, Validation, ValidationKind},
-    ActionPrototype, ActionPrototypeContext, AttributeContextBuilder, AttributePrototypeArgument,
-    AttributeReadContext, AttributeValue, AttributeValueError, DalContext, ExternalProvider,
-    ExternalProviderId, Func, FuncArgument, FuncError, FuncId, InternalProvider, Prop, PropId,
-    PropKind, Schema, SchemaId, SchemaVariant, SchemaVariantError, SchemaVariantId, StandardModel,
+    validation::{Validation, ValidationKind},
+    ActionKind, ActionPrototype, ActionPrototypeContext, AttributeContextBuilder,
+    AttributePrototype, AttributePrototypeArgument, AttributePrototypeId, AttributeReadContext,
+    AttributeValue, AttributeValueError, ChangeSet, ChangeSetPk, DalContext, ExternalProvider,
+    ExternalProviderId, Func, FuncArgument, FuncError, FuncId, InternalProvider, LeafKind, Prop,
+    PropId, PropKind, Schema, SchemaId, SchemaVariant, SchemaVariantError, SchemaVariantId, Socket,
+    StandardModel, Tenancy, ValidationPrototype, ValidationPrototypeContext, Workspace,
+    WorkspacePk,
 };
 
 use super::{PkgError, PkgResult};
 
-type FuncMap = std::collections::HashMap<String, Func>;
+#[derive(Clone, Debug)]
+enum Thing {
+    ActionPrototype(ActionPrototype),
+    AttributePrototypeArgument(AttributePrototypeArgument),
+    Func(Func),
+    FuncArgument(FuncArgument),
+    Schema(Schema),
+    SchemaVariant(SchemaVariant),
+    Socket(Box<(Socket, Option<InternalProvider>, Option<ExternalProvider>)>),
+    Validation(ValidationPrototype),
+}
+
+type ThingMap = HashMap<String, Thing>;
+
+struct ChangeSetThingMap(HashMap<ChangeSetPk, ThingMap>);
+
+impl ChangeSetThingMap {
+    fn new() -> Self {
+        let head_thing_map = ThingMap::new();
+
+        let mut change_set_map: HashMap<ChangeSetPk, ThingMap> = HashMap::new();
+        change_set_map.insert(ChangeSetPk::NONE, head_thing_map);
+
+        Self(change_set_map)
+    }
+
+    fn get(
+        &self,
+        change_set_pk: Option<ChangeSetPk>,
+        thing_id: impl Into<String>,
+    ) -> Option<&Thing> {
+        let thing_id: String = thing_id.into();
+
+        match self.0.get(&change_set_pk.unwrap_or(ChangeSetPk::NONE)) {
+            Some(change_set_map) => change_set_map.get(&thing_id).or_else(|| {
+                self.0
+                    .get(&ChangeSetPk::NONE)
+                    .and_then(|things| things.get(&thing_id))
+            }),
+            None => self
+                .0
+                .get(&ChangeSetPk::NONE)
+                .and_then(|things| things.get(&thing_id)),
+        }
+    }
+
+    fn insert(
+        &mut self,
+        change_set_pk: Option<ChangeSetPk>,
+        id: &str,
+        thing: Thing,
+    ) -> Option<Thing> {
+        self.0
+            .entry(change_set_pk.unwrap_or(ChangeSetPk::NONE))
+            .or_insert(ThingMap::new())
+            .insert(id.into(), thing)
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct ImportOptions {
     pub schemas: Option<Vec<String>>,
-    pub skip_import_funcs: Option<FuncMap>,
+    pub skip_import_funcs: Option<HashMap<String, Func>>,
     /// If set to `true`, the importer will install the assets from the module
     /// but will not make a record of the install as an "installed module".
     pub no_record: bool,
 }
 
-pub async fn import_pkg_from_pkg(
+#[allow(clippy::too_many_arguments)]
+async fn import_change_set(
     ctx: &DalContext,
-    pkg: &SiPkg,
-    file_name: &str,
-    options: Option<ImportOptions>,
-) -> PkgResult<(Option<InstalledPkgId>, Vec<SchemaVariantId>)> {
-    // We have to write the installed_pkg row first, so that we have an id, and rely on transaction
-    // semantics to remove the row if anything in the installation process fails
-    let root_hash = pkg.hash()?.to_string();
-
-    let options = options.unwrap_or_default();
-
-    if InstalledPkg::find_by_hash(ctx, &root_hash).await?.is_some() {
-        return Err(PkgError::PackageAlreadyInstalled(root_hash));
-    }
-
-    // TODO: store pkg.metadata()?.name() instead of file_name, but we'll need
-    // to also store the file name unless we stop using the .sipkg file
-    // completely after install
-    let installed_pkg_id = if options.no_record {
-        None
-    } else {
-        Some(
-            *InstalledPkg::new(ctx, &file_name, pkg.hash()?.to_string())
-                .await?
-                .id(),
-        )
-    };
-
-    let mut funcs_by_unique_id = FuncMap::new();
-    for func_spec in pkg.funcs()? {
+    change_set_pk: Option<ChangeSetPk>,
+    metadata: &SiPkgMetadata,
+    funcs: &[SiPkgFunc<'_>],
+    schemas: &[SiPkgSchema<'_>],
+    installed_pkg_id: Option<InstalledPkgId>,
+    thing_map: &mut ChangeSetThingMap,
+    options: &ImportOptions,
+) -> PkgResult<Vec<SchemaVariantId>> {
+    for func_spec in funcs {
         info!(
-            "installing function '{}' from {}",
+            "installing function '{}' from {} - {}",
             func_spec.name(),
-            file_name,
+            metadata.name(),
+            metadata.version()
         );
         let unique_id = func_spec.unique_id().to_string();
 
         // This is a hack because the hash of the intrinsics has changed from the version in the
-        // packages. We also apply this to si:resourcePayloadToValue and si:normalizeToArray since
-        // it should be an intrinsic but is only in our packages
-        let special_case_funcs = vec!["si:resourcePayloadToValue", "si:normalizeToArray"];
+        // packages. We also apply this to si:resourcePayloadToValue since it should be an
+        // intrinsic but is only in our packages
+        let special_case_funcs = ["si:resourcePayloadToValue", "si:normalizeToArray"];
         if func::is_intrinsic(func_spec.name()) || special_case_funcs.contains(&func_spec.name()) {
-            let func = if let Some(func) = Func::find_by_name(ctx, func_spec.name()).await? {
-                func
-            } else {
-                create_func(ctx, func_spec, installed_pkg_id).await?
-            };
-            funcs_by_unique_id.insert(unique_id, func);
+            if let Some(func) = Func::find_by_name(ctx, func_spec.name()).await? {
+                thing_map.insert(change_set_pk, &unique_id, Thing::Func(func.to_owned()));
+            } else if let Some(func) =
+                import_func(ctx, None, func_spec, installed_pkg_id, thing_map).await?
+            {
+                let args = func_spec.arguments()?;
+
+                if !args.is_empty() {
+                    import_func_arguments(ctx, None, *func.id(), &args, thing_map).await?;
+                }
+            }
         } else {
             let func = if let Some(Some(func)) = options
                 .skip_import_funcs
@@ -109,17 +161,33 @@ pub async fn import_pkg_from_pkg(
                     .await?;
                 }
 
-                func.to_owned()
+                // We're not going to import this func but we need it in the map for lookups later
+                thing_map.insert(
+                    change_set_pk,
+                    func_spec.unique_id(),
+                    Thing::Func(func.to_owned()),
+                );
+
+                None
             } else {
-                create_func(ctx, func_spec, installed_pkg_id).await?
+                import_func(ctx, change_set_pk, func_spec, installed_pkg_id, thing_map).await?
             };
-            funcs_by_unique_id.insert(unique_id, func);
-        }
+
+            if let Some(func) = func {
+                thing_map.insert(change_set_pk, &unique_id, Thing::Func(func.to_owned()));
+
+                let args = func_spec.arguments()?;
+
+                if !args.is_empty() {
+                    import_func_arguments(ctx, change_set_pk, *func.id(), &args, thing_map).await?;
+                }
+            }
+        };
     }
 
     let mut installed_schema_variant_ids = vec![];
 
-    for schema_spec in pkg.schemas()? {
+    for schema_spec in schemas {
         match &options.schemas {
             None => {}
             Some(schemas) => {
@@ -132,185 +200,605 @@ pub async fn import_pkg_from_pkg(
         info!(
             "installing schema '{}' from {}",
             schema_spec.name(),
-            file_name
+            metadata.name(),
         );
 
         let (_, schema_variant_ids) =
-            create_schema(ctx, schema_spec, installed_pkg_id, &funcs_by_unique_id).await?;
+            import_schema(ctx, change_set_pk, schema_spec, installed_pkg_id, thing_map).await?;
 
         installed_schema_variant_ids.extend(schema_variant_ids);
     }
 
-    Ok((installed_pkg_id, installed_schema_variant_ids))
+    Ok(installed_schema_variant_ids)
 }
 
-pub async fn import_pkg(ctx: &DalContext, pkg_file_path: impl AsRef<Path>) -> PkgResult<SiPkg> {
-    let pkg_file_path_str = pkg_file_path.as_ref().to_string_lossy().to_string();
-
-    let pkg = SiPkg::load_from_file(&pkg_file_path).await?;
-
-    import_pkg_from_pkg(ctx, &pkg, &pkg_file_path_str, None).await?;
-
-    Ok(pkg)
-}
-
-async fn create_func(
+pub async fn import_pkg_from_pkg(
     ctx: &DalContext,
-    func_spec: SiPkgFunc<'_>,
-    installed_pkg_id: Option<InstalledPkgId>,
-) -> PkgResult<Func> {
-    let hash = func_spec.hash().to_string();
-    let existing_func =
-        InstalledPkgAsset::list_for_kind_and_hash(ctx, InstalledPkgAssetKind::Func, &hash)
-            .await?
-            .pop();
+    pkg: &SiPkg,
+    options: Option<ImportOptions>,
+) -> PkgResult<(Option<InstalledPkgId>, Vec<SchemaVariantId>)> {
+    // We have to write the installed_pkg row first, so that we have an id, and rely on transaction
+    // semantics to remove the row if anything in the installation process fails
+    let root_hash = pkg.hash()?.to_string();
 
-    let func = match existing_func {
-        Some(installed_func_record) => match installed_func_record.as_installed_func()? {
-            InstalledPkgAssetTyped::Func { id, .. } => match Func::get_by_id(ctx, &id).await? {
-                Some(func) => func,
-                None => return Err(PkgError::InstalledFuncMissing(id)),
-            },
-            _ => unreachable!(),
-        },
-        None => {
-            let name = func_spec.name();
+    let options = options.unwrap_or_default();
 
-            let func_spec_data = func_spec
-                .data()
-                .ok_or(PkgError::DataNotFound(name.into()))?;
+    if InstalledPkg::find_by_hash(ctx, &root_hash).await?.is_some() {
+        return Err(PkgError::PackageAlreadyInstalled(root_hash));
+    }
 
-            // How to handle name conflicts?
-            let mut func = Func::new(
+    let metadata = pkg.metadata()?;
+
+    let installed_pkg_id = if options.no_record {
+        None
+    } else {
+        Some(
+            *InstalledPkg::new(ctx, metadata.name(), pkg.hash()?.to_string())
+                .await?
+                .id(),
+        )
+    };
+
+    let mut change_set_things = ChangeSetThingMap::new();
+
+    match metadata.kind() {
+        SiPkgKind::Module => {
+            let installed_schema_variant_ids = import_change_set(
                 ctx,
-                name,
-                func_spec_data.backend_kind().into(),
-                func_spec_data.response_type().into(),
+                None,
+                &metadata,
+                &pkg.funcs()?,
+                &pkg.schemas()?,
+                installed_pkg_id,
+                &mut change_set_things,
+                &options,
             )
             .await?;
 
-            func.set_display_name(ctx, func_spec_data.display_name())
-                .await?;
-            func.set_code_base64(ctx, Some(func_spec_data.code_base64()))
-                .await?;
-            func.set_description(ctx, func_spec_data.description())
-                .await?;
-            func.set_handler(ctx, Some(func_spec_data.handler()))
-                .await?;
-            func.set_hidden(ctx, func.hidden()).await?;
-            func.set_link(ctx, func_spec.link().map(|l| l.to_string()))
-                .await?;
+            Ok((installed_pkg_id, installed_schema_variant_ids))
+        }
+        SiPkgKind::WorkspaceBackup => {
+            let mut ctx = ctx.clone_with_new_visibility(ctx.visibility().to_head());
 
-            // If the func exists above with the matching hash, we assume the arguments are correct
-            // and only create the arguments if we're creating the function
-            for arg in func_spec.arguments()? {
-                FuncArgument::new(
-                    ctx,
-                    arg.name(),
-                    arg.kind().into(),
-                    arg.element_kind().cloned().map(|kind| kind.into()),
-                    *func.id(),
+            let workspace_pk = WorkspacePk::from_str(
+                metadata
+                    .workspace_pk()
+                    .ok_or(PkgError::WorkspacePkNotInBackup)?,
+            )?;
+            let workspace_name = metadata
+                .workspace_name()
+                .ok_or(PkgError::WorkspaceNameNotInBackup)?;
+            let default_change_set_name = metadata.default_change_set().unwrap_or("head");
+
+            Workspace::clear_or_create_workspace(&mut ctx, workspace_pk, workspace_name).await?;
+
+            ctx.update_tenancy(Tenancy::new(workspace_pk));
+
+            let change_sets = pkg.change_sets()?;
+            let default_change_set = change_sets
+                .iter()
+                .find(|cs| cs.name() == default_change_set_name)
+                .ok_or(PkgError::WorkspaceBackupNoDefaultChangeSet(
+                    default_change_set_name.into(),
+                ))?;
+
+            import_change_set(
+                &ctx,
+                Some(ChangeSetPk::NONE),
+                &metadata,
+                &default_change_set.funcs()?,
+                &default_change_set.schemas()?,
+                installed_pkg_id,
+                &mut change_set_things,
+                &options,
+            )
+            .await?;
+
+            for change_set in change_sets {
+                if change_set.name() == default_change_set_name {
+                    continue;
+                }
+
+                // Revert to head to create new change set
+                let ctx = ctx.clone_with_new_visibility(ctx.visibility().to_head());
+                let new_cs = ChangeSet::new(&ctx, change_set.name(), None).await?;
+                // Switch to new change set visibility
+                let ctx = ctx.clone_with_new_visibility(ctx.visibility().to_change_set(new_cs.pk));
+
+                import_change_set(
+                    &ctx,
+                    Some(new_cs.pk),
+                    &metadata,
+                    &change_set.funcs()?,
+                    &change_set.schemas()?,
+                    installed_pkg_id,
+                    &mut change_set_things,
+                    &options,
                 )
                 .await?;
             }
 
-            func
+            Ok((None, vec![]))
+        }
+    }
+}
+
+pub async fn import_pkg(ctx: &DalContext, pkg_file_path: impl AsRef<Path>) -> PkgResult<SiPkg> {
+    let pkg = SiPkg::load_from_file(&pkg_file_path).await?;
+
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
+
+    Ok(pkg)
+}
+
+async fn create_func(ctx: &DalContext, func_spec: &SiPkgFunc<'_>) -> PkgResult<Func> {
+    let name = func_spec.name();
+
+    let func_spec_data = func_spec
+        .data()
+        .ok_or(PkgError::DataNotFound(name.into()))?;
+
+    // How to handle name conflicts?
+    let mut func = Func::new(
+        ctx,
+        name,
+        func_spec_data.backend_kind().into(),
+        func_spec_data.response_type().into(),
+    )
+    .await?;
+
+    func.set_display_name(ctx, func_spec_data.display_name())
+        .await?;
+    func.set_code_base64(ctx, Some(func_spec_data.code_base64()))
+        .await?;
+    func.set_description(ctx, func_spec_data.description())
+        .await?;
+    func.set_handler(ctx, Some(func_spec_data.handler()))
+        .await?;
+    func.set_hidden(ctx, func_spec_data.hidden()).await?;
+    func.set_link(ctx, func_spec_data.link().map(|l| l.to_string()))
+        .await?;
+
+    Ok(func)
+}
+
+async fn update_func(
+    ctx: &DalContext,
+    func: &mut Func,
+    func_spec_data: &SiPkgFuncData,
+) -> PkgResult<()> {
+    func.set_name(ctx, func_spec_data.name()).await?;
+    func.set_backend_kind(ctx, func_spec_data.backend_kind())
+        .await?;
+    func.set_backend_response_type(ctx, func_spec_data.response_type())
+        .await?;
+    func.set_display_name(ctx, func_spec_data.display_name())
+        .await?;
+    func.set_code_base64(ctx, Some(func_spec_data.code_base64()))
+        .await?;
+    func.set_description(ctx, func_spec_data.description())
+        .await?;
+    func.set_handler(ctx, Some(func_spec_data.handler()))
+        .await?;
+    func.set_hidden(ctx, func_spec_data.hidden()).await?;
+    func.set_link(ctx, func_spec_data.link().map(|l| l.to_string()))
+        .await?;
+
+    Ok(())
+}
+
+async fn import_func(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    func_spec: &SiPkgFunc<'_>,
+    installed_pkg_id: Option<InstalledPkgId>,
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<Option<Func>> {
+    let func = match change_set_pk {
+        None => {
+            let hash = func_spec.hash().to_string();
+            let existing_func =
+                InstalledPkgAsset::list_for_kind_and_hash(ctx, InstalledPkgAssetKind::Func, &hash)
+                    .await?
+                    .pop();
+
+            let (func, created) = match existing_func {
+                Some(installed_func_record) => match installed_func_record.as_installed_func()? {
+                    InstalledPkgAssetTyped::Func { id, .. } => {
+                        match Func::get_by_id(ctx, &id).await? {
+                            Some(func) => (func, false),
+                            None => return Err(PkgError::InstalledFuncMissing(id)),
+                        }
+                    }
+                    _ => unreachable!(),
+                },
+                None => (create_func(ctx, func_spec).await?, true),
+            };
+
+            if let Some(installed_pkg_id) = installed_pkg_id {
+                InstalledPkgAsset::new(
+                    ctx,
+                    InstalledPkgAssetTyped::new_for_func(*func.id(), installed_pkg_id, hash),
+                )
+                .await?;
+            }
+
+            thing_map.insert(
+                change_set_pk,
+                func_spec.unique_id(),
+                Thing::Func(func.to_owned()),
+            );
+
+            if created {
+                Some(func)
+            } else {
+                None
+            }
+        }
+        Some(_) => {
+            let existing_func = thing_map.get(change_set_pk, func_spec.unique_id());
+
+            match existing_func {
+                Some(Thing::Func(existing_func)) => {
+                    let mut existing_func = existing_func.to_owned();
+
+                    if func_spec.deleted() {
+                        existing_func.delete_by_id(ctx).await?;
+
+                        None
+                    } else {
+                        if let Some(data) = func_spec.data() {
+                            update_func(ctx, &mut existing_func, data).await?;
+                        }
+
+                        Some(existing_func)
+                    }
+                }
+                _ => {
+                    if func_spec.deleted() {
+                        // If we're "deleted" but there is no existing function, this means we're
+                        // deleted only in a change set. Do nothing
+                        None
+                    } else {
+                        Some(create_func(ctx, func_spec).await?)
+                    }
+                }
+            }
         }
     };
 
-    if let Some(installed_pkg_id) = installed_pkg_id {
-        InstalledPkgAsset::new(
-            ctx,
-            InstalledPkgAssetTyped::new_for_func(*func.id(), installed_pkg_id, hash),
-        )
-        .await?;
+    if let Some(func) = func.as_ref() {
+        thing_map.insert(
+            change_set_pk,
+            func_spec.unique_id(),
+            Thing::Func(func.to_owned()),
+        );
     }
 
     Ok(func)
 }
 
-async fn create_schema(
+async fn create_func_argument(
     ctx: &DalContext,
-    schema_spec: SiPkgSchema<'_>,
+    func_id: FuncId,
+    func_arg: &SiPkgFuncArgument<'_>,
+) -> PkgResult<FuncArgument> {
+    Ok(FuncArgument::new(
+        ctx,
+        func_arg.name(),
+        func_arg.kind().into(),
+        func_arg.element_kind().to_owned().map(|&kind| kind.into()),
+        func_id,
+    )
+    .await?)
+}
+
+async fn update_func_argument(
+    ctx: &DalContext,
+    existing_arg: &mut FuncArgument,
+    func_id: FuncId,
+    func_arg: &SiPkgFuncArgument<'_>,
+) -> PkgResult<()> {
+    existing_arg.set_name(ctx, func_arg.name()).await?;
+    existing_arg.set_kind(ctx, func_arg.kind()).await?;
+    let element_kind: Option<FuncArgumentKind> = func_arg.element_kind().map(|&kind| kind.into());
+    existing_arg.set_element_kind(ctx, element_kind).await?;
+    existing_arg.set_func_id(ctx, func_id).await?;
+
+    Ok(())
+}
+
+async fn import_func_arguments(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    func_id: FuncId,
+    func_arguments: &[SiPkgFuncArgument<'_>],
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<()> {
+    match change_set_pk {
+        None => {
+            for arg in func_arguments {
+                create_func_argument(ctx, func_id, arg).await?;
+            }
+        }
+        Some(_) => {
+            for arg in func_arguments {
+                let unique_id =
+                    arg.unique_id()
+                        .ok_or(PkgError::MissingUniqueIdForNode(format!(
+                            "func-argument-{}",
+                            arg.hash()
+                        )))?;
+
+                match thing_map.get(change_set_pk, unique_id) {
+                    Some(Thing::FuncArgument(existing_arg)) => {
+                        let mut existing_arg = existing_arg.to_owned();
+
+                        if arg.deleted() {
+                            existing_arg.delete_by_id(ctx).await?;
+                        } else {
+                            update_func_argument(ctx, &mut existing_arg, func_id, arg).await?;
+                            thing_map.insert(
+                                change_set_pk,
+                                unique_id,
+                                Thing::FuncArgument(existing_arg.to_owned()),
+                            );
+                        }
+                    }
+                    _ => {
+                        if !arg.deleted() {
+                            let new_arg = create_func_argument(ctx, func_id, arg).await?;
+                            thing_map.insert(
+                                change_set_pk,
+                                unique_id,
+                                Thing::FuncArgument(new_arg),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn create_schema(ctx: &DalContext, schema_spec_data: &SiPkgSchemaData) -> PkgResult<Schema> {
+    let mut schema = Schema::new(ctx, schema_spec_data.name(), &ComponentKind::Standard).await?;
+    schema
+        .set_ui_hidden(ctx, schema_spec_data.ui_hidden())
+        .await?;
+
+    let ui_menu = SchemaUiMenu::new(
+        ctx,
+        schema_spec_data
+            .category_name()
+            .unwrap_or_else(|| schema_spec_data.name()),
+        schema_spec_data.category(),
+    )
+    .await?;
+    ui_menu.set_schema(ctx, schema.id()).await?;
+
+    Ok(schema)
+}
+
+async fn update_schema(
+    ctx: &DalContext,
+    schema: &mut Schema,
+    schema_spec_data: &SiPkgSchemaData,
+) -> PkgResult<()> {
+    if schema_spec_data.name() != schema.name() {
+        schema.set_name(ctx, schema_spec_data.name()).await?;
+    }
+
+    if schema_spec_data.ui_hidden() != schema.ui_hidden() {
+        schema
+            .set_ui_hidden(ctx, schema_spec_data.ui_hidden())
+            .await?;
+    }
+
+    if let Some(mut ui_menu) = schema.ui_menus(ctx).await?.pop() {
+        if let Some(category_name) = schema_spec_data.category_name() {
+            if category_name != ui_menu.name() {
+                ui_menu.set_name(ctx, category_name).await?;
+            }
+            if schema_spec_data.category() != ui_menu.category() {
+                ui_menu.set_name(ctx, schema_spec_data.category()).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn import_schema(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    schema_spec: &SiPkgSchema<'_>,
     installed_pkg_id: Option<InstalledPkgId>,
-    func_map: &FuncMap,
-) -> PkgResult<(SchemaId, Vec<SchemaVariantId>)> {
-    let hash = schema_spec.hash().to_string();
-    let existing_schema =
-        InstalledPkgAsset::list_for_kind_and_hash(ctx, InstalledPkgAssetKind::Schema, &hash)
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<(Option<SchemaId>, Vec<SchemaVariantId>)> {
+    let schema = match change_set_pk {
+        None => {
+            let hash = schema_spec.hash().to_string();
+            let existing_schema = InstalledPkgAsset::list_for_kind_and_hash(
+                ctx,
+                InstalledPkgAssetKind::Schema,
+                &hash,
+            )
             .await?
             .pop();
 
-    let mut schema = match existing_schema {
-        None => {
-            let mut schema = Schema::new(ctx, schema_spec.name(), &ComponentKind::Standard).await?;
+            let schema = match existing_schema {
+                None => {
+                    let data = schema_spec
+                        .data()
+                        .ok_or(PkgError::DataNotFound("schema".into()))?;
 
-            let schema_spec_data = schema_spec
-                .data()
-                .ok_or(PkgError::DataNotFound(schema.name().into()))?;
+                    create_schema(ctx, data).await?
+                }
+                Some(installed_schema_record) => {
+                    match installed_schema_record.as_installed_schema()? {
+                        InstalledPkgAssetTyped::Schema { id, .. } => {
+                            match Schema::get_by_id(ctx, &id).await? {
+                                Some(schema) => schema,
+                                None => return Err(PkgError::InstalledSchemaMissing(id)),
+                            }
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+            };
 
-            schema
-                .set_ui_hidden(ctx, schema_spec_data.ui_hidden())
+            // Even if the asset is already installed, we write a record of the asset installation so that
+            // we can track the installed packages that share schemas.
+            if let Some(installed_pkg_id) = installed_pkg_id {
+                InstalledPkgAsset::new(
+                    ctx,
+                    InstalledPkgAssetTyped::new_for_schema(*schema.id(), installed_pkg_id, hash),
+                )
                 .await?;
+            }
 
-            let ui_menu = SchemaUiMenu::new(
-                ctx,
-                schema_spec_data
-                    .category_name()
-                    .unwrap_or_else(|| schema_spec.name()),
-                schema_spec_data.category(),
-            )
-            .await?;
-            ui_menu.set_schema(ctx, schema.id()).await?;
-
-            schema
+            Some(schema)
         }
-        Some(installed_schema_record) => match installed_schema_record.as_installed_schema()? {
-            InstalledPkgAssetTyped::Schema { id, .. } => match Schema::get_by_id(ctx, &id).await? {
-                Some(schema) => schema,
-                None => return Err(PkgError::InstalledSchemaMissing(id)),
-            },
-            _ => unreachable!(),
-        },
+        Some(_) => {
+            let unique_id = schema_spec
+                .unique_id()
+                .ok_or(PkgError::MissingUniqueIdForNode(format!(
+                    "schema {}",
+                    schema_spec.hash()
+                )))?;
+
+            match thing_map.get(change_set_pk, unique_id) {
+                Some(Thing::Schema(schema)) => {
+                    let mut schema = schema.to_owned();
+
+                    if schema_spec.deleted() {
+                        schema.delete_by_id(ctx).await?;
+                        // delete all schema children?
+
+                        None
+                    } else {
+                        if let Some(data) = schema_spec.data() {
+                            update_schema(ctx, &mut schema, data).await?;
+                        }
+
+                        Some(schema)
+                    }
+                }
+                _ => {
+                    if schema_spec.deleted() {
+                        None
+                    } else {
+                        Some(
+                            create_schema(
+                                ctx,
+                                schema_spec
+                                    .data()
+                                    .ok_or(PkgError::DataNotFound("schema".into()))?,
+                            )
+                            .await?,
+                        )
+                    }
+                }
+            }
+        }
     };
 
-    // Even if the asset is already installed, we write a record of the asset installation so that
-    // we can track the installed packages that share schemas.
-    if let Some(installed_pkg_id) = installed_pkg_id {
-        InstalledPkgAsset::new(
-            ctx,
-            InstalledPkgAssetTyped::new_for_schema(*schema.id(), installed_pkg_id, hash),
-        )
-        .await?;
+    if let Some(mut schema) = schema {
+        if let Some(unique_id) = schema_spec.unique_id() {
+            thing_map.insert(change_set_pk, unique_id, Thing::Schema(schema.to_owned()));
+        }
+
+        let mut installed_schema_variant_ids = vec![];
+        for variant_spec in &schema_spec.variants()? {
+            let variant = import_schema_variant(
+                ctx,
+                change_set_pk,
+                &mut schema,
+                variant_spec,
+                installed_pkg_id,
+                thing_map,
+            )
+            .await?;
+
+            if let Some(variant) = variant {
+                installed_schema_variant_ids.push(*variant.id());
+
+                if let Some(variant_spec_data) = variant_spec.data() {
+                    let func_unique_id = variant_spec_data.func_unique_id().to_owned();
+
+                    set_default_schema_variant_id(
+                        ctx,
+                        change_set_pk,
+                        &mut schema,
+                        schema_spec
+                            .data()
+                            .as_ref()
+                            .and_then(|data| data.default_schema_variant()),
+                        variant_spec.unique_id(),
+                        *variant.id(),
+                    )
+                    .await?;
+
+                    if let Thing::Func(asset_func) =
+                        thing_map
+                            .get(change_set_pk, &func_unique_id)
+                            .ok_or(PkgError::MissingFuncUniqueId(func_unique_id.to_string()))?
+                    {
+                        create_schema_variant_definition(
+                            ctx,
+                            schema_spec.clone(),
+                            installed_pkg_id,
+                            *variant.id(),
+                            asset_func,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+
+        Ok((Some(*schema.id()), installed_schema_variant_ids))
+    } else {
+        Ok((None, vec![]))
+    }
+}
+
+async fn set_default_schema_variant_id(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    schema: &mut Schema,
+    spec_default_unique_id: Option<&str>,
+    variant_unique_id: Option<&str>,
+    variant_id: SchemaVariantId,
+) -> PkgResult<()> {
+    match (change_set_pk, variant_unique_id, spec_default_unique_id) {
+        (None, _, _) | (Some(_), None, _) | (_, Some(_), None) => {
+            if schema.default_schema_variant_id().is_none() {
+                schema
+                    .set_default_schema_variant_id(ctx, Some(variant_id))
+                    .await?;
+            }
+        }
+        (Some(_), Some(variant_unique_id), Some(spec_default_unique_id)) => {
+            if variant_unique_id == spec_default_unique_id {
+                let current_default_variant_id = schema
+                    .default_schema_variant_id()
+                    .copied()
+                    .unwrap_or(SchemaVariantId::NONE);
+
+                if variant_id != current_default_variant_id {
+                    schema
+                        .set_default_schema_variant_id(ctx, Some(variant_id))
+                        .await?;
+                }
+            }
+        }
     }
 
-    let mut installed_schema_variant_ids = vec![];
-    for variant_spec in schema_spec.variants()? {
-        let variant_spec_data = variant_spec
-            .data()
-            .ok_or(PkgError::DataNotFound(schema_spec.name().into()))?;
-
-        let func_unique_id = variant_spec_data.func_unique_id().to_owned();
-        let schema_variant_id =
-            create_schema_variant(ctx, &mut schema, variant_spec, installed_pkg_id, func_map)
-                .await?;
-        installed_schema_variant_ids.push(schema_variant_id);
-
-        let asset_func = func_map
-            .get(&func_unique_id.clone())
-            .ok_or(PkgError::MissingFuncUniqueId(func_unique_id.to_string()))?;
-
-        create_schema_variant_definition(
-            ctx,
-            schema_spec.clone(),
-            installed_pkg_id,
-            schema_variant_id,
-            asset_func,
-        )
-        .await?;
-    }
-
-    Ok((*schema.id(), installed_schema_variant_ids))
+    Ok(())
 }
 
 async fn create_schema_variant_definition(
@@ -414,21 +902,22 @@ enum DefaultValueInfo {
     },
 }
 
-struct PropVisitContext<'a, 'b> {
+struct PropVisitContext<'a> {
     pub ctx: &'a DalContext,
-    pub schema_id: SchemaId,
     pub schema_variant_id: SchemaVariantId,
-    pub func_map: &'b FuncMap,
     pub attr_funcs: Mutex<Vec<AttrFuncInfo>>,
     pub default_values: Mutex<Vec<DefaultValueInfo>>,
     pub map_key_funcs: Mutex<Vec<(String, AttrFuncInfo)>>,
+    pub validations: Mutex<Vec<(PropId, ValidationSpec)>>,
+    pub change_set_pk: Option<ChangeSetPk>,
 }
 
-async fn create_leaf_function(
+async fn import_leaf_function(
     ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
     leaf_func: SiPkgLeafFunction<'_>,
     schema_variant_id: SchemaVariantId,
-    func_map: &FuncMap,
+    thing_map: &mut ChangeSetThingMap,
 ) -> PkgResult<()> {
     let inputs: Vec<LeafInputLocation> = leaf_func
         .inputs()
@@ -436,24 +925,19 @@ async fn create_leaf_function(
         .map(|input| input.into())
         .collect();
 
-    match func_map.get(&leaf_func.func_unique_id().to_owned()) {
-        Some(func) => {
-            SchemaVariant::upsert_leaf_function(
-                ctx,
-                schema_variant_id,
-                None,
-                leaf_func.leaf_kind().into(),
-                &inputs,
-                func,
-            )
-            .await?;
+    let kind: LeafKind = leaf_func.leaf_kind().into();
+
+    match thing_map.get(change_set_pk, leaf_func.func_unique_id()) {
+        Some(Thing::Func(func)) => {
+            SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, None, kind, &inputs, func)
+                .await?;
         }
-        None => {
+        _ => {
             return Err(PkgError::MissingFuncUniqueId(
                 leaf_func.func_unique_id().to_string(),
             ));
         }
-    };
+    }
 
     Ok(())
 }
@@ -486,315 +970,610 @@ async fn get_identity_func(
 
 async fn create_socket(
     ctx: &DalContext,
-    socket_spec: SiPkgSocket<'_>,
+    data: &SiPkgSocketData,
     schema_id: SchemaId,
     schema_variant_id: SchemaVariantId,
-    func_map: &FuncMap,
-) -> PkgResult<()> {
+) -> PkgResult<(Socket, Option<InternalProvider>, Option<ExternalProvider>)> {
     let (identity_func, identity_func_binding, identity_fbrv, _) = get_identity_func(ctx).await?;
 
-    let name = socket_spec.name();
-
-    let data = socket_spec
-        .data()
-        .ok_or(PkgError::DataNotFound(name.into()))?;
-
-    let arity = data.arity();
-
-    let mut socket = match data.kind() {
+    let (mut socket, ip, ep) = match data.kind() {
         SocketSpecKind::Input => {
-            let (_, socket) = InternalProvider::new_explicit_with_socket(
+            let (ip, socket) = InternalProvider::new_explicit_with_socket(
                 ctx,
                 schema_variant_id,
-                name,
+                data.name(),
                 *identity_func.id(),
                 *identity_func_binding.id(),
                 *identity_fbrv.id(),
-                arity.into(),
+                data.arity().into(),
                 false,
             )
             .await?;
 
-            if let Some(func_unique_id) = data.func_unique_id() {
-                dbg!(
-                    "Input socket that is set by a function?",
-                    func_unique_id,
-                    socket_spec.inputs()?
-                );
-            }
-
-            socket
+            (socket, Some(ip), None)
         }
         SocketSpecKind::Output => {
             let (ep, socket) = ExternalProvider::new_with_socket(
                 ctx,
                 schema_id,
                 schema_variant_id,
-                name,
+                data.name(),
                 None,
                 *identity_func.id(),
                 *identity_func_binding.id(),
                 *identity_fbrv.id(),
-                arity.into(),
+                data.arity().into(),
                 false,
             )
             .await?;
 
-            if let Some(func_unique_id) = data.func_unique_id() {
-                create_attribute_function_for_output_socket(
-                    ctx,
-                    schema_variant_id,
-                    *ep.id(),
-                    func_unique_id,
-                    socket_spec.inputs()?.drain(..).map(Into::into).collect(),
-                    func_map,
-                )
-                .await?;
-            }
-
-            socket
+            (socket, None, Some(ep))
         }
     };
 
     socket.set_ui_hidden(ctx, data.ui_hidden()).await?;
 
+    Ok((socket, ip, ep))
+}
+
+async fn import_socket(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    socket_spec: SiPkgSocket<'_>,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<()> {
+    let (socket, ip, ep) = match change_set_pk {
+        None => {
+            let data = socket_spec
+                .data()
+                .ok_or(PkgError::DataNotFound(socket_spec.name().into()))?;
+
+            create_socket(ctx, data, schema_id, schema_variant_id).await?
+        }
+        Some(_) => {
+            let unique_id = socket_spec
+                .unique_id()
+                .ok_or(PkgError::MissingUniqueIdForNode(format!(
+                    "socket {}",
+                    socket_spec.hash()
+                )))?;
+
+            match thing_map.get(change_set_pk, unique_id) {
+                Some(Thing::Socket(socket_box)) => {
+                    (
+                        socket_box.0.to_owned(),
+                        socket_box.1.to_owned(),
+                        socket_box.2.to_owned(),
+                    )
+                    // prop trees, including sockets and providers, are created whole cloth, so
+                    // should not have differences in change sets (currently)
+                }
+                _ => {
+                    let data = socket_spec
+                        .data()
+                        .ok_or(PkgError::DataNotFound(socket_spec.name().into()))?;
+
+                    create_socket(ctx, data, schema_id, schema_variant_id).await?
+                }
+            }
+        }
+    };
+
+    if let Some(unique_id) = socket_spec.unique_id() {
+        thing_map.insert(
+            change_set_pk,
+            unique_id,
+            Thing::Socket(Box::new((socket, ip.to_owned(), ep.to_owned()))),
+        );
+    }
+
+    match (
+        socket_spec.data().and_then(|data| data.func_unique_id()),
+        ep,
+        ip,
+    ) {
+        (Some(func_unique_id), Some(ep), None) => {
+            import_attr_func_for_output_socket(
+                ctx,
+                change_set_pk,
+                schema_variant_id,
+                *ep.id(),
+                func_unique_id,
+                socket_spec.inputs()?.drain(..).map(Into::into).collect(),
+                thing_map,
+            )
+            .await?;
+        }
+        (Some(func_unique_id), _, Some(_)) => {
+            dbg!(
+                "Input socket that is set by a function?",
+                func_unique_id,
+                socket_spec.inputs()?
+            );
+        }
+        _ => {}
+    }
+
     Ok(())
 }
 
-async fn create_action_func(
+async fn create_action_protoype(
     ctx: &DalContext,
-    action_func_spec: SiPkgActionFunc<'_>,
+    action_func_spec: &SiPkgActionFunc<'_>,
+    func_id: FuncId,
     schema_variant_id: SchemaVariantId,
-    func_map: &FuncMap,
-) -> PkgResult<()> {
-    let func = func_map
-        .get(&action_func_spec.func_unique_id().to_owned())
-        .ok_or(PkgError::MissingFuncUniqueId(
-            action_func_spec.func_unique_id().to_string(),
-        ))?;
-
-    ActionPrototype::new(
+) -> PkgResult<ActionPrototype> {
+    let mut proto = ActionPrototype::new(
         ctx,
-        *func.id(),
+        func_id,
         action_func_spec.kind().into(),
         ActionPrototypeContext { schema_variant_id },
     )
     .await?;
 
+    if let Some(name) = action_func_spec.name() {
+        proto.set_name(ctx, Some(name)).await?;
+    }
+
+    Ok(proto)
+}
+
+async fn update_action_prototype(
+    ctx: &DalContext,
+    prototype: &mut ActionPrototype,
+    action_func_spec: &SiPkgActionFunc<'_>,
+    func_id: FuncId,
+    schema_variant_id: SchemaVariantId,
+) -> PkgResult<()> {
+    if prototype.schema_variant_id() != schema_variant_id {
+        prototype
+            .set_schema_variant_id(ctx, schema_variant_id)
+            .await?;
+    }
+
+    if prototype.name() != action_func_spec.name() {
+        prototype.set_name(ctx, action_func_spec.name()).await?;
+    }
+
+    if prototype.func_id() != func_id {
+        prototype.set_func_id(ctx, func_id).await?;
+    }
+
+    let kind: ActionKind = action_func_spec.kind().into();
+    if *prototype.kind() != kind {
+        prototype.set_kind(ctx, kind).await?;
+    }
+
     Ok(())
+}
+
+async fn import_action_func(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    action_func_spec: &SiPkgActionFunc<'_>,
+    schema_variant_id: SchemaVariantId,
+    thing_map: &ChangeSetThingMap,
+) -> PkgResult<Option<ActionPrototype>> {
+    let prototype = match thing_map.get(change_set_pk, action_func_spec.func_unique_id()) {
+        Some(Thing::Func(func)) => {
+            let func_id = *func.id();
+
+            if let Some(unique_id) = action_func_spec.unique_id() {
+                match thing_map.get(change_set_pk, unique_id) {
+                    Some(Thing::ActionPrototype(prototype)) => {
+                        let mut prototype = prototype.to_owned();
+
+                        if action_func_spec.deleted() {
+                            prototype.delete_by_id(ctx).await?;
+                        } else {
+                            update_action_prototype(
+                                ctx,
+                                &mut prototype,
+                                action_func_spec,
+                                func_id,
+                                schema_variant_id,
+                            )
+                            .await?;
+                        }
+
+                        Some(prototype)
+                    }
+                    _ => {
+                        if action_func_spec.deleted() {
+                            None
+                        } else {
+                            Some(
+                                create_action_protoype(
+                                    ctx,
+                                    action_func_spec,
+                                    func_id,
+                                    schema_variant_id,
+                                )
+                                .await?,
+                            )
+                        }
+                    }
+                }
+            } else {
+                Some(
+                    create_action_protoype(ctx, action_func_spec, func_id, schema_variant_id)
+                        .await?,
+                )
+            }
+        }
+        _ => {
+            return Err(PkgError::MissingFuncUniqueId(
+                action_func_spec.func_unique_id().into(),
+            ));
+        }
+    };
+
+    Ok(prototype)
+}
+
+#[derive(Default, Clone, Debug)]
+struct CreatePropsSideEffects {
+    attr_funcs: Vec<AttrFuncInfo>,
+    default_values: Vec<DefaultValueInfo>,
+    map_key_funcs: Vec<(String, AttrFuncInfo)>,
+    validations: Vec<(PropId, ValidationSpec)>,
 }
 
 async fn create_props(
     ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
     variant_spec: &SiPkgSchemaVariant<'_>,
     prop_root: SchemaVariantSpecPropRoot,
     prop_root_prop_id: PropId,
-    schema_id: SchemaId,
     schema_variant_id: SchemaVariantId,
-    func_map: &FuncMap,
-) -> PkgResult<(
-    Vec<AttrFuncInfo>,
-    Vec<DefaultValueInfo>,
-    Vec<(String, AttrFuncInfo)>,
-)> {
+) -> PkgResult<CreatePropsSideEffects> {
     let context = PropVisitContext {
         ctx,
-        schema_id,
         schema_variant_id,
-        func_map,
         attr_funcs: Mutex::new(vec![]),
         default_values: Mutex::new(vec![]),
         map_key_funcs: Mutex::new(vec![]),
+        validations: Mutex::new(vec![]),
+        change_set_pk,
     };
 
+    let parent_info = (prop_root_prop_id, PropPath::new(prop_root.path_parts()));
+
     variant_spec
-        .visit_prop_tree(prop_root, create_prop, Some(prop_root_prop_id), &context)
+        .visit_prop_tree(prop_root, create_prop, Some(parent_info), &context)
         .await?;
 
-    Ok((
-        context.attr_funcs.into_inner(),
-        context.default_values.into_inner(),
-        context.map_key_funcs.into_inner(),
-    ))
+    Ok(CreatePropsSideEffects {
+        attr_funcs: context.attr_funcs.into_inner(),
+        default_values: context.default_values.into_inner(),
+        map_key_funcs: context.map_key_funcs.into_inner(),
+        validations: context.validations.into_inner(),
+    })
 }
 
-async fn create_schema_variant(
+async fn update_schema_variant(
     ctx: &DalContext,
+    schema_variant: &mut SchemaVariant,
+    name: &str,
+    schema_id: SchemaId,
+) -> PkgResult<()> {
+    let current_schema_id = schema_variant
+        .schema(ctx)
+        .await?
+        .map(|schema| *schema.id())
+        .ok_or(SchemaVariantError::MissingSchema(*schema_variant.id()))?;
+
+    if schema_id != current_schema_id {
+        schema_variant.set_schema(ctx, &schema_id).await?;
+    }
+
+    if schema_variant.name() != name {
+        schema_variant.set_name(ctx, name).await?;
+    }
+
+    Ok(())
+}
+
+async fn import_schema_variant(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
     schema: &mut Schema,
-    variant_spec: SiPkgSchemaVariant<'_>,
+    variant_spec: &SiPkgSchemaVariant<'_>,
     installed_pkg_id: Option<InstalledPkgId>,
-    func_map: &FuncMap,
-) -> PkgResult<SchemaVariantId> {
-    let hash = variant_spec.hash().to_string();
-    let existing_schema_variant =
-        InstalledPkgAsset::list_for_kind_and_hash(ctx, InstalledPkgAssetKind::SchemaVariant, &hash)
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<Option<SchemaVariant>> {
+    let mut schema_variant = match change_set_pk {
+        None => {
+            let hash = variant_spec.hash().to_string();
+            let existing_schema_variant = InstalledPkgAsset::list_for_kind_and_hash(
+                ctx,
+                InstalledPkgAssetKind::SchemaVariant,
+                &hash,
+            )
             .await?
             .pop();
 
-    let variant_id = match existing_schema_variant {
-        Some(installed_sv_record) => match installed_sv_record.as_installed_schema_variant()? {
-            InstalledPkgAssetTyped::SchemaVariant { id, .. } => id,
-            _ => unreachable!(
-                "the as_installed_schema_variant method ensures we cannot hit this branch"
-            ),
-        },
-        None => {
-            let (mut schema_variant, root_prop) =
-                SchemaVariant::new(ctx, *schema.id(), variant_spec.name()).await?;
-
-            schema
-                .set_default_schema_variant_id(ctx, Some(schema_variant.id()))
-                .await?;
-
-            let variant_spec_data = variant_spec.data().ok_or(PkgError::DataNotFound(format!(
-                "variant for {}",
-                schema.name()
-            )))?;
-
-            if let Some(color) = variant_spec_data.color() {
-                schema_variant.set_color(ctx, color.to_owned()).await?;
-            }
-
-            let (domain_attr_funcs, domain_default_values, map_key_funcs) = create_props(
-                ctx,
-                &variant_spec,
-                SchemaVariantSpecPropRoot::Domain,
-                root_prop.domain_prop_id,
-                *schema.id(),
-                *schema_variant.id(),
-                func_map,
-            )
-            .await?;
-
-            let (rv_attr_funcs, rv_default_values, rv_map_key_funcs) = match schema_variant
-                .find_prop(ctx, &["root", "resource_value"])
-                .await
-            {
-                Ok(resource_value_prop) => {
-                    create_props(
-                        ctx,
-                        &variant_spec,
-                        SchemaVariantSpecPropRoot::ResourceValue,
-                        *resource_value_prop.id(),
-                        *schema.id(),
-                        *schema_variant.id(),
-                        func_map,
-                    )
-                    .await?
+            let (variant, created) = match existing_schema_variant {
+                Some(installed_sv_record) => {
+                    match installed_sv_record.as_installed_schema_variant()? {
+                        InstalledPkgAssetTyped::SchemaVariant { id, .. } => (
+                            SchemaVariant::get_by_id(ctx, &id)
+                                .await?
+                                .ok_or(PkgError::InstalledSchemaVariantMissing(id))?,
+                            false,
+                        ),
+                        _ => unreachable!(
+                        "the as_installed_schema_variant method ensures we cannot hit this branch"
+                    ),
+                    }
                 }
-                Err(SchemaVariantError::PropNotFoundAtPath(_, _, _)) => {
-                    warn!("Cannot find /root/resource_value prop, so skipping creating props under the resource value. If the /root/resource_value pr has been merged, this should be an error!");
-                    (vec![], vec![], vec![])
-                }
-                Err(err) => Err(err)?,
+                None => (
+                    SchemaVariant::new(ctx, *schema.id(), variant_spec.name())
+                        .await?
+                        .0,
+                    true,
+                ),
             };
 
-            schema_variant
-                .finalize(ctx, Some(variant_spec_data.component_type().into()))
-                .await?;
-
-            for action_func in variant_spec.action_funcs()? {
-                create_action_func(ctx, action_func, *schema_variant.id(), func_map).await?;
-            }
-
-            for leaf_func in variant_spec.leaf_functions()? {
-                create_leaf_function(ctx, leaf_func, *schema_variant.id(), func_map).await?;
-            }
-
-            for socket in variant_spec.sockets()? {
-                create_socket(ctx, socket, *schema.id(), *schema_variant.id(), func_map).await?;
-            }
-
-            // Default values must be set before attribute functions are configured so they don't
-            // override the prototypes set there
-            for default_value_info in domain_default_values
-                .into_iter()
-                .chain(rv_default_values.into_iter())
-            {
-                set_default_value(ctx, default_value_info).await?;
-            }
-
-            // Set a default name value for all name props, this ensures region has a name before
-            // the function is executed
-            {
-                let name_prop = schema_variant
-                    .find_prop(ctx, &["root", "si", "name"])
-                    .await?;
-                let name_default_value_info = DefaultValueInfo::String {
-                    prop_id: *name_prop.id(),
-                    default_value: schema.name().to_lowercase(),
-                };
-
-                set_default_value(ctx, name_default_value_info).await?;
-            }
-
-            for si_prop_func in variant_spec.si_prop_funcs()? {
-                let prop = schema_variant
-                    .find_prop(ctx, &si_prop_func.kind().prop_path())
-                    .await?;
-                create_attribute_function_for_prop(
+            if let Some(installed_pkg_id) = installed_pkg_id {
+                InstalledPkgAsset::new(
                     ctx,
-                    *schema_variant.id(),
-                    AttrFuncInfo {
-                        func_unique_id: si_prop_func.func_unique_id().to_owned(),
-                        prop_id: *prop.id(),
-                        inputs: si_prop_func
-                            .inputs()?
-                            .iter()
-                            .map(|input| input.to_owned().into())
-                            .collect(),
-                    },
-                    None,
-                    func_map,
+                    InstalledPkgAssetTyped::new_for_schema_variant(
+                        *variant.id(),
+                        installed_pkg_id,
+                        hash,
+                    ),
                 )
                 .await?;
             }
 
-            for attr_func in domain_attr_funcs
-                .into_iter()
-                .chain(rv_attr_funcs.into_iter())
-            {
-                create_attribute_function_for_prop(
-                    ctx,
-                    *schema_variant.id(),
-                    attr_func,
-                    None,
-                    func_map,
-                )
-                .await?;
+            if created {
+                Some(variant)
+            } else {
+                None
             }
+        }
+        Some(_) => {
+            let unique_id = variant_spec
+                .unique_id()
+                .ok_or(PkgError::MissingUniqueIdForNode(format!(
+                    "variant {}",
+                    variant_spec.hash()
+                )))?;
 
-            for (key, map_key_func) in map_key_funcs
-                .into_iter()
-                .chain(rv_map_key_funcs.into_iter())
-            {
-                create_attribute_function_for_prop(
-                    ctx,
-                    *schema_variant.id(),
-                    map_key_func,
-                    Some(key),
-                    func_map,
-                )
-                .await?;
+            match thing_map.get(change_set_pk, unique_id) {
+                Some(Thing::SchemaVariant(variant)) => {
+                    let mut variant = variant.to_owned();
+                    update_schema_variant(ctx, &mut variant, variant_spec.name(), *schema.id())
+                        .await?;
+
+                    if variant_spec.deleted() {
+                        variant.delete_by_id(ctx).await?;
+
+                        None
+                    } else {
+                        Some(variant)
+                    }
+                }
+                _ => {
+                    if variant_spec.deleted() {
+                        None
+                    } else {
+                        Some(
+                            SchemaVariant::new(ctx, *schema.id(), variant_spec.name())
+                                .await?
+                                .0,
+                        )
+                    }
+                }
             }
-
-            schema_variant
-                .finalize(ctx, Some(variant_spec_data.component_type().into()))
-                .await?;
-
-            *schema_variant.id()
         }
     };
 
-    if let Some(installed_pkg_id) = installed_pkg_id {
-        InstalledPkgAsset::new(
+    if let Some(schema_variant) = schema_variant.as_mut() {
+        if let Some(unique_id) = variant_spec.unique_id() {
+            thing_map.insert(
+                change_set_pk,
+                unique_id,
+                Thing::SchemaVariant(schema_variant.to_owned()),
+            );
+        }
+
+        if let Some(data) = variant_spec.data() {
+            if let (Some(spec_color), current_color) =
+                (data.color(), schema_variant.color(ctx).await?)
+            {
+                if current_color.is_none()
+                    || spec_color
+                        != current_color.expect("is none condition ensures this won't panic")
+                {
+                    schema_variant.set_color(ctx, spec_color.to_owned()).await?;
+                }
+            }
+        }
+
+        let domain_prop_id = schema_variant
+            .find_prop(ctx, &["root", "domain"])
+            .await?
+            .id()
+            .to_owned();
+
+        let domain_side_effects = create_props(
             ctx,
-            InstalledPkgAssetTyped::new_for_schema_variant(variant_id, installed_pkg_id, hash),
+            change_set_pk,
+            variant_spec,
+            SchemaVariantSpecPropRoot::Domain,
+            domain_prop_id,
+            *schema_variant.id(),
         )
         .await?;
+
+        let rv_side_effects = match schema_variant
+            .find_prop(ctx, &["root", "resource_value"])
+            .await
+        {
+            Ok(resource_value_prop) => {
+                create_props(
+                    ctx,
+                    change_set_pk,
+                    variant_spec,
+                    SchemaVariantSpecPropRoot::ResourceValue,
+                    *resource_value_prop.id(),
+                    *schema_variant.id(),
+                )
+                .await?
+            }
+            Err(SchemaVariantError::PropNotFoundAtPath(_, _, _)) => {
+                warn!("Cannot find /root/resource_value prop, so skipping creating props under the resource value. If the /root/resource_value pr has been merged, this should be an error!");
+                CreatePropsSideEffects::default()
+            }
+            Err(err) => Err(err)?,
+        };
+
+        if let Some(data) = variant_spec.data() {
+            schema_variant
+                .finalize(ctx, Some(data.component_type().into()))
+                .await?;
+        }
+
+        for action_func in &variant_spec.action_funcs()? {
+            let prototype = import_action_func(
+                ctx,
+                change_set_pk,
+                action_func,
+                *schema_variant.id(),
+                thing_map,
+            )
+            .await?;
+
+            if let (Some(prototype), Some(unique_id)) = (prototype, action_func.unique_id()) {
+                thing_map.insert(change_set_pk, unique_id, Thing::ActionPrototype(prototype));
+            }
+        }
+
+        for leaf_func in variant_spec.leaf_functions()? {
+            import_leaf_function(
+                ctx,
+                change_set_pk,
+                leaf_func,
+                *schema_variant.id(),
+                thing_map,
+            )
+            .await?;
+        }
+
+        for socket in variant_spec.sockets()? {
+            import_socket(
+                ctx,
+                change_set_pk,
+                socket,
+                *schema.id(),
+                *schema_variant.id(),
+                thing_map,
+            )
+            .await?;
+        }
+
+        // Default values must be set before attribute functions are configured so they don't
+        // override the prototypes set there
+        for default_value_info in domain_side_effects
+            .default_values
+            .into_iter()
+            .chain(rv_side_effects.default_values.into_iter())
+        {
+            set_default_value(ctx, default_value_info).await?;
+        }
+
+        // Set a default name value for all name props, this ensures region has a name before
+        // the function is executed
+        {
+            let name_prop = schema_variant
+                .find_prop(ctx, &["root", "si", "name"])
+                .await?;
+            let name_default_value_info = DefaultValueInfo::String {
+                prop_id: *name_prop.id(),
+                default_value: schema.name().to_lowercase(),
+            };
+
+            set_default_value(ctx, name_default_value_info).await?;
+        }
+
+        for si_prop_func in variant_spec.si_prop_funcs()? {
+            let prop = schema_variant
+                .find_prop(ctx, &si_prop_func.kind().prop_path())
+                .await?;
+            import_attr_func_for_prop(
+                ctx,
+                change_set_pk,
+                *schema_variant.id(),
+                AttrFuncInfo {
+                    func_unique_id: si_prop_func.func_unique_id().to_owned(),
+                    prop_id: *prop.id(),
+                    inputs: si_prop_func
+                        .inputs()?
+                        .iter()
+                        .map(|input| input.to_owned().into())
+                        .collect(),
+                },
+                None,
+                thing_map,
+            )
+            .await?;
+        }
+
+        for attr_func in domain_side_effects
+            .attr_funcs
+            .into_iter()
+            .chain(rv_side_effects.attr_funcs.into_iter())
+        {
+            import_attr_func_for_prop(
+                ctx,
+                change_set_pk,
+                *schema_variant.id(),
+                attr_func,
+                None,
+                thing_map,
+            )
+            .await?;
+        }
+
+        for (key, map_key_func) in domain_side_effects
+            .map_key_funcs
+            .into_iter()
+            .chain(rv_side_effects.map_key_funcs.into_iter())
+        {
+            import_attr_func_for_prop(
+                ctx,
+                change_set_pk,
+                *schema_variant.id(),
+                map_key_func,
+                Some(key),
+                thing_map,
+            )
+            .await?;
+        }
+
+        for (prop_id, validation_spec) in domain_side_effects
+            .validations
+            .into_iter()
+            .chain(rv_side_effects.validations.into_iter())
+        {
+            import_prop_validation(
+                ctx,
+                change_set_pk,
+                validation_spec,
+                *schema.id(),
+                *schema_variant.id(),
+                prop_id,
+                thing_map,
+            )
+            .await?;
+        }
     }
 
-    Ok(variant_id)
+    Ok(schema_variant)
 }
 
 async fn set_default_value(
@@ -824,8 +1603,9 @@ async fn set_default_value(
     Ok(())
 }
 
-async fn create_attribute_function_for_prop(
+async fn import_attr_func_for_prop(
     ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
     schema_variant_id: SchemaVariantId,
     AttrFuncInfo {
         func_unique_id,
@@ -833,73 +1613,73 @@ async fn create_attribute_function_for_prop(
         inputs,
     }: AttrFuncInfo,
     key: Option<String>,
-    func_map: &FuncMap,
+    thing_map: &mut ChangeSetThingMap,
 ) -> PkgResult<()> {
-    let func = func_map
-        .get(&func_unique_id)
-        .ok_or(PkgError::MissingFuncUniqueId(func_unique_id.to_string()))?;
-
-    create_attribute_function(
-        ctx,
-        AttributeReadContext {
-            prop_id: Some(prop_id),
-            ..Default::default()
-        },
-        key,
-        schema_variant_id,
-        *func.id(),
-        inputs,
-    )
-    .await?;
+    match thing_map.get(change_set_pk, &func_unique_id) {
+        Some(Thing::Func(func)) => {
+            import_attr_func(
+                ctx,
+                change_set_pk,
+                AttributeReadContext {
+                    prop_id: Some(prop_id),
+                    ..Default::default()
+                },
+                key,
+                schema_variant_id,
+                *func.id(),
+                inputs,
+                thing_map,
+            )
+            .await?;
+        }
+        _ => return Err(PkgError::MissingFuncUniqueId(func_unique_id.to_string())),
+    }
 
     Ok(())
 }
 
-async fn create_attribute_function_for_output_socket(
+async fn import_attr_func_for_output_socket(
     ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
     schema_variant_id: SchemaVariantId,
     external_provider_id: ExternalProviderId,
     func_unique_id: &str,
     inputs: Vec<SiPkgAttrFuncInputView>,
-    func_map: &FuncMap,
+    thing_map: &mut ChangeSetThingMap,
 ) -> PkgResult<()> {
-    let func = func_map
-        .get(&func_unique_id.to_string())
-        .ok_or(PkgError::MissingFuncUniqueId(func_unique_id.to_string()))?;
-
-    create_attribute_function(
-        ctx,
-        AttributeReadContext {
-            external_provider_id: Some(external_provider_id),
-            ..Default::default()
-        },
-        None,
-        schema_variant_id,
-        *func.id(),
-        inputs,
-    )
-    .await?;
+    match thing_map.get(change_set_pk, func_unique_id) {
+        Some(Thing::Func(func)) => {
+            import_attr_func(
+                ctx,
+                change_set_pk,
+                AttributeReadContext {
+                    external_provider_id: Some(external_provider_id),
+                    ..Default::default()
+                },
+                None,
+                schema_variant_id,
+                *func.id(),
+                inputs,
+                thing_map,
+            )
+            .await?;
+        }
+        _ => return Err(PkgError::MissingFuncUniqueId(func_unique_id.to_string())),
+    }
 
     Ok(())
 }
 
-async fn create_attribute_function(
+async fn get_prototype_for_context(
     ctx: &DalContext,
     context: AttributeReadContext,
     key: Option<String>,
-    schema_variant_id: SchemaVariantId,
-    func_id: FuncId,
-    inputs: Vec<SiPkgAttrFuncInputView>,
-) -> PkgResult<()> {
+) -> PkgResult<AttributePrototype> {
     let value = AttributeValue::find_for_context(ctx, context)
         .await?
         .ok_or(AttributeValueError::Missing)?;
 
-    // If we are provided a key, this means we're configuring a function to set the value for a key
-    // to a map (array setters not supported yet). In that case we need to insert an unset value
-    // for the key into the map to create the attribute value and then we can set the function and
-    // inputs up for the prototype for the inserted value
-    let mut prototype = if let Some(key) = key {
+    let real_value = if let Some(key) = key {
         let parent_prop_id = context
             .prop_id()
             .ok_or(PkgError::AttributeFuncForKeyMissingProp(
@@ -925,24 +1705,32 @@ async fn create_attribute_function(
                     .set_prop_id(*item_prop.id())
                     .to_context()?;
 
-                // TODO: We assume the item does not yet exist, but if the package is incorrectly
-                // constructed, it could have two map key funcs for the same key. We should
-                // check for this case on both export and import
-                let item_id = AttributeValue::insert_for_context(
+                let item_read_context: AttributeReadContext = item_write_context.to_owned().into();
+
+                match AttributeValue::find_with_parent_and_key_for_context(
                     ctx,
-                    item_write_context,
-                    *value.id(),
-                    None,
-                    Some(key),
+                    Some(*value.id()),
+                    Some(key.to_owned()),
+                    item_read_context,
                 )
-                .await?;
-                let item_av = AttributeValue::get_by_id(ctx, &item_id)
-                    .await?
-                    .ok_or(AttributeValueError::MissingForId(item_id))?;
-                item_av
-                    .attribute_prototype(ctx)
-                    .await?
-                    .ok_or(AttributeValueError::MissingAttributePrototype)?
+                .await?
+                {
+                    Some(item_av) => item_av,
+                    None => {
+                        let item_id = AttributeValue::insert_for_context(
+                            ctx,
+                            item_write_context,
+                            *value.id(),
+                            None,
+                            Some(key),
+                        )
+                        .await?;
+
+                        AttributeValue::get_by_id(ctx, &item_id)
+                            .await?
+                            .ok_or(AttributeValueError::MissingForId(item_id))?
+                    }
+                }
             }
             None => {
                 return Err(PkgError::MissingItemPropForMapProp(parent_prop_id));
@@ -950,61 +1738,213 @@ async fn create_attribute_function(
         }
     } else {
         value
-            .attribute_prototype(ctx)
-            .await?
-            .ok_or(AttributeValueError::MissingAttributePrototype)?
     };
 
-    prototype.set_func_id(ctx, func_id).await?;
+    Ok(real_value
+        .attribute_prototype(ctx)
+        .await?
+        .ok_or(AttributeValueError::MissingAttributePrototype)?)
+}
 
-    for input in inputs {
-        let arg = match &input {
-            SiPkgAttrFuncInputView::Prop { name, .. }
-            | SiPkgAttrFuncInputView::InputSocket { name, .. }
-            | SiPkgAttrFuncInputView::OutputSocket { name, .. } => {
-                FuncArgument::find_by_name_for_func(ctx, name, func_id)
-                    .await?
-                    .ok_or(PkgError::MissingFuncArgument(name.to_owned(), func_id))?
-            }
-        };
-
-        match input {
-            SiPkgAttrFuncInputView::Prop { prop_path, .. } => {
-                let prop =
-                    Prop::find_prop_by_path(ctx, schema_variant_id, &prop_path.into()).await?;
-                let prop_ip = InternalProvider::find_for_prop(ctx, *prop.id())
-                    .await?
-                    .ok_or(PkgError::MissingInternalProviderForProp(*prop.id()))?;
-
-                AttributePrototypeArgument::new_for_intra_component(
-                    ctx,
-                    *prototype.id(),
-                    *arg.id(),
-                    *prop_ip.id(),
-                )
-                .await?;
-            }
-            SiPkgAttrFuncInputView::InputSocket { socket_name, .. } => {
-                let explicit_ip = InternalProvider::find_explicit_for_schema_variant_and_name(
-                    ctx,
-                    schema_variant_id,
-                    &socket_name,
-                )
+async fn create_attr_proto_arg(
+    ctx: &DalContext,
+    prototype_id: AttributePrototypeId,
+    input: &SiPkgAttrFuncInputView,
+    func_id: FuncId,
+    schema_variant_id: SchemaVariantId,
+) -> PkgResult<AttributePrototypeArgument> {
+    let arg = match &input {
+        SiPkgAttrFuncInputView::Prop { name, .. }
+        | SiPkgAttrFuncInputView::InputSocket { name, .. }
+        | SiPkgAttrFuncInputView::OutputSocket { name, .. } => {
+            FuncArgument::find_by_name_for_func(ctx, name, func_id)
                 .await?
-                .ok_or(PkgError::MissingInternalProviderForSocketName(
-                    socket_name.to_owned(),
-                ))?;
+                .ok_or(PkgError::MissingFuncArgument(name.to_owned(), func_id))?
+        }
+    };
 
-                AttributePrototypeArgument::new_for_intra_component(
-                    ctx,
-                    *prototype.id(),
-                    *arg.id(),
-                    *explicit_ip.id(),
-                )
-                .await?;
+    Ok(match input {
+        SiPkgAttrFuncInputView::Prop { prop_path, .. } => {
+            let prop = Prop::find_prop_by_path(ctx, schema_variant_id, &prop_path.into()).await?;
+            let prop_ip = InternalProvider::find_for_prop(ctx, *prop.id())
+                .await?
+                .ok_or(PkgError::MissingInternalProviderForProp(*prop.id()))?;
+
+            AttributePrototypeArgument::new_for_intra_component(
+                ctx,
+                prototype_id,
+                *arg.id(),
+                *prop_ip.id(),
+            )
+            .await?
+        }
+        SiPkgAttrFuncInputView::InputSocket { socket_name, .. } => {
+            let explicit_ip = InternalProvider::find_explicit_for_schema_variant_and_name(
+                ctx,
+                schema_variant_id,
+                &socket_name,
+            )
+            .await?
+            .ok_or(PkgError::MissingInternalProviderForSocketName(
+                socket_name.to_owned(),
+            ))?;
+
+            AttributePrototypeArgument::new_for_intra_component(
+                ctx,
+                prototype_id,
+                *arg.id(),
+                *explicit_ip.id(),
+            )
+            .await?
+        }
+        _ => {
+            // xxx: make this an error
+            panic!("unsupported taking external provider as input for prop");
+        }
+    })
+}
+
+async fn update_attr_proto_arg(
+    ctx: &DalContext,
+    apa: &mut AttributePrototypeArgument,
+    _prototype_id: AttributePrototypeId,
+    input: &SiPkgAttrFuncInputView,
+    func_id: FuncId,
+    schema_variant_id: SchemaVariantId,
+) -> PkgResult<()> {
+    let arg = match &input {
+        SiPkgAttrFuncInputView::Prop { name, .. }
+        | SiPkgAttrFuncInputView::InputSocket { name, .. }
+        | SiPkgAttrFuncInputView::OutputSocket { name, .. } => {
+            FuncArgument::find_by_name_for_func(ctx, name, func_id)
+                .await?
+                .ok_or(PkgError::MissingFuncArgument(name.to_owned(), func_id))?
+        }
+    };
+
+    if apa.func_argument_id() != *arg.id() {
+        apa.set_func_argument_id(ctx, arg.id()).await?;
+    }
+
+    match input {
+        SiPkgAttrFuncInputView::Prop { prop_path, .. } => {
+            let prop = Prop::find_prop_by_path(ctx, schema_variant_id, &prop_path.into()).await?;
+            let prop_ip = InternalProvider::find_for_prop(ctx, *prop.id())
+                .await?
+                .ok_or(PkgError::MissingInternalProviderForProp(*prop.id()))?;
+
+            if apa.internal_provider_id() != *prop_ip.id() {
+                apa.set_internal_provider_id_safe(ctx, *prop_ip.id())
+                    .await?;
             }
-            _ => {
-                dbg!("unsupported taking external provider as input for prop");
+        }
+        SiPkgAttrFuncInputView::InputSocket { socket_name, .. } => {
+            let explicit_ip = InternalProvider::find_explicit_for_schema_variant_and_name(
+                ctx,
+                schema_variant_id,
+                &socket_name,
+            )
+            .await?
+            .ok_or(PkgError::MissingInternalProviderForSocketName(
+                socket_name.to_owned(),
+            ))?;
+
+            if apa.internal_provider_id() != *explicit_ip.id() {
+                apa.set_internal_provider_id_safe(ctx, *explicit_ip.id())
+                    .await?;
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn import_attr_func(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    context: AttributeReadContext,
+    key: Option<String>,
+    schema_variant_id: SchemaVariantId,
+    func_id: FuncId,
+    inputs: Vec<SiPkgAttrFuncInputView>,
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<()> {
+    let mut prototype = get_prototype_for_context(ctx, context, key).await?;
+
+    if prototype.func_id() != func_id {
+        prototype.set_func_id(ctx, &func_id).await?;
+    }
+
+    for input in &inputs {
+        match change_set_pk {
+            None => {
+                create_attr_proto_arg(ctx, *prototype.id(), input, func_id, schema_variant_id)
+                    .await?;
+            }
+            Some(_) => {
+                let (unique_id, deleted) = match input {
+                    SiPkgAttrFuncInputView::Prop {
+                        unique_id, deleted, ..
+                    }
+                    | SiPkgAttrFuncInputView::InputSocket {
+                        unique_id, deleted, ..
+                    }
+                    | SiPkgAttrFuncInputView::OutputSocket {
+                        unique_id, deleted, ..
+                    } => (
+                        unique_id
+                            .as_deref()
+                            .ok_or(PkgError::MissingUniqueIdForNode("attr-func-input".into()))?,
+                        *deleted,
+                    ),
+                };
+
+                let apa = match thing_map.get(change_set_pk, unique_id) {
+                    Some(Thing::AttributePrototypeArgument(apa)) => {
+                        let mut apa = apa.to_owned();
+                        if deleted {
+                            apa.delete_by_id(ctx).await?;
+                        } else {
+                            update_attr_proto_arg(
+                                ctx,
+                                &mut apa,
+                                *prototype.id(),
+                                input,
+                                func_id,
+                                schema_variant_id,
+                            )
+                            .await?;
+                        }
+
+                        Some(apa)
+                    }
+                    _ => {
+                        if deleted {
+                            None
+                        } else {
+                            Some(
+                                create_attr_proto_arg(
+                                    ctx,
+                                    *prototype.id(),
+                                    input,
+                                    func_id,
+                                    schema_variant_id,
+                                )
+                                .await?,
+                            )
+                        }
+                    }
+                };
+
+                if let Some(apa) = apa {
+                    thing_map.insert(
+                        change_set_pk,
+                        unique_id,
+                        Thing::AttributePrototypeArgument(apa),
+                    );
+                }
             }
         }
     }
@@ -1012,119 +1952,275 @@ async fn create_attribute_function(
     Ok(())
 }
 
-async fn create_prop_validation(
-    spec: SiPkgValidation<'_>,
+async fn create_validation(
+    ctx: &DalContext,
+    validation_kind: ValidationKind,
+    builtin_func_id: FuncId,
     prop_id: PropId,
-    ctx: &PropVisitContext<'_, '_>,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+) -> PkgResult<ValidationPrototype> {
+    let (validation_func_id, validation_args) = match validation_kind {
+        ValidationKind::Builtin(validation) => (
+            builtin_func_id,
+            serde_json::to_value(FuncBackendValidationArgs::new(validation))?,
+        ),
+
+        ValidationKind::Custom(func_id) => (func_id, serde_json::json!(null)),
+    };
+    let mut builder = ValidationPrototypeContext::builder();
+    builder
+        .set_prop_id(prop_id)
+        .set_schema_id(schema_id)
+        .set_schema_variant_id(schema_variant_id);
+
+    Ok(ValidationPrototype::new(
+        ctx,
+        validation_func_id,
+        validation_args,
+        builder.to_context(ctx).await?,
+    )
+    .await?)
+}
+
+async fn update_validation(
+    ctx: &DalContext,
+    prototype: &mut ValidationPrototype,
+    validation_kind: ValidationKind,
+    builtin_func_id: FuncId,
+    prop_id: PropId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
 ) -> PkgResult<()> {
-    // Consider grabbing this much earlier and sticking it on the PropVisitContext, since we will
-    // fetch it for every validation!
-    let builtin_validation_func = Func::find_by_attr(ctx.ctx, "name", &"si:validation")
+    let (validation_func_id, validation_args) = match validation_kind {
+        ValidationKind::Builtin(validation) => (
+            builtin_func_id,
+            serde_json::to_value(FuncBackendValidationArgs::new(validation))?,
+        ),
+
+        ValidationKind::Custom(func_id) => (func_id, serde_json::json!(null)),
+    };
+
+    prototype.set_prop_id(ctx, prop_id).await?;
+    prototype.set_schema_id(ctx, schema_id).await?;
+    prototype
+        .set_schema_variant_id(ctx, schema_variant_id)
+        .await?;
+    prototype.set_args(ctx, validation_args).await?;
+    prototype.set_func_id(ctx, validation_func_id).await?;
+
+    Ok(())
+}
+
+async fn import_prop_validation(
+    ctx: &DalContext,
+    change_set_pk: Option<ChangeSetPk>,
+    spec: ValidationSpec,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    prop_id: PropId,
+    thing_map: &mut ChangeSetThingMap,
+) -> PkgResult<()> {
+    let builtin_validation_func = Func::find_by_attr(ctx, "name", &"si:validation")
         .await?
         .pop()
         .ok_or(FuncError::NotFoundByName("si:validation".to_string()))?;
 
-    let validation_kind = match spec {
-        SiPkgValidation::IntegerIsBetweenTwoIntegers {
+    let validation_kind = match &spec {
+        ValidationSpec::IntegerIsBetweenTwoIntegers {
             lower_bound,
             upper_bound,
             ..
         } => ValidationKind::Builtin(Validation::IntegerIsBetweenTwoIntegers {
             value: None,
-            lower_bound,
-            upper_bound,
+            lower_bound: *lower_bound,
+            upper_bound: *upper_bound,
         }),
-        SiPkgValidation::IntegerIsNotEmpty { .. } => {
+        ValidationSpec::IntegerIsNotEmpty { .. } => {
             ValidationKind::Builtin(Validation::IntegerIsNotEmpty { value: None })
         }
-        SiPkgValidation::StringEquals { expected, .. } => {
+        ValidationSpec::StringEquals { expected, .. } => {
             ValidationKind::Builtin(Validation::StringEquals {
                 value: None,
-                expected,
+                expected: expected.to_owned(),
             })
         }
-        SiPkgValidation::StringHasPrefix { expected, .. } => {
+        ValidationSpec::StringHasPrefix { expected, .. } => {
             ValidationKind::Builtin(Validation::StringHasPrefix {
                 value: None,
-                expected,
+                expected: expected.to_owned(),
             })
         }
-        SiPkgValidation::StringInStringArray {
+        ValidationSpec::StringInStringArray {
             expected,
             display_expected,
             ..
         } => ValidationKind::Builtin(Validation::StringInStringArray {
             value: None,
-            expected,
-            display_expected,
+            expected: expected.to_owned(),
+            display_expected: *display_expected,
         }),
-        SiPkgValidation::StringIsHexColor { .. } => {
+        ValidationSpec::StringIsHexColor { .. } => {
             ValidationKind::Builtin(Validation::StringIsHexColor { value: None })
         }
-        SiPkgValidation::StringIsNotEmpty { .. } => {
+        ValidationSpec::StringIsNotEmpty { .. } => {
             ValidationKind::Builtin(Validation::StringIsNotEmpty { value: None })
         }
-        SiPkgValidation::StringIsValidIpAddr { .. } => {
+        ValidationSpec::StringIsValidIpAddr { .. } => {
             ValidationKind::Builtin(Validation::StringIsValidIpAddr { value: None })
         }
-        SiPkgValidation::CustomValidation { func_unique_id, .. } => ValidationKind::Custom(
-            *ctx.func_map
-                .get(&func_unique_id)
-                .ok_or(PkgError::MissingFuncUniqueId(func_unique_id.to_string()))?
-                .id(),
-        ),
+        ValidationSpec::CustomValidation { func_unique_id, .. } => {
+            ValidationKind::Custom(match thing_map.get(None, func_unique_id.as_str()) {
+                Some(Thing::Func(func)) => *func.id(),
+                _ => return Err(PkgError::MissingFuncUniqueId(func_unique_id.to_string())),
+            })
+        }
     };
 
-    create_validation(
-        ctx.ctx,
-        validation_kind,
-        *builtin_validation_func.id(),
-        prop_id,
-        ctx.schema_id,
-        ctx.schema_variant_id,
-    )
-    .await?;
+    match change_set_pk {
+        None => {
+            create_validation(
+                ctx,
+                validation_kind,
+                *builtin_validation_func.id(),
+                prop_id,
+                schema_id,
+                schema_variant_id,
+            )
+            .await?;
+        }
+        Some(_) => {
+            let unique_id = spec
+                .unique_id()
+                .ok_or(PkgError::MissingUniqueIdForNode("validation".into()))?;
+            let deleted = spec.deleted();
+
+            let validation_prototype = match thing_map.get(change_set_pk, unique_id) {
+                Some(Thing::Validation(prototype)) => {
+                    let mut prototype = prototype.to_owned();
+
+                    if deleted {
+                        prototype.delete_by_id(ctx).await?;
+                    } else {
+                        update_validation(
+                            ctx,
+                            &mut prototype,
+                            validation_kind,
+                            *builtin_validation_func.id(),
+                            prop_id,
+                            schema_id,
+                            schema_variant_id,
+                        )
+                        .await?;
+                    }
+
+                    Some(prototype)
+                }
+                _ => {
+                    if deleted {
+                        None
+                    } else {
+                        Some(
+                            create_validation(
+                                ctx,
+                                validation_kind,
+                                *builtin_validation_func.id(),
+                                prop_id,
+                                schema_id,
+                                schema_variant_id,
+                            )
+                            .await?,
+                        )
+                    }
+                }
+            };
+
+            if let Some(prototype) = validation_prototype {
+                thing_map.insert(change_set_pk, unique_id, Thing::Validation(prototype));
+            }
+        }
+    }
 
     Ok(())
 }
 
-async fn create_prop(
-    spec: SiPkgProp<'_>,
-    parent_prop_id: Option<PropId>,
-    ctx: &PropVisitContext<'_, '_>,
-) -> PkgResult<Option<PropId>> {
-    let data = match &spec {
-        SiPkgProp::Array { data, .. }
-        | SiPkgProp::Boolean { data, .. }
-        | SiPkgProp::Map { data, .. }
-        | SiPkgProp::Number { data, .. }
-        | SiPkgProp::Object { data, .. }
-        | SiPkgProp::String { data, .. } => data
-            .to_owned()
-            .ok_or(PkgError::DataNotFound(format!("prop {}", spec.name())))?,
-    };
+fn prop_kind_for_pkg_prop(pkg_prop: &SiPkgProp<'_>) -> PropKind {
+    match pkg_prop {
+        SiPkgProp::Array { .. } => PropKind::Array,
+        SiPkgProp::Boolean { .. } => PropKind::Boolean,
+        SiPkgProp::Map { .. } => PropKind::Map,
+        SiPkgProp::Number { .. } => PropKind::Integer,
+        SiPkgProp::Object { .. } => PropKind::Object,
+        SiPkgProp::String { .. } => PropKind::String,
+    }
+}
 
+async fn create_dal_prop(
+    ctx: &DalContext,
+    data: &SiPkgPropData,
+    kind: PropKind,
+    schema_variant_id: SchemaVariantId,
+    parent_prop_id: Option<PropId>,
+) -> PkgResult<Prop> {
     let mut prop = Prop::new(
-        ctx.ctx,
-        spec.name(),
-        match &spec {
-            SiPkgProp::Array { .. } => PropKind::Array,
-            SiPkgProp::Boolean { .. } => PropKind::Boolean,
-            SiPkgProp::Map { .. } => PropKind::Map,
-            SiPkgProp::Number { .. } => PropKind::Integer,
-            SiPkgProp::Object { .. } => PropKind::Object,
-            SiPkgProp::String { .. } => PropKind::String,
-        },
-        Some(((&data.widget_kind).into(), data.widget_options)),
-        ctx.schema_variant_id,
+        ctx,
+        &data.name,
+        kind,
+        Some(((&data.widget_kind).into(), data.widget_options.to_owned())),
+        schema_variant_id,
         parent_prop_id,
     )
     .await
     .map_err(SiPkgError::visit_prop)?;
 
-    prop.set_hidden(ctx.ctx, data.hidden).await?;
-    prop.set_doc_link(ctx.ctx, data.doc_link.as_ref().map(|l| l.to_string()))
+    prop.set_hidden(ctx, data.hidden).await?;
+    prop.set_doc_link(ctx, data.doc_link.as_ref().map(|l| l.to_string()))
         .await?;
+
+    Ok(prop)
+}
+
+async fn create_prop(
+    spec: SiPkgProp<'_>,
+    parent_prop_info: Option<(PropId, PropPath)>,
+    ctx: &PropVisitContext<'_>,
+) -> PkgResult<Option<(PropId, PropPath)>> {
+    let prop = match ctx.change_set_pk {
+        None => {
+            let data = spec.data().ok_or(PkgError::DataNotFound("prop".into()))?;
+            create_dal_prop(
+                ctx.ctx,
+                data,
+                prop_kind_for_pkg_prop(&spec),
+                ctx.schema_variant_id,
+                parent_prop_info.map(|info| info.0),
+            )
+            .await?
+        }
+        Some(_) => {
+            let parent_path = parent_prop_info
+                .as_ref()
+                .map(|info| info.1.to_owned())
+                .unwrap_or(PropPath::new(["root"]));
+
+            let path = parent_path.join(&PropPath::new([spec.name()]));
+
+            match Prop::find_prop_by_path_opt(ctx.ctx, ctx.schema_variant_id, &path).await? {
+                None => {
+                    let data = spec.data().ok_or(PkgError::DataNotFound("prop".into()))?;
+                    create_dal_prop(
+                        ctx.ctx,
+                        data,
+                        prop_kind_for_pkg_prop(&spec),
+                        ctx.schema_variant_id,
+                        parent_prop_info.as_ref().map(|info| info.0.to_owned()),
+                    )
+                    .await?
+                }
+                Some(prop) => prop,
+            }
+        }
+    };
 
     let prop_id = *prop.id();
 
@@ -1133,48 +2229,50 @@ async fn create_prop(
     // queues up to the outer context via the PropVisitContext, which uses Mutexes for interior
     // mutability (maybe there's a better type for that here?)
 
-    if let Some(default_value_info) = match &spec {
-        SiPkgProp::String { .. } => {
-            if let Some(serde_json::Value::String(default_value)) = data.default_value {
-                Some(DefaultValueInfo::String {
-                    prop_id,
-                    default_value,
-                })
-            } else {
-                // Raise error here for type mismatch
-                None
+    if let Some(data) = spec.data() {
+        if let Some(default_value_info) = match &spec {
+            SiPkgProp::String { .. } => {
+                if let Some(serde_json::Value::String(default_value)) = &data.default_value {
+                    Some(DefaultValueInfo::String {
+                        prop_id,
+                        default_value: default_value.to_owned(),
+                    })
+                } else {
+                    // Raise error here for type mismatch
+                    None
+                }
             }
-        }
-        SiPkgProp::Number { .. } => {
-            if let Some(serde_json::Value::Number(default_value_number)) = data.default_value {
-                if default_value_number.is_i64() {
-                    default_value_number
-                        .as_i64()
-                        .map(|dv_i64| DefaultValueInfo::Number {
-                            prop_id,
-                            default_value: dv_i64,
-                        })
+            SiPkgProp::Number { .. } => {
+                if let Some(serde_json::Value::Number(default_value_number)) = &data.default_value {
+                    if default_value_number.is_i64() {
+                        default_value_number
+                            .as_i64()
+                            .map(|dv_i64| DefaultValueInfo::Number {
+                                prop_id,
+                                default_value: dv_i64,
+                            })
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
-            } else {
-                None
             }
-        }
-        SiPkgProp::Boolean { .. } => {
-            if let Some(serde_json::Value::Bool(default_value)) = data.default_value {
-                Some(DefaultValueInfo::Boolean {
-                    prop_id,
-                    default_value,
-                })
-            } else {
-                None
+            SiPkgProp::Boolean { .. } => {
+                if let Some(serde_json::Value::Bool(default_value)) = &data.default_value {
+                    Some(DefaultValueInfo::Boolean {
+                        prop_id,
+                        default_value: *default_value,
+                    })
+                } else {
+                    None
+                }
             }
+            // Default values for complex types are not yet supported in packages
+            _ => None,
+        } {
+            ctx.default_values.lock().await.push(default_value_info);
         }
-        // Default values for complex types are not yet supported in packages
-        _ => None,
-    } {
-        ctx.default_values.lock().await.push(default_value_info);
     }
 
     if matches!(&spec, SiPkgProp::Map { .. }) {
@@ -1194,18 +2292,23 @@ async fn create_prop(
         }
     }
 
-    if let Some(func_unique_id) = data.func_unique_id {
+    if let Some(func_unique_id) = spec.data().and_then(|data| data.func_unique_id.to_owned()) {
         let mut inputs = spec.inputs()?;
         ctx.attr_funcs.lock().await.push(AttrFuncInfo {
-            func_unique_id: func_unique_id.to_owned(),
+            func_unique_id,
             prop_id,
             inputs: inputs.drain(..).map(Into::into).collect(),
         });
     }
 
-    for validation_spec in spec.validations()? {
-        create_prop_validation(validation_spec, *prop.id(), ctx).await?;
+    for validation_pkg_spec in spec.validations()? {
+        let validation_spec: ValidationSpec = validation_pkg_spec.try_into()?;
+
+        ctx.validations
+            .lock()
+            .await
+            .push((*prop.id(), validation_spec));
     }
 
-    Ok(Some(*prop.id()))
+    Ok(Some((*prop.id(), prop.path())))
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -454,6 +454,21 @@ impl Prop {
         schema_variant_id: SchemaVariantId,
         path: &PropPath,
     ) -> PropResult<Self> {
+        Self::find_prop_by_path_opt(ctx, schema_variant_id, path)
+            .await?
+            .ok_or(PropError::NotFoundAtPath(
+                path.to_string(),
+                *ctx.visibility(),
+            ))
+    }
+
+    /// Finds a prop by a path made up of prop names separated by
+    /// [`PROP_PATH_SEPARATOR`](crate::prop::PROP_PATH_SEPARATOR) for each depth level
+    pub async fn find_prop_by_path_opt(
+        ctx: &DalContext,
+        schema_variant_id: SchemaVariantId,
+        path: &PropPath,
+    ) -> PropResult<Option<Self>> {
         let row = ctx
             .txns()
             .await?
@@ -469,10 +484,7 @@ impl Prop {
             )
             .await?;
 
-        object_option_from_row_option(row)?.ok_or(PropError::NotFoundAtPath(
-            path.to_string(),
-            *ctx.visibility(),
-        ))
+        Ok(object_option_from_row_option(row)?)
     }
 
     pub async fn create_default_prototypes_and_values(

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 
 use crate::{
-    impl_standard_model, pk, standard_model, standard_model_belongs_to, DalContext, StandardModel,
-    Tenancy, Timestamp, Visibility,
+    impl_standard_model, pk, standard_model, standard_model_accessor, standard_model_belongs_to,
+    DalContext, StandardModel, Tenancy, Timestamp, Visibility,
 };
 
 use super::{Schema, SchemaId, SchemaResult};
@@ -64,13 +64,8 @@ impl SchemaUiMenu {
         Ok(object)
     }
 
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn category(&self) -> &str {
-        &self.category
-    }
+    standard_model_accessor!(name, String, SchemaResult);
+    standard_model_accessor!(category, String, SchemaResult);
 
     standard_model_belongs_to!(
         lookup_fn: schema,

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -475,6 +475,7 @@ impl SchemaVariantDefinitionJson {
 
         let schema_data = schema_spec.data.unwrap_or(SchemaSpecData {
             name: schema_spec.name.to_owned(),
+            default_schema_variant: variant_spec.unique_id.to_owned(),
             category: "".into(),
             category_name: None,
             ui_hidden: false,

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -319,20 +319,19 @@ impl SchemaVariant {
         .await?;
         resource_value_prop.set_hidden(ctx, true).await?;
 
-        let reconciliation_func: Func =
+        if let Some(reconciliation_func) =
             Func::find_by_attr(ctx, "name", &"si:defaultReconciliation")
                 .await?
                 .pop()
-                .ok_or(FuncError::NotFoundByName(
-                    "si:defaultReconciliation".to_owned(),
-                ))?;
-        ReconciliationPrototype::upsert(
-            ctx,
-            *reconciliation_func.id(),
-            "Reconciliation",
-            ReconciliationPrototypeContext::new(*schema_variant.id()),
-        )
-        .await?;
+        {
+            ReconciliationPrototype::upsert(
+                ctx,
+                *reconciliation_func.id(),
+                "Reconciliation",
+                ReconciliationPrototypeContext::new(*schema_variant.id()),
+            )
+            .await?;
+        }
 
         SchemaVariant::create_default_prototypes_and_values(ctx, *schema_variant.id()).await?;
         SchemaVariant::create_implicit_internal_providers(ctx, *schema_variant.id()).await?;

--- a/lib/dal/src/validation/prototype.rs
+++ b/lib/dal/src/validation/prototype.rs
@@ -13,7 +13,7 @@ use crate::{
     standard_model_accessor, DalContext, HistoryEventError, PropId, SchemaVariantId, StandardModel,
     StandardModelError, Tenancy, Timestamp, Visibility,
 };
-use crate::{PropKind, TransactionsError, ValidationPrototypeContext};
+use crate::{PropKind, SchemaId, TransactionsError, ValidationPrototypeContext};
 
 pub mod context;
 
@@ -60,8 +60,9 @@ pub struct ValidationPrototype {
     func_id: FuncId,
     args: serde_json::Value,
     link: Option<String>,
-    #[serde(flatten)]
-    context: ValidationPrototypeContext,
+    prop_id: PropId,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
     #[serde(flatten)]
     tenancy: Tenancy,
     #[serde(flatten)]
@@ -111,9 +112,20 @@ impl ValidationPrototype {
     standard_model_accessor!(func_id, Pk(FuncId), ValidationPrototypeResult);
     standard_model_accessor!(args, Json<JsonValue>, ValidationPrototypeResult);
     standard_model_accessor!(link, Option<String>, ValidationPrototypeResult);
+    standard_model_accessor!(prop_id, Pk(PropId), ValidationPrototypeResult);
+    standard_model_accessor!(schema_id, Pk(SchemaId), ValidationPrototypeResult);
+    standard_model_accessor!(
+        schema_variant_id,
+        Pk(SchemaVariantId),
+        ValidationPrototypeResult
+    );
 
-    pub fn context(&self) -> &ValidationPrototypeContext {
-        &self.context
+    pub fn context(&self) -> ValidationPrototypeContext {
+        ValidationPrototypeContext::new_unchecked(
+            self.prop_id,
+            self.schema_variant_id,
+            self.schema_id,
+        )
     }
 
     /// List all [`ValidationPrototypes`](Self) for a given [`Prop`](crate::Prop).

--- a/lib/dal/src/validation/prototype/context.rs
+++ b/lib/dal/src/validation/prototype/context.rs
@@ -123,6 +123,19 @@ impl ValidationPrototypeContext {
         ValidationPrototypeContextBuilder::new()
     }
 
+    /// Create a new [`ValidationPrototypeContext`] from raw fields
+    pub fn new_unchecked(
+        prop_id: PropId,
+        schema_variant_id: SchemaVariantId,
+        schema_id: SchemaId,
+    ) -> Self {
+        Self {
+            prop_id,
+            schema_variant_id,
+            schema_id,
+        }
+    }
+
     /// Convert [`Self`] into [`ValidationPrototypeContextBuilder`].
     pub fn to_builder(&self) -> ValidationPrototypeContextBuilder {
         ValidationPrototypeContextBuilder::from(self.clone())

--- a/lib/object-tree/src/graph.rs
+++ b/lib/object-tree/src/graph.rs
@@ -937,6 +937,24 @@ pub fn write_key_value_line<W: Write>(
     write!(writer, "{key}:{len}={value}{NL}").map_err(GraphError::IoWrite)
 }
 
+/// If the optional value provided is "Some", Writes a key/value formatted line
+/// to a writer with the given key and value.
+///
+/// # Errors
+///
+/// Returns `Err` if an I/O error occurs while writing to the writer
+pub fn write_key_value_line_opt<W: Write>(
+    writer: &mut W,
+    key: impl fmt::Display,
+    maybe_value: Option<impl fmt::Display>,
+) -> Result<(), GraphError> {
+    if let Some(value) = maybe_value {
+        write_key_value_line(writer, key, value)
+    } else {
+        Ok(())
+    }
+}
+
 /// Writes a separator/blank line to a writer.
 ///
 /// # Errors

--- a/lib/object-tree/src/lib.rs
+++ b/lib/object-tree/src/lib.rs
@@ -84,7 +84,8 @@ pub use crate::tar::{
     write::{TarWriter, TarWriterError},
 };
 pub use graph::{
-    read_key_value_line, read_key_value_line_opt, write_key_value_line, GraphError, HashedNode,
-    NameStr, NodeChild, NodeKind, NodeWithChildren, ObjectTree, ReadBytes, WriteBytes,
+    read_key_value_line, read_key_value_line_opt, write_key_value_line, write_key_value_line_opt,
+    GraphError, HashedNode, NameStr, NodeChild, NodeKind, NodeWithChildren, ObjectTree, ReadBytes,
+    WriteBytes,
 };
 pub use hash::{Hash, HashParseError};

--- a/lib/sdf-server/src/server/service/pkg/export_workspace.rs
+++ b/lib/sdf-server/src/server/service/pkg/export_workspace.rs
@@ -1,0 +1,103 @@
+use super::{PkgError, PkgResult};
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient, RawAccessToken};
+use crate::server::tracking::track;
+use axum::extract::OriginalUri;
+use axum::Json;
+use chrono::Utc;
+use dal::{HistoryActor, User, Visibility, Workspace, WorkspacePk, WsEvent};
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportWorkspaceRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportWorkspaceResponse {
+    pub success: bool,
+    pub full_path: String,
+}
+
+pub async fn export_workspace(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    RawAccessToken(raw_access_token): RawAccessToken,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<ExportWorkspaceRequest>,
+) -> PkgResult<Json<ExportWorkspaceResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let user = match ctx.history_actor() {
+        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk).await?,
+        _ => None,
+    };
+
+    let (created_by_name, created_by_email) = user
+        .map(|user| (user.name().to_owned(), user.email().to_owned()))
+        .unwrap_or((
+            "unauthenticated user name".into(),
+            "unauthenticated user email".into(),
+        ));
+
+    info!("Exporting workspace backup module");
+
+    let workspace_pk = ctx.tenancy().workspace_pk().unwrap_or(WorkspacePk::NONE);
+    let workspace = Workspace::get_by_pk(&ctx, &workspace_pk)
+        .await?
+        .ok_or(PkgError::WorkspaceNotFound(workspace_pk))?;
+
+    let version = Utc::now().format("%Y-%m-%d_%H:%M:%S").to_string();
+    let description = "workspace backup";
+
+    let mut exporter = dal::pkg::PkgExporter::new_workspace_exporter(
+        workspace.name().as_str(),
+        &created_by_email,
+        &version,
+        description,
+    );
+
+    let module_payload = exporter.export_as_bytes(&ctx).await?;
+
+    let module_index_url = match ctx.module_index_url() {
+        Some(url) => url,
+        None => return Err(PkgError::ModuleIndexNotConfigured),
+    };
+
+    let index_client =
+        module_index_client::IndexClient::new(module_index_url.try_into()?, &raw_access_token);
+    let response = index_client
+        .upload_module(workspace.name().as_str(), &version, module_payload)
+        .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "export_workspace",
+        serde_json::json!({
+                    "pkg_name": workspace.name().to_owned(),
+                    "pkg_version": version,
+                    "pkg_created_by_name": created_by_name,
+                    "pkg_created_by_email": created_by_email,
+                    "pkg_hash": response.latest_hash,
+        }),
+    );
+
+    // TODO: Is this really the WsEvent we want to send right now?
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(ExportWorkspaceResponse {
+        success: true,
+        full_path: "Get this from module-index service".to_owned(),
+    }))
+}

--- a/lib/sdf-server/src/server/service/pkg/install_pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg/install_pkg.rs
@@ -47,7 +47,7 @@ pub async fn install_pkg(
 
     let pkg = SiPkg::load_from_bytes(pkg_data)?;
     let pkg_name = pkg.metadata()?.name().to_owned();
-    import_pkg_from_pkg(&ctx, &pkg, &pkg_name, None).await?;
+    import_pkg_from_pkg(&ctx, &pkg, None).await?;
 
     track(
         &posthog_client,

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -152,7 +152,6 @@ pub async fn exec_variant_def(
     let (_, schema_variant_ids) = import_pkg_from_pkg(
         &ctx,
         &pkg,
-        metadata.clone().name.as_str(),
         Some(dal::pkg::ImportOptions {
             schemas: None,
             skip_import_funcs: Some(HashMap::from_iter([(

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -3,9 +3,10 @@ mod pkg;
 mod spec;
 
 pub use pkg::{
-    SiPkg, SiPkgActionFunc, SiPkgAttrFuncInput, SiPkgAttrFuncInputView, SiPkgError, SiPkgFunc,
-    SiPkgKind, SiPkgLeafFunction, SiPkgMapKeyFunc, SiPkgMetadata, SiPkgProp, SiPkgSchema,
-    SiPkgSchemaVariant, SiPkgSocket, SiPkgValidation,
+    SiPkg, SiPkgActionFunc, SiPkgAttrFuncInput, SiPkgAttrFuncInputView, SiPkgChangeSet, SiPkgError,
+    SiPkgFunc, SiPkgFuncArgument, SiPkgFuncData, SiPkgKind, SiPkgLeafFunction, SiPkgMapKeyFunc,
+    SiPkgMetadata, SiPkgProp, SiPkgPropData, SiPkgSchema, SiPkgSchemaData, SiPkgSchemaVariant,
+    SiPkgSchemaVariantData, SiPkgSocket, SiPkgSocketData, SiPkgValidation,
 };
 pub use spec::{
     ActionFuncSpec, ActionFuncSpecBuilder, ActionFuncSpecKind, AttrFuncInputSpec,

--- a/lib/si-pkg/src/node/package.rs
+++ b/lib/si-pkg/src/node/package.rs
@@ -21,6 +21,7 @@ const KEY_KIND_STR: &str = "kind";
 const KEY_NAME_STR: &str = "name";
 const KEY_VERSION_STR: &str = "version";
 const KEY_WORKSPACE_PK_STR: &str = "workspace_pk";
+const KEY_WORKSPACE_NAME_STR: &str = "workspace_name";
 
 #[derive(Clone, Debug)]
 pub struct PackageNode {
@@ -33,6 +34,7 @@ pub struct PackageNode {
     pub created_by: String,
     pub default_change_set: Option<String>,
     pub workspace_pk: Option<String>,
+    pub workspace_name: Option<String>,
 }
 
 impl NameStr for PackageNode {
@@ -54,6 +56,9 @@ impl WriteBytes for PackageNode {
         }
         if let Some(workspace_pk) = &self.workspace_pk {
             write_key_value_line(writer, KEY_WORKSPACE_PK_STR, workspace_pk.as_str())?;
+        }
+        if let Some(workspace_name) = &self.workspace_name {
+            write_key_value_line(writer, KEY_WORKSPACE_NAME_STR, workspace_name.as_str())?;
         }
         Ok(())
     }
@@ -78,6 +83,7 @@ impl ReadBytes for PackageNode {
         let created_by = read_key_value_line(reader, KEY_CREATED_BY_STR)?;
         let default_change_set = read_key_value_line_opt(reader, KEY_DEFAULT_CHANGE_SET)?;
         let workspace_pk = read_key_value_line_opt(reader, KEY_WORKSPACE_PK_STR)?;
+        let workspace_name = read_key_value_line_opt(reader, KEY_WORKSPACE_NAME_STR)?;
 
         Ok(Some(Self {
             kind,
@@ -88,6 +94,7 @@ impl ReadBytes for PackageNode {
             created_by,
             default_change_set,
             workspace_pk,
+            workspace_name,
         }))
     }
 }
@@ -107,6 +114,7 @@ impl NodeChild for PkgSpec {
                 created_by: self.created_by.to_owned(),
                 default_change_set: self.default_change_set.to_owned(),
                 workspace_pk: self.workspace_pk.to_owned(),
+                workspace_name: self.workspace_name.to_owned(),
             }),
             match self.kind {
                 SiPkgKind::Module => vec![

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -217,6 +217,14 @@ impl SiPkg {
             .created_at(metadata.created_at())
             .created_by(metadata.created_by());
 
+        if let Some(workspace_pk) = metadata.workspace_pk() {
+            builder.workspace_pk(workspace_pk);
+        }
+
+        if let Some(workspace_name) = metadata.workspace_name() {
+            builder.workspace_name(workspace_name);
+        }
+
         for func in self.funcs()? {
             builder.func(FuncSpec::try_from(func)?);
         }
@@ -347,6 +355,7 @@ pub struct SiPkgMetadata {
     created_by: String,
     default_change_set: Option<String>,
     workspace_pk: Option<String>,
+    workspace_name: Option<String>,
     hash: Hash,
 }
 
@@ -372,6 +381,7 @@ impl SiPkgMetadata {
             created_by: metadata_node.created_by,
             default_change_set: metadata_node.default_change_set,
             workspace_pk: metadata_node.workspace_pk,
+            workspace_name: metadata_node.workspace_name,
             hash: metadata_hashed_node.hash(),
         })
     }
@@ -406,6 +416,10 @@ impl SiPkgMetadata {
 
     pub fn workspace_pk(&self) -> Option<&str> {
         self.workspace_pk.as_deref()
+    }
+
+    pub fn workspace_name(&self) -> Option<&str> {
+        self.workspace_name.as_deref()
     }
 
     pub fn hash(&self) -> Hash {

--- a/lib/si-pkg/src/pkg/action_func.rs
+++ b/lib/si-pkg/src/pkg/action_func.rs
@@ -8,6 +8,7 @@ use crate::{node::PkgNode, ActionFuncSpec, ActionFuncSpecKind};
 #[derive(Clone, Debug)]
 pub struct SiPkgActionFunc<'a> {
     func_unique_id: String,
+    name: Option<String>,
     kind: ActionFuncSpecKind,
     unique_id: Option<String>,
     deleted: bool,
@@ -33,6 +34,7 @@ impl<'a> SiPkgActionFunc<'a> {
         };
 
         Ok(Self {
+            name: node.name,
             func_unique_id: node.func_unique_id,
             kind: node.kind,
             unique_id: node.unique_id,
@@ -41,6 +43,10 @@ impl<'a> SiPkgActionFunc<'a> {
             hash: hashed_node.hash(),
             source: Source::new(graph, node_idx),
         })
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
     }
 
     pub fn func_unique_id(&self) -> &str {

--- a/lib/si-pkg/src/pkg/prop.rs
+++ b/lib/si-pkg/src/pkg/prop.rs
@@ -235,6 +235,28 @@ impl<'a> SiPkgProp<'a> {
         })
     }
 
+    pub fn data(&self) -> Option<&SiPkgPropData> {
+        match self {
+            SiPkgProp::Array { data, .. }
+            | SiPkgProp::Boolean { data, .. }
+            | SiPkgProp::Map { data, .. }
+            | SiPkgProp::Number { data, .. }
+            | SiPkgProp::Object { data, .. }
+            | SiPkgProp::String { data, .. } => data.as_ref(),
+        }
+    }
+
+    pub fn unique_id(&self) -> Option<&str> {
+        match self {
+            SiPkgProp::Array { unique_id, .. }
+            | SiPkgProp::Boolean { unique_id, .. }
+            | SiPkgProp::Map { unique_id, .. }
+            | SiPkgProp::Number { unique_id, .. }
+            | SiPkgProp::Object { unique_id, .. }
+            | SiPkgProp::String { unique_id, .. } => unique_id.as_deref(),
+        }
+    }
+
     pub fn name(&self) -> &str {
         match self {
             Self::String { name, .. }

--- a/lib/si-pkg/src/pkg/schema.rs
+++ b/lib/si-pkg/src/pkg/schema.rs
@@ -12,6 +12,7 @@ pub struct SiPkgSchemaData {
     pub category: String,
     pub category_name: Option<String>,
     pub ui_hidden: bool,
+    pub default_schema_variant: Option<String>,
 }
 
 impl SiPkgSchemaData {
@@ -29,6 +30,10 @@ impl SiPkgSchemaData {
 
     pub fn ui_hidden(&self) -> bool {
         self.ui_hidden
+    }
+
+    pub fn default_schema_variant(&self) -> Option<&str> {
+        self.default_schema_variant.as_deref()
     }
 }
 
@@ -67,6 +72,7 @@ impl<'a> SiPkgSchema<'a> {
                 category: data.category,
                 category_name: data.category_name,
                 ui_hidden: data.ui_hidden,
+                default_schema_variant: data.default_schema_variant,
             }),
             unique_id: schema_node.unique_id,
             deleted: schema_node.deleted,
@@ -126,6 +132,9 @@ impl<'a> SiPkgSchema<'a> {
             data_builder.name(self.name());
             if let Some(category_name) = data.category_name() {
                 data_builder.category_name(category_name);
+            }
+            if let Some(default_schema_variant) = data.default_schema_variant() {
+                data_builder.default_schema_variant(default_schema_variant);
             }
             data_builder.ui_hidden(data.ui_hidden());
             data_builder.category(data.category());

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -45,6 +45,8 @@ pub struct PkgSpec {
     #[builder(setter(into, strip_option), default)]
     #[serde(default)]
     pub workspace_pk: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    pub workspace_name: Option<String>,
 
     #[builder(setter(each(name = "schema", into)), default)]
     #[serde(default)]

--- a/lib/si-pkg/src/spec/action_func.rs
+++ b/lib/si-pkg/src/spec/action_func.rs
@@ -32,6 +32,9 @@ pub struct ActionFuncSpec {
     #[builder(setter(into))]
     pub func_unique_id: String,
 
+    #[builder(setter(into, strip_option), default)]
+    pub name: Option<String>,
+
     #[builder(setter(into))]
     pub kind: ActionFuncSpecKind,
 

--- a/lib/si-pkg/src/spec/schema.rs
+++ b/lib/si-pkg/src/spec/schema.rs
@@ -15,6 +15,8 @@ pub struct SchemaSpecData {
     pub category_name: Option<String>,
     #[builder(setter(into), default)]
     pub ui_hidden: bool,
+    #[builder(setter(into, strip_option), default)]
+    pub default_schema_variant: Option<String>,
 }
 
 impl SchemaSpecData {

--- a/lib/si-pkg/src/spec/validation.rs
+++ b/lib/si-pkg/src/spec/validation.rs
@@ -86,6 +86,34 @@ impl ValidationSpec {
     pub fn builder() -> ValidationSpecBuilder {
         ValidationSpecBuilder::default()
     }
+
+    pub fn unique_id(&self) -> Option<&str> {
+        match self {
+            Self::CustomValidation { unique_id, .. }
+            | Self::IntegerIsBetweenTwoIntegers { unique_id, .. }
+            | Self::IntegerIsNotEmpty { unique_id, .. }
+            | Self::StringEquals { unique_id, .. }
+            | Self::StringHasPrefix { unique_id, .. }
+            | Self::StringInStringArray { unique_id, .. }
+            | Self::StringIsHexColor { unique_id, .. }
+            | Self::StringIsNotEmpty { unique_id, .. }
+            | Self::StringIsValidIpAddr { unique_id, .. } => unique_id.as_deref(),
+        }
+    }
+
+    pub fn deleted(&self) -> bool {
+        match self {
+            Self::CustomValidation { deleted, .. }
+            | Self::IntegerIsBetweenTwoIntegers { deleted, .. }
+            | Self::IntegerIsNotEmpty { deleted, .. }
+            | Self::StringEquals { deleted, .. }
+            | Self::StringHasPrefix { deleted, .. }
+            | Self::StringInStringArray { deleted, .. }
+            | Self::StringIsHexColor { deleted, .. }
+            | Self::StringIsNotEmpty { deleted, .. }
+            | Self::StringIsValidIpAddr { deleted, .. } => *deleted,
+        }
+    }
 }
 
 #[remain::sorted]

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -56,6 +56,15 @@ pub enum SchemaVariantSpecPropRoot {
     ResourceValue,
 }
 
+impl SchemaVariantSpecPropRoot {
+    pub fn path_parts(&self) -> &'static [&'static str] {
+        match self {
+            Self::Domain => &["root", "domain"],
+            Self::ResourceValue => &["root", "resource_value"],
+        }
+    }
+}
+
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[builder(build_fn(error = "SpecError"))]


### PR DESCRIPTION
Enables the export and import of workspaces and changesets. Includes schema variants and all associated objects but workspace import will destroy components on the graph. Changeset import attempts to apply only the differences to the recreated changeset.