### PR TITLE
(cleanup) fix issues related to formatting

### DIFF
--- a/lib/sdf-server/tests/service_tests/functions.rs
+++ b/lib/sdf-server/tests/service_tests/functions.rs
@@ -1,16 +1,9 @@
-use axum::{
-    Router, http::Method 
-};
+use axum::{http::Method, Router};
 
-use dal::{StandardModel, Func, FuncBackendKind, FuncBackendResponseType, };
-use dal_test::{
-    sdf_test,
-    AuthTokenRef, DalContextHead,
-};
+use dal::{Func, FuncBackendKind, FuncBackendResponseType, StandardModel};
+use dal_test::{sdf_test, AuthTokenRef, DalContextHead};
 
-use sdf_server::service::func::execute::{
-    ExecuteRequest, ExecuteResponse 
-}; 
+use sdf_server::service::func::execute::{ExecuteRequest, ExecuteResponse};
 
 use crate::service_tests::api_request_auth_json_body;
 
@@ -20,34 +13,47 @@ async fn test_execution_endpoint_qualification_function(
     app: Router,
     AuthTokenRef(auth_token): AuthTokenRef<'_>,
 ) {
-    let mut func = Func::new(&ctx, "keebiscool", FuncBackendKind::JsAttribute, FuncBackendResponseType::Qualification).await.expect("cannot create new function");
-    func.set_code_plaintext(&ctx, Some("async function qualification(component: Input): Promise < Output > {
+    let mut func = Func::new(
+        &ctx,
+        "keebiscool",
+        FuncBackendKind::JsAttribute,
+        FuncBackendResponseType::Qualification,
+    )
+    .await
+    .expect("cannot create new function");
+    func.set_code_plaintext(
+        &ctx,
+        Some(
+            "async function qualification(component: Input): Promise < Output > {
 
         return {
             result: 'success',
             message: component.properties.some
         };
-    }")).await.expect("unable to set code plaintext");
-    func.set_handler(&ctx, Some("qualification".to_string())).await.expect("unable to set entrypoint");
-    
+    }",
+        ),
+    )
+    .await
+    .expect("unable to set code plaintext");
+    func.set_handler(&ctx, Some("qualification".to_string()))
+        .await
+        .expect("unable to set entrypoint");
+
     ctx.commit().await.expect("cannot commit");
 
     let request = ExecuteRequest {
-        id: *func.id(), 
+        id: *func.id(),
         args: serde_json::json!({"properties": {"some" : "info"}}),
         execution_key: "somethingfun".to_string(),
-        visibility: *ctx.visibility()
+        visibility: *ctx.visibility(),
     };
 
-    let response: ExecuteResponse = api_request_auth_json_body(
-        app,
-        Method::POST,
-        "/api/func/execute",
-        auth_token,
-        &request,
-    )
-    .await;
+    let response: ExecuteResponse =
+        api_request_auth_json_body(app, Method::POST, "/api/func/execute", auth_token, &request)
+            .await;
 
-    assert_eq!(response.output, serde_json::json!({"result": "success", "message": "info"}));
-
+    assert_eq!(
+        response.output,
+        serde_json::json!({"result": "success", "message": "info"})
+    );
 }

--- a/lib/sdf-server/tests/service_tests/mod.rs
+++ b/lib/sdf-server/tests/service_tests/mod.rs
@@ -8,11 +8,11 @@ use tower::ServiceExt;
 
 mod change_set;
 mod component;
+mod functions;
 mod scenario;
 mod schema;
 mod secret;
 mod session;
-mod functions;
 
 pub async fn api_request_auth_query<Req: Serialize, Res: DeserializeOwned>(
     app: Router,


### PR DESCRIPTION
I did not cargo fmt prior to committing code after adding unit tests for the new `/execute` endpoint