### PR TITLE
Make crdt tests stable

### DIFF
--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -77,6 +77,7 @@ rust_test(
         "//third-party/rust:yrs",
         "//third-party/rust:tower",
         "//third-party/rust:futures",
+        "//third-party/rust:futures-lite",
         ":sdf-server",
     ],
     crate_root = "tests/api.rs",

--- a/lib/sdf-server/src/server/service/ws.rs
+++ b/lib/sdf-server/src/server/service/ws.rs
@@ -1,7 +1,7 @@
 use axum::{
     http::StatusCode, response::IntoResponse, response::Response, routing::get, Json, Router,
 };
-use dal::TransactionsError;
+use dal::{TransactionsError, WsEventError};
 use si_data_pg::{PgError, PgPoolError};
 use thiserror::Error;
 
@@ -14,11 +14,15 @@ pub enum WsError {
     #[error(transparent)]
     Crdt(#[from] CrdtError),
     #[error(transparent)]
+    Nats(#[from] si_data_nats::Error),
+    #[error(transparent)]
     Pg(#[from] PgError),
     #[error(transparent)]
     PgPool(#[from] PgPoolError),
     #[error(transparent)]
     Transactions(#[from] TransactionsError),
+    #[error("wsevent error: {0}")]
+    WsEvent(#[from] WsEventError),
 }
 
 pub mod crdt;


### PR DESCRIPTION
Since we used websockets the port had to be available when starting the test, causing a failure if for some reason it isn't.

So we moved that logic from websockets to Streams and Sinks.

- Abstract CRDT broadcast logic over a `Sink<Message>` and `Stream<Message>` instead of using WebSockets directly
- Create a `Sink<Message>` and a `Stream<Message>` in tests from a tokio::broadcast channel pair
- Create a `Sink<Vec<u8>>` and a `Stream<Vec<u8>>` in tests from the `Sink<Message>/Stream<Message>`, to properly integrate with y_sync test machinery
- Create server and client structs over those sinks/streams to emulate the websocket ones