### PR TITLE
feat(dal,si-pkg): Import components from workspace backups

### DIFF
--- a/app/web/src/components/AttributeDebugView.vue
+++ b/app/web/src/components/AttributeDebugView.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="overflow-x-scroll my-2 p-4 border-opacity-10 border-l-2">
     <dl>
+      <dt class="uppercase text-xs italic opacity-80">Attribute Value Id</dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10">
+        <pre>{{ data.valueId }}</pre>
+      </dd>
       <dt class="uppercase text-xs italic opacity-80">Type</dt>
       <dd class="p-2 my-2 border-2 border-opacity-10">
         <pre>{{ data.kind ?? "any" }}</pre>
@@ -35,6 +39,11 @@
       <dd class="p-2 my-2 border-2 border-opacity-10">
         <pre>{{ data.prototypeContext }}</pre>
       </dd>
+      <p class="text-2xs p-2 my-2 border-2 border-opacity-10">
+        prototype in change set?
+        {{ data.prototypeInChangeSet ? "y" : "n" }} value in change set?
+        {{ data.valueInChangeSet ? "y" : "n" }}
+      </p>
     </dl>
   </div>
 </template>

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -155,6 +155,8 @@ export interface AttributeDebugData {
     component_id: string;
   };
   kind: string;
+  prototypeInChangeSet: boolean;
+  valueInChangeSet: boolean;
 }
 
 export interface AttributeDebugView {

--- a/lib/dal/src/attribute/context.rs
+++ b/lib/dal/src/attribute/context.rs
@@ -54,7 +54,7 @@ pub enum AttributeContextError {
 
 pub type AttributeContextResult<T> = Result<T, AttributeContextError>;
 
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AttributeContext {
     #[serde(rename = "attribute_context_prop_id")]
     prop_id: PropId,
@@ -295,6 +295,15 @@ impl AttributeContextBuilder {
             internal_provider_id: InternalProviderId::NONE,
             external_provider_id: ExternalProviderId::NONE,
             component_id: ComponentId::NONE,
+        }
+    }
+
+    pub fn to_context_unchecked(&self) -> AttributeContext {
+        AttributeContext {
+            prop_id: self.prop_id,
+            internal_provider_id: self.internal_provider_id,
+            external_provider_id: self.external_provider_id,
+            component_id: self.component_id,
         }
     }
 

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -43,6 +43,8 @@ pub enum ExternalProviderError {
     HistoryEvent(#[from] HistoryEventError),
     #[error("not found for id: {0}")]
     NotFound(ExternalProviderId),
+    #[error("not found for socket name: {0}")]
+    NotFoundForSocketName(String),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("schema id mismatch: {0} (self) and {1} (provided)")]

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -144,6 +144,8 @@ pub enum InternalProviderError {
     NotFound(InternalProviderId),
     #[error("internal provider not found for prop id: {0}")]
     NotFoundForProp(PropId),
+    #[error("internal provider not found for prop socket name: {0}")]
+    NotFoundForSocketName(String),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("prop error: {0}")]

--- a/lib/dal/src/queries/find_schema_variant_for_schema_and_name.sql
+++ b/lib/dal/src/queries/find_schema_variant_for_schema_and_name.sql
@@ -1,0 +1,4 @@
+SELECT row_to_json(sv.*) AS object FROM schema_variants_v1($1, $2) sv
+  JOIN schema_variant_belongs_to_schema_v1($1, $2) svbts
+    ON svbts.belongs_to_id = $3
+WHERE sv.id = svbts.object_id AND sv.name = $4 LIMIT 1

--- a/lib/module-index-server/src/s3.rs
+++ b/lib/module-index-server/src/s3.rs
@@ -16,7 +16,7 @@ impl Default for S3Config {
             access_key_id: None,
             secret_access_key: None,
             region: String::from("us-east-2"),
-            bucket: String::from("modules-index-dev"),
+            bucket: String::from("modules-index-sandbox"),
             // TODO? is this right?
             path_prefix: String::from("dev"),
         }

--- a/lib/sdf-server/src/server/service/component/debug.rs
+++ b/lib/sdf-server/src/server/service/component/debug.rs
@@ -45,6 +45,8 @@ pub struct AttributeMetadataView {
     pub value: Option<serde_json::Value>,
     pub prototype_id: AttributePrototypeId,
     pub prototype_context: AttributeContext,
+    pub prototype_in_change_set: bool,
+    pub value_in_change_set: bool,
     pub kind: Option<PropKind>,
 }
 
@@ -184,5 +186,7 @@ async fn get_attribute_metadata(
         prototype_id: *debug_view.prototype.id(),
         prototype_context: debug_view.prototype.context,
         kind: debug_view.prop.map(|prop| *prop.kind()),
+        prototype_in_change_set: debug_view.prototype.visibility().in_change_set(),
+        value_in_change_set: debug_view.attribute_value.visibility().in_change_set(),
     })
 }

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -2,26 +2,8 @@ pub(crate) mod node;
 mod pkg;
 mod spec;
 
-pub use pkg::{
-    SiPkg, SiPkgActionFunc, SiPkgAttrFuncInput, SiPkgAttrFuncInputView, SiPkgChangeSet, SiPkgError,
-    SiPkgFunc, SiPkgFuncArgument, SiPkgFuncData, SiPkgKind, SiPkgLeafFunction, SiPkgMapKeyFunc,
-    SiPkgMetadata, SiPkgProp, SiPkgPropData, SiPkgSchema, SiPkgSchemaData, SiPkgSchemaVariant,
-    SiPkgSchemaVariantData, SiPkgSocket, SiPkgSocketData, SiPkgValidation,
-};
-pub use spec::{
-    ActionFuncSpec, ActionFuncSpecBuilder, ActionFuncSpecKind, AttrFuncInputSpec,
-    AttrFuncInputSpecKind, AttributeValuePath, AttributeValueSpec, ChangeSetSpec,
-    ChangeSetSpecBuilder, ChangeSetSpecStatus, ComponentSpec, ComponentSpecVariant,
-    FuncArgumentKind, FuncArgumentSpec, FuncArgumentSpecBuilder, FuncSpec, FuncSpecBackendKind,
-    FuncSpecBackendResponseType, FuncSpecData, FuncSpecDataBuilder, LeafFunctionSpec,
-    LeafFunctionSpecBuilder, LeafInputLocation, LeafKind, MapKeyFuncSpec, MapKeyFuncSpecBuilder,
-    PkgSpec, PkgSpecBuilder, PositionSpec, PropSpec, PropSpecBuilder, PropSpecKind,
-    PropSpecWidgetKind, SchemaSpec, SchemaSpecBuilder, SchemaSpecData, SchemaSpecDataBuilder,
-    SchemaVariantSpec, SchemaVariantSpecBuilder, SchemaVariantSpecComponentType,
-    SchemaVariantSpecData, SchemaVariantSpecPropRoot, SiPropFuncSpec, SiPropFuncSpecBuilder,
-    SiPropFuncSpecKind, SocketSpec, SocketSpecArity, SocketSpecData, SocketSpecDataBuilder,
-    SocketSpecKind, SpecError, ValidationSpec, ValidationSpecKind,
-};
+pub use pkg::*;
+pub use spec::*;
 
 #[cfg(test)]
 mod tests {

--- a/lib/si-pkg/src/node/component.rs
+++ b/lib/si-pkg/src/node/component.rs
@@ -8,7 +8,7 @@ use object_tree::{
     NodeWithChildren, ReadBytes, WriteBytes,
 };
 
-use super::{component_child::ComponentChild, PkgNode, KEY_DELETED_STR};
+use super::{component_child::ComponentChild, PkgNode, KEY_DELETED_STR, KEY_UNIQUE_ID_STR};
 use crate::{ComponentSpec, ComponentSpecVariant};
 
 const KEY_NAME_STR: &str = "name";
@@ -22,6 +22,7 @@ pub struct ComponentNode {
     pub variant: ComponentSpecVariant,
     pub needs_destroy: bool,
     pub deletion_user_pk: Option<String>,
+    pub unique_id: String,
     pub deleted: bool,
 }
 
@@ -47,6 +48,7 @@ impl WriteBytes for ComponentNode {
             "".into()
         };
         write_key_value_line(writer, KEY_DELETION_USER_PK_STR, deletion_user_pk_str)?;
+        write_key_value_line(writer, KEY_UNIQUE_ID_STR, &self.unique_id)?;
         write_key_value_line(writer, KEY_DELETED_STR, self.deleted)?;
 
         Ok(())
@@ -71,6 +73,7 @@ impl ReadBytes for ComponentNode {
         } else {
             Some(deletion_user_pk_str.to_owned())
         };
+        let unique_id = read_key_value_line(reader, KEY_UNIQUE_ID_STR)?;
         let deleted = bool::from_str(&read_key_value_line(reader, KEY_DELETED_STR)?)
             .map_err(GraphError::parse)?;
 
@@ -79,6 +82,7 @@ impl ReadBytes for ComponentNode {
             variant,
             needs_destroy,
             deletion_user_pk,
+            unique_id,
             deleted,
         }))
     }
