### PR TITLE
fix(module-index): Ensure that we download from the production module-index

### DIFF
--- a/lib/module-index-client/src/client.rs
+++ b/lib/module-index-client/src/client.rs
@@ -1,3 +1,4 @@
+use reqwest::StatusCode;
 use ulid::Ulid;
 use url::Url;
 
@@ -150,11 +151,29 @@ impl IndexClient {
             .join("modules/")?
             .join(&format!("{}/", module_id.to_string()))?
             .join("download_builtin"))?;
-        let response = reqwest::Client::new()
+        let mut response = reqwest::Client::new()
             .get(download_url)
             .send()
             .await?
             .error_for_status()?;
+
+        if response.status() == StatusCode::NOT_FOUND
+            && self.base_url.clone().as_str().contains("http://localhost")
+        {
+            // We want to fall back to the production module index to pull builtins from there instead
+            let url = Url::parse("https://module-index.systeminit.com")?
+                .join("modules/")?
+                .join(&format!("{}/", module_id.to_string()))?
+                .join("download_builtin")?;
+
+            let prod_response = reqwest::Client::new()
+                .get(url)
+                .send()
+                .await?
+                .error_for_status()?;
+
+            response = prod_response
+        }
 
         let bytes = response.bytes().await?;
 

--- a/lib/module-index-client/src/client.rs
+++ b/lib/module-index-client/src/client.rs
@@ -151,11 +151,7 @@ impl IndexClient {
             .join("modules/")?
             .join(&format!("{}/", module_id.to_string()))?
             .join("download_builtin"))?;
-        let mut response = reqwest::Client::new()
-            .get(download_url)
-            .send()
-            .await?
-            .error_for_status()?;
+        let mut response = reqwest::Client::new().get(download_url).send().await?;
 
         if response.status() == StatusCode::NOT_FOUND
             && self.base_url.clone().as_str().contains("http://localhost")
@@ -166,16 +162,12 @@ impl IndexClient {
                 .join(&format!("{}/", module_id.to_string()))?
                 .join("download_builtin")?;
 
-            let prod_response = reqwest::Client::new()
-                .get(url)
-                .send()
-                .await?
-                .error_for_status()?;
+            let prod_response = reqwest::Client::new().get(url).send().await?;
 
             response = prod_response
         }
 
-        let bytes = response.bytes().await?;
+        let bytes = response.error_for_status()?.bytes().await?;
 
         Ok(bytes.to_vec())
     }


### PR DESCRIPTION
If the local module index returns a 404 then we should pull the builtin from the production module-index