### PR TITLE
feat(web, dal): Add component debug view

### DIFF
--- a/app/web/src/components/AttributeDebugView.vue
+++ b/app/web/src/components/AttributeDebugView.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="overflow-x-scroll m-4">
+    <dl>
+      <dt class="type-bold-base">Set By Function</dt>
+      <dd class="m-4 border-black">{{ data.funcName }} {{ data.funcId }}</dd>
+      <dt class="type-bold-base">Input</dt>
+      <dd class="m-4">
+        <pre>{{ data.funcArgs }}</pre>
+      </dd>
+      <dt class="type-bold-base">Input sources</dt>
+      <dd class="m-4">
+        <ul v-if="data.argSources && Object.keys(data.argSources).length">
+          <li v-for="[k, v] in Object.entries(data.argSources)" :key="k">
+            <strong>{{ k }}</strong>
+            : {{ v ?? "?" }}
+          </li>
+        </ul>
+        <p v-else>No input sources</p>
+      </dd>
+      <dt class="type-bold-base">Value</dt>
+      <dd class="m-4">
+        <pre>{{ data.value }}</pre>
+      </dd>
+    </dl>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AttributeDebugData } from "@/store/components.store";
+
+defineProps<{ data: AttributeDebugData }>();
+</script>

--- a/app/web/src/components/ComponentDebugModal.vue
+++ b/app/web/src/components/ComponentDebugModal.vue
@@ -1,0 +1,87 @@
+<template>
+  <Modal ref="modalRef" title="Component Debug" size="4xl">
+    Component Id: {{ selectedComponentId ?? "none" }}
+    <Stack v-if="debugData" class="m-4 overflow-y-scroll max-h-[80vh]">
+      <Collapsible
+        label="Attributes"
+        :defaultOpen="false"
+        contentAs="ul"
+        textSize="lg"
+      >
+        <Collapsible
+          v-for="attribute in debugData.attributes"
+          :key="attribute.path"
+          class="m-2"
+          :label="attribute.path"
+          :defaultOpen="false"
+          as="li"
+        >
+          <AttributeDebugView :data="attribute.debugData" />
+        </Collapsible>
+      </Collapsible>
+      <Collapsible
+        label="Input Sockets"
+        :defaultOpen="false"
+        contentAs="ul"
+        textSize="lg"
+      >
+        <Collapsible
+          v-for="attribute in debugData.inputSockets"
+          :key="attribute.name"
+          class="m-2"
+          :label="attribute.name"
+          :defaultOpen="false"
+          as="li"
+        >
+          <AttributeDebugView :data="attribute.debugData" />
+        </Collapsible>
+      </Collapsible>
+      <Collapsible
+        label="Output Sockets"
+        :defaultOpen="false"
+        contentAs="ul"
+        textSize="lg"
+      >
+        <Collapsible
+          v-for="attribute in debugData.outputSockets"
+          :key="attribute.name"
+          class="m-2"
+          :label="attribute.name"
+          :defaultOpen="false"
+          as="li"
+        >
+          <AttributeDebugView :data="attribute.debugData" />
+        </Collapsible>
+      </Collapsible>
+    </Stack>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { Modal, Stack, useModal, Collapsible } from "@si/vue-lib/design-system";
+import { ref } from "vue";
+import {
+  ComponentDebugView,
+  useComponentsStore,
+} from "@/store/components.store";
+import AttributeDebugView from "./AttributeDebugView.vue";
+
+const componentsStore = useComponentsStore();
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const selectedComponentId = ref<string | undefined>();
+const debugData = ref<ComponentDebugView | undefined>();
+
+const { open: openModal, close } = useModal(modalRef);
+
+async function open(componentId: string) {
+  selectedComponentId.value = componentId;
+  const res = await componentsStore.FETCH_COMPONENT_DEBUG_VIEW(componentId);
+  if (res.result.success) {
+    debugData.value = res.result.data;
+    openModal();
+  }
+}
+
+defineExpose({ open, close });
+</script>

--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -8,7 +8,10 @@
     </div> -->
 
     <div v-if="DEV_MODE" class="px-xs pt-xs text-2xs italic opacity-30">
