### PR TITLE
feat(web,sdf-server): Add ability to delete orphaned functions

### DIFF
--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -60,6 +60,17 @@
                 loadingText="Detaching..."
                 @click="detachFunc"
               />
+
+              <VButton
+                :loading="isDeleting"
+                tone="destructive"
+                :disabled="hasAssociations"
+                icon="x"
+                label="Delete"
+                size="md"
+                loadingText="Deleting..."
+                @click="deleteFunc"
+              />
             </div>
 
             <ErrorMessage
@@ -376,6 +387,22 @@ const detachFunc = async () => {
     }
   }
 };
+
+const isDeleting = ref(false);
+const deleteFunc = async () => {
+  if (!funcId.value) return;
+  await funcStore.DELETE_FUNC(funcId.value);
+};
+
+const hasAssociations = computed(() => {
+  if (editingFunc?.value) {
+    return (
+      editingFunc.value.associations === undefined &&
+      !editingFunc.value.isBuiltin
+    );
+  }
+  return false;
+});
 
 // const getExecutionReqStatus = funcStore.getRequestStatus(
 //   "GET_FUNC_LAST_EXECUTION",

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -68,6 +68,10 @@ export interface SaveFuncResponse {
   success: boolean;
 }
 
+export interface DeleteFuncResponse {
+  success: boolean;
+}
+
 export interface OutputLocationOption {
   label: string;
   value: OutputLocation;
@@ -335,6 +339,16 @@ export const useFuncStore = () => {
             keyRequestStatusBy: funcId,
             onSuccess: (response) => {
               this.funcDetailsById[response.id] = response;
+            },
+          });
+        },
+        async DELETE_FUNC(funcId: FuncId) {
+          return new ApiRequest<DeleteFuncResponse>({
+            method: "post",
+            url: "func/delete_func",
+            params: {
+              id: funcId,
+              ...visibility,
             },
           });
         },

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -29,6 +29,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 pub mod create_func;
+pub mod delete_func;
 pub mod get_func;
 pub mod list_funcs;
 pub mod list_input_sources;
@@ -114,6 +115,8 @@ pub enum FuncError {
     FuncExecutionFailed(String),
     #[error("Function execution failed: this function is not connected to any assets, and was not executed")]
     FuncExecutionFailedNoPrototypes,
+    #[error("Function still has associations: {0}")]
+    FuncHasAssociations(FuncId),
     #[error("Function named \"{0}\" already exists in this changeset")]
     FuncNameExists(String),
     #[error("Function not found")]
@@ -684,7 +687,7 @@ async fn compile_leaf_function_input_types(
             get_per_variant_types_for_prop_path(
                 ctx,
                 schema_variant_ids,
-                &input_location.prop_path()
+                &input_location.prop_path(),
             )
             .await?
         );
@@ -815,6 +818,7 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/create_func", post(create_func::create_func))
         .route("/save_func", post(save_func::save_func))
+        .route("/delete_func", post(delete_func::delete_func))
         .route("/save_and_exec", post(save_and_exec::save_and_exec))
         .route("/revert_func", post(revert_func::revert_func))
         .route(

--- a/lib/sdf-server/src/server/service/func/delete_func.rs
+++ b/lib/sdf-server/src/server/service/func/delete_func.rs
@@ -1,0 +1,112 @@
+use super::FuncResult;
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::tracking::track;
+use crate::service::func::{get_func_view, FuncAssociations, FuncError};
+use axum::extract::OriginalUri;
+use axum::{response::IntoResponse, Json};
+use dal::{ChangeSet, Func, FuncId, StandardModel, Visibility, WsEvent};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteFuncRequest {
+    pub id: FuncId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteFuncResponse {
+    pub success: bool,
+}
+
+pub async fn delete_func(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Json(request): Json<DeleteFuncRequest>,
+) -> FuncResult<impl IntoResponse> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut force_changeset_pk = None;
+    if ctx.visibility().is_head() {
+        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
+
+        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
+
+        ctx.update_visibility(new_visibility);
+
+        force_changeset_pk = Some(change_set.pk);
+
+        WsEvent::change_set_created(&ctx, change_set.pk)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    };
+
+    let mut func = Func::get_by_id(&ctx, &request.id)
+        .await?
+        .ok_or(FuncError::FuncNotFound)?;
+
+    let func_details = get_func_view(&ctx, &func).await?;
+    if let Some(associations) = func_details.associations {
+        let has_associations = match associations {
+            FuncAssociations::Action {
+                schema_variant_ids,
+                kind: _,
+            } => !schema_variant_ids.is_empty(),
+            FuncAssociations::Attribute {
+                prototypes,
+                arguments,
+            } => !prototypes.is_empty() || !arguments.is_empty(),
+            FuncAssociations::CodeGeneration {
+                schema_variant_ids,
+                component_ids,
+                inputs: _,
+            } => !schema_variant_ids.is_empty() || !component_ids.is_empty(),
+            FuncAssociations::Qualification {
+                schema_variant_ids,
+                component_ids,
+                inputs: _,
+            } => !schema_variant_ids.is_empty() || !component_ids.is_empty(),
+            FuncAssociations::SchemaVariantDefinitions { schema_variant_ids } => {
+                schema_variant_ids.is_empty()
+            }
+            FuncAssociations::Validation { prototypes } => !prototypes.is_empty(),
+        };
+
+        if has_associations {
+            return Err(FuncError::FuncHasAssociations(*func.id()));
+        }
+    };
+
+    func.delete_by_id(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "deleted_func",
+        serde_json::json!({
+                    "func_id": func.id().to_owned(),
+                    "func_name": func.name().to_owned(),
+        }),
+    );
+
+    WsEvent::change_set_written(&ctx)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+    ctx.commit().await?;
+
+    let mut response = axum::response::Response::builder();
+    response = response.header("Content-Type", "application/json");
+    if let Some(force_changeset_pk) = force_changeset_pk {
+        response = response.header("force_changeset_pk", force_changeset_pk.to_string());
+    }
+    Ok(response.body(serde_json::to_string(&DeleteFuncResponse {
+        success: true,
+    })?)?)
+}


### PR DESCRIPTION
An orphaned function is a function that has zero associations to
prototypes, components or assets

PLEASE NOTE: We do not allow deletion of builtin functions at this time
