### PR TITLE
Introduce VectorClockId and use it in rebaser-server

### DIFF
--- a/lib/dal/src/change_set_pointer.rs
+++ b/lib/dal/src/change_set_pointer.rs
@@ -9,6 +9,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::{Generator, Ulid};
 
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::workspace_snapshot::WorkspaceSnapshotId;
 use crate::{pk, DalContext, TransactionsError};
 
@@ -86,6 +87,12 @@ impl ChangeSetPointer {
             )
             .await?;
         Ok(Self::try_from(row)?)
+    }
+
+    /// Create a [`VectorClockId`] from the [`ChangeSetPointer`].
+    pub fn vector_clock_id(&self) -> VectorClockId {
+        let ulid: Ulid = self.id.into();
+        VectorClockId::from(ulid)
     }
 
     pub fn generate_ulid(&self) -> ChangeSetPointerResult<Ulid> {

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -43,6 +43,7 @@ use crate::workspace_snapshot::conflict::Conflict;
 use crate::workspace_snapshot::edge_weight::EdgeWeight;
 use crate::workspace_snapshot::node_weight::NodeWeight;
 use crate::workspace_snapshot::update::Update;
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
     pk,
     workspace_snapshot::{graph::WorkspaceSnapshotGraphError, node_weight::NodeWeightError},
@@ -172,16 +173,15 @@ impl WorkspaceSnapshot {
     }
 
     pub async fn detect_conflicts_and_updates(
-        &self,
-        ctx: &DalContext,
-        to_rebase_change_set: &ChangeSetPointer,
-        onto_change_set: &ChangeSetPointer,
+        &mut self,
+        to_rebase_vector_clock_id: VectorClockId,
+        onto_workspace_snapshot: &WorkspaceSnapshot,
+        onto_vector_clock_id: VectorClockId,
     ) -> WorkspaceSnapshotResult<(Vec<Conflict>, Vec<Update>)> {
-        let onto: WorkspaceSnapshot = Self::find_for_change_set(ctx, onto_change_set.id).await?;
-        Ok(self.snapshot()?.detect_conflicts_and_updates(
-            to_rebase_change_set,
-            &onto.snapshot()?,
-            onto_change_set,
+        Ok(self.working_copy()?.detect_conflicts_and_updates(
+            to_rebase_vector_clock_id,
+            &onto_workspace_snapshot.snapshot()?,
+            onto_vector_clock_id,
         )?)
     }
 

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -52,7 +52,7 @@ impl EdgeWeight {
         &mut self,
         change_set: &ChangeSetPointer,
     ) -> EdgeWeightResult<()> {
-        self.vector_clock_write.inc(change_set)?;
+        self.vector_clock_write.inc(change_set.vector_clock_id())?;
 
         Ok(())
     }
@@ -62,16 +62,21 @@ impl EdgeWeight {
     }
 
     pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
-        if self.vector_clock_first_seen.entry_for(change_set).is_none() {
-            self.vector_clock_first_seen.inc_to(change_set, seen_at);
+        if self
+            .vector_clock_first_seen
+            .entry_for(change_set.vector_clock_id())
+            .is_none()
+        {
+            self.vector_clock_first_seen
+                .inc_to(change_set.vector_clock_id(), seen_at);
         }
     }
 
     pub fn new(change_set: &ChangeSetPointer, kind: EdgeWeightKind) -> EdgeWeightResult<Self> {
         Ok(Self {
             kind,
-            vector_clock_first_seen: VectorClock::new(change_set)?,
-            vector_clock_write: VectorClock::new(change_set)?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
         })
     }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -50,9 +50,9 @@ impl ContentNodeWeight {
             lineage_id: change_set.generate_ulid()?,
             content_address,
             merkle_tree_hash: ContentHash::default(),
-            vector_clock_first_seen: VectorClock::new(change_set)?,
-            vector_clock_recently_seen: VectorClock::new(change_set)?,
-            vector_clock_write: VectorClock::new(change_set)?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
         })
     }
 
@@ -72,8 +72,9 @@ impl ContentNodeWeight {
         &mut self,
         change_set: &ChangeSetPointer,
     ) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set)?;
-        self.vector_clock_recently_seen.inc(change_set)?;
+        self.vector_clock_write.inc(change_set.vector_clock_id())?;
+        self.vector_clock_recently_seen
+            .inc(change_set.vector_clock_id())?;
 
         Ok(())
     }
