### PR TITLE
feat(dal,si-pkg): components in workspace backups, improve dbg view

### DIFF
--- a/app/web/src/components/AttributeDebugView.vue
+++ b/app/web/src/components/AttributeDebugView.vue
@@ -1,14 +1,16 @@
 <template>
-  <div class="overflow-x-scroll m-4">
+  <div class="overflow-x-scroll my-2 p-4 border-opacity-10 border-l-2">
     <dl>
-      <dt class="type-bold-base">Set By Function</dt>
-      <dd class="m-4 border-black">{{ data.funcName }} {{ data.funcId }}</dd>
-      <dt class="type-bold-base">Input</dt>
-      <dd class="m-4">
-        <pre>{{ data.funcArgs }}</pre>
+      <dt class="uppercase text-xs italic opacity-80">Set By Function</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10">
+        <pre>{{ data.funcName }} {{ data.funcId }}</pre>
       </dd>
-      <dt class="type-bold-base">Input sources</dt>
-      <dd class="m-4">
+      <dt class="uppercase text-xs italic opacity-80">Input</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10 overflow-x-scroll">
+        <pre>{{ data.funcArgs ?? "NULL" }}</pre>
+      </dd>
+      <dt class="uppercase text-xs italic opacity-80">Input sources</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10 overflow-x-scroll">
         <ul v-if="data.argSources && Object.keys(data.argSources).length">
           <li v-for="[k, v] in Object.entries(data.argSources)" :key="k">
             <strong>{{ k }}</strong>
@@ -17,9 +19,17 @@
         </ul>
         <p v-else>No input sources</p>
       </dd>
-      <dt class="type-bold-base">Value</dt>
-      <dd class="m-4">
-        <pre>{{ data.value }}</pre>
+      <dt class="uppercase text-xs italic opacity-80">Value</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10 overflow-x-scroll">
+        <pre>{{ data.value ?? "NULL" }}</pre>
+      </dd>
+      <dt class="uppercase text-xs italic opacity-80">Prototype Id</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10">
+        <pre>{{ data.prototypeId }}</pre>
+      </dd>
+      <dt class="uppercase text-xs italic opacity-80">Prototype Context</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10">
+        <pre>{{ data.prototypeContext }}</pre>
       </dd>
     </dl>
   </div>

--- a/app/web/src/components/ComponentDebugModal.vue
+++ b/app/web/src/components/ComponentDebugModal.vue
@@ -1,7 +1,22 @@
 <template>
   <Modal ref="modalRef" title="Component Debug" size="4xl">
-    Component Id: {{ selectedComponentId ?? "none" }}
     <Stack v-if="debugData" class="m-4 overflow-y-scroll max-h-[80vh]">
+      <Collapsible label="Component" defaultOpen textSize="lg">
+        <dl class="border-l-2 p-2 my-2">
+          <dt class="uppercase text-xs italic opacity-80">Id</dt>
+          <dd class="p-2 my-2 border-2 border-opacity-10">
+            <pre>{{ selectedComponentId ?? "none" }}</pre>
+          </dd>
+          <dt class="uppercase text-xs italic opacity-80">Name</dt>
+          <dd class="p-2 my-2 border-2 border-opacity-10">
+            {{ debugData.name }}
+          </dd>
+          <dt class="uppercase text-xs italic opacity-80">Variant Id</dt>
+          <dd class="p-2 my-2 border-2 border-opacity-10">
+            <pre>{{ debugData.schemaVariantId }}</pre>
+          </dd>
+        </dl>
+      </Collapsible>
       <Collapsible
         label="Attributes"
         :defaultOpen="false"

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -147,6 +147,13 @@ export interface AttributeDebugData {
     visibility_deleted_at: Date | undefined | null;
   };
   value: object | string | number | boolean | null;
