### PR TITLE
Add si-cbor and use for WorkspaceSnapshot and ContentPair (ENG-1983)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +921,7 @@ dependencies = [
  "remain",
  "serde",
  "serde_json",
+ "si-cbor",
  "si-data-pg",
  "telemetry",
  "thiserror",
@@ -1223,6 +1251,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_with 3.3.0",
+ "si-cbor",
  "si-data-nats",
  "si-data-pg",
  "si-pkg",
@@ -2072,6 +2101,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -4848,6 +4883,16 @@ dependencies = [
  "strum",
  "telemetry-application",
  "tokio",
+]
+
+[[package]]
+name = "si-cbor"
+version = "0.1.0"
+dependencies = [
+ "ciborium",
+ "remain",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "lib/object-tree",
     "lib/pinga-server",
     "lib/sdf-server",
+    "lib/si-cbor",
     "lib/si-data-nats",
     "lib/si-data-pg",
     "lib/si-pkg",
@@ -58,6 +59,7 @@ base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = "1.4.0"
 chrono = { version = "0.4.24", features = ["serde"] }
+ciborium = { version = "0.2.1" }
 clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.2"
 colored = "2.0.4"

--- a/lib/content-store/BUCK
+++ b/lib/content-store/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "content-store",
     deps = [
+        "//lib/si-cbor:si-cbor",
         "//lib/si-data-pg:si-data-pg",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:async-trait",

--- a/lib/content-store/Cargo.toml
+++ b/lib/content-store/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+si-cbor = { path = "../../lib/si-cbor" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 telemetry = { path = "../../lib/telemetry-rs" }
 

--- a/lib/content-store/src/pair.rs
+++ b/lib/content-store/src/pair.rs
@@ -21,6 +21,7 @@ pub(crate) type ContentPairResult<T> = Result<T, ContentPairError>;
 pub(crate) struct ContentPair {
     key: String,
     created_at: DateTime<Utc>,
+    /// Serialized CBOR bytes.
     value: Vec<u8>,
 }
 

--- a/lib/content-store/src/store.rs
+++ b/lib/content-store/src/store.rs
@@ -1,5 +1,6 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use si_cbor::CborError;
 use si_data_pg::{PgError, PgPoolError};
 use thiserror::Error;
 
@@ -13,6 +14,8 @@ pub(crate) mod pg;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum StoreError {
+    #[error("cbor error: {0}")]
+    Cbor(#[from] CborError),
     #[error("content pair error: {0}")]
     ContentPair(#[from] ContentPairError),
     #[error("pg error: {0}")]

--- a/lib/content-store/src/store/pg.rs
+++ b/lib/content-store/src/store/pg.rs
@@ -65,7 +65,7 @@ impl Store for PgStore {
     where
         T: Serialize + ?Sized,
     {
-        let value = serde_json::to_vec(object)?;
+        let value = si_cbor::encode(object)?;
         let key = ContentHash::new(&value);
         self.inner.insert(key, PgStoreItem::new(value));
         Ok(key)
@@ -79,9 +79,9 @@ impl Store for PgStore {
             Some(item) => serde_json::from_slice(&item.value)?,
             None => match ContentPair::find(&self.pg_pool, key).await? {
                 Some(content_pair) => {
-                    let bytes = content_pair.value();
-                    self.add(bytes)?;
-                    serde_json::from_slice(bytes)?
+                    let encoded = content_pair.value();
+                    self.add(encoded)?;
+                    si_cbor::decode(encoded)?
                 }
                 None => return Ok(None),
             },

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -7,6 +7,7 @@ load(
 rust_library(
     name = "dal",
     deps = [
+        "//lib/si-cbor:si-cbor",
         "//lib/content-store:content-store",
         "//lib/council-server:council-server",
         "//lib/nats-subscriber:nats-subscriber",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true }
 serde-aux = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+si-cbor = { path = "../../lib/si-cbor" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-pkg = { path = "../../lib/si-pkg" }

--- a/lib/dal/src/migrations/U3000__workspace_snapshots.sql
+++ b/lib/dal/src/migrations/U3000__workspace_snapshots.sql
@@ -2,7 +2,7 @@ CREATE TABLE workspace_snapshots
 (
     id         ident primary key        NOT NULL DEFAULT ident_create_v1(),
     created_at timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
-    snapshot   jsonb                    NOT NULL
+    snapshot   bytea                    NOT NULL
     -- TODO(nick): add once workspaces are added
     -- workspace_id ident REFERENCES workspaces_v2 (id) NOT NULL,
     -- TODO(nick): replace the existing primary key with this once workspaces are added

--- a/lib/rebaser-server/src/server/change_set_loop.rs
+++ b/lib/rebaser-server/src/server/change_set_loop.rs
@@ -124,12 +124,13 @@ async fn process_delivery(
     let onto_workspace_snapshot_id = onto_change_set.workspace_snapshot_id.ok_or(
         ChangeSetLoopError::MissingWorkspaceSnapshotForChangeSet(onto_change_set.id),
     )?;
-    let onto_workspace_snapshot = WorkspaceSnapshot::find(ctx, onto_workspace_snapshot_id).await?;
+    let mut onto_workspace_snapshot =
+        WorkspaceSnapshot::find(ctx, onto_workspace_snapshot_id).await?;
 
     let (conflicts, updates) = to_rebase_workspace_snapshot
         .detect_conflicts_and_updates(
             message.to_rebase_vector_clock_id.into(),
-            &onto_workspace_snapshot,
+            &mut onto_workspace_snapshot,
             onto_change_set.vector_clock_id(),
         )
         .await?;

--- a/lib/si-cbor/BUCK
+++ b/lib/si-cbor/BUCK
@@ -1,0 +1,12 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "si-cbor",
+    deps = [
+        "//third-party/rust:ciborium",
+        "//third-party/rust:remain",
+        "//third-party/rust:serde",
+        "//third-party/rust:thiserror",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+)

--- a/lib/si-cbor/Cargo.toml
+++ b/lib/si-cbor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "si-cbor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ciborium = { workspace = true }
+remain = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/lib/si-cbor/src/lib.rs
+++ b/lib/si-cbor/src/lib.rs
@@ -1,0 +1,74 @@
+//! This library provides the ability to encode (serialize) and decode (deserialize)
+//! [CBOR](https://en.wikipedia.org/wiki/CBOR) objects.
+
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    unreachable_pub,
+    bad_style,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true,
+    clippy::missing_panics_doc
+)]
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::BufReader;
+use thiserror::Error;
+
+#[allow(missing_docs)]
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum CborError {
+    #[error("ciborium deserialization error: {0}")]
+    CiboriumDeserialization(#[from] ciborium::de::Error<std::io::Error>),
+    #[error("ciborium serialization error: {0}")]
+    CiboriumSerialization(#[from] ciborium::ser::Error<std::io::Error>),
+}
+
+type CborResult<T> = Result<T, CborError>;
+
+/// Serialize the given value to CBOR.
+pub fn encode<T>(value: &T) -> CborResult<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    let mut encoded = Vec::new();
+    ciborium::into_writer(value, &mut encoded)?;
+    Ok(encoded)
+}
+
+/// Deserialize from CBOR to a provided type.
+pub fn decode<T>(value: &[u8]) -> CborResult<T>
+where
+    T: DeserializeOwned,
+{
+    let reader = BufReader::new(value);
+    Ok(ciborium::from_reader(reader)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string() {
+        let original = "mybrainhurts";
+
+        let bytes = encode(original).expect("could not encode");
+        let round_trip: String = decode(&bytes).expect("could not decode");
+
+        assert_eq!(original, round_trip.as_str());
+    }
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -471,10 +471,8 @@ cargo.rust_library(
     edition = "2021",
     env = {
         "CARGO_MANIFEST_DIR": "async-nats-0.31.0.crate",
-        "CARGO_PKG_AUTHORS": "Tomasz Pietrek <tomasz@nats.io>:Casper Beyer <caspervonb@pm.me>",
         "CARGO_PKG_DESCRIPTION": "A async Rust NATS client",
         "CARGO_PKG_NAME": "async-nats",
-        "CARGO_PKG_REPOSITORY": "https://github.com/nats-io/nats.rs",
         "CARGO_PKG_VERSION": "0.31.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "31",
@@ -673,10 +671,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "attohttpc-0.22.0.crate",
-        "CARGO_PKG_AUTHORS": "Simon Bernier St-Pierre <git@sbstp.ca>",
         "CARGO_PKG_DESCRIPTION": "Small and lightweight HTTP client",
         "CARGO_PKG_NAME": "attohttpc",
-        "CARGO_PKG_REPOSITORY": "https://github.com/sbstp/attohttpc",
         "CARGO_PKG_VERSION": "0.22.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "22",
@@ -1704,6 +1700,80 @@ cargo.rust_library(
 )
 
 alias(
+    name = "ciborium",
+    actual = ":ciborium-0.2.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "ciborium-0.2.1.crate",
+    sha256 = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926",
+    strip_prefix = "ciborium-0.2.1",
+    urls = ["https://crates.io/api/v1/crates/ciborium/0.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ciborium-0.2.1",
+    srcs = [":ciborium-0.2.1.crate"],
+    crate = "ciborium",
+    crate_root = "ciborium-0.2.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":ciborium-io-0.2.1",
+        ":ciborium-ll-0.2.1",
+        ":serde-1.0.164",
+    ],
+)
+
+http_archive(
+    name = "ciborium-io-0.2.1.crate",
+    sha256 = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656",
+    strip_prefix = "ciborium-io-0.2.1",
+    urls = ["https://crates.io/api/v1/crates/ciborium-io/0.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ciborium-io-0.2.1",
+    srcs = [":ciborium-io-0.2.1.crate"],
+    crate = "ciborium_io",
+    crate_root = "ciborium-io-0.2.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
+    name = "ciborium-ll-0.2.1.crate",
+    sha256 = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b",
+    strip_prefix = "ciborium-ll-0.2.1",
+    urls = ["https://crates.io/api/v1/crates/ciborium-ll/0.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ciborium-ll-0.2.1",
+    srcs = [":ciborium-ll-0.2.1.crate"],
+    crate = "ciborium_ll",
+    crate_root = "ciborium-ll-0.2.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":ciborium-io-0.2.1",
+        ":half-1.8.2",
+    ],
+)
+
+alias(
     name = "clap",
     actual = ":clap-4.3.4",
     visibility = ["PUBLIC"],
@@ -2443,10 +2513,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "crossbeam-utils-0.8.16.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Utilities for concurrent programming",
         "CARGO_PKG_NAME": "crossbeam-utils",
-        "CARGO_PKG_REPOSITORY": "https://github.com/crossbeam-rs/crossbeam",
         "CARGO_PKG_VERSION": "0.8.16",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "8",
@@ -4219,10 +4287,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "futures-channel-0.3.28.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Channels for asynchronous communication using futures-rs.\n",
         "CARGO_PKG_NAME": "futures-channel",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
         "CARGO_PKG_VERSION": "0.3.28",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
@@ -4258,10 +4324,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "futures-core-0.3.28.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "The core traits and types in for the `futures` library.\n",
         "CARGO_PKG_NAME": "futures-core",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
         "CARGO_PKG_VERSION": "0.3.28",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
@@ -4453,10 +4517,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "futures-task-0.3.28.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Tools for working with tasks.\n",
         "CARGO_PKG_NAME": "futures-task",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
         "CARGO_PKG_VERSION": "0.3.28",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
@@ -4491,10 +4553,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "futures-util-0.3.28.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Common utilities and extension traits for the futures-rs library.\n",
         "CARGO_PKG_NAME": "futures-util",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
         "CARGO_PKG_VERSION": "0.3.28",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
@@ -4716,6 +4776,23 @@ cargo.rust_library(
         ":tokio-util-0.7.8",
         ":tracing-0.1.37",
     ],
+)
+
+http_archive(
+    name = "half-1.8.2.crate",
+    sha256 = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7",
+    strip_prefix = "half-1.8.2",
+    urls = ["https://crates.io/api/v1/crates/half/1.8.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "half-1.8.2",
+    srcs = [":half-1.8.2.crate"],
+    crate = "half",
+    crate_root = "half-1.8.2.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 http_archive(
@@ -6908,10 +6985,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "names-0.14.0.crate",
-        "CARGO_PKG_AUTHORS": "Fletcher Nichol <fnichol@nichol.ca>",
         "CARGO_PKG_DESCRIPTION": "A random name generator with names suitable for use in container\ninstances, project names, application instances, etc.\n",
         "CARGO_PKG_NAME": "names",
-        "CARGO_PKG_REPOSITORY": "https://github.com/fnichol/names",
         "CARGO_PKG_VERSION": "0.14.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "14",
@@ -6931,10 +7006,8 @@ cargo.rust_binary(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "names-0.14.0.crate",
-        "CARGO_PKG_AUTHORS": "Fletcher Nichol <fnichol@nichol.ca>",
         "CARGO_PKG_DESCRIPTION": "A random name generator with names suitable for use in container\ninstances, project names, application instances, etc.\n",
         "CARGO_PKG_NAME": "names",
-        "CARGO_PKG_REPOSITORY": "https://github.com/fnichol/names",
         "CARGO_PKG_VERSION": "0.14.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "14",
@@ -7754,10 +7827,8 @@ cargo.rust_library(
     edition = "2021",
     env = {
         "CARGO_MANIFEST_DIR": "opentelemetry-otlp-0.11.0.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Exporter for the OpenTelemetry Collector",
         "CARGO_PKG_NAME": "opentelemetry-otlp",
-        "CARGO_PKG_REPOSITORY": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp",
         "CARGO_PKG_VERSION": "0.11.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "11",
@@ -7928,10 +7999,8 @@ cargo.rust_library(
     edition = "2021",
     env = {
         "CARGO_MANIFEST_DIR": "opentelemetry_sdk-0.18.0.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "The SDK for the OpenTelemetry metrics collection and distributed tracing framework",
         "CARGO_PKG_NAME": "opentelemetry_sdk",
-        "CARGO_PKG_REPOSITORY": "https://github.com/open-telemetry/opentelemetry-rust",
         "CARGO_PKG_VERSION": "0.18.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "18",
@@ -8923,10 +8992,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "portable-atomic-1.4.0.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
         "CARGO_PKG_NAME": "portable-atomic",
-        "CARGO_PKG_REPOSITORY": "https://github.com/taiki-e/portable-atomic",
         "CARGO_PKG_VERSION": "1.4.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "4",
@@ -8948,10 +9015,8 @@ cargo.rust_binary(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "portable-atomic-1.4.0.crate",
-        "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
         "CARGO_PKG_NAME": "portable-atomic",
-        "CARGO_PKG_REPOSITORY": "https://github.com/taiki-e/portable-atomic",
         "CARGO_PKG_VERSION": "1.4.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "4",
@@ -9173,10 +9238,8 @@ cargo.rust_library(
     edition = "2021",
     env = {
         "CARGO_MANIFEST_DIR": "prettyplease-0.1.25.crate",
-        "CARGO_PKG_AUTHORS": "David Tolnay <dtolnay@gmail.com>",
         "CARGO_PKG_DESCRIPTION": "A minimal `syn` syntax tree pretty-printer",
         "CARGO_PKG_NAME": "prettyplease",
-        "CARGO_PKG_REPOSITORY": "https://github.com/dtolnay/prettyplease",
         "CARGO_PKG_VERSION": "0.1.25",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "1",
@@ -11083,12 +11146,18 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
+            named_deps = {
+                "libc_errno": ":errno-0.3.1",
+            },
             deps = [
                 ":libc-0.2.146",
                 ":linux-raw-sys-0.3.8",
             ],
         ),
         "linux-x86_64": dict(
+            named_deps = {
+                "libc_errno": ":errno-0.3.1",
+            },
             deps = [
                 ":libc-0.2.146",
                 ":linux-raw-sys-0.3.8",
@@ -13584,6 +13653,7 @@ cargo.rust_binary(
         ":blake3-1.4.0",
         ":bytes-1.4.0",
         ":chrono-0.4.26",
+        ":ciborium-0.2.1",
         ":clap-4.3.4",
         ":color-eyre-0.6.2",
         ":colored-2.0.4",
@@ -14446,10 +14516,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "tonic-0.8.3.crate",
-        "CARGO_PKG_AUTHORS": "Lucio Franco <luciofranco14@gmail.com>",
         "CARGO_PKG_DESCRIPTION": "A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.\n",
         "CARGO_PKG_NAME": "tonic",
-        "CARGO_PKG_REPOSITORY": "https://github.com/hyperium/tonic",
         "CARGO_PKG_VERSION": "0.8.3",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "8",
@@ -14854,10 +14922,8 @@ cargo.rust_library(
     edition = "2018",
     env = {
         "CARGO_MANIFEST_DIR": "tracing-opentelemetry-0.18.0.crate",
-        "CARGO_PKG_AUTHORS": "Julian Tescher <julian@tescher.me>:Tokio Contributors <team@tokio.rs>",
         "CARGO_PKG_DESCRIPTION": "OpenTelemetry integration for tracing",
         "CARGO_PKG_NAME": "tracing-opentelemetry",
-        "CARGO_PKG_REPOSITORY": "https://github.com/tokio-rs/tracing",
         "CARGO_PKG_VERSION": "0.18.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "18",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -629,6 +629,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1789,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -4707,6 +4740,7 @@ dependencies = [
  "blake3",
  "bytes 1.4.0",
  "chrono",
+ "ciborium",
  "clap",
  "color-eyre",
  "colored",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = "1.4.0"
 chrono = { version = "0.4.24", features = ["serde"] }
+ciborium = { version = "0.2.1" }
 clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.2"
 colored = "2.0.4"


### PR DESCRIPTION
Add a new library, si-cbor, for quickly encoding and decoding CBOR serialized objects.

Use si-cbor for both the serialized snapshots in WorkspaceSnapshot and for the value in ContentPair. This should help with space savings and performance in the long term.