### PR TITLE
feat(web,dal,sdf,lang-js): Integrate secret widget into PropertyEditor

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -55,7 +55,7 @@ export interface PropertyEditorPropWidgetKindSelect {
 
 export interface PropertyEditorPropWidgetKindSecret {
   kind: "secret";
-  options: LabelList<string | number>;
+  options: LabelList<string>;
 }
 
 export interface PropertyEditorPropWidgetKindColor {

--- a/app/web/src/components/AddSecretForm.vue
+++ b/app/web/src/components/AddSecretForm.vue
@@ -44,11 +44,11 @@
           </template>
         </VormInput>
         <VormInput
-          v-for="field in testDefinition.fields"
-          :key="field.id"
-          v-model="secretFormData.value[field.id]"
+          v-for="(field, index) in fields"
+          :key="index"
+          v-model="secretFormData.value[field.name]"
           type="text"
-          :label="field.displayName"
+          :label="field.name"
           required
         />
       </div>
@@ -91,23 +91,14 @@ import {
   useValidatedInputGroup,
   ErrorMessage,
 } from "@si/vue-lib/design-system";
-import { PropType, reactive } from "vue";
+import { PropType, reactive, computed } from "vue";
 import * as _ from "lodash-es";
 import clsx from "clsx";
 import {
   Secret,
-  SecretDefinition,
   SecretDefinitionId,
   useSecretsStore,
 } from "@/store/secrets.store";
-
-// TODO(Wendy) - replace this test definition with a lookup of the given definitionId's definition
-const testDefinition: SecretDefinition = {
-  fields: {
-    test1: { id: "test1", displayName: "Test Value", value: "" },
-    test2: { id: "test2", displayName: "Whatever", value: "" },
-  },
-};
 
 const { validationState, validationMethods } = useValidatedInputGroup();
 
@@ -122,6 +113,10 @@ const props = defineProps({
 });
 
 const secretsStore = useSecretsStore();
+
+const fields = computed(
+  () => secretsStore.secretFormSchemaByDefinitionId[props.definitionId],
+);
 
 const addSecretReqStatus = secretsStore.getRequestStatus("SAVE_SECRET");
 

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -32,8 +32,8 @@
       </template>
 
       <Stack class="p-xs py-sm">
-        <ErrorMessage v-if="disabled" icon="alert-triangle" tone="warning"
-          >{{ disabledWarning }}
+        <ErrorMessage v-if="disabled" icon="alert-triangle" tone="warning">
+          {{ disabledWarning }}
         </ErrorMessage>
 
         <ErrorMessage

--- a/app/web/src/components/PropertyEditor.vue
+++ b/app/web/src/components/PropertyEditor.vue
@@ -22,16 +22,6 @@
         @add-to-map="addToMap($event)"
       />
     </div>
-    <!-- temporary code for testing secrets popover -->
-    <WidgetSecret
-      name="TEST SECRET EXAMPLE YAY"
-      :collapsedPaths="[]"
-      :value="undefined"
-      propId="test"
-      valueId="test"
-      docLink="https://www.wendywildsha.pe/"
-    />
-    <!-- temporary code for testing secrets popover -->
   </div>
 </template>
 
@@ -51,7 +41,6 @@ import {
 import { useComponentsStore } from "@/store/components.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import PropertyWidget from "./PropertyEditor/PropertyWidget.vue";
-import WidgetSecret from "./PropertyEditor/WidgetSecret.vue";
 
 const featureFlagsStore = useFeatureFlagsStore();
 

--- a/app/web/src/components/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/components/PropertyEditor/PropertyWidget.vue
@@ -130,13 +130,15 @@
       @updated-property="updatedProperty($event)"
     />
     <WidgetSecret
-      v-else-if="schemaProp.widgetKind.kind === 'secret' && propValue.value"
+      v-else-if="schemaProp.widgetKind.kind === 'secret'"
       :name="schemaProp.name"
       :path="path"
+      :options="schemaProp.widgetKind.options || []"
       :collapsedPaths="collapsedPaths"
-      :value="(propValue.value as Secret)"
+      :value="(propValue.value as SecretId)"
       :propId="propValue.propId"
       :valueId="propValue.id"
+      @updated-property="updatedProperty($event)"
     />
 
     <!-- restricting to text props for now -->
@@ -177,7 +179,7 @@ import {
   AddToMap,
   PropertyPath,
 } from "@/api/sdf/dal/property_editor";
-import { Secret } from "@/store/secrets.store";
+import { SecretId } from "@/store/secrets.store";
 import WidgetHeader from "./WidgetHeader.vue";
 import WidgetTextBox from "./WidgetTextBox.vue";
 import WidgetCheckBox from "./WidgetCheckBox.vue";

--- a/app/web/src/components/PropertyEditor/WidgetSecret.vue
+++ b/app/web/src/components/PropertyEditor/WidgetSecret.vue
@@ -7,7 +7,7 @@
     <div class="flex flex-row items-center w-full">
       <div class="flex flex-col grow">
         <div
-          v-if="value"
+          v-if="secret"
           :class="
             clsx(
               'sm:text-sm font-bold grow p-xs block',
@@ -18,7 +18,7 @@
           "
           @click="(e) => popoverRef.open(e)"
         >
-          {{ value.name }}
+          {{ secret.name }}
         </div>
         <VButton
           v-else
@@ -26,7 +26,7 @@
           @click="(e) => popoverRef.open(e)"
         />
         <Popover ref="popoverRef" anchorDirectionX="left" anchorAlignY="bottom">
-          <SecretsList definitionId="Mocks" @select="setField" />
+          <SecretsList :definitionId="definitionId" @select="setField" />
         </Popover>
       </div>
       <div v-if="value" class="pl-xs">
@@ -59,10 +59,12 @@ import {
   PropertyPath,
   UpdatedProperty,
 } from "@/api/sdf/dal/property_editor";
-import { Secret } from "@/store/secrets.store";
+import { Secret, SecretId, useSecretsStore } from "@/store/secrets.store";
+import { LabelList } from "@/api/sdf/dal/label_list";
 import SiButtonIcon from "../SiButtonIcon.vue";
 
 const featureFlagsStore = useFeatureFlagsStore();
+const secretStore = useSecretsStore();
 
 const popoverRef = ref();
 
@@ -70,7 +72,8 @@ const props = defineProps<{
   name: string;
   path?: PropertyPath;
   collapsedPaths: Array<Array<string>>;
-  value?: Secret;
+  options: LabelList<string>;
+  value?: SecretId;
   propId: string;
   valueId: string;
   validation?: PropertyEditorValidation;
@@ -106,9 +109,20 @@ const unsetField = () => {
 const setField = (secret: Secret) => {
   popoverRef.value.close();
   emit("updatedProperty", {
-    value: secret,
+    value: secret.id,
     propId: propId.value,
     valueId: valueId.value,
   });
 };
+
+const secret = computed(() =>
+  props.value ? secretStore.secretsById[props.value] : undefined,
+);
+
+const definitionId = computed(() => {
+  return (
+    props.options.find((e) => e.label === "secretKind")?.value ??
+    "NO secretKind ON WIDGET"
+  );
+});
 </script>

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -358,6 +358,23 @@ export const useAssetStore = () => {
                 "updatedAt",
               ]),
             },
+            onFail(response) {
+              const rawMessage = response?.error?.message;
+              if (typeof rawMessage === "string") {
+                const match = rawMessage.match(
+                  "function execution result failure:.*message=(.*?),",
+                )?.[1];
+
+                if (match) {
+                  return {
+                    error: {
+                      ...response?.error,
+                      message: match,
+                    },
+                  };
+                }
+              }
+            },
           });
         },
       },

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -1,742 +1,803 @@
 export type ValueFromKind = "inputSocket" | "outputSocket" | "prop";