+  prototypeId: string;
+  prototypeContext: {
+    prop_id: string;
+    internal_provider_id: string;
+    external_provider_id: string;
+    component_id: string;
+  };
 }
 
 export interface AttributeDebugView {
@@ -156,6 +163,8 @@ export interface AttributeDebugView {
 }
 
 export interface ComponentDebugView {
+  name: string;
+  schemaVariantId: string;
   attributes: AttributeDebugView[];
   inputSockets: AttributeDebugView[];
   outputSockets: AttributeDebugView[];

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1238,7 +1238,7 @@ impl AttributeValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AttributeValuePayload {
     pub prop: Prop,
     pub func_binding_return_value: Option<FuncBindingReturnValue>,

--- a/lib/dal/src/component/view.rs
+++ b/lib/dal/src/component/view.rs
@@ -10,8 +10,10 @@ use crate::{
     PropId, SchemaVariantId, SecretError, SecretId, StandardModel, StandardModelError,
 };
 
+pub mod debug;
 pub mod properties;
 
+pub use debug::{AttributeDebugView, ComponentDebugView};
 pub use properties::ComponentViewProperties;
 
 type ComponentViewResult<T> = Result<T, ComponentViewError>;

--- a/lib/dal/src/component/view/debug.rs
+++ b/lib/dal/src/component/view/debug.rs
@@ -1,0 +1,442 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
+use thiserror::Error;
+
+use crate::{
+    func::execution::{FuncExecution, FuncExecutionError},
+    socket::{SocketEdgeKind, SocketError},
+    AttributePrototype, AttributeReadContext, AttributeValue, AttributeValueError,
+    AttributeValueId, AttributeValuePayload, Component, ComponentError, ComponentId, DalContext,
+    ExternalProvider, ExternalProviderId, Func, FuncBinding, FuncBindingError,
+    FuncBindingReturnValue, FuncBindingReturnValueError, FuncError, InternalProvider,
+    InternalProviderError, InternalProviderId, Prop, PropError, PropId, PropKind,
+    SchemaVariantError, SchemaVariantId, SecretError, SecretId, Socket, SocketId, StandardModel,
+    StandardModelError,
+};
+
+type ComponentDebugViewResult<T> = Result<T, ComponentDebugViewError>;
+
+/// A generated view for an [`Component`](crate::Component) that contains metadata about each of
+/// the components attributes. Used for constructing a debug view of the component and also for
+/// cloning a component
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentDebugView {
+    pub name: String,
+    pub schema_variant_id: SchemaVariantId,
+    pub attributes: Vec<AttributeDebugView>,
+    pub input_sockets: Vec<AttributeDebugView>,
+    pub output_sockets: Vec<AttributeDebugView>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeDebugView {
+    pub path: String,
+    pub parent_attribute_value_id: Option<AttributeValueId>,
+    pub attribute_value: AttributeValue,
+    pub func: Func,
+    pub func_binding: FuncBinding,
+    pub func_binding_return_value: FuncBindingReturnValue,
+    pub func_execution: FuncExecution,
+    pub prop: Option<Prop>,
+    pub internal_provider: Option<InternalProvider>,
+    pub external_provider: Option<ExternalProvider>,
+    pub prototype: AttributePrototype,
+}
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum ComponentDebugViewError {
+    #[error(transparent)]
+    AttributeValue(#[from] AttributeValueError),
+    #[error("Attribute Value tree badly constructed with root prop of {0}")]
+    AttributeValueTreeBad(AttributeValueId),
+    #[error("component error: {0}")]
+    Component(String),
+    #[error("external provider not found for output socket: {0}")]
+    ExternalProviderNotFoundForInputSocket(SocketId),
+    #[error(transparent)]
+    Func(#[from] FuncError),
+    #[error(transparent)]
+    FuncBinding(#[from] FuncBindingError),
+    #[error(transparent)]
+    FuncBindingReturnValue(#[from] FuncBindingReturnValueError),
+    #[error(transparent)]
+    FuncExecution(#[from] FuncExecutionError),
+    #[error(transparent)]
+    InternalProvider(#[from] InternalProviderError),
+    #[error("internal provider not found for input socket: {0}")]
+    InternalProviderNotFoundForInputSocket(SocketId),
+    #[error("json pointer not found: {1:?} at {0}")]
+    JSONPointerNotFound(serde_json::Value, String),
+    #[error("no attribute value found for context {0:?}")]
+    NoAttributeValue(AttributeReadContext),
+    #[error("no internal provider for prop {0}")]
+    NoInternalProvider(PropId),
+    #[error("no root prop found for schema variant {0}")]
+    NoRootProp(SchemaVariantId),
+    #[error("schema variant not found for component {0}")]
+    NoSchemaVariant(ComponentId),
+    #[error("component not found {0}")]
+    NotFound(ComponentId),
+    #[error(transparent)]
+    Prop(#[from] PropError),
+    #[error(transparent)]
+    SchemaVariant(#[from] SchemaVariantError),
+    #[error(transparent)]
+    Secret(#[from] SecretError),
+    #[error("secret not found: {0}")]
+    SecretNotFound(SecretId),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    Socket(#[from] SocketError),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+    #[error(transparent)]
+    UlidDecode(#[from] ulid::DecodeError),
+}
+
+pub enum AttributeDebugInput<'a> {
+    ComponentSocket((Socket, ComponentId)),
+    AttributeValuePayload(&'a AttributeValuePayload),
+}
+
+impl ComponentDebugView {
+    pub async fn new(ctx: &DalContext, component: &Component) -> ComponentDebugViewResult<Self> {
+        let debug_view_start = Instant::now();
+
+        let schema_variant = component
+            .schema_variant(ctx)
+            .await
+            .map_err(|e| ComponentDebugViewError::Component(e.to_string()))?
+            .ok_or(ComponentError::NoSchemaVariant(*component.id()))
+            .map_err(|e| ComponentDebugViewError::Component(e.to_string()))?;
+
+        let root_prop_id = schema_variant
+            .root_prop_id()
+            .ok_or(ComponentDebugViewError::NoRootProp(*schema_variant.id()))?;
+
+        let root_av_context = AttributeReadContext {
+            prop_id: Some(*root_prop_id),
+            internal_provider_id: Some(InternalProviderId::NONE),
+            external_provider_id: Some(ExternalProviderId::NONE),
+            component_id: Some(*component.id()),
+        };
+
+        let root_prop_av = AttributeValue::find_for_context(ctx, root_av_context)
+            .await?
+            .ok_or(AttributeValueError::NotFoundForReadContext(root_av_context))?;
+
+        let view_context = AttributeReadContext {
+            prop_id: None,
+            internal_provider_id: Some(InternalProviderId::NONE),
+            external_provider_id: Some(ExternalProviderId::NONE),
+            component_id: Some(*component.id()),
+        };
+
+        let mut initial_work = AttributeValue::list_payload_for_read_context_and_root(
+            ctx,
+            *root_prop_av.id(),
+            view_context,
+        )
+        .await?;
+
+        // We sort the work queue according to the order of every nested IndexMap. This ensures that
+        // when we reconstruct the final shape, we don't have to worry about the order that things
+        // appear in.
+        let attribute_value_order: Vec<AttributeValueId> = initial_work
+            .iter()
+            .filter_map(|avp| avp.attribute_value.index_map())
+            .flat_map(|index_map| index_map.order())
+            .copied()
+            .collect();
+        initial_work.sort_by_cached_key(|avp| {
+            attribute_value_order
+                .iter()
+                .position(|attribute_value_id| attribute_value_id == avp.attribute_value.id())
+                .unwrap_or(0)
+        });
+
+        let mut index_map: HashMap<PropId, i64> = HashMap::new();
+        let mut work_queue = VecDeque::from(initial_work);
+        let mut parent_queue: VecDeque<(Option<AttributeValue>, Option<PropKind>, String)> =
+            VecDeque::from([(None, None, "".to_string())]);
+        let mut attributes = vec![];
+
+        while !work_queue.is_empty() {
+            let mut unprocessed = vec![];
+
+            if let Some((parent, parent_kind, parent_path)) = parent_queue.pop_front() {
+                let mut current_parent = parent;
+                let mut current_parent_kind = parent_kind;
+                let mut current_parent_path = parent_path;
+
+                while let Some(payload) = work_queue.pop_front() {
+                    if current_parent.as_ref().map(|parent| *parent.id())
+                        == payload.parent_attribute_value_id
+                    {
+                        let current_prop_name = payload.prop.name();
+                        let prop_full_path = match current_parent_kind {
+                            Some(PropKind::Array) => {
+                                let array_index = *index_map.get(payload.prop.id()).unwrap_or(&0);
+                                let path = format!(
+                                    "{}/{}/{}",
+                                    &current_parent_path, current_prop_name, array_index
+                                );
+                                index_map.insert(*payload.prop.id(), array_index + 1);
+                                path
+                            }
+                            Some(PropKind::Map) => {
+                                if let Some(key) = payload.attribute_value.key() {
+                                    format!(
+                                        "{}/{}/{}",
+                                        &current_parent_path, current_prop_name, key
+                                    )
+                                } else {
+                                    // This should be an error
+                                    format!("{}/{}", &current_parent_path, current_prop_name)
+                                }
+                            }
+                            _ => format!("{}/{}", &current_parent_path, current_prop_name),
+                        };
+
+                        attributes.push(
+                            Self::get_attribute_debug_view(
+                                ctx,
+                                AttributeDebugInput::AttributeValuePayload(&payload),
+                                current_parent.as_ref().map(|parent| *parent.id()),
+                                Some(prop_full_path.to_owned()),
+                            )
+                            .await?,
+                        );
+
+                        match payload.prop.kind() {
+                            PropKind::Object | PropKind::Array | PropKind::Map => {
+                                // The current parent is pushed back onto the queue and swapped
+                                // with this value, which transforms this into a depth-first search
+                                // (but preserves index-map ordering above)
+                                parent_queue.push_front((
+                                    current_parent,
+                                    current_parent_kind,
+                                    current_parent_path,
+                                ));
+                                // too much cloning!
+                                current_parent = Some(payload.attribute_value.to_owned());
+                                current_parent_kind = Some(*payload.prop.kind());
+                                current_parent_path = prop_full_path;
+
+                                // Since we've changed parents we need to reprocess the unprocessed
+                                // in case they are children of this parent but were skipped
+                                for unprocessed_payload in unprocessed {
+                                    work_queue.push_front(unprocessed_payload);
+                                }
+                                unprocessed = vec![];
+
+                                continue;
+                            }
+                            _ => {}
+                        }
+                    } else {
+                        unprocessed.push(payload);
+                    }
+                }
+                work_queue = VecDeque::from(unprocessed);
+
+                // If we are out of roots but we have work left to process, something went wrong
+                // with the attribute value structure in the database (we had an orphaned child
+                // with no parent)
+                if parent_queue.is_empty() && !work_queue.is_empty() {
+                    return Err(ComponentDebugViewError::AttributeValueTreeBad(
+                        *root_prop_av.id(),
+                    ));
+                }
+            }
+        }
+
+        let attributes_duration = debug_view_start.elapsed();
+        let sockets_start = Instant::now();
+
+        let mut input_sockets = vec![];
+        let mut output_sockets = vec![];
+
+        for socket in Socket::list_for_component(ctx, *component.id()).await? {
+            let socket_debug_data = Self::get_attribute_debug_view(
+                ctx,
+                AttributeDebugInput::ComponentSocket((socket, *component.id())),
+                None,
+                None,
+            )
+            .await?;
+
+            if socket_debug_data.internal_provider.is_some() {
+                input_sockets.push(socket_debug_data);
+            } else {
+                output_sockets.push(socket_debug_data)
+            }
+        }
+
+        let sockets_duration = sockets_start.elapsed();
+
+        dbg!(attributes_duration, sockets_duration);
+
+        let debug_view = ComponentDebugView {
+            name: component
+                .name(ctx)
+                .await
+                .map_err(|e| ComponentDebugViewError::Component(e.to_string()))?,
+            schema_variant_id: *schema_variant.id(),
+            attributes,
+            input_sockets,
+            output_sockets,
+        };
+
+        Ok(debug_view)
+    }
+
+    pub async fn get_attribute_debug_view(
+        ctx: &DalContext,
+        payload: AttributeDebugInput<'_>,
+        parent_attribute_value_id: Option<AttributeValueId>,
+        path: Option<String>,
+    ) -> ComponentDebugViewResult<AttributeDebugView> {
+        let (
+            attribute_value,
+            prop,
+            internal_provider,
+            external_provider,
+            func_binding_return_value,
+            path,
+        ) = match payload {
+            AttributeDebugInput::AttributeValuePayload(payload) => {
+                let func_binding_return_value = match &payload.func_binding_return_value {
+                    Some(fbrv) => fbrv.to_owned(),
+                    None => FuncBindingReturnValue::get_by_id(
+                        ctx,
+                        &payload.attribute_value.func_binding_return_value_id(),
+                    )
+                    .await?
+                    .ok_or(FuncBindingReturnValueError::NotFound(
+                        payload.attribute_value.func_binding_return_value_id(),
+                    ))?,
+                };
+
+                let path = path.unwrap_or(payload.prop.name().into());
+
+                (
+                    payload.attribute_value.to_owned(),
+                    Some(payload.prop.to_owned()),
+                    None,
+                    None,
+                    func_binding_return_value,
+                    path,
+                )
+            }
+            AttributeDebugInput::ComponentSocket((socket, component_id)) => {
+                let (attribute_value, internal_provider, external_provider, path) =
+                    match socket.edge_kind() {
+                        SocketEdgeKind::ConfigurationInput => {
+                            let internal_provider = socket.internal_provider(ctx).await?.ok_or(
+                                ComponentDebugViewError::InternalProviderNotFoundForInputSocket(
+                                    *socket.id(),
+                                ),
+                            )?;
+
+                            let input_socket_value_context = AttributeReadContext {
+                                prop_id: Some(PropId::NONE),
+                                internal_provider_id: Some(*internal_provider.id()),
+                                external_provider_id: Some(ExternalProviderId::NONE),
+                                component_id: Some(component_id),
+                            };
+                            let attribute_value =
+                                AttributeValue::find_for_context(ctx, input_socket_value_context)
+                                    .await?
+                                    .ok_or(AttributeValueError::NotFoundForReadContext(
+                                        input_socket_value_context,
+                                    ))?;
+
+                            let name = internal_provider.name().to_owned();
+                            (attribute_value, Some(internal_provider), None, name)
+                        }
+                        SocketEdgeKind::ConfigurationOutput => {
+                            let external_provider = socket.external_provider(ctx).await?.ok_or(
+                                ComponentDebugViewError::ExternalProviderNotFoundForInputSocket(
+                                    *socket.id(),
+                                ),
+                            )?;
+
+                            let input_socket_value_context = AttributeReadContext {
+                                prop_id: Some(PropId::NONE),
+                                internal_provider_id: Some(InternalProviderId::NONE),
+                                external_provider_id: Some(*external_provider.id()),
+                                component_id: Some(component_id),
+                            };
+                            let attribute_value =
+                                AttributeValue::find_for_context(ctx, input_socket_value_context)
+                                    .await?
+                                    .ok_or(AttributeValueError::NotFoundForReadContext(
+                                        input_socket_value_context,
+                                    ))?;
+
+                            let name = external_provider.name().to_owned();
+                            (attribute_value, None, Some(external_provider), name)
+                        }
+                    };
+
+                let func_binding_return_value = FuncBindingReturnValue::get_by_id(
+                    ctx,
+                    &attribute_value.func_binding_return_value_id(),
+                )
+                .await?
+                .ok_or(FuncBindingReturnValueError::NotFound(
+                    attribute_value.func_binding_return_value_id(),
+                ))?;
+
+                (
+                    attribute_value,
+                    None,
+                    internal_provider,
+                    external_provider,
+                    func_binding_return_value,
+                    path,
+                )
+            }
+        };
+
+        let prototype = attribute_value.attribute_prototype(ctx).await?.ok_or(
+            AttributeValueError::AttributePrototypeNotFound(
+                *attribute_value.id(),
+                *ctx.visibility(),
+            ),
+        )?;
+
+        let func = Func::get_by_id(ctx, &prototype.func_id())
+            .await?
+            .ok_or(FuncError::NotFound(prototype.func_id()))?;
+
+        let func_binding = FuncBinding::get_by_id(ctx, &attribute_value.func_binding_id())
+            .await?
+            .ok_or(FuncBindingError::NotFound(
+                attribute_value.func_binding_id(),
+            ))?;
+
+        let func_execution =
+            FuncExecution::get_by_pk(ctx, &func_binding_return_value.func_execution_pk()).await?;
+
+        Ok(AttributeDebugView {
+            path,
+            parent_attribute_value_id,
+            attribute_value,
+            func,
+            func_binding,
+            func_binding_return_value,
+            func_execution,
+            prop,
+            internal_provider,
+            external_provider,
+            prototype,
+        })
+    }
+}

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -27,6 +27,8 @@ pub enum FuncExecutionError {
     #[error("nats txn error: {0}")]
     Nats(#[from] NatsError),
     #[error("pg error: {0}")]
+    NotFound(FuncExecutionPk),
+    #[error(transparent)]
     Pg(#[from] PgError),
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
@@ -283,4 +285,9 @@ impl FuncExecution {
 
     standard_model_accessor_ro!(func_id, FuncId);
     standard_model_accessor_ro!(function_failure, Option<FunctionResultFailure>);
+    standard_model_accessor_ro!(func_binding_args, serde_json::Value);
+    standard_model_accessor_ro!(handler, Option<String>);
+    standard_model_accessor_ro!(backend_kind, FuncBackendKind);
+    standard_model_accessor_ro!(backend_response_type, FuncBackendResponseType);
+    standard_model_accessor_ro!(code_base64, Option<String>);
 }

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -6,7 +6,8 @@ use axum::{
 };
 use dal::change_status::ChangeStatusError;
 use dal::{
-    node::NodeError, property_editor::PropertyEditorError, AttributeContextBuilderError,
+    component::view::debug::ComponentDebugViewError, node::NodeError,
+    property_editor::PropertyEditorError, AttributeContextBuilderError,
     AttributePrototypeArgumentError, AttributePrototypeError, AttributeValueError, ChangeSetError,
     ComponentError as DalComponentError, ComponentId, DiagramError, ExternalProviderError,
     FuncBindingError, FuncError, InternalProviderError, PropId, ReconciliationPrototypeError,
@@ -53,8 +54,10 @@ pub enum ComponentError {
     ChangeStatus(#[from] ChangeStatusError),
     #[error("component error: {0}")]
     Component(#[from] DalComponentError),
-    #[error("component debug error: {0}")]
+    #[error("component debug view error: {0}")]
     ComponentDebug(String),
+    #[error("component debug view error: {0}")]
+    ComponentDebugView(#[from] ComponentDebugViewError),
     #[error("component name not found")]
     ComponentNameNotFound,
     #[error("component not found for id: {0}")]

--- a/lib/sdf-server/src/server/service/component/debug.rs
+++ b/lib/sdf-server/src/server/service/component/debug.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
+use std::time::Instant;
 
 use axum::extract::Query;
 use axum::Json;
@@ -8,23 +9,25 @@ use serde::{Deserialize, Serialize};
 use super::{ComponentError, ComponentResult};
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use dal::{
-    socket::SocketEdgeKind, AttributePrototypeArgument, AttributeReadContext, AttributeValue,
-    AttributeValueId, AttributeView, Component, ComponentId, DalContext, ExternalProviderId, Func,
-    FuncArgument, FuncBinding, FuncId, InternalProvider, InternalProviderId, Prop, PropId, Socket,
-    StandardModel, Visibility,
+    component::view::{AttributeDebugView, ComponentDebugView},
+    AttributeContext, AttributePrototypeArgument, AttributePrototypeId, AttributeValueId,
+    Component, ComponentId, DalContext, FuncArgument, FuncId, InternalProvider, Prop, PropId,
+    SchemaVariantId, StandardModel, Visibility,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ComponentDebugView {
-    attributes: Vec<AttributeDebugView>,
-    input_sockets: Vec<AttributeDebugView>,
-    output_sockets: Vec<AttributeDebugView>,
+pub struct FrontendComponentDebugView {
+    name: String,
+    schema_variant_id: SchemaVariantId,
+    attributes: Vec<FrontendAttributeDebugView>,
+    input_sockets: Vec<FrontendAttributeDebugView>,
+    output_sockets: Vec<FrontendAttributeDebugView>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AttributeDebugView {
+pub struct FrontendAttributeDebugView {
     name: String,
     path: String,
     debug_data: AttributeMetadataView,
@@ -34,13 +37,14 @@ pub struct AttributeDebugView {
 #[serde(rename_all = "camelCase")]
 pub struct AttributeMetadataView {
     pub value_id: AttributeValueId,
-    pub proxy_for: Option<AttributeValueId>,
     pub func_name: String,
     pub func_id: FuncId,
     pub func_args: serde_json::Value,
     pub arg_sources: HashMap<String, Option<String>>,
     pub visibility: Visibility,
     pub value: Option<serde_json::Value>,
+    pub prototype_id: AttributePrototypeId,
+    pub prototype_context: AttributeContext,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -51,7 +55,7 @@ pub struct DebugComponentRequest {
     pub visibility: Visibility,
 }
 
-type DebugComponentResponse = ComponentDebugView;
+type DebugComponentResponse = FrontendComponentDebugView;
 
 pub async fn debug_component(
     HandlerContext(builder): HandlerContext,
@@ -64,171 +68,51 @@ pub async fn debug_component(
         .await?
         .ok_or(ComponentError::ComponentDebug("component not found".into()))?;
 
-    let schema_variant =
-        component
-            .schema_variant(&ctx)
-            .await?
-            .ok_or(ComponentError::ComponentDebug(
-                "schema variant not found for component".into(),
-            ))?;
+    let debug_view = ComponentDebugView::new(&ctx, &component).await?;
 
-    let root_prop_id = schema_variant
-        .root_prop_id()
-        .ok_or(ComponentError::ComponentDebug(
-            "could not get root prop for schema variant".into(),
-        ))?;
-
-    let av_context = AttributeReadContext {
-        prop_id: Some(*root_prop_id),
-        internal_provider_id: Some(InternalProviderId::NONE),
-        external_provider_id: Some(ExternalProviderId::NONE),
-        component_id: Some(*component.id()),
-    };
-
-    let root_prop_av = AttributeValue::find_for_context(&ctx, av_context)
-        .await?
-        .ok_or(ComponentError::ComponentDebug(
-            "could not get attribute value for root prop".into(),
-        ))?;
-
-    let view_context = AttributeReadContext {
-        prop_id: None,
-        internal_provider_id: Some(InternalProviderId::NONE),
-        external_provider_id: Some(ExternalProviderId::NONE),
-        component_id: Some(*component.id()),
-    };
-
-    let root_prop_view = AttributeView::new(&ctx, view_context, Some(*root_prop_av.id())).await?;
-
-    let pointer_to_av_ids: HashMap<String, AttributeValueId> = root_prop_view
-        .json_pointers_for_attribute_value_id()
-        .iter()
-        .map(|(k, v)| (v.to_owned(), k.to_owned()))
-        .collect();
-
-    let mut value_stack = VecDeque::from([(
-        "/root".to_string(),
-        "root".to_string(),
-        root_prop_view.value().to_owned(),
-    )]);
-
-    let mut attribute_views = vec![];
-    let mut input_socket_views = vec![];
-    let mut output_socket_views = vec![];
-
-    while let Some((pointer, name, value)) = value_stack.pop_front() {
-        if let Some(av_id) = pointer_to_av_ids.get(&pointer) {
-            attribute_views.push(AttributeDebugView {
-                path: pointer.to_owned(),
-                name: name.to_owned(),
-                debug_data: get_attribute_metadata(&ctx, *av_id).await?,
-            });
-        }
-
-        match value {
-            serde_json::Value::Object(map_object) => {
-                for (k, v) in map_object.iter() {
-                    let new_pointer = format!("{}/{}", &pointer, &k);
-                    value_stack.push_front((new_pointer, k.to_owned(), v.to_owned()));
-                }
-            }
-            serde_json::Value::Array(array) => {
-                for (pos, v) in array.iter().enumerate() {
-                    let position_string = format!("{}", &pos);
-                    let new_pointer = format!("{}/{}", &pointer, &position_string);
-
-                    value_stack.push_front((new_pointer, position_string, v.to_owned()));
-                }
-            }
-            _ => {}
-        }
-    }
-
+    let mut attributes = vec![];
     let mut input_sockets = vec![];
     let mut output_sockets = vec![];
 
-    for socket in Socket::list_for_component(&ctx, request.component_id)
-        .await
-        .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
-    {
-        match socket.edge_kind() {
-            SocketEdgeKind::ConfigurationInput => {
-                let internal_provider = socket
-                    .internal_provider(&ctx)
-                    .await
-                    .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
-                    .ok_or(ComponentError::ComponentDebug(
-                        "could not find internal provider for an input socket".into(),
-                    ))?;
+    let transform_start = Instant::now();
 
-                let input_socket_value_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(*internal_provider.id()),
-                    external_provider_id: Some(ExternalProviderId::NONE),
-                    component_id: Some(*component.id()),
-                };
-                let socket_value =
-                    AttributeValue::find_for_context(&ctx, input_socket_value_context)
-                        .await?
-                        .ok_or(ComponentError::ComponentDebug(
-                            "could not find attribute value for an input socket".into(),
-                        ))?;
-
-                input_sockets.push((
-                    internal_provider.name().to_string(),
-                    get_attribute_metadata(&ctx, *socket_value.id()).await?,
-                ))
-            }
-            SocketEdgeKind::ConfigurationOutput => {
-                let external_provider = socket
-                    .external_provider(&ctx)
-                    .await
-                    .map_err(|e| ComponentError::ComponentDebug(e.to_string()))?
-                    .ok_or(ComponentError::ComponentDebug(
-                        "could not find external_provider for an output socket".into(),
-                    ))?;
-
-                let output_socket_value_context = AttributeReadContext {
-                    prop_id: Some(PropId::NONE),
-                    internal_provider_id: Some(InternalProviderId::NONE),
-                    external_provider_id: Some(*external_provider.id()),
-                    component_id: Some(*component.id()),
-                };
-                let socket_value =
-                    AttributeValue::find_for_context(&ctx, output_socket_value_context)
-                        .await?
-                        .ok_or(ComponentError::ComponentDebug(
-                            "could not find attribute value for an output socket".into(),
-                        ))?;
-
-                output_sockets.push((
-                    external_provider.name().to_string(),
-                    get_attribute_metadata(&ctx, *socket_value.id()).await?,
-                ))
-            }
-        }
-    }
-
-    for (name, metadata) in input_sockets {
-        input_socket_views.push(AttributeDebugView {
-            path: "Input Socket".to_owned(),
-            name,
-            debug_data: metadata,
+    for attribute_debug in debug_view.attributes {
+        attributes.push(FrontendAttributeDebugView {
+            name: attribute_debug
+                .prop
+                .as_ref()
+                .map(|p| p.name())
+                .unwrap_or("")
+                .into(),
+            path: attribute_debug.path.to_owned(),
+            debug_data: get_attribute_metadata(&ctx, attribute_debug).await?,
         });
     }
 
-    for (name, metadata) in output_sockets {
-        output_socket_views.push(AttributeDebugView {
-            path: "Out Socket".to_owned(),
-            name,
-            debug_data: metadata,
+    for attribute_debug in debug_view.input_sockets {
+        input_sockets.push(FrontendAttributeDebugView {
+            name: attribute_debug.path.to_owned(),
+            path: "Input Socket".into(),
+            debug_data: get_attribute_metadata(&ctx, attribute_debug).await?,
         });
     }
 
-    let component_view = ComponentDebugView {
-        attributes: attribute_views,
-        input_sockets: input_socket_views,
-        output_sockets: output_socket_views,
+    for attribute_debug in debug_view.output_sockets {
+        output_sockets.push(FrontendAttributeDebugView {
+            name: attribute_debug.path.to_owned(),
+            path: "Output Socket".into(),
+            debug_data: get_attribute_metadata(&ctx, attribute_debug).await?,
+        });
+    }
+
+    dbg!(transform_start.elapsed());
+
+    let component_view = DebugComponentResponse {
+        name: debug_view.name,
+        schema_variant_id: debug_view.schema_variant_id,
+        attributes,
+        input_sockets,
+        output_sockets,
     };
 
     Ok(Json(component_view))
@@ -236,55 +120,31 @@ pub async fn debug_component(
 
 async fn get_attribute_metadata(
     ctx: &DalContext,
-    value_id: AttributeValueId,
+    debug_view: AttributeDebugView,
 ) -> ComponentResult<AttributeMetadataView> {
-    let value =
-        AttributeValue::get_by_id(ctx, &value_id)
-            .await?
-            .ok_or(ComponentError::ComponentDebug(
-                "could not find attribute value".into(),
-            ))?;
+    let func_args = debug_view.func_binding.args().to_owned();
+
     let mut arg_sources = HashMap::new();
 
-    let prototype = value
-        .attribute_prototype(ctx)
-        .await?
-        .ok_or(ComponentError::ComponentDebug(
-            "could not find attribute prototype for value".into(),
-        ))?;
-
-    let proxy_for = value.proxy_for_attribute_value_id().copied();
-
-    let func =
-        Func::get_by_id(ctx, &prototype.func_id())
-            .await?
-            .ok_or(ComponentError::ComponentDebug(
-                "could not find func used to set value".into(),
-            ))?;
-
-    let fb = FuncBinding::get_by_id(ctx, &value.func_binding_id())
-        .await?
-        .ok_or(ComponentError::ComponentDebug(
-            "could not find func binding used to set value".into(),
-        ))?;
-    let func_args = fb.args().to_owned();
-
     for apa in
-        AttributePrototypeArgument::list_for_attribute_prototype(ctx, *prototype.id()).await?
+        AttributePrototypeArgument::list_for_attribute_prototype(ctx, *debug_view.prototype.id())
+            .await?
     {
         let arg = FuncArgument::get_by_id(ctx, &apa.func_argument_id())
             .await?
-            .ok_or(ComponentError::ComponentDebug(
-                "could not find func argument".into(),
-            ))?;
+            .ok_or(ComponentError::ComponentDebug(format!(
+                "could not find func argument {}",
+                apa.func_argument_id()
+            )))?;
 
         let internal_provider_id = apa.internal_provider_id();
         let input_ip_name = if internal_provider_id.is_some() {
             let ip = InternalProvider::get_by_id(ctx, &internal_provider_id)
                 .await?
-                .ok_or(ComponentError::ComponentDebug(
-                    "could not find internal provider for input".into(),
-                ))?;
+                .ok_or(ComponentError::ComponentDebug(format!(
+                    "could not find internal provider for input: {}",
+                    internal_provider_id
+                )))?;
 
             let prop_id = *ip.prop_id();
             let path = if prop_id == PropId::NONE {
@@ -293,9 +153,10 @@ async fn get_attribute_metadata(
                 let prop =
                     Prop::get_by_id(ctx, &prop_id)
                         .await?
-                        .ok_or(ComponentError::ComponentDebug(
-                            "could not find prop for provider for input".into(),
-                        ))?;
+                        .ok_or(ComponentError::ComponentDebug(format!(
+                            "could not find prop {} for provider for input {}",
+                            prop_id, internal_provider_id
+                        )))?;
 
                 format!("Prop: /{}", prop.path().with_replaced_sep("/"))
             };
@@ -309,13 +170,17 @@ async fn get_attribute_metadata(
     }
 
     Ok(AttributeMetadataView {
-        value_id,
-        proxy_for,
-        func_name: func.name().into(),
-        func_id: func.id().to_owned(),
+        value_id: *debug_view.attribute_value.id(),
+        func_name: debug_view.func.name().into(),
+        func_id: debug_view.func.id().to_owned(),
         func_args,
         arg_sources,
-        visibility: value.visibility().to_owned(),
-        value: value.get_unprocessed_value(ctx).await?,
+        visibility: debug_view.attribute_value.visibility().to_owned(),
+        value: debug_view
+            .attribute_value
+            .get_unprocessed_value(ctx)
+            .await?,
+        prototype_id: *debug_view.prototype.id(),
+        prototype_context: debug_view.prototype.context,
     })
 }

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -10,16 +10,17 @@ pub use pkg::{
 };
 pub use spec::{
     ActionFuncSpec, ActionFuncSpecBuilder, ActionFuncSpecKind, AttrFuncInputSpec,
-    AttrFuncInputSpecKind, ChangeSetSpec, ChangeSetSpecBuilder, ChangeSetSpecStatus,
+    AttrFuncInputSpecKind, AttributeValuePath, AttributeValueSpec, ChangeSetSpec,
+    ChangeSetSpecBuilder, ChangeSetSpecStatus, ComponentSpec, ComponentSpecVariant,
     FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder, FuncSpec, FuncSpecBackendKind,
     FuncSpecBackendResponseType, FuncSpecData, FuncSpecDataBuilder, LeafFunctionSpec,
     LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, MapKeyFuncSpec, MapKeyFuncSpecBuilder,
-    PkgSpec, PkgSpecBuilder, PropSpec, PropSpecBuilder, PropSpecKind, PropSpecWidgetKind,
-    SchemaSpec, SchemaSpecBuilder, SchemaSpecData, SchemaSpecDataBuilder, SchemaVariantSpec,
-    SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SchemaVariantSpecData,
-    SchemaVariantSpecPropRoot, SiPropFuncSpec, SiPropFuncSpecBuilder, SiPropFuncSpecKind,
-    SocketSpec, SocketSpecArity, SocketSpecData, SocketSpecDataBuilder, SocketSpecKind, SpecError,
-    ValidationSpec, ValidationSpecKind,
+    PkgSpec, PkgSpecBuilder, PositionSpec, PropSpec, PropSpecBuilder, PropSpecKind,
+    PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder, SchemaSpecData, SchemaSpecDataBuilder,
+    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType,
+    SchemaVariantSpecData, SchemaVariantSpecPropRoot, SiPropFuncSpec, SiPropFuncSpecBuilder,
+    SiPropFuncSpecKind, SocketSpec, SocketSpecArity, SocketSpecData, SocketSpecDataBuilder,
+    SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind,
 };
 
 #[cfg(test)]

--- a/lib/si-pkg/src/node/attribute_value.rs
+++ b/lib/si-pkg/src/node/attribute_value.rs
@@ -1,0 +1,237 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
+};
+
+use super::{attribute_value_child::AttributeValueChild, PkgNode};
+use crate::spec::{
+    AttributeValuePath, AttributeValueSpec, FuncSpecBackendKind, FuncSpecBackendResponseType,
+};
+
+const KEY_BACKEND_KIND_STR: &str = "backend_kind";
+const KEY_RESPONSE_TYPE_STR: &str = "response_type";
+const KEY_CODE_STR: &str = "code";
+const KEY_FUNC_BINDING_ARGS_STR: &str = "func_binding_args";
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+const KEY_HANDLER_STR: &str = "handler";
+const KEY_KEY_STR: &str = "key";
+const KEY_OUTPUT_STREAM_STR: &str = "output_stream";
+const KEY_PARENT_PATH_STR: &str = "parent_path";
+const KEY_PATH_STR: &str = "path";
+const KEY_SEALED_PROXY_STR: &str = "sealed_proxy";
+const KEY_UNPROCESSED_VALUE_STR: &str = "unprocessed_value";
+const KEY_VALUE_STR: &str = "value";
+const KEY_COMPONENT_SPECIFIC_STR: &str = "component_specific";
+
+#[derive(Clone, Debug)]
+pub struct AttributeValueNode {
+    pub backend_kind: FuncSpecBackendKind,
+    pub code_base64: Option<String>,
+    pub func_binding_args: serde_json::Value,
+    pub func_unique_id: String,
+    pub handler: Option<String>,
+    pub key: Option<String>,
+    pub output_stream: Option<serde_json::Value>,
+    pub parent_path: Option<AttributeValuePath>,
+    pub path: AttributeValuePath,
+    pub response_type: FuncSpecBackendResponseType,
+    pub sealed_proxy: bool,
+    pub component_specific: bool,
+    pub unprocessed_value: Option<serde_json::Value>,
+    pub value: Option<serde_json::Value>,
+}
+
+impl WriteBytes for AttributeValueNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_BACKEND_KIND_STR, self.backend_kind)?;
+
+        write_key_value_line(
+            writer,
+            KEY_CODE_STR,
+            self.code_base64.as_deref().unwrap_or(""),
+        )?;
+
+        write_key_value_line(
+            writer,
+            KEY_FUNC_BINDING_ARGS_STR,
+            serde_json::to_string(&self.func_binding_args).map_err(GraphError::parse)?,
+        )?;
+
+        write_key_value_line(writer, KEY_FUNC_UNIQUE_ID_STR, &self.func_unique_id)?;
+        write_key_value_line(
+            writer,
+            KEY_HANDLER_STR,
+            self.handler.as_deref().unwrap_or(""),
+        )?;
+        write_key_value_line(writer, KEY_KEY_STR, self.key.as_deref().unwrap_or(""))?;
+
+        let output_stream = if let Some(output_stream_value) = &self.output_stream {
+            serde_json::to_string(output_stream_value).map_err(GraphError::parse)?
+        } else {
+            "".into()
+        };
+        write_key_value_line(writer, KEY_OUTPUT_STREAM_STR, output_stream)?;
+
+        let parent_path_str = if let Some(parent_path) = &self.parent_path {
+            serde_json::to_string(parent_path).map_err(GraphError::parse)?
+        } else {
+            "".into()
+        };
+        write_key_value_line(writer, KEY_PARENT_PATH_STR, parent_path_str)?;
+        write_key_value_line(
+            writer,
+            KEY_PATH_STR,
+            serde_json::to_string(&self.path).map_err(GraphError::parse)?,
+        )?;
+        write_key_value_line(writer, KEY_RESPONSE_TYPE_STR, self.response_type)?;
+        write_key_value_line(writer, KEY_SEALED_PROXY_STR, self.sealed_proxy)?;
+        write_key_value_line(writer, KEY_COMPONENT_SPECIFIC_STR, self.component_specific)?;
+
+        let unprocessed_value_str = if let Some(unprocessed_value) = &self.unprocessed_value {
+            serde_json::to_string(unprocessed_value).map_err(GraphError::parse)?
+        } else {
+            "".into()
+        };
+        write_key_value_line(writer, KEY_UNPROCESSED_VALUE_STR, unprocessed_value_str)?;
+
+        let value_str = if let Some(value) = &self.value {
+            serde_json::to_string(value).map_err(GraphError::parse)?
+        } else {
+            "".into()
+        };
+        write_key_value_line(writer, KEY_VALUE_STR, value_str)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for AttributeValueNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let backend_kind_str = read_key_value_line(reader, KEY_BACKEND_KIND_STR)?;
+        let backend_kind =
+            FuncSpecBackendKind::from_str(&backend_kind_str).map_err(GraphError::parse)?;
+
+        let code_base64_str = read_key_value_line(reader, KEY_CODE_STR)?;
+        let code_base64 = if code_base64_str.is_empty() {
+            None
+        } else {
+            Some(code_base64_str)
+        };
+
+        let func_binding_args_str = read_key_value_line(reader, KEY_FUNC_BINDING_ARGS_STR)?;
+        let func_binding_args: serde_json::Value =
+            serde_json::from_str(&func_binding_args_str).map_err(GraphError::parse)?;
+
+        let func_unique_id = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+
+        let handler_str = read_key_value_line(reader, KEY_HANDLER_STR)?;
+        let handler = if handler_str.is_empty() {
+            None
+        } else {
+            Some(handler_str)
+        };
+
+        let key_str = read_key_value_line(reader, KEY_KEY_STR)?;
+        let key = if key_str.is_empty() {
+            None
+        } else {
+            Some(key_str)
+        };
+
+        let output_stream_str = read_key_value_line(reader, KEY_OUTPUT_STREAM_STR)?;
+        let output_stream = if output_stream_str.is_empty() {
+            None
+        } else {
+            Some(serde_json::from_str(&output_stream_str).map_err(GraphError::parse)?)
+        };
+
+        let parent_path_str = read_key_value_line(reader, KEY_PARENT_PATH_STR)?;
+        let parent_path = if parent_path_str.is_empty() {
+            None
+        } else {
+            Some(serde_json::from_str(&parent_path_str).map_err(GraphError::parse)?)
+        };
+
+        let path_str = read_key_value_line(reader, KEY_PATH_STR)?;
+        let path = serde_json::from_str(&path_str).map_err(GraphError::parse)?;
+
+        let response_type_str = read_key_value_line(reader, KEY_RESPONSE_TYPE_STR)?;
+        let response_type =
+            FuncSpecBackendResponseType::from_str(&response_type_str).map_err(GraphError::parse)?;
+
+        let sealed_proxy = bool::from_str(&read_key_value_line(reader, KEY_SEALED_PROXY_STR)?)
+            .map_err(GraphError::parse)?;
+        let component_specific =
+            bool::from_str(&read_key_value_line(reader, KEY_COMPONENT_SPECIFIC_STR)?)
+                .map_err(GraphError::parse)?;
+
+        let unprocessed_value_str = read_key_value_line(reader, KEY_UNPROCESSED_VALUE_STR)?;
+        let unprocessed_value = if unprocessed_value_str.is_empty() {
+            None
+        } else {
+            Some(serde_json::from_str(&unprocessed_value_str).map_err(GraphError::parse)?)
+        };
+
+        let value_str = read_key_value_line(reader, KEY_VALUE_STR)?;
+        let value = if value_str.is_empty() {
+            None
+        } else {
+            Some(serde_json::from_str(&value_str).map_err(GraphError::parse)?)
+        };
+
+        Ok(Some(Self {
+            backend_kind,
+            code_base64,
+            func_binding_args,
+            func_unique_id,
+            handler,
+            key,
+            output_stream,
+            parent_path,
+            path,
+            response_type,
+            sealed_proxy,
+            component_specific,
+            unprocessed_value,
+            value,
+        }))
+    }
+}
+
+impl NodeChild for AttributeValueSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::AttributeValue(AttributeValueNode {
+                backend_kind: self.backend_kind,
+                code_base64: self.code_base64.as_ref().cloned(),
+                func_binding_args: self.func_binding_args.to_owned(),
+                func_unique_id: self.func_unique_id.to_owned(),
+                handler: self.handler.to_owned(),
+                key: self.key.to_owned(),
+                output_stream: self.output_stream.as_ref().cloned(),
+                parent_path: self.parent_path.as_ref().cloned(),
+                path: self.path.to_owned(),
+                response_type: self.reponse_type,
+                sealed_proxy: self.sealed_proxy,
+                component_specific: self.component_specific,
+                unprocessed_value: self.unprocessed_value.as_ref().cloned(),
+                value: self.value.as_ref().cloned(),
+            }),
+            vec![
+                Box::new(AttributeValueChild::AttrFuncInputs(self.inputs.to_owned()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            ],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/attribute_value_child.rs
+++ b/lib/si-pkg/src/node/attribute_value_child.rs
@@ -1,0 +1,89 @@
+use std::io::{BufRead, Write};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::AttrFuncInputSpec;
+
+use super::PkgNode;
+
+const ATTRIBUTE_VALUE_CHILD_TYPE_ATTR_FUNC_INPUTS: &str = "attr_func_inputs";
+
+const KEY_KIND_STR: &str = "kind";
+
+#[remain::sorted]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AttributeValueChild {
+    AttrFuncInputs(Vec<AttrFuncInputSpec>),
+}
+
+#[remain::sorted]
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum AttributeValueChildNode {
+    AttrFuncInputs,
+}
+
+impl AttributeValueChildNode {
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::AttrFuncInputs => ATTRIBUTE_VALUE_CHILD_TYPE_ATTR_FUNC_INPUTS,
+        }
+    }
+}
+
+impl NameStr for AttributeValueChildNode {
+    fn name(&self) -> &str {
+        match self {
+            Self::AttrFuncInputs => ATTRIBUTE_VALUE_CHILD_TYPE_ATTR_FUNC_INPUTS,
+        }
+    }
+}
+
+impl WriteBytes for AttributeValueChildNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind_str())?;
+        Ok(())
+    }
+}
+
+impl ReadBytes for AttributeValueChildNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+
+        let node = match kind_str.as_str() {
+            ATTRIBUTE_VALUE_CHILD_TYPE_ATTR_FUNC_INPUTS => Self::AttrFuncInputs,
+            invalid_kind => {
+                dbg!(format!("invalid schema variant child kind: {invalid_kind}"));
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(node))
+    }
+}
+
+impl NodeChild for AttributeValueChild {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        match self {
+            Self::AttrFuncInputs(inputs) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::AttributeValueChild(AttributeValueChildNode::AttrFuncInputs),
+                inputs
+                    .iter()
+                    .map(|input| {
+                        Box::new(input.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+        }
+    }
+}

--- a/lib/si-pkg/src/node/change_set.rs
+++ b/lib/si-pkg/src/node/change_set.rs
@@ -81,6 +81,8 @@ impl NodeChild for ChangeSetSpec {
                 based_on_change_set: self.based_on_change_set.to_owned(),
             }),
             vec![
+                Box::new(ChangeSetChild::Components(self.components.clone()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(ChangeSetChild::Schemas(self.schemas.clone()))
                     as Box<dyn NodeChild<NodeType = Self::NodeType>>,
                 Box::new(ChangeSetChild::Funcs(self.funcs.clone()))

--- a/lib/si-pkg/src/node/component.rs
+++ b/lib/si-pkg/src/node/component.rs
@@ -1,0 +1,113 @@
+use std::{
+    io::{BufRead, Write},
+    str::FromStr,
+};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+
+use super::{component_child::ComponentChild, PkgNode, KEY_DELETED_STR};
+use crate::{ComponentSpec, ComponentSpecVariant};
+
+const KEY_NAME_STR: &str = "name";
+const KEY_VARIANT_STR: &str = "variant";
+const KEY_NEEDS_DESTROY_STR: &str = "needs_destroy";
+const KEY_DELETION_USER_PK_STR: &str = "deletion_user_pk";
+
+#[derive(Clone, Debug)]
+pub struct ComponentNode {
+    pub name: String,
+    pub variant: ComponentSpecVariant,
+    pub needs_destroy: bool,
+    pub deletion_user_pk: Option<String>,
+    pub deleted: bool,
+}
+
+impl NameStr for ComponentNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl WriteBytes for ComponentNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_NAME_STR, self.name())?;
+        write_key_value_line(
+            writer,
+            KEY_VARIANT_STR,
+            serde_json::to_string(&self.variant).map_err(GraphError::parse)?,
+        )?;
+        write_key_value_line(writer, KEY_NEEDS_DESTROY_STR, self.needs_destroy)?;
+
+        let deletion_user_pk_str: String = if let Some(deletion_user_pk) = &self.deletion_user_pk {
+            deletion_user_pk.into()
+        } else {
+            "".into()
+        };
+        write_key_value_line(writer, KEY_DELETION_USER_PK_STR, deletion_user_pk_str)?;
+        write_key_value_line(writer, KEY_DELETED_STR, self.deleted)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for ComponentNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let name = read_key_value_line(reader, KEY_NAME_STR)?;
+        let variant_str = read_key_value_line(reader, KEY_VARIANT_STR)?;
+        let variant: ComponentSpecVariant =
+            serde_json::from_str(&variant_str).map_err(GraphError::parse)?;
+        let needs_destroy = bool::from_str(&read_key_value_line(reader, KEY_NEEDS_DESTROY_STR)?)
+            .map_err(GraphError::parse)?;
+
+        let deletion_user_pk_str = read_key_value_line(reader, KEY_DELETION_USER_PK_STR)?;
+        let deletion_user_pk = if deletion_user_pk_str.is_empty() {
+            None
+        } else {
+            Some(deletion_user_pk_str.to_owned())
+        };
+        let deleted = bool::from_str(&read_key_value_line(reader, KEY_DELETED_STR)?)
+            .map_err(GraphError::parse)?;
+
+        Ok(Some(Self {
+            name,
+            variant,
+            needs_destroy,
+            deletion_user_pk,
+            deleted,
+        }))
+    }
+}
+
+impl NodeChild for ComponentSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::Component(ComponentNode {
+                name: self.name.to_owned(),
+                variant: self.variant.to_owned(),
+                needs_destroy: self.needs_destroy,
+                deletion_user_pk: self.deletion_user_pk.to_owned(),
+                deleted: self.deleted,
+            }),
+            vec![
+                Box::new(ComponentChild::Attributes(self.attributes.to_owned()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(ComponentChild::InputSockets(self.input_sockets.to_owned()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(ComponentChild::OutputSockets(
+                    self.output_sockets.to_owned(),
+                )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+                Box::new(ComponentChild::Position(self.position.to_owned()))
+                    as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            ],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/component_child.rs
+++ b/lib/si-pkg/src/node/component_child.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NameStr, NodeChild, NodeKind,
+    NodeWithChildren, ReadBytes, WriteBytes,
+};
+
+use super::PkgNode;
+use crate::{AttributeValueSpec, PositionSpec};
+
+const CHANGE_SET_CHILD_TYPE_ATTRIBUTES: &str = "attributes";
+const CHANGE_SET_CHILD_TYPE_INPUT_SOCKETS: &str = "input_sockets";
+const CHANGE_SET_CHILD_TYPE_OUTPUT_SOCKETS: &str = "output_sockets";
+const CHANGE_SET_CHILD_TYPE_POSITION: &str = "position";
+
+const KEY_KIND_STR: &str = "kind";
+
+#[remain::sorted]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ComponentChild {
+    Attributes(Vec<AttributeValueSpec>),
+    InputSockets(Vec<AttributeValueSpec>),
+    OutputSockets(Vec<AttributeValueSpec>),
+    Position(PositionSpec),
+}
+
+#[remain::sorted]
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum ComponentChildNode {
+    Attributes,
+    InputSockets,
+    OutputSockets,
+    Position,
+}
+
+impl ComponentChildNode {
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Attributes => CHANGE_SET_CHILD_TYPE_ATTRIBUTES,
+            Self::InputSockets => CHANGE_SET_CHILD_TYPE_INPUT_SOCKETS,
+            Self::OutputSockets => CHANGE_SET_CHILD_TYPE_OUTPUT_SOCKETS,
+            Self::Position => CHANGE_SET_CHILD_TYPE_POSITION,
+        }
+    }
+}
+
+impl NameStr for ComponentChildNode {
+    fn name(&self) -> &str {
+        match self {
+            Self::Attributes => CHANGE_SET_CHILD_TYPE_ATTRIBUTES,
+            Self::InputSockets => CHANGE_SET_CHILD_TYPE_INPUT_SOCKETS,
+            Self::OutputSockets => CHANGE_SET_CHILD_TYPE_OUTPUT_SOCKETS,
+            Self::Position => CHANGE_SET_CHILD_TYPE_POSITION,
+        }
+    }
+}
+
+impl WriteBytes for ComponentChildNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_KIND_STR, self.kind_str())?;
+        Ok(())
+    }
+}
+
+impl ReadBytes for ComponentChildNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let kind_str = read_key_value_line(reader, KEY_KIND_STR)?;
+
+        let node = match kind_str.as_str() {
+            CHANGE_SET_CHILD_TYPE_ATTRIBUTES => Self::Attributes,
+            CHANGE_SET_CHILD_TYPE_INPUT_SOCKETS => Self::InputSockets,
+            CHANGE_SET_CHILD_TYPE_OUTPUT_SOCKETS => Self::OutputSockets,
+            CHANGE_SET_CHILD_TYPE_POSITION => Self::Position,
+            invalid_kind => {
+                dbg!(format!(
+                    "invalid change set child node kind: {invalid_kind}"
+                ));
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(node))
+    }
+}
+
+impl NodeChild for ComponentChild {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        match self {
+            Self::Attributes(entries) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::ComponentChild(ComponentChildNode::Attributes),
+                entries
+                    .iter()
+                    .map(|attr| {
+                        Box::new(attr.to_owned()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::InputSockets(entries) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::ComponentChild(ComponentChildNode::InputSockets),
+                entries
+                    .iter()
+                    .map(|input| {
+                        Box::new(input.to_owned()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::OutputSockets(entries) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::ComponentChild(ComponentChildNode::OutputSockets),
+                entries
+                    .iter()
+                    .map(|output| {
+                        Box::new(output.to_owned()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::Position(position) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::ComponentChild(ComponentChildNode::Position),
+                vec![Box::new(position.to_owned()) as Box<dyn NodeChild<NodeType = Self::NodeType>>],
+            ),
+        }
+    }
+}

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -10,14 +10,19 @@ use object_tree::{
 
 mod action_func;
 mod attr_func_input;
+mod attribute_value;
+mod attribute_value_child;
 mod category;
 mod change_set;
 mod change_set_child;
+mod component;
+mod component_child;
 mod func;
 mod func_argument;
 mod leaf_function;
 mod map_key_func;
 mod package;
+mod position;
 mod prop;
 mod prop_child;
 mod schema;
@@ -30,14 +35,19 @@ mod validation;
 pub(crate) use self::{
     action_func::ActionFuncNode,
     attr_func_input::AttrFuncInputNode,
+    attribute_value::AttributeValueNode,
+    attribute_value_child::AttributeValueChildNode,
     category::CategoryNode,
     change_set::ChangeSetNode,
     change_set_child::{ChangeSetChild, ChangeSetChildNode},
+    component::ComponentNode,
+    component_child::ComponentChildNode,
     func::FuncNode,
     func_argument::FuncArgumentNode,
     leaf_function::LeafFunctionNode,
     map_key_func::MapKeyFuncNode,
     package::PackageNode,
+    position::PositionNode,
     prop::{PropNode, PropNodeData},
     prop_child::PropChildNode,
     schema::SchemaNode,
@@ -49,22 +59,27 @@ pub(crate) use self::{
 };
 
 const NODE_KIND_ACTION_FUNC: &str = "action_func";
+const NODE_KIND_ATTRIBUTE_VALUE: &str = "attribute_value";
+const NODE_KIND_ATTRIBUTE_VALUE_CHILD: &str = "attribute_value_child";
 const NODE_KIND_ATTR_FUNC_INPUT: &str = "attr_func_input";
 const NODE_KIND_CATEGORY: &str = "category";
 const NODE_KIND_CHANGE_SET: &str = "change_set";
 const NODE_KIND_CHANGE_SET_CHILD: &str = "change_set_child";
+const NODE_KIND_COMPONENT: &str = "component";
+const NODE_KIND_COMPONENT_CHILD: &str = "component_child";
 const NODE_KIND_FUNC: &str = "func";
 const NODE_KIND_FUNC_ARGUMENT: &str = "func_argument";
 const NODE_KIND_LEAF_FUNCTION: &str = "leaf_function";
 const NODE_KIND_MAP_KEY_FUNC: &str = "map_key_func";
 const NODE_KIND_PACKAGE: &str = "package";
+const NODE_KIND_POSITION: &str = "position";
 const NODE_KIND_PROP: &str = "prop";
 const NODE_KIND_PROP_CHILD: &str = "prop_child";
 const NODE_KIND_SCHEMA: &str = "schema";
 const NODE_KIND_SCHEMA_VARIANT: &str = "schema_variant";
 const NODE_KIND_SCHEMA_VARIANT_CHILD: &str = "schema_variant_child";
-const NODE_KIND_SOCKET: &str = "socket";
 const NODE_KIND_SI_PROP_FUNC: &str = "si_prop_func";
+const NODE_KIND_SOCKET: &str = "socket";
 const NODE_KIND_VALIDATION: &str = "validation";
 
 const KEY_NODE_KIND_STR: &str = "node_kind";
@@ -115,14 +130,19 @@ fn write_common_fields<W: Write>(
 pub enum PkgNode {
     ActionFunc(ActionFuncNode),
     AttrFuncInput(AttrFuncInputNode),
+    AttributeValue(AttributeValueNode),
+    AttributeValueChild(AttributeValueChildNode),
     Category(CategoryNode),
     ChangeSet(ChangeSetNode),
     ChangeSetChild(ChangeSetChildNode),
+    Component(ComponentNode),
+    ComponentChild(ComponentChildNode),
     Func(FuncNode),
     FuncArgument(FuncArgumentNode),
     LeafFunction(LeafFunctionNode),
     MapKeyFunc(MapKeyFuncNode),
     Package(PackageNode),
+    Position(PositionNode),
     Prop(PropNode),
     PropChild(PropChildNode),
     Schema(SchemaNode),
@@ -136,9 +156,13 @@ pub enum PkgNode {
 impl PkgNode {
     pub const ACTION_FUNC_KIND_STR: &str = NODE_KIND_ACTION_FUNC;
     pub const ATTR_FUNC_INPUT_KIND_STR: &str = NODE_KIND_ATTR_FUNC_INPUT;
+    pub const ATTRIBUTE_VALUE_KIND_STR: &str = NODE_KIND_ATTRIBUTE_VALUE;
+    pub const ATTRIBUTE_VALUE_CHILD_KIND_STR: &str = NODE_KIND_ATTRIBUTE_VALUE_CHILD;
     pub const CATEGORY_KIND_STR: &str = NODE_KIND_CATEGORY;
     pub const CHANGE_SET_KIND_STR: &str = NODE_KIND_CHANGE_SET;
     pub const CHANGE_SET_CHILD_KIND_STR: &str = NODE_KIND_CHANGE_SET_CHILD;
+    pub const COMPONENT_KIND_STR: &str = NODE_KIND_COMPONENT;
+    pub const COMPONENT_CHILD_KIND_STR: &str = NODE_KIND_COMPONENT_CHILD;
     pub const FUNC_KIND_STR: &str = NODE_KIND_FUNC;
     pub const FUNC_ARGUMENT_KIND_STR: &str = NODE_KIND_FUNC_ARGUMENT;
     pub const LEAF_FUNCTION_KIND_STR: &str = NODE_KIND_LEAF_FUNCTION;
@@ -155,23 +179,28 @@ impl PkgNode {
 
     pub fn node_kind_str(&self) -> &'static str {
         match self {
+            Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
             Self::AttrFuncInput(_) => NODE_KIND_ATTR_FUNC_INPUT,
+            Self::AttributeValue(_) => NODE_KIND_ATTRIBUTE_VALUE,
+            Self::AttributeValueChild(_) => NODE_KIND_ATTRIBUTE_VALUE_CHILD,
             Self::Category(_) => NODE_KIND_CATEGORY,
             Self::ChangeSet(_) => NODE_KIND_CHANGE_SET,
             Self::ChangeSetChild(_) => NODE_KIND_CHANGE_SET_CHILD,
-            Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
+            Self::Component(_) => NODE_KIND_COMPONENT,
+            Self::ComponentChild(_) => NODE_KIND_COMPONENT_CHILD,
             Self::Func(_) => NODE_KIND_FUNC,
             Self::FuncArgument(_) => NODE_KIND_FUNC_ARGUMENT,
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
             Self::MapKeyFunc(_) => NODE_KIND_MAP_KEY_FUNC,
             Self::Package(_) => NODE_KIND_PACKAGE,
+            Self::Position(_) => NODE_KIND_POSITION,
             Self::Prop(_) => NODE_KIND_PROP,
             Self::PropChild(_) => NODE_KIND_PROP_CHILD,
             Self::Schema(_) => NODE_KIND_SCHEMA,
             Self::SchemaVariant(_) => NODE_KIND_SCHEMA_VARIANT,
             Self::SchemaVariantChild(_) => NODE_KIND_SCHEMA_VARIANT_CHILD,
-            Self::Socket(_) => NODE_KIND_SOCKET,
             Self::SiPropFunc(_) => NODE_KIND_SI_PROP_FUNC,
+            Self::Socket(_) => NODE_KIND_SOCKET,
             Self::Validation(_) => NODE_KIND_VALIDATION,
         }
     }
@@ -180,23 +209,28 @@ impl PkgNode {
 impl NameStr for PkgNode {
     fn name(&self) -> &str {
         match self {
+            Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
             Self::AttrFuncInput(node) => node.name(),
+            Self::AttributeValue(_) => NODE_KIND_ATTRIBUTE_VALUE,
+            Self::AttributeValueChild(node) => node.name(),
             Self::Category(node) => node.name(),
             Self::ChangeSet(node) => node.name(),
             Self::ChangeSetChild(node) => node.name(),
-            Self::ActionFunc(_) => NODE_KIND_ACTION_FUNC,
+            Self::Component(node) => node.name(),
+            Self::ComponentChild(node) => node.name(),
             Self::Func(node) => node.name(),
             Self::FuncArgument(node) => node.name(),
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
             Self::MapKeyFunc(_) => NODE_KIND_MAP_KEY_FUNC,
             Self::Package(node) => node.name(),
+            Self::Position(_) => NODE_KIND_POSITION,
             Self::Prop(node) => node.name(),
             Self::PropChild(node) => node.name(),
             Self::Schema(node) => node.name(),
             Self::SchemaVariant(node) => node.name(),
             Self::SchemaVariantChild(node) => node.name(),
-            Self::Socket(node) => node.name(),
             Self::SiPropFunc(_) => NODE_KIND_SI_PROP_FUNC,
+            Self::Socket(node) => node.name(),
             Self::Validation(_) => NODE_KIND_VALIDATION,
         }
     }
@@ -207,23 +241,28 @@ impl WriteBytes for PkgNode {
         write_key_value_line(writer, KEY_NODE_KIND_STR, self.node_kind_str())?;
 
         match self {
+            Self::ActionFunc(node) => node.write_bytes(writer)?,
             Self::AttrFuncInput(node) => node.write_bytes(writer)?,
+            Self::AttributeValue(node) => node.write_bytes(writer)?,
+            Self::AttributeValueChild(node) => node.write_bytes(writer)?,
             Self::Category(node) => node.write_bytes(writer)?,
             Self::ChangeSet(node) => node.write_bytes(writer)?,
             Self::ChangeSetChild(node) => node.write_bytes(writer)?,
-            Self::ActionFunc(node) => node.write_bytes(writer)?,
+            Self::Component(node) => node.write_bytes(writer)?,
+            Self::ComponentChild(node) => node.write_bytes(writer)?,
             Self::Func(node) => node.write_bytes(writer)?,
             Self::FuncArgument(node) => node.write_bytes(writer)?,
             Self::LeafFunction(node) => node.write_bytes(writer)?,
             Self::MapKeyFunc(node) => node.write_bytes(writer)?,
             Self::Package(node) => node.write_bytes(writer)?,
+            Self::Position(node) => node.write_bytes(writer)?,
             Self::Prop(node) => node.write_bytes(writer)?,
             Self::PropChild(node) => node.write_bytes(writer)?,
             Self::Schema(node) => node.write_bytes(writer)?,
             Self::SchemaVariant(node) => node.write_bytes(writer)?,
             Self::SchemaVariantChild(node) => node.write_bytes(writer)?,
-            Self::Socket(node) => node.write_bytes(writer)?,
             Self::SiPropFunc(node) => node.write_bytes(writer)?,
+            Self::Socket(node) => node.write_bytes(writer)?,
             Self::Validation(node) => node.write_bytes(writer)?,
         };
 
@@ -243,10 +282,20 @@ impl ReadBytes for PkgNode {
             NODE_KIND_ATTR_FUNC_INPUT => {
                 AttrFuncInputNode::read_bytes(reader)?.map(Self::AttrFuncInput)
             }
+            NODE_KIND_ATTRIBUTE_VALUE => {
+                AttributeValueNode::read_bytes(reader)?.map(Self::AttributeValue)
+            }
+            NODE_KIND_ATTRIBUTE_VALUE_CHILD => {
+                AttributeValueChildNode::read_bytes(reader)?.map(Self::AttributeValueChild)
+            }
             NODE_KIND_CATEGORY => CategoryNode::read_bytes(reader)?.map(Self::Category),
             NODE_KIND_CHANGE_SET => ChangeSetNode::read_bytes(reader)?.map(Self::ChangeSet),
             NODE_KIND_CHANGE_SET_CHILD => {
                 ChangeSetChildNode::read_bytes(reader)?.map(Self::ChangeSetChild)
+            }
+            NODE_KIND_COMPONENT => ComponentNode::read_bytes(reader)?.map(Self::Component),
+            NODE_KIND_COMPONENT_CHILD => {
+                ComponentChildNode::read_bytes(reader)?.map(Self::ComponentChild)
             }
             NODE_KIND_FUNC => FuncNode::read_bytes(reader)?.map(Self::Func),
             NODE_KIND_FUNC_ARGUMENT => {
@@ -257,6 +306,7 @@ impl ReadBytes for PkgNode {
             }
             NODE_KIND_MAP_KEY_FUNC => MapKeyFuncNode::read_bytes(reader)?.map(Self::MapKeyFunc),
             NODE_KIND_PACKAGE => PackageNode::read_bytes(reader)?.map(Self::Package),
+            NODE_KIND_POSITION => PositionNode::read_bytes(reader)?.map(Self::Position),
             NODE_KIND_PROP => PropNode::read_bytes(reader)?.map(Self::Prop),
             NODE_KIND_PROP_CHILD => PropChildNode::read_bytes(reader)?.map(Self::PropChild),
             NODE_KIND_SCHEMA => SchemaNode::read_bytes(reader)?.map(Self::Schema),

--- a/lib/si-pkg/src/node/position.rs
+++ b/lib/si-pkg/src/node/position.rs
@@ -1,0 +1,69 @@
+use std::io::{BufRead, Write};
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
+};
+
+use super::PkgNode;
+use crate::spec::PositionSpec;
+
+const KEY_X_STR: &str = "x";
+const KEY_Y_STR: &str = "y";
+const KEY_WIDTH_STR: &str = "width";
+const KEY_HEIGHT_STR: &str = "height";
+
+#[derive(Clone, Debug)]
+pub struct PositionNode {
+    pub x: String,
+    pub y: String,
+    pub width: String,
+    pub height: String,
+}
+
+impl WriteBytes for PositionNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_X_STR, &self.x)?;
+        write_key_value_line(writer, KEY_Y_STR, &self.y)?;
+        write_key_value_line(writer, KEY_WIDTH_STR, &self.width)?;
+        write_key_value_line(writer, KEY_HEIGHT_STR, &self.height)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for PositionNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let x = read_key_value_line(reader, KEY_X_STR)?;
+        let y = read_key_value_line(reader, KEY_Y_STR)?;
+        let width = read_key_value_line(reader, KEY_WIDTH_STR)?;
+        let height = read_key_value_line(reader, KEY_HEIGHT_STR)?;
+
+        Ok(Some(Self {
+            x,
+            y,
+            width,
+            height,
+        }))
+    }
+}
+
+impl NodeChild for PositionSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Leaf,
+            Self::NodeType::Position(PositionNode {
+                x: self.x.to_owned(),
+                y: self.y.to_owned(),
+                width: self.width.to_owned(),
+                height: self.height.to_owned(),
+            }),
+            vec![],
+        )
+    }
+}

--- a/lib/si-pkg/src/pkg/func.rs
+++ b/lib/si-pkg/src/pkg/func.rs
@@ -151,6 +151,7 @@ pub struct SiPkgFunc<'a> {
     data: Option<SiPkgFuncData>,
     unique_id: String,
     deleted: bool,
+    is_from_builtin: Option<bool>,
 
     hash: Hash,
     source: Source<'a>,
@@ -188,6 +189,7 @@ impl<'a> SiPkgFunc<'a> {
             hash: func_hashed_node.hash(),
             unique_id: func_node.unique_id,
             deleted: func_node.deleted,
+            is_from_builtin: func_node.is_from_builtin,
             source: Source::new(graph, node_idx),
         })
     }
@@ -256,6 +258,10 @@ impl<'a> SiPkgFunc<'a> {
             None => None,
             Some(data) => data.link.as_ref(),
         }
+    }
+
+    pub fn is_from_builtin(&self) -> Option<bool> {
+        self.is_from_builtin
     }
 
     pub fn hash(&self) -> Hash {

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -5,10 +5,13 @@ use thiserror::Error;
 
 mod action_func;
 mod attr_func_input;
+mod attribute_value;
 mod change_set;
+mod component;
 mod func;
 mod leaf_function;
 mod map_key_func;
+mod position;
 mod prop;
 mod schema;
 mod si_prop_func;
@@ -17,8 +20,9 @@ mod validation;
 mod variant;
 
 pub use {
-    action_func::*, attr_func_input::*, change_set::*, func::*, leaf_function::*, map_key_func::*,
-    prop::*, schema::*, si_prop_func::*, socket::*, validation::*, variant::*,
+    action_func::*, attr_func_input::*, attribute_value::*, change_set::*, component::*, func::*,
+    leaf_function::*, map_key_func::*, position::*, prop::*, schema::*, si_prop_func::*, socket::*,
+    validation::*, variant::*,
 };
 
 use super::SiPkgKind;

--- a/lib/si-pkg/src/spec/attribute_value.rs
+++ b/lib/si-pkg/src/spec/attribute_value.rs
@@ -1,0 +1,59 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    func::{FuncSpecBackendKind, FuncSpecBackendResponseType},
+    AttrFuncInputSpec, SpecError,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AttributeValuePath {
+    Prop(String),
+    InputSocket(String),
+    OutputSocket(String),
+}
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct AttributeValueSpec {
+    #[builder(setter(into, strip_option), default)]
+    pub parent_path: Option<AttributeValuePath>,
+    #[builder(setter(into))]
+    pub path: AttributeValuePath,
+    #[builder(setter(into))]
+    pub func_unique_id: String,
+    #[builder(setter(into))]
+    pub func_binding_args: serde_json::Value,
+    #[builder(setter(into, strip_option), default)]
+    pub key: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    pub handler: Option<String>,
+    #[builder(setter(into))]
+    pub backend_kind: FuncSpecBackendKind,
+    #[builder(setter(into))]
+    pub reponse_type: FuncSpecBackendResponseType,
+    #[builder(setter(into, strip_option), default)]
+    pub code_base64: Option<String>,
+    #[builder(setter(into, strip_option), default)]
+    pub unprocessed_value: Option<serde_json::Value>,
+    #[builder(setter(into, strip_option), default)]
+    pub value: Option<serde_json::Value>,
+    #[builder(setter(into, strip_option), default)]
+    pub output_stream: Option<serde_json::Value>,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub sealed_proxy: bool,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub component_specific: bool,
+    #[builder(setter(each = "input"), default)]
+    pub inputs: Vec<AttrFuncInputSpec>,
+}
+
+impl AttributeValueSpec {
+    pub fn builder() -> AttributeValueSpecBuilder {
+        AttributeValueSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/change_set.rs
+++ b/lib/si-pkg/src/spec/change_set.rs
@@ -1,4 +1,4 @@
-use super::{FuncSpec, SchemaSpec, SpecError};
+use super::{ComponentSpec, FuncSpec, SchemaSpec, SpecError};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
@@ -25,6 +25,10 @@ pub struct ChangeSetSpec {
 
     #[builder(setter(into), default = "ChangeSetSpecStatus::Open")]
     pub status: ChangeSetSpecStatus,
+
+    #[builder(setter(each(name = "component", into)), default)]
+    #[serde(default)]
+    pub components: Vec<ComponentSpec>,
 
     #[builder(setter(each(name = "schema", into)), default)]
     #[serde(default)]

--- a/lib/si-pkg/src/spec/component.rs
+++ b/lib/si-pkg/src/spec/component.rs
@@ -1,0 +1,51 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use super::SpecError;
+use super::{attribute_value::AttributeValueSpec, position::PositionSpec};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ComponentSpecVariant {
+    BuiltinVariant {
+        schema_name: String,
+        variant_name: String,
+        //        hash: String,
+    },
+    WorkspaceVariant {
+        variant_unique_id: String,
+    },
+}
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct ComponentSpec {
+    #[builder(setter(into))]
+    pub name: String,
+    #[builder(setter(into))]
+    pub position: PositionSpec,
+    #[builder(setter(into))]
+    pub variant: ComponentSpecVariant,
+    #[builder(setter(into), default)]
+    pub needs_destroy: bool,
+    #[builder(setter(into, strip_option), default)]
+    pub deletion_user_pk: Option<String>,
+    #[builder(setter(into), default)]
+    pub deleted: bool,
+
+    #[builder(setter(each(name = "attribute"), into), default)]
+    pub attributes: Vec<AttributeValueSpec>,
+
+    #[builder(setter(each(name = "input_socket"), into), default)]
+    pub input_sockets: Vec<AttributeValueSpec>,
+
+    #[builder(setter(each(name = "output_socket"), into), default)]
+    pub output_sockets: Vec<AttributeValueSpec>,
+}
+
+impl ComponentSpec {
+    pub fn builder() -> ComponentSpecBuilder {
+        ComponentSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/func.rs
+++ b/lib/si-pkg/src/spec/func.rs
@@ -158,6 +158,9 @@ pub struct FuncSpec {
     #[builder(setter(into), default)]
     #[serde(default)]
     pub deleted: bool,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub is_from_builtin: Option<bool>,
 
     #[builder(setter(each(name = "argument"), into), default)]
     pub arguments: Vec<FuncArgumentSpec>,

--- a/lib/si-pkg/src/spec/position.rs
+++ b/lib/si-pkg/src/spec/position.rs
@@ -1,0 +1,25 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use super::SpecError;
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct PositionSpec {
+    #[builder(setter(into))]
+    pub x: String,
+    #[builder(setter(into))]
+    pub y: String,
+    #[builder(setter(into))]
+    pub width: String,
+    #[builder(setter(into))]
+    pub height: String,
+}
+
+impl PositionSpec {
+    #[must_use]
+    pub fn builder() -> PositionSpecBuilder {
+        PositionSpecBuilder::default()
+    }
+}


### PR DESCRIPTION
Adds the ability to export a component in a change set as a bag of attribute values. Disabled by default because the structure might change as import is implemented.

Also adds some more detail to the component debug view, and makes it prettier.