### PR TITLE
feat(web, dal, sdf): Create a light approval / notification system

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -8,6 +8,7 @@ export enum ChangeSetStatus {
   Failed = "Failed",
   Closed = "Closed",
   Abandoned = "Abandoned",
+  NeedsApproval = "NeedsApproval",
 }
 
 export type ChangeSetId = string;
@@ -19,6 +20,8 @@ export interface ChangeSet {
   status: ChangeSetStatus;
   appliedByUserId?: UserId;
   appliedAt?: IsoDateString;
+  mergeRequestedAt?: IsoDateString;
+  mergeRequestedByUserId?: UserId;
 }
 
 export type ChangeStatus = "added" | "deleted" | "modified" | "unmodified";

--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -8,17 +8,20 @@
     loadingText="Applying Changes"
     :requestStatus="applyChangeSetReqStatus"
     :disabled="statusStoreUpdating"
-    @click.stop="createModalRef?.open()"
+    @click.stop="openModalHandler"
   >
     Apply Changes
 
-    <!-- modal is teleported out of here, but better to leave the button as the single root node -->
-    <Modal ref="createModalRef" title="Apply Change Set">
-      <template v-if="requiresVoting">
+    <Modal
+      ref="applyModalRef"
+      title="Apply Change Set"
+      :noExit="!canCloseModal"
+    >
+      <template v-if="changeSet.status === ChangeSetStatus.NeedsApproval">
         <div
           :class="
             clsx(
-              'p-sm flex flex-row gap-xs items-center',
+              'p-sm flex items-center gap-3',
               !appliedByYou && 'border-b dark:border-neutral-500',
             )
           "
@@ -27,7 +30,7 @@
           <div>
             <template v-if="appliedByYou">You have</template>
             <template v-else>
-              <span class="italic">{{ applyUser.name }}</span> has
+              <span class="italic">{{ applyUser?.name }}</span> has
             </template>
             clicked the Apply Changes button to apply all of the changes in this
             change set to Head.<template v-if="appliedByYou">
@@ -36,25 +39,122 @@
             </template>
           </div>
         </div>
-        <div
-          v-if="appliedByYou"
-          class="flex w-full gap-xs justify-center items-center"
-        >
-          <VButton
-            ref="applyButtonRef"
-            icon="tools"
-            size="sm"
-            tone="success"
-            loadingText="Applying Changes"
-            label="Skip Approval And Apply"
-            :requestStatus="applyChangeSetReqStatus"
-            :disabled="statusStoreUpdating"
-            @click="applyChangeSet"
-          />
+        <div>
+          <template v-if="appliedByYou">
+            <div class="flex w-full justify-center pb-2">
+              <VButton
+                icon="tools"
+                size="sm"
+                tone="success"
+                loadingText="Applying Changes"
+                label="Override Approval And Apply"
+                :requestStatus="applyChangeSetReqStatus"
+                :disabled="statusStoreUpdating"
+                @click="applyChangeSet"
+              />
+            </div>
+            <div
+              class="text-sm pb-2 italic text-center w-full text-neutral-400 border-b dark:border-neutral-500"
+            >
+              <template v-if="!allUsersVoted"
+                >Waiting on other users in the changeset to vote.</template
+              >
+            </div>
+            <div class="pt-2">
+              <div
+                v-for="(user, index) in presenceStore.usersInChangeset"
+                :key="index"
+                class="flex items-center pr-sm justify-center gap-4"
+              >
+                <div class="min-w-0">
+                  <UserCard :user="user" hideChangesetInfo />
+                </div>
+                <Icon
+                  v-if="
+                    changeSetsStore.changeSetApprovals[user.pk] === 'Approve'
+                  "
+                  name="thumbs-up"
+                  size="lg"
+                  class="text-success-400"
+                />
+                <Icon
+                  v-else-if="
+                    changeSetsStore.changeSetApprovals[user.pk] === 'Pass'
+                  "
+                  name="minus"
+                  size="lg"
+                  class="text-neutral-400"
+                />
+                <Icon
+                  v-else-if="
+                    changeSetsStore.changeSetApprovals[user.pk] === 'Reject'
+                  "
+                  name="thumbs-down"
+                  size="lg"
+                  class="text-destructive-500"
+                />
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <template v-if="!successfullyVoted">
+              <div class="flex w-full justify-center pt-2 gap-2">
+                <VButton
+                  icon="thumbs-up"
+                  variant="ghost"
+                  tone="success"
+                  loadingText="Approving"
+                  label="Approve"
+                  :disabled="statusStoreUpdating"
+                  @click="changeSetApprovalVote('Approve')"
+                />
+                <VButton
+                  icon="minus"
+                  variant="ghost"
+                  tone="error"
+                  loadingText="Passing"
+                  label="Pass"
+                  :disabled="statusStoreUpdating"
+                  @click="changeSetApprovalVote('Pass')"
+                />
+                <VButton
+                  icon="thumbs-down"
+                  variant="ghost"
+                  tone="error"
+                  loadingText="Rejecting"
+                  label="Reject"
+                  :disabled="statusStoreUpdating"
+                  @click="changeSetApprovalVote('Reject')"
+                />
+              </div>
+            </template>
+            <template v-if="successfullyVoted">
+              <div class="flex gap-4 w-full p-2">
+                <Icon name="lock" size="lg" tone="warning" />
+                <span class="text-sm align-middle"
+                  >Changeset is locked until all users in the changeset have
+                  voted on the merge</span
+                >
+              </div>
+              <div class="grid grid-flow-col justify-center w-full">
+                <RouterLink
+                  :to="{
+                    name: 'workspace-single',
+                    params: {
+                      ...route.params,
+                      changeSetId: 'head',
+                    },
+                  }"
+                  class="border border-transparent dark:text-white hover:cursor-pointer hover:border-action-500 dark:hover:border-action-300 p-2"
+                  >Go to head</RouterLink
+                >
+              </div>
+            </template>
+          </template>
         </div>
       </template>
