### PR TITLE
feat(sdf,dal): api to test functions, streaming logs

### DIFF
--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -10,6 +10,7 @@ import { FuncVariant } from "@/api/sdf/dal/func";
 import { nilId } from "@/utils/nilId";
 import { trackEvent } from "@/utils/tracking";
 import keyedDebouncer from "@/utils/keyedDebouncer";
+import { OutputStream } from "@/api/sdf/dal/resource";
 import { useChangeSetsStore } from "../change_sets.store";
 import { useRealtimeStore } from "../realtime/realtime.store";
 import { useComponentsStore } from "../components.store";
@@ -447,6 +448,24 @@ export const useFuncStore = () => {
             onSuccess: (response) => {
               this.lastFuncExecutionLogByFuncId[funcId] = response;
             },
+          });
+        },
+
+        async EXECUTE(executeRequest: {
+          id: FuncId;
+          args: unknown;
+          executionKey: string;
+        }) {
+          return new ApiRequest<{
+            id: FuncId;
+            args: unknown;
+            output: unknown;
+            executionKey: string;
+            logs: OutputStream[];
+          }>({
+            method: "post",
+            url: "func/execute",
+            params: { ...executeRequest, ...visibility },
           });
         },
 

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -2,6 +2,8 @@
 // used in the subscribe fn to limit valid event names and set callback payload type
 
 import { ActorView } from "@/api/sdf/dal/history_actor";
