### PR TITLE
feat(module-index): Allow larger uploads, order modules by created at

### DIFF
--- a/lib/module-index-server/src/routes.rs
+++ b/lib/module-index-server/src/routes.rs
@@ -1,4 +1,5 @@
 use axum::{
+    extract::DefaultBodyLimit,
     response::Json,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -17,6 +18,9 @@ pub(crate) mod reject_module_route;
 pub(crate) mod upsert_module_route;
 
 use super::{app_state::AppState, server::ServerError};
+
+// 20Mb upload limit
+const MAX_UPLOAD_BYTES: usize = 1024 * 1024 * 20;
 
 #[allow(clippy::too_many_arguments)]
 pub fn routes(state: AppState) -> Router {
@@ -37,7 +41,8 @@ pub fn routes(state: AppState) -> Router {
             "/modules/:module_id/reject",
             post(reject_module_route::reject_module),
         )
-        .layer(CorsLayer::permissive());
+        .layer(CorsLayer::permissive())
+        .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES));
 
     router.with_state(state)
 }

--- a/lib/module-index-server/src/routes/list_modules_route.rs
+++ b/lib/module-index-server/src/routes/list_modules_route.rs
@@ -65,8 +65,6 @@ pub async fn list_module_route(
     let su = request.su.unwrap_or(false)
         && is_systeminit_auth_token(&auth_token, state.token_emails()).await?;
 
-    dbg!(&su);
-
     let kind = request.kind.unwrap_or(si_module::ModuleKind::Module);
 
     // filters
@@ -87,7 +85,9 @@ pub async fn list_module_route(
     };
 
     // ordering
-    let query = query.order_by_asc(si_module::Column::Name);
+    let query = query
+        .order_by_desc(si_module::Column::OwnerUserId)
+        .order_by_desc(si_module::Column::CreatedAt);
 
     let modules: Vec<si_module::Model> = query.all(&txn).await?;
 

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::Multipart,
+    extract::{multipart::MultipartError, Multipart},
     response::{IntoResponse, Response},
     Json,
 };
@@ -31,6 +31,8 @@ pub enum UpsertModuleError {
     DbErr(#[from] DbErr),
     #[error("file upload error: {0}")]
     IoError(#[from] std::io::Error),
+    #[error("multipart decode error: {0}")]
+    Multipart(#[from] MultipartError),
     #[error("s3 error: {0}")]
     S3Error(#[from] S3Error),
     #[error("JSON serialization/deserialization error: {0}")]
@@ -67,7 +69,7 @@ pub async fn upsert_module_route(
         None => return Err(UpsertModuleError::UploadRequiredError),
     };
     info!("Found multipart field");
-    let data = field.bytes().await.unwrap();
+    let data = field.bytes().await?;
     info!("Got part data");
 
     // SiPkg using old term "package" but we are dealing with a "module"


### PR DESCRIPTION
Axum's default body limit of 2mb is too small for uploading a large workspace. Ordering by created_at makes more sense, especially for the workspace backup list.