### PR TITLE
feat(auth-api, auth-portal): Show the owner of the workspace when you are an editor

### DIFF
--- a/app/auth-portal/src/components/WorkspaceLinkWidget.vue
+++ b/app/auth-portal/src/components/WorkspaceLinkWidget.vue
@@ -42,6 +42,16 @@
         <div class="text-sm opacity-70 capsize">
           <div class="truncate w-full">{{ workspace.instanceUrl }}</div>
         </div>
+        <div
+          v-if="workspace.role !== 'OWNER'"
+          class="font-bold text-sm capsize"
+        >
+          Owner: {{ workspace.creatorUser.firstName }}
+          {{ workspace.creatorUser.lastName }}
+        </div>
+        <div v-if="workspace.role !== 'OWNER'" class="text-xs">
+          Invited: {{ formatters.timeAgo(workspace.invitedAt) }}
+        </div>
         <div class="font-bold">Role: {{ toSentenceCase(workspace.role) }}</div>
         <div class="flex items-center text-xs gap-md pt-xs">
           <div class="flex items-center gap-xs">
@@ -126,7 +136,7 @@
 
 <script setup lang="ts">
 import { computed, PropType, ref } from "vue";
-
+import { formatters } from "@si/vue-lib";
 import { Icon, Stack } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useWorkspacesStore, WorkspaceId } from "@/store/workspaces.store";

--- a/app/auth-portal/src/store/workspaces.store.ts
+++ b/app/auth-portal/src/store/workspaces.store.ts
@@ -14,8 +14,13 @@ export type Workspace = {
   displayName: string;
   slug: string;
   createdByUserId: UserId;
+  creatorUser: {
+    firstName?: string;
+    lastName?: string;
+  };
   createdAt: ISODateString;
   role: string;
+  invitedAt: Date;
 };
 
 export type WorkspaceMember = {

--- a/bin/auth-api/prisma/migrations/20231102231111_workspace_members_invited_at/migration.sql
+++ b/bin/auth-api/prisma/migrations/20231102231111_workspace_members_invited_at/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "WorkspaceMembers" ADD COLUMN     "invited_at" TIMESTAMP(3);
+
+-- Backfill the existing rows in the database
+UPDATE "WorkspaceMembers"
+SET "invited_at"  = NOW() where "invited_at" IS NULL;

--- a/bin/auth-api/prisma/schema.prisma
+++ b/bin/auth-api/prisma/schema.prisma
@@ -87,6 +87,9 @@ model WorkspaceMembers {
     // Role of the user
     roleType RoleType @map("role_type")
 
+    // Invitation to workspace date
+    invitedAt DateTime? @map("invited_at")
+
     @@unique([userId, workspaceId])
 }
 

--- a/bin/auth-api/src/services/workspaces.service.ts
+++ b/bin/auth-api/src/services/workspaces.service.ts
@@ -48,6 +48,7 @@ export async function createWorkspace(creatorUser: User, instanceUrl = 'http://l
       workspaceId: newWorkspace.id,
       userId: creatorUser.id,
       roleType: RoleType.OWNER,
+      invitedAt: new Date(),
     },
   });
 
@@ -71,9 +72,16 @@ export async function getUserWorkspaces(userId: UserId) {
       UserMemberships: {
         select: {
           roleType: true,
+          invitedAt: true,
         },
         where: {
           userId,
+        },
+      },
+      creatorUser: {
+        select: {
+          firstName: true,
+          lastName: true,
         },
       },
     },
@@ -82,6 +90,7 @@ export async function getUserWorkspaces(userId: UserId) {
   return _.map(workspaces, (w) => ({
     ..._.omit(w, "UserMemberships"),
     role: w.UserMemberships[0].roleType,
+    invitedAt: w.UserMemberships[0].invitedAt,
   }));
 }
 
@@ -121,6 +130,7 @@ export async function inviteMember(email: string, id: WorkspaceId) {
       workspaceId: id,
       userId: user.id,
       roleType: RoleType.EDITOR,
+      invitedAt: new Date(),
     },
   });
 }


### PR DESCRIPTION
Also, show when you were invited to a workspace. Any existing invitations will be set to the date we run this migration as we don’t have a backward set of data on this

<img width="1225" alt="Screenshot 2023-11-03 at 18 28 23" src="https://github.com/systeminit/si/assets/227823/90c0f3b8-88a5-4bcf-bb0e-305c13a92733">

