### PR TITLE
feat(web): add hover tooltip for the code editor

### DIFF
--- a/lib/sdf-server/src/server/service/ts_types/asset_types.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_types.d.ts
@@ -166,7 +166,29 @@ class PropBuilder implements IPropBuilder {
     setDocLink(link: string): this;
     setDocLinkRef(ref: string): this;
     setHidden(hidden: boolean): this;
+
+    /**
+    * The type of the prop
+    *
+    * @param {string} kind [array | boolean | integer | map | object | string]
+    *
+    * @returns this
+    *
+    * @example
+    * .setKind("text")
+    */
     setKind(kind: PropDefinitionKind): this;
+
+    /**
+    * The prop name. This will appear in the model UI
+    *
+    * @param {string} name - the name of the prop
+    *
+    * @returns this
+    *
+    * @example
+    * .setName("Region")
+    */
     setName(name: string): this;
     setValueFrom(valueFrom: ValueFrom): this;
     setWidget(widget: PropWidgetDefinition): this;


### PR DESCRIPTION
Hover over a func to see tooltips! Pulls from comments in the `asset_types.d.ts` file. Currently on `setKind` and `setName` on `PropBuilder` have comments. We'll want to pad the rest of these out as we go.

![image](https://github.com/systeminit/si/assets/3621657/17b9cadb-b496-4e59-bd71-82c3a6675d5b)

![image](https://github.com/systeminit/si/assets/3621657/4924b167-2cd7-470c-adb5-6516794b5a26)
