### PR TITLE
feat(buck2): create `nix_omnibus_pkg` rule to make portable binary pkgs

### DIFF
--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -3,6 +3,7 @@ load(
     "docker_image",
     "rootfs",
     "export_file",
+    "nix_omnibus_pkg",
     "rust_binary",
     "shellcheck",
     "shfmt_check",
@@ -61,6 +62,12 @@ docker_image(
         "//bin/cyclone:cyclone",
         "//bin/lang-js:bin",
     ]
+)
+
+nix_omnibus_pkg(
+    name = "omnibus",
+    pkg_name = "cyclone",
+    build_dep = "//bin/cyclone:cyclone",
 )
 
 rootfs(

--- a/bin/lang-js/BUCK
+++ b/bin/lang-js/BUCK
@@ -1,15 +1,16 @@
 load(
     "@prelude-si//:macros.bzl",
     "eslint",
-    "jest",
     "export_file",
+    "jest",
+    "nix_omnibus_pkg",
     "node_pkg_bin",
+    "package_node_modules",
     "prettier_check",
     "typescript_check",
     "typescript_dist",
     "typescript_runnable_dist",
     "typescript_runnable_dist_bin",
-    "package_node_modules",
 )
 
 export_file(
@@ -79,4 +80,10 @@ jest(
     srcs = [":src", ":test_src"] + glob(["jest.config.js"]),
     prod_deps_srcs = prod_deps_srcs,
     dev_deps_srcs = dev_deps_srcs,
+)
+
+nix_omnibus_pkg(
+    name = "omnibus",
+    pkg_name = "lang-js",
+    build_dep = "//bin/lang-js:bin",
 )

--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -2,6 +2,7 @@ load(
     "@prelude-si//:macros.bzl",
     "docker_image",
     "export_file",
+    "nix_omnibus_pkg",
     "rust_binary",
     "shellcheck",
     "shfmt_check",
@@ -68,4 +69,10 @@ docker_image(
         "//bin/cyclone:cyclone",
         "//bin/lang-js:bin",
     ]
+)
+
+nix_omnibus_pkg(
+    name = "omnibus",
+    pkg_name = "veritech",
+    build_dep = "//bin/veritech:veritech",
 )

--- a/prelude-si/git/git_info.py
+++ b/prelude-si/git/git_info.py
@@ -98,6 +98,11 @@ def finalize(data: Dict[str, Any]):
 
         cal_ver = dt_utc.strftime("%Y%m%d.%H%M%S.0")
         canonical_version = f"{cal_ver}-sha.{abbreviated_commit_hash}"
+        if is_dirty == True:
+            canonical_version += "-dirty"
+            data.update({
+                COMMIT_HASH: "{}-dirty".format(data.get(COMMIT_HASH)),
+            })
 
         data.update({
             CAL_VER: cal_ver,

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -27,8 +27,10 @@ rootfs = _rootfs
 load(
     "@prelude-si//macros:nix.bzl",
     _nix_flake_lock = "nix_flake_lock",
+    _nix_omnibus_pkg = "nix_omnibus_pkg",
 )
 nix_flake_lock = _nix_flake_lock
+nix_omnibus_pkg = _nix_omnibus_pkg
 
 load(
     "@prelude-si//macros:pnpm.bzl",

--- a/prelude-si/macros/nix.bzl
+++ b/prelude-si/macros/nix.bzl
@@ -1,6 +1,7 @@
 load(
     "@prelude-si//:nix.bzl",
     _nix_flake_lock = "nix_flake_lock",
+    _nix_omnibus_pkg = "nix_omnibus_pkg",
 )
 
 def nix_flake_lock(
@@ -13,6 +14,22 @@ def nix_flake_lock(
         name = name,
         src = src or name,
         nix_flake = nix_flake,
+        visibility = visibility,
+        **kwargs,
+    )
+
+def nix_omnibus_pkg(
+        name,
+        source_url = "http://github.com/systeminit/si.git",
+        author = "The System Initiative <dev@systeminit.com>",
+        license = "Apache-2.0",
+        visibility = ["PUBLIC"],
+        **kwargs):
+    _nix_omnibus_pkg(
+        name = name,
+        source_url = source_url,
+        author = author,
+        license = license,
         visibility = visibility,
         **kwargs,
     )

--- a/prelude-si/nix.bzl
+++ b/prelude-si/nix.bzl
@@ -1,3 +1,36 @@
+load(
+    "@prelude//python:toolchain.bzl",
+    "PythonToolchainInfo",
+)
+load(
+    "//build_context:toolchain.bzl",
+    "BuildContextToolchainInfo",
+)
+load(
+    "//git:toolchain.bzl",
+    "GitToolchainInfo",
+)
+load(
+    "//nix:toolchain.bzl",
+    "NixToolchainInfo",
+)
+load(
+    "//build_context.bzl",
+    "BuildContext",
+    _build_context = "build_context",
+)
+load(
+    "//git.bzl",
+    "GitInfo",
+    _git_info = "git_info",
+)
+
+NixOmnibusPkgInfo = provider(fields = {
+    "artifact": provider_field(typing.Any, default = None),  # [Artifact]
+    "build_metadata": provider_field(typing.Any, default = None),  # [Artifact]
+    "pkg_metadata": provider_field(typing.Any, default = None),  # [Artifact]
+})
+
 def nix_flake_lock_impl(ctx: AnalysisContext) -> list[DefaultInfo]:
     out = ctx.actions.declare_output("flake.lock")
 
@@ -14,6 +47,107 @@ nix_flake_lock = rule(
         "nix_flake": attrs.dep(
             default = "//:flake.nix",
             doc = """Nix flake dependency.""",
+        ),
+    },
+)
+
+def nix_omnibus_pkg_impl(ctx: AnalysisContext) -> list[[
+    DefaultInfo,
+    NixOmnibusPkgInfo,
+    GitInfo,
+]]:
+    if ctx.attrs.pkg_name:
+        name = ctx.attrs.pkg_name
+    else:
+        name = ctx.attrs.name
+
+    build_context = _build_context(ctx, [ctx.attrs.build_dep], ctx.attrs.srcs)
+    git_info = _git_info(ctx)
+
+    artifact = ctx.actions.declare_output("{}.tar.gz".format(name))
+    build_metadata = ctx.actions.declare_output("build_metadata.json")
+    pkg_metadata = ctx.actions.declare_output("pkg_metadata.json")
+
+    nix_toolchain = ctx.attrs._nix_toolchain[NixToolchainInfo]
+
+    cmd = cmd_args(
+        ctx.attrs._python_toolchain[PythonToolchainInfo].interpreter,
+        nix_toolchain.nix_omnibus_pkg_build[DefaultInfo].default_outputs,
+        "--git-info-json",
+        git_info.file,
+        "--artifact-out-file",
+        artifact.as_output(),
+        "--build-metadata-out-file",
+        build_metadata.as_output(),
+        "--pkg-metadata-out-file",
+        pkg_metadata.as_output(),
+        "--build-context-dir",
+        build_context.root,
+        "--name",
+        name,
+        "--author",
+        ctx.attrs.author,
+        "--source-url",
+        ctx.attrs.source_url,
+        "--license",
+        ctx.attrs.license,
+    )
+
+    ctx.actions.run(cmd, category = "nix_omnibus_pkg_build")
+
+    return [
+        DefaultInfo(
+            default_output = artifact,
+        ),
+        NixOmnibusPkgInfo(
+            artifact = artifact,
+            build_metadata = build_metadata,
+            pkg_metadata = pkg_metadata,
+        ),
+        git_info,
+    ]
+
+nix_omnibus_pkg = rule(
+    impl = nix_omnibus_pkg_impl,
+    attrs = {
+        "pkg_name": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """package name (default: 'attrs.name').""",
+        ),
+        "build_dep": attrs.dep(
+            doc = """Buck2 target that will be built in a package.""",
+        ),
+        "srcs": attrs.dict(
+            attrs.source(allow_directory = True),
+            attrs.string(),
+            default = {},
+            doc = """Mapping of sources files to the relative directory in a build context..""",
+        ),
+        "author": attrs.string(
+            doc = """Image author to be used in image metadata.""",
+        ),
+        "source_url": attrs.string(
+            doc = """Source code URL to be used in image metadata.""",
+        ),
+        "license": attrs.string(
+            doc = """Image license string to be used in image metadata.""",
+        ),
+        "_python_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:python",
+            providers = [PythonToolchainInfo],
+        ),
+        "_build_context_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:build_context",
+            providers = [BuildContextToolchainInfo],
+        ),
+        "_git_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:git",
+            providers = [GitToolchainInfo],
+        ),
+        "_nix_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:nix",
+            providers = [NixToolchainInfo],
         ),
     },
 )

