### PR TITLE
[wip] firecracker spawn variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ name = "cyclone-core"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
- "nix",
+ "nix 0.26.2",
  "remain",
  "serde",
  "serde_json",
@@ -1225,6 +1225,7 @@ dependencies = [
  "tokio",
  "tokio-serde",
  "tokio-util",
+ "tokio-vsock",
  "tower",
  "tower-http",
 ]
@@ -1443,7 +1444,7 @@ dependencies = [
  "deadpool",
  "derive_builder",
  "futures",
- "nix",
+ "nix 0.26.2",
  "rand 0.8.5",
  "remain",
  "serde",
@@ -2745,6 +2746,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -2920,6 +2930,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -2927,7 +2949,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -4398,7 +4420,7 @@ dependencies = [
  "hyper",
  "module-index-client",
  "names",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "pathdiff",
  "pretty_assertions_sorted",
@@ -5718,6 +5740,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes 1.4.0",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6208,6 +6243,16 @@ dependencies = [
  "stable_deref_trait",
  "tar-parser2",
  "vfs",
+]
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.18.0"
 tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-vsock = { version = "0.4.0"}
 toml = { version = "0.7.6" }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors", "trace"] }

--- a/bin/cyclone/Dockerfile
+++ b/bin/cyclone/Dockerfile
@@ -21,6 +21,11 @@ RUN cp -R $(nix-store --query --requisites result/) /tmp/nix-store-closure
 # hadolint ignore=SC2046
 RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
 
+# Add wrapper/entrypoint for `$BIN` to exec `.$BIN`
+RUN set -eux; \
+    mv -v "/tmp/local-bin/$BIN" "/tmp/local-bin/.$BIN"; \
+    cp -pv /workdir/bin/$BIN/docker-entrypoint.sh "/tmp/local-bin/$BIN";
+
 ###########################################################################
 # Builder Stage: lang-js
 ###########################################################################
@@ -47,7 +52,7 @@ RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
 ###########################################################################
 # Final Stage
 ###########################################################################
-FROM alpine:3 AS final
+FROM alpine:3.18 AS final
 ARG BIN=cyclone
 
 # hadolint ignore=DL3018

--- a/bin/cyclone/create-firecracker-root-fs.sh
+++ b/bin/cyclone/create-firecracker-root-fs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# vars
+GITROOT="$(git rev-parse --show-toplevel)"
+PACKAGEDIR="$GITROOT/cyclone-pkg"
+ROOTFS="$PACKAGEDIR/cyclone-rootfs.ext4"
+ROOTFSMOUNT="$PACKAGEDIR/rootfs"
+GUESTDISK="/rootfs"
+INITSCRIPT="$PACKAGEDIR/init.sh"
+
+# create disk and mount to a known locations
+sudo rm -rf $PACKAGEDIR
+mkdir -p $ROOTFSMOUNT $KERNELMOUNT
+dd if=/dev/zero of=$ROOTFS bs=1M count=1024
+mkfs.ext4 $ROOTFS
+sudo mount $ROOTFS $ROOTFSMOUNT
+
+# create our script to add an init system to our container image
+cat << EOL > $INITSCRIPT
+apk update
+apk add openrc openssh
+
+ssh-keygen -A
+
+# Make sure special file systems are mounted on boot:
+rc-update add devfs boot
+rc-update add procfs boot
+rc-update add sysfs boot
+rc-update add local default
+rc-update add networking boot
+rc-update add sshd
+
+# Then, copy the newly configured system to the rootfs image:
+for d in bin dev etc lib root sbin usr nix; do tar c "/\${d}" | tar x -C ${GUESTDISK}; done
+for dir in proc run sys var; do mkdir ${GUESTDISK}/\${dir}; done
+
+# autostart cyclone
+cat << EOF > ${GUESTDISK}/etc/init.d/cyclone
+#!/sbin/openrc-run
+
+name="cyclone"
+description="Cyclone"
+supervisor="supervise-daemon"
+command="cyclone"
+command_args="--bind-vsock 3:52 --decryption-key /dev.decryption.key --lang-server /usr/local/bin/lang-js --enable-watch --limit-requests 1 --watch-timeout 10 --enable-ping --enable-resolver --enable-action-run"
+pidfile="/run/agent.pid"
+EOF
+
+chmod +x ${GUESTDISK}/usr/local/bin/cyclone
+chmod +x ${GUESTDISK}/usr/local/bin/lang-js
+chmod +x ${GUESTDISK}/etc/init.d/cyclone
+
+chroot ${GUESTDISK} rc-update add cyclone boot
+
+# networking bits
+echo "nameserver 8.8.8.8" > ${GUESTDISK}/etc/resolv.conf
+cat << EOZ >${GUESTDISK}/etc/network/interfaces
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+        address 10.0.0.1/30
+        gateway 10.0.0.2
+EOZ
+EOL
+
+# run the script, mounting the disk so we can create a rootfs
+sudo docker run \
+  -v $ROOTFSMOUNT:$GUESTDISK \
+  -v $INITSCRIPT:/init.sh \
+  -it --rm \
+  --entrypoint sh \
+  systeminit/cyclone:sha-ef6a35641b2cd8f07475ad5c7a46504883f0a6af-dirty-amd64  \
+  /init.sh
+
+# lets go find the dev decryption key for now
+sudo cp $GITROOT/lib/cyclone-server/src/dev.decryption.key $ROOTFSMOUNT
+
+# cleanup the PACKAGEDIR
+sudo umount $ROOTFSMOUNT
+rm -rf $ROOTFSMOUNT $KERNELMOUNT $INITSCRIPT $KERNELISO
+
+# move the package
+sudo mv $PACKAGEDIR/cyclone-rootfs.ext4 /firecracker-data/rootfs.ext4
+
+# cleanup
+sudo rm -rf $PACKAGEDIR

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -61,6 +61,13 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
                 .run()
                 .await?
         }
