### PR TITLE
feat(sdf): Make module-index API url configurable

### DIFF
--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -73,6 +73,10 @@ pub(crate) struct Args {
 
     /// Location on disk of available packages
     pub(crate) pkgs_path: Option<String>,
+
+    /// The base URL for the module-index API server
+    #[arg(long, env = "SI_MODULE_INDEX_URL")]
+    pub(crate) module_index_url: Option<String>,
 }
 
 impl TryFrom<Args> for Config {
@@ -106,6 +110,9 @@ impl TryFrom<Args> for Config {
             }
             if let Some(pkgs_path) = args.pkgs_path {
                 config_map.set("pkgs_path", pkgs_path);
+            }
+            if let Some(module_index_url) = args.module_index_url {
+                config_map.set("module_index_url", module_index_url);
             }
 
             config_map.set("pg.application_name", NAME);

--- a/lib/sdf-server/src/server/config.rs
+++ b/lib/sdf-server/src/server/config.rs
@@ -19,6 +19,7 @@ pub use dal::{CycloneKeyPair, MigrationMode};
 pub use si_settings::{StandardConfig, StandardConfigFile};
 
 const DEFAULT_SIGNUP_SECRET: &str = "cool-steam";
+const DEFAULT_MODULE_INDEX_URL: &str = "https://module-index.systeminit.com";
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -73,7 +74,7 @@ pub struct Config {
 }
 
 fn default_module_index_url() -> String {
-    "https://module-index.systeminit.com".into()
+    DEFAULT_MODULE_INDEX_URL.into()
 }
 
 impl StandardConfig for Config {


### PR DESCRIPTION
Pass `--module-index-url=` to the `sdf` binary, or set the `SI_MODULE_INDEX_URL` environment variable before starting `sdf` to point it to a different module-index endpoint (e.g., `localhost:5157` to hit the local module-index). Also needs to be set in `app/web/.env.local` as `VITE_MODULE_INDEX_API_URL`.