### PR TITLE
feat(dal,si-pkg,sdf): Export/import functions on direct children of root

### DIFF
--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -26,6 +26,8 @@ pub enum FuncArgumentError {
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("history event error: {0}")]
     HistoryEvent(#[from] HistoryEventError),
+    #[error("func argument not found with name {0} for Func {1}")]
+    NotFoundByNameForFunc(String, FuncId),
     #[error("pg error: {0}")]
     Pg(#[from] si_data_pg::PgError),
     #[error("error serializing/deserializing json: {0}")]

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -8,8 +8,8 @@ mod import;
 
 pub use export::{get_component_type, PkgExporter};
 pub use import::{
-    import_pkg, import_pkg_from_pkg, ImportAttributeSkip, ImportEdgeSkip, ImportOptions,
-    ImportSkips,
+    attach_resource_payload_to_value, import_pkg, import_pkg_from_pkg, ImportAttributeSkip,
+    ImportEdgeSkip, ImportOptions, ImportSkips,
 };
 
 use si_pkg::{FuncSpecBackendKind, FuncSpecBackendResponseType, SiPkgError, SpecError};

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -19,8 +19,11 @@ use crate::{
     component::ComponentKind,
     edge::EdgeKind,
     func::{
-        self, argument::FuncArgumentKind, backend::validation::FuncBackendValidationArgs,
-        binding::FuncBinding, binding_return_value::FuncBindingReturnValue,
+        self,
+        argument::{FuncArgumentError, FuncArgumentKind},
+        backend::validation::FuncBackendValidationArgs,
+        binding::FuncBinding,
+        binding_return_value::FuncBindingReturnValue,
     },
     installed_pkg::{
         InstalledPkg, InstalledPkgAsset, InstalledPkgAssetKind, InstalledPkgAssetTyped,
@@ -40,9 +43,10 @@ use crate::{
     AttributePrototype, AttributePrototypeArgument, AttributePrototypeId, AttributeReadContext,
     AttributeValue, AttributeValueError, ChangeSet, ChangeSetPk, Component, ComponentId,
     DalContext, Edge, ExternalProvider, ExternalProviderId, Func, FuncArgument, FuncError, FuncId,
-    InternalProvider, InternalProviderId, LeafKind, Node, Prop, PropId, PropKind, Schema, SchemaId,
-    SchemaVariant, SchemaVariantError, SchemaVariantId, Socket, StandardModel, Tenancy, UserPk,
-    ValidationPrototype, ValidationPrototypeContext, Workspace, WorkspacePk,
+    InternalProvider, InternalProviderError, InternalProviderId, LeafKind, Node, Prop, PropId,
+    PropKind, Schema, SchemaId, SchemaVariant, SchemaVariantError, SchemaVariantId, Socket,
+    StandardModel, Tenancy, UserPk, ValidationPrototype, ValidationPrototypeContext, Workspace,
+    WorkspacePk,
 };
 
 use super::{PkgError, PkgResult};
@@ -559,7 +563,6 @@ async fn import_component_attribute(
     prop_cache: &mut HashMap<String, Option<Prop>>,
     thing_map: &mut ThingMap,
 ) -> PkgResult<Option<ImportAttributeSkip>> {
-    dbg!("start import_component_attribute");
     match attribute.path() {
         AttributeValuePath::Prop { path, key, index } => {
             if attribute.parent_path().is_none() && (key.is_some() || index.is_some()) {
@@ -2318,6 +2321,37 @@ async fn import_schema_variant(
             .await?;
         }
 
+        let mut has_resource_value_func = false;
+        for root_prop_func in variant_spec.root_prop_funcs()? {
+            if root_prop_func.prop() == SchemaVariantSpecPropRoot::ResourceValue {
+                has_resource_value_func = true;
+            }
+
+            let prop = schema_variant
+                .find_prop(ctx, root_prop_func.prop().path_parts())
+                .await?;
+            import_attr_func_for_prop(
+                ctx,
+                change_set_pk,
+                *schema_variant.id(),
+                AttrFuncInfo {
+                    func_unique_id: root_prop_func.func_unique_id().to_owned(),
+                    prop_id: *prop.id(),
+                    inputs: root_prop_func
+                        .inputs()?
+                        .iter()
+                        .map(|input| input.to_owned().into())
+                        .collect(),
+                },
+                None,
+                thing_map,
+            )
+            .await?;
+        }
+        if !has_resource_value_func {
+            attach_resource_payload_to_value(ctx, *schema_variant.id()).await?;
+        }
+
         for attr_func in side_effects.attr_funcs {
             import_attr_func_for_prop(
                 ctx,
@@ -2357,6 +2391,69 @@ async fn import_schema_variant(
     }
 
     Ok(schema_variant)
+}
+
+pub async fn attach_resource_payload_to_value(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> PkgResult<()> {
+    let func_id = *Func::find_by_name(ctx, "si:resourcePayloadToValue")
+        .await?
+        .ok_or(FuncError::NotFoundByName(
+            "si:resourcePayloadToValue".into(),
+        ))?
+        .id();
+
+    let func_argument_id = *FuncArgument::find_by_name_for_func(ctx, "payload", func_id)
+        .await?
+        .ok_or(FuncArgumentError::NotFoundByNameForFunc(
+            "payload".into(),
+            func_id,
+        ))?
+        .id();
+
+    let source = {
+        let prop = SchemaVariant::find_prop_in_tree(
+            ctx,
+            schema_variant_id,
+            &["root", "resource", "payload"],
+        )
+        .await?;
+
+        InternalProvider::find_for_prop(ctx, *prop.id())
+            .await?
+            .ok_or(InternalProviderError::NotFoundForProp(*prop.id()))?
+    };
+
+    let target = {
+        let resource_value_prop =
+            SchemaVariant::find_prop_in_tree(ctx, schema_variant_id, &["root", "resource_value"])
+                .await?;
+
+        let mut prototype = AttributeValue::find_for_context(
+            ctx,
+            AttributeReadContext::default_with_prop(*resource_value_prop.id()),
+        )
+        .await?
+        .ok_or(AttributeValueError::Missing)?
+        .attribute_prototype(ctx)
+        .await?
+        .ok_or(AttributeValueError::MissingAttributePrototype)?;
+
+        prototype.set_func_id(ctx, func_id).await?;
+
+        prototype
+    };
+
+    AttributePrototypeArgument::new_for_intra_component(
+        ctx,
+        *target.id(),
+        func_argument_id,
+        *source.id(),
+    )
+    .await?;
+
+    Ok(())
 }
 
 async fn set_default_value(

--- a/lib/dal/tests/integration_test/internal/component.rs
+++ b/lib/dal/tests/integration_test/internal/component.rs
@@ -445,10 +445,9 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
             },
             "resource": {
                 "logs": [],
-                "payload": { "quantum": true },
                 "status": "ok",
+                "payload": { "quantum": true },
             },
-            "resource_value": {}
         }], // expected
         ekwb_component_view.properties // actual
     );
@@ -496,7 +495,6 @@ async fn dependent_values_resource_intelligence(mut octx: DalContext) {
                 "payload": { "quantum": true },
                 "status": "ok",
             },
-            "resource_value": {}
         }], // expected
         ekwb_component_view.properties // actual
     );

--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use dal::{
     attribute::prototype::argument::{AttributePrototypeArgument, AttributePrototypeArgumentError},
-    func::argument::FuncArgumentId,
+    func::argument::{FuncArgumentError, FuncArgumentId},
     installed_pkg::InstalledPkgError,
     pkg::PkgError,
     schema::variant::definition::SchemaVariantDefinition,
@@ -72,6 +72,8 @@ pub enum SchemaVariantDefinitionError {
     ExternalProviderNotFoundForSocket(SocketId),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
+    #[error(transparent)]
+    FuncArgument(#[from] FuncArgumentError),
     #[error("func argument not found: {0}")]
     FuncArgumentNotFound(FuncArgumentId),
     #[error(transparent)]

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -14,7 +14,7 @@ use chrono::Utc;
 use convert_case::{Case, Casing};
 use dal::{
     func::intrinsics::IntrinsicFunc,
-    pkg::import_pkg_from_pkg,
+    pkg::{attach_resource_payload_to_value, import_pkg_from_pkg},
     schema::variant::definition::{
         SchemaVariantDefinition, SchemaVariantDefinitionJson, SchemaVariantDefinitionMetadataJson,
     },
@@ -212,62 +212,67 @@ pub async fn exec_variant_def(
         .ok_or(SchemaVariantDefinitionError::NoAssetCreated)?;
 
     let (detached_attribute_prototypes, detached_validation_prototypes) =
-        if let Some(previous_schema_variant_id) = maybe_previous_variant_id {
-            migrate_leaf_functions_to_new_schema_variant(
-                &ctx,
-                leaf_funcs_to_migrate,
-                schema_variant_id,
-            )
-            .await?;
-            migrate_actions_to_new_schema_variant(
-                &ctx,
-                previous_schema_variant_id,
-                schema_variant_id,
-            )
-            .await?;
-
-            let schema_variant = SchemaVariant::get_by_id(&ctx, &schema_variant_id)
-                .await?
-                .ok_or(SchemaVariantError::NotFound(schema_variant_id))?;
-
-            let attribute_prototypes = migrate_attribute_functions_to_new_schema_variant(
-                &ctx,
-                attribute_prototypes,
-                &schema_variant,
-            )
-            .await?;
-            let mut detached_attribute_prototypes = Vec::with_capacity(attribute_prototypes.len());
-
-            for attribute_prototype in attribute_prototypes {
-                let func = Func::get_by_id(&ctx, &attribute_prototype.func_id)
-                    .await?
-                    .ok_or_else(|| {
-                        SchemaVariantDefinitionError::FuncNotFound(attribute_prototype.func_id)
-                    })?;
-                detached_attribute_prototypes.push(AttributePrototypeView {
-                    id: attribute_prototype.id,
-                    func_id: attribute_prototype.func_id,
-                    func_name: func.name().to_owned(),
-                    variant: (&func).try_into().ok(),
-                    key: attribute_prototype.key,
-                    context: attribute_prototype.context,
-                });
-            }
-
-            let detached_validation_prototypes =
-                migrate_validation_functions_to_new_schema_variant(
+        match maybe_previous_variant_id {
+            Some(previous_schema_variant_id) => {
+                migrate_leaf_functions_to_new_schema_variant(
                     &ctx,
-                    validation_prototypes,
+                    leaf_funcs_to_migrate,
+                    schema_variant_id,
+                )
+                .await?;
+                migrate_actions_to_new_schema_variant(
+                    &ctx,
+                    previous_schema_variant_id,
                     schema_variant_id,
                 )
                 .await?;
 
-            (
-                detached_attribute_prototypes,
-                detached_validation_prototypes,
-            )
-        } else {
-            (Vec::new(), Vec::new())
+                let schema_variant = SchemaVariant::get_by_id(&ctx, &schema_variant_id)
+                    .await?
+                    .ok_or(SchemaVariantError::NotFound(schema_variant_id))?;
+
+                let attribute_prototypes = migrate_attribute_functions_to_new_schema_variant(
+                    &ctx,
+                    attribute_prototypes,
+                    &schema_variant,
+                )
+                .await?;
+                let mut detached_attribute_prototypes =
+                    Vec::with_capacity(attribute_prototypes.len());
+
+                for attribute_prototype in attribute_prototypes {
+                    let func = Func::get_by_id(&ctx, &attribute_prototype.func_id)
+                        .await?
+                        .ok_or_else(|| {
+                            SchemaVariantDefinitionError::FuncNotFound(attribute_prototype.func_id)
+                        })?;
+                    detached_attribute_prototypes.push(AttributePrototypeView {
+                        id: attribute_prototype.id,
+                        func_id: attribute_prototype.func_id,
+                        func_name: func.name().to_owned(),
+                        variant: (&func).try_into().ok(),
+                        key: attribute_prototype.key,
+                        context: attribute_prototype.context,
+                    });
+                }
+
+                let detached_validation_prototypes =
+                    migrate_validation_functions_to_new_schema_variant(
+                        &ctx,
+                        validation_prototypes,
+                        schema_variant_id,
+                    )
+                    .await?;
+
+                (
+                    detached_attribute_prototypes,
+                    detached_validation_prototypes,
+                )
+            }
+            None => {
+                attach_resource_payload_to_value(&ctx, schema_variant_id).await?;
+                (vec![], vec![])
+            }
         };
 
     track(

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -26,6 +26,7 @@ mod package;
 mod position;
 mod prop;
 mod prop_child;
+mod root_prop_func;
 mod schema;
 mod schema_variant;
 mod schema_variant_child;
@@ -52,6 +53,7 @@ pub(crate) use self::{
     position::PositionNode,
     prop::{PropNode, PropNodeData},
     prop_child::PropChildNode,
+    root_prop_func::RootPropFuncNode,
     schema::SchemaNode,
     schema_variant::SchemaVariantNode,
     schema_variant_child::{SchemaVariantChild, SchemaVariantChildNode},
@@ -78,6 +80,7 @@ const NODE_KIND_PACKAGE: &str = "package";
 const NODE_KIND_POSITION: &str = "position";
 const NODE_KIND_PROP: &str = "prop";
 const NODE_KIND_PROP_CHILD: &str = "prop_child";
+const NODE_KIND_ROOT_PROP_FUNC: &str = "root_prop_func";
 const NODE_KIND_SCHEMA: &str = "schema";
 const NODE_KIND_SCHEMA_VARIANT: &str = "schema_variant";
 const NODE_KIND_SCHEMA_VARIANT_CHILD: &str = "schema_variant_child";
@@ -149,6 +152,7 @@ pub enum PkgNode {
     Position(PositionNode),
     Prop(PropNode),
     PropChild(PropChildNode),
+    RootPropFunc(RootPropFuncNode),
     Schema(SchemaNode),
     SchemaVariant(SchemaVariantNode),
     SchemaVariantChild(SchemaVariantChildNode),
@@ -176,6 +180,7 @@ impl PkgNode {
     pub const POSTITION_KIND_STR: &str = NODE_KIND_POSITION;
     pub const PROP_KIND_STR: &str = NODE_KIND_PROP;
     pub const PROP_CHILD_KIND_STR: &str = NODE_KIND_PROP_CHILD;
+    pub const ROOT_PROP_FUNC_KIND_STR: &str = NODE_KIND_ROOT_PROP_FUNC;
     pub const SCHEMA_KIND_STR: &str = NODE_KIND_SCHEMA;
     pub const SCHEMA_VARIANT_KIND_STR: &str = NODE_KIND_SCHEMA_VARIANT;
     pub const SCHEMA_VARIANT_KIND_CHILD_STR: &str = NODE_KIND_SCHEMA_VARIANT_CHILD;
@@ -203,6 +208,7 @@ impl PkgNode {
             Self::Position(_) => NODE_KIND_POSITION,
             Self::Prop(_) => NODE_KIND_PROP,
             Self::PropChild(_) => NODE_KIND_PROP_CHILD,
+            Self::RootPropFunc(_) => NODE_KIND_ROOT_PROP_FUNC,
             Self::Schema(_) => NODE_KIND_SCHEMA,
             Self::SchemaVariant(_) => NODE_KIND_SCHEMA_VARIANT,
             Self::SchemaVariantChild(_) => NODE_KIND_SCHEMA_VARIANT_CHILD,
@@ -234,6 +240,7 @@ impl NameStr for PkgNode {
             Self::Position(_) => NODE_KIND_POSITION,
             Self::Prop(node) => node.name(),
             Self::PropChild(node) => node.name(),
+            Self::RootPropFunc(_) => NODE_KIND_ROOT_PROP_FUNC,
             Self::Schema(node) => node.name(),
             Self::SchemaVariant(node) => node.name(),
             Self::SchemaVariantChild(node) => node.name(),
@@ -267,6 +274,7 @@ impl WriteBytes for PkgNode {
             Self::Position(node) => node.write_bytes(writer)?,
             Self::Prop(node) => node.write_bytes(writer)?,
             Self::PropChild(node) => node.write_bytes(writer)?,
+            Self::RootPropFunc(node) => node.write_bytes(writer)?,
             Self::Schema(node) => node.write_bytes(writer)?,
             Self::SchemaVariant(node) => node.write_bytes(writer)?,
             Self::SchemaVariantChild(node) => node.write_bytes(writer)?,
@@ -319,6 +327,9 @@ impl ReadBytes for PkgNode {
             NODE_KIND_POSITION => PositionNode::read_bytes(reader)?.map(Self::Position),
             NODE_KIND_PROP => PropNode::read_bytes(reader)?.map(Self::Prop),
             NODE_KIND_PROP_CHILD => PropChildNode::read_bytes(reader)?.map(Self::PropChild),
+            NODE_KIND_ROOT_PROP_FUNC => {
+                RootPropFuncNode::read_bytes(reader)?.map(Self::RootPropFunc)
+            }
             NODE_KIND_SCHEMA => SchemaNode::read_bytes(reader)?.map(Self::Schema),
             NODE_KIND_SCHEMA_VARIANT => {
                 SchemaVariantNode::read_bytes(reader)?.map(Self::SchemaVariant)

--- a/lib/si-pkg/src/node/root_prop_func.rs
+++ b/lib/si-pkg/src/node/root_prop_func.rs
@@ -1,0 +1,77 @@
+use std::io::{BufRead, Write};
+use std::str::FromStr;
+
+use object_tree::{
+    read_key_value_line, write_key_value_line, GraphError, NodeChild, NodeKind, NodeWithChildren,
+    ReadBytes, WriteBytes,
+};
+
+use crate::{RootPropFuncSpec, SchemaVariantSpecPropRoot};
+
+use super::{read_common_fields, write_common_fields, PkgNode};
+
+const KEY_PROP_STR: &str = "PROP";
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+
+#[derive(Clone, Debug)]
+pub struct RootPropFuncNode {
+    pub prop: SchemaVariantSpecPropRoot,
+    pub func_unique_id: String,
+    pub unique_id: Option<String>,
+    pub deleted: bool,
+}
+
+impl WriteBytes for RootPropFuncNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(writer, KEY_PROP_STR, self.prop)?;
+        write_key_value_line(
+            writer,
+            KEY_FUNC_UNIQUE_ID_STR,
+            self.func_unique_id.to_string(),
+        )?;
+        write_common_fields(writer, self.unique_id.as_deref(), self.deleted)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for RootPropFuncNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let prop_str = read_key_value_line(reader, KEY_PROP_STR)?;
+        let prop = SchemaVariantSpecPropRoot::from_str(&prop_str).map_err(GraphError::parse)?;
+        let func_unique_id = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+        let (unique_id, deleted) = read_common_fields(reader)?;
+
+        Ok(Some(Self {
+            prop,
+            func_unique_id,
+            unique_id,
+            deleted,
+        }))
+    }
+}
+
+impl NodeChild for RootPropFuncSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::RootPropFunc(RootPropFuncNode {
+                prop: self.prop.to_owned(),
+                func_unique_id: self.func_unique_id.to_owned(),
+                unique_id: self.unique_id.to_owned(),
+                deleted: self.deleted,
+            }),
+            self.inputs
+                .iter()
+                .map(|input| {
+                    Box::new(input.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                })
+                .collect(),
+        )
+    }
+}

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -134,6 +134,9 @@ impl NodeChild for SchemaVariantSpec {
                 as Box<dyn NodeChild<NodeType = Self::NodeType>>,
             Box::new(SchemaVariantChild::Secrets(self.secrets.clone()))
                 as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            Box::new(SchemaVariantChild::RootPropFuncs(
+                self.root_prop_funcs.clone(),
+            )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
         ];
 
         if let Some(secret_definition) = self.secret_definition.clone() {

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -6,7 +6,9 @@ use object_tree::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{ActionFuncSpec, LeafFunctionSpec, PropSpec, SiPropFuncSpec, SocketSpec};
+use crate::{
+    ActionFuncSpec, LeafFunctionSpec, PropSpec, RootPropFuncSpec, SiPropFuncSpec, SocketSpec,
+};
 
 use super::PkgNode;
 
@@ -18,6 +20,7 @@ const VARIANT_CHILD_TYPE_SI_PROP_FUNCS: &str = "si_prop_funcs";
 const VARIANT_CHILD_TYPE_SOCKETS: &str = "sockets";
 const VARIANT_CHILD_TYPE_SECRET_DEFINITION: &str = "secret_definition";
 const VARIANT_CHILD_TYPE_SECRETS: &str = "secrets";
+const VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS: &str = "root_prop_funcs";
 
 const KEY_KIND_STR: &str = "kind";
 
@@ -29,6 +32,7 @@ pub enum SchemaVariantChild {
     Domain(PropSpec),
     LeafFunctions(Vec<LeafFunctionSpec>),
     ResourceValue(PropSpec),
+    RootPropFuncs(Vec<RootPropFuncSpec>),
     SecretDefinition(PropSpec),
     Secrets(PropSpec),
     SiPropFuncs(Vec<SiPropFuncSpec>),
@@ -42,6 +46,7 @@ pub enum SchemaVariantChildNode {
     Domain,
     LeafFunctions,
     ResourceValue,
+    RootPropFuncs,
     SecretDefinition,
     Secrets,
     SiPropFuncs,
@@ -55,6 +60,7 @@ impl SchemaVariantChildNode {
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
             Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
+            Self::RootPropFuncs => VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS,
             Self::SecretDefinition => VARIANT_CHILD_TYPE_SECRET_DEFINITION,
             Self::Secrets => VARIANT_CHILD_TYPE_SECRETS,
             Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
@@ -70,6 +76,7 @@ impl NameStr for SchemaVariantChildNode {
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
             Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
+            Self::RootPropFuncs => VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS,
             Self::SecretDefinition => VARIANT_CHILD_TYPE_SECRET_DEFINITION,
             Self::Secrets => VARIANT_CHILD_TYPE_SECRETS,
             Self::SiPropFuncs => VARIANT_CHILD_TYPE_SI_PROP_FUNCS,
@@ -98,6 +105,7 @@ impl ReadBytes for SchemaVariantChildNode {
             VARIANT_CHILD_TYPE_LEAF_FUNCTIONS => Self::LeafFunctions,
             VARIANT_CHILD_TYPE_RESOURCE_VALUE => Self::ResourceValue,
             VARIANT_CHILD_TYPE_SI_PROP_FUNCS => Self::SiPropFuncs,
+            VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS => Self::RootPropFuncs,
             VARIANT_CHILD_TYPE_SOCKETS => Self::Sockets,
             VARIANT_CHILD_TYPE_SECRETS => Self::Secrets,
             VARIANT_CHILD_TYPE_SECRET_DEFINITION => Self::SecretDefinition,
@@ -195,6 +203,16 @@ impl NodeChild for SchemaVariantChild {
                     .map(|si_prop_func| {
                         Box::new(si_prop_func.clone())
                             as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::RootPropFuncs(root_prop_funcs) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::RootPropFuncs),
+                root_prop_funcs
+                    .iter()
+                    .map(|prop_func| {
+                        Box::new(prop_func.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
                     })
                     .collect(),
             ),

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -22,6 +22,7 @@ mod leaf_function;
 mod map_key_func;
 mod position;
 mod prop;
+mod root_prop_func;
 mod schema;
 mod si_prop_func;
 mod socket;
@@ -30,8 +31,8 @@ mod variant;
 
 pub use {
     action_func::*, attr_func_input::*, attribute_value::*, change_set::*, component::*, edge::*,
-    func::*, leaf_function::*, map_key_func::*, position::*, prop::*, schema::*, si_prop_func::*,
-    socket::*, validation::*, variant::*,
+    func::*, leaf_function::*, map_key_func::*, position::*, prop::*, root_prop_func::*, schema::*,
+    si_prop_func::*, socket::*, validation::*, variant::*,
 };
 
 use crate::{

--- a/lib/si-pkg/src/pkg/root_prop_func.rs
+++ b/lib/si-pkg/src/pkg/root_prop_func.rs
@@ -1,0 +1,102 @@
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+
+use super::{PkgResult, SiPkgError, Source};
+
+use crate::SchemaVariantSpecPropRoot;
+use crate::{node::PkgNode, AttrFuncInputSpec, RootPropFuncSpec, SiPkgAttrFuncInput};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgRootPropFunc<'a> {
+    prop: SchemaVariantSpecPropRoot,
+    func_unique_id: String,
+    unique_id: Option<String>,
+    deleted: bool,
+
+    hash: Hash,
+    source: Source<'a>,
+}
+
+impl<'a> SiPkgRootPropFunc<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::RootPropFunc(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::ROOT_PROP_FUNC_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            prop: node.prop,
+            func_unique_id: node.func_unique_id,
+            unique_id: node.unique_id,
+            deleted: node.deleted,
+
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn prop(&self) -> SchemaVariantSpecPropRoot {
+        self.prop
+    }
+
+    pub fn func_unique_id(&self) -> &str {
+        self.func_unique_id.as_str()
+    }
+
+    pub fn unique_id(&self) -> Option<&str> {
+        self.unique_id.as_deref()
+    }
+
+    pub fn deleted(&self) -> bool {
+        self.deleted
+    }
+
+    pub fn inputs(&self) -> PkgResult<Vec<SiPkgAttrFuncInput>> {
+        let mut inputs = vec![];
+
+        for idx in self
+            .source
+            .graph
+            .neighbors_directed(self.source.node_idx, Outgoing)
+        {
+            inputs.push(SiPkgAttrFuncInput::from_graph(self.source.graph, idx)?);
+        }
+
+        Ok(inputs)
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgRootPropFunc<'a>> for RootPropFuncSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgRootPropFunc<'a>) -> Result<Self, Self::Error> {
+        let mut builder = RootPropFuncSpec::builder();
+        for input in value.inputs()? {
+            builder.input(AttrFuncInputSpec::try_from(input)?);
+        }
+
+        Ok(builder
+            .prop(value.prop)
+            .unique_id(value.unique_id)
+            .deleted(value.deleted)
+            .func_unique_id(value.func_unique_id)
+            .build()?)
+    }
+}

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -15,7 +15,7 @@ use crate::{
     node::{PkgNode, PropChildNode, SchemaVariantChildNode},
     AttrFuncInputSpec, MapKeyFuncSpec, PropSpec, PropSpecBuilder, PropSpecKind, SchemaVariantSpec,
     SchemaVariantSpecBuilder, SchemaVariantSpecComponentType, SchemaVariantSpecData,
-    SchemaVariantSpecPropRoot,
+    SchemaVariantSpecPropRoot, SiPkgRootPropFunc,
 };
 
 #[derive(Clone, Debug)]
@@ -163,6 +163,11 @@ impl<'a> SiPkgSchemaVariant<'a> {
         secret_definitions,
         SchemaVariantChildNode::SecretDefinition,
         SiPkgProp
+    );
+    impl_variant_children_from_graph!(
+        root_prop_funcs,
+        SchemaVariantChildNode::RootPropFuncs,
+        SiPkgRootPropFunc
     );
 
     fn prop_stack_from_source<I>(

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -14,6 +14,7 @@ mod leaf_function;
 mod map_key_func;
 mod position;
 mod prop;
+mod root_prop_func;
 mod schema;
 mod si_prop_func;
 mod socket;
@@ -22,8 +23,8 @@ mod variant;
 
 pub use {
     action_func::*, attr_func_input::*, attribute_value::*, change_set::*, component::*, edge::*,
-    func::*, leaf_function::*, map_key_func::*, position::*, prop::*, schema::*, si_prop_func::*,
-    socket::*, validation::*, variant::*,
+    func::*, leaf_function::*, map_key_func::*, position::*, prop::*, root_prop_func::*, schema::*,
+    si_prop_func::*, socket::*, validation::*, variant::*,
 };
 
 use super::SiPkgKind;

--- a/lib/si-pkg/src/spec/root_prop_func.rs
+++ b/lib/si-pkg/src/spec/root_prop_func.rs
@@ -1,0 +1,32 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use crate::SchemaVariantSpecPropRoot;
+
+use super::{AttrFuncInputSpec, SpecError};
+
+/// RootPropFuncs track custom functions for for props that are immediate children of the root.
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct RootPropFuncSpec {
+    #[builder(setter(into))]
+    pub prop: SchemaVariantSpecPropRoot,
+    #[builder(setter(into))]
+    pub func_unique_id: String,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub unique_id: Option<String>,
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub deleted: bool,
+
+    #[builder(setter(each(name = "input"), into), default)]
+    pub inputs: Vec<AttrFuncInputSpec>,
+}
+
+impl RootPropFuncSpec {
+    pub fn builder() -> RootPropFuncSpecBuilder {
+        RootPropFuncSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -4,8 +4,8 @@ use strum::{AsRefStr, Display, EnumIter, EnumString};
 use url::Url;
 
 use super::{
-    ActionFuncSpec, LeafFunctionSpec, PropSpec, PropSpecData, PropSpecWidgetKind, SiPropFuncSpec,
-    SocketSpec, SpecError,
+    ActionFuncSpec, LeafFunctionSpec, PropSpec, PropSpecData, PropSpecWidgetKind, RootPropFuncSpec,
+    SiPropFuncSpec, SocketSpec, SpecError,
 };
 
 #[remain::sorted]
@@ -144,6 +144,10 @@ pub struct SchemaVariantSpec {
 
     #[builder(private, default = "Self::default_resource_value()")]
     pub resource_value: PropSpec,
+
+    #[builder(setter(each(name = "root_prop_func"), into), default)]
+    #[serde(default)]
+    pub root_prop_funcs: Vec<RootPropFuncSpec>,
 }
 
 impl SchemaVariantSpec {


### PR DESCRIPTION
This allows us to define a function on a direct child of root (domain, resource_value, secrets, etc.) and then have it preserved in module import/export.

To preserve existing behavior, if a function is not defined on resource_value, we will automatically attach si:resourcePayloadToValue to set that value. Otherwise the custom function will be used.

That function must be detached before a custom function is attached to an asset's resource_value prop.