-      COMPONENT ID = {{ selectedComponent.id }}
+      COMPONENT ID =
+      <span @click="openDebugModal(selectedComponent?.id)">{{
+        selectedComponent?.id
+      }}</span>
       <br />
       NODE ID = {{ selectedComponent.nodeId }}
     </div>
@@ -110,11 +113,12 @@
         </TabGroup>
       </div>
     </template>
+    <ComponentDebugModal ref="debugModalRef" />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeMount } from "vue";
+import { computed, onBeforeMount, ref } from "vue";
 import {
   Icon,
   ErrorMessage,
@@ -131,10 +135,18 @@ import CodeViewer from "@/components/CodeViewer.vue";
 import ComponentCard from "./ComponentCard.vue";
 import DetailsPanelTimestamps from "./DetailsPanelTimestamps.vue";
 import ComponentDetailsResource from "./ComponentDetailsResource.vue";
+import ComponentDebugModal from "./ComponentDebugModal.vue";
 
 const emit = defineEmits(["delete", "restore"]);
 
 const DEV_MODE = import.meta.env.DEV;
+
+const debugModalRef = ref<InstanceType<typeof ComponentDebugModal>>();
+const openDebugModal = (componentId?: string) => {
+  if (debugModalRef.value && componentId) {
+    debugModalRef.value?.open(componentId);
+  }
+};
 
 const componentsStore = useComponentsStore();
 const changeSetStore = useChangeSetsStore();

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -135,6 +135,32 @@ const confirmationStatusToIconMap: Record<
   failure: { icon: "tools", tone: "error" },
 };
 
+export interface AttributeDebugData {
+  valueId: string;
+  proxyFor?: string | null;
+  funcName: string;
+  funcId: string;
+  funcArgs: object;
+  argSources: { [key: string]: string | null } | null;
+  visibility: {
+    visibility_change_set_pk: string;
+    visibility_deleted_at: Date | undefined | null;
+  };
+  value: object | string | number | boolean | null;
+}
+
+export interface AttributeDebugView {
+  path: string;
+  name: string;
+  debugData: AttributeDebugData;
+}
+
+export interface ComponentDebugView {
+  attributes: AttributeDebugView[];
+  inputSockets: AttributeDebugView[];
+  outputSockets: AttributeDebugView[];
+}
+
 export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
   const workspacesStore = useWorkspacesStore();
   const workspaceId = workspacesStore.selectedWorkspacePk;
@@ -451,6 +477,16 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           });
         },
 
