### PR TITLE
Perform updates in the rebaser (ENG-1933)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,6 +3925,7 @@ dependencies = [
 name = "rebaser-client"
 version = "0.1.0"
 dependencies = [
+ "log",
  "rebaser-core",
  "remain",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,6 +3941,7 @@ name = "rebaser-core"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "ulid",
 ]
 

--- a/lib/dal/src/change_set_pointer.rs
+++ b/lib/dal/src/change_set_pointer.rs
@@ -86,13 +86,12 @@ impl ChangeSetPointer {
                 &[&name],
             )
             .await?;
-        Ok(Self::try_from(row)?)
+        Self::try_from(row)
     }
 
     /// Create a [`VectorClockId`] from the [`ChangeSetPointer`].
     pub fn vector_clock_id(&self) -> VectorClockId {
-        let ulid: Ulid = self.id.into();
-        VectorClockId::from(ulid)
+        VectorClockId::from(Ulid::from(self.id))
     }
 
     pub fn generate_ulid(&self) -> ChangeSetPointerResult<Ulid> {
@@ -134,7 +133,7 @@ impl ChangeSetPointer {
                 &[&change_set_pointer_id],
             )
             .await?;
-        Ok(Self::try_from(row)?)
+        Self::try_from(row)
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/conflict.rs
+++ b/lib/dal/src/workspace_snapshot/conflict.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 #[remain::sorted]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Conflict {
-    // TODO(nick,jacob): this variant will not be possible until ordering is in place.
     ChildOrder {
         onto: NodeIndex,
         to_rebase: NodeIndex,

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::change_set_pointer::ChangeSetPointer;
-use crate::workspace_snapshot::vector_clock::{VectorClock, VectorClockError};
+use crate::workspace_snapshot::vector_clock::{VectorClock, VectorClockError, VectorClockId};
 
 #[derive(Debug, Error)]
 pub enum EdgeWeightError {
@@ -61,14 +61,14 @@ impl EdgeWeight {
         &self.kind
     }
 
-    pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
+    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
         if self
             .vector_clock_first_seen
-            .entry_for(change_set.vector_clock_id())
+            .entry_for(vector_clock_id)
             .is_none()
         {
             self.vector_clock_first_seen
-                .inc_to(change_set.vector_clock_id(), seen_at);
+                .inc_to(vector_clock_id, seen_at);
         }
     }
 

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use ulid::Ulid;
 
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
     change_set_pointer::{ChangeSetPointer, ChangeSetPointerError},
     workspace_snapshot::{
@@ -88,13 +89,15 @@ impl NodeWeight {
         }
     }
 
-    pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
+    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
         match self {
-            NodeWeight::Content(content_weight) => content_weight.mark_seen_at(change_set, seen_at),
-            NodeWeight::Ordering(ordering_weight) => {
-                ordering_weight.mark_seen_at(change_set, seen_at)
+            NodeWeight::Content(content_weight) => {
+                content_weight.mark_seen_at(vector_clock_id, seen_at)
             }
-            NodeWeight::Prop(prop_weight) => prop_weight.mark_seen_at(change_set, seen_at),
+            NodeWeight::Ordering(ordering_weight) => {
+                ordering_weight.mark_seen_at(vector_clock_id, seen_at)
+            }
+            NodeWeight::Prop(prop_weight) => prop_weight.mark_seen_at(vector_clock_id, seen_at),
         }
     }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -3,6 +3,7 @@ use content_store::ContentHash;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
     change_set_pointer::ChangeSetPointer,
     workspace_snapshot::{
@@ -83,16 +84,16 @@ impl ContentNodeWeight {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
+    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
         self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), seen_at.clone());
+            .inc_to(vector_clock_id, seen_at);
         if self
             .vector_clock_first_seen
-            .entry_for(change_set.vector_clock_id())
+            .entry_for(vector_clock_id)
             .is_none()
         {
             self.vector_clock_first_seen
-                .inc_to(change_set.vector_clock_id(), seen_at);
+                .inc_to(vector_clock_id, seen_at);
         }
     }
 
@@ -132,7 +133,7 @@ impl ContentNodeWeight {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Prop".to_string(),
                     "Content".to_string(),
-                ))
+                ));
             }
             ContentAddress::Root => return Err(NodeWeightError::CannotUpdateRootNodeContentHash),
             ContentAddress::Schema(_) => ContentAddress::Schema(content_hash),

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
 use crate::change_set_pointer::ChangeSetPointer;
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::workspace_snapshot::{node_weight::NodeWeightResult, vector_clock::VectorClock};
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -51,16 +52,16 @@ impl OrderingNodeWeight {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
+    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
         self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), seen_at.clone());
