### PR TITLE
feat: add migration of built-in functions from module index

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -527,6 +527,7 @@ async fn global_setup(test_context_builer: TestContextBuilder) -> Result<()> {
     let selected_test_builtin_schemas = determine_selected_test_builtin_schemas();
 
     info!("creating builtins");
+    // TODO: @stack72 - remove this code path and install these from the module-index??
     dal::migrate_builtins(
         services_ctx.pg_pool(),
         services_ctx.nats_conn(),

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 // Private builtins modules.
-mod func;
+pub mod func;
 pub mod schema;
 
 pub const SI_AWS_PKG: &str = "si-aws-2023-09-13.sipkg";

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -216,25 +216,14 @@ pub type ModelResult<T> = Result<T, ModelError>;
 #[instrument(skip_all)]
 pub async fn migrate_all(
     pg: &PgPool,
-    nats: &NatsClient,
-    job_processor: Box<dyn JobQueueProcessor + Send + Sync>,
-    veritech: Client,
-    encryption_key: &EncryptionKey,
-    pkgs_path: PathBuf,
-    module_index_url: String,
+    _nats: &NatsClient,
+    _job_processor: Box<dyn JobQueueProcessor + Send + Sync>,
+    _veritech: Client,
+    _encryption_key: &EncryptionKey,
+    _pkgs_path: PathBuf,
+    _module_index_url: String,
 ) -> ModelResult<()> {
     migrate(pg).await?;
-    migrate_builtins(
-        pg,
-        nats,
-        job_processor,
-        veritech,
-        encryption_key,
-        None,
-        pkgs_path,
-        module_index_url,
-    )
-    .await?;
     Ok(())
 }
 

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -159,6 +159,7 @@ pub async fn exec_variant_def(
                 asset_func.clone(),
             )])),
             no_record: true,
+            is_builtin: false,
         }),
     )
     .await?;


### PR DESCRIPTION
This commit adds support for migrating built-in functions from a module index. The `migrate_builtins_from_module_index` function is introduced, which takes in the necessary dependencies such as the PostgreSQL pool, Nats client, job processor, Veritech client, encryption key, package path, and module index URL.

The function starts by creating a context with the provided dependencies and initializing a workspace. It then updates the tenancy and commits the changes. Next, it migrates the intrinsic functions using the `migrate_intrinsics` function from the `builtins::func` module.

After that, it retrieves the list of built-in modules from the module index and starts installing each module in parallel using the `install_builtins` function. The installation process is executed in a spawned tokio::spawn loop. Once all modules are installed successfully, the migration is considered completed and SDF starts up as normal