### PR TITLE
feat(dal): properly delete components that are deleted in backups

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -237,7 +237,7 @@ pub struct Component {
     pk: ComponentPk,
     id: ComponentId,
     kind: ComponentKind,
-    pub deletion_user_pk: Option<UserPk>,
+    deletion_user_pk: Option<UserPk>,
     needs_destroy: bool,
     #[serde(flatten)]
     tenancy: Tenancy,
@@ -339,6 +339,7 @@ impl Component {
 
     standard_model_accessor!(kind, Enum(ComponentKind), ComponentResult);
     standard_model_accessor!(needs_destroy, bool, ComponentResult);
+    standard_model_accessor!(deletion_user_pk, Option<Pk(UserPk)>, ComponentResult);
 
     standard_model_belongs_to!(
         lookup_fn: schema,

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -225,8 +225,8 @@ impl DiagramComponentView {
         let mut deleted_info: Option<HistoryEventMetadata> = None;
         {
             if let Some(deleted_at) = ctx.visibility().deleted_at {
-                if let Some(deletion_user_pk) = component.deletion_user_pk {
-                    let history_actor = history_event::HistoryActor::User(deletion_user_pk);
+                if let Some(deletion_user_pk) = component.deletion_user_pk() {
+                    let history_actor = history_event::HistoryActor::User(*deletion_user_pk);
                     let actor = ActorView::from_history_actor(ctx, history_actor).await?;
 
                     deleted_info = Some(HistoryEventMetadata {


### PR DESCRIPTION
We need to preserve deleted components in backups so they can be restored if they have a resource. This ensures we restore them in their deleted state.