-      <template v-else-if="!requiresVoting">
-        <template v-if="!requiresVoting && !hasActions">
+      <template v-if="changeSet.status === ChangeSetStatus.Open">
+        <template v-if="!hasActions">
           <span class="text-center text-sm"
             >Applying this change set may have side-effects.</span
           >
@@ -62,7 +162,7 @@
             >Are you sure you want to apply this change set?</span
           >
         </template>
-        <template v-if="!requiresVoting && hasActions">
+        <template v-if="hasActions">
           <span class="text-center text-sm"
             >Applying this change set may have side-effects.</span
           >
@@ -79,56 +179,116 @@
             />
           </li>
         </template>
+        <VButton
+          v-if="!changeSetsStore.headSelected"
+          ref="applyButtonRef"
+          icon="tools"
+          size="sm"
+          tone="success"
+          :loadingText="
+            requiresVoting ? 'Beginning Approval Flow' : 'Applying Changes'
+          "
+          :label="requiresVoting ? 'Begin Approval Flow' : 'Apply Changes'"
+          :requestStatus="
+            requiresVoting
+              ? beginMergeApprovalReqStatus
+              : applyChangeSetReqStatus
+          "
+          :disabled="statusStoreUpdating"
+          @click="requiresVoting ? beginMergeApproval() : applyChangeSet()"
+        />
       </template>
