### PR TITLE
feat: add vsock support to cyclone-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "cyclone-server",
  "telemetry-application",
  "tokio",
+ "tokio-vsock",
 ]
 
 [[package]]
@@ -1187,7 +1188,7 @@ name = "cyclone-core"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
- "nix",
+ "nix 0.26.2",
  "remain",
  "serde",
  "serde_json",
@@ -1225,6 +1226,7 @@ dependencies = [
  "tokio",
  "tokio-serde",
  "tokio-util",
+ "tokio-vsock",
  "tower",
  "tower-http",
 ]
@@ -1443,7 +1445,7 @@ dependencies = [
  "deadpool",
  "derive_builder",
  "futures",
- "nix",
+ "nix 0.26.2",
  "rand 0.8.5",
  "remain",
  "serde",
@@ -1936,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1946,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
@@ -1974,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -1995,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2006,21 +2008,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2745,6 +2747,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -2920,6 +2931,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -2927,7 +2950,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -4398,7 +4421,7 @@ dependencies = [
  "hyper",
  "module-index-client",
  "names",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "pathdiff",
  "pretty_assertions_sorted",
@@ -5718,6 +5741,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes 1.4.0",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6208,6 +6244,16 @@ dependencies = [
  "stable_deref_trait",
  "tar-parser2",
  "vfs",
+]
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.18.0"
 tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-vsock = { version = "0.4.0"}
 toml = { version = "0.7.6" }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors", "trace"] }

--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -34,6 +34,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-vsock",
     ],
     srcs = glob(["src/**/*.rs"]),
 )

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { version = "0.6.1" }
 cyclone-server = { path = "../../lib/cyclone-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-vsock = { workspace = true }

--- a/bin/cyclone/Dockerfile
+++ b/bin/cyclone/Dockerfile
@@ -21,6 +21,11 @@ RUN cp -R $(nix-store --query --requisites result/) /tmp/nix-store-closure
 # hadolint ignore=SC2046
 RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
 
+# Add wrapper/entrypoint for `$BIN` to exec `.$BIN`
+RUN set -eux; \
+    mv -v "/tmp/local-bin/$BIN" "/tmp/local-bin/.$BIN"; \
+    cp -pv /workdir/bin/$BIN/docker-entrypoint.sh "/tmp/local-bin/$BIN";
+
 ###########################################################################
 # Builder Stage: lang-js
 ###########################################################################

--- a/bin/cyclone/create-firecracker-root-fs.sh
+++ b/bin/cyclone/create-firecracker-root-fs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# vars
+GITROOT="$(git rev-parse --show-toplevel)"
+PACKAGEDIR="$GITROOT/cyclone-pkg"
+ROOTFS="$PACKAGEDIR/cyclone-rootfs.ext4"
+ROOTFSMOUNT="$PACKAGEDIR/rootfs"
+GUESTDISK="/rootfs"
+INITSCRIPT="$PACKAGEDIR/init.sh"
+
+# create disk and mount to a known locations
+sudo rm -rf $PACKAGEDIR
+mkdir -p $ROOTFSMOUNT $KERNELMOUNT
+dd if=/dev/zero of=$ROOTFS bs=1M count=1024
+mkfs.ext4 $ROOTFS
+sudo mount $ROOTFS $ROOTFSMOUNT
+
+# create our script to add an init system to our container image
+cat << EOL > $INITSCRIPT
+apk add openrc mingetty
+
+# Make sure special file systems are mounted on boot:
+rc-update add devfs boot
+rc-update add procfs boot
+rc-update add sysfs boot
+rc-update add local boot
+
+# Then, copy the newly configured system to the rootfs image:
+for d in bin etc lib root sbin usr nix; do tar c "/\${d}" | tar x -C ${GUESTDISK}; done
+for dir in dev proc run sys var; do mkdir ${GUESTDISK}/\${dir}; done
+
+# autologin
+echo "ttyS0::respawn:/sbin/mingetty --autologin root --noclear ttyS0" >> ${GUESTDISK}/etc/inittab
+sed -i 's/root:*::0:::::/root:::0:::::/g' $GUESTDISK/etc/shadow
+
+# autostart cyclone
+cat << EOF > /rootfs/etc/init.d/cyclone
+#!/sbin/openrc-run
+
+name="cyclone"
+description="Cyclone"
+supervisor="supervise-daemon"
+command="cyclone"
+command_args="--bind-vsock 3:52 --decryption-key /dev.decryption.key --lang-server /usr/local/bin/lang-js --enable-watch --limit-requests 1 --watch-timeout 10 --enable-ping --enable-resolver --enable-action-run -v"
+pidfile="/run/agent.pid"
+EOF
+
+chmod +x ${GUESTDISK}/usr/local/bin/cyclone
+chmod +x ${GUESTDISK}/usr/local/bin/lang-js
+chmod +x ${GUESTDISK}/etc/init.d/cyclone
+
+chroot ${GUESTDISK} rc-update add cyclone boot
+
+EOL
+
+# run the script, mounting the disk so we can create a rootfs
+sudo docker run \
+  -v $ROOTFSMOUNT:$GUESTDISK \
+  -v $INITSCRIPT:/init.sh \
+  -it --rm \
+  --entrypoint sh \
+  systeminit/cyclone:sha-880fc9c75cccf0159ba20129f02c9f559301bb56-dirty-amd64 \
+  /init.sh
+
+# lets go find the dev decryption key for now
+sudo cp $GITROOT/lib/cyclone-server/src/dev.decryption.key $ROOTFSMOUNT
+
+# cleanup the PACKAGEDIR
+sudo umount $ROOTFSMOUNT
+rm -rf $ROOTFSMOUNT $KERNELMOUNT $INITSCRIPT $KERNELISO
+
+sudo mv cyclone-pkg/cyclone-rootfs.ext4 /firecracker-data/rootfs.ext4
+
+# cleanup
+sudo rm -rf $PACKAGEDIR

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -61,6 +61,12 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
                 .run()
                 .await?
         }