+            .inc_to(vector_clock_id, seen_at);
         if self
             .vector_clock_first_seen
-            .entry_for(change_set.vector_clock_id())
+            .entry_for(vector_clock_id)
             .is_none()
         {
             self.vector_clock_first_seen
-                .inc_to(change_set.vector_clock_id(), seen_at);
+                .inc_to(vector_clock_id, seen_at);
         }
     }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -3,6 +3,7 @@ use content_store::ContentHash;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
+use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
     change_set_pointer::ChangeSetPointer,
     workspace_snapshot::{
@@ -75,16 +76,16 @@ impl PropNodeWeight {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, change_set: &ChangeSetPointer, seen_at: DateTime<Utc>) {
+    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
         self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), seen_at.clone());
+            .inc_to(vector_clock_id, seen_at);
         if self
             .vector_clock_first_seen
-            .entry_for(change_set.vector_clock_id())
+            .entry_for(vector_clock_id)
             .is_none()
         {
             self.vector_clock_first_seen
-                .inc_to(change_set.vector_clock_id(), seen_at);
+                .inc_to(vector_clock_id, seen_at);
         }
     }
 
@@ -119,62 +120,62 @@ impl PropNodeWeight {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "AttributePrototype".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::AttributeValue(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "AttributeValue".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::Component(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Component".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::ExternalProvider(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "ExternalProvider".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::Func(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Func".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::FuncArg(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "FuncArc".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::InternalProvider(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "InternalProvider".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::Prop(_) => ContentAddress::Prop(content_hash),
             ContentAddress::Root => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Root".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::Schema(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Schema".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
             ContentAddress::SchemaVariant(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "SchemaVariant".to_string(),
                     "Prop".to_string(),
-                ))
+                ));
             }
         };
 

--- a/lib/dal/src/workspace_snapshot/update.rs
+++ b/lib/dal/src/workspace_snapshot/update.rs
@@ -8,17 +8,17 @@ use serde::{Deserialize, Serialize};
 pub enum Update {
     NewEdge {
         source: NodeIndex,
+        // Check if already exists in "onto" (source). Grab node weight from "to_rebase"
+        // (destination) and see if there is an equivalent node (id and lineage) in "onto".
+        // If not, use "import_subgraph".
         destination: NodeIndex,
         edge_weight: EdgeWeight,
     },
-    NewSubgraph {
-        source: NodeIndex,
-    },
     RemoveEdge(EdgeIndex),
     ReplaceSubgraph {
-        // "onto"
-        new: NodeIndex,
-        // "to_rebase"
-        old: NodeIndex,
+        onto: NodeIndex,
+        // Check if already exists in "onto". Grab node weight from "to_rebase" and see if there is
+        // an equivalent node (id and lineage) in "onto". If not, use "import_subgraph".
+        to_rebase: NodeIndex,
     },
 }

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
@@ -3,5 +3,6 @@
 //!
 //! For all tests in this module, provide "SI_TEST_BUILTIN_SCHEMAS=none" as an environment variable.
 
