### PR TITLE
fix: bump docker-api crate to git ref

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -29,6 +29,11 @@ alias(
 )
 
 alias(
+    name = "si",
+    actual = "//bin/si:si",
+)
+
+alias(
     name = "veritech",
     actual = "//bin/veritech:veritech",
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,8 +1589,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "docker-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4576e993f4ef4805931a835b7afe71dec6cbd096e9b08bbd8e8f03e1940b2745"
+source = "git+https://github.com/vv9k/docker-api-rs.git?rev=b1f1891d1d17cb522cc20212452c8c039c5e0810#b1f1891d1d17cb522cc20212452c8c039c5e0810"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
@@ -1613,9 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "docker-api-stubs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6198e6d77eb486d04c9b3997aec536428a7cbba833e84cdfda49e144c8df1734"
+version = "0.6.0"
+source = "git+https://github.com/vv9k/docker-api-rs.git?rev=b1f1891d1d17cb522cc20212452c8c039c5e0810#b1f1891d1d17cb522cc20212452c8c039c5e0810"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ derive_builder = "0.12.0"
 derive_more = "0.99.17"
 diff = "0.1.13"
 directories = "5.0.1"
-docker-api = "0.14"
+docker-api = { "git" = "https://github.com/vv9k/docker-api-rs.git", rev = "b1f1891d1d17cb522cc20212452c8c039c5e0810" }
 dyn-clone = "1.0.11"
 flate2 = "1.0.26"
 futures = "0.3.28"

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -24,6 +24,13 @@ git_fetch(
     visibility = [],
 )
 
+git_fetch(
+    name = "vv9k/docker-api-rs.git",
+    repo = "https://github.com/vv9k/docker-api-rs.git",
+    rev = "b1f1891d1d17cb522cc20212452c8c039c5e0810",
+    visibility = [],
+)
+
 http_archive(
     name = "Inflector-0.11.4.crate",
     sha256 = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3",
@@ -3556,19 +3563,11 @@ alias(
     visibility = ["PUBLIC"],
 )
 
-http_archive(
-    name = "docker-api-0.14.0.crate",
-    sha256 = "4576e993f4ef4805931a835b7afe71dec6cbd096e9b08bbd8e8f03e1940b2745",
-    strip_prefix = "docker-api-0.14.0",
-    urls = ["https://crates.io/api/v1/crates/docker-api/0.14.0/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
     name = "docker-api-0.14.0",
-    srcs = [":docker-api-0.14.0.crate"],
+    srcs = [":vv9k/docker-api-rs.git"],
     crate = "docker_api",
-    crate_root = "docker-api-0.14.0.crate/src/lib.rs",
+    crate_root = "vv9k/docker-api-rs/src/lib.rs",
     edition = "2021",
     features = [
         "chrono",
@@ -3582,7 +3581,7 @@ cargo.rust_library(
         ":bytes-1.4.0",
         ":chrono-0.4.26",
         ":containers-api-0.9.0",
-        ":docker-api-stubs-0.5.0",
+        ":docker-api-stubs-0.6.0",
         ":futures-util-0.3.28",
         ":http-0.2.9",
         ":hyper-0.14.26",
@@ -3596,19 +3595,11 @@ cargo.rust_library(
     ],
 )
 
-http_archive(
-    name = "docker-api-stubs-0.5.0.crate",
-    sha256 = "6198e6d77eb486d04c9b3997aec536428a7cbba833e84cdfda49e144c8df1734",
-    strip_prefix = "docker-api-stubs-0.5.0",
-    urls = ["https://crates.io/api/v1/crates/docker-api-stubs/0.5.0/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
-    name = "docker-api-stubs-0.5.0",
-    srcs = [":docker-api-stubs-0.5.0.crate"],
+    name = "docker-api-stubs-0.6.0",
+    srcs = [":vv9k/docker-api-rs.git"],
     crate = "docker_api_stubs",
-    crate_root = "docker-api-stubs-0.5.0.crate/src/lib.rs",
+    crate_root = "vv9k/docker-api-rs/docker-api-stubs/lib/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -1317,8 +1317,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "docker-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4576e993f4ef4805931a835b7afe71dec6cbd096e9b08bbd8e8f03e1940b2745"
+source = "git+https://github.com/vv9k/docker-api-rs.git?rev=b1f1891d1d17cb522cc20212452c8c039c5e0810#b1f1891d1d17cb522cc20212452c8c039c5e0810"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
@@ -1341,9 +1340,8 @@ dependencies = [
 
 [[package]]
 name = "docker-api-stubs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6198e6d77eb486d04c9b3997aec536428a7cbba833e84cdfda49e144c8df1734"
+version = "0.6.0"
+source = "git+https://github.com/vv9k/docker-api-rs.git?rev=b1f1891d1d17cb522cc20212452c8c039c5e0810#b1f1891d1d17cb522cc20212452c8c039c5e0810"
 dependencies = [
  "chrono",
  "serde",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -42,7 +42,7 @@ derive_builder = "0.12.0"
 derive_more = "0.99.17"
 diff = "0.1.13"
 directories = "5.0.1"
-docker-api = "0.14"
+docker-api = { "git" = "https://github.com/vv9k/docker-api-rs.git", rev = "b1f1891d1d17cb522cc20212452c8c039c5e0810" }
 dyn-clone = "1.0.11"
 flate2 = "1.0.26"
 futures = "0.3.28"


### PR DESCRIPTION
Ref: Discord issue regarding issues with SI Launcher.

[Bump models to v1.43](https://github.com/vv9k/docker-api-rs/commit/851f7091e945d04c055b24809a9b375fc3f0c80d) was merged into the docker-api crate on 10th June
The commit/change never made it into the crate itself, being [last published on 5th June](https://crates.io/crates/docker-api/versions) (0.14.0): There isn't a version of this crate with the updated option config in it

To that end, moved to using a git reference off HEAD for the build.

NB: It's noteworthy we have two different crates for docker-api interaction across our monorepo: bollard and docker-api. I suggest at some point we consolidate these/use the most common one.

Added `:si` build target for Buck for convenience

```
~/D/RISCOSPi.5.28 > si update
System Initiative Launcher is in "local" mode


The application panicked (crashed).
Message:  Unable to push events to Posthog: ()
Location: bin/si/src/main.rs:166

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
Error: 
   0: docker api: missing field `VirtualSize` at line 1 column 1626
   1: missing field `VirtualSize` at line 1 column 1626

Location:
   bin/si/src/main.rs:138

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```