@@ -95,6 +99,7 @@ impl NodeChild for ComponentSpec {
                 variant: self.variant.to_owned(),
                 needs_destroy: self.needs_destroy,
                 deletion_user_pk: self.deletion_user_pk.to_owned(),
+                unique_id: self.unique_id.to_owned(),
                 deleted: self.deleted,
             }),
             vec![

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -168,6 +168,7 @@ impl PkgNode {
     pub const LEAF_FUNCTION_KIND_STR: &str = NODE_KIND_LEAF_FUNCTION;
     pub const MAP_KEY_FUNC_KIND_STR: &str = NODE_KIND_MAP_KEY_FUNC;
     pub const PACKAGE_KIND_STR: &str = NODE_KIND_PACKAGE;
+    pub const POSTITION_KIND_STR: &str = NODE_KIND_POSITION;
     pub const PROP_KIND_STR: &str = NODE_KIND_PROP;
     pub const PROP_CHILD_KIND_STR: &str = NODE_KIND_PROP_CHILD;
     pub const SCHEMA_KIND_STR: &str = NODE_KIND_SCHEMA;

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -13,10 +13,13 @@ use thiserror::Error;
 
 mod action_func;
 mod attr_func_input;
+mod attribute_value;
 mod change_set;
+mod component;
 mod func;
 mod leaf_function;
 mod map_key_func;
+mod position;
 mod prop;
 mod schema;
 mod si_prop_func;
@@ -25,8 +28,9 @@ mod validation;
 mod variant;
 
 pub use {
-    action_func::*, attr_func_input::*, change_set::*, func::*, leaf_function::*, map_key_func::*,
-    prop::*, schema::*, si_prop_func::*, socket::*, validation::*, variant::*,
+    action_func::*, attr_func_input::*, attribute_value::*, change_set::*, component::*, func::*,
+    leaf_function::*, map_key_func::*, position::*, prop::*, schema::*, si_prop_func::*, socket::*,
+    validation::*, variant::*,
 };
 
 use crate::{
@@ -37,6 +41,8 @@ use crate::{
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum SiPkgError {
+    #[error("component pkg node {0} missing position child")]
+    ComponentMissingPosition(String),
     #[error(transparent)]
     Graph(#[from] GraphError),
     #[error(transparent)]

--- a/lib/si-pkg/src/pkg/attr_func_input.rs
+++ b/lib/si-pkg/src/pkg/attr_func_input.rs
@@ -170,6 +170,14 @@ impl<'a> SiPkgAttrFuncInput<'a> {
             },
         })
     }
+
+    pub fn name(&self) -> &str {
+        match self {
+            SiPkgAttrFuncInput::Prop { name, .. }
+            | SiPkgAttrFuncInput::InputSocket { name, .. }
+            | SiPkgAttrFuncInput::OutputSocket { name, .. } => name.as_str(),
+        }
+    }
 }
 
 impl<'a> TryFrom<SiPkgAttrFuncInput<'a>> for AttrFuncInputSpec {

--- a/lib/si-pkg/src/pkg/attribute_value.rs
+++ b/lib/si-pkg/src/pkg/attribute_value.rs
@@ -1,0 +1,216 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgAttrFuncInput, SiPkgError, Source};
+
+use crate::{
+    node::{AttributeValueChildNode, PkgNode},
+    AttrFuncInputSpec, AttributeValuePath, AttributeValueSpec, FuncSpecBackendKind,
+    FuncSpecBackendResponseType,
+};
+
+pub struct SiPkgAttributeValue<'a> {
+    parent_path: Option<AttributeValuePath>,
+    path: AttributeValuePath,
+    func_unique_id: String,
+    func_binding_args: serde_json::Value,
+    handler: Option<String>,
+    backend_kind: FuncSpecBackendKind,
+    response_type: FuncSpecBackendResponseType,
+    code_base64: Option<String>,
+    unprocessed_value: Option<serde_json::Value>,
+    value: Option<serde_json::Value>,
+    output_stream: Option<serde_json::Value>,
+    is_proxy: bool,
+    sealed_proxy: bool,
+    component_specific: bool,
+
+    hash: Hash,
+    source: Source<'a>,
+}
+
+macro_rules! impl_attribute_value_children_from_graph {
+    ($fn_name:ident, AttributeValueChildNode::$child_node:ident, $pkg_type:ident) => {
+        pub fn $fn_name(&self) -> PkgResult<Vec<$pkg_type>> {
+            let mut entries = vec![];
+            if let Some(child_idxs) = self
+                .source
+                .graph
+                .neighbors_directed(self.source.node_idx, Outgoing)
+                .find(|node_idx| {
+                    matches!(
+                        &self.source.graph[*node_idx].inner(),
+                        PkgNode::AttributeValueChild(AttributeValueChildNode::$child_node)
+                    )
+                })
+            {
+                let child_node_idxs: Vec<_> = self
+                    .source
+                    .graph
+                    .neighbors_directed(child_idxs, Outgoing)
+                    .collect();
+
+                for child_idx in child_node_idxs {
+                    entries.push($pkg_type::from_graph(self.source.graph, child_idx)?);
+                }
+            }
+
+            Ok(entries)
+        }
+    };
+}
+
+impl<'a> SiPkgAttributeValue<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::AttributeValue(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::ATTRIBUTE_VALUE_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            parent_path: node.parent_path,
+            path: node.path,
+            func_unique_id: node.func_unique_id,
+            func_binding_args: node.func_binding_args,
+            handler: node.handler,
+            backend_kind: node.backend_kind,
+            response_type: node.response_type,
+            code_base64: node.code_base64,
+            unprocessed_value: node.unprocessed_value,
+            value: node.value,
+            output_stream: node.output_stream,
+            is_proxy: node.is_proxy,
+            sealed_proxy: node.sealed_proxy,
+            component_specific: node.component_specific,
+
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn parent_path(&self) -> Option<&AttributeValuePath> {
+        self.parent_path.as_ref()
+    }
+
+    pub fn path(&self) -> &AttributeValuePath {
+        &self.path
+    }
+
+    pub fn func_unique_id(&self) -> &str {
+        self.func_unique_id.as_str()
+    }
+
+    pub fn func_binding_args(&self) -> &serde_json::Value {
+        &self.func_binding_args
+    }
+
+    pub fn handler(&self) -> Option<&str> {
+        self.handler.as_deref()
+    }
+
+    pub fn backend_kind(&self) -> FuncSpecBackendKind {
+        self.backend_kind
+    }
+
+    pub fn response_type(&self) -> FuncSpecBackendResponseType {
+        self.response_type
+    }
+
+    pub fn code_base64(&self) -> Option<&str> {
+        self.code_base64.as_deref()
+    }
+
+    pub fn unprocessed_value(&self) -> Option<&serde_json::Value> {
+        self.unprocessed_value.as_ref()
+    }
+
+    pub fn value(&self) -> Option<&serde_json::Value> {
+        self.value.as_ref()
+    }
+
+    pub fn output_stream(&self) -> Option<&serde_json::Value> {
+        self.output_stream.as_ref()
+    }
+
+    pub fn is_proxy(&self) -> bool {
+        self.is_proxy
+    }
+
+    pub fn sealed_proxy(&self) -> bool {
+        self.sealed_proxy
+    }
+
+    pub fn component_specific(&self) -> bool {
+        self.component_specific
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+
+    impl_attribute_value_children_from_graph!(
+        inputs,
+        AttributeValueChildNode::AttrFuncInputs,
+        SiPkgAttrFuncInput
+    );
+}
+
+impl<'a> TryFrom<SiPkgAttributeValue<'a>> for AttributeValueSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgAttributeValue<'a>) -> Result<Self, Self::Error> {
+        let mut builder = AttributeValueSpec::builder();
+
+        if let Some(parent_path) = value.parent_path() {
+            builder.parent_path(parent_path.to_owned());
+        }
+
+        if let Some(handler) = value.handler() {
+            builder.handler(handler);
+        }
+
+        if let Some(code_base64) = value.code_base64() {
+            builder.code_base64(code_base64);
+        }
+
+        if let Some(unprocessed_value) = value.unprocessed_value() {
+            builder.unprocessed_value(unprocessed_value.to_owned());
+        }
+
+        if let Some(value) = value.value() {
+            builder.value(value.to_owned());
+        }
+
+        if let Some(output_stream) = value.output_stream() {
+            builder.output_stream(output_stream.to_owned());
+        }
+
+        builder
+            .path(value.path().to_owned())
+            .func_unique_id(value.func_unique_id())
+            .func_binding_args(value.func_binding_args().to_owned())
+            .backend_kind(value.backend_kind())
+            .response_type(value.response_type())
+            .sealed_proxy(value.sealed_proxy())
+            .component_specific(value.component_specific());
+
+        for input in value.inputs()? {
+            builder.input(AttrFuncInputSpec::try_from(input)?);
+        }
+
+        Ok(builder.build()?)
+    }
+}