+mod change_set;
 mod content_store;
 mod rebaser;

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/change_set.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/change_set.rs
@@ -1,0 +1,13 @@
+use dal::change_set_pointer::ChangeSetPointer;
+use dal::DalContext;
+use dal_test::test;
+use ulid::Ulid;
+
+#[test]
+async fn vector_clock_id(ctx: &mut DalContext) {
+    let change_set = ChangeSetPointer::new(ctx, "main")
+        .await
+        .expect("could not create change set");
+    let vector_clock_id_as_ulid: Ulid = change_set.vector_clock_id().into();
+    assert_eq!(change_set.id, vector_clock_id_as_ulid.into());
+}

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/content_store.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/content_store.rs
@@ -1,5 +1,3 @@
-//! For all tests in this file, provide "SI_TEST_BUILTIN_SCHEMAS=none" as an environment variable.
-
 use content_store::Store;
 use dal::component::ComponentKind;
 use dal::{DalContext, Schema};

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/rebaser.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/rebaser.rs
@@ -89,12 +89,7 @@ async fn simple_rebase(ctx: &mut DalContext) {
         .expect("could not send");
 
     // TODO(nick): do something useful with this.
-    match response {
-        ChangeSetReplyMessage::Success { results } => {
-            dbg!(results);
-        }
-        ChangeSetReplyMessage::Failure { error } => panic!("{}", error),
-    }
+    dbg!(response);
 
     // TODO(nick): move cleanup to the test harness.
     let _ = client

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/rebaser.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/rebaser.rs
@@ -1,22 +1,21 @@
-//! For all tests in this module, provide "SI_TEST_BUILTIN_SCHEMAS=none" as an environment variable.
-
 use content_store::ContentHash;
 use dal::change_set_pointer::ChangeSetPointer;
+use dal::workspace_snapshot::conflict::Conflict;
 use dal::workspace_snapshot::content_address::ContentAddress;
 use dal::workspace_snapshot::node_weight::NodeWeight;
+use dal::workspace_snapshot::update::Update;
 use dal::{DalContext, Tenancy, Visibility, WorkspacePk, WorkspaceSnapshot};
 use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
 use rebaser_client::Client;
 use rebaser_core::ChangeSetReplyMessage;
 
 #[test]
-async fn simple_rebase(ctx: &mut DalContext) {
+async fn pure_update_and_single_conflict(ctx: &mut DalContext) {
     ctx.update_visibility(Visibility::new_head(false));
     ctx.update_tenancy(Tenancy::new(WorkspacePk::NONE));
-    let ctx = &ctx;
 
-    let mut client = Client::new().await.expect("could not build client");
-
+    // Start with the base change set and the initial snapshot.
     let mut base_change_set = ChangeSetPointer::new(ctx, "main")
         .await
         .expect("could not create change set");
@@ -25,74 +24,204 @@ async fn simple_rebase(ctx: &mut DalContext) {
         .await
         .expect("could not create workspace snapshot");
 
-    // Add a new node.
-    snapshot
+    // Add a new node, write and update the pointer.
+    let olivia_rodrigo_id = base_change_set
+        .generate_ulid()
+        .expect("could not generate id");
+    let olivia_rodrigo_node_index = snapshot
         .add_node(
             NodeWeight::new_content(
                 base_change_set,
-                base_change_set
-                    .generate_ulid()
-                    .expect("cannot generate ulid"),
-                ContentAddress::Schema(ContentHash::from("lacy - olivia rodrigo")),
+                olivia_rodrigo_id,
+                ContentAddress::Component(ContentHash::from("lacy - olivia rodrigo")),
             )
             .expect("could not create node weight"),
         )
         .expect("could not add node");
-
-    snapshot.write(ctx).await.expect("could not write snapshot");
+    snapshot
+        .add_edge_from_root(base_change_set, olivia_rodrigo_node_index)
+        .expect("could not add edge");
+    snapshot
+        .write(ctx, base_change_set.vector_clock_id())
+        .await
+        .expect("could not write snapshot");
     base_change_set
         .update_pointer(ctx, snapshot.id())
         .await
-        .expect("could not update pointer");
+        .expect("could not update change set");
 
-    // Create another change set and update.
+    // Create another change set and update the snapshot.
     let mut forked_change_set = ChangeSetPointer::new(ctx, "fork")
         .await
         .expect("could not create change set");
     let forked_change_set = &mut forked_change_set;
-    snapshot
+    let mut forked_snapshot = WorkspaceSnapshot::find_for_change_set(ctx, base_change_set.id)
+        .await
+        .expect("could not find snapshot");
+    let victoria_monet_id = forked_change_set
+        .generate_ulid()
+        .expect("could not generate id");
+    let victoria_monet_node_index = forked_snapshot
         .add_node(
             NodeWeight::new_content(
                 forked_change_set,
-                forked_change_set
-                    .generate_ulid()
-                    .expect("cannot generate ulid"),
-                ContentAddress::Schema(ContentHash::from("i'm the one - victoria monét")),
+                victoria_monet_id,
+                ContentAddress::Component(ContentHash::from("i'm the one - victoria monét")),
             )
             .expect("could not create node weight"),
         )
         .expect("could not add node");
-    snapshot.write(ctx).await.expect("could not write snapshot");
-    forked_change_set
-        .update_pointer(ctx, snapshot.id())
+    let victoria_monet_edge_index = forked_snapshot
+        .add_edge_from_root(forked_change_set, victoria_monet_node_index)
+        .expect("could not add edge");
+    forked_snapshot
+        .write(ctx, forked_change_set.vector_clock_id())
         .await
-        .expect("could not update pointer");
+        .expect("could not write snapshot");
+    forked_change_set
+        .update_pointer(ctx, forked_snapshot.id())
+        .await
+        .expect("could not update change set");
 
-    // Rebase!
-    let response = client
-        .send_management_open_change_set(base_change_set.id.into())
+    // Commit all changes made so that the rebaser can access them.
+    ctx.blocking_commit().await.expect("could not commit");
+
+    // Create a rebaser client and open a change set loop.
+    let mut client = Client::new().await.expect("could not build client");
+    let _ = client
+        .open_stream_for_change_set(base_change_set.id.into())
         .await
         .expect("could not send management");
 
-    // TODO(nick): do something useful with this.
-    dbg!(response);
-
-    ctx.blocking_commit().await.expect("could not do this");
-
+    // Cache expected updates and then perform a rebase.
+    let expected_updates = [Update::NewEdge {
+        source: snapshot.root().expect("could not get root"),
+        destination: forked_snapshot
+            .get_node_index_by_id(victoria_monet_id)
+            .expect("could not get node index"),
+        edge_weight: forked_snapshot
+            .get_edge_by_index_stableish(victoria_monet_edge_index)
+            .expect("could not find edge by index"),
+    }];
     let response = client
-        .send_with_reply(
+        .request_rebase(
             base_change_set.id.into(),
-            snapshot.id().into(),
-            forked_change_set.id.into(),
+            forked_snapshot.id().into(),
+            forked_change_set.vector_clock_id().into(),
         )
         .await
         .expect("could not send");
 
-    // TODO(nick): do something useful with this.
-    dbg!(response);
+    // Ensure the rebase was successful and no updates needed to be performed.
+    match response {
+        ChangeSetReplyMessage::Success { updates_performed } => {
+            let actual_updates: Vec<Update> =
+                serde_json::from_value(updates_performed).expect("could not deserialize");
+            assert_eq!(
+                &expected_updates,         // expected
+                actual_updates.as_slice()  // actual
+            );
+        }
+        ChangeSetReplyMessage::ConflictsFound {
+            conflicts_found,
+            updates_found_and_skipped: _,
+        } => {
+            let conflicts: Vec<Conflict> =
+                serde_json::from_value(conflicts_found).expect("could not deserialize");
+            panic!("unexpected conflicts: {conflicts:?}");
+        }
+        ChangeSetReplyMessage::Error { message } => {
+            panic!("unexpected error: {message}");
+        }
+    }
+
+    // Now, create a conflict.
+    let mut snapshot = WorkspaceSnapshot::find_for_change_set(ctx, base_change_set.id)
+        .await
+        .expect("could not find snapshot");
+    snapshot
+        .update_content(
+            base_change_set,
+            olivia_rodrigo_id,
+            ContentHash::from("onto updated"),
+        )
+        .expect("could not update content");
+    snapshot
+        .write(ctx, base_change_set.vector_clock_id())
+        .await
+        .expect("could not write snapshot");
+    base_change_set
+        .update_pointer(ctx, snapshot.id())
+        .await
+        .expect("could not update change set");
+    let mut forked_snapshot = WorkspaceSnapshot::find_for_change_set(ctx, forked_change_set.id)
+        .await
+        .expect("could not find snapshot");
+    forked_snapshot
+        .update_content(
+            forked_change_set,
+            olivia_rodrigo_id,
+            ContentHash::from("to rebase updated"),
+        )
+        .expect("could not update content");
+    forked_snapshot
+        .write(ctx, forked_change_set.vector_clock_id())
+        .await
+        .expect("could not write snapshot");
+    forked_change_set
+        .update_pointer(ctx, forked_snapshot.id())
+        .await
+        .expect("could not update change set");
+
+    // Commit all changes made so that the rebaser can access them.
+    ctx.blocking_commit().await.expect("could not commit");
+
+    // Cache the expected conflict and perform the rebase with the conflict.
+    let expected_conflicts = [Conflict::NodeContent {
+        onto: forked_snapshot
+            .get_node_index_by_id(olivia_rodrigo_id)
+            .expect("could not get node index by id"),
+        to_rebase: snapshot
+            .get_node_index_by_id(olivia_rodrigo_id)
+            .expect("could not get node index by id"),
+    }];
+    let response = client
+        .request_rebase(
+            base_change_set.id.into(),
+            forked_snapshot.id().into(),
+            forked_change_set.vector_clock_id().into(),
+        )
+        .await
+        .expect("could not send");
+
+    // Ensure we see the conflict.
+    match response {
+        ChangeSetReplyMessage::Success { updates_performed } => {
+            let updates_performed: Vec<Update> =
+                serde_json::from_value(updates_performed).expect("could not deserialize");
+            panic!("unexpected success: {updates_performed:?}")
+        }
+        ChangeSetReplyMessage::ConflictsFound {
+            conflicts_found,
+            updates_found_and_skipped,
+        } => {
+            let actual_conflicts: Vec<Conflict> =
+                serde_json::from_value(conflicts_found).expect("could not deserialize");
+            assert_eq!(
+                &expected_conflicts,         // expected
+                actual_conflicts.as_slice()  // actual
+            );
+            let updates_found_and_skipped: Vec<Update> =
+                serde_json::from_value(updates_found_and_skipped).expect("could not deserialize");
+            assert!(updates_found_and_skipped.is_empty());
+        }
+        ChangeSetReplyMessage::Error { message } => {
+            panic!("unexpected error: {message}");
+        }
+    }
 
     // TODO(nick): move cleanup to the test harness.
     let _ = client
-        .send_management_close_change_set(base_change_set.id.into())
+        .close_stream_for_change_set(base_change_set.id.into())
         .await;
 }

--- a/lib/rebaser-client/Cargo.toml
+++ b/lib/rebaser-client/Cargo.toml
@@ -14,3 +14,4 @@ telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 ulid = { workspace = true }
+log = "0.4.20"

--- a/lib/rebaser-client/src/lib.rs
+++ b/lib/rebaser-client/src/lib.rs
@@ -29,7 +29,6 @@ pub use client::Client;
 use si_rabbitmq::{Delivery, RabbitError};
 use telemetry::prelude::error;
 use thiserror::Error;
-use tokio::time::error::Elapsed;
 
 #[allow(missing_docs)]
 #[remain::sorted]
@@ -43,8 +42,8 @@ pub enum ClientError {
     Rabbit(#[from] RabbitError),
     #[error("rebaser stream for change set not found")]
     RebaserStreamForChangeSetNotFound,
-    #[error("hit timeout while waiting for message on reply stream: {0}")]
-    ReplyTimeout(Elapsed),
+    #[error("hit timeout while waiting for message on reply stream")]
+    ReplyTimeout,
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 }

--- a/lib/rebaser-core/BUCK
+++ b/lib/rebaser-core/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "rebaser-core",
     deps = [
         "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
         "//third-party/rust:ulid",
     ],
     srcs = glob([

--- a/lib/rebaser-core/Cargo.toml
+++ b/lib/rebaser-core/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 ulid = { workspace = true }

--- a/lib/rebaser-core/src/lib.rs
+++ b/lib/rebaser-core/src/lib.rs
@@ -27,6 +27,7 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use serde_json::Value;
 use ulid::Ulid;
 
 /// Stream to manage rebaser consumer loops.
@@ -68,14 +69,16 @@ pub struct ChangeSetMessage {
 /// The message shape that the rebaser change set loop will use for replying to the client.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ChangeSetReplyMessage {
-    /// Processing the delivery was a success.
-    Success {
-        /// The results of processing the delivery.
-        results: String,
+    /// Updates performed when processing the delivery.
+    Success(Value),
+    /// Conflicts found when processing the delivery.
+    ConflictsFound {
+        /// A serialized list of the conflicts found during detection.
+        conflicts_found: Value,
+        /// A serialized list of the updates found during detection and skipped because at least
+        /// once conflict was found.
+        updates_found_and_skipped: Value,
     },
-    /// Processing the delivery was a failure.
-    Failure {
-        /// The error encountered when processing the delivery.
-        error: String,
-    },
+    /// Error encountered when processing the delivery.
+    Error(String),
 }

--- a/lib/si-rabbitmq/src/lib.rs
+++ b/lib/si-rabbitmq/src/lib.rs
@@ -60,7 +60,7 @@ mod tests {
             .await
             .expect("could not create stream");
 
-        let mut producer = Producer::new(&environment, "producer", stream)
+        let mut producer = Producer::new(&environment, stream)
             .await
             .expect("could not create producer");
 


### PR DESCRIPTION
## Description

This PR contains two commits that enable us to perform updates in the rebaser.

## Commit 1/2: [Bail on conflicts in rebaser-server](https://github.com/systeminit/si/commit/9a0a4fd098631b6639f822aa9c3c795d6ad8661a) 

Bail on conflicts in rebaser-server by returning a new variant of the
ChangeSetReplyMessage. The new variant, ConflictsFound, indicates that
while no functions failed, there was at least one conflict found.
Therefore, no updates could be performed.

## Commit 2/2: [Perform updates in the rebaser](https://github.com/systeminit/si/commit/d3780aab4e8ab25a5fc99d8fb0267e63f84f7726) 

This commit adds the ability for the rebaser to perform the updates it
finds.

Two new tests have been added: one showcasing a "fork" rebasing
flow including a simple conflict. The other test is contained within
WorkspaceSnapshotGraph and helped fix a bug found while writing the
former test: when "to_rebase" has never seen anything from the "onto"
change set, all items are new. Before this commit, those updates were
not detected.

Primary dal changes:
- Add ability to update content, import subgraph, remove edge by
  EdgeIndex (only when performing updates), replace references, get node
  weight, find equivalent node, print "dot" output to stdout, get node
  index by id, and add edge from root for WorkspaceSnapshot
  - It is likely that many of these methods will not last the test of
    time and exist mainly for the commit's integration test
- Replace ChangeSetPointer function parameters with VectorClockId where
  appropriate (continuation of prior work with VectorClockId)
- Re-export NodeIndex for use outside of WorkspaceSnapshotGraph
  - This should be rarely used and we may be able to abstract it away in
    the future
- Add ability to get the root NodeIndex, find an equivalent node, and
  remove edge by EdgeIndex for WorkspaceSnapshotGraph

Primary rebaser changes:
- Renamed client methods to closer match intent
- Centralize stream name generation into core
- Add debug logging to both the client and server to aid in debugging
  timeouts
- Expand ChangeSetReplyMessage options to aid in testing and debugging
  in production
- Move DalContext building into the listener loop rather than re-using
  the same DalContext for every delivery
- Convert Producer from "Dedup" to "Nodedup" since a Producer can be
  re-created for the same stream and process
  - Without this change, you could produce a message to a stream, see
    that it would not appear as "ready" in the RabbitMQ Dashboard and
    observe that no error or failure occurred (read: this was a pain in
    the ass)
  - From this change, the number of constructors have been reduced from
    two to one

## GIF

<img src="https://media0.giphy.com/media/3oEduJjIJv13yhZNBu/giphy.gif"/>