### PR TITLE
fix(dal,si-pkg): export and import resource properly in backup

### DIFF
--- a/app/web/src/components/AttributeDebugView.vue
+++ b/app/web/src/components/AttributeDebugView.vue
@@ -39,6 +39,22 @@
       <dd class="p-2 my-2 border-2 border-opacity-10">
         <pre>{{ data.prototypeContext }}</pre>
       </dd>
+      <dt class="uppercase text-xs italic opacity-80">
+        Implicit Attribute Value
+      </dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10 overflow-x-scroll">
+        <pre>{{
+          typeof data.implicitValue === "undefined"
+            ? "none"
+            : data.implicitValue ?? "NULL"
+        }}</pre>
+      </dd>
+      <dt class="uppercase text-xs italic opacity-80">
+        Implicit Set By Function
+      </dt>
+      <dd class="p-2 my-2 border-2 border-opacity-10">
+        <pre>{{ data.implicitFuncName }} </pre>
+      </dd>
       <p class="text-2xs p-2 my-2 border-2 border-opacity-10">
         prototype in change set?
         {{ data.prototypeInChangeSet ? "y" : "n" }} value in change set?

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -157,6 +157,14 @@ export interface AttributeDebugData {
   kind: string;
   prototypeInChangeSet: boolean;
   valueInChangeSet: boolean;
+  implicitValue?: object | string | number | boolean | null;
+  implicitValueContext?: {
+    prop_id: string;
+    internal_provider_id: string;
+    external_provider_id: string;
+    component_id: string;
+  };
+  implicitFuncName?: string;
 }
 
 export interface AttributeDebugView {

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -1501,6 +1501,11 @@ impl PkgExporter {
         if let Some(value) = view.func_binding_return_value.value() {
             builder.value(value.to_owned());
         }
+        if let Some(implicit_value) = view.implicit_attribute_value {
+            if let Some(value) = implicit_value.get_value(ctx).await? {
+                builder.implicit_value(value);
+            }
+        }
         if let Some(output_stream) = view.func_execution.output_stream() {
             builder.output_stream(serde_json::to_value(output_stream)?);
         }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -55,6 +55,10 @@ impl PropPath {
         &self.0
     }
 
+    pub fn as_parts(&self) -> Vec<&str> {
+        self.0.split(PROP_PATH_SEPARATOR).collect()
+    }
+
     pub fn as_owned_parts(&self) -> Vec<String> {
         self.0.split(PROP_PATH_SEPARATOR).map(Into::into).collect()
     }
@@ -65,6 +69,20 @@ impl PropPath {
 
     pub fn with_replaced_sep(&self, sep: &str) -> String {
         self.0.to_owned().replace(PROP_PATH_SEPARATOR, sep)
+    }
+
+    /// Returns true if this PropPath is a descendant (at any depth) of `maybe_parent`
+    pub fn is_descendant_of(&self, maybe_parent: &PropPath) -> bool {
+        let this_parts = self.as_parts();
+        let maybe_parent_parts = maybe_parent.as_parts();
+
+        for (idx, parent_part) in maybe_parent_parts.iter().enumerate() {
+            if Some(parent_part) != this_parts.get(idx) {
+                return false;
+            }
+        }
+
+        true
     }
 }
 

--- a/lib/sdf-server/src/server/service/pkg/install_pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg/install_pkg.rs
@@ -68,7 +68,7 @@ pub async fn install_pkg(
         .await?
         .publish_on_commit(&ctx)
         .await?;
-    ctx.commit().await?;
+    ctx.blocking_commit().await?;
 
     Ok(Json(InstallPkgResponse {
         success: true,

--- a/lib/si-pkg/src/pkg/attribute_value.rs
+++ b/lib/si-pkg/src/pkg/attribute_value.rs
@@ -24,6 +24,7 @@ pub struct SiPkgAttributeValue<'a> {
     is_proxy: bool,
     sealed_proxy: bool,
     component_specific: bool,
+    implicit_value: Option<serde_json::Value>,
 
     hash: Hash,
     source: Source<'a>,
@@ -91,6 +92,7 @@ impl<'a> SiPkgAttributeValue<'a> {
             is_proxy: node.is_proxy,
             sealed_proxy: node.sealed_proxy,
             component_specific: node.component_specific,
+            implicit_value: node.implicit_value,
 
             hash: hashed_node.hash(),
             source: Source::new(graph, node_idx),
@@ -151,6 +153,10 @@ impl<'a> SiPkgAttributeValue<'a> {
 
     pub fn component_specific(&self) -> bool {
         self.component_specific
+    }
+
+    pub fn implicit_value(&self) -> Option<&serde_json::Value> {
+        self.implicit_value.as_ref()
     }
 
     pub fn hash(&self) -> Hash {

--- a/lib/si-pkg/src/spec/attribute_value.rs
+++ b/lib/si-pkg/src/spec/attribute_value.rs
@@ -55,6 +55,8 @@ pub struct AttributeValueSpec {
     pub component_specific: bool,
     #[builder(setter(each = "input"), default)]
     pub inputs: Vec<AttrFuncInputSpec>,
+    #[builder(setter(into, strip_option), default)]
+    pub implicit_value: Option<serde_json::Value>,
 }
 
 impl AttributeValueSpec {


### PR DESCRIPTION
Two issues were preventing the resource from being restored from a workspace backup:
  1. The resource "payload" prop was being skipped because it is typed as a string but we store an object there typically (we store unrestricted json on it even though it is a "string").
  2. We need to emit the implicit attribute values for props if they are there.

Adding 2 did not totally fix it, so component.set_resource was resorted to to set the resource on the component if a value for it exists.