### PR TITLE
Add systeminit/rabbitmq DockerHub image (ENG-1990)

### DIFF
--- a/component/rabbitmq/BUCK
+++ b/component/rabbitmq/BUCK
@@ -1,0 +1,19 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+)
+
+docker_image(
+    name = "rabbitmq",
+    build_args = {
+        "BASE_VERSION": "3.12-management-alpine",
+    },
+    run_docker_args = [
+        "--publish",
+        "5552:5552",
+        "--publish",
+        "15672:15672",
+        "--env",
+        "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host localhost"
+    ],
+)

--- a/component/rabbitmq/Dockerfile
+++ b/component/rabbitmq/Dockerfile
@@ -1,0 +1,3 @@
+ARG BASE_VERSION
+FROM rabbitmq:${BASE_VERSION}
+RUN rabbitmq-plugins enable --offline rabbitmq_stream

--- a/component/rabbitmq/README.md
+++ b/component/rabbitmq/README.md
@@ -1,0 +1,11 @@
+# RabbitMQ
+
+This directory contains our [RabbitMQ](https://www.rabbitmq.com/) image.
+
+## Notes
+
+- We use the ["streams"](https://www.rabbitmq.com/streams.html) protocol not only for performance and ease-of-use, but also because the [official Rust library](https://crates.io/crates/rabbitmq-stream-client) is based on the "streams" protocol
+- Since we use "streams", we use non-standard ports, which are provided on the [upstream networking page](https://www.rabbitmq.com/networking.html)
+- In our Docker Image, we enable the "streams" plugin by default, which is outlined in the [upstream DockerHub page](https://hub.docker.com/_/rabbitmq)
+- The `-management` tagged upstream image enable the dashboard feature by default
+- The `-alpine` tagged upstream images use [Alpine Linux](https://alpinelinux.org/) as the base image and offer size reduction


### PR DESCRIPTION
## Description

Add si-rabbitmq DockerHub image for ENG-1703 ("Mostly Everything is a Node or an Edge") graph work. This directory is being added to main to get the image building and published in advance to the long running dev branch getting merged.

The new image is not used for anything other than image building, promoting and publishing.

## Reference

The code in this PR was taken from https://github.com/systeminit/si/pull/2424.

## GIF

<img src="https://media3.giphy.com/media/WiXMlla4ZFR8Q/giphy.gif"/>