### PR TITLE
feat(web,dal,sdf): add code editor widget

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -15,6 +15,10 @@ export enum PropertyEditorPropKind {
   Map = "map",
 }
 
+export interface PropertyEditorPropWidgetKindCodeEditor {
+  kind: "codeEditor";
+}
+
 export interface PropertyEditorPropWidgetKindArray {
   kind: "array";
 }
@@ -70,6 +74,7 @@ export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindInteger
   | PropertyEditorPropWidgetKindHeader
   | PropertyEditorPropWidgetKindArray
+  | PropertyEditorPropWidgetKindCodeEditor
   | PropertyEditorPropWidgetKindComboBox
   | PropertyEditorPropWidgetKindSelect
   | PropertyEditorPropWidgetKindSecret

--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -63,6 +63,7 @@ const props = defineProps({
 
 const emit = defineEmits<{
   "update:modelValue": [v: string];
+  blur: [v: string];
   change: [v: string];
   explicitSave: [];
   close: [];
@@ -321,6 +322,7 @@ const mountEditor = async () => {
 
   view.contentDOM.onblur = () => {
     draftValue.value = autoformat(draftValue.value);
+    emit("blur", draftValue.value);
   };
 };
 

--- a/app/web/src/components/PropertyEditor/PropertyWidget.vue
+++ b/app/web/src/components/PropertyEditor/PropertyWidget.vue
@@ -71,6 +71,21 @@
       :class="INPUT_CLASSES"
       @updated-property="updatedProperty($event)"
     />
+    <WidgetCodeEditor
+      v-else-if="schemaProp.widgetKind.kind === 'codeEditor'"
+      :name="schemaProp.name"
+      :path="path"
+      :collapsedPaths="collapsedPaths"
+      :value="propValue.value"
+      :propId="propValue.propId"
+      :valueId="propValue.id"
+      :propKind="schemaProp.kind"
+      :docLink="schemaProp.docLink"
+      :validation="validation"
+      :disabled="disabled"
+      :class="INPUT_CLASSES"
+      @updated-property="updatedProperty($event)"
+    />
     <WidgetCheckBox
       v-else-if="schemaProp.widgetKind.kind === 'checkbox'"
       :name="schemaProp.name"
@@ -182,6 +197,7 @@ import {
 import { SecretId } from "@/store/secrets.store";
 import WidgetHeader from "./WidgetHeader.vue";
 import WidgetTextBox from "./WidgetTextBox.vue";
+import WidgetCodeEditor from "./WidgetCodeEditor.vue";
 import WidgetCheckBox from "./WidgetCheckBox.vue";
 import WidgetSelectBox from "./WidgetSelectBox.vue";
 import WidgetArray from "./WidgetArray.vue";

--- a/app/web/src/components/PropertyEditor/WidgetCodeEditor.vue
+++ b/app/web/src/components/PropertyEditor/WidgetCodeEditor.vue
@@ -1,0 +1,190 @@
+<template>
+  <div v-show="isShown" class="flex content-center mb-3">
+    <div class="flex grow">
+      <div class="w-full h-44">
+        <label v-if="id" :for="id" class="block text-sm font-medium mb-1">
+          {{ props.name }}
+        </label>
+
+        <CodeEditor
+          :id="id"
+          v-model="currentValue"
+          :disabled="disabled"
+          class="cursor-pointer"
+          @click="editorModalRef?.open()"
+          @blur="blur"
+        />
+
+        <div
+          v-if="inError"
+          class="absolute inset-y-0 right-0 pr-2 flex items-center text-destructive-400"
+        >
+          <Icon name="exclamation-circle" />
+        </div>
+
+        <p v-if="docLink" class="mt-2 text-xs text-action-500">
+          <a :href="docLink" target="_blank" class="hover:underline">
+            Documentation
+          </a>
+        </p>
+
+        <SiValidation
+          :value="currentValue"
+          :validations="validations"
+          class="mt-2"
+          @errors="setInError($event)"
+        />
+      </div>
+    </div>
+
+    <UnsetButton
+      v-if="canUnset && !disabled"
+      :disabled="disableUnset"
+      @click="unsetField"
+    />
+
+    <Modal ref="editorModalRef" size="6xl">
+      <CodeEditor
+        :id="id"
+        v-model="currentValue"
+        :disabled="disabled"
+        class="height-widget-code-editor"
+        @blur="blur"
+      />
+    </Modal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, toRefs, computed, watch, onBeforeUnmount } from "vue";
+import * as _ from "lodash-es";
+import { Icon, Modal } from "@si/vue-lib/design-system";
+import CodeEditor from "@/components/CodeEditor.vue";
+import { usePropertyEditorIsShown } from "@/utils/usePropertyEditorIsShown";
+import SiValidation from "@/components/SiValidation.vue";
+import {
+  PropertyEditorValidation,
+  UpdatedProperty,
+  PropertyPath,
+  PropertyEditorPropKind,
+} from "@/api/sdf/dal/property_editor";
+import {
+  useValidations,
+  usePropertyEditorValidations,
+} from "@/utils/input_validations";
+import { useComponentsStore } from "@/store/components.store";
+import UnsetButton from "./UnsetButton.vue";
+
+const componentsStore = useComponentsStore();
+
+const id = computed(() =>
+  componentsStore.selectedComponentId
+    ? `value-${componentsStore.selectedComponentId}-${props.propId}`
+    : undefined,
+);
+
+const props = defineProps<{
+  name: string;
+  path?: PropertyPath;
+  collapsedPaths: Array<Array<string>>;
+  value: unknown;
+  propId: string;
+  valueId: string;
+  propKind: PropertyEditorPropKind;
+  docLink?: string;
+  validation?: PropertyEditorValidation;
+  disabled?: boolean;
+}>();
+
+const editorModalRef = ref();
+
+const blur = () => {
+  setDirty();
+  setField();
+};
+const emit = defineEmits<{
+  (e: "updatedProperty", v: UpdatedProperty): void;
+  (e: "error", v: boolean): void;
+}>();
+
+const { name, path, collapsedPaths, valueId, propId, value, validation } =
+  toRefs(props);
+
+const currentValue = ref<string>("");
+watch(
+  value,
+  (newValue, oldValue) => {
+    if (oldValue !== newValue) {
+      if (_.isString(newValue)) {
+        currentValue.value = newValue;
+      } else if (_.isNumber(newValue)) {
+        currentValue.value = `${newValue}`;
+      } else {
+        currentValue.value = "";
+      }
+    }
+  },
+  { immediate: true },
+);
+
+const disableUnset = computed(() => {
+  if (_.isNull(value.value)) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
+const { isShown } = usePropertyEditorIsShown(name, collapsedPaths, path);
+
+const setField = () => {
+  if (
+    !_.isNull(currentValue.value) &&
+    currentValue.value !== props.value &&
+    ((!props.value && currentValue.value) || props.value)
+  ) {
+    if (props.propKind === "integer") {
+      emit("updatedProperty", {
+        value: _.parseInt(currentValue.value, 10),
+        propId: propId.value,
+        valueId: valueId.value,
+      });
+    } else {
+      emit("updatedProperty", {
+        value: currentValue.value,
+        propId: propId.value,
+        valueId: valueId.value,
+      });
+    }
+  }
+};
+
+const unsetField = () => {
+  emit("updatedProperty", {
+    value: null,
+    propId: propId.value,
+    valueId: valueId.value,
+  });
+};
+
+const validations = usePropertyEditorValidations(validation);
+
+const alwaysValidate = ref(true);
+const { inError, setInError, setDirty } = useValidations(
+  alwaysValidate,
+  setField,
+  (inError: boolean) => emit("error", inError),
+);
+
+onBeforeUnmount(setField);
+
+const canUnset = computed(() => {
+  return (props.path?.triggerPath ?? []).join(".") !== "name.si.root";
+});
+</script>
+
+<style lang="less">
+.height-widget-code-editor {
+  height: 80vh;
+}
+</style>

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -346,6 +346,7 @@ export class ValidationBuilder implements IValidationBuilder {
 export type PropWidgetDefinitionKind =
   | "array"
   | "checkbox"
+  | "codeEditor"
   | "color"
   | "comboBox"
   | "header"
@@ -395,7 +396,7 @@ export class PropWidgetDefinitionBuilder
   /**
    * The type of widget
    *
-   * @param {string} kind [array | checkbox | color | comboBox | header | map | secret | select | text | textArea]
+   * @param {string} kind [array | checkbox | color | comboBox | header | map | secret | select | text | textArea | codeEditor]
    *
    * @returns this
    *
@@ -410,7 +411,7 @@ export class PropWidgetDefinitionBuilder
   /**
    * Add an option when using a comboBox
    *
-   * @param {string} key - the value displayed in the comboBoxx
+   * @param {string} key - the value displayed in the comboBox
    * @param {string} value - the value the prop is set to
    *
    * @returns this

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -136,6 +136,7 @@ impl From<&PropKind> for PropertyEditorPropKind {
 pub enum PropertyEditorPropWidgetKind {
     Array,
     Checkbox,
+    CodeEditor,
     Color,
     ComboBox { options: Option<Value> },
     Header,
@@ -157,6 +158,7 @@ pub enum PropertyEditorPropWidgetKind {
 pub enum WidgetKind {
     Array,
     Checkbox,
+    CodeEditor,
     Color,
     /// Provides a text input with auto-completion for corresponding "primitive" (e.g. string, number, boolean)
     /// [`PropKinds`](crate::PropKind).
@@ -176,6 +178,7 @@ impl From<WidgetKind> for PropSpecWidgetKind {
         match value {
             WidgetKind::Array => Self::Array,
             WidgetKind::Checkbox => Self::Checkbox,
+            WidgetKind::CodeEditor => Self::CodeEditor,
             WidgetKind::Header => Self::Header,
             WidgetKind::Map => Self::Map,
             WidgetKind::Select => Self::Select,
@@ -193,6 +196,7 @@ impl From<&PropSpecWidgetKind> for WidgetKind {
         match value {
             PropSpecWidgetKind::Array => Self::Array,
             PropSpecWidgetKind::Checkbox => Self::Checkbox,
+            PropSpecWidgetKind::CodeEditor => Self::CodeEditor,
             PropSpecWidgetKind::Header => Self::Header,
             PropSpecWidgetKind::Map => Self::Map,
             PropSpecWidgetKind::Select => Self::Select,
@@ -210,6 +214,7 @@ impl PropertyEditorPropWidgetKind {
         match widget_kind {
             WidgetKind::Array => Self::Array,
             WidgetKind::Checkbox => Self::Checkbox,
+            WidgetKind::CodeEditor => Self::CodeEditor,
             WidgetKind::Header => Self::Header,
             WidgetKind::Map => Self::Map,
             WidgetKind::Select => Self::Select {

--- a/lib/sdf-server/src/server/service/ts_types/asset_builder.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_builder.d.ts
@@ -198,7 +198,7 @@ declare class ValidationBuilder implements IValidationBuilder {
     setKind(kind: ValidationKind): this;
     setUpperBound(value: number): this;
 }
-type PropWidgetDefinitionKind = "array" | "checkbox" | "color" | "comboBox" | "header" | "map" | "secret" | "select" | "text" | "textArea";
+type PropWidgetDefinitionKind = "array" | "checkbox" | "color" | "comboBox" | "header" | "map" | "secret" | "select" | "text" | "textArea" | "codeEditor";
 interface Option {
     label: string;
     value: string;

--- a/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
+++ b/lib/sdf-server/src/server/service/ts_types/asset_types_with_secrets.d.ts
@@ -198,7 +198,7 @@ declare class ValidationBuilder implements IValidationBuilder {
     setKind(kind: ValidationKind): this;
     setUpperBound(value: number): this;
 }
-type PropWidgetDefinitionKind = "array" | "checkbox" | "color" | "comboBox" | "header" | "map" | "secret" | "select" | "text" | "textArea";
+type PropWidgetDefinitionKind = "array" | "checkbox" | "color" | "comboBox" | "header" | "map" | "secret" | "select" | "text" | "textArea" | "codeEditor";
 interface Option {
     label: string;
     value: string;
@@ -226,7 +226,7 @@ declare class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilde
     /**
      * The type of widget
      *
-     * @param {string} kind [array | checkbox | color | comboBox | header | map | secret | select | text | textArea]
+     * @param {string} kind [array | checkbox | color | comboBox | header | map | secret | select | text | textArea | codeEditor]
      *
      * @returns this
      *
@@ -237,7 +237,7 @@ declare class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilde
     /**
      * Add an option when using a comboBox
      *
-     * @param {string} key - the value displayed in the comboBoxx
+     * @param {string} key - the value displayed in the comboBox
      * @param {string} value - the value the prop is set to
      *
      * @returns this

--- a/lib/si-pkg/src/spec/prop.rs
+++ b/lib/si-pkg/src/spec/prop.rs
@@ -23,6 +23,7 @@ use super::{AttrFuncInputSpec, MapKeyFuncSpec, SpecError, ValidationSpec};
 pub enum PropSpecWidgetKind {
     Array,
     Checkbox,
+    CodeEditor,
     Color,
     ComboBox,
     Header,

--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -49,6 +49,7 @@
                     xl: 'max-w-xl',
                     '2xl': 'max-w-2xl',
                     '4xl': 'max-w-4xl',
+                    '6xl': 'max-w-6xl',
                   }[size],
                 )
               "
@@ -132,7 +133,7 @@ import { useThemeContainer } from "../utils/theme_tools";
 const props = defineProps({
   beginOpen: { type: Boolean, default: false },
   size: {
-    type: String as PropType<"sm" | "md" | "lg" | "xl" | "2xl" | "4xl">,
+    type: String as PropType<"sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "6xl">,
     default: "md",
   },
   title: { type: String },


### PR DESCRIPTION
Does not have syntax highlighter, linter, etc because it doesn't know the language, we should improve that somehow (it's not clear to me right now how to do it best and it feels like a immediate benefit even without it)

![image](https://github.com/systeminit/si/assets/6289779/a4a490b4-5bb2-4ec8-9b33-13f15c61de5d)
