### PR TITLE
fix(sdf): add json content-type to create_node response

### DIFF
--- a/lib/sdf-server/src/server/service/diagram/create_node.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_node.rs
@@ -198,6 +198,7 @@ pub async fn create_node(
     if let Some(force_changeset_pk) = force_changeset_pk {
         response = response.header("force_changeset_pk", force_changeset_pk.to_string());
     }
+    response = response.header("content-type", "application/json");
     Ok(response.body(serde_json::to_string(&CreateNodeResponse {
         component_id: *component.id(),
         node_id: *node.id(),


### PR DESCRIPTION
The lack of a content-type header on the create_node HTTP response causes Firefox to raise an XML Parsing Error on every call (since it interprets the type as XML by default), and likely will cause issues with other HTTP clients. This quiets those errors.