--- a/lib/si-pkg/src/pkg/change_set.rs
+++ b/lib/si-pkg/src/pkg/change_set.rs
@@ -4,7 +4,7 @@ use petgraph::prelude::*;
 use super::{PkgResult, SiPkgError, SiPkgSchema, Source};
 use crate::{
     node::{ChangeSetChildNode, PkgNode},
-    ChangeSetSpec, ChangeSetSpecStatus, FuncSpec, SiPkgFunc,
+    ChangeSetSpec, ChangeSetSpecStatus, FuncSpec, SiPkgComponent, SiPkgFunc,
 };
 
 #[derive(Clone, Debug)]
@@ -92,6 +92,11 @@ impl<'a> SiPkgChangeSet<'a> {
         self.hash
     }
 
+    impl_change_set_children_from_graph!(
+        components,
+        ChangeSetChildNode::Components,
+        SiPkgComponent
+    );
     impl_change_set_children_from_graph!(funcs, ChangeSetChildNode::Funcs, SiPkgFunc);
     impl_change_set_children_from_graph!(schemas, ChangeSetChildNode::Schemas, SiPkgSchema);
 

--- a/lib/si-pkg/src/pkg/component.rs
+++ b/lib/si-pkg/src/pkg/component.rs
@@ -1,0 +1,171 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgAttributeValue, SiPkgError, SiPkgPosition, Source};
+
+use crate::{
+    node::{ComponentChildNode, PkgNode},
+    AttributeValueSpec, ComponentSpec, ComponentSpecVariant, PositionSpec,
+};
+
+pub struct SiPkgComponent<'a> {
+    name: String,
+    variant: ComponentSpecVariant,
+    needs_destroy: bool,
+    deletion_user_pk: Option<String>,
+    unique_id: String,
+    deleted: bool,
+
+    hash: Hash,
+    source: Source<'a>,
+}
+
+macro_rules! impl_component_children_from_graph {
+    ($fn_name:ident, ComponentChildNode::$child_node:ident, $pkg_type:ident) => {
+        pub fn $fn_name(&self) -> PkgResult<Vec<$pkg_type>> {
+            let mut entries = vec![];
+            if let Some(child_idxs) = self
+                .source
+                .graph
+                .neighbors_directed(self.source.node_idx, Outgoing)
+                .find(|node_idx| {
+                    matches!(
+                        &self.source.graph[*node_idx].inner(),
+                        PkgNode::ComponentChild(ComponentChildNode::$child_node)
+                    )
+                })
+            {
+                let child_node_idxs: Vec<_> = self
+                    .source
+                    .graph
+                    .neighbors_directed(child_idxs, Outgoing)
+                    .collect();
+
+                for child_idx in child_node_idxs {
+                    entries.push($pkg_type::from_graph(self.source.graph, child_idx)?);
+                }
+            }
+
+            Ok(entries)
+        }
+    };
+}
+
+impl<'a> SiPkgComponent<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::Component(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::COMPONENT_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            name: node.name,
+            variant: node.variant,
+            needs_destroy: node.needs_destroy,
+            deletion_user_pk: node.deletion_user_pk,
+            deleted: node.deleted,
+            unique_id: node.unique_id,
+
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    impl_component_children_from_graph!(
+        attributes,
+        ComponentChildNode::Attributes,
+        SiPkgAttributeValue
+    );
+
+    impl_component_children_from_graph!(
+        input_sockets,
+        ComponentChildNode::InputSockets,
+        SiPkgAttributeValue
+    );
+
+    impl_component_children_from_graph!(
+        output_sockets,
+        ComponentChildNode::OutputSockets,
+        SiPkgAttributeValue
+    );
+
+    impl_component_children_from_graph!(position, ComponentChildNode::Position, SiPkgPosition);
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn variant(&self) -> &ComponentSpecVariant {
+        &self.variant
+    }
+
+    pub fn needs_destroy(&self) -> bool {
+        self.needs_destroy
+    }
+
+    pub fn deletion_user_pk(&self) -> Option<&str> {
+        self.deletion_user_pk.as_deref()
+    }
+
+    pub fn unique_id(&self) -> &str {
+        self.unique_id.as_str()
+    }
+
+    pub fn deleted(&self) -> bool {
+        self.deleted
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgComponent<'a>> for ComponentSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgComponent<'a>) -> Result<Self, Self::Error> {
+        let mut builder = ComponentSpec::builder();
+
+        builder
+            .name(value.name())
+            .variant(value.variant().to_owned())
+            .needs_destroy(value.needs_destroy())
+            .deleted(value.deleted());
+
+        if let Some(deletion_user_pk) = value.deletion_user_pk() {
+            builder.deletion_user_pk(deletion_user_pk);
+        }
+
+        for attribute in value.attributes()? {
+            builder.attribute(AttributeValueSpec::try_from(attribute)?);
+        }
+        for input_socket in value.input_sockets()? {
+            builder.attribute(AttributeValueSpec::try_from(input_socket)?);
+        }
+        for output_socket in value.output_sockets()? {
+            builder.attribute(AttributeValueSpec::try_from(output_socket)?);
+        }
+
+        let position = value
+            .position()?
+            .pop()
+            .ok_or(SiPkgError::ComponentMissingPosition(value.name().into()))?;
+
+        builder.position(PositionSpec::try_from(position)?);
+
+        Ok(builder.build()?)
+    }
+}