@@ -84,9 +85,14 @@ impl ContentNodeWeight {
 
     pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
         self.vector_clock_recently_seen
-            .inc_to(change_set, seen_at.clone());
-        if self.vector_clock_first_seen.entry_for(change_set).is_none() {
-            self.vector_clock_first_seen.inc_to(change_set, seen_at);
+            .inc_to(change_set.vector_clock_id(), seen_at.clone());
+        if self
+            .vector_clock_first_seen
+            .entry_for(change_set.vector_clock_id())
+            .is_none()
+        {
+            self.vector_clock_first_seen
+                .inc_to(change_set.vector_clock_id(), seen_at);
         }
     }
 
@@ -96,11 +102,13 @@ impl ContentNodeWeight {
         other: &Self,
     ) -> NodeWeightResult<()> {
         self.vector_clock_write
-            .merge(change_set, &other.vector_clock_write)?;
+            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set, &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen
-            .merge(change_set, &other.vector_clock_recently_seen)?;
+            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen.merge(
+            change_set.vector_clock_id(),
+            &other.vector_clock_recently_seen,
+        )?;
 
         Ok(())
     }
@@ -159,7 +167,8 @@ impl ContentNodeWeight {
         change_set: &ChangeSetPointer,
         new_val: DateTime<Utc>,
     ) {
-        self.vector_clock_recently_seen.inc_to(change_set, new_val);
+        self.vector_clock_recently_seen
+            .inc_to(change_set.vector_clock_id(), new_val);
     }
 
     pub fn vector_clock_first_seen(&self) -> &VectorClock {

--- a/lib/dal/src/workspace_snapshot/vector_clock.rs
+++ b/lib/dal/src/workspace_snapshot/vector_clock.rs
@@ -6,10 +6,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::workspace_snapshot::{
-    lamport_clock::{LamportClock, LamportClockError},
-    {ChangeSetPointer, ChangeSetPointerId},
-};
+use crate::pk;
+use crate::workspace_snapshot::lamport_clock::{LamportClock, LamportClockError};
 
 #[derive(Debug, Error)]
 pub enum VectorClockError {
@@ -19,74 +17,78 @@ pub enum VectorClockError {
 
 pub type VectorClockResult<T> = Result<T, VectorClockError>;
 
+pk!(VectorClockId);
+
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct VectorClock {
-    entries: HashMap<ChangeSetPointerId, LamportClock>,
+    entries: HashMap<VectorClockId, LamportClock>,
 }
 
 impl VectorClock {
-    /// Create a new [`VectorClock`] with an entry for [`ChangeSetPointer`].
-    pub fn new(change_set: &ChangeSetPointer) -> VectorClockResult<VectorClock> {
+    /// Create a new [`VectorClock`] with an entry for [`VectorClockId`].
+    pub fn new(vector_clock_id: VectorClockId) -> VectorClockResult<VectorClock> {
         let lamport_clock = LamportClock::new()?;
         let mut entries = HashMap::new();
-        entries.insert(change_set.id, lamport_clock);
+        entries.insert(vector_clock_id, lamport_clock);
 
         Ok(VectorClock { entries })
     }
 
-    pub fn entry_for(&self, change_set: &ChangeSetPointer) -> Option<LamportClock> {
-        self.entries.get(&change_set.id).copied()
+    pub fn entry_for(&self, vector_clock_id: VectorClockId) -> Option<LamportClock> {
+        self.entries.get(&vector_clock_id).copied()
     }
 
     pub fn has_entries_newer_than(&self, clock_stamp: LamportClock) -> bool {
         self.entries.values().any(|v| *v > clock_stamp)
     }
 
-    pub fn inc_to(&mut self, change_set: &ChangeSetPointer, new_clock_value: DateTime<Utc>) {
-        if let Some(lamport_clock) = self.entries.get_mut(&change_set.id) {
+    pub fn inc_to(&mut self, vector_clock_id: VectorClockId, new_clock_value: DateTime<Utc>) {
+        if let Some(lamport_clock) = self.entries.get_mut(&vector_clock_id) {
             lamport_clock.inc_to(new_clock_value);
         } else {
-            self.entries
-                .insert(change_set.id, LamportClock::new_with_value(new_clock_value));
+            self.entries.insert(
+                vector_clock_id,
+                LamportClock::new_with_value(new_clock_value),
+            );
         }
     }
 
-    /// Increment the entry for [`ChangeSetPointer`], adding one if there wasn't one already.
-    pub fn inc(&mut self, change_set: &ChangeSetPointer) -> VectorClockResult<()> {
-        if let Some(lamport_clock) = self.entries.get_mut(&change_set.id) {
+    /// Increment the entry for [`VectorClockId`], adding one if there wasn't one already.
+    pub fn inc(&mut self, vector_clock_id: VectorClockId) -> VectorClockResult<()> {
+        if let Some(lamport_clock) = self.entries.get_mut(&vector_clock_id) {
             lamport_clock.inc()?;
         } else {
-            self.entries.insert(change_set.id, LamportClock::new()?);
+            self.entries.insert(vector_clock_id, LamportClock::new()?);
         }
 
         Ok(())
     }
 
     /// Add all entries in `other` to `self`, taking the most recent value if the entry already
-    /// exists in `self`, then increment the entry for [`ChangeSetPointer`] (adding one if it is not
+    /// exists in `self`, then increment the entry for [`VectorClockId`] (adding one if it is not
     /// already there).
     pub fn merge(
         &mut self,
-        change_set: &ChangeSetPointer,
+        vector_clock_id: VectorClockId,
         other: &VectorClock,
     ) -> VectorClockResult<()> {
-        for (other_change_set_id, other_lamport_clock) in other.entries.iter() {
-            if let Some(lamport_clock) = self.entries.get_mut(other_change_set_id) {
+        for (other_vector_clock_id, other_lamport_clock) in other.entries.iter() {
+            if let Some(lamport_clock) = self.entries.get_mut(other_vector_clock_id) {
                 lamport_clock.merge(other_lamport_clock);
             } else {
                 self.entries
-                    .insert(*other_change_set_id, *other_lamport_clock);
+                    .insert(*other_vector_clock_id, *other_lamport_clock);
             }
         }
-        self.inc(change_set)?;
+        self.inc(vector_clock_id)?;
 
         Ok(())
     }
 
-    /// Return a new [`VectorClock`] with the entry for [`ChangeSetPointer`] incremented.
-    pub fn fork(&self, change_set: &ChangeSetPointer) -> VectorClockResult<VectorClock> {
+    /// Return a new [`VectorClock`] with the entry for [`VectorClockId`] incremented.
+    pub fn fork(&self, vector_clock_id: VectorClockId) -> VectorClockResult<VectorClock> {
         let mut forked = self.clone();
-        forked.inc(change_set)?;
+        forked.inc(vector_clock_id)?;
 
         Ok(forked)
     }
@@ -95,8 +97,8 @@ impl VectorClock {
     /// `self`, meaning that `self` has already seen/incorporated all of the information
     /// in `other`.
     pub fn is_newer_than(&self, other: &VectorClock) -> bool {
-        for (other_change_set_id, other_lamport_clock) in &other.entries {
-            if let Some(my_clock) = self.entries.get(other_change_set_id) {
+        for (other_vector_clock_id, other_lamport_clock) in &other.entries {
+            if let Some(my_clock) = self.entries.get(other_vector_clock_id) {
                 if other_lamport_clock > my_clock {
                     return false;
                 }

--- a/lib/rebaser-client/src/client.rs
+++ b/lib/rebaser-client/src/client.rs
@@ -81,9 +81,10 @@ impl Client {
             .producer
             .send_single(
                 ChangeSetMessage {
-                    change_set_to_update,
-                    workspace_snapshot_to_rebase_on_top_of_current_snapshot_being_pointed_at,
-                    change_set_that_dictates_changes,
+                    to_rebase_vector_clock_id: change_set_to_update,
+                    to_rebase_workspace_snapshot_id:
+                        workspace_snapshot_to_rebase_on_top_of_current_snapshot_being_pointed_at,
+                    onto_change_set_id: change_set_that_dictates_changes,
                 },
                 Some(stream.reply_stream.clone()),
             )

--- a/lib/rebaser-core/src/lib.rs
+++ b/lib/rebaser-core/src/lib.rs
@@ -55,13 +55,14 @@ pub struct ManagementMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChangeSetMessage {
     /// Corresponds to the change set whose pointer is to be updated.
-    pub change_set_to_update: Ulid,
-    /// Corresponds to the workspace snapshot that will be rebased on top of the snapshot that the
-    /// change set is currently pointing at.
-    pub workspace_snapshot_to_rebase_on_top_of_current_snapshot_being_pointed_at: Ulid,
-    /// Corresponds to the change set that's either the base change set, the last change set before
-    /// edits were made, or the change set that you are trying to “merge” into the base.
-    pub change_set_that_dictates_changes: Ulid,
+    pub onto_change_set_id: Ulid,
+    /// Corresponds to the workspace snapshot that will be rebased on top of the workspace snapshot
+    /// that the change set is currently pointing at.
+    pub to_rebase_workspace_snapshot_id: Ulid,
+    /// Derived from the ephemeral or persisted change set that's either the base change set, the
+    /// last change set before edits were made, or the change set that you are trying to rebase
+    /// onto base.
+    pub to_rebase_vector_clock_id: Ulid,
 }
 
 /// The message shape that the rebaser change set loop will use for replying to the client.


### PR DESCRIPTION
Introduce VectorClockId to separate ChangeSetPointers from VectorClocks. This will make the behavior of the rebaser-server easier to understand because, as it stands today, VectorClockIds are just ChangeSetPointerIds. They share the same ULID. That might not always be the case either, so this change has domain-driven benefits too.

Use the new VectorClockId in rebaser-server and change "updates and conflicts" detection to actually perform as intended. As a result, detection no longer requires ChangeSetPointers directly and only requires VectorClockIds.

Ensure the ChangeSetMessage reflects the new VectorClockId changes. The fields now use "to_rebase" and "onto" prefixes to help imply how to prepare the payload.

Add ChangeSetLoopError to differentiate errors in the rebaser-server outer loop to the inner loop(s).