### PR TITLE
feat(sdf,dal,cyclone): handle js crashes except for attributes

### DIFF
--- a/lib/cyclone-core/src/schema_variant_definition.rs
+++ b/lib/cyclone-core/src/schema_variant_definition.rs
@@ -13,4 +13,7 @@ pub struct SchemaVariantDefinitionRequest {
 pub struct SchemaVariantDefinitionResultSuccess {
     pub execution_id: String,
     pub definition: serde_json::Value,
+    // Collects the error if the function throws
+    #[serde(default)]
+    pub error: Option<String>,
 }

--- a/lib/dal/src/func/backend/js_reconciliation.rs
+++ b/lib/dal/src/func/backend/js_reconciliation.rs
@@ -61,6 +61,15 @@ impl FuncDispatch for FuncBackendJsReconciliation {
         let value = veritech
             .execute_reconciliation(output_tx.clone(), &self.request)
             .await?;
+        let value = match value {
+            FunctionResult::Failure(failure) => FunctionResult::Success(Self::Output {
+                execution_id: failure.execution_id,
+                updates: Default::default(),
+                actions: Default::default(),
+                message: Some(failure.error.message.clone()),
+            }),
+            FunctionResult::Success(value) => FunctionResult::Success(value),
+        };
 
         Ok(value)
     }

--- a/lib/dal/tests/integration_test/internal/func/schema_variant_definition.rs
+++ b/lib/dal/tests/integration_test/internal/func/schema_variant_definition.rs
@@ -41,7 +41,6 @@ async fn execute_schema_variant_definition(ctx: &DalContext) {
     assert_eq!(
         return_value.value(),
         Some(&serde_json::json!({
-            "logs": [],
             "definition": {
                 "props": [
                     {
@@ -51,7 +50,8 @@ async fn execute_schema_variant_definition(ctx: &DalContext) {
                 ],
                 "inputSockets": [],
                 "outputSockets": [],
-            }
+            },
+            "error": serde_json::Value::Null
         }))
     );
 }

--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -78,6 +78,8 @@ pub enum SchemaVariantDefinitionError {
     FuncBinding(#[from] FuncBindingError),
     #[error("func execution error: {0}")]
     FuncExecution(FuncId),
+    #[error("func execution failure error: {0}")]
+    FuncExecutionFailure(String),
     #[error("func has no handler: {0}")]
     FuncHasNoHandler(FuncId),
     #[error("func is empty: {0}")]

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -115,6 +115,23 @@ pub async fn exec_variant_def(
     let (_, return_value) =
         FuncBinding::create_and_execute(&ctx, serde_json::Value::Null, *asset_func.id()).await?;
 
+    if let Some(error) = return_value
+        .value()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .as_object()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .get("error")
+        .and_then(|e| e.as_str())
+    {
+        return Err(SchemaVariantDefinitionError::FuncExecutionFailure(
+            error.to_owned(),
+        ));
+    }
+
     let func_resp = return_value
         .value()
         .ok_or(SchemaVariantDefinitionError::FuncExecution(


### PR DESCRIPTION
Attribute functions will need more work to deal with how to return the failure to the user. As regular attribute functions only return a prop value, like a string or number.

We can implement for code-gen, qualification, etc. Which will be the next steps, but regular propagation functions will be though.