### PR TITLE
fix(sdf-server): add missing content-type headers

### DIFF
--- a/lib/sdf-server/src/server/service/diagram/connect_component_to_frame.rs
+++ b/lib/sdf-server/src/server/service/diagram/connect_component_to_frame.rs
@@ -318,9 +318,9 @@ pub async fn connect_component_to_frame(
     if let Some(force_changeset_pk) = force_changeset_pk {
         response = response.header("force_changeset_pk", force_changeset_pk.to_string());
     }
-    Ok(
-        response.body(serde_json::to_string(&CreateFrameConnectionResponse {
+    Ok(response
+        .header("content-type", "application/json")
+        .body(serde_json::to_string(&CreateFrameConnectionResponse {
             connection,
-        })?)?,
-    )
+        })?)?)
 }

--- a/lib/sdf-server/src/server/service/diagram/create_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_connection.rs
@@ -157,9 +157,9 @@ pub async fn create_connection(
     if let Some(force_changeset_pk) = force_changeset_pk {
         response = response.header("force_changeset_pk", force_changeset_pk.to_string());
     }
-    Ok(
-        response.body(serde_json::to_string(&CreateConnectionResponse {
+    Ok(response
+        .header("content-type", "application/json")
+        .body(serde_json::to_string(&CreateConnectionResponse {
             connection,
-        })?)?,
-    )
+        })?)?)
 }


### PR DESCRIPTION
Two sdf endpoints were still missing application/json content-types