### PR TITLE
bug (app): removed repeat line for testlogs

### DIFF
--- a/app/web/src/components/FuncEditor/FuncTest.vue
+++ b/app/web/src/components/FuncEditor/FuncTest.vue
@@ -134,7 +134,7 @@
               class="relative flex-shrink overflow-auto basis-full"
             >
               <CodeViewer
-                :code="_.repeat(testLogs.stdout, 1000)"
+                :code="testLogs.stdout"
                 :title="`stdout: ${testComponentDisplayName}`"
                 showTitle
               />


### PR DESCRIPTION
Previously the test log was repeated 1000 times, now it is not.