### PR TITLE
feat(sdf, dal, web): Add ability to understand who has taken what action in a changeset

### DIFF
--- a/app/web/src/api/sdf/dal/history_actor.ts
+++ b/app/web/src/api/sdf/dal/history_actor.ts
@@ -1,5 +1,5 @@
 // The actor entitiy that initiates an activitiy--this could represent be a
 // person, service, etc.
 export type ActorView =
-  | { kind: "system"; label: string }
-  | { kind: "user"; label: string; id?: string };
+  | { kind: "system"; label: string; email?: string }
+  | { kind: "user"; label: string; id?: string; email?: string };

--- a/app/web/src/components/ActionSprite.vue
+++ b/app/web/src/components/ActionSprite.vue
@@ -10,6 +10,9 @@
         <!-- TODO(wendy) - sometimes the component name doesn't load properly? not sure why -->
         {{ component?.displayName ?? "unknown" }}
       </div>
+      <div v-if="hasActor" class="text-neutral-400 truncate">
+        By: {{ action.actor }}
+      </div>
     </div>
     <VButton
       v-if="props.action.actionInstanceId"
@@ -44,6 +47,8 @@ const actionName = computed(() => {
   const name = (props.action.displayName || props.action.name).trim();
   return name.length ? name.slice(0, 1).toUpperCase() + name.slice(1) : "";
 });
