### PR TITLE
build(buck2): create a `jest` rule for use in lang-js' test-unit target

### DIFF
--- a/bin/lang-js/BUCK
+++ b/bin/lang-js/BUCK
@@ -1,6 +1,7 @@
 load(
     "@prelude-si//:macros.bzl",
     "eslint",
+    "jest",
     "export_file",
     "node_pkg_bin",
     "prettier_check",
@@ -9,11 +10,6 @@ load(
     "typescript_runnable_dist",
     "typescript_runnable_dist_bin",
     "package_node_modules",
-)
-load(
-    "@prelude-si//:pnpm.bzl",
-    "pnpm_task_binary",
-    "pnpm_task_test",
 )
 
 export_file(
@@ -69,31 +65,7 @@ prettier_check(
     srcs = [":src", ":test_src"] + glob([".prettier*"]),
 )
 
-#
-#
-#
-# TODO(fnichol): DEAL
-#
-#
-#
-
-pnpm_task_test(
-    name = "zzz-test",
-    command = "test",
-    deps = [
-        ":dist",
-    ],
-    path = "bin/lang-js",
-    visibility = ["PUBLIC"],
-)
-
-pnpm_task_binary(
-    name = "generate",
-    command = "generate",
-    srcs = glob(["*"]),
-    path = "bin/lang-js",
-    deps = [
-        "//:node_modules",
-    ],
-    visibility = ["PUBLIC"],
+jest(
+    name = "test-unit",
+    srcs = [":src", ":test_src"] + glob(["jest.config.js"]),
 )

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -27,6 +27,7 @@ nix_flake_lock = _nix_flake_lock
 load(
     "@prelude-si//macros:pnpm.bzl",
     _eslint = "eslint",
+    _jest = "jest",
     _node_pkg_bin = "node_pkg_bin",
     _npm_bin = "npm_bin",
     _package_node_modules = "package_node_modules",
@@ -41,6 +42,7 @@ load(
     _workspace_node_modules = "workspace_node_modules",
 )
 eslint = _eslint
+jest = _jest
 node_pkg_bin = _node_pkg_bin
 npm_bin = _npm_bin
 package_node_modules = _package_node_modules

--- a/prelude-si/macros/pnpm.bzl
+++ b/prelude-si/macros/pnpm.bzl
@@ -1,6 +1,7 @@
 load(
     "@prelude-si//:pnpm.bzl",
     _eslint = "eslint",
+    _jest = "jest",
     _node_pkg_bin = "node_pkg_bin",
     _npm_bin = "npm_bin",
     _package_node_modules = "package_node_modules",
@@ -31,6 +32,26 @@ def eslint(
     _eslint(
         eslint = ":{}".format(eslint_bin),
         directories = directories,
+        package_node_modules = package_node_modules,
+        visibility = visibility,
+        **kwargs
+    )
+
+def jest(
+        jest_bin = "jest",
+        jest = ":jest",
+        package_node_modules = ":node_modules",
+        visibility = ["PUBLIC"],
+        **kwargs):
+    if not rule_exists(jest_bin):
+        _npm_bin(
+            name = jest_bin,
+            node_modules = package_node_modules,
+            visibility = visibility,
+        )
+
+    _jest(
+        jest = ":{}".format(jest_bin),
         package_node_modules = package_node_modules,
         visibility = visibility,
         **kwargs

--- a/prelude-si/pnpm.bzl
+++ b/prelude-si/pnpm.bzl
@@ -188,6 +188,89 @@ eslint = rule(
     },
 )
 
+def jest_impl(ctx: AnalysisContext) -> list[[
+    DefaultInfo,
+    RunInfo,
+    ExternalRunnerTestInfo,
+]]:
+    args = cmd_args()
+    args.add(ctx.attrs.args)
+
+    return _npm_test_impl(
+        ctx,
+        ctx.attrs.jest[RunInfo],
+        args,
+        "jest",
+    )
+
+jest = rule(
+    impl = jest_impl,
+    attrs = {
+        "srcs": attrs.list(
+            attrs.source(),
+            default = [],
+            doc = """List of package source files to track.""",
+        ),
+        "prod_deps_srcs": attrs.dict(
+            attrs.string(),
+            attrs.source(allow_directory = True),
+            default = {},
+            doc = """Mapping of dependent prod package paths to source files to track.""",
+        ),
+        "dev_deps_srcs": attrs.dict(
+            attrs.string(),
+            attrs.source(allow_directory = True),
+            default = {},
+            doc = """Mapping of dependent dev package paths to source files from to track.""",
+        ),
+        "jest": attrs.dep(
+            providers = [RunInfo],
+            doc = """jest dependency.""",
+        ),
+        "args": attrs.list(
+            attrs.string(),
+            default = [],
+            doc = """Extra arguments passed to jest.""",
+        ),
+        "package_node_modules": attrs.source(
+            doc = """Target which builds package `node_modules`.""",
+        ),
+        "pnpm_exec_cmd_override": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """Invoke a command via 'pnpm exec' rather than npm_bin script.""",
+        ),
+        "env": attrs.dict(
+            key = attrs.string(),
+            value = attrs.arg(),
+            sorted = False,
+            default = {},
+            doc = """Set environment variables for this rule's invocation of jest. The environment
+            variable values may include macros which are expanded.""",
+        ),
+        "labels": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "contacts": attrs.list(
+            attrs.string(),
+            default = [],
+        ),
+        "remote_execution": buck.re_opts_for_tests_arg(),
+        "_inject_test_env": attrs.default_only(
+            attrs.dep(default = "prelude//test/tools:inject_test_env"),
+        ),
+        "_python_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:python",
+            providers = [PythonToolchainInfo],
+        ),
+        "_pnpm_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:pnpm",
+            providers = [PnpmToolchainInfo],
+        ),
+    },
+)
+
 def typescript_check_impl(ctx: AnalysisContext) -> list[[
     DefaultInfo,
     RunInfo,


### PR DESCRIPTION
With this change, the jest-implementated test suite for `bin/lang-js` will be executable and automatically picked up for execution in the CI environment.

<img src="https://media4.giphy.com/media/WB8FIRi2S0tmWbg6Ji/giphy.gif"/>