### PR TITLE
feat(lang-js): add script for generating the correct types file for lang-js

### DIFF
--- a/bin/lang-js/BUCK
+++ b/bin/lang-js/BUCK
@@ -11,6 +11,7 @@ load(
 )
 load(
     "@prelude-si//:pnpm.bzl",
+    "pnpm_task_binary",
     "pnpm_task_test",
 )
 
@@ -77,5 +78,16 @@ pnpm_task_test(
         ":dist",
     ],
     path = "bin/lang-js",
+    visibility = ["PUBLIC"],
+)
+
+pnpm_task_binary(
+    name = "generate",
+    command = "generate",
+    srcs = glob(["*"]),
+    path = "bin/lang-js",
+    deps = [
+        "//:node_modules",
+    ],
     visibility = ["PUBLIC"],
 )

--- a/bin/lang-js/package.json
+++ b/bin/lang-js/package.json
@@ -25,6 +25,7 @@
     "build:watch": "npm run clean && tsc --watch",
     "package": "pnpm run build && pkg . --output ./target/lang-js",
     "package:nobuild": "pkg . --output ./target/lang-js",
+    "generate": "OUTDIR=\"$(git rev-parse --show-toplevel)/lib/sdf-server/src/server/service/ts_types/\" && tsc --emitDeclarationOnly --declaration --target es2020 --moduleResolution node --outDir $OUTDIR ./src/asset_builder.ts && sed 's/export //g' -i $OUTDIR/asset_builder.d.ts",
     "watch": "npm run build:watch",
     "lint": "eslint --ext .ts,.js --ignore-path .gitignore src",
     "lint:fix": "eslint --fix",

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -481,11 +481,31 @@ export class PropBuilder implements IPropBuilder {
         return this;
     }
 
+    /**
+    * The type of the prop
+    *
+    * @param {string} kind [array | boolean | integer | map | object | string]
+    *
+    * @returns this
+    *
+    * @example
+    * .setKind("text")
+    */
     setKind(kind: PropDefinitionKind): this {
         this.prop.kind = kind;
         return this;
     }
 
+    /**
+    * The prop name. This will appear in the model UI
+    *
+    * @param {string} name - the name of the prop
+    *
+    * @returns this
+    *
+    * @example
+    * .setName("Region")
+    */
     setName(name: string): this {
         this.prop.name = name;
         return this;

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -629,7 +629,7 @@ pub fn compile_return_types(ty: FuncBackendResponseType, kind: FuncBackendKind) 
         FuncBackendResponseType::Object => "type Output = any;",
         FuncBackendResponseType::Unset => "type Output = undefined | null;",
         FuncBackendResponseType::SchemaVariantDefinition => concat!(
-            include_str!("./ts_types/asset_types.d.ts"),
+            include_str!("./ts_types/asset_builder.d.ts"),
             "\n",
             "type Output = any;"
         ),

--- a/lib/sdf-server/src/server/service/ts_types/asset_builder.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_builder.d.ts
@@ -166,7 +166,6 @@ declare class PropBuilder implements IPropBuilder {
     setDocLink(link: string): this;
     setDocLinkRef(ref: string): this;
     setHidden(hidden: boolean): this;
-
     /**
     * The type of the prop
     *
@@ -178,7 +177,6 @@ declare class PropBuilder implements IPropBuilder {
     * .setKind("text")
     */
     setKind(kind: PropDefinitionKind): this;
-
     /**
     * The prop name. This will appear in the model UI
     *

--- a/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
@@ -166,7 +166,27 @@ declare class PropBuilder implements IPropBuilder {
     setDocLink(link: string): this;
     setDocLinkRef(ref: string): this;
     setHidden(hidden: boolean): this;
+    /**
+    * The type of the prop
+    *
+    * @param {string} kind [array | boolean | integer | map | object | string]
+    *
+    * @returns this
+    *
+    * @example
+    * .setKind("text")
+    */
     setKind(kind: PropDefinitionKind): this;
+    /**
+    * The prop name. This will appear in the model UI
+    *
+    * @param {string} name - the name of the prop
+    *
+    * @returns this
+    *
+    * @example
+    * .setName("Region")
+    */
     setName(name: string): this;
     setValueFrom(valueFrom: ValueFrom): this;
     setWidget(widget: PropWidgetDefinition): this;


### PR DESCRIPTION
Just added a script for packaging the lang-js types and mocing them over to SDF. It currently `sed`s the `export`s away. We could be a lot smarter about this, but this will work for now. I have a feeling we should have bigger conversation about these types and how they get where they need to go. We can start adding docs to `./src/asset_builder.ts` after this is done.