+
+const hasActor = computed(() => props.action.actor);
 
 const component = computed(
   () => componentStore.componentsById[props.action.componentId],

--- a/app/web/src/components/ApplyHistoryItem.vue
+++ b/app/web/src/components/ApplyHistoryItem.vue
@@ -10,7 +10,7 @@
               fixBatch.fixes.filter((f) => f.status === 'success').length ===
                 fixBatch.fixes.length
             "
-            class="pl-xs whitespace-nowrap"
+            class="pl-xs text-lg whitespace-nowrap"
           >
             All actions applied
           </div>
@@ -51,13 +51,25 @@
         >
           <!-- <Timestamp v-if="fixBatch.finishedAt" :date="fixBatch.finishedAt" size="extended" /> -->
         </div>
-        <div>By: {{ fixBatch.author }}</div>
+        <div><span class="font-bold">By:</span> {{ fixBatch.author }}</div>
+        <div v-if="hasCollaborators">
+          <span class="font-bold">Contributors:</span>
+          <ul class="list-disc">
+            <li
+              v-for="(author, index) in fixBatch.actors"
+              :key="index"
+              class="pl-sm list-inside"
+            >
+              {{ author }}
+            </li>
+          </ul>
+        </div>
         <div v-if="fixBatch.startedAt" class="italic">
-          Started At:
+          <span class="font-bold">Started At: </span>
           <Timestamp size="long" :date="new Date(fixBatch.startedAt)" />
         </div>
         <div v-if="fixBatch.finishedAt" class="italic">
-          Finished At:
+          <span class="font-bold">Finished At: </span>
           <Timestamp size="long" :date="new Date(fixBatch.finishedAt)" />
         </div>
       </div>
@@ -104,7 +116,7 @@
                   </div>
                 </template>
               </CodeViewer>
-              <template v-else-if="fix.resource.message">
+              <div v-else-if="fix.resource.message" class="text-sm pl-xs">
                 {{ fix.resource.message }}
                 <FixDetails
                   v-if="fix.resource.logs && fix.resource.logs.length > 0"
@@ -117,8 +129,8 @@
                   "
                   :details="fix.resource.logs"
                 />
-              </template>
-              <template v-else>
+              </div>
+              <div v-else class="text-sm pl-xs">
                 {{
                   fix.resource.status === "ok"
                     ? "Completed successfully"
@@ -135,7 +147,7 @@
                   "
                   :details="fix.resource.logs"
                 />
-              </template>
+              </div>
             </div>
           </template>
         </Collapsible>
@@ -152,12 +164,17 @@ import {
   Timestamp,
   Collapsible,
 } from "@si/vue-lib/design-system";
+import { computed } from "vue";
 import { FixBatch } from "@/store/fixes.store";
 import CodeViewer from "./CodeViewer.vue";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
 import FixDetails from "./FixDetails.vue";
 
 const props = defineProps<{ fixBatch: FixBatch }>();
+
+const hasCollaborators = computed(
+  () => props.fixBatch.actors && props.fixBatch.actors.length > 0,
+);
 
 const formatTitle = (title: string) => {
   return title

--- a/app/web/src/components/ChangesPanel.vue
+++ b/app/web/src/components/ChangesPanel.vue
@@ -51,6 +51,7 @@
           <div class="text-neutral-400 truncate">
             {{ componentsStore.componentsById[diff.componentId]?.displayName }}
           </div>
+          <div class="text-neutral-400 truncate">By: {{ diff.actor }}</div>
         </div>
       </div>
 
@@ -108,16 +109,20 @@ const diffs = computed(() => {
     .filter((c) => c.changeStatus !== "unmodified")
     .map((c) => {
       let updatedAt = c.updatedInfo.timestamp;
+      let actor = c.updatedInfo.actor.email || c.updatedInfo.actor.label;
       if (c.changeStatus === "added") {
         updatedAt = c.createdInfo.timestamp;
+        actor = c.createdInfo.actor.email || c.createdInfo.actor.label;
       } else if (c.changeStatus === "deleted" && c.deletedInfo) {
         updatedAt = c.deletedInfo.timestamp;
+        actor = c.deletedInfo.actor.email || c.deletedInfo.actor.label;
       }
 
       return {
         componentId: c.id,
         status: c.changeStatus,
         updatedAt,
+        actor,
       };
     });
   arr.sort(

--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -31,12 +31,14 @@ export interface ActionInstance {
   actionPrototypeId: ActionPrototypeId;
   name: string;
   componentId: ComponentId;
+  actor?: string;
 }
 
 export type FullAction = {
   actionPrototypeId: ActionPrototypeId;
   actionInstanceId?: ActionId;
   componentId?: ComponentId;
+  actor?: string;
 } & Omit<ActionPrototype, "id">;
 
 export type ProposedAction = FullAction & {
@@ -87,6 +89,7 @@ export const useActionsStore = () => {
                       actionPrototypeId: actionPrototype.id,
                       actionInstanceId: actionInstance?.id,
                       componentId: actionInstance?.componentId,
+                      actor: actionInstance?.actor,
                       ..._.omit(actionPrototype, "id"),
                     };
                   }),

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -46,6 +46,7 @@ export type FixBatch = {
   id: FixBatchId;
   status?: FixStatus;
   author: string;
+  actors?: string[];
   fixes: Fix[];
   startedAt?: string;
   finishedAt?: string;

--- a/lib/dal/src/actor_view.rs
+++ b/lib/dal/src/actor_view.rs
@@ -26,6 +26,8 @@ pub enum ActorView {
         pk: UserPk,
         /// A display label
         label: String,
+        /// An email for user display purposes
+        email: Option<String>,
     },
 }
 
@@ -52,6 +54,7 @@ impl ActorView {
                 Ok(Self::User {
                     pk: user.pk(),
                     label: user.name().to_string(),
+                    email: Some(user.email().to_string()),
                 })
             }
             HistoryActor::SystemInit => Ok(Self::System {

--- a/lib/dal/src/diagram/node.rs
+++ b/lib/dal/src/diagram/node.rs
@@ -311,8 +311,8 @@ impl DiagramComponentView {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoryEventMetadata {
-    pub(crate) actor: ActorView,
-    pub(crate) timestamp: DateTime<Utc>,
+    pub actor: ActorView,
+    pub timestamp: DateTime<Utc>,
 }
 
 impl HistoryEventMetadata {

--- a/lib/dal/src/migrations/U2402__actions_with_actor.sql
+++ b/lib/dal/src/migrations/U2402__actions_with_actor.sql
@@ -1,0 +1,43 @@
+ALTER TABLE actions
+ADD COLUMN creation_user_id ident;
+
+CREATE OR REPLACE FUNCTION action_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_action_prototype_id ident,
+    this_component_id ident,
+    this_user_id ident,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           actions%ROWTYPE;
+
+    this_index             smallint;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    SELECT COUNT(id)
+    FROM actions_v1(this_tenancy, this_visibility)
+    WHERE change_set_pk = this_visibility_record.visibility_change_set_pk
+    INTO STRICT this_index;
+
+    INSERT INTO actions (tenancy_workspace_pk,
+                         visibility_change_set_pk,
+						 index,
+                         action_prototype_id,
+                         change_set_pk,
+                         component_id, creation_user_id)
+    VALUES (this_tenancy_record.tenancy_workspace_pk,
+            this_visibility_record.visibility_change_set_pk,
+		    this_index,
+            this_action_prototype_id,
+            this_visibility_record.visibility_change_set_pk,
+            this_component_id, this_user_id)
+    RETURNING * INTO this_new_row;
+
+    object := row_to_json(this_new_row);
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/migrations/U2403__fix_batch_with_actor.sql
+++ b/lib/dal/src/migrations/U2403__fix_batch_with_actor.sql
@@ -1,0 +1,26 @@
+ALTER TABLE fix_batches
+ADD COLUMN actors TEXT;
+
+CREATE OR REPLACE FUNCTION fix_batch_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_author text,
+    this_actors text,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           fix_batches%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+INSERT INTO fix_batches (tenancy_workspace_pk, visibility_change_set_pk, author, actors)
+VALUES (this_tenancy_record.tenancy_workspace_pk,
+        this_visibility_record.visibility_change_set_pk, this_author, this_actors)
+    RETURNING * INTO this_new_row;
+
+object := row_to_json(this_new_row);
+END
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/change_set/get_actors.sql
+++ b/lib/dal/src/queries/change_set/get_actors.sql
@@ -1,0 +1,7 @@
+select distinct u.email
+FROM history_events ha
+    INNER JOIN users u ON u.pk = (ha.actor->>'User')::ident
+WHERE ha.tenancy_workspace_pk = $1
+    AND ha.data::jsonb -> 'visibility' ->> 'visibility_change_set_pk' = $2
+
+

--- a/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
@@ -34,6 +34,8 @@ pub async fn apply_change_set(
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
     let actions = change_set.actions(&ctx).await?;
+    let actors = change_set.actors(&ctx).await?;
+    dbg!(&actors);
     change_set.apply(&mut ctx).await?;
 
     track(
@@ -57,7 +59,8 @@ pub async fn apply_change_set(
     };
 
     if !actions.is_empty() {
-        let batch = FixBatch::new(&ctx, user.email()).await?;
+        let actors_delimited_string = actors.join(",");
+        let batch = FixBatch::new(&ctx, user.email(), &actors_delimited_string).await?;
         let mut fixes = Vec::with_capacity(actions.len());
 
         for action in actions {

--- a/lib/sdf-server/src/server/service/fix/list.rs
+++ b/lib/sdf-server/src/server/service/fix/list.rs
@@ -21,6 +21,7 @@ pub struct BatchHistoryView {
     pub id: FixBatchId,
     pub status: Option<FixCompletionStatus>,
     author: String,
+    actors: Option<Vec<String>>,
     fixes: Vec<FixHistoryView>,
     started_at: Option<String>,
     finished_at: Option<String>,
@@ -58,11 +59,23 @@ pub async fn list(
             }
         }
 
+        let author = batch.author();
+        let mut fix_actors: Option<Vec<String>> = None;
+        {
+            if let Some(actors) = batch.actors() {
+                let mut full_actors: Vec<String> =
+                    actors.split(',').map(|s| s.trim().to_string()).collect();
+                full_actors.retain(|a| *a != author);
+                fix_actors = Some(full_actors);
+            }
+        }
+
         batch_views.push(BatchHistoryView {
             id: *batch.id(),
             status: completion_status,
             fixes: fix_views,
-            author: batch.author(),
+            author,
+            actors: fix_actors,
             started_at: batch.started_at().map(|s| s.to_string()),
             finished_at: batch.finished_at().map(|s| s.to_string()),
         })

--- a/lib/sdf-server/src/server/service/fix/run.rs
+++ b/lib/sdf-server/src/server/service/fix/run.rs
@@ -48,7 +48,7 @@ pub async fn run(
 
         HistoryActor::SystemInit => return Err(FixError::InvalidUserSystemInit),
     };
-    let batch = FixBatch::new(&ctx, user.email()).await?;
+    let batch = FixBatch::new(&ctx, user.email(), "").await?;
     let mut fixes = Vec::with_capacity(request.list.len());
 
     for fix_run_request in request.list {


### PR DESCRIPTION
We now show history actor details at an action and change level:

<img width="402" alt="Screenshot 2023-10-31 at 22 06 54" src="https://github.com/systeminit/si/assets/227823/1c0dc2f1-edc4-4507-9a1f-f5ccc06ab7c1">

and we also work out the full list of actors involved in the Applied Changeset and list them alongside the person who merged the changeset

<img width="673" alt="Screenshot 2023-11-01 at 00 38 34" src="https://github.com/systeminit/si/assets/227823/f9648f36-12d0-4530-87ff-3804155a45d9">