+        #[cfg(target_os = "linux")]
+        IncomingStream::VsockSocket(_) => {
+            Server::vsock(config, telemetry, decryption_key)
+                .await?
+                .run()
+                .await?
+        }
     }
 
     Ok(())

--- a/lib/cyclone-server/BUCK
+++ b/lib/cyclone-server/BUCK
@@ -26,7 +26,12 @@ rust_library(
         "//third-party/rust:tokio-util",
         "//third-party/rust:tower",
         "//third-party/rust:tower-http",
-    ],
+    ] + select({
+        "DEFAULT": [],
+        "config//os:linux": [
+            "//third-party/rust:tokio-vsock",
+        ],
+    }),
     srcs = glob(["src/**/*.rs"]),
 )
 

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -29,3 +29,6 @@ tokio-serde = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-vsock = { workspace = true }

--- a/lib/cyclone-server/src/config.rs
+++ b/lib/cyclone-server/src/config.rs
@@ -132,6 +132,11 @@ impl ConfigBuilder {
     pub fn unix_domain_socket(&mut self, path: impl Into<PathBuf>) -> &mut Self {
         self.incoming_stream(IncomingStream::unix_domain_socket(path))
     }
+
+    #[cfg(target_os = "linux")]
+    pub fn vsock_socket(&mut self, addr: tokio_vsock::VsockAddr) -> &mut Self {
+        self.incoming_stream(IncomingStream::vsock_socket(addr))
+    }
 }
 
 #[remain::sorted]
