### PR TITLE
feat(web,sdf-server): Remove the need to set handler on functions and assets

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -85,15 +85,6 @@
           @blur="updateAsset"
         />
         <VormInput
-          id="handler"
-          v-model="editingAsset.handler"
-          type="text"
-          :disabled="disabled"
-          label="Entrypoint"
-          placeholder="(mandatory) Provide the function entrypoint to the asset"
-          @blur="updateAsset"
-        />
-        <VormInput
           id="category"
           v-model="editingAsset.category"
           type="text"

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -148,13 +148,6 @@
                 @blur="updateFunc"
               />
               <VormInput
-                v-model="editingFunc.handler"
-                label="Entrypoint"
-                required
-                placeholder="The name of the function that will be executed..."
-                @blur="updateFunc"
-              />
-              <VormInput
                 v-model="editingFunc.description"
                 type="textarea"
                 placeholder="Provide a brief description of this function here..."

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -91,7 +91,6 @@ export interface VariantDef extends ListedVariantDef {
   link?: string;
   schemaVariantId?: string;
   code: string;
-  handler: string;
   types?: string;
   hasComponents: boolean;
   hasAttrFuncs: boolean;
@@ -239,7 +238,6 @@ export const useAssetStore = () => {
             id: nilId(),
             name: `new asset ${Math.floor(Math.random() * 10000)}`,
             code: "",
-            handler: "",
             color: this.generateMockColor(),
             description: "",
             category: "",

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -29,7 +29,6 @@ export type FuncId = string;
 
 export type FuncSummary = {
   id: string;
-  handler: string;
   variant: FuncVariant;
   name: string;
   displayName?: string;

--- a/app/web/src/utils/typescriptLinter.ts
+++ b/app/web/src/utils/typescriptLinter.ts
@@ -120,12 +120,25 @@ export const createTypescriptSource = async (
     const doc = view.state.doc;
     // We could be more efficient by updating only the changed spans
     const docString = doc.toString();
+
+    let diagnostics: Diagnostic[] = [];
+
+    // custom lint rule to ensure that we have a `main` function entrypoint
+    if (!docString.includes("function main(")) {
+      diagnostics = diagnostics.concat(
+        diagnosticsForMessage(
+          1,
+          1,
+          "Function should include a `main` function for code execution",
+        ),
+      );
+    }
+
     tsEnv.updateFile(
       defaultFilename,
       docString.trim().length === 0 ? fallbackCode : docString,
     );
 
-    let diagnostics: Diagnostic[] = [];
     for (const tsDiagnostic of tsEnv.languageService.getSyntacticDiagnostics(
       defaultFilename,
     )) {

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -562,7 +562,6 @@ pub async fn get_func_view(ctx: &DalContext, func: &Func) -> FuncResult<GetFuncR
 
     Ok(GetFuncResponse {
         id: func.id().to_owned(),
-        handler: func.handler().map(|h| h.to_owned()),
         variant: func.try_into()?,
         display_name: func.display_name().map(Into::into),
         name: func.name().to_owned(),

--- a/lib/sdf-server/src/server/service/func/create_func.rs
+++ b/lib/sdf-server/src/server/service/func/create_func.rs
@@ -70,15 +70,11 @@ pub struct CreateFuncResponse {
     pub code: Option<String>,
 }
 
-pub static DEFAULT_ATTRIBUTE_CODE_HANDLER: &str = "setAttribute";
+pub static DEFAULT_CODE_HANDLER: &str = "main";
 pub static DEFAULT_ATTRIBUTE_CODE: &str = include_str!("./defaults/attribute.ts");
-pub static DEFAULT_CODE_GENERATION_HANDLER: &str = "generateCode";
 pub static DEFAULT_CODE_GENERATION_CODE: &str = include_str!("./defaults/code_generation.ts");
-pub static DEFAULT_QUALIFICATION_HANDLER: &str = "qualification";
 pub static DEFAULT_QUALIFICATION_CODE: &str = include_str!("./defaults/qualification.ts");
-pub static DEFAULT_ACTION_HANDLER: &str = "action";
 pub static DEFAULT_ACTION_CODE: &str = include_str!("./defaults/action.ts");
-pub static DEFAULT_VALIDATION_HANDLER: &str = "validate";
 pub static DEFAULT_VALIDATION_CODE: &str = include_str!("./defaults/validation.ts");
 
 async fn create_func_stub(
@@ -113,7 +109,7 @@ async fn create_validation_func(
         FuncVariant::Validation,
         FuncBackendResponseType::Validation,
         DEFAULT_VALIDATION_CODE,
-        DEFAULT_VALIDATION_HANDLER,
+        DEFAULT_CODE_HANDLER,
     )
     .await?;
 
@@ -165,7 +161,7 @@ async fn create_action_func(
         FuncVariant::Action,
         FuncBackendResponseType::Action,
         DEFAULT_ACTION_CODE,
-        DEFAULT_ACTION_HANDLER,
+        DEFAULT_CODE_HANDLER,
     )
     .await?;
 
@@ -225,17 +221,17 @@ async fn create_attribute_func(
     let (code, handler, response_type) = match variant {
         FuncVariant::Attribute => (
             DEFAULT_ATTRIBUTE_CODE,
-            DEFAULT_ATTRIBUTE_CODE_HANDLER,
+            DEFAULT_CODE_HANDLER,
             FuncBackendResponseType::Unset,
         ),
         FuncVariant::CodeGeneration => (
             DEFAULT_CODE_GENERATION_CODE,
-            DEFAULT_CODE_GENERATION_HANDLER,
+            DEFAULT_CODE_HANDLER,
             FuncBackendResponseType::CodeGeneration,
         ),
         FuncVariant::Qualification => (
             DEFAULT_QUALIFICATION_CODE,
-            DEFAULT_QUALIFICATION_HANDLER,
+            DEFAULT_CODE_HANDLER,
             FuncBackendResponseType::Qualification,
         ),
         _ => {

--- a/lib/sdf-server/src/server/service/func/defaults/action.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/action.ts
@@ -1,3 +1,3 @@
-async function action() {
+async function main() {
   throw new Error("unimplemented!");
 }

--- a/lib/sdf-server/src/server/service/func/defaults/attribute.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/attribute.ts
@@ -1,3 +1,3 @@
-async function setAttribute(input: Input): Promise<Output> {
+async function main(input: Input): Promise<Output> {
   return null;
 }

--- a/lib/sdf-server/src/server/service/func/defaults/code_generation.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/code_generation.ts
@@ -1,4 +1,4 @@
-async function generateCode(component: Input): Promise<Output> {
+async function main(component: Input): Promise<Output> {
   return {
     format: "json",
     code: JSON.stringify(component),

--- a/lib/sdf-server/src/server/service/func/defaults/qualification.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/qualification.ts
@@ -1,4 +1,4 @@
-async function qualification(component: Input): Promise<Output> {
+async function main(component: Input): Promise<Output> {
   return {
     result: 'success',
     message: 'Component qualified'

--- a/lib/sdf-server/src/server/service/func/defaults/validation.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/validation.ts
@@ -1,4 +1,4 @@
-async function validate(value: Input): Promise<Output> {
+async function main(value: Input): Promise<Output> {
   return {
     valid: true,
     message: "validation error message",

--- a/lib/sdf-server/src/server/service/func/get_func.rs
+++ b/lib/sdf-server/src/server/service/func/get_func.rs
@@ -36,7 +36,6 @@ pub struct GetFuncRequest {
 #[serde(rename_all = "camelCase")]
 pub struct GetFuncResponse {
     pub id: FuncId,
-    pub handler: Option<String>,
     pub variant: FuncVariant,
     pub name: String,
     pub display_name: Option<String>,

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -26,7 +26,6 @@ use dal::{FuncBackendResponseType, PropKind, SchemaVariant, ValidationPrototype}
 #[serde(rename_all = "camelCase")]
 pub struct SaveFuncRequest {
     pub id: FuncId,
-    pub handler: Option<String>,
     pub display_name: Option<String>,
     pub name: String,
     pub description: Option<String>,
@@ -581,7 +580,6 @@ pub async fn do_save_func(
     func.set_display_name(ctx, request.display_name).await?;
     func.set_name(ctx, request.name).await?;
     func.set_description(ctx, request.description).await?;
-    func.set_handler(ctx, request.handler).await?;
     func.set_code_plaintext(ctx, request.code.as_deref())
         .await?;
 
@@ -732,7 +730,6 @@ pub async fn save_func<'a>(
         "save_func",
         serde_json::json!({
                     "func_id": func.id(),
-                    "func_handler": func.handler().map(|h| h.to_owned()),
                     "func_name": func.name(),
                     "func_variant": *func.backend_response_type(),
                     "func_is_builtin": func.builtin(),

--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -188,7 +188,6 @@ pub async fn save_variant_def(
     asset_func
         .set_code_plaintext(ctx, Some(&request.code))
         .await?;
-    asset_func.set_handler(ctx, Some(&request.handler)).await?;
 
     if let Some(updated_name) = updated_func_name {
         asset_func.set_name(ctx, updated_name).await?;

--- a/lib/sdf-server/src/server/service/variant_definition/create_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/create_variant_def.rs
@@ -10,9 +10,8 @@ use dal::{
 };
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_ASSET_CODE: &str = r#"function createAsset() {
-  const asset = new AssetBuilder();
-  return asset.build()
+const DEFAULT_ASSET_CODE: &str = r#"function main() {
+  return new AssetBuilder().build()
 }"#;
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -67,7 +66,7 @@ pub async fn create_variant_def(
         FuncBackendResponseType::SchemaVariantDefinition,
     )
     .await?;
-    asset_func.set_handler(&ctx, Some("createAsset")).await?;
+    asset_func.set_handler(&ctx, Some("main")).await?;
     asset_func
         .set_code_plaintext(&ctx, Some(DEFAULT_ASSET_CODE))
         .await?;

--- a/lib/sdf-server/src/server/service/variant_definition/get_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/get_variant_def.rs
@@ -32,7 +32,6 @@ pub struct GetVariantDefResponse {
     pub link: Option<String>,
     pub description: Option<String>,
     pub code: String,
-    pub handler: String,
     pub schema_variant_id: Option<SchemaVariantId>,
     pub component_type: ComponentType,
     pub funcs: Vec<ListedFuncView>,
@@ -58,7 +57,6 @@ impl From<SchemaVariantDefinition> for GetVariantDefResponse {
             funcs: vec![],
             schema_variant_id: None,
             component_type: *def.component_type(),
-            handler: "".to_string(), //TODO @stack72
             types: "".to_string(),
             has_components: false,
             has_attr_funcs: false,
@@ -99,12 +97,6 @@ pub async fn get_variant_def(
             .ok_or(SchemaVariantDefinitionError::FuncIsEmpty(
                 variant_def.func_id(),
             ))?;
-    response.handler = asset_func
-        .handler()
-        .ok_or(SchemaVariantDefinitionError::FuncHasNoHandler(
-            variant_def.func_id(),
-        ))?
-        .into();
 
     if let Some(variant_id) = variant_id {
         response.funcs = SchemaVariant::all_funcs(&ctx, variant_id)

--- a/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
@@ -17,7 +17,6 @@ pub struct SaveVariantDefRequest {
     pub color: String,
     pub link: Option<String>,
     pub code: String,
-    pub handler: String,
     pub description: Option<String>,
     pub component_type: ComponentType,
     #[serde(default)]

--- a/lib/sdf-server/tests/service_tests/functions.rs
+++ b/lib/sdf-server/tests/service_tests/functions.rs
@@ -24,7 +24,7 @@ async fn test_execution_endpoint_qualification_function(
     func.set_code_plaintext(
         &ctx,
         Some(
-            "async function qualification(component: Input): Promise < Output > {
+            "async function main(component: Input): Promise < Output > {
 
         return {
             result: 'success',
@@ -35,7 +35,7 @@ async fn test_execution_endpoint_qualification_function(
     )
     .await
     .expect("unable to set code plaintext");
-    func.set_handler(&ctx, Some("qualification".to_string()))
+    func.set_handler(&ctx, Some("main".to_string()))
         .await
         .expect("unable to set entrypoint");
 

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -422,7 +422,6 @@ impl ScenarioHarness {
             link: Some("https://www.systeminit.com/".to_string()),
             code,
             component_type: ComponentType::Component,
-            handler: "createAsset".to_string(),
             description: None,
             auto_reattach_functions: true,
             visibility: *visibility,
@@ -452,7 +451,6 @@ impl ScenarioHarness {
             code,
             component_type: ComponentType::Component,
             auto_reattach_functions: true,
-            handler: "createAsset".to_string(),
             description: None,
             visibility: *visibility,
         };

--- a/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/authoring_flow_asset.rs
@@ -30,7 +30,7 @@ async fn authoring_flow_asset(
 
     // Update the asset with the schema
     // harness.update_asset(&ctx, )
-    let asset_definition = r#"function createAsset() {
+    let asset_definition = r#"function main() {
         const imageProp = new PropBuilder()
             .setKind("string")
             .setName("image")


### PR DESCRIPTION
We now handcode this to be `main` by default. We have already updated all the builtins to use `main` and we have added a typescript lint warning to let people know they need a main entrypoint for a function

<img width="981" alt="Screenshot 2023-10-18 at 22 52 37" src="https://github.com/systeminit/si/assets/227823/cef291fb-e43a-4f92-9b76-23d21b3a4a66">
