### PR TITLE
feature: watch in siExec

### DIFF
--- a/bin/lang-js/tests/exec.spec.ts
+++ b/bin/lang-js/tests/exec.spec.ts
@@ -27,6 +27,7 @@ describe("exec", () => {
             let didIt = "nope";
             const r = await e.watch({
                 cmd: "bigGunsBangBang", args: ["+%s"], retryMs: 2000, callback: async (r) => {
+		    console.log(r)
                     didIt = "yep";
                     return true;
                 }

--- a/bin/lang-js/tests/exec.spec.ts
+++ b/bin/lang-js/tests/exec.spec.ts
@@ -1,0 +1,54 @@
+import {makeExec} from "../src/sandbox/exec";
+
+describe("exec", () => {
+    test("exec a command", async () => {
+        const e = makeExec("p");
+        const r = await e.waitUntilEnd("echo", ["poop"]);
+        expect(r.all).toBe("poop");
+    });
+
+    describe("watch a command", () => {
+        test("until it succeeds", async () => {
+            const e = makeExec("p");
+            const getCurrentTime = await e.waitUntilEnd("date", ["+%s"]);
+            const startSeconds = getCurrentTime.all || "3";
+            const waitUntil = startSeconds + 3;
+            const r = await e.watch({
+                cmd: "date", args: ["+%s"], retryMs: 2000, callback: async (r) => {
+                    const elapsed = r.all || "3";
+                    return elapsed > waitUntil;
+                }
+            });
+            expect(r.result.exitCode).toBe(0);
+        });
+
+        test("fail immediately if the command fails", async () => {
+            const e = makeExec("p");
+            let didIt = "nope";
+            const r = await e.watch({
+                cmd: "bigGunsBangBang", args: ["+%s"], retryMs: 2000, callback: async (r) => {
+                    didIt = "yep";
+                    return true;
+                }
+            });
+            expect(r.result.failed).toBe(true);
+            expect(r.failed).toBe("commandFailed");
+            expect(didIt).toBe("nope");
+        });
+
+        test("fail if the deadline is exceeded", async () => {
+            const e = makeExec("p");
+            const getCurrentTime = await e.waitUntilEnd("date", ["+%s"]);
+            const startSeconds = getCurrentTime.all || "3";
+            const waitUntil = startSeconds + 30000;
+            const r = await e.watch({
+                cmd: "date", args: ["+%s"], retryMs: 2000, maxRetryCount: 2, callback: async (r) => {
+                    const elapsed = r.all || "3";
+                    return elapsed > waitUntil;
+                }
+            });
+            expect(r.result.exitCode).toBe(0);
+            expect(r.failed).toBe("deadlineExceeded");
+        });
+    });
+});


### PR DESCRIPTION
This adds 'siExec.watch()' to lang-js. It allows you to watch the output of an siExec.waitUntilEnd over repeated calls, and should be handy any time you need to poll the state of something while you wait for it to succeed.

```typescript
// Get the date in seconds since the epoch
const getCurrentTime = await siExec.waitUntilEnd("date", ["+%s"]);
const startSeconds = getCurrentTime.all || "3";
// Wait until its at least 3 seconds later;
const waitUntil = startSeconds + 3;

// Call date, trying again every 2 seconds, a maximum of 10 times, and
// return true if more than 3 seconds have elapsed.
const r = siExec.watch({
      cmd: "date",
      args: ["+%s"],
      retryMs: 2000,
      maxRetryCount: 10,
      callback: async (r) => {
        const elapsed = r.all || "3";
        return elapsed > waitUntil;
      }
    });
// r.result == the SiExecResult
// r.failed? == "commandFailed" | "deadlineExceeded"
```

Should help DRY up any repeat calls for status.