### PR TITLE
chore(direnv) Make not having a .env no longer an error

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 # Also load things from .env for developer-specific environment variables.
-dotenv
+dotenv_if_exists
 
 PATH_add .bin
 


### PR DESCRIPTION
In the `.envrc` the `dotenv` directive requires the `.env` exist, or direnv will output an error message. Having a `.env` is an optional thing to support developer-specific things. By using `dotenv_if_exists`, direnv no longer considers it an error if the file doesn't exist.