--- a/prelude-si/nix/BUCK
+++ b/prelude-si/nix/BUCK
@@ -1,0 +1,8 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "export_file",
+)
+
+export_file(
+    name = "nix_omnibus_pkg_build.py",
+)

--- a/prelude-si/nix/nix_omnibus_pkg_build.py
+++ b/prelude-si/nix/nix_omnibus_pkg_build.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+Builds a package of Nix packages with a primary program entrypoint.
+"""
+import argparse
+import glob
+import os
+import shutil
+import subprocess
+import json
+import sys
+from enum import Enum, EnumMeta
+import tempfile
+from typing import Any, Dict, List, Union
+
+
+# A slightly more Rust-y feeling enum
+# Thanks to: https://stackoverflow.com/a/65225753
+class MetaEnum(EnumMeta):
+
+    def __contains__(self: type[Any], member: object) -> bool:
+        try:
+            self(member)
+        except ValueError:
+            return False
+        return True
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
+
+
+class PlatformArchitecture(BaseEnum):
+    Aarch64 = "aarch64"
+    X86_64 = "x86_64"
+
+
+class PlatformOS(BaseEnum):
+    Darwin = "darwin"
+    Linux = "linux"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--git-info-json",
+        required=True,
+        help="Path to the Git metadata JSON file",
+    )
+    parser.add_argument(
+        "--artifact-out-file",
+        required=True,
+        help="Path to write the image artifact file",
+    )
+    parser.add_argument(
+        "--build-metadata-out-file",
+        required=True,
+        help="Path to write the build metadata JSON file",
+    )
+    parser.add_argument(
+        "--pkg-metadata-out-file",
+        required=True,
+        help="Path to write the package metadata JSON file",
+    )
+    parser.add_argument(
+        "--build-context-dir",
+        required=True,
+        help="Path to build context directory",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Name of package to build",
+    )
+    parser.add_argument(
+        "--author",
+        required=True,
+        help="Author to be used in package metadata",
+    )
+    parser.add_argument(
+        "--source-url",
+        required=True,
+        help="Source code URL to be used in package metadata",
+    )
+    parser.add_argument(
+        "--license",
+        required=True,
+        help="Image license to be used in package metadata",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    git_info = load_git_info(args.git_info_json)
+    architecture = detect_architecture()
+    os = detect_os()
+
+    nix_store_pkg_path = build_nix_package(args.name, args.build_context_dir)
+    nix_pkgs_closure = compute_nix_pkgs_closure(nix_store_pkg_path)
+    pkg_metadata = compute_pkg_metadata(
+        git_info,
+        args.name,
+        args.author,
+        args.source_url,
+        args.license,
+        architecture,
+        os,
+        nix_store_pkg_path,
+        nix_pkgs_closure,
+    )
+    build_tar_archive(
+        args.artifact_out_file,
+        nix_store_pkg_path,
+        nix_pkgs_closure,
+        pkg_metadata,
+    )
+
+    write_json(args.pkg_metadata_out_file, pkg_metadata)
+
+    b3sum = compute_b3sum(args.artifact_out_file)
+    build_metadata = compute_build_metadata(
+        git_info,
+        args.name,
+        architecture,
+        os,
+        b3sum,
+    )
+    write_json(args.build_metadata_out_file, build_metadata)
+
+    return 0
+
+
+def build_nix_package(name: str, build_context_dir: str) -> str:
+    cmd = [
+        "nix",
+        "build",
+        "--extra-experimental-features",
+        "nix-command flakes impure-derivations ca-derivations",
+        "--option",
+        "filter-syscalls",
+        "false",
+        "--print-build-logs",
+        f".#{name}",
+    ]
+
+    # We are purposefully escaping the default `$TMPDIR` location as Buck2 sets
+    # `$TMPDIR` to be under the `buck-out/` directory. Unfortunately (for us in
+    # this context), `nix build` will recursely look up the directory tree
+    # searching for a `.git/` directory so we avoid this by running our build
+    # under the system's `/tmp/` directory. Sorry folks!
+    with tempfile.TemporaryDirectory(
+            prefix="/tmp/nix_pkg_tar_build-") as tempdir:
+        root_dir = os.path.join(tempdir, "root")
+
+        # Copy build context into tempdir
+        shutil.copytree(
+            build_context_dir,
+            root_dir,
+            symlinks=True,
+        )
+
+        print("--- Build nix package with: '{}'".format(" ".join(cmd)))
+        subprocess.run(cmd, cwd=root_dir).check_returncode()
+
+        nix_store_pkg_path = os.readlink(os.path.join(root_dir, "result"))
+
+    return nix_store_pkg_path
+
+
+def compute_nix_pkgs_closure(nix_store_pkg_path: str) -> List[str]:
+    cmd = [
+        "nix-store",
+        "--query",
+        "--requisites",
+        nix_store_pkg_path,
+    ]
+
+    result = subprocess.run(cmd, capture_output=True)
+    # Print out stderr from process if it failed
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("ascii"))
+    result.check_returncode()
+
+    pkgs_closure = result.stdout.decode("ascii").splitlines()
+    pkgs_closure.sort()
+
+    return pkgs_closure
+
+
+def build_tar_archive(
+    out_file: str,
+    nix_store_pkg_path: str,
+    pkgs_closure: List[str],
+    pkg_metadata: Dict[str, str],
+):
+    temp_file = os.path.join(
+        os.path.dirname(out_file),
+        ".{}".format(os.path.basename(out_file)).rstrip(".gz"),
+    )
+
+    tar_create_cmd = [
+        "tar",
+        "-cpf",
+        temp_file,
+    ]
+    tar_create_cmd.extend(pkgs_closure)
+    subprocess.run(tar_create_cmd).check_returncode()
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        bin_dir = os.path.join(
+            tempdir,
+            "usr",
+            "local",
+            "bin",
+        )
+        os.makedirs(bin_dir, exist_ok=True)
+        metadata_dir = os.path.join(
+            tempdir,
+            "etc",
+            "nix-omnibus",
+            pkg_metadata.get("name", "UNKNOWN-NAME"),
+            pkg_metadata.get("version", "UNKNOWN-VERSION"),
+        )
+        os.makedirs(metadata_dir, exist_ok=True)
+
+        binaries = glob.glob(os.path.join(nix_store_pkg_path, "bin", "*"))
+        for binary in binaries:
+            os.symlink(binary, os.path.join(bin_dir, os.path.basename(binary)))
+
+        write_json(os.path.join(metadata_dir, "metadata.json"), pkg_metadata)
+
+        tar_append_cmd = [
+            "tar",
+            "-rpf",
+            os.path.abspath(temp_file),
+            "--owner=0",
+            "--group=0",
+            "usr",
+            "etc",
+        ]
+        subprocess.run(tar_append_cmd, cwd=tempdir).check_returncode()
+
+    # Remember that by default `gzip` creates a *new* file and appends the
+    # `.gz` file extension, so in terms of this operation it looks like a
+    # rename/move
+    gzip_cmd = [
+        "gzip",
+        "-9",
+        temp_file,
+    ]
+    subprocess.run(gzip_cmd).check_returncode()
+
+    # Atomically move temp file to out file
+    os.rename(f"{temp_file}.gz", out_file)
+
+
+def write_json(output: str, metadata: Union[Dict[str, str], List[str]]):
+    with open(output, "w") as file:
+        json.dump(metadata, file, sort_keys=True)
+
+
+# Possible machine architecture detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_architecture() -> PlatformArchitecture:
+    machine = os.uname().machine
+
+    if (machine == "amd64" or machine == "x86_64" or machine == "x86-64"
+            or machine == "x64"):
+        return PlatformArchitecture.X86_64
+    elif (machine == "arm64" or machine == "aarch64" or machine == "arm64v8"):
+        return PlatformArchitecture.Aarch64
+    else:
+        print(
+            f"xxx Failed to determine architecure or unsupported: {machine}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# Possible machine operating system detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_os() -> PlatformOS:
+    platform_os = os.uname().sysname
+
+    if (platform_os == "Darwin"):
+        return PlatformOS.Darwin
+    elif (platform_os == "Linux"):
+        return PlatformOS.Linux
+    else:
+        print(
+            f"xxx Failed to determine operating system or unsupported: {platform_os}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def load_git_info(git_info_file: str) -> Dict[str, str | int | bool]:
+    with open(git_info_file) as file:
+        return json.load(file)
+
+
+def compute_pkg_metadata(
+    git_info: Dict[str, str | int | bool],
+    name: str,
+    author: str,
+    source_url: str,
+    license: str,
+    architecture: PlatformArchitecture,
+    platform_os: PlatformOS,
+    nix_store_pkg_path: str,
+    pkgs_closure: List[str],
+) -> Dict[str, str]:
+    binaries = glob.glob(os.path.join(nix_store_pkg_path, "bin", "*"))
+
+    metadata = {
+        "name": name,
+        "version": git_info.get("canonical_version"),
+        "author": author,
+        "source_url": source_url,
+        "license": license,
+        "architecture": architecture.value,
+        "os": platform_os.value,
+        "commit": git_info.get("commit_hash"),
+        "binaries": binaries,
+        "nix_closure": pkgs_closure
+    }
+
+    return metadata
+
+
+def compute_b3sum(artifact_file: str) -> str:
+    cmd = [
+        "b3sum",
+        "--no-names",
+        artifact_file,
+    ]
+    result = subprocess.run(cmd, capture_output=True)
+    # Print out stderr from process if it failed
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("ascii"))
+    result.check_returncode()
+    b3sum = result.stdout.decode("ascii").rstrip()
+
+    return b3sum
+
+
+def compute_build_metadata(
+    git_info: Dict[str, str | int | bool],
+    name: str,
+    architecture: PlatformArchitecture,
+    os: PlatformOS,
+    b3sum: str,
+) -> Dict[str, str]:
+    metadata = {
+        "kind":
+        "nix_omnibus",
+        "name":
+        "{}--{}--{}--{}.tar.gz".format(
+            name,
+            git_info.get("canonical_version"),
+            os.value,
+            architecture.value,
+        ),
+        "version":
+        git_info.get("canonical_version"),
+        "architecture":
+        architecture.value,
+        "os":
+        os.value,
+        "commit":
+        git_info.get("commit_hash"),
+        "b3sum":
+        b3sum,
+    }
+
+    return metadata
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prelude-si/nix/toolchain.bzl
+++ b/prelude-si/nix/toolchain.bzl
@@ -1,0 +1,24 @@
+NixToolchainInfo = provider(fields = {
+    "nix_omnibus_pkg_build": typing.Any,
+})
+
+def nix_toolchain_impl(ctx) -> list[[DefaultInfo, NixToolchainInfo]]:
+    """
+    A Nix toolchain.
+    """
+    return [
+        DefaultInfo(),
+        NixToolchainInfo(
+            nix_omnibus_pkg_build = ctx.attrs._nix_omnibus_pkg_build,
+        ),
+    ]
+
+nix_toolchain = rule(
+    impl = nix_toolchain_impl,
+    attrs = {
+        "_nix_omnibus_pkg_build": attrs.dep(
+            default = "prelude-si//nix:nix_omnibus_pkg_build.py",
+        ),
+    },
+    is_toolchain_rule = True,
+)

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -10,6 +10,7 @@ load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude-si//build_context:toolchain.bzl", "build_context_toolchain")
 load("@prelude-si//docker:toolchain.bzl", "docker_toolchain")
 load("@prelude-si//git:toolchain.bzl", "git_toolchain")
+load("@prelude-si//nix:toolchain.bzl", "nix_toolchain")
 load("@prelude-si//pnpm:toolchain.bzl", "pnpm_toolchain")
 load("@prelude-si//python:toolchain.bzl", "si_python_toolchain")
 load("@prelude-si//rust:toolchain.bzl", "si_rust_toolchain")
@@ -60,6 +61,11 @@ docker_toolchain(
 
 git_toolchain(
     name = "git",
+    visibility = ["PUBLIC"],
+)
+
+nix_toolchain(
+    name = "nix",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This change adds a new Buck2 rule type called `nix_omnibus_pkg` which
can build a Nix package (that is, one from the local Nix flake) and
produce a compressed tarball with all required runtime packages
necessary to run the software (Nix users might call this a "nix package
closure").

<img src="https://media4.giphy.com/media/vPEG16RyMBfwTRqEYr/giphy.gif"/>

Package Metadata
----------------

Some package metadata is generated to help track the origin of
the various Nix packages on disk. For example, after building a package
for `bin/council`, the following metadata might be produced:

```json
{
  "architecture": "x86_64",
  "author": "The System Initiative <dev@systeminit.com>",
  "binaries": [
    "/nix/store/qckjfjc1b1zyqbg5qc6aaxlwll2xnrfi-council/bin/council"
  ],
  "commit": "9a1545a37afbf704699be0920f21ef48c7f43515-dirty",
  "license": "Apache-2.0",
  "name": "council",
  "nix_closure": [
    "/nix/store/08n25j4vxyjidjf93fyc15icxwrxm2p8-libidn2-2.3.4",
    "/nix/store/lmidwx4id2q87f4z9aj79xwb03gsmq5j-xgcc-12.3.0-libgcc",
    "/nix/store/qckjfjc1b1zyqbg5qc6aaxlwll2xnrfi-council",
    "/nix/store/qn3ggz5sf3hkjs2c797xf7nan3amdxmp-glibc-2.38-27",
    "/nix/store/s2f1sqfsdi4pmh23nfnrh42v17zsvi5y-libunistring-1.1"
  ],
  "os": "linux",
  "source_url": "http://github.com/systeminit/si.git",
  "version": "20231130.231017.0-sha.9a1545a37-dirty"
}
```

This file would be found on the system at:

```
/etc/nix-omnibus/council/20231130.231017.0-sha.9a1545a37-dirty/metadata.json
```

Binary Symlinks
---------------

To help integrate these systems into running environments, Docker
images, rootfs', etc. a symlink for each program under Nix package's
`bin/` directory will be created under `/usr/local/bin`. For example, in
the above `bin/council` example case the following symlinks would
exist:

- `/usr/local/bin/council` -> `/nix/store/qckjfjc1b1zyqbg5qc6aaxlwll2xnrfi-council/bin/council`