@@ -139,6 +144,8 @@ impl ConfigBuilder {
 pub enum IncomingStream {
     HTTPSocket(SocketAddr),
     UnixDomainSocket(PathBuf),
+    #[cfg(target_os = "linux")]
+    VsockSocket(tokio_vsock::VsockAddr),
 }
 
 impl Default for IncomingStream {
@@ -160,5 +167,10 @@ impl IncomingStream {
     pub fn unix_domain_socket(path: impl Into<PathBuf>) -> Self {
         let pathbuf = path.into();
         Self::UnixDomainSocket(pathbuf)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn vsock_socket(addr: tokio_vsock::VsockAddr) -> Self {
+        Self::VsockSocket(addr)
     }
 }

--- a/lib/cyclone-server/src/lib.rs
+++ b/lib/cyclone-server/src/lib.rs
@@ -10,10 +10,16 @@ mod state;
 mod timestamp;
 mod tower;
 mod uds;
+#[cfg(target_os = "linux")]
+mod vsock;
 mod watch;
 
 pub use axum::extract::ws::Message as WebSocketMessage;
 pub use config::{Config, ConfigBuilder, ConfigError, IncomingStream};
 pub use server::{Server, ShutdownSource};
 pub use timestamp::timestamp;
+#[cfg(target_os = "linux")]
+pub use tokio_vsock::VsockAddr;
 pub use uds::{UdsIncomingStream, UdsIncomingStreamError};
+#[cfg(target_os = "linux")]
+pub use vsock::{VsockIncomingStream, VsockIncomingStreamError};

--- a/lib/cyclone-server/src/vsock.rs
+++ b/lib/cyclone-server/src/vsock.rs
@@ -1,0 +1,45 @@
+use std::task::{Context, Poll};
+
+use futures::ready;
+use hyper::server::accept::Accept;
+use thiserror::Error;
+
+use tokio_vsock::{VsockAddr, VsockListener, VsockStream};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum VsockIncomingStreamError {
+    #[error("failed to bind to vsock: {1}")]
+    Bind(#[source] std::io::Error, VsockAddr),
+    #[error("IO error")]
+    IO(#[from] std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, VsockIncomingStreamError>;
+
+pub struct VsockIncomingStream {
+    vsock: VsockListener,
+}
+
+// Change this to Port, so that Vsock can pick up the port and translate onto the host v.sock
+impl VsockIncomingStream {
+    pub async fn create(addr: VsockAddr) -> Result<Self> {
+        let vsock = VsockListener::bind(addr.cid(), addr.port())
+            .map_err(|err| VsockIncomingStreamError::Bind(err, addr))?;
+
+        Ok(Self { vsock })
+    }
+}
+
+impl Accept for VsockIncomingStream {
+    type Conn = VsockStream;
+    type Error = VsockIncomingStreamError;
+
+    fn poll_accept(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn>>> {
+        let (stream, _addr) = ready!(self.vsock.poll_accept(cx))?;
+        Poll::Ready(Some(Ok(stream)))
+    }
+}

--- a/lib/deadpool-cyclone/examples/deadpool-cyclone-resolver-function-pool/main.rs
+++ b/lib/deadpool-cyclone/examples/deadpool-cyclone-resolver-function-pool/main.rs
@@ -98,7 +98,6 @@ async fn execute(
     info!(status = ?pool.status(), "Getting an instance from the pool");
     let mut instance = pool.get().await?;
     info!("Checking if instance is healthy");
-    instance.ensure_healthy().await?;
 
     info!(
         execution_id = &request.execution_id.as_str(),

--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -132,20 +132,6 @@ mod tests {
             .await
             .expect("failed to create instance");
 
-        let status = instance
-            .liveness()
-            .await
-            .expect("failed to run liveness check");
-        assert_eq!(status, LivenessStatus::Ok);
-        instance.ensure_healthy().await.expect("failed healthy");
-
-        let status = instance
-            .readiness()
-            .await
-            .expect("failed to run readiness check");
-        assert_eq!(status, ReadinessStatus::Ready);
-        instance.ensure_healthy().await.expect("failed healthy");
-
         instance
             .execute_ping()
             .await
@@ -204,6 +190,44 @@ mod tests {
             .start()
             .await
             .expect("failed to start protocol");
+        instance.ensure_healthy().await.expect("failed healthy");
+
+        instance.terminate().await.expect("failed to terminate");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn chop() {
+        let mut config_file = veritech_server::ConfigFile::default_local_uds();
+        veritech_server::detect_and_configure_development(&mut config_file)
+            .expect("failed to determine test configuration");
+
+        let spec = LocalUdsInstance::spec()
+            .try_cyclone_cmd_path(config_file.cyclone.cyclone_cmd_path())
+            .expect("failed to find cyclone program")
+            .cyclone_decryption_key_path(config_file.cyclone.cyclone_decryption_key_path())
+            .try_lang_server_cmd_path(config_file.cyclone.lang_server_cmd_path())
+            .expect("failed to find lang server program")
+            .limit_requests(2)
+            .runtime_strategy(LocalUdsRuntimeStrategy::LocalFirecracker)
+            .socket_strategy(LocalUdsSocketStrategy::Random)
+            .ping()
+            .build()
+            .expect("failed to build spec");
+        let manager = Manager::new(spec);
+
+        let mut instance = managed::Manager::create(&manager)
+            .await
+            .expect("failed to create instance");
+
+        instance
+            .execute_ping()
+            .await
+            .expect("failed execute ping")
+            .start()
+            .await
+            .expect("failed to start protocol");
+
         instance.ensure_healthy().await.expect("failed healthy");
 
         instance.terminate().await.expect("failed to terminate");

--- a/lib/sdf-server/tests/service_tests/functions.rs
+++ b/lib/sdf-server/tests/service_tests/functions.rs
@@ -1,6 +1,6 @@
 use axum::{http::Method, Router};
 
-use dal::{Func, FuncBackendKind, FuncBackendResponseType, StandardModel, ComponentId};
+use dal::{ComponentId, Func, FuncBackendKind, FuncBackendResponseType, StandardModel};
 use dal_test::{sdf_test, AuthTokenRef, DalContextHead};
 
 use sdf_server::service::func::execute::{ExecuteRequest, ExecuteResponse};

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -356,7 +356,6 @@ async fn resolver_function_request(
     }
 
     let function_result = progress.finish().await?;
-
     Ok(function_result)
 }
 

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -6906,6 +6906,24 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "memoffset-0.6.5.crate",
+    sha256 = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce",
+    strip_prefix = "memoffset-0.6.5",
+    urls = ["https://crates.io/api/v1/crates/memoffset/0.6.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "memoffset-0.6.5",
+    srcs = [":memoffset-0.6.5.crate"],
+    crate = "memoffset",
+    crate_root = "memoffset-0.6.5.crate/src/lib.rs",
+    edition = "2015",
+    features = ["default"],
+    visibility = [],
+)
+
+http_archive(
     name = "memoffset-0.7.1.crate",
     sha256 = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4",
     strip_prefix = "memoffset-0.7.1",
@@ -7208,6 +7226,84 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [":unicode-segmentation-1.10.1"],
+)
+
+http_archive(
+    name = "nix-0.24.3.crate",
+    sha256 = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069",
+    strip_prefix = "nix-0.24.3",
+    urls = ["https://crates.io/api/v1/crates/nix/0.24.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "nix-0.24.3",
+    srcs = [":nix-0.24.3.crate"],
+    crate = "nix",
+    crate_root = "nix-0.24.3.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "acct",
+        "aio",
+        "default",
+        "dir",
+        "env",
+        "event",
+        "feature",
+        "fs",
+        "hostname",
+        "inotify",
+        "ioctl",
+        "kmod",
+        "memoffset",
+        "mman",
+        "mount",
+        "mqueue",
+        "net",
+        "personality",
+        "poll",
+        "process",
+        "pthread",
+        "ptrace",
+        "quota",
+        "reboot",
+        "resource",
+        "sched",
+        "signal",
+        "socket",
+        "term",
+        "time",
+        "ucontext",
+        "uio",
+        "user",
+        "zerocopy",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "macos-arm64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "windows-gnu": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+        "windows-msvc": dict(
+            deps = [":memoffset-0.6.5"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":bitflags-1.3.2",
+        ":cfg-if-1.0.0",
+        ":libc-0.2.146",
+    ],
 )
 
 alias(
@@ -13864,6 +13960,7 @@ cargo.rust_binary(
         ":tokio-test-0.4.2",
         ":tokio-tungstenite-0.18.0",
         ":tokio-util-0.7.8",
+        ":tokio-vsock-0.4.0",
         ":toml-0.7.6",
         ":tower-0.4.13",
         ":tower-http-0.4.1",
@@ -14528,6 +14625,36 @@ cargo.rust_library(
         ":pin-project-lite-0.2.9",
         ":tokio-1.28.2",
         ":tracing-0.1.37",
+    ],
+)
+
+alias(
+    name = "tokio-vsock",
+    actual = ":tokio-vsock-0.4.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tokio-vsock-0.4.0.crate",
+    sha256 = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd",
+    strip_prefix = "tokio-vsock-0.4.0",
+    urls = ["https://crates.io/api/v1/crates/tokio-vsock/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tokio-vsock-0.4.0",
+    srcs = [":tokio-vsock-0.4.0.crate"],
+    crate = "tokio_vsock",
+    crate_root = "tokio-vsock-0.4.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":bytes-1.4.0",
+        ":futures-0.3.28",
+        ":libc-0.2.146",
+        ":tokio-1.28.2",
+        ":vsock-0.3.0",
     ],
 )
 
@@ -15651,6 +15778,27 @@ cargo.rust_library(
         ":stable_deref_trait-1.2.0",
         ":tar-parser2-0.9.1",
         ":vfs-0.9.0",
+    ],
+)
+
+http_archive(
+    name = "vsock-0.3.0.crate",
+    sha256 = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57",
+    strip_prefix = "vsock-0.3.0",
+    urls = ["https://crates.io/api/v1/crates/vsock/0.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "vsock-0.3.0",
+    srcs = [":vsock-0.3.0.crate"],
+    crate = "vsock",
+    crate_root = "vsock-0.3.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":libc-0.2.146",
+        ":nix-0.24.3",
     ],
 )
 

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -2458,6 +2458,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -2561,6 +2570,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -2568,7 +2589,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -4807,7 +4828,7 @@ dependencies = [
  "jwt-simple",
  "lazy_static",
  "names",
- "nix",
+ "nix 0.26.2",
  "nkeys 0.2.0",
  "num_cpus",
  "once_cell",
@@ -4855,6 +4876,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
+ "tokio-vsock",
  "toml 0.7.6",
  "tower",
  "tower-http",
@@ -5112,6 +5134,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes 1.4.0",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
 ]
 
 [[package]]
@@ -5525,6 +5560,16 @@ dependencies = [
  "stable_deref_trait",
  "tar-parser2",
  "vfs",
+]
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -109,6 +109,7 @@ tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.18.0"
 tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-vsock = { version = "0.4.0"}
 toml = { version = "0.7.6" }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors", "trace"] }


### PR DESCRIPTION
Adds a new function execution platform variant of (`LocalUdsRuntimeStrategy` named `LocalFirecracker`) which uses Firecracker Micro-VMs to execute the functions within.

This PR also includes conditional compiling of the VSOCK elements which are not supported on Mac `M` series chips and some others. This allows the default compilation execution strategy (LocalProcess) to be used on `all` hosts compatible with SI, not just those which are compatible with the `firecracker specific` elements on the build. It's important to note that due to this, binaries produced on a host which does not support firecracker, will not be able to execute on firecracker even on another host that `does` support it. 

Currently the Firecracker host must be `local` to the context of the rest of the stack. I.e. this PR does not add "remote execution host" functionality to the SI stack although adding this should be possible leveraging a router or similar execution-host manager. Additionally, because of the above and the nature of how firecracker has to interact at a privileged level, to run the stack under the state of this PR, the `buck2 run dev` needs to run as `root` to allow it to take the relevant actions.

<hr />

This change will be dead code, unless the values for  these attributes are set:

Enabling in Cyclone Server:
`lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs`
```
impl Default for LocalUdsRuntimeStrategy {
    fn default() -> Self {
        Self::LocalFirecracker                           // set from Self::LocalProcess
    }
}
```

Enabling in Cyclone Client:
`lib/cyclone-client/src/client.rs`
```
impl Default for ClientConfig {
    fn default() -> Self {
        Self {
            firecracker_connect: true,             // firecracker-setup: set from false
            watch_timeout: Duration::from_secs(10),
        }
    }
}
```

<hr/>

**Kernel and Rootfs Generation:**
- Producing the kernel image at this time is as follows:
  - Clone the kernel repo https://github.com/torvalds/linux on the relevant/chosen git tag
  - Build the kernel image using `make vmlinux` / `make Image` depending on platform, drive the installation with a supported kernel configuration from [here](https://github.com/firecracker-microvm/firecracker/tree/main/resources/guest_configs)
  
 - Producing the Rootfs at this time is as follows:
   - Clone SI repo
   - Run `buck2 run bin/cyclone:image` to generate the cyclone image (This puts it into the docker daemon on the host)
   - Use the outputted cyclone image reference into the `bin/cyclone/create-firecracker-root-fs.sh` script in the `docker run stage` and execute the script. This outputs the new rootfs into the `/firecracker-data/` folder on the host.

We will migrate the production of both of these artifacts into CI at some point in the future.

<hr/>

**Execution Environment**
- Each Firecracker micro-vm is spawned via the jailer binary, a binary which significantly improves the security posture of the host, find more information on exactly what it does here [jailer docs]( https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md)
- Each micro-vm has it's own network namespace and two routes: 
  - One out to the internet via the external host interface
  - One VSOCK interface to allow cyclone-server and cyclone-client (veritech) to talk privately via the virtio-vsock kernel module
- Each has it's own Linux user, group and root filesystem path on the host under which it has limited permissions. The path for these are set to the default for firecracker at the minute, namely: `/srv/jailer/firecracker/<id>/root/`
- Currently we don't pass any cgroups to the jailer, but this can be added for process-level cpu allocation isolation in the future.
- Each execution has it's own process namespace
<hr/>

**Validation on Host**
A test has been added (disabled) within `lib/deadpool-cyclone/src/lib.rs` called `chop` which validates that the firecracker execution environment on the host running the test is valid and works at a high level (can launch firecracker VM and establish a ping/pong websocket connection through to cyclone server).

**Prerequisites on Host**
- The host must have the SI repository and all prerequisites to compile and run the code. 
- The Firecracker VMM is built to be processor agnostic. 64-bit Intel, AMD and Arm CPUs with hardware virtualization support are generally available for production workloads. (i.e. does not support Mac `M` series chips)
- The host must have had the [si-firecracker-config](https://github.com/systeminit/si-firecracker-config/blob/main/machine-userdata.sh) host config executed against it. It's likely at some point in the near future this config will merge into the main `si` monorepo to keep the rust and required system configuration together.

**Further Notes**

- There are various TODO's left in the code which can be dealt with at a later point in time:
  - Hardcoded ProcessRuntime: This should be configurable or otherwise driven by external system/environment settings. 
  - Killall VMs script (currently we only kill one at a time on a host)
  - Observability deep dive 
    - We have no manner of debugging or seeing traces from cyclone-server running within firecracker.
    - How do we detect kernel issues (ooms, etc) - we have no real manner to detect or monitor for these
  - We are using a shared SSH private key on the host to connect to micro-vms. We will likely need to protect this route in more formally using tailscale or similar in the future as customer code will be accessible within that context.
  - Build/test pipeline - As mentioned in the creation of the kernel and rootfs section, we currently manually create both these artifacts and have limited/zero test coverage over them until we manually check their validity.
  - Shareable remote host - As mentioned in the pre-amble description, this PR only supports a single-tenanted SI Stack as we do not talk remotely to a firecracker-capable host to run the execution. 
  - Capacity planning - how many VMs per metal instance, how much memory do the VMs need, etc. These calculations and estimations will come as time passes.
  - No formal performance tests have been executed but the system seems suitably performant at this time.
  - Tying cyclone image build to rootfs generation. Currently this is a manual process whereby 
  - stop.sh is not getting triggered on oom or similar firecracker fault. I.e. the firecracker micro-vm API process is left intact/unterminated. From the UI/cyclone-server perspective you get a connection lost error.
  - The provisioning strategy for micro-vms does not support parallelism at this time. The processes will clash when manipulating the hosts iptables rules and cause the secondary one to fail. When we move to use parallel execution we will need to make mild adjustments here to the pooling/launching strategy from veritech.
