### PR TITLE
fix(auth-api): Ensure we are setting auth0id

### DIFF
--- a/bin/auth-api/src/services/users.service.ts
+++ b/bin/auth-api/src/services/users.service.ts
@@ -99,10 +99,16 @@ export async function createOrUpdateUserFromAuth0Details(auth0UserData: Auth0.Us
     if (!existingUser.signupAt) {
       existingUser.signupAt = new Date();
     }
+    if (!existingUser.auth0Id) {
+      existingUser.auth0Id = auth0Id;
+    }
     _.assign(existingUser, userData);
     await prisma.user.update({
       where: { id: existingUser.id },
-      data: _.omit(existingUser, 'id', 'auth0Id', 'auth0Details', 'onboardingDetails'),
+      data: {
+        ..._.omit(existingUser, 'id', 'onboardingDetails'),
+        auth0Details: auth0UserData as Prisma.JsonObject,
+      },
     });
 
     tracker.identifyUser(existingUser);


### PR DESCRIPTION
If a user was invited, then signed up, we would get the auth0Id but never set it to the database. When they logged back in, they would have a signupAt but no auth0Id which would cause a user to be a new user not an existing user

This would have again caused a user to lose their invite as it would be for an account that didn’t exist