### PR TITLE
fix(auth) - RichText hljs plaintext support

### DIFF
--- a/app/auth-portal/src/pages/tutorial/TutorialPage.vue
+++ b/app/auth-portal/src/pages/tutorial/TutorialPage.vue
@@ -242,8 +242,6 @@ watch(activeStepSlug, () => {
   const kebabStepSlug = activeStepSlug.value.replace(/_/g, "-");
   // if going from /tutorial to /tutorial/intro, we use replace, otherwise push
 
-  console.log(kebabStepSlug);
-
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   router[route.params.stepSlug ? "push" : "replace"]({
     ...router.currentRoute,

--- a/app/auth-portal/src/pages/tutorial/TutorialPage.vue
+++ b/app/auth-portal/src/pages/tutorial/TutorialPage.vue
@@ -131,7 +131,6 @@ import { RouterLink, useRoute, useRouter } from "vue-router";
 import { useHead } from "@vueuse/head";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import Confetti from "@/components/Confetti.vue";
-
 import WorkspaceLinkWidget from "@/components/WorkspaceLinkWidget.vue";
 import { useOnboardingStore } from "@/store/onboarding.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
@@ -191,6 +190,7 @@ const stepsEnabled = computed(() => {
     }
   });
 });
+
 const lastEnabledStepSlug = computed(() =>
   _.last(_.keys(_.pickBy(stepsEnabled.value))),
 );
@@ -241,6 +241,8 @@ const route = useRoute();
 watch(activeStepSlug, () => {
   const kebabStepSlug = activeStepSlug.value.replace(/_/g, "-");
   // if going from /tutorial to /tutorial/intro, we use replace, otherwise push
+
+  console.log(kebabStepSlug);
 
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   router[route.params.stepSlug ? "push" : "replace"]({

--- a/lib/vue-lib/src/design-system/general/RichText.vue
+++ b/lib/vue-lib/src/design-system/general/RichText.vue
@@ -11,6 +11,7 @@ import { useHead } from "@vueuse/head";
 
 import hljs from "highlight.js/lib/core";
 import hljsJsLang from "highlight.js/lib/languages/javascript";
+import hljsTextLang from "highlight.js/lib/languages/plaintext";
 import hljsShellLang from "highlight.js/lib/languages/shell";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
@@ -21,6 +22,7 @@ import hljsThemeDark from "highlight.js/styles/github-dark.css?raw";
 import { useTheme } from "../utils/theme_tools";
 
 hljs.registerLanguage("javascript", hljsJsLang);
+hljs.registerLanguage("text", hljsTextLang);
 hljs.registerAliases("js", { languageName: "javascript" });
 hljs.registerLanguage("shell", hljsShellLang);
 


### PR DESCRIPTION
Tutorial navigation bug was actually caused by an issue with the RichText markdown parser. Fixed!