+import { OutputStream } from "@/api/sdf/dal/resource";
+import { FuncId } from "@/store/func/funcs.store";
 import { ComponentId } from "../components.store";
 import { FixStatus } from "../fixes.store";
 import {
@@ -32,6 +34,11 @@ export type WsEventPayloadMap = {
 
   // NOT CURRENTLY USED - but leaving here so we remember these events exist
   // SecretCreated: number;
+  LogLine: {
+    line: OutputStream;
+    funcId: FuncId;
+    executionKey: string;
+  };
   ResourceRefreshed: {
     componentId: string;
   };

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -7,6 +7,7 @@ use crate::component::ComponentCreatedPayload;
 use crate::{
     component::{code::CodeGeneratedPayload, resource::ResourceRefreshedPayload},
     fix::{batch::FixBatchReturn, FixReturn},
+    func::binding::LogLinePayload,
     qualification::QualificationCheckPayload,
     status::StatusMessage,
     AttributeValueId, ChangeSetPk, ComponentId, DalContext, PropId, SchemaPk, SocketId,
@@ -46,6 +47,7 @@ pub enum WsPayload {
     ComponentCreated(ComponentCreatedPayload),
     FixBatchReturn(FixBatchReturn),
     FixReturn(FixReturn),
+    LogLine(LogLinePayload),
     ResourceRefreshed(ResourceRefreshedPayload),
     SchemaCreated(SchemaPk),
     StatusUpdate(StatusMessage),

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -27,9 +27,11 @@ use dal::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 pub mod create_func;
 pub mod delete_func;
+pub mod execute;
 pub mod get_func;
 pub mod list_funcs;
 pub mod list_input_sources;
@@ -133,6 +135,8 @@ pub enum FuncError {
     Hyper(#[from] hyper::http::Error),
     #[error("internal provider error: {0}")]
     InternalProvider(#[from] InternalProviderError),
+    #[error("failed to join async task; bug!")]
+    Join(#[from] JoinError),
     #[error("Missing required options for creating a function")]
     MissingOptions,
     #[error("Function is read-only")]
@@ -822,6 +826,7 @@ pub fn routes() -> Router<AppState> {
         .route("/save_func", post(save_func::save_func))
         .route("/delete_func", post(delete_func::delete_func))
         .route("/save_and_exec", post(save_and_exec::save_and_exec))
+        .route("/execute", post(execute::execute))
         .route("/revert_func", post(revert_func::revert_func))
         .route(
             "/list_input_sources",

--- a/lib/sdf-server/src/server/service/func/execute.rs
+++ b/lib/sdf-server/src/server/service/func/execute.rs
@@ -1,0 +1,99 @@
+use super::FuncResult;
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use axum::Json;
+use dal::{
+    func::binding::FuncBindingResult, func::binding::LogLinePayload, DalContext, Func, FuncBinding,
+    FuncBindingError, FuncError, FuncId, StandardModel, Visibility, WsEvent,
+};
+use serde::{Deserialize, Serialize};
+use veritech_client::OutputStream;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecuteRequest {
+    pub id: FuncId,
+    pub args: serde_json::Value,
+    pub execution_key: String,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecuteResponse {
+    pub id: FuncId,
+    pub args: serde_json::Value,
+    pub output: serde_json::Value,
+    pub execution_key: String,
+    pub logs: Vec<OutputStream>,
+}
+
+pub async fn execute(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(req): Json<ExecuteRequest>,
+) -> FuncResult<Json<ExecuteResponse>> {
+    let ctx = builder.build(request_ctx.build(req.visibility)).await?;
+
+    let func = Func::get_by_id(&ctx, &req.id)
+        .await?
+        .ok_or(FuncError::NotFound(req.id))?;
+    let func_binding =
+        FuncBinding::new(&ctx, req.args.clone(), req.id, *func.backend_kind()).await?;
+
+    let (func, _execution, context, mut rx) = func_binding.prepare_execution(&ctx).await?;
+    ctx.rollback().await?;
+
+    // Doesn't use transaction in ctx
+    let (func_id, inner_ctx, execution_key) = (*func.id(), ctx.clone(), req.execution_key.clone());
+    let log_handler = tokio::spawn(async move {
+        let (ctx, mut output) = (&inner_ctx, Vec::new());
+
+        while let Some(output_stream) = rx.recv().await {
+            output.push(output_stream.clone());
+
+            let log_line = LogLinePayload {
+                line: output_stream,
+                func_id,
+                execution_key: execution_key.clone(),
+            };
+            publish_immediately(ctx, WsEvent::log_line(ctx, log_line).await?).await?;
+        }
+        Ok::<_, FuncBindingError>(output)
+    });
+
+    let (value, _unprocessed_value) = func_binding
+        .execute_critical_section(func.clone(), context)
+        .await?;
+    let logs = log_handler.await??;
+
+    Ok(Json(ExecuteResponse {
+        id: req.id,
+        args: req.args,
+        execution_key: req.execution_key,
+        output: value.unwrap_or(serde_json::Value::Null),
+        logs,
+    }))
+}
+
+/// Publish a [`WsEvent`](crate::WsEvent) immediately.
+///
+/// # Errors
+///
+/// Returns [`Err`] if the [`event`](crate::WsEvent) could not be published or the payload
+/// could not be serialized.
+///
+/// # Notes
+///
+/// This should only be done unless the caller is _certain_ that the [`event`](crate::WsEvent)
+/// should be published immediately. If unsure, use
+/// [`WsEvent::publish`](crate::WsEvent::publish_on_commit).
+///
+/// This method requires an owned [`WsEvent`](crate::WsEvent), despite it not needing to,
+///  because [`events`](crate::WsEvent) should likely not be reused.
+async fn publish_immediately(ctx: &DalContext, ws_event: WsEvent) -> FuncBindingResult<()> {
+    let subject = format!("si.workspace_pk.{}.event", ws_event.workspace_pk());
+    let msg_bytes = serde_json::to_vec(&ws_event)?;
+    ctx.nats_conn().publish(subject, msg_bytes).await?;
+    Ok(())
+}


### PR DESCRIPTION
Tested with:

*Note: the argument has to be the `FuncBackendJs{...}Args`, the one that the dispatcher sends to js, so each function kind will have a different wrapper*

```
fetch(http://localhost:8080/api/func/execute", { 
  method: "POST", 
  headers: { 
    'Content-Type': 'application/json',
    authorization: `Bearer ${yourBearerToken}`,
    WorkspacePk: yourWorkspace,
    body: JSON.stringify({
      id: yourFuncId,
      args: yourArgument,
      executionKey: "random-key-to-group-logs-by",
      visibility_change_set_pk: yourChangeSetPk
    })
 } ) 
```