+        IncomingStream::VsockSocket(_) => {
+            Server::vsock(config, telemetry, decryption_key)
+                .await?
+                .run()
+                .await?
+        }
     }
 
     Ok(())

--- a/lib/cyclone-server/BUCK
+++ b/lib/cyclone-server/BUCK
@@ -26,6 +26,7 @@ rust_library(
         "//third-party/rust:tokio-util",
         "//third-party/rust:tower",
         "//third-party/rust:tower-http",
+        "//third-party/rust:tokio-vsock",
     ],
     srcs = glob(["src/**/*.rs"]),
 )

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -29,3 +29,4 @@ tokio-serde = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+tokio-vsock = { workspace = true }

--- a/lib/cyclone-server/src/config.rs
+++ b/lib/cyclone-server/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 use derive_builder::Builder;
 use si_std::{CanonicalFile, CanonicalFileError};
 use thiserror::Error;
+use tokio_vsock::VsockAddr;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -139,6 +140,7 @@ impl ConfigBuilder {
 pub enum IncomingStream {
     HTTPSocket(SocketAddr),
     UnixDomainSocket(PathBuf),
+    VsockSocket(VsockAddr),
 }
 
 impl Default for IncomingStream {
@@ -160,5 +162,9 @@ impl IncomingStream {
     pub fn unix_domain_socket(path: impl Into<PathBuf>) -> Self {
         let pathbuf = path.into();
         Self::UnixDomainSocket(pathbuf)
+    }
+
+    pub fn vsock_socket(addr: VsockAddr) -> Self {
+        Self::VsockSocket(addr)
     }
 }

--- a/lib/cyclone-server/src/lib.rs
+++ b/lib/cyclone-server/src/lib.rs
@@ -10,6 +10,7 @@ mod state;
 mod timestamp;
 mod tower;
 mod uds;
+mod vsock;
 mod watch;
 
 pub use axum::extract::ws::Message as WebSocketMessage;
@@ -17,3 +18,4 @@ pub use config::{Config, ConfigBuilder, ConfigError, IncomingStream};
 pub use server::{Server, ShutdownSource};
 pub use timestamp::timestamp;
 pub use uds::{UdsIncomingStream, UdsIncomingStreamError};
+pub use vsock::{VsockIncomingStream, VsockIncomingStreamError};

--- a/lib/cyclone-server/src/vsock.rs
+++ b/lib/cyclone-server/src/vsock.rs
@@ -1,0 +1,45 @@
+use std::task::{Context, Poll};
+
+use futures::ready;
+use hyper::server::accept::Accept;
+use thiserror::Error;
+
+use tokio_vsock::{VsockAddr, VsockListener, VsockStream};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum VsockIncomingStreamError {
+    #[error("failed to bind to vsock: {1}")]
+    Bind(#[source] std::io::Error, VsockAddr),
+    #[error("IO error")]
+    IO(#[from] std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, VsockIncomingStreamError>;
+
+pub struct VsockIncomingStream {
+    vsock: VsockListener,
+}
+
+// Change this to Port, so that Vsock can pick up the port and translate onto the host v.sock
+impl VsockIncomingStream {
+    pub async fn create(addr: VsockAddr) -> Result<Self> {
+        let vsock = VsockListener::bind(addr.cid(), addr.port())
+            .map_err(|err| VsockIncomingStreamError::Bind(err, addr))?;
+
+        Ok(Self { vsock })
+    }
+}
+
+impl Accept for VsockIncomingStream {
+    type Conn = VsockStream;
+    type Error = VsockIncomingStreamError;
+
+    fn poll_accept(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn>>> {
+        let (stream, _addr) = ready!(self.vsock.poll_accept(cx))?;
+        Poll::Ready(Some(Ok(stream)))
+    }
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -6906,6 +6906,24 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "memoffset-0.6.5.crate",
+    sha256 = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce",
+    strip_prefix = "memoffset-0.6.5",
+    urls = ["https://crates.io/api/v1/crates/memoffset/0.6.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "memoffset-0.6.5",
+    srcs = [":memoffset-0.6.5.crate"],
+    crate = "memoffset",
+    crate_root = "memoffset-0.6.5.crate/src/lib.rs",
+    edition = "2015",
+    features = ["default"],
+    visibility = [],
+)
+
+http_archive(
     name = "memoffset-0.7.1.crate",
     sha256 = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4",
     strip_prefix = "memoffset-0.7.1",
@@ -7208,6 +7226,84 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [":unicode-segmentation-1.10.1"],
+)
+
+http_archive(
+    name = "nix-0.24.3.crate",
+    sha256 = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069",
+    strip_prefix = "nix-0.24.3",
+    urls = ["https://crates.io/api/v1/crates/nix/0.24.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "nix-0.24.3",
+    srcs = [":nix-0.24.3.crate"],
+    crate = "nix",
+    crate_root = "nix-0.24.3.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "acct",
+        "aio",
+        "default",
+        "dir",
+        "env",
+        "event",
+        "feature",
+        "fs",
+        "hostname",
+        "inotify",
+        "ioctl",
+        "kmod",
+        "memoffset",
+        "mman",
+        "mount",
+        "mqueue",
+        "net",
+        "personality",
+        "poll",
+        "process",
+        "pthread",
+        "ptrace",
+        "quota",
+        "reboot",
+        "resource",
+        "sched",
+        "signal",
+        "socket",
+        "term",
+        "time",
+        "ucontext",
+        "uio",
+        "user",
+        "zerocopy",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "macos-arm64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "windows-gnu": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "windows-msvc": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":bitflags-1.3.2",
+        ":cfg-if-1.0.0",
+        ":libc-0.2.146",
+    ],
 )
 
 alias(
@@ -13864,6 +13960,7 @@ cargo.rust_binary(
         ":tokio-test-0.4.2",
         ":tokio-tungstenite-0.18.0",
         ":tokio-util-0.7.8",
+        ":tokio-vsock-0.4.0",
         ":toml-0.7.6",
         ":tower-0.4.13",
         ":tower-http-0.4.1",
@@ -14528,6 +14625,36 @@ cargo.rust_library(
         ":pin-project-lite-0.2.9",
         ":tokio-1.28.2",
         ":tracing-0.1.37",
+    ],
+)
+
+alias(
+    name = "tokio-vsock",
+    actual = ":tokio-vsock-0.4.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tokio-vsock-0.4.0.crate",
+    sha256 = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd",
+    strip_prefix = "tokio-vsock-0.4.0",
+    urls = ["https://crates.io/api/v1/crates/tokio-vsock/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tokio-vsock-0.4.0",
+    srcs = [":tokio-vsock-0.4.0.crate"],
+    crate = "tokio_vsock",
+    crate_root = "tokio-vsock-0.4.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":bytes-1.4.0",
+        ":futures-0.3.28",
+        ":libc-0.2.146",
+        ":tokio-1.28.2",
+        ":vsock-0.3.0",
     ],
 )
 
@@ -15651,6 +15778,27 @@ cargo.rust_library(
         ":stable_deref_trait-1.2.0",
         ":tar-parser2-0.9.1",
         ":vfs-0.9.0",
+    ],
+)
+
+http_archive(
+    name = "vsock-0.3.0.crate",
+    sha256 = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57",
+    strip_prefix = "vsock-0.3.0",
+    urls = ["https://crates.io/api/v1/crates/vsock/0.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "vsock-0.3.0",
+    srcs = [":vsock-0.3.0.crate"],
+    crate = "vsock",
+    crate_root = "vsock-0.3.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":libc-0.2.146",
+        ":nix-0.24.3",
     ],
 )
 

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -2458,6 +2458,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -2561,6 +2570,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -2568,7 +2589,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -4807,7 +4828,7 @@ dependencies = [
  "jwt-simple",
  "lazy_static",
  "names",
- "nix",
+ "nix 0.26.2",
  "nkeys 0.2.0",
  "num_cpus",
  "once_cell",
@@ -4855,6 +4876,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
+ "tokio-vsock",
  "toml 0.7.6",
  "tower",
  "tower-http",
@@ -5112,6 +5134,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes 1.4.0",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
 ]
 
 [[package]]
@@ -5525,6 +5560,16 @@ dependencies = [
  "stable_deref_trait",
  "tar-parser2",
  "vfs",
+]
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -109,6 +109,7 @@ tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.18.0"
 tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-vsock = { version = "0.4.0" }
 toml = { version = "0.7.6" }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors", "trace"] }


### PR DESCRIPTION
Allows cyclone-server to connect via vsock.

The changes for deadpool and cyclone-client (if any) are not ready to be merged. The changes introduced by this should be non-functional/dead until the other half of the change is merged into main.