### PR TITLE
feat: small fixes for the startup scripts

### DIFF
--- a/component/firecracker-base/prepare_jailer.sh
+++ b/component/firecracker-base/prepare_jailer.sh
@@ -53,7 +53,6 @@ function user_prep() {
 }
 
 if ! id 10000$SB_ID >/dev/null 2>&1; then
-  echo "Creating user 10000$SB_ID"
   retry user_prep
 fi
 
@@ -68,7 +67,7 @@ touch $JAIL/logs
 touch $JAIL/metrics
 
 function kernel_prep() {
-  cp -v $KERNEL_IMG "$JAIL/$KERNEL"
+  cp $KERNEL_IMG "$JAIL/$KERNEL"
   # TODO(scott): make this work. First attempt yielded a
   # kernel loader InvalidElfMagicNumber error
   # OVERLAY="kernel-overlay-$SB_ID"

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -457,7 +457,7 @@ fn default_runtime_strategy() -> LocalUdsRuntimeStrategy {
 }
 
 fn default_pool_size() -> u16 {
-    5000
+    1000
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development


### PR DESCRIPTION
Just some small enhancements to the startup script. I'm pinning the jails to 1k instead of 5k for now. Creating 5k jails takes way too long, get exponentially slower and flakier as more jails are created. I think this is the best this script can do and that the more correct answer here is to have a discrete service or a background thread in Veritech that recycles jails as needed.