### PR TITLE
fix(web): slightly rework workpace export modal logic

### DIFF
--- a/app/web/src/components/WorkspaceExportModal.vue
+++ b/app/web/src/components/WorkspaceExportModal.vue
@@ -7,14 +7,12 @@
   >
     <Stack>
       <template v-if="exportReqStatus.isSuccess">
-        <p>Success!</p>
+        <p>Export succeeded!</p>
         <p>
           You can now import this workspace by going to
           <br />
           workspace settings (gear in top right) > "Import Workspace"
         </p>
-
-        <VButton icon="check" @click="close">Close this window</VButton>
       </template>
       <template v-else>
         <p>
@@ -25,15 +23,17 @@
         <p>Click the button below to continue:</p>
 
         <ErrorMessage :requestStatus="exportReqStatus" />
-
-        <VButton
-          icon="cloud-upload"
-          :requestStatus="exportReqStatus"
-          loadingText="Exporting your workspace..."
-          @click="continueHandler"
-          >Export this workspace</VButton
-        >
       </template>
+
+      <VButton
+        v-if="!exportReqStatus.isSuccess"
+        icon="cloud-upload"
+        :requestStatus="exportReqStatus"
+        loadingText="Exporting your workspace..."
+        @click="continueHandler"
+        >Export this workspace</VButton
+      >
+      <VButton v-else icon="check" @click="close">Close this window</VButton>
     </Stack>
   </Modal>
 </template>
@@ -60,8 +60,8 @@ function open() {
   openModal();
 }
 
-function continueHandler() {
-  moduleStore.EXPORT_WORKSPACE();
+async function continueHandler() {
+  await moduleStore.EXPORT_WORKSPACE();
 }
 function closeHandler() {
   moduleStore.clearRequestStatus("EXPORT_WORKSPACE");


### PR DESCRIPTION
The production build of the web app seems to be reacting differently, causing the loading button on the workspace export modal to stick around. This logic rework fixes it when tested with `vite build; vite preview`