### PR TITLE
fix(si): Change SI container restart policy

### DIFF
--- a/lib/si-cli/src/engine/docker_engine.rs
+++ b/lib/si-cli/src/engine/docker_engine.rs
@@ -316,7 +316,6 @@ impl ContainerEngine for DockerEngine {
             .name(name.clone())
             .image(format!("{0}:stable", image))
             .links(["local-jaeger-1:jaeger"])
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -329,7 +328,6 @@ impl ContainerEngine for DockerEngine {
             .name(name)
             .image(format!("{0}:stable", image))
             .expose(PublishPort::tcp(16686), HostPort::new(16686))
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -342,7 +340,6 @@ impl ContainerEngine for DockerEngine {
             .name(name)
             .image(format!("{0}:stable", image))
             .command(vec!["--config", "nats-server.conf", "-DVV"])
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -360,7 +357,6 @@ impl ContainerEngine for DockerEngine {
                 "POSTGRES_USER=si",
                 "POSTGRES_DB=si",
             ])
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -377,7 +373,6 @@ impl ContainerEngine for DockerEngine {
                 "SI_COUNCIL__NATS__URL=nats",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
             ])
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -407,7 +402,6 @@ impl ContainerEngine for DockerEngine {
             .links(vec!["local-nats-1:nats", "local-otelcol-1:otelcol"])
             .env(env_vars)
             .volumes([format!("{}:/run/cyclone:z", data_dir.display())])
-            .restart_policy("on-failure", 3)
             .build();
 
         let container = self.docker.containers().create(&create_opts).await?;
@@ -429,7 +423,6 @@ impl ContainerEngine for DockerEngine {
                 "SI_PINGA__PG__HOSTNAME=postgres",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
             ])
-            .restart_policy("on-failure", 3)
             .volumes([format!("{}:/run/pinga:z", data_dir.display())])
             .build();
 
@@ -460,7 +453,6 @@ impl ContainerEngine for DockerEngine {
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
             ])
             .network_mode("bridge")
-            .restart_policy("on-failure", 3)
             .expose(
                 PublishPort::tcp(5156),
                 HostPort::with_ip(host_port, host_ip),
@@ -495,7 +487,6 @@ impl ContainerEngine for DockerEngine {
             .links(vec!["local-sdf-1:sdf"])
             .env(["SI_LOG=trace"])
             .network_mode("bridge")
-            .restart_policy("on-failure", 3)
             .expose(
                 PublishPort::tcp(8080),
                 HostPort::with_ip(host_port, host_ip),

--- a/lib/si-cli/src/engine/podman_engine.rs
+++ b/lib/si-cli/src/engine/podman_engine.rs
@@ -382,8 +382,6 @@ impl ContainerEngine for PodmanEngine {
                     static_mac: None,
                 },
             )]))
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -419,8 +417,6 @@ impl ContainerEngine for PodmanEngine {
                 protocol: None,
                 range: None,
             }])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -450,8 +446,6 @@ impl ContainerEngine for PodmanEngine {
                 },
             )]))
             .command(vec!["--config", "nats-server.conf", "-DVV"])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -486,8 +480,6 @@ impl ContainerEngine for PodmanEngine {
                 ("POSTGRES_USER", "si"),
                 ("POSTGRES_DB", "si"),
             ]))
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -520,8 +512,6 @@ impl ContainerEngine for PodmanEngine {
                 ("SI_COUNCIL__NATS__URL", "nats"),
                 ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317"),
             ]))
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -580,8 +570,6 @@ impl ContainerEngine for PodmanEngine {
                 uid_mappings: None,
                 gid_mappings: None,
             }])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -623,8 +611,6 @@ impl ContainerEngine for PodmanEngine {
                 uid_mappings: None,
                 gid_mappings: None,
             }])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -700,8 +686,6 @@ impl ContainerEngine for PodmanEngine {
                     gid_mappings: None,
                 },
             ])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;
@@ -744,8 +728,6 @@ impl ContainerEngine for PodmanEngine {
                 protocol: None,
                 range: None,
             }])
-            .restart_policy(podman_api::opts::ContainerRestartPolicy::OnFailure)
-            .restart_tries(3)
             .build();
 
         let container = self.podman.containers().create(&create_opts).await?;


### PR DESCRIPTION
Currently, we had a restart policy of on-failure BUT this causes us to
try and start containers on system boot as docker doesn't keep track
of the previous state - https://github.com/moby/moby/issues/35166#issuecomment-338211235

This means that we will continually hit this problem and the containers
may fail to start due to ordering issues

Fixes: #2802 
