### PR TITLE
feat(dal,web): Remove func name uniqueness, graceful builtin backups

### DIFF
--- a/app/web/src/api/sdf/dal/diagram.ts
+++ b/app/web/src/api/sdf/dal/diagram.ts
@@ -31,6 +31,7 @@ export interface DiagramInputSocket {
 export interface DiagramSchemaVariant {
   id: string;
   name: string;
+  builtin: boolean;
   schemaName: string;
   schemaId: string;
   color: string;

--- a/app/web/src/components/modules/ModuleExportModal.vue
+++ b/app/web/src/components/modules/ModuleExportModal.vue
@@ -37,7 +37,7 @@
           @click="addSchemaVariantToExport"
         />
       </div>
-      <ul class="flex flex-col gap-2xs">
+      <ul class="flex flex-col gap-2xs max-h-72 overflow-y-scroll">
         <li
           v-for="svId in schemaVariantsForExport"
           :key="svId"
@@ -45,6 +45,7 @@
         >
           <span class="pr-2" role="decoration">•</span>
           {{ schemaVariantsById?.[svId]?.schemaName }}
+          {{ schemaVariantsById?.[svId]?.builtin ? "(builtin)" : "" }}
           <VButton
             class="ml-auto"
             size="xs"
@@ -86,7 +87,6 @@
 </template>
 
 <script lang="ts" setup>
-import { emit } from "process";
 import { ref, computed } from "vue";
 import {
   Modal,
@@ -168,7 +168,7 @@ const schemaVariantOptions = computed(() =>
   componentStore.schemaVariants
     .filter((sv) => !schemaVariantsForExport.value.includes(sv.id))
     .map((sv) => ({
-      label: sv.schemaName,
+      label: sv.schemaName + (sv.builtin ? " (builtin)" : ""),
       value: sv.id,
     })),
 );

--- a/lib/dal/src/migrations/U2311__drop_unique_func_name_live.sql
+++ b/lib/dal/src/migrations/U2311__drop_unique_func_name_live.sql
@@ -1,0 +1,1 @@
+DROP INDEX unique_func_name_live;

--- a/lib/sdf-server/src/server/service/diagram/list_schema_variants.rs
+++ b/lib/sdf-server/src/server/service/diagram/list_schema_variants.rs
@@ -54,6 +54,7 @@ pub struct InputSocketView {
 #[serde(rename_all = "camelCase")]
 pub struct SchemaVariantView {
     id: SchemaVariantId,
+    builtin: bool,
     name: String,
     schema_name: String,
     schema_id: SchemaId,
@@ -125,6 +126,7 @@ pub async fn list_schema_variants(
 
         variants_view.push(SchemaVariantView {
             id: *variant.id(),
+            builtin: variant.is_builtin(&ctx).await?,
             name: variant.name().to_owned(),
             schema_id: *schema.id(),
             schema_name: schema.name().to_owned(),

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -119,6 +119,8 @@ pub enum FuncError {
     FuncHasAssociations(FuncId),
     #[error("Function named \"{0}\" already exists in this changeset")]
     FuncNameExists(String),
+    #[error("The function name \"{0}\" is reserved")]
+    FuncNameReserved(String),
     #[error("Function not found")]
     FuncNotFound,
     #[error("func is not revertible")]

--- a/lib/sdf-server/src/server/service/func/create_func.rs
+++ b/lib/sdf-server/src/server/service/func/create_func.rs
@@ -316,6 +316,14 @@ pub async fn create_func(
 ) -> FuncResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
+    if let Some(name) = request.name.as_deref() {
+        if dal::func::is_intrinsic(name)
+            || ["si:resourcePayloadToValue", "si:normalizeToArray"].contains(&name)
+        {
+            return Err(FuncError::FuncNameReserved(name.into()));
+        }
+    }
+
     let mut force_changeset_pk = None;
     if ctx.visibility().is_head() {
         let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;


### PR DESCRIPTION
Remove the func name uniqueness condition to ease the import of updated builtins. A new schema variant will be imported with the same name, and the connected functions will be recreated, with the original functions left intact after import.

If a schema variant is net-new (whether a changed builtin or a new schema variant), it might reference a function from head. This lead to those functions being skipped from the package and missing on import, since they were not in the changeset that contained the new schema variant. This will grab them and create them new, with an identical name.

Adds a "builtin" boolean to the SchemaVariantView so that we can use that metadata to figure out which schema variant we want to add to a module export.

CAVEAT: This makes it possible for a user to create a function with the same name as an intrinsic (e.g., si:identity), which is likely to cause problems (although we will skip those on module/workspaceBackup imports). We still reference these functions by name in a few places, so a custom function with the same name as an intrinsic that comes first in the query order would break in the places where we expect the intrinsic.