### PR TITLE
feat(dal,sdf-server): Gracefully import components from outdated builtins

### DIFF
--- a/app/web/src/components/WorkspaceExportModal.vue
+++ b/app/web/src/components/WorkspaceExportModal.vue
@@ -24,6 +24,8 @@
 
         <p>Click the button below to continue:</p>
 
+        <ErrorMessage :requestStatus="exportReqStatus" />
+
         <VButton
           icon="cloud-upload"
           :requestStatus="exportReqStatus"
@@ -37,7 +39,13 @@
 </template>
 
 <script setup lang="ts">
-import { Modal, Stack, VButton, useModal } from "@si/vue-lib/design-system";
+import {
+  ErrorMessage,
+  Modal,
+  Stack,
+  VButton,
+  useModal,
+} from "@si/vue-lib/design-system";
 import { ref } from "vue";
 import { useModuleStore } from "@/store/module.store";
 

--- a/app/web/src/components/WorkspaceImportModal.vue
+++ b/app/web/src/components/WorkspaceImportModal.vue
@@ -72,6 +72,8 @@
           I understand my local workspace data will be overwritten
         </VormInput>
 
+        <ErrorMessage :requestStatus="importReqStatus" />
+
         <VButton
           icon="cloud-download"
           :disabled="!loadExportsReqStatus.isSuccess || validationState.isError"

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -6,7 +6,10 @@ mod export;
 mod import;
 
 pub use export::{get_component_type, PkgExporter};
-pub use import::{import_pkg, import_pkg_from_pkg, ImportOptions};
+pub use import::{
+    import_pkg, import_pkg_from_pkg, ImportAttributeSkip, ImportEdgeSkip, ImportOptions,
+    ImportSkips,
+};
 
 use si_pkg::{FuncSpecBackendKind, FuncSpecBackendResponseType, SiPkgError, SpecError};
 
@@ -137,6 +140,8 @@ pub enum PkgError {
     MissingAttributeValueForContext(AttributeReadContext),
     #[error("Missing a func map for changeset {0}")]
     MissingChangeSetFuncMap(ChangeSetPk),
+    #[error("Missing component {0} for edge from {1} to {2}")]
+    MissingComponentForEdge(String, String, String),
     #[error("Func {0} missing from exported funcs")]
     MissingExportedFunc(FuncId),
     #[error("Cannot find FuncArgument {0} for Func {1}")]

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -34,7 +34,7 @@ use crate::{AttributeValueError, AttributeValueId, FuncBackendResponseType, Tran
 pub const PROP_PATH_SEPARATOR: &str = "\x0B";
 
 /// This type should be used to manage prop paths instead of a raw string
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PropPath(String);
 
 impl PropPath {

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -149,7 +149,7 @@ pub async fn exec_variant_def(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
-    let (_, schema_variant_ids) = import_pkg_from_pkg(
+    let (_, schema_variant_ids, _) = import_pkg_from_pkg(
         &ctx,
         &pkg,
         Some(dal::pkg::ImportOptions {


### PR DESCRIPTION
Does not create attributes for props that are missing or have changed types on the builtin. Also avoid connecting functions to inputs if the prop for that input cannot be found.

The info for the mismatch is not yet displayed in the import modal, but is returned on the install_pkg API response.