### PR TITLE
feat(Web): Change how Apply Changeset button works

### DIFF
--- a/app/web/src/store/presence.store.ts
+++ b/app/web/src/store/presence.store.ts
@@ -63,6 +63,15 @@ export const usePresenceStore = () => {
       }),
       getters: {
         users: (state) => _.values(state.usersById),
+        usersInChangeset: (state) =>
+          _.filter(
+            _.mapValues(
+              state.usersById,
+              (u) =>
+                u.changeSetId &&
+                u.changeSetId === changeSetsStore.selectedChangeSetId,
+            ),
+          ),
         diagramCursors: (state): DiagramCursorDef[] =>
           _.filter(
             _.values(


### PR DESCRIPTION
We now have 3 ways the modal can work:

-> There are no other users in the changeset and no actions - we get a simple confirmation

![Screenshot 2023-11-16 at 17 35 08](https://github.com/systeminit/si/assets/227823/42ce772e-2b0c-41b3-9e14-843c97a6ef2d)

-> There are no other users in the changeset BUT there are actions - we get a modal with a list of the actions that will be applied

![Screenshot 2023-11-16 at 17 35 27](https://github.com/systeminit/si/assets/227823/ac46b1da-110a-4a82-9e28-613c9fa6eec8)

-> There are other users in the workspace - we now show a modal to the user who merged. That modal (in this turn) only gives the ability to `Skip Approval and Merge`

![Screenshot 2023-11-16 at 17 35 54](https://github.com/systeminit/si/assets/227823/3992f9df-ecd4-48fd-8fce-f90dfd91d7ce)

The next follow on will be to show the approvals workflow.

The outstanding question is:

* At what point do we list the actions that will be merged in the changeset? I beliefe that we should show it as part of the voting dialogue…