-      <VButton
-        v-if="!changeSetsStore.headSelected && !requiresVoting"
-        ref="applyButtonRef"
-        icon="tools"
-        size="sm"
-        tone="success"
-        loadingText="Applying Changes"
-        :label="!hasActions ? 'Confirm' : 'Apply Changes'"
-        :requestStatus="applyChangeSetReqStatus"
-        :disabled="statusStoreUpdating"
-        @click="applyChangeSet"
-      />
+      <template v-if="rejectedWorkflow && appliedByYou">
+        <span class="text-sm pb-2"
+          >One of the users in this changeset has rejected the merge. You can
+          either override and merge the changeset, above or 'Cancel' the merge
+          flow</span
+        >
+        <VButton
+          label="Cancel Merge Flow"
+          variant="ghost"
+          size="sm"
+          tone="warning"
+          loadingText="Cancelling Merge Flow"
+          ruquestStatus="cancelMergeApprovalReqStatus"
+          @click="cancelMergeHandler"
+        />
+      </template>
+    </Modal>
+    <Modal ref="changeSetAppliedRef" title="Change Set Has Been Merged" noExit>
+      <div
+        class="bg-white dark:bg-neutral-700 rounded-lg flex flex-col items-center max-h-[90vh] shadow-md overflow-hidden pb-xs"
+      >
+        <div class="px-sm pt-sm pb-xs w-full">
+          The change set you were in was merged by:
+        </div>
+
+        <div v-if="appliedByUser" class="pr-xs">
+          <UserCard :user="appliedByUser" hideChangesetInfo />
+        </div>
+        <div class="px-sm pb-sm pt-xs w-full">
+          You are now on Head. You can continue your work by creating a new
+          change set or joining another existing change set.
+        </div>
+        <VButton
+          label="Ok"
+          variant="ghost"
+          size="sm"
+          @click="changeSetAppliedHandler()"
+        />
+      </div>
     </Modal>
   </VButton>
 </template>
 
 <script lang="ts" setup>
-import { onMounted, computed, ref } from "vue";
+import { onMounted, computed, ref, watch } from "vue";
 import * as _ from "lodash-es";
 import { useRouter, useRoute } from "vue-router";
-import { VButton, Modal } from "@si/vue-lib/design-system";
+import { VButton, Modal, Icon } from "@si/vue-lib/design-system";
 import JSConfetti from "js-confetti";
 import clsx from "clsx";
+import { storeToRefs } from "pinia";
 import ActionSprite from "@/components/ActionSprite.vue";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useStatusStore } from "@/store/status.store";
 import { useActionsStore } from "@/store/actions.store";
 import { usePresenceStore } from "@/store/presence.store";
-import { UserInfo } from "@/components/layout/navbar/Collaborators.vue";
 import UserIcon from "@/components/layout/navbar/UserIcon.vue";
+import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import { useAuthStore } from "@/store/auth.store";
+import UserCard from "@/components/layout/navbar/UserCard.vue";
 
-const createModalRef = ref<InstanceType<typeof Modal>>();
-
+const applyModalRef = ref<InstanceType<typeof Modal> | null>(null);
 const presenceStore = usePresenceStore();
+const statusStore = useStatusStore();
+const changeSetsStore = useChangeSetsStore();
+const actionsStore = useActionsStore();
+const authStore = useAuthStore();
+const router = useRouter();
+const route = useRoute();
+
+const changeSetAppliedRef = ref();
+const rejectedWorkflow = ref<boolean>();
+const canCloseModal = ref<boolean>();
+const successfullyVoted = ref<boolean>();
+const allUsersVoted = ref<boolean>();
 
 const hasActions = computed(() => actionsStore.proposedActions.length > 0);
 const requiresVoting = computed(
   () => presenceStore.usersInChangeset.length > 0,
 );
 
-const changeSetsStore = useChangeSetsStore();
-const actionsStore = useActionsStore();
-const router = useRouter();
-const route = useRoute();
+function openModalHandler() {
+  changeSetAppliedRef.value.close();
+  applyModalRef.value?.open();
+  resetState();
+}
 
-const applyButtonRef = ref();
-
-const applyChangeSetReqStatus =
-  changeSetsStore.getRequestStatus("APPLY_CHANGE_SET");
+function resetState() {
+  rejectedWorkflow.value = false;
+  successfullyVoted.value = false;
+}
 
 let jsConfetti: JSConfetti;
 const confettis = [
@@ -146,17 +306,12 @@ onMounted(() => {
   });
 });
 
