### PR TITLE
feat: copy-on-write layer for rootfs

### DIFF
--- a/component/firecracker-base/start.sh
+++ b/component/firecracker-base/start.sh
@@ -7,7 +7,7 @@ JAILER_BINARY="/usr/bin/jailer"
 JAILER_NS="jailer-$SB_ID"
 JAIL="/srv/jailer/firecracker/$SB_ID/root"
 
-if ! test -f "$JAIL/rootfs.ext4"; then
+if ! test -f "$JAIL/firecracker.conf"; then
   echo "Files missing from $JAIL. Has the machine configuration been completed?"
 else
   echo "Starting jailer $SB_ID..."
@@ -20,7 +20,8 @@ else
     --uid 10000$SB_ID \
     --gid 10000 \
     --netns /var/run/netns/$JAILER_NS \
-    --new-pid-ns \
     -- \
-    --config-file ./firecracker.conf
+    --config-file ./firecracker.conf &
+  # note: if you forget the & above, nothing will work and you will spend hours
+  # trying to figure out why.
 fi

--- a/component/firecracker-base/stop.sh
+++ b/component/firecracker-base/stop.sh
@@ -18,15 +18,23 @@ ip link del veth-main$SB_ID 2> /dev/null || true
 ip link del veth-jailer$SB_ID 2> /dev/null || true
 
 # Remove iptables rules
-ip netns exec jailer-$SB_ID iptables -t nat -D POSTROUTING -o veth-jailer$SB_ID -j MASQUERADE
-ip netns exec jailer-$SB_ID iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-ip netns exec jailer-$SB_ID iptables -D FORWARD -i fc-$SB_ID-tap0 -o veth-jailer$SB_ID -j ACCEPT
+ip netns exec jailer-$SB_ID iptables -t nat -D POSTROUTING -o veth-jailer$SB_ID -j MASQUERADE || true
+ip netns exec jailer-$SB_ID iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
+ip netns exec jailer-$SB_ID iptables -D FORWARD -i fc-$SB_ID-tap0 -o veth-jailer$SB_ID -j ACCEPT || true
 
 # Remove network namespace
-ip netns del jailer-$SB_ID
+ip netns del jailer-$SB_ID || true
 
 # Remove user and group
-userdel jailer-$SB_ID
+userdel jailer-$SB_ID || true
 
 # Remove directories and files
+umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true
+umount /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4 || true
+dmsetup remove rootfs-overlay-$SB_ID || true
+dmsetup remove kernel-overlay-$SB_ID || true
+# TODO(scott): figure out a better way to do this.
+# this will only detach devices removed from device-mapper
+# but it still feels bad
+losetup --detach-all
 rm -rf /srv/jailer/firecracker/$SB_ID

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -697,7 +697,7 @@ impl LocalFirecrackerRuntime {
         // over, ensuring that we do cleanup along the way
         // Obviously this has the potential to clash, but overall the risk here is fairly low
         // assuming that cleanup works as expected ;)
-        let vm_id: String = thread_rng().gen_range(0..100).to_string();
+        let vm_id: String = thread_rng().gen_range(0..5000).to_string();
         let sock = PathBuf::from(&format!("/srv/jailer/firecracker/{}/root/v.sock", vm_id));
 
         Ok(Box::new(LocalFirecrackerRuntime {


### PR DESCRIPTION
This fixes some bugs from the last round of changes, but primarily it adds Copy-on-Write support for the rootfs so we no longer need to copy the 1gb image to each jail. This drastically reduces both the size of the jails and the speed at which we can create them. this should allow us to create 5000+ jails in advance on the metal instances.

This was heavily influenced by the approach [here](https://parandrus.dev/devicemapper/)