### PR TITLE
feat: (lang-js) Added zlib to the standard sandbox. 

### DIFF
--- a/bin/lang-js/src/sandbox.ts
+++ b/bin/lang-js/src/sandbox.ts
@@ -2,6 +2,7 @@ import os from "os";
 import fs from "fs";
 import path from "path";
 import fetch from "node-fetch";
+import zlib from "zlib";
 
 import _ from "lodash";
 import yaml from "js-yaml";
@@ -26,6 +27,7 @@ function commonSandbox(executionId: string): Sandbox {
     console: makeConsole(executionId),
     _,
     Buffer,
+    zlib,
   };
 }
 

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -865,6 +865,11 @@ fn langjs_types() -> &'static str {
     "declare namespace YAML {
     function stringify(obj: unknown): string;
 }
+
+    declare namespace zlib {
+        function gzip(inputstr: string, callback: any);
+    }
+
     declare namespace siExec {
 
     interface WatchArgs {


### PR DESCRIPTION
This will allow assets which need gzipped strings to be created.

Tested with a codegen func defined like so

```typescript
async function main(component: Input): Promise < Output > {
    const zippedstring = "This string will be zipped";

    zlib.gzip(zippedstring, (err, compressedData) => {
        if (!err) {
            console.log('Compressed data:', compressedData.toString('base64'));
        } else {
            console.error('Error compressing data:', err);
        }
    });

    return {
        format: "json",
        code: JSON.stringify(component),
    };
}
```