### PR TITLE
chore: introduce typos / spellchecking

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,18 @@
+name: Spelling
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+      - name: Spell Check Repo
+        uses: crate-ci/typos@master
+        with:
+          config: typos.toml
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ We contributors to System Initiative:
 * Scott Prutton (@sprutton1)
 * Nick Stinemates (@keeb)
 * Luca Palmieri (@LukeMathWalker)
+* Justin Carter (@bodymindarts)

--- a/flake.nix
+++ b/flake.nix
@@ -218,7 +218,7 @@
               mv -v "$out/bin/lang-js" "$out/bin/.lang-js"
               # Need to escape this shell variable which should not be
               # iterpreted in Nix as a variable nor a shell variable when run
-              # but rather a litteral string which happens to be a shell
+              # but rather a literal string which happens to be a shell
               # variable. Nuclear arms race of quoting and escaping special
               # characters to make this work...
               substituteInPlace "$out/bin/.lang-js" \
@@ -321,6 +321,7 @@
               shellcheck
               shfmt
               tilt
+              typos
             ]
             # Directly add the build dependencies for the packages rather than
             # use: `inputsFrom = lib.attrValues packages;`.


### PR DESCRIPTION
Hi System Init team,

I am opening this PR to fix a typo that our spellchecker caught in a snippet I cargo culted from this repo (OSS FTW). Thank you so much for the trailblazing work you've done with setting up buck2. It's been extremely helpful to have this as an example while I introduce it into our monorepo.

As a small thank you I would like to introduce you to https://github.com/crate-ci/typos. Even though it's 'just' a spell checker it has prevented many bugs entering production(!).

If you check out this PR branch and and run `typos` in the root you will find 280 typos in this repo.
```
$ typos | grep 'error:' | wc -l
280
```

Any false positives you can ignore by editing the `typos.toml` in the root (check out the [README](https://github.com/crate-ci/typos#false-positives) on how to).

I think there are some interesting ones in here that may be bugs like:
```
error: `isntance` should be `instance`
  --> ./designs/system-graph/dsl.js:17:40
   |
17 | network.addCompute(integration: "AWS", isntanceType: "x1.large");
```

Regards!