### PR TITLE
feat(si-cli): Add support for custom AWS ENDPOINT URLs

### DIFF
--- a/lib/si-cli/src/cmd/configure.rs
+++ b/lib/si-cli/src/cmd/configure.rs
@@ -3,7 +3,7 @@ use crate::key_management::{
     write_veritech_credentials,
 };
 use crate::{state::AppState, CliResult, SiCliError};
-use inquire::{Password, PasswordDisplayMode};
+use inquire::{Password, PasswordDisplayMode, Text};
 
 impl AppState {
     pub async fn configure(&self, reconfigure: bool) -> CliResult<()> {
@@ -66,6 +66,19 @@ async fn invoke(_is_preview: bool, reconfigure: bool) -> CliResult<()> {
             Err(_) => println!(
                 "An error happened when asking for your AWS Secret Access Key, try again later."
             ),
+        }
+    }
+
+    if prompt_everything {
+        let endpoint_url = Text::new("Set a Custom AWS Endpoint (e.g. Localstack)").prompt();
+
+        match endpoint_url {
+            Ok(url) => {
+                raw_creds.aws_endpoint_url = Some(url);
+                requires_rewrite = true;
+            }
+            Err(inquire::InquireError::OperationInterrupted) => return Err(SiCliError::CtrlC),
+            Err(_) => println!("Not setting a custom AWS Endpoint"),
         }
     }
 

--- a/lib/si-cli/src/key_management.rs
+++ b/lib/si-cli/src/key_management.rs
@@ -13,6 +13,7 @@ use std::{fs, io};
 pub struct Credentials {
     pub aws_access_key_id: String,
     pub aws_secret_access_key: String,
+    pub aws_endpoint_url: Option<String>,
     pub docker_hub_user_name: Option<String>,
     pub docker_hub_credential: Option<String>,
     pub si_email: Option<String>,
@@ -115,6 +116,12 @@ pub async fn format_credentials_for_veritech() -> CliResult<Vec<String>> {
         "AWS_SECRET_ACCESS_KEY={}",
         raw_creds.aws_secret_access_key
     ));
+
+    if raw_creds.aws_endpoint_url.is_some() {
+        if let Some(url) = raw_creds.aws_endpoint_url {
+            creds.push(format!("AWS_ENDPOINT_URL={}", url));
+        }
+    }
 
     if raw_creds.docker_hub_user_name.is_some() && raw_creds.docker_hub_credential.is_some() {
         let mut username = "".to_string();


### PR DESCRIPTION
Fixes: #2659

This allows us to point our SI instance against a localstack setup in the veritech container
All we need to do is to pass an endpoint url as part of the configure command :) It can even use fake credentials

PLEASE NOTE: Qualifications that use `--dry-run` in AWS will return an empty response from localstack - but you would be able to check the localstack logs for a 200 response:

```
2023-10-18T22:11:31.320  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS ec2.CreateVpc => 200
```

https://share.descript.com/view/Uq3tBNcL3oU