+
 export interface ValueFrom {
-    kind: ValueFromKind;
-    socket_name?: string;
-    prop_path?: string[];
+  kind: ValueFromKind;
+  socket_name?: string;
+  prop_path?: string[];
 }
 
 export interface IValueFromBuilder {
-    setKind(kind: ValueFromKind): this;
+  setKind(kind: ValueFromKind): this;
 
-    setSocketName(name: string): this;
+  setSocketName(name: string): this;
 
-    setPropPath(path: string[]): this;
+  setPropPath(path: string[]): this;
 
-    build(): ValueFrom;
+  build(): ValueFrom;
 }
 
 export class ValueFromBuilder implements IValueFromBuilder {
-    valueFrom = <ValueFrom>{};
+  valueFrom = <ValueFrom>{};
 
-    constructor() {
-        this.valueFrom = <ValueFrom>{};
+  constructor() {
+    this.valueFrom = <ValueFrom>{};
+  }
+
+  setKind(kind: ValueFromKind): this {
+    this.valueFrom.kind = kind;
+    return this;
+  }
+
+  setSocketName(name: string): this {
+    if (
+      this.valueFrom.kind !== "inputSocket" &&
+      this.valueFrom.kind !== "outputSocket"
+    ) {
+      return this;
     }
 
-    setKind(kind: ValueFromKind): this {
-        this.valueFrom.kind = kind;
-        return this;
+    this.valueFrom.socket_name = name;
+    return this;
+  }
+
+  setPropPath(path: string[]): this {
+    if (this.valueFrom.kind !== "prop") {
+      return this;
     }
 
-    setSocketName(name: string): this {
-        if (
-            this.valueFrom.kind !== "inputSocket" &&
-            this.valueFrom.kind !== "outputSocket"
-        ) {
-            return this;
-        }
+    this.valueFrom.prop_path = path;
+    return this;
+  }
 
-        this.valueFrom.socket_name = name;
-        return this;
-    }
-
-    setPropPath(path: string[]): this {
-        if (this.valueFrom.kind !== "prop") {
-            return this;
-        }
-
-        this.valueFrom.prop_path = path;
-        return this;
-    }
-
-    build(): ValueFrom {
-        return this.valueFrom;
-    }
+  build(): ValueFrom {
+    return this.valueFrom;
+  }
 }
 
 export type SocketDefinitionArityType = "many" | "one";
+
 export interface SocketDefinition {
-    name: string;
-    arity: SocketDefinitionArityType;
-    uiHidden?: boolean;
-    valueFrom?: ValueFrom;
+  name: string;
+  arity: SocketDefinitionArityType;
+  uiHidden?: boolean;
+  valueFrom?: ValueFrom;
 }
 
 export interface ISocketDefinitionBuilder {
-    setName(name: string): this;
+  setName(name: string): this;
 
-    setArity(arity: SocketDefinitionArityType): this;
+  setArity(arity: SocketDefinitionArityType): this;
 
-    setUiHidden(hidden: boolean): this;
+  setUiHidden(hidden: boolean): this;
 
-    setValueFrom(valueFrom: ValueFrom): this;
+  setValueFrom(valueFrom: ValueFrom): this;
 
-    build(): SocketDefinition;
+  build(): SocketDefinition;
 }
 
 export class SocketDefinitionBuilder implements ISocketDefinitionBuilder {
-    socket = <SocketDefinition>{};
+  socket = <SocketDefinition>{};
 
-    constructor() {
-        this.socket = <SocketDefinition>{};
-    }
+  constructor() {
+    this.socket = <SocketDefinition>{};
+  }
 
-    build(): SocketDefinition {
-        return this.socket;
-    }
+  build(): SocketDefinition {
+    return this.socket;
+  }
 
-    setArity(arity: SocketDefinitionArityType): this {
-        this.socket.arity = arity;
-        return this;
-    }
+  setArity(arity: SocketDefinitionArityType): this {
+    this.socket.arity = arity;
+    return this;
+  }
 
-    setName(name: string): this {
-        this.socket.name = name;
-        return this;
-    }
+  setName(name: string): this {
+    this.socket.name = name;
+    return this;
+  }
 
-    setUiHidden(hidden: boolean): this {
-        this.socket.uiHidden = hidden;
-        return this;
-    }
+  setUiHidden(hidden: boolean): this {
+    this.socket.uiHidden = hidden;
+    return this;
+  }
 
-    setValueFrom(valueFrom: ValueFrom): this {
-        this.socket.valueFrom = valueFrom;
-        return this;
-    }
+  setValueFrom(valueFrom: ValueFrom): this {
+    this.socket.valueFrom = valueFrom;
+    return this;
+  }
 }
 
 export type ValidationKind =
-    | "customValidation"
-    | "integerIsBetweenTwoIntegers"
-    | "integerIsNotEmpty"
-    | "stringEquals"
-    | "stringHasPrefix"
-    | "stringInStringArray"
-    | "stringIsHexColor"
-    | "stringIsNotEmpty"
-    | "stringIsValidIpAddr";
+  | "customValidation"
+  | "integerIsBetweenTwoIntegers"
+  | "integerIsNotEmpty"
+  | "stringEquals"
+  | "stringHasPrefix"
+  | "stringInStringArray"
+  | "stringIsHexColor"
+  | "stringIsNotEmpty"
+  | "stringIsValidIpAddr";
 
 export interface Validation {
-    kind: ValidationKind;
-    funcUniqueId?: Record<string, unknown>;
-    lowerBound?: number;
-    upperBound?: number;
-    expected?: string[];
-    displayExpected?: boolean;
+  kind: ValidationKind;
+  funcUniqueId?: Record<string, unknown>;
+  lowerBound?: number;
+  upperBound?: number;
+  expected?: string[];
+  displayExpected?: boolean;
 }
 
 export interface IValidationBuilder {
-    setKind(kind: ValidationKind): this;
+  setKind(kind: ValidationKind): this;
 
-    addFuncUniqueId(key: string, value: unknown): this;
+  addFuncUniqueId(key: string, value: unknown): this;
 
-    setLowerBound(value: number): this;
+  setLowerBound(value: number): this;
 
-    setUpperBound(value: number): this;
+  setUpperBound(value: number): this;
 
-    addExpected(expected: string): this;
+  addExpected(expected: string): this;
 
-    setDisplayExpected(display: boolean): this;
+  setDisplayExpected(display: boolean): this;
 
-    build(): Validation;
+  build(): Validation;
 }
 
 export class ValidationBuilder implements IValidationBuilder {
-    validation = <Validation>{};
+  validation = <Validation>{};
 
-    constructor() {
-        this.validation = <Validation>{};
+  constructor() {
+    this.validation = <Validation>{};
+  }
+
+  addFuncUniqueId(key: string, value: unknown): this {
+    if (this.validation.kind !== "customValidation") {
+      return this;
     }
 
-    addFuncUniqueId(key: string, value: unknown): this {
-        if (this.validation.kind !== "customValidation") {
-            return this;
-        }
-
-        if (!this.validation.funcUniqueId) {
-            this.validation.funcUniqueId = {};
-        }
-
-        this.validation.funcUniqueId[key] = value;
-        return this;
+    if (!this.validation.funcUniqueId) {
+      this.validation.funcUniqueId = {};
     }
 
-    build(): Validation {
-        return this.validation;
+    this.validation.funcUniqueId[key] = value;
+    return this;
+  }
+
+  build(): Validation {
+    return this.validation;
+  }
+
+  setDisplayExpected(display: boolean): this {
+    if (this.validation.kind !== "stringInStringArray") {
+      return this;
     }
 
-    setDisplayExpected(display: boolean): this {
-        if (this.validation.kind !== "stringInStringArray") {
-            return this;
-        }
+    this.validation.displayExpected = display;
+    return this;
+  }
 
-        this.validation.displayExpected = display;
-        return this;
+  addExpected(expected: string): this {
+    if (
+      this.validation.kind !== "stringEquals" &&
+      this.validation.kind !== "stringHasPrefix" &&
+      this.validation.kind !== "stringInStringArray"
+    ) {
+      return this;
     }
 
-    addExpected(expected: string): this {
-        if (
-            this.validation.kind !== "stringEquals" &&
-            this.validation.kind !== "stringHasPrefix" &&
-            this.validation.kind !== "stringInStringArray"
-        ) {
-            return this;
-        }
-
-        if (!this.validation.expected) {
-            this.validation.expected = [];
-        }
-
-        this.validation.expected.push(expected);
-        return this;
+    if (!this.validation.expected) {
+      this.validation.expected = [];
     }
 
-    setLowerBound(value: number): this {
-        if (this.validation.kind !== "integerIsBetweenTwoIntegers") {
-            return this;
-        }
-        this.validation.lowerBound = value;
-        return this;
-    }
+    this.validation.expected.push(expected);
+    return this;
+  }
 
-    setKind(kind: ValidationKind): this {
-        this.validation.kind = kind;
-        return this;
+  setLowerBound(value: number): this {
+    if (this.validation.kind !== "integerIsBetweenTwoIntegers") {
+      return this;
     }
+    this.validation.lowerBound = value;
+    return this;
+  }
 
-    setUpperBound(value: number): this {
-        if (this.validation.kind !== "integerIsBetweenTwoIntegers") {
-            return this;
-        }
-        this.validation.upperBound = value;
-        return this;
+  setKind(kind: ValidationKind): this {
+    this.validation.kind = kind;
+    return this;
+  }
+
+  setUpperBound(value: number): this {
+    if (this.validation.kind !== "integerIsBetweenTwoIntegers") {
+      return this;
     }
+    this.validation.upperBound = value;
+    return this;
+  }
 }
 
 export type PropWidgetDefinitionKind =
-    | "array"
-    | "checkbox"
-    | "color"
-    | "comboBox"
-    | "header"
-    | "map"
-    | "secret"
-    | "select"
-    | "text"
-    | "textArea";
+  | "array"
+  | "checkbox"
+  | "color"
+  | "comboBox"
+  | "header"
+  | "map"
+  | "secret"
+  | "select"
+  | "text"
+  | "textArea";
 
 export interface Option {
-    label: string;
-    value: string;
+  label: string;
+  value: string;
 }
 
 export interface PropWidgetDefinition {
-    kind: PropWidgetDefinitionKind;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    options: Option[];
+  kind: PropWidgetDefinitionKind;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: Option[];
 }
 
 export interface IPropWidgetDefinitionBuilder {
-    setKind(kind: string): this;
+  setKind(kind: string): this;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    addOption(key: string, value: string): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addOption(key: string, value: string): this;
 
-    build(): PropWidgetDefinition;
+  build(): PropWidgetDefinition;
 }
 
 export class PropWidgetDefinitionBuilder
-    implements IPropWidgetDefinitionBuilder
-{
-    propWidget = <PropWidgetDefinition>{};
+  implements IPropWidgetDefinitionBuilder {
+  propWidget = <PropWidgetDefinition>{};
 
-    constructor() {
-        this.propWidget = <PropWidgetDefinition>{};
+  constructor() {
+    this.propWidget = <PropWidgetDefinition>{};
+  }
+
+  setKind(kind: PropWidgetDefinitionKind): this {
+    this.propWidget.kind = kind;
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addOption(key: string, value: string): this {
+    if (!this.propWidget.options) {
+      this.propWidget.options = [];
     }
 
-    setKind(kind: PropWidgetDefinitionKind): this {
-        this.propWidget.kind = kind;
-        return this;
-    }
+    this.propWidget.options.push(<Option>{
+      label: key,
+      value: value,
+    });
+    return this;
+  }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    addOption(key: string, value: string): this {
-        if (!this.propWidget.options) {
-            this.propWidget.options = [];
-        }
-
-        this.propWidget.options.push(<Option>{
-            label: key,
-            value: value,
-        });
-        return this;
-    }
-
-    build(): PropWidgetDefinition {
-        return this.propWidget;
-    }
+  build(): PropWidgetDefinition {
+    return this.propWidget;
+  }
 }
 
 export interface MapKeyFunc {
-    key: string;
-    valueFrom?: ValueFrom;
+  key: string;
+  valueFrom?: ValueFrom;
 }
 
 export interface IMapKeyFuncBuilder {
-    setKey(key: string): this;
+  setKey(key: string): this;
 
-    setValueFrom(valueFrom: ValueFrom): this;
+  setValueFrom(valueFrom: ValueFrom): this;
 
-    build(): MapKeyFunc;
+  build(): MapKeyFunc;
 }
 
 export class MapKeyFuncBuilder implements IMapKeyFuncBuilder {
-    mapKeyFunc = <MapKeyFunc>{};
+  mapKeyFunc = <MapKeyFunc>{};
 
-    constructor() {
-        this.mapKeyFunc = <MapKeyFunc>{};
-    }
+  constructor() {
+    this.mapKeyFunc = <MapKeyFunc>{};
+  }
 
-    build(): MapKeyFunc {
-        return this.mapKeyFunc;
-    }
+  build(): MapKeyFunc {
+    return this.mapKeyFunc;
+  }
 
-    setKey(key: string): this {
-        this.mapKeyFunc.key = key;
-        return this;
-    }
+  setKey(key: string): this {
+    this.mapKeyFunc.key = key;
+    return this;
+  }
 
-    setValueFrom(valueFrom: ValueFrom): this {
-        this.mapKeyFunc.valueFrom = valueFrom;
-        return this;
-    }
+  setValueFrom(valueFrom: ValueFrom): this {
+    this.mapKeyFunc.valueFrom = valueFrom;
+    return this;
+  }
 }
 
 export type SiPropValueFromDefinitionKind =
-    | "color"
-    | "name"
-    | "resourcePayload";
+  | "color"
+  | "name"
+  | "resourcePayload";
 
 export interface SiPropValueFromDefinition {
-    kind: SiPropValueFromDefinitionKind;
-    valueFrom: ValueFrom;
+  kind: SiPropValueFromDefinitionKind;
+  valueFrom: ValueFrom;
 }
 
 export interface ISiPropValueFromDefinitionBuilder {
-    setKind(kind: SiPropValueFromDefinitionKind): this;
+  setKind(kind: SiPropValueFromDefinitionKind): this;
 
-    setValueFrom(valueFrom: ValueFrom): this;
+  setValueFrom(valueFrom: ValueFrom): this;
 
-    build(): SiPropValueFromDefinition;
+  build(): SiPropValueFromDefinition;
 }
 
 export class SiPropValueFromDefinitionBuilder
-    implements ISiPropValueFromDefinitionBuilder
-{
-    definition = <SiPropValueFromDefinition>{};
+  implements ISiPropValueFromDefinitionBuilder {
+  definition = <SiPropValueFromDefinition>{};
 
-    constructor() {
-        this.definition = <SiPropValueFromDefinition>{};
-    }
+  constructor() {
+    this.definition = <SiPropValueFromDefinition>{};
+  }
 
-    build(): SiPropValueFromDefinition {
-        return this.definition;
-    }
+  build(): SiPropValueFromDefinition {
+    return this.definition;
+  }
 
-    setKind(kind: SiPropValueFromDefinitionKind): this {
-        this.definition.kind = kind;
-        return this;
-    }
+  setKind(kind: SiPropValueFromDefinitionKind): this {
+    this.definition.kind = kind;
+    return this;
+  }
 
-    setValueFrom(valueFrom: ValueFrom): this {
-        this.definition.valueFrom = valueFrom;
-        return this;
-    }
+  setValueFrom(valueFrom: ValueFrom): this {
+    this.definition.valueFrom = valueFrom;
+    return this;
+  }
 }
 
 export type PropDefinitionKind =
-    | "array"
-    | "boolean"
-    | "integer"
-    | "map"
-    | "object"
-    | "string";
+  | "array"
+  | "boolean"
+  | "integer"
+  | "map"
+  | "object"
+  | "string";
 
 export interface PropDefinition {
-    name: string;
-    kind: PropDefinitionKind;
-    docLinkRef?: string;
-    docLink?: string;
-    children?: PropDefinition[];
-    entry?: PropDefinition;
-    widget?: PropWidgetDefinition;
-    valueFrom?: ValueFrom;
-    hidden?: boolean;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    defaultValue?: any;
-    validations?: Validation[];
-    mapKeyFuncs?: MapKeyFunc[];
+  name: string;
+  kind: PropDefinitionKind;
+  docLinkRef?: string;
+  docLink?: string;
+  children?: PropDefinition[];
+  entry?: PropDefinition;
+  widget?: PropWidgetDefinition;
+  valueFrom?: ValueFrom;
+  hidden?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultValue?: any;
+  validations?: Validation[];
+  mapKeyFuncs?: MapKeyFunc[];
 }
 
 export interface IPropBuilder {
-    setName(name: string): this;
+  setName(name: string): this;
 
-    setKind(kind: PropDefinitionKind): this;
+  setKind(kind: PropDefinitionKind): this;
 
-    setDocLinkRef(ref: string): this;
+  setDocLinkRef(ref: string): this;
 
-    setDocLink(link: string): this;
+  setDocLink(link: string): this;
 
-    addChild(child: PropDefinition): this;
+  addChild(child: PropDefinition): this;
 
-    setEntry(entry: PropDefinition): this;
+  setEntry(entry: PropDefinition): this;
 
-    setWidget(widget: PropWidgetDefinition): this;
+  setWidget(widget: PropWidgetDefinition): this;
 
-    setValueFrom(valueFrom: ValueFrom): this;
+  setValueFrom(valueFrom: ValueFrom): this;
 
-    setHidden(hidden: boolean): this;
+  setHidden(hidden: boolean): this;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setDefaultValue(value: any): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setDefaultValue(value: any): this;
 
-    addValidation(validation: Validation): this;
+  addValidation(validation: Validation): this;
 
-    addMapKeyFunc(func: MapKeyFunc): this;
+  addMapKeyFunc(func: MapKeyFunc): this;
 
-    build(): PropDefinition;
+  build(): PropDefinition;
 }
 
 export class PropBuilder implements IPropBuilder {
-    prop = <PropDefinition>{};
+  prop = <PropDefinition>{};
 
-    constructor() {
-        this.prop = <PropDefinition>{};
+  constructor() {
+    this.prop = <PropDefinition>{};
+  }
+
+  addChild(child: PropDefinition): this {
+    if (this.prop.kind !== "object") {
+      throw new Error(
+        "addChild can only be called on props that are objects"
+      );
     }
 
-    addChild(child: PropDefinition): this {
-        if (this.prop.kind !== "object") {
-            throw new Error(
-                "addChild can only be called on props that are objects"
-            );
-        }
-
-        if (!this.prop.children) {
-            this.prop.children = [];
-        }
-
-        this.prop.children.push(child);
-        return this;
+    if (!this.prop.children) {
+      this.prop.children = [];
     }
 
-    setEntry(entry: PropDefinition): this {
-        if (this.prop.kind !== "array" && this.prop.kind !== "map") {
-            throw new Error(
-                "setEntry can only be called on prop that are arrays or maps"
-            );
-        }
+    this.prop.children.push(child);
+    return this;
+  }
 
-        this.prop.entry = entry;
-        return this;
+  setEntry(entry: PropDefinition): this {
+    if (this.prop.kind !== "array" && this.prop.kind !== "map") {
+      throw new Error(
+        "setEntry can only be called on prop that are arrays or maps"
+      );
     }
 
-    addMapKeyFunc(func: MapKeyFunc): this {
-        if (!this.prop.mapKeyFuncs) {
-            this.prop.mapKeyFuncs = [];
-        }
-        this.prop.mapKeyFuncs.push(func);
-        return this;
-    }
+    this.prop.entry = entry;
+    return this;
+  }
 
-    addValidation(validation: Validation): this {
-        if (!this.prop.validations) {
-            this.prop.validations = [];
-        }
-        this.prop.validations.push(validation);
-        return this;
+  addMapKeyFunc(func: MapKeyFunc): this {
+    if (!this.prop.mapKeyFuncs) {
+      this.prop.mapKeyFuncs = [];
     }
+    this.prop.mapKeyFuncs.push(func);
+    return this;
+  }
 
-    build(): PropDefinition {
-        return this.prop;
+  addValidation(validation: Validation): this {
+    if (!this.prop.validations) {
+      this.prop.validations = [];
     }
+    this.prop.validations.push(validation);
+    return this;
+  }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setDefaultValue(value: any): this {
-        this.prop.defaultValue = value;
-        return this;
-    }
+  build(): PropDefinition {
+    return this.prop;
+  }
 
-    setDocLink(link: string): this {
-        this.prop.docLink = link;
-        return this;
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setDefaultValue(value: any): this {
+    this.prop.defaultValue = value;
+    return this;
+  }
 
-    setDocLinkRef(ref: string): this {
-        this.prop.docLinkRef = ref;
-        return this;
-    }
+  setDocLink(link: string): this {
+    this.prop.docLink = link;
+    return this;
+  }
 
-    setHidden(hidden: boolean): this {
-        this.prop.hidden = hidden;
-        return this;
-    }
+  setDocLinkRef(ref: string): this {
+    this.prop.docLinkRef = ref;
+    return this;
+  }
 
-    /**
-    * The type of the prop
-    *
-    * @param {string} kind [array | boolean | integer | map | object | string]
-    *
-    * @returns this
-    *
-    * @example
-    * .setKind("text")
-    */
-    setKind(kind: PropDefinitionKind): this {
-        this.prop.kind = kind;
-        return this;
-    }
+  setHidden(hidden: boolean): this {
+    this.prop.hidden = hidden;
+    return this;
+  }
 
-    /**
-    * The prop name. This will appear in the model UI
-    *
-    * @param {string} name - the name of the prop
-    *
-    * @returns this
-    *
-    * @example
-    * .setName("Region")
-    */
-    setName(name: string): this {
-        this.prop.name = name;
-        return this;
-    }
+  /**
+   * The type of the prop
+   *
+   * @param {string} kind [array | boolean | integer | map | object | string]
+   *
+   * @returns this
+   *
+   * @example
+   * .setKind("text")
+   */
+  setKind(kind: PropDefinitionKind): this {
+    this.prop.kind = kind;
+    return this;
+  }
 
-    setValueFrom(valueFrom: ValueFrom): this {
-        this.prop.valueFrom = valueFrom;
-        return this;
-    }
+  /**
+   * The prop name. This will appear in the model UI
+   *
+   * @param {string} name - the name of the prop
+   *
+   * @returns this
+   *
+   * @example
+   * .setName("Region")
+   */
+  setName(name: string): this {
+    this.prop.name = name;
+    return this;
+  }
 
-    setWidget(widget: PropWidgetDefinition): this {
-        if(widget.kind === 'secret') {
-          throw new Error("Cannot create prop with secret widget. Use addSecretProp() to create those.");
-        }
-        this.prop.widget = widget;
-        return this;
+  setValueFrom(valueFrom: ValueFrom): this {
+    this.prop.valueFrom = valueFrom;
+    return this;
+  }
+
+  setWidget(widget: PropWidgetDefinition): this {
+    if (widget.kind === 'secret') {
+      throw new Error("Cannot create prop with secret widget. Use addSecretProp() to create those.");
     }
+    this.prop.widget = widget;
+    return this;
+  }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SecretPropDefinition extends PropDefinition {}
+export interface SecretPropDefinition extends PropDefinition {
+  hasInputSocket: boolean
+}
 
 export interface ISecretPropBuilder {
-    setName(name: string): this;
+  setName(name: string): this;
 
-    setSecretKind(kind: string): this;
+  setSecretKind(kind: string): this;
 
-    setDocLinkRef(ref: string): this;
+  setDocLinkRef(ref: string): this;
 
-    setDocLink(link: string): this;
+  setDocLink(link: string): this;
 
-    addValidation(validation: Validation): this;
+  addValidation(validation: Validation): this;
 
-    build(): SecretPropDefinition;
+  skipInputSocket(): this;
+
+  build(): SecretPropDefinition;
 }
 
 export class SecretPropBuilder implements ISecretPropBuilder {
-    prop = <SecretPropDefinition>{};
+  prop = <SecretPropDefinition>{};
 
-    constructor() {
-        this.prop = <SecretPropDefinition>{};
-        this.prop.kind = "string";
-        this.prop.widget = {
-            kind: "secret",
-            options: [],
-        };
+  constructor() {
+    this.prop = <SecretPropDefinition>{};
+    this.prop.kind = "string";
+    this.prop.widget = {
+      kind: "secret",
+      options: [],
+    };
+    this.prop.hasInputSocket = true;
+  }
+
+  setName(name: string): this {
+    this.prop.name = name;
+    return this;
+  }
+
+  setSecretKind(kind: string): this {
+    this.prop.widget?.options.push({label: "secretKind", value: kind});
+    return this;
+  }
+
+  setDocLinkRef(ref: string): this {
+    this.prop.docLinkRef = ref;
+    return this;
+  }
+
+  setDocLink(link: string): this {
+    this.prop.docLink = link;
+    return this;
+  }
+
+  addValidation(validation: Validation): this {
+    if (!this.prop.validations) {
+      this.prop.validations = [];
     }
-    setName(name: string): this {
-        this.prop.name = name;
-        return this;
+    this.prop.validations.push(validation);
+    return this;
+  }
+
+  skipInputSocket(): this {
+    this.prop.hasInputSocket = false;
+    return this
+  }
+
+  build(): SecretPropDefinition {
+    if (
+      this.prop.widget?.options?.find(
+        (option) => option.label === "secretKind"
+      ) === undefined
+    ) {
+      throw new Error("must call setSecretKind() before build()");
     }
 
-    setSecretKind(kind: string): this {
-        this.prop.widget?.options.push({ label: "secretKind", value: kind });
-        return this;
-    }
-
-    setDocLinkRef(ref: string): this {
-        this.prop.docLinkRef = ref;
-        return this;
-    }
-
-    setDocLink(link: string): this {
-        this.prop.docLink = link;
-        return this;
-    }
-
-    addValidation(validation: Validation): this {
-        if (!this.prop.validations) {
-            this.prop.validations = [];
-        }
-        this.prop.validations.push(validation);
-        return this;
-    }
-
-    build(): SecretPropDefinition {
-        if (
-            this.prop.widget?.options?.find(
-                (option) => option.label === "secretKind"
-            ) === undefined
-        ) {
-            throw new Error("must call setSecretKind() before build()");
-        }
-
-        return this.prop;
-    }
+    return this.prop;
+  }
 }
 
 export interface SecretDefinition {
-    name: string;
-    props?: PropDefinition[];
+  name: string;
+  props: PropDefinition[];
 }
 
 export interface ISecretDefinitionBuilder {
-    addProp(prop: PropDefinition): this;
+  addProp(prop: PropDefinition): this;
 
-    build(): SecretDefinition;
+  build(): SecretDefinition;
 }
 
 export class SecretDefinitionBuilder implements ISecretDefinitionBuilder {
-    definition: SecretDefinition;
+  definition: SecretDefinition;
 
-    constructor() {
-        this.definition = <SecretDefinition>{};
+  constructor() {
+    this.definition = <SecretDefinition>{};
+    this.definition.name = '';
+    this.definition.props = [];
+  }
+
+  setName(name: string): this {
+    this.definition.name = name;
+    return this;
+  }
+
+  addProp(prop: PropDefinition): this {
+    this.definition.props?.push(prop);
+    return this;
+  }
+
+  build(): SecretDefinition {
+
+    const def = this.definition
+
+    if (def.name.length === 0) {
+      throw new Error(
+        "Cannot build SecretDefinition with empty name"
+      );
     }
 
-    setName(name: string): this {
-        this.definition.name = name;
-        return this;
+    if (def.props.length === 0) {
+      throw new Error(
+        "Cannot build SecretDefinition with no props"
+      );
     }
 
-    addProp(prop: PropDefinition): this {
-        if (!this.definition.props) {
-            this.definition.props = [];
-        }
-        this.definition.props?.push(prop);
-        return this;
-    }
-
-    build(): SecretDefinition {
-        return this.definition;
-    }
+    return this.definition;
+  }
 }
 
 export interface Asset {
-    props: PropDefinition[];
-    secretProps: SecretPropDefinition[];
-    secretDefinition?: PropDefinition[];
-    resourceProps: PropDefinition[];
-    siPropValueFroms: SiPropValueFromDefinition[];
-    inputSockets: SocketDefinition[];
-    outputSockets: SocketDefinition[];
-    docLinks: Record<string, string>;
+  props: PropDefinition[];
+  secretProps: SecretPropDefinition[];
+  secretDefinition?: PropDefinition[];
+  resourceProps: PropDefinition[];
+  siPropValueFroms: SiPropValueFromDefinition[];
+  inputSockets: SocketDefinition[];
+  outputSockets: SocketDefinition[];
+  docLinks: Record<string, string>;
 }
 
 export interface IAssetBuilder {
-    addProp(prop: PropDefinition): this;
+  addProp(prop: PropDefinition): this;
 
-    addSecretProp(prop: SecretPropDefinition): this;
+  addSecretProp(prop: SecretPropDefinition): this;
 
-    defineSecret(definition: SecretDefinition): this;
+  defineSecret(definition: SecretDefinition): this;
 
-    addResourceProp(prop: PropDefinition): this;
+  addResourceProp(prop: PropDefinition): this;
 
-    addInputSocket(socket: SocketDefinition): this;
+  addInputSocket(socket: SocketDefinition): this;
 
-    addOutputSocket(socket: SocketDefinition): this;
+  addOutputSocket(socket: SocketDefinition): this;
 
-    addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
+  addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
 
-    addDocLink(key: string, value: string): this;
+  addDocLink(key: string, value: string): this;
 
-    build(): Asset;
+  build(): Asset;
 }
 
 export class AssetBuilder implements IAssetBuilder {
-    asset = <Asset>{};
+  asset = <Asset>{};
 
-    constructor() {
-        this.asset = <Asset>{};
+  constructor() {
+    this.asset = <Asset>{};
+  }
+
+  addProp(prop: PropDefinition) {
+    if (!this.asset.props) {
+      this.asset.props = [];
+    }
+    this.asset.props?.push(prop);
+    return this;
+  }
+
+  addSecretProp(prop: SecretPropDefinition) {
+    if (!this.asset.secretProps) {
+      this.asset.secretProps = [];
     }
 
-    addProp(prop: PropDefinition) {
-        if (!this.asset.props) {
-            this.asset.props = [];
-        }
-        this.asset.props?.push(prop);
-        return this;
+    if (prop.hasInputSocket) {
+      const secretKind = prop.widget?.options?.find(
+        (option) => option.label === "secretKind"
+      )?.value;
+
+      if (secretKind === undefined) {
+        throw new Error(`Could not find secretKind for ${prop.name}`)
+      }
+
+      this.addInputSocket(
+        new SocketDefinitionBuilder()
+          .setArity("one")
+          .setName(secretKind)
+          .build()
+      )
+
+      prop.valueFrom = new ValueFromBuilder()
+        .setKind("inputSocket")
+        .setSocketName(secretKind)
+        .build()
     }
 
-    addSecretProp(prop: SecretPropDefinition) {
-        if (!this.asset.secretProps) {
-            this.asset.secretProps = [];
-        }
-        this.asset.secretProps?.push(prop);
-        return this;
+    this.asset.secretProps?.push(prop);
+
+    return this;
+  }
+
+  defineSecret(definition: SecretDefinition): this {
+    this.asset.secretDefinition = definition.props;
+    this.addSecretProp(
+      new SecretPropBuilder()
+        .setName(definition.name)
+        .setSecretKind(definition.name)
+        .skipInputSocket()
+        .build()
+    );
+
+    this.addOutputSocket(
+      new SocketDefinitionBuilder()
+        .setArity("one")
+        .setName(definition.name)
+        .setValueFrom(new ValueFromBuilder().setKind("prop").setPropPath(["root", "secrets", definition.name]).build())
+        .build()
+    )
+
+    return this;
+  }
+
+  addResourceProp(prop: PropDefinition) {
+    if (!this.asset.resourceProps) {
+      this.asset.resourceProps = [];
+    }
+    this.asset.resourceProps?.push(prop);
+    return this;
+  }
+
+  addInputSocket(socket: SocketDefinition) {
+    if (!this.asset.inputSockets) {
+      this.asset.inputSockets = [];
+    }
+    this.asset.inputSockets?.push(socket);
+    return this;
+  }
+
+  addOutputSocket(socket: SocketDefinition) {
+    if (!this.asset.outputSockets) {
+      this.asset.outputSockets = [];
+    }
+    this.asset.outputSockets?.push(socket);
+    return this;
+  }
+
+  addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this {
+    if (!this.asset.siPropValueFroms) {
+      this.asset.siPropValueFroms = [];
+    }
+    this.asset.siPropValueFroms.push(siPropValueFrom);
+    return this;
+  }
+
+  addDocLink(key: string, value: string) {
+    if (!this.asset.docLinks) {
+      this.asset.docLinks = {};
+    }
+    this.asset.docLinks[key] = value;
+    return this;
+  }
+
+  build() {
+    if (this.asset.secretDefinition && this.asset.secretProps?.length !== 1) {
+      throw new Error("Secret defining schema shouldn't define any extra secret props")
     }
 
-    defineSecret(definition: SecretDefinition): this {
-        this.asset.secretDefinition = definition.props;
-        this.addSecretProp(
-            new SecretPropBuilder()
-                .setName(definition.name)
-                .setSecretKind(definition.name)
-                .build()
-        );
-
-        return this;
-    }
-
-    addResourceProp(prop: PropDefinition) {
-        if (!this.asset.resourceProps) {
-            this.asset.resourceProps = [];
-        }
-        this.asset.resourceProps?.push(prop);
-        return this;
-    }
-
-    addInputSocket(socket: SocketDefinition) {
-        if (!this.asset.inputSockets) {
-            this.asset.inputSockets = [];
-        }
-        this.asset.inputSockets?.push(socket);
-        return this;
-    }
-
-    addOutputSocket(socket: SocketDefinition) {
-        if (!this.asset.outputSockets) {
-            this.asset.outputSockets = [];
-        }
-        this.asset.outputSockets?.push(socket);
-        return this;
-    }
-
-    addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this {
-        if (!this.asset.siPropValueFroms) {
-            this.asset.siPropValueFroms = [];
-        }
-        this.asset.siPropValueFroms.push(siPropValueFrom);
-        return this;
-    }
-
-    addDocLink(key: string, value: string) {
-        if (!this.asset.docLinks) {
-            this.asset.docLinks = {};
-        }
-        this.asset.docLinks[key] = value;
-        return this;
-    }
-
-    build() {
-        return this.asset;
-    }
+    return this.asset;
+  }
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -315,6 +315,7 @@ impl Prop {
     standard_model_accessor!(hidden, bool, PropResult);
     standard_model_accessor!(refers_to_prop_id, Option<Pk(PropId)>, PropResult);
     standard_model_accessor!(diff_func_id, Option<Pk(FuncId)>, PropResult);
+    standard_model_accessor!(schema_variant_id, Pk(SchemaVariantId), PropResult);
 
     pub fn path(&self) -> PropPath {
         self.path.to_owned().into()

--- a/lib/dal/src/queries/secrets/list_secret_definitions.sql
+++ b/lib/dal/src/queries/secrets/list_secret_definitions.sql
@@ -1,0 +1,15 @@
+SELECT json_build_object(
+               'secret_definition', prop_secret.name,
+               'form_data', json_agg(
+                       json_build_object('name', fields.name, 'kind', fields.kind, 'widget_kind', fields.widget_kind,
+                                         'widget_options', fields.widget_options)
+                   )) AS object
+FROM props_v1($1, $2) prop_definition
+         JOIN prop_belongs_to_prop pbtp ON prop_definition.id = pbtp.belongs_to_id
+         JOIN props_v1($1, $2) fields ON fields.id = pbtp.object_id
+
+         JOIN props_v1($1, $2) prop_secret ON
+            prop_definition.schema_variant_id = prop_secret.schema_variant_id
+        AND prop_secret.path LIKE 'rootsecrets%'
+WHERE prop_definition.path = 'rootsecret_definition'
+GROUP BY prop_definition.id, prop_secret.name;

--- a/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
@@ -1,262 +1,433 @@
 type ValueFromKind = "inputSocket" | "outputSocket" | "prop";
+
 interface ValueFrom {
-    kind: ValueFromKind;
-    socket_name?: string;
-    prop_path?: string[];
+  kind: ValueFromKind;
+  socket_name?: string;
+  prop_path?: string[];
 }
+
 interface IValueFromBuilder {
-    setKind(kind: ValueFromKind): this;
-    setSocketName(name: string): this;
-    setPropPath(path: string[]): this;
-    build(): ValueFrom;
+  setKind(kind: ValueFromKind): this;
+
+  setSocketName(name: string): this;
+
+  setPropPath(path: string[]): this;
+
+  build(): ValueFrom;
 }
+
 declare class ValueFromBuilder implements IValueFromBuilder {
-    valueFrom: ValueFrom;
-    constructor();
-    setKind(kind: ValueFromKind): this;
-    setSocketName(name: string): this;
-    setPropPath(path: string[]): this;
-    build(): ValueFrom;
+  valueFrom: ValueFrom;
+
+  constructor();
+
+  setKind(kind: ValueFromKind): this;
+
+  setSocketName(name: string): this;
+
+  setPropPath(path: string[]): this;
+
+  build(): ValueFrom;
 }
+
 type SocketDefinitionArityType = "many" | "one";
+
 interface SocketDefinition {
-    name: string;
-    arity: SocketDefinitionArityType;
-    uiHidden?: boolean;
-    valueFrom?: ValueFrom;
+  name: string;
+  arity: SocketDefinitionArityType;
+  uiHidden?: boolean;
+  valueFrom?: ValueFrom;
 }
+
 interface ISocketDefinitionBuilder {
-    setName(name: string): this;
-    setArity(arity: SocketDefinitionArityType): this;
-    setUiHidden(hidden: boolean): this;
-    setValueFrom(valueFrom: ValueFrom): this;
-    build(): SocketDefinition;
+  setName(name: string): this;
+
+  setArity(arity: SocketDefinitionArityType): this;
+
+  setUiHidden(hidden: boolean): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
+
+  build(): SocketDefinition;
 }
+
 declare class SocketDefinitionBuilder implements ISocketDefinitionBuilder {
-    socket: SocketDefinition;
-    constructor();
-    build(): SocketDefinition;
-    setArity(arity: SocketDefinitionArityType): this;
-    setName(name: string): this;
-    setUiHidden(hidden: boolean): this;
-    setValueFrom(valueFrom: ValueFrom): this;
+  socket: SocketDefinition;
+
+  constructor();
+
+  build(): SocketDefinition;
+
+  setArity(arity: SocketDefinitionArityType): this;
+
+  setName(name: string): this;
+
+  setUiHidden(hidden: boolean): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
 }
-type ValidationKind = "customValidation" | "integerIsBetweenTwoIntegers" | "integerIsNotEmpty" | "stringEquals" | "stringHasPrefix" | "stringInStringArray" | "stringIsHexColor" | "stringIsNotEmpty" | "stringIsValidIpAddr";
+
+type ValidationKind =
+  "customValidation"
+  | "integerIsBetweenTwoIntegers"
+  | "integerIsNotEmpty"
+  | "stringEquals"
+  | "stringHasPrefix"
+  | "stringInStringArray"
+  | "stringIsHexColor"
+  | "stringIsNotEmpty"
+  | "stringIsValidIpAddr";
+
 interface Validation {
-    kind: ValidationKind;
-    funcUniqueId?: Record<string, unknown>;
-    lowerBound?: number;
-    upperBound?: number;
-    expected?: string[];
-    displayExpected?: boolean;
+  kind: ValidationKind;
+  funcUniqueId?: Record<string, unknown>;
+  lowerBound?: number;
+  upperBound?: number;
+  expected?: string[];
+  displayExpected?: boolean;
 }
+
 interface IValidationBuilder {
-    setKind(kind: ValidationKind): this;
-    addFuncUniqueId(key: string, value: unknown): this;
-    setLowerBound(value: number): this;
-    setUpperBound(value: number): this;
-    addExpected(expected: string): this;
-    setDisplayExpected(display: boolean): this;
-    build(): Validation;
+  setKind(kind: ValidationKind): this;
+
+  addFuncUniqueId(key: string, value: unknown): this;
+
+  setLowerBound(value: number): this;
+
+  setUpperBound(value: number): this;
+
+  addExpected(expected: string): this;
+
+  setDisplayExpected(display: boolean): this;
+
+  build(): Validation;
 }
+
 declare class ValidationBuilder implements IValidationBuilder {
-    validation: Validation;
-    constructor();
-    addFuncUniqueId(key: string, value: unknown): this;
-    build(): Validation;
-    setDisplayExpected(display: boolean): this;
-    addExpected(expected: string): this;
-    setLowerBound(value: number): this;
-    setKind(kind: ValidationKind): this;
-    setUpperBound(value: number): this;
+  validation: Validation;
+
+  constructor();
+
+  addFuncUniqueId(key: string, value: unknown): this;
+
+  build(): Validation;
+
+  setDisplayExpected(display: boolean): this;
+
+  addExpected(expected: string): this;
+
+  setLowerBound(value: number): this;
+
+  setKind(kind: ValidationKind): this;
+
+  setUpperBound(value: number): this;
 }
-type PropWidgetDefinitionKind = "array" | "checkbox" | "color" | "comboBox" | "header" | "map" | "secret" | "select" | "text" | "textArea";
+
+type PropWidgetDefinitionKind =
+  "array"
+  | "checkbox"
+  | "color"
+  | "comboBox"
+  | "header"
+  | "map"
+  | "secret"
+  | "select"
+  | "text"
+  | "textArea";
+
 interface Option {
-    label: string;
-    value: string;
+  label: string;
+  value: string;
 }
+
 interface PropWidgetDefinition {
-    kind: PropWidgetDefinitionKind;
-    options: Option[];
+  kind: PropWidgetDefinitionKind;
+  options: Option[];
 }
+
 interface IPropWidgetDefinitionBuilder {
-    setKind(kind: string): this;
-    addOption(key: string, value: string): this;
-    build(): PropWidgetDefinition;
+  setKind(kind: string): this;
+
+  addOption(key: string, value: string): this;
+
+  build(): PropWidgetDefinition;
 }
+
 declare class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilder {
-    propWidget: PropWidgetDefinition;
-    constructor();
-    setKind(kind: PropWidgetDefinitionKind): this;
-    addOption(key: string, value: string): this;
-    build(): PropWidgetDefinition;
+  propWidget: PropWidgetDefinition;
+
+  constructor();
+
+  setKind(kind: PropWidgetDefinitionKind): this;
+
+  addOption(key: string, value: string): this;
+
+  build(): PropWidgetDefinition;
 }
+
 interface MapKeyFunc {
-    key: string;
-    valueFrom?: ValueFrom;
+  key: string;
+  valueFrom?: ValueFrom;
 }
+
 interface IMapKeyFuncBuilder {
-    setKey(key: string): this;
-    setValueFrom(valueFrom: ValueFrom): this;
-    build(): MapKeyFunc;
+  setKey(key: string): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
+
+  build(): MapKeyFunc;
 }
+
 declare class MapKeyFuncBuilder implements IMapKeyFuncBuilder {
-    mapKeyFunc: MapKeyFunc;
-    constructor();
-    build(): MapKeyFunc;
-    setKey(key: string): this;
-    setValueFrom(valueFrom: ValueFrom): this;
+  mapKeyFunc: MapKeyFunc;
+
+  constructor();
+
+  build(): MapKeyFunc;
+
+  setKey(key: string): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
 }
+
 type SiPropValueFromDefinitionKind = "color" | "name" | "resourcePayload";
+
 interface SiPropValueFromDefinition {
-    kind: SiPropValueFromDefinitionKind;
-    valueFrom: ValueFrom;
+  kind: SiPropValueFromDefinitionKind;
+  valueFrom: ValueFrom;
 }
+
 interface ISiPropValueFromDefinitionBuilder {
-    setKind(kind: SiPropValueFromDefinitionKind): this;
-    setValueFrom(valueFrom: ValueFrom): this;
-    build(): SiPropValueFromDefinition;
+  setKind(kind: SiPropValueFromDefinitionKind): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
+
+  build(): SiPropValueFromDefinition;
 }
+
 declare class SiPropValueFromDefinitionBuilder implements ISiPropValueFromDefinitionBuilder {
-    definition: SiPropValueFromDefinition;
-    constructor();
-    build(): SiPropValueFromDefinition;
-    setKind(kind: SiPropValueFromDefinitionKind): this;
-    setValueFrom(valueFrom: ValueFrom): this;
+  definition: SiPropValueFromDefinition;
+
+  constructor();
+
+  build(): SiPropValueFromDefinition;
+
+  setKind(kind: SiPropValueFromDefinitionKind): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
 }
+
 type PropDefinitionKind = "array" | "boolean" | "integer" | "map" | "object" | "string";
+
 interface PropDefinition {
-    name: string;
-    kind: PropDefinitionKind;
-    docLinkRef?: string;
-    docLink?: string;
-    children?: PropDefinition[];
-    entry?: PropDefinition;
-    widget?: PropWidgetDefinition;
-    valueFrom?: ValueFrom;
-    hidden?: boolean;
-    defaultValue?: any;
-    validations?: Validation[];
-    mapKeyFuncs?: MapKeyFunc[];
+  name: string;
+  kind: PropDefinitionKind;
+  docLinkRef?: string;
+  docLink?: string;
+  children?: PropDefinition[];
+  entry?: PropDefinition;
+  widget?: PropWidgetDefinition;
+  valueFrom?: ValueFrom;
+  hidden?: boolean;
+  defaultValue?: any;
+  validations?: Validation[];
+  mapKeyFuncs?: MapKeyFunc[];
 }
+
 interface IPropBuilder {
-    setName(name: string): this;
-    setKind(kind: PropDefinitionKind): this;
-    setDocLinkRef(ref: string): this;
-    setDocLink(link: string): this;
-    addChild(child: PropDefinition): this;
-    setEntry(entry: PropDefinition): this;
-    setWidget(widget: PropWidgetDefinition): this;
-    setValueFrom(valueFrom: ValueFrom): this;
-    setHidden(hidden: boolean): this;
-    setDefaultValue(value: any): this;
-    addValidation(validation: Validation): this;
-    addMapKeyFunc(func: MapKeyFunc): this;
-    build(): PropDefinition;
+  setName(name: string): this;
+
+  setKind(kind: PropDefinitionKind): this;
+
+  setDocLinkRef(ref: string): this;
+
+  setDocLink(link: string): this;
+
+  addChild(child: PropDefinition): this;
+
+  setEntry(entry: PropDefinition): this;
+
+  setWidget(widget: PropWidgetDefinition): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
+
+  setHidden(hidden: boolean): this;
+
+  setDefaultValue(value: any): this;
+
+  addValidation(validation: Validation): this;
+
+  addMapKeyFunc(func: MapKeyFunc): this;
+
+  build(): PropDefinition;
 }
+
 declare class PropBuilder implements IPropBuilder {
-    prop: PropDefinition;
-    constructor();
-    addChild(child: PropDefinition): this;
-    setEntry(entry: PropDefinition): this;
-    addMapKeyFunc(func: MapKeyFunc): this;
-    addValidation(validation: Validation): this;
-    build(): PropDefinition;
-    setDefaultValue(value: any): this;
-    setDocLink(link: string): this;
-    setDocLinkRef(ref: string): this;
-    setHidden(hidden: boolean): this;
-    /**
-    * The type of the prop
-    *
-    * @param {string} kind [array | boolean | integer | map | object | string]
-    *
-    * @returns this
-    *
-    * @example
-    * .setKind("text")
-    */
-    setKind(kind: PropDefinitionKind): this;
-    /**
-    * The prop name. This will appear in the model UI
-    *
-    * @param {string} name - the name of the prop
-    *
-    * @returns this
-    *
-    * @example
-    * .setName("Region")
-    */
-    setName(name: string): this;
-    setValueFrom(valueFrom: ValueFrom): this;
-    setWidget(widget: PropWidgetDefinition): this;
+  prop: PropDefinition;
+
+  constructor();
+
+  addChild(child: PropDefinition): this;
+
+  setEntry(entry: PropDefinition): this;
+
+  addMapKeyFunc(func: MapKeyFunc): this;
+
+  addValidation(validation: Validation): this;
+
+  build(): PropDefinition;
+
+  setDefaultValue(value: any): this;
+
+  setDocLink(link: string): this;
+
+  setDocLinkRef(ref: string): this;
+
+  setHidden(hidden: boolean): this;
+
+  /**
+   * The type of the prop
+   *
+   * @param {string} kind [array | boolean | integer | map | object | string]
+   *
+   * @returns this
+   *
+   * @example
+   * .setKind("text")
+   */
+  setKind(kind: PropDefinitionKind): this;
+
+  /**
+   * The prop name. This will appear in the model UI
+   *
+   * @param {string} name - the name of the prop
+   *
+   * @returns this
+   *
+   * @example
+   * .setName("Region")
+   */
+  setName(name: string): this;
+
+  setValueFrom(valueFrom: ValueFrom): this;
+
+  setWidget(widget: PropWidgetDefinition): this;
 }
+
 interface SecretPropDefinition extends PropDefinition {
+  hasInputSocket: boolean;
 }
+
 interface ISecretPropBuilder {
-    setName(name: string): this;
-    setSecretKind(kind: string): this;
-    setDocLinkRef(ref: string): this;
-    setDocLink(link: string): this;
-    addValidation(validation: Validation): this;
-    build(): SecretPropDefinition;
+  setName(name: string): this;
+
+  setSecretKind(kind: string): this;
+
+  setDocLinkRef(ref: string): this;
+
+  setDocLink(link: string): this;
+
+  addValidation(validation: Validation): this;
+
+  skipInputSocket(): this;
+
+  build(): SecretPropDefinition;
 }
+
 declare class SecretPropBuilder implements ISecretPropBuilder {
-    prop: SecretPropDefinition;
-    constructor();
-    setName(name: string): this;
-    setSecretKind(kind: string): this;
-    setDocLinkRef(ref: string): this;
-    setDocLink(link: string): this;
-    addValidation(validation: Validation): this;
-    build(): SecretPropDefinition;
+  prop: SecretPropDefinition;
+
+  constructor();
+
+  setName(name: string): this;
+
+  setSecretKind(kind: string): this;
+
+  setDocLinkRef(ref: string): this;
+
+  setDocLink(link: string): this;
+
+  addValidation(validation: Validation): this;
+
+  skipInputSocket(): this;
+
+  build(): SecretPropDefinition;
 }
+
 interface SecretDefinition {
-    name: string;
-    props?: PropDefinition[];
+  name: string;
+  props: PropDefinition[];
 }
+
 interface ISecretDefinitionBuilder {
-    addProp(prop: PropDefinition): this;
-    build(): SecretDefinition;
+  addProp(prop: PropDefinition): this;
+
+  build(): SecretDefinition;
 }
+
 declare class SecretDefinitionBuilder implements ISecretDefinitionBuilder {
-    definition: SecretDefinition;
-    constructor();
-    setName(name: string): this;
-    addProp(prop: PropDefinition): this;
-    build(): SecretDefinition;
+  definition: SecretDefinition;
+
+  constructor();
+
+  setName(name: string): this;
+
+  addProp(prop: PropDefinition): this;
+
+  build(): SecretDefinition;
 }
+
 interface Asset {
-    props: PropDefinition[];
-    secretProps: SecretPropDefinition[];
-    secretDefinition?: PropDefinition[];
-    resourceProps: PropDefinition[];
-    siPropValueFroms: SiPropValueFromDefinition[];
-    inputSockets: SocketDefinition[];
-    outputSockets: SocketDefinition[];
-    docLinks: Record<string, string>;
+  props: PropDefinition[];
+  secretProps: SecretPropDefinition[];
+  secretDefinition?: PropDefinition[];
+  resourceProps: PropDefinition[];
+  siPropValueFroms: SiPropValueFromDefinition[];
+  inputSockets: SocketDefinition[];
+  outputSockets: SocketDefinition[];
+  docLinks: Record<string, string>;
 }
+
 interface IAssetBuilder {
-    addProp(prop: PropDefinition): this;
-    addSecretProp(prop: SecretPropDefinition): this;
-    defineSecret(definition: SecretDefinition): this;
-    addResourceProp(prop: PropDefinition): this;
-    addInputSocket(socket: SocketDefinition): this;
-    addOutputSocket(socket: SocketDefinition): this;
-    addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
-    addDocLink(key: string, value: string): this;
-    build(): Asset;
+  addProp(prop: PropDefinition): this;
+
+  addSecretProp(prop: SecretPropDefinition): this;
+
+  defineSecret(definition: SecretDefinition): this;
+
+  addResourceProp(prop: PropDefinition): this;
+
+  addInputSocket(socket: SocketDefinition): this;
+
+  addOutputSocket(socket: SocketDefinition): this;
+
+  addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
+
+  addDocLink(key: string, value: string): this;
+
+  build(): Asset;
 }
+
 declare class AssetBuilder implements IAssetBuilder {
-    asset: Asset;
-    constructor();
-    addProp(prop: PropDefinition): this;
-    addSecretProp(prop: SecretPropDefinition): this;
-    defineSecret(definition: SecretDefinition): this;
-    addResourceProp(prop: PropDefinition): this;
-    addInputSocket(socket: SocketDefinition): this;
-    addOutputSocket(socket: SocketDefinition): this;
-    addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
-    addDocLink(key: string, value: string): this;
-    build(): Asset;
+  asset: Asset;
+
+  constructor();
+
+  addProp(prop: PropDefinition): this;
+
+  addSecretProp(prop: SecretPropDefinition): this;
+
+  defineSecret(definition: SecretDefinition): this;
+
+  addResourceProp(prop: PropDefinition): this;
+
+  addInputSocket(socket: SocketDefinition): this;
+
+  addOutputSocket(socket: SocketDefinition): this;
+
+  addSiPropValueFrom(siPropValueFrom: SiPropValueFromDefinition): this;
+
+  addDocLink(key: string, value: string): this;
+
+  build(): Asset;
 }


### PR DESCRIPTION
- Fail secret defining schema creation with more than one secret prop
- Show function exec errors asset creation
- Load secret Definitions from the backend
<img width="1009" alt="image" src="https://github.com/systeminit/si/assets/6564471/54ae86a8-4abf-47f7-921c-2edea7bac628">