+        async FETCH_COMPONENT_DEBUG_VIEW(componentId: string) {
+          return new ApiRequest<ComponentDebugView>({
+            url: "component/debug",
+            params: {
+              componentId,
+              ...visibilityParams,
+            },
+          });
+        },
+
         // used when adding new nodes
         async FETCH_AVAILABLE_SCHEMAS() {
           return new ApiRequest<DiagramSchemaVariants>({
@@ -523,6 +559,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           }>({
             method: "post",
             url: "diagram/create_node",
+            headers: { accept: "application/json" },
             params: {
               schemaId,
               parentId: parentNodeId,

--- a/lib/dal/src/attribute/value/view.rs
+++ b/lib/dal/src/attribute/value/view.rs
@@ -19,6 +19,7 @@ pub struct AttributeView {
     /// The value that was generated from [`Self::new()`]. This can also be referred to as the
     /// "properties" or "tree" of the view.
     value: Value,
+    json_pointer_for_attribute_value_id: HashMap<AttributeValueId, String>,
 }
 
 impl AttributeView {
@@ -139,6 +140,7 @@ impl AttributeView {
                                     // After we've processed the "root" property, we shouldn't hit this case any more.
                                     json_pointer.clone()
                                 };
+
                             let write_location = match properties.pointer_mut(&insertion_pointer) {
                                 Some(write_location) => write_location,
                                 None => {
@@ -220,7 +222,10 @@ impl AttributeView {
                         so the \"properties\" object is empty ({:?}), and does not contain a key matching \
                         our prop's name (root attribute value ({:?}) and root prop ({:?}))", properties, root_attribute_value, root_prop
                     );
-                    return Ok(Self { value: Value::Null });
+                    return Ok(Self {
+                        value: Value::Null,
+                        json_pointer_for_attribute_value_id,
+                    });
                 }
             };
 
@@ -228,16 +233,22 @@ impl AttributeView {
                 .pointer(root_json_pointer)
                 .ok_or(AttributeValueError::NoValueForJsonPointer)?;
             return Ok(Self {
-                value: properties.clone(),
+                value: properties.to_owned(),
+                json_pointer_for_attribute_value_id,
             });
         }
 
         Ok(Self {
-            value: properties.clone(),
+            value: properties.to_owned(),
+            json_pointer_for_attribute_value_id,
         })
     }
 
     pub fn value(&self) -> &serde_json::Value {
         &self.value
+    }
+
+    pub fn json_pointers_for_attribute_value_id(&self) -> &HashMap<AttributeValueId, String> {
+        &self.json_pointer_for_attribute_value_id
     }
 }

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 use crate::{server::state::AppState, service::schema::SchemaError};
 
 pub mod alter_simulation;
+pub mod debug;
 pub mod get_code;
 pub mod get_components_metadata;
 pub mod get_diff;
@@ -52,6 +53,8 @@ pub enum ComponentError {
     ChangeStatus(#[from] ChangeStatusError),
     #[error("component error: {0}")]
     Component(#[from] DalComponentError),
+    #[error("component debug error: {0}")]
+    ComponentDebug(String),
     #[error("component name not found")]
     ComponentNameNotFound,
     #[error("component not found for id: {0}")]
@@ -164,4 +167,5 @@ pub fn routes() -> Router<AppState> {
             "/alter_simulation",
             post(alter_simulation::alter_simulation),
         )
+        .route("/debug", get(debug::debug_component))
 }

--- a/lib/sdf-server/src/server/service/component/debug.rs
+++ b/lib/sdf-server/src/server/service/component/debug.rs
@@ -1,0 +1,321 @@
+use std::collections::{HashMap, VecDeque};
+
+use axum::extract::Query;
+use axum::Json;
+
+use serde::{Deserialize, Serialize};
+
+use super::{ComponentError, ComponentResult};
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use dal::{
+    socket::SocketEdgeKind, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
+    AttributeValueId, AttributeView, Component, ComponentId, DalContext, ExternalProviderId, Func,
+    FuncArgument, FuncBinding, FuncId, InternalProvider, InternalProviderId, Prop, PropId, Socket,
+    StandardModel, Visibility,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentDebugView {
+    attributes: Vec<AttributeDebugView>,
+    input_sockets: Vec<AttributeDebugView>,
+    output_sockets: Vec<AttributeDebugView>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeDebugView {
+    name: String,
+    path: String,
+    debug_data: AttributeMetadataView,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeMetadataView {
+    pub value_id: AttributeValueId,
+    pub proxy_for: Option<AttributeValueId>,
+    pub func_name: String,
+    pub func_id: FuncId,
+    pub func_args: serde_json::Value,
+    pub arg_sources: HashMap<String, Option<String>>,
+    pub visibility: Visibility,
+    pub value: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugComponentRequest {
+    pub component_id: ComponentId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+type DebugComponentResponse = ComponentDebugView;
+
+pub async fn debug_component(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<DebugComponentRequest>,
+) -> ComponentResult<Json<DebugComponentResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let component = Component::get_by_id(&ctx, &request.component_id)
+        .await?
+        .ok_or(ComponentError::ComponentDebug("component not found".into()))?;
+
+    let schema_variant =
+        component
+            .schema_variant(&ctx)
+            .await?
+            .ok_or(ComponentError::ComponentDebug(
+                "schema variant not found for component".into(),
+            ))?;
+
+    let root_prop_id = schema_variant
+        .root_prop_id()
+        .ok_or(ComponentError::ComponentDebug(
+            "could not get root prop for schema variant".into(),
+        ))?;
+
+    let av_context = AttributeReadContext {
+        prop_id: Some(*root_prop_id),
+        internal_provider_id: Some(InternalProviderId::NONE),
+        external_provider_id: Some(ExternalProviderId::NONE),
+        component_id: Some(*component.id()),
+    };
+
+    let root_prop_av = AttributeValue::find_for_context(&ctx, av_context)
+        .await?
+        .ok_or(ComponentError::ComponentDebug(
+            "could not get attribute value for root prop".into(),
+        ))?;
+
+    let view_context = AttributeReadContext {
+        prop_id: None,
+        internal_provider_id: Some(InternalProviderId::NONE),
+        external_provider_id: Some(ExternalProviderId::NONE),
+        component_id: Some(*component.id()),
+    };
+
+    let root_prop_view = AttributeView::new(&ctx, view_context, Some(*root_prop_av.id())).await?;
+
+    let pointer_to_av_ids: HashMap<String, AttributeValueId> = root_prop_view
+        .json_pointers_for_attribute_value_id()
+        .iter()
+        .map(|(k, v)| (v.to_owned(), k.to_owned()))
+        .collect();
+
+    let mut value_stack = VecDeque::from([(
+        "/root".to_string(),
+        "root".to_string(),
+        root_prop_view.value().to_owned(),
+    )]);
+
+    let mut attribute_views = vec![];
+    let mut input_socket_views = vec![];
+    let mut output_socket_views = vec![];
+
+    while let Some((pointer, name, value)) = value_stack.pop_front() {
+        if let Some(av_id) = pointer_to_av_ids.get(&pointer) {
+            attribute_views.push(AttributeDebugView {
+                path: pointer.to_owned(),
+                name: name.to_owned(),
+                debug_data: get_attribute_metadata(&ctx, *av_id).await?,
+            });
+        }
+
+        match value {
+            serde_json::Value::Object(map_object) => {
+                for (k, v) in map_object.iter() {
+                    let new_pointer = format!("{}/{}", &pointer, &k);
+                    value_stack.push_front((new_pointer, k.to_owned(), v.to_owned()));
+                }
+            }
+            serde_json::Value::Array(array) => {
+                for (pos, v) in array.iter().enumerate() {
+                    let position_string = format!("{}", &pos);
+                    let new_pointer = format!("{}/{}", &pointer, &position_string);
+
+                    value_stack.push_front((new_pointer, position_string, v.to_owned()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut input_sockets = vec![];
+    let mut output_sockets = vec![];
+
+    for socket in Socket::list_for_component(&ctx, request.component_id)
+        .await
+        .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
+    {
+        match socket.edge_kind() {
+            SocketEdgeKind::ConfigurationInput => {
+                let internal_provider = socket
+                    .internal_provider(&ctx)
+                    .await
+                    .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
+                    .ok_or(ComponentError::ComponentDebug(
+                        "could not find internal provider for an input socket".into(),
+                    ))?;
+
+                let input_socket_value_context = AttributeReadContext {
+                    prop_id: Some(PropId::NONE),
+                    internal_provider_id: Some(*internal_provider.id()),
+                    external_provider_id: Some(ExternalProviderId::NONE),
+                    component_id: Some(*component.id()),
+                };
+                let socket_value =
+                    AttributeValue::find_for_context(&ctx, input_socket_value_context)
+                        .await?
+                        .ok_or(ComponentError::ComponentDebug(
+                            "could not find attribute value for an input socket".into(),
+                        ))?;
+
+                input_sockets.push((
+                    internal_provider.name().to_string(),
+                    get_attribute_metadata(&ctx, *socket_value.id()).await?,
+                ))
+            }
+            SocketEdgeKind::ConfigurationOutput => {
+                let external_provider = socket
+                    .external_provider(&ctx)
+                    .await
+                    .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
+                    .ok_or(ComponentError::ComponentDebug(
+                        "could not find external_provider for an output socket".into(),
+                    ))?;
+
+                let output_socket_value_context = AttributeReadContext {
+                    prop_id: Some(PropId::NONE),
+                    internal_provider_id: Some(InternalProviderId::NONE),
+                    external_provider_id: Some(*external_provider.id()),
+                    component_id: Some(*component.id()),
+                };
+                let socket_value =
+                    AttributeValue::find_for_context(&ctx, output_socket_value_context)
+                        .await?
+                        .ok_or(ComponentError::ComponentDebug(
+                            "could not find attribute value for an output socket".into(),
+                        ))?;
+
+                output_sockets.push((
+                    external_provider.name().to_string(),
+                    get_attribute_metadata(&ctx, *socket_value.id()).await?,
+                ))
+            }
+        }
+    }
+
+    for (name, metadata) in input_sockets {
+        input_socket_views.push(AttributeDebugView {
+            path: "Input Socket".to_owned(),
+            name,
+            debug_data: metadata,
+        });
+    }
+
+    for (name, metadata) in output_sockets {
+        output_socket_views.push(AttributeDebugView {
+            path: "Out Socket".to_owned(),
+            name,
+            debug_data: metadata,
+        });
+    }
+
+    let component_view = ComponentDebugView {
+        attributes: attribute_views,
+        input_sockets: input_socket_views,
+        output_sockets: output_socket_views,
+    };
+
+    Ok(Json(component_view))
+}
+
+async fn get_attribute_metadata(
+    ctx: &DalContext,
+    value_id: AttributeValueId,
+) -> ComponentResult<AttributeMetadataView> {
+    let value =
+        AttributeValue::get_by_id(ctx, &value_id)
+            .await?
+            .ok_or(ComponentError::ComponentDebug(
+                "could not find attribute value".into(),
+            ))?;
+    let mut arg_sources = HashMap::new();
+
+    let prototype = value
+        .attribute_prototype(ctx)
+        .await?
+        .ok_or(ComponentError::ComponentDebug(
+            "could not find attribute prototype for value".into(),
+        ))?;
+
+    let proxy_for = value.proxy_for_attribute_value_id().copied();
+
+    let func =
+        Func::get_by_id(ctx, &prototype.func_id())
+            .await?
+            .ok_or(ComponentError::ComponentDebug(
+                "could not find func used to set value".into(),
+            ))?;
+
+    let fb = FuncBinding::get_by_id(ctx, &value.func_binding_id())
+        .await?
+        .ok_or(ComponentError::ComponentDebug(
+            "could not find func binding used to set value".into(),
+        ))?;
+    let func_args = fb.args().to_owned();
+
+    for apa in
+        AttributePrototypeArgument::list_for_attribute_prototype(ctx, *prototype.id()).await?
+    {
+        let arg = FuncArgument::get_by_id(ctx, &apa.func_argument_id())
+            .await?
+            .ok_or(ComponentError::ComponentDebug(
+                "could not find func argument".into(),
+            ))?;
+
+        let internal_provider_id = apa.internal_provider_id();
+        let input_ip_name = if internal_provider_id.is_some() {
+            let ip = InternalProvider::get_by_id(ctx, &internal_provider_id)
+                .await?
+                .ok_or(ComponentError::ComponentDebug(
+                    "could not find internal provider for input".into(),
+                ))?;
+
+            let prop_id = *ip.prop_id();
+            let path = if prop_id == PropId::NONE {
+                format!("Input Socket: {}", ip.name())
+            } else {
+                let prop =
+                    Prop::get_by_id(ctx, &prop_id)
+                        .await?
+                        .ok_or(ComponentError::ComponentDebug(
+                            "could not find prop for provider for input".into(),
+                        ))?;
+
+                format!("Prop: /{}", prop.path().with_replaced_sep("/"))
+            };
+
+            Some(path)
+        } else {
+            None
+        };
+
+        arg_sources.insert(arg.name().into(), input_ip_name);
+    }
+
+    Ok(AttributeMetadataView {
+        value_id,
+        proxy_for,
+        func_name: func.name().into(),
+        func_id: func.id().to_owned(),
+        func_args,
+        arg_sources,
+        visibility: value.visibility().to_owned(),
+        value: value.get_unprocessed_value(ctx).await?,
+    })
+}


### PR DESCRIPTION
We often want to know the answer to a few questions about a component's state:

  - which function set each value on the component?
  - what was the input to that function?
  - where did the function get its input?

This adds a modal (accessed by clicking on the component id on the attributes panel) which will display that information in a basic way so a the source for the data for each attribute on a component can be quickly inspected.

This came out of an effort to understand the necessary pieces for reconstructing a component from a workspace backup, but should be helpful for us outside of that context.

![image](https://github.com/systeminit/si/assets/1928978/5cc9b659-4c4c-485d-bddb-9f4e999fa624)