--- a/lib/si-pkg/src/pkg/position.rs
+++ b/lib/si-pkg/src/pkg/position.rs
@@ -1,0 +1,82 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgError, Source};
+
+use crate::{node::PkgNode, PositionSpec};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgPosition<'a> {
+    x: String,
+    y: String,
+    height: String,
+    width: String,
+
+    hash: Hash,
+    source: Source<'a>,
+}
+
+impl<'a> SiPkgPosition<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::Position(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::POSTITION_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            x: node.x,
+            y: node.y,
+            height: node.height,
+            width: node.width,
+
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn x(&self) -> &str {
+        self.x.as_str()
+    }
+
+    pub fn y(&self) -> &str {
+        self.y.as_str()
+    }
+
+    pub fn height(&self) -> &str {
+        self.height.as_str()
+    }
+
+    pub fn width(&self) -> &str {
+        self.width.as_str()
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgPosition<'a>> for PositionSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgPosition<'a>) -> Result<Self, Self::Error> {
+        Ok(PositionSpec::builder()
+            .x(value.x())
+            .y(value.y())
+            .height(value.height())
+            .width(value.width())
+            .build()?)
+    }
+}

--- a/lib/si-pkg/src/spec/attribute_value.rs
+++ b/lib/si-pkg/src/spec/attribute_value.rs
@@ -9,7 +9,11 @@ use super::{
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum AttributeValuePath {
-    Prop(String),
+    Prop {
+        path: String,
+        key: Option<String>,
+        index: Option<i64>,
+    },
     InputSocket(String),
     OutputSocket(String),
 }
@@ -27,13 +31,11 @@ pub struct AttributeValueSpec {
     #[builder(setter(into))]
     pub func_binding_args: serde_json::Value,
     #[builder(setter(into, strip_option), default)]
-    pub key: Option<String>,
-    #[builder(setter(into, strip_option), default)]
     pub handler: Option<String>,
     #[builder(setter(into))]
     pub backend_kind: FuncSpecBackendKind,
     #[builder(setter(into))]
-    pub reponse_type: FuncSpecBackendResponseType,
+    pub response_type: FuncSpecBackendResponseType,
     #[builder(setter(into, strip_option), default)]
     pub code_base64: Option<String>,
     #[builder(setter(into, strip_option), default)]
@@ -42,6 +44,9 @@ pub struct AttributeValueSpec {
     pub value: Option<serde_json::Value>,
     #[builder(setter(into, strip_option), default)]
     pub output_stream: Option<serde_json::Value>,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub is_proxy: bool,
     #[builder(setter(into), default)]
     #[serde(default)]
     pub sealed_proxy: bool,

--- a/lib/si-pkg/src/spec/component.rs
+++ b/lib/si-pkg/src/spec/component.rs
@@ -32,6 +32,8 @@ pub struct ComponentSpec {
     #[builder(setter(into, strip_option), default)]
     pub deletion_user_pk: Option<String>,
     #[builder(setter(into), default)]
+    pub unique_id: String,
+    #[builder(setter(into), default)]
     pub deleted: bool,
 
     #[builder(setter(each(name = "attribute"), into), default)]


### PR DESCRIPTION
Components exported to workspace backups are now imported. Edges are not connected but all other attributes set on the component will be restored with the values they had on export.