### PR TITLE
feat(web,vue-lib) alternate minimal tab style

### DIFF
--- a/app/web/src/components/AssetActionsDetails.vue
+++ b/app/web/src/components/AssetActionsDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="h-full relative">
-    <TabGroup>
+    <TabGroup minimal>
       <TabGroupItem label="Select" slug="action-selection">
         <div
           v-if="actions.length === 0"

--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -68,10 +68,10 @@
 
     <template v-else>
       <div class="absolute inset-0">
-        <TabGroup>
-          <TabGroupItem>
+        <TabGroup trackingSlug="asset_details">
+          <TabGroupItem slug="component">
             <template #label>
-              <Inline>
+              <Inline noWrap>
                 <span>Component</span>
                 <StatusIndicatorIcon
                   v-if="selectedComponentQualificationStatus"
@@ -80,16 +80,7 @@
                 />
               </Inline>
             </template>
-
-            <TabGroup
-              :startSelectedTabSlug="
-                changeSetStore.headSelected ? 'resource' : 'attributes'
-              "
-              :rememberSelectedTabKey="`component_details_${
-                changeSetStore.headSelected ? 'view' : 'model'
-              }`"
-              trackingSlug="component_details"
-            >
+            <TabGroup trackingSlug="asset_details/component" minimal>
               <TabGroupItem label="Attributes" slug="attributes">
                 <AttributeViewer
                   class="dark:text-neutral-50 text-neutral-900"
@@ -127,9 +118,9 @@
               </TabGroupItem>
             </TabGroup>
           </TabGroupItem>
-          <TabGroupItem>
+          <TabGroupItem slug="resources">
             <template #label>
-              <Inline>
+              <Inline noWrap>
                 <span>Resource</span>
                 <StatusIndicatorIcon
                   v-if="selectedComponent.resource.data"
@@ -140,9 +131,9 @@
             </template>
             <ComponentDetailsResource />
           </TabGroupItem>
-          <TabGroupItem>
+          <TabGroupItem slug="actions">
             <template #label>
-              <Inline>
+              <Inline noWrap>
                 <span>Actions</span>
                 <PillCounter :count="selectedComponentActionsCount" />
               </Inline>

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -60,7 +60,7 @@
     rememberSizeKey="details-panel"
     side="right"
     :defaultSize="380"
-    :minSize="300"
+    :minSize="350"
     :disableSubpanelResizing="!changesPanelRef?.isOpen"
   >
     <div class="h-full overflow-hidden relative">

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -40,7 +40,7 @@ impl ComponentDiff {
         // live any longer (that is, it's garbage collected at a reasonable time)
         let head_ctx = ctx.clone_with_head();
 
-        if ctx.visibility().is_head() || ctx.visibility().deleted_at.is_some() {
+        if ctx.visibility().deleted_at.is_some() {
             return Err(ComponentError::InvalidContextForDiff);
         }
 
@@ -57,6 +57,14 @@ impl ComponentDiff {
         curr_component_view.drop_private();
 
         let curr_json = serde_json::to_string_pretty(&curr_component_view)?;
+
+        if ctx.visibility().is_head() {
+            return Ok(Self {
+                component_id,
+                current: CodeView::new(CodeLanguage::Json, Some(curr_json)),
+                diffs: Vec::new(),
+            });
+        }
 
         // Find the "diffs" given the head dal context only if the component exists on head.
         let diffs: Vec<CodeView> = if Component::get_by_id(&head_ctx, &component_id)

--- a/lib/vue-lib/src/design-system/layout/Inline.vue
+++ b/lib/vue-lib/src/design-system/layout/Inline.vue
@@ -30,6 +30,7 @@ const propsDefinition = {
     type: Boolean,
     default: false,
   },
+  noWrap: Boolean,
 } as const;
 
 function flipAlignIfReversed(
@@ -87,6 +88,8 @@ const Inline = (
     ...(props.collapseBelow && {
       [`--collapse-below-${props.collapseBelow}`]: true,
     }),
+
+    "--no-wrap": props.noWrap,
   };
 
   const wrappedChildren = [] as VNode[];
@@ -130,6 +133,10 @@ export default Inline;
 
   &.--reverse {
     flex-direction: row-reverse;
+  }
+
+  &.--no-wrap {
+    flex-wrap: nowrap;
   }
 
   each(@spacing-rem, .(@size-px, @size-name){

--- a/lib/vue-lib/src/design-system/tabs/TabGroup.vue
+++ b/lib/vue-lib/src/design-system/tabs/TabGroup.vue
@@ -41,15 +41,24 @@
             :class="
               clsx(
                 'focus:outline-none whitespace-nowrap',
-                'text-neutral-400 border-b border-neutral-300 dark:border-neutral-600 border-x border-t border-x-neutral-300 border-t-neutral-300 dark:border-x-neutral-600 dark:border-t-neutral-600',
-                'h-11 px-2 text-sm inline-flex items-center rounded-t group-hover:border-shade-100 dark:group-hover:border-shade-0',
-                tab.props.slug === selectedTabSlug
-                  ? 'border-b-white dark:border-b-neutral-800 border-b text-action-700 dark:text-action-300 font-bold'
-                  : themeClasses(
-                      'hover:text-neutral-400 font-medium hover:bg-neutral-100',
-                      'hover:text-neutral-300 font-medium hover:bg-neutral-900',
-                    ),
+                'h-11 px-2 text-sm inline-flex items-center',
                 growTabsToFillWidth && 'flex-grow justify-center',
+                minimal
+                  ? [
+                      'border-b ',
+                      tab.props.slug === selectedTabSlug
+                        ? 'border-current text-action-500 dark:text-action-300 font-bold'
+                        : 'border-neutral-300 dark:border-neutral-600 hover:border-shade-100 dark:hover:border-shade-0',
+                    ]
+                  : [
+                      'text-neutral-400 border-b border-neutral-300 dark:border-neutral-600 border-x border-t border-x-neutral-300 border-t-neutral-300 dark:border-x-neutral-600 dark:border-t-neutral-600 rounded-t group-hover:border-shade-100 dark:group-hover:border-shade-0',
+                      tab.props.slug === selectedTabSlug
+                        ? 'border-b-white dark:border-b-neutral-800 border-b text-action-700 dark:text-action-300 font-bold'
+                        : themeClasses(
+                            'hover:text-neutral-400 font-medium hover:bg-neutral-100',
+                            'hover:text-neutral-300 font-medium hover:bg-neutral-900',
+                          ),
+                    ],
               )
             "
             @click.prevent="selectTab(tab.props.slug)"
@@ -184,6 +193,7 @@ const props = defineProps({
   },
   trackingSlug: String,
   growTabsToFillWidth: { type: Boolean },
+  minimal: { type: Boolean },
 });
 
 const emit = defineEmits<{


### PR DESCRIPTION
adds new minimal tab style which can be toggled on. For now we'll use wherever we have nested tabs, but may want to consider using in other places as well.

<img width="502" alt="image" src="https://github.com/systeminit/si/assets/1158956/592956fe-efeb-42b7-b5aa-dea7f6316cd2">

also fixes the diff tab when viewing head and other small tab related issues.
