### PR TITLE
fix(web): Ensure we format the component code tab

### DIFF
--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -93,12 +93,8 @@
                       {{ selectedComponentCode[0]?.message }}
                     </ErrorMessage>
                     <CodeViewer
-                      :code="
-                        selectedComponentCode[0]?.code ||
-                        '# No code generated yet'
-                      "
-                    >
-                    </CodeViewer>
+                      :code="formattedCode || '#No code generated yet'"
+                    />
                   </div>
                 </template>
               </TabGroupItem>
@@ -223,6 +219,17 @@ const selectedComponentFailingQualificationsCount = computed(
 const selectedComponentCode = computed(
   () => componentsStore.selectedComponentCode,
 );
+
+const formattedCode = computed(() => {
+  const compCode = componentsStore.selectedComponentCode;
+  if (compCode && compCode.length > 0) {
+    if (compCode[0]?.language === "json") {
+      return JSON.stringify(JSON.parse(compCode[0]?.code || ""), null, 2);
+    }
+    return compCode[0]?.code;
+  }
+  return "# No code generated yet";
+});
 
 const selectedComponentActionsCount = computed(() => {
   return _.filter(


### PR DESCRIPTION
<img width="685" alt="Screenshot 2023-12-05 at 17 25 19" src="https://github.com/systeminit/si/assets/227823/1ec880a7-ede7-4af9-8fd7-8140f390b68b">