-const appliedByYou = computed(() => true);
-
-const applyUser = ref<UserInfo>({
-  name: "cool user 666",
-  color: "magenta",
-  status: "active",
-});
-
-// Applies the current change set
+const applyChangeSetReqStatus =
+  changeSetsStore.getRequestStatus("APPLY_CHANGE_SET");
+// Applies the current change set3
 const applyChangeSet = async () => {
   if (!route.name) return;
+  applyModalRef.value?.close();
   await changeSetsStore.APPLY_CHANGE_SET();
   window.localStorage.setItem("applied-changes", "true");
   router.replace({
@@ -169,11 +324,142 @@ const applyChangeSet = async () => {
   await jsConfetti.addConfetti(_.sample(confettis));
 };
 
-const statusStore = useStatusStore();
+const beginMergeApprovalReqStatus = changeSetsStore.getRequestStatus(
+  "BEGIN_APPROVAL_PROCESS",
+);
+const beginMergeApproval = async () => {
+  await changeSetsStore.BEGIN_APPROVAL_PROCESS();
+};
+
+async function changeSetApprovalVote(vote: string) {
+  await changeSetsStore.APPLY_CHANGE_SET_VOTE(vote);
+  successfullyVoted.value = true;
+  canCloseModal.value = false;
+  rejectedWorkflow.value = false;
+}
+
+async function cancelMergeHandler() {
+  await cancelApprovalProcess();
+}
+
+async function cancelApprovalProcess() {
+  await changeSetsStore.CANCEL_APPROVAL_PROCESS();
+  rejectedWorkflow.value = true;
+  canCloseModal.value = true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const changeSet = computed(() => changeSetsStore.selectedChangeSet!);
+const appliedByYou = computed(
+  () =>
+    changeSetsStore.selectedChangeSet?.mergeRequestedByUserId ===
+    authStore.user?.pk,
+);
+const applyUser = computed(() => {
+  const systemUser = {
+    name: "System User",
+    color: "magenta",
+    status: "active",
+  };
+  if (changeSet.value?.mergeRequestedByUserId) {
+    const user =
+      presenceStore.usersById[changeSet.value?.mergeRequestedByUserId];
+    if (user) {
+      return user;
+    }
+
+    return systemUser;
+  }
+
+  return systemUser;
+});
+
 const statusStoreUpdating = computed(() => {
   if (statusStore.globalStatus) {
     return statusStore.globalStatus.isUpdating;
   } else return false;
+});
+
+watch(
+  () => changeSetsStore.selectedChangeSet?.status,
+  (newVal, oldVal) => {
+    if (newVal === ChangeSetStatus.NeedsApproval) {
+      applyModalRef.value?.open();
+      successfullyVoted.value = false;
+    }
+    if (
+      newVal === ChangeSetStatus.Open &&
+      oldVal === ChangeSetStatus.NeedsApproval
+    ) {
+      applyModalRef.value?.close();
+      canCloseModal.value = true;
+      rejectedWorkflow.value = false;
+    }
+
+    if (
+      newVal === ChangeSetStatus.Applied &&
+      oldVal === ChangeSetStatus.NeedsApproval
+    ) {
+      applyModalRef.value?.close();
+      changeSetAppliedRef.value?.open();
+    }
+  },
+);
+
+watch(
+  () => changeSetsStore.changeSetApprovals,
+  () => {
+    if (!appliedByYou.value) return;
+    if (
+      _.values(changeSetsStore.changeSetApprovals).length !==
+      presenceStore.usersInChangeset.length + 1
+      // This is the number of other users + the person who triggered the merge
+    )
+      return;
+    if (
+      _.every(
+        _.values(changeSetsStore.changeSetApprovals),
+        (a) => a === "Approve" || a === "Pass",
+      )
+    ) {
+      applyChangeSet();
+    } else {
+      rejectedWorkflow.value = true;
+      allUsersVoted.value = true;
+    }
+  },
+  {
+    deep: true,
+  },
+);
+
+const { postApplyActor } = storeToRefs(changeSetsStore);
+watch(postApplyActor, () => {
+  if (
+    postApplyActor.value !== null &&
+    postApplyActor.value !== authStore.user?.pk
+  ) {
+    changeSetAppliedRef.value?.open();
+  }
+});
+
+function changeSetAppliedHandler() {
+  changeSetAppliedRef.value?.close();
+  // Redirect the user to head changeset
+  if (route.name) {
+    router.push({
+      name: route.name,
+      params: {
+        ...route.params,
+        changeSetId: "head",
+      },
+    });
+  }
+}
+
+const appliedByUser = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return presenceStore.usersById[changeSetsStore.postApplyActor!];
 });
 </script>
 

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -84,29 +84,6 @@
         </div>
       </template>
     </Wipe>
-    <Modal ref="changeSetAppliedRef" noExit>
-      <div
-        class="bg-white dark:bg-neutral-700 rounded-lg flex flex-col items-center w-96 max-h-[90vh] shadow-md overflow-hidden pb-xs"
-      >
-        <div class="px-sm pt-sm pb-xs w-full">
-          The change set you were in was merged by:
-        </div>
-
-        <div v-if="applyUser" class="pr-xs">
-          <UserCard :user="applyUser" hideChangesetInfo />
-        </div>
-        <div class="px-sm pb-sm pt-xs w-full">
-          You are now on Head. You can continue your work by creating a new
-          change set or joining another existing change set.
-        </div>
-        <VButton
-          label="Ok"
-          variant="ghost"
-          size="sm"
-          @click="changeSetAppliedHandler()"
-        />
-      </div>
-    </Modal>
   </div>
 </template>
 
@@ -122,22 +99,16 @@ import {
   Modal,
   useValidatedInputGroup,
 } from "@si/vue-lib/design-system";
-import { storeToRefs } from "pinia";
 import { nilId } from "@/utils/nilId";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useFixesStore } from "@/store/fixes.store";
-import UserCard from "@/components/layout/navbar/UserCard.vue";
-import { usePresenceStore } from "@/store/presence.store";
-import { useAuthStore } from "@/store/auth.store";
 import Wipe from "../../Wipe.vue";
 
 const dropdownRef = ref();
-const changeSetAppliedRef = ref();
+
 const wipeRef = ref<InstanceType<typeof Wipe>>();
 
 const changeSetsStore = useChangeSetsStore();
-const presenceStore = usePresenceStore();
-const authStore = useAuthStore();
 const fixesStore = useFixesStore();
 const openChangeSets = computed(() => changeSetsStore.openChangeSets);
 const selectedChangeSetId = computed(() => changeSetsStore.selectedChangeSetId);
@@ -219,33 +190,4 @@ function openCreateModal() {
   createChangeSetName.value = changeSetsStore.getGeneratedChangesetName();
   createModalRef.value?.open();
 }
-
-const { postApplyActor } = storeToRefs(changeSetsStore);
-watch(postApplyActor, () => {
-  if (
-    postApplyActor.value !== null &&
-    postApplyActor.value !== authStore.user?.pk
-  ) {
-    changeSetAppliedRef.value?.open();
-  }
-});
-
-function changeSetAppliedHandler() {
-  changeSetAppliedRef.value?.close();
-  // Redirect the user to head changeset
-  if (route.name) {
-    router.push({
-      name: route.name,
-      params: {
-        ...route.params,
-        changeSetId: "head",
-      },
-    });
-  }
-}
-
-const applyUser = computed(() => {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return presenceStore.usersById[changeSetsStore.postApplyActor!];
-});
 </script>

--- a/app/web/src/store/presence.store.ts
+++ b/app/web/src/store/presence.store.ts
@@ -62,16 +62,15 @@ export const usePresenceStore = () => {
         lastSeenAt: new Date(),
       }),
       getters: {
-        users: (state) => _.values(state.usersById),
-        usersInChangeset: (state) =>
-          _.filter(
-            _.mapValues(
-              state.usersById,
-              (u) =>
-                u.changeSetId &&
-                u.changeSetId === changeSetsStore.selectedChangeSetId,
-            ),
-          ),
+        users(): OnlineUser[] {
+          return _.values(this.usersById);
+        },
+        usersInChangeset(): OnlineUser[] {
+          return _.filter(
+            this.users,
+            (u) => u.changeSetId === changeSetsStore.selectedChangeSetId,
+          );
+        },
         diagramCursors: (state): DiagramCursorDef[] =>
           _.filter(
             _.values(
@@ -215,7 +214,7 @@ export const usePresenceStore = () => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 this.usersById[payload.userPk] ||= {} as any;
                 _.assign(this.usersById[payload.userPk], {
-                  userId: payload.userPk,
+                  pk: payload.userPk,
                   ..._.pick(payload, "name", "idle", "pictureUrl"),
                   changeSetId: payload.changeSetPk,
                   lastOnlineAt: new Date(),

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -3,6 +3,7 @@
 
 import { ActorView } from "@/api/sdf/dal/history_actor";
 import { FuncId } from "@/store/func/funcs.store";
+import { ChangeSetId } from "@/store/change_sets.store";
 import { ComponentId } from "../components.store";
 import { FixStatus } from "../fixes.store";
 import {
@@ -57,6 +58,19 @@ export type WsEventPayloadMap = {
   ChangeSetApplied: string;
   ChangeSetWritten: string;
   ChangeSetCancelled: string;
+  ChangeSetBeginApprovalProcess: {
+    changeSetPk: ChangeSetId;
+    userPk: UserId;
+  };
+  ChangeSetCancelApprovalProcess: {
+    changeSetPk: ChangeSetId;
+    userPk: UserId;
+  };
+  ChangeSetMergeVote: {
+    changeSetPk: ChangeSetId;
+    userPk: UserId;
+    vote: string;
+  };
 
   CheckedQualifications: {
     prototypeId: string;

--- a/lib/dal/src/queries/change_set/cancel_merge_flow.sql
+++ b/lib/dal/src/queries/change_set/cancel_merge_flow.sql
@@ -1,4 +1,4 @@
 UPDATE change_sets
-SET status = 'NeedsApproval', updated_at = now()
+SET status = 'Open', updated_at = now()
 WHERE pk = $1
 RETURNING updated_at

--- a/lib/dal/src/queries/change_set/open_list.sql
+++ b/lib/dal/src/queries/change_set/open_list.sql
@@ -1,5 +1,5 @@
 SELECT row_to_json(change_sets.*) AS object
 FROM change_sets
 WHERE
-    status = 'Open'
+    status in ('Open', 'NeedsApproval')
     AND in_tenancy_v1($1, change_sets.tenancy_workspace_pk)

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -3,7 +3,7 @@ use si_data_nats::NatsError;
 use si_data_pg::PgError;
 use thiserror::Error;
 
-use crate::change_set::{ChangeSetAppliedPayload, ChangeSetMergeVotePayload};
+use crate::change_set::{ChangeSetActorPayload, ChangeSetMergeVotePayload};
 use crate::component::ComponentCreatedPayload;
 use crate::pkg::ModuleImported;
 use crate::{
@@ -43,8 +43,9 @@ pub type WsEventResult<T> = Result<T, WsEventError>;
 #[serde(tag = "kind", content = "data")]
 #[allow(clippy::large_enum_variant)]
 pub enum WsPayload {
-    ChangeSetApplied(ChangeSetAppliedPayload),
-    ChangeSetBeginApprovalProcess(ChangeSetPk),
+    ChangeSetApplied(ChangeSetActorPayload),
+    ChangeSetBeginApprovalProcess(ChangeSetActorPayload),
+    ChangeSetCancelApprovalProcess(ChangeSetActorPayload),
     ChangeSetCanceled(ChangeSetPk),
     ChangeSetCreated(ChangeSetPk),
     ChangeSetMergeVote(ChangeSetMergeVotePayload),

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -109,8 +109,12 @@ pub fn routes() -> Router<AppState> {
             post(update_selected_change_set::update_selected_change_set),
         )
         .route(
-            "/being_merge_flow",
+            "/begin_approval_process",
             post(begin_approval_process::begin_approval_process),
+        )
+        .route(
+            "/cancel_approval_process",
+            post(begin_approval_process::cancel_approval_process),
         )
         .route("/merge_vote", post(merge_vote::merge_vote))
 }

--- a/lib/sdf-server/src/server/service/change_set/begin_approval_process.rs
+++ b/lib/sdf-server/src/server/service/change_set/begin_approval_process.rs
@@ -3,12 +3,19 @@ use crate::server::tracking::track;
 use crate::service::change_set::{ChangeSetError, ChangeSetResult};
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{ChangeSet, Visibility, WsEvent};
+use dal::{ChangeSet, HistoryActor, User, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BeginMergeFlow {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelMergeFlow {
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -27,6 +34,18 @@ pub async fn begin_approval_process(
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
     change_set.begin_approval_flow(&mut ctx).await?;
 
+    let user_pk = match ctx.history_actor() {
+        HistoryActor::User(user_pk) => {
+            let user = User::get_by_pk(&ctx, *user_pk)
+                .await?
+                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
+
+            Some(user.pk())
+        }
+
+        HistoryActor::SystemInit => None,
+    };
+
     track(
         &posthog_client,
         &ctx,
@@ -38,7 +57,64 @@ pub async fn begin_approval_process(
         }),
     );
 
-    WsEvent::change_set_begin_approval_process(&ctx, ctx.visibility().change_set_pk)
+    WsEvent::change_set_begin_approval_process(&ctx, ctx.visibility().change_set_pk, user_pk)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    WsEvent::change_set_merge_vote(
+        &ctx,
+        ctx.visibility().change_set_pk,
+        user_pk.expect("A user was definitely found as per above"),
+        "Approve".to_string(),
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(()))
+}
+
+pub async fn cancel_approval_process(
+    OriginalUri(original_uri): OriginalUri,
+    PosthogClient(posthog_client): PosthogClient,
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Json(request): Json<CancelMergeFlow>,
+) -> ChangeSetResult<Json<()>> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let mut change_set = ChangeSet::get_by_pk(&ctx, &ctx.visibility().change_set_pk)
+        .await?
+        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    change_set.cancel_approval_flow(&mut ctx).await?;
+
+    let user_pk = match ctx.history_actor() {
+        HistoryActor::User(user_pk) => {
+            let user = User::get_by_pk(&ctx, *user_pk)
+                .await?
+                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
+
+            Some(user.pk())
+        }
+
+        HistoryActor::SystemInit => None,
+    };
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "cancel_approval_process",
+        serde_json::json!({
+            "how": "/change_set/cancel_approval_process",
+            "change_set_pk": ctx.visibility().change_set_pk,
+        }),
+    );
+
+    WsEvent::change_set_cancel_approval_process(&ctx, ctx.visibility().change_set_pk, user_pk)
         .await?
         .publish_on_commit(&ctx)
         .await?;

--- a/lib/sdf-server/src/server/service/change_set/merge_vote.rs
+++ b/lib/sdf-server/src/server/service/change_set/merge_vote.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MergeVoteRequest {
-    pub approve: bool,
+    pub vote: String,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -40,7 +40,7 @@ pub async fn merge_vote(
             "how": "/change_set/merge_vote",
             "change_set_pk": ctx.visibility().change_set_pk,
             "user_pk": user.pk(),
-            "vote": request.approve,
+            "vote": request.vote,
         }),
     );
 
@@ -48,7 +48,7 @@ pub async fn merge_vote(
         &ctx,
         ctx.visibility().change_set_pk,
         user.pk(),
-        request.approve,
+        request.vote,
     )
     .await?
     .publish_on_commit(&ctx)


### PR DESCRIPTION
There are a number of differnet states going on here:

1. No collaborators on the changeset
 * No Actions so we get a simple confirmation modal (this is new!!)
 * Actions so we get a list of actions to be applied in the modal

2. Collaborators in the changeset
 * We begin a change set approval - changeset status moves to NeedsApproval
 * Each collaborate gets a modal to vote (Accept, Pass, Reject)
 * When a collaborate has voted their changeset usage is locked until the merge has completed or been cancelled
 * If *ANY* of the collaborators reject the merge then the person needs to take an action of override or cancel. * If approved then it's a normal merge process * If cancelled then the changeset is unlocked for everyone and the status changes back to Open
 * If all collaborators choose pass or approve, then the changeset will autoapprove
 * If the person chooses to override the merge, then all collaborators are told so