### PR TITLE
feat(buck2): create `artifact_promote` rule & update `artifact_publish`

### DIFF
--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -78,24 +78,3 @@ rootfs(
         "//bin/lang-js:omnibus",
     ],
 )
-
-load(
-    "@prelude-si//:artifact.bzl",
-    "artifact_promote",
-    "artifact_publish",
-)
-
-artifact_publish(
-    name = "publish-omnibus",
-    artifact = ":omnibus",
-    destination = "s3://si-artifacts-prod",
-    cname = "artifacts.systeminit.com",
-)
-
-artifact_promote(
-    name = "promote-omnibus",
-    family = "cyclone",
-    variant = "omnibus",
-    destination = "s3://si-artifacts-prod",
-    cname = "artifacts.systeminit.com",
-)

--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -1,9 +1,9 @@
 load(
     "@prelude-si//:macros.bzl",
     "docker_image",
-    "rootfs",
     "export_file",
     "nix_omnibus_pkg",
+    "rootfs",
     "rust_binary",
     "shellcheck",
     "shfmt_check",
@@ -61,7 +61,7 @@ docker_image(
         "//bin/cyclone:docker-entrypoint.sh",
         "//bin/cyclone:cyclone",
         "//bin/lang-js:bin",
-    ]
+    ],
 )
 
 nix_omnibus_pkg(
@@ -75,16 +75,27 @@ rootfs(
     rootfs_name = "cyclone-rootfs",
     build_deps = [
         ":omnibus",
-        "//bin/lang-js:omnibus"
-    ]
+        "//bin/lang-js:omnibus",
+    ],
 )
 
 load(
     "@prelude-si//:artifact.bzl",
-    "artifact_publish"
+    "artifact_promote",
+    "artifact_publish",
 )
 
 artifact_publish(
     name = "publish-omnibus",
     artifact = ":omnibus",
+    destination = "s3://si-artifacts-prod",
+    cname = "artifacts.systeminit.com",
+)
+
+artifact_promote(
+    name = "promote-omnibus",
+    family = "cyclone",
+    variant = "omnibus",
+    destination = "s3://si-artifacts-prod",
+    cname = "artifacts.systeminit.com",
 )

--- a/prelude-si/artifact.bzl
+++ b/prelude-si/artifact.bzl
@@ -16,21 +16,16 @@ def artifact_publish_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
     cmd = cmd_args(
         ctx.attrs._python_toolchain[PythonToolchainInfo].interpreter,
         artifact_toolchain.publish[DefaultInfo].default_outputs,
+        "--destination",
+        ctx.attrs.destination,
         "--artifact-file",
         ctx.attrs.artifact[ArtifactInfo].artifact,
         "--metadata-file",
         ctx.attrs.artifact[ArtifactInfo].metadata,
-        "--family",
-        ctx.attrs.artifact[ArtifactInfo].family,
-        "--variant",
-        ctx.attrs.artifact[ArtifactInfo].variant,
-        # This S3 destination is our public artifacts portfolio
-        # we can parse s3:// variants off the front in the future.
-        # i.e. we could pass gcs://bucket-name or docker://reg name
-        # within the python
-        "--destination",
-        "s3://si-artifacts-prod"
     )
+    if ctx.attrs.cname:
+      cmd.add("--cname")
+      cmd.add(ctx.attrs.cname)
 
     ctx.actions.write(cli_args.as_output(), cmd)
 
@@ -42,9 +37,85 @@ def artifact_publish_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
 artifact_publish = rule(
     impl = artifact_publish_impl,
     attrs = {
+        "destination": attrs.string(
+            doc = """Destination [examples: {}].""".format(", ".join([
+                "s3://my-bucket",
+                "gcs://bucket-name",
+                "docker://docker.io",
+            ])),
+        ),
         "artifact": attrs.dep(
             providers = [ArtifactInfo],
             doc = """The `artifact` to publish.""",
+        ),
+        "cname": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """Hostname used when calculating canonical URLs.""",
+        ),
+        "_python_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:python",
+            providers = [PythonToolchainInfo],
+        ),
+        "_artifact_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:artifact",
+            providers = [ArtifactToolchainInfo],
+        ),
+    },
+)
+
+def artifact_promote_impl(ctx: AnalysisContext) -> list[[DefaultInfo, RunInfo]]:
+    cli_args = ctx.actions.declare_output("args.txt")
+
+    artifact_toolchain = ctx.attrs._artifact_toolchain[ArtifactToolchainInfo]
+
+    cmd = cmd_args(
+        ctx.attrs._python_toolchain[PythonToolchainInfo].interpreter,
+        artifact_toolchain.promote[DefaultInfo].default_outputs,
+        "--destination",
+        ctx.attrs.destination,
+        "--channel",
+        ctx.attrs.channel,
+        "--family",
+        ctx.attrs.family,
+        "--variant",
+        ctx.attrs.variant,
+    )
+    if ctx.attrs.cname:
+      cmd.add("--cname")
+      cmd.add(ctx.attrs.cname)
+
+    ctx.actions.write(cli_args.as_output(), cmd)
+
+    return [
+        DefaultInfo(default_output = cli_args),
+        RunInfo(args = cmd),
+    ]
+
+artifact_promote = rule(
+    impl = artifact_promote_impl,
+    attrs = {
+        "destination": attrs.string(
+            doc = """Destination [examples: {}].""".format(", ".join([
+                "s3://my-bucket",
+                "gcs://bucket-name",
+                "docker://docker.io",
+            ])),
+        ),
+        "channel": attrs.string(
+            doc = """Release channel.""",
+            default = "stable",
+        ),
+        "family": attrs.string(
+            doc = """Artifact family.""",
+        ),
+        "variant": attrs.string(
+            doc = """Artifact variant.""",
+        ),
+        "cname": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """Hostname used when calculating canonical URLs.""",
         ),
         "_python_toolchain": attrs.toolchain_dep(
             default = "toolchains//:python",

--- a/prelude-si/artifact/BUCK
+++ b/prelude-si/artifact/BUCK
@@ -1,8 +1,26 @@
 load(
     "@prelude-si//:macros.bzl",
     "export_file",
+    "test_suite",
+    "yapf_check",
+)
+
+export_file(
+    name = "promote.py",
 )
 
 export_file(
     name = "publish.py",
+)
+
+yapf_check(
+    name = "check-format-python",
+    srcs = glob(["**/*.py"]),
+)
+
+test_suite(
+    name = "check-format",
+    tests = [
+        ":check-format-python",
+    ],
 )

--- a/prelude-si/artifact/promote.py
+++ b/prelude-si/artifact/promote.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Promotes an artifact to a channel in an object store such as AWS S3.
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+from enum import Enum, EnumMeta
+from typing import Any, Tuple
+from urllib.parse import urlparse
+
+
+# A slightly more Rust-y feeling enum
+# Thanks to: https://stackoverflow.com/a/65225753
+class MetaEnum(EnumMeta):
+
+    def __contains__(self: type[Any], member: object) -> bool:
+        try:
+            self(member)
+        except ValueError:
+            return False
+        return True
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
+
+
+class Destination(BaseEnum):
+    S3 = "s3"
+
+
+class PlatformArch(BaseEnum):
+    Aarch64 = "aarch64"
+    X86_64 = "x86_64"
+
+
+class PlatformOS(BaseEnum):
+    Darwin = "darwin"
+    Linux = "linux"
+
+
+Target = Tuple[PlatformOS, PlatformArch]
+
+
+class Variant(BaseEnum):
+    Omnibus = "omnibus"
+    Rootfs = "rootfs"
+
+
+class ArtifactMetadata(object):
+
+    def __init__(
+        self,
+        family: str,
+        version: str,
+        variant: Variant,
+        platform_os: PlatformOS,
+        platform_arch: PlatformArch,
+    ) -> None:
+        self.family = family
+        self.version = version
+        self.variant = variant
+        self.os = platform_os
+        self.arch = platform_arch
+
+
+def parse_args() -> tuple[
+    argparse.Namespace,
+    Destination,
+    list[ArtifactMetadata],
+]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--destination",
+        required=True,
+        help="Destination [examples: {}]".format(", ".join([
+            "s3://my-bucket",
+            "gcs://bucket-name",
+            "docker://docker.io",
+        ])),
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        help="Release channel",
+    )
+    parser.add_argument(
+        "--family",
+        required=True,
+        help="Artifact family",
+    )
+    parser.add_argument(
+        "--variant",
+        required=True,
+        type=Variant,
+        help="Artifact variant [values: {}]".format(", ".join(
+            [m.value for m in Variant])),
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Artifact version",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        choices=all_target_strs(),
+        default=None,
+        help="Artifact targets [default: {}]".format(linux_target_strs()),
+    )
+    parser.add_argument(
+        "--cname",
+        help="URL hostname for artifacts references",
+    )
+    parser.add_argument(
+        "--cloudfront-distribution-id",
+        default=os.environ.get("AWS_CLOUDFRONT_DISTRIBUTION_ID"),
+        help="AWS Cloudfront distribution ID, used for invalidation",
+    )
+
+    args = parser.parse_args()
+    destination = None
+    for d in Destination:
+        if args.destination.startswith(f"{d.value}://"):
+            destination = d
+    if destination is None:
+        parser.error(f"destination scheme not supported: {args.destination}")
+
+    targets = list(map(parse_target, args.target or linux_target_strs()))
+    artifacts = list(map(lambda e: parse_metadata(args, e), targets))
+
+    return (args, destination, artifacts)
+
+
+def main() -> int:
+    (args, destination, artifacts) = parse_args()
+
+    match destination:
+        case Destination.S3:
+            s3_promote(
+                args.channel,
+                args.destination,
+                artifacts,
+                args.cname,
+                args.cloudfront_distribution_id,
+            )
+
+    return 0
+
+
+def parse_metadata(
+    args: argparse.Namespace,
+    target: tuple[PlatformOS, PlatformArch],
+) -> ArtifactMetadata:
+    return ArtifactMetadata(
+        args.family,
+        args.version,
+        args.variant,
+        target[0],
+        target[1],
+    )
+
+
+def s3_promote(
+    channel: str,
+    s3_bucket: str,
+    artifacts: list[ArtifactMetadata],
+    cname: str | None,
+    cloudfront_distribution_id: str | None,
+):
+    if not artifacts:
+        return
+
+    bucket_name = re.sub(r"^s3://", "", s3_bucket)
+
+    if cname is None:
+        base_url = f"https://{bucket_name}.s3.amazonaws.com"
+    else:
+        base_url = f"https://{cname}"
+
+    md = artifacts[0]
+    print(
+        f"--- Promoting /{md.family}/{md.version}/{md.variant.value}/* artifacts to '{channel}'"
+    )
+
+    artifact_urls = []
+
+    for md in artifacts:
+        src_path = object_store_path(md)
+        src_url = "/".join([
+            base_url,
+            src_path,
+        ])
+        md.version = channel
+        dst_path = object_store_path(md)
+        dst_url = "/".join([
+            base_url,
+            dst_path,
+        ])
+
+        s3_put_object(
+            bucket_name,
+            src_url,
+            dst_path,
+        )
+        s3_put_object(
+            bucket_name,
+            f"{src_url}.metadata.json",
+            f"{dst_path}.metadata.json",
+        )
+
+        artifact_urls.append(dst_url)
+
+    if cloudfront_distribution_id:
+        cloudfront_invalidate_paths(
+            cloudfront_distribution_id,
+            channel,
+            artifact_urls,
+        )
+
+    print("\n--- Artifacts promoted")
+    for url in artifact_urls:
+        print(f"  - {url}")
+
+
+def s3_put_object(
+    bucket_name: str,
+    src_url: str,
+    dst_path: str,
+):
+    print(f"  - /{dst_path} -> {src_url}")
+
+    cmd = [
+        "aws",
+        "s3api",
+        "put-object",
+        "--bucket",
+        bucket_name,
+        "--key",
+        dst_path,
+        "--website-redirect-location",
+        src_url,
+    ]
+    subprocess.run(cmd).check_returncode()
+
+
+def cloudfront_invalidate_paths(
+    distribution_id: str,
+    channel: str,
+    artifact_urls: list[str],
+):
+    invalidation_paths = {
+        cloudfront_invalidation_path(e)
+        for e in artifact_urls
+    }
+
+    print(
+        f"--- Invalidating AWS CloudFront paths for '{channel}' channel redirects"
+    )
+    for path in invalidation_paths:
+        print(f"  - {path}")
+
+    cmd = [
+        "aws",
+        "cloudfront",
+        "create-invalidation",
+        "--distribution-id",
+        distribution_id,
+        "--paths",
+    ]
+    cmd.extend(invalidation_paths)
+    subprocess.run(cmd).check_returncode()
+
+
+def all_target_strs() -> list[str]:
+    return [f"{o.value}-{a.value}" for o in PlatformOS for a in PlatformArch]
+
+
+def linux_target_strs() -> list[str]:
+    return [f"{PlatformOS.Linux.value}-{a.value}" for a in PlatformArch]
+
+
+def parse_target(s: str) -> Target:
+    (o, a) = s.split("-", 1)
+    return (PlatformOS(o), PlatformArch(a))
+
+
+def cloudfront_invalidation_path(url_str: str) -> str:
+    url = urlparse(url_str)
+    path = "/".join([
+        # Pop off `$os/$arch/$filename` from the URL path
+        os.path.dirname(os.path.dirname(os.path.dirname(url.path))),
+        "*",
+    ])
+    # Builds a "/$family/$channel/$variant/*" path string
+    return path
+
+
+def artifact_name(md: ArtifactMetadata) -> str:
+    prefix = f"{md.family}-{md.version}-{md.variant.value}-{md.os.value}-{md.arch.value}"
+
+    match md.variant:
+        case Variant.Omnibus:
+            return f"{prefix}.tar.gz"
+        case _:
+            raise TypeError(f"unsupport Variant type: {md.variant}")
+
+
+def object_store_path(md: ArtifactMetadata) -> str:
+    return "/".join([
+        md.family,
+        md.version,
+        md.variant.value,
+        md.os.value,
+        md.arch.value,
+        artifact_name(md),
+    ])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prelude-si/artifact/publish.py
+++ b/prelude-si/artifact/publish.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 """
-Publishes an artifact to our Production S3 Bucket for mass Distribution
+Publishes an artifact to a destination.
 """
 import argparse
+import os
+import pathlib
+import re
 import subprocess
 import sys
-import os
 import json
 from enum import Enum, EnumMeta
-from typing import Any, Dict, List, Union
+from typing import Any, Dict
+
 
 # A slightly more Rust-y feeling enum
 # Thanks to: https://stackoverflow.com/a/65225753
 class MetaEnum(EnumMeta):
+
     def __contains__(self: type[Any], member: object) -> bool:
         try:
             self(member)
@@ -21,61 +25,183 @@ class MetaEnum(EnumMeta):
         return True
 
 
-def sync_to_s3(localfile, url):
-    aws_cli_command = ['aws', 's3', 'cp', localfile, f'{url}']
-    subprocess.run(aws_cli_command, check=True)
-    print(f'Successfully synced {localfile} to {url}')
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
 
-def parse_args() -> argparse.Namespace:
+
+class Destination(BaseEnum):
+    S3 = "s3"
+
+
+class PlatformArch(BaseEnum):
+    Aarch64 = "aarch64"
+    X86_64 = "x86_64"
+
+
+class PlatformOS(BaseEnum):
+    Darwin = "darwin"
+    Linux = "linux"
+
+
+class Variant(BaseEnum):
+    Omnibus = "omnibus"
+    Rootfs = "rootfs"
+
+
+class ArtifactMetadata(object):
+
+    def __init__(
+        self,
+        family: str,
+        version: str,
+        variant: Variant,
+        platform_os: PlatformOS,
+        platform_arch: PlatformArch,
+        b3sum: str,
+        commit: str,
+        extra: Dict[str, Any],
+    ) -> None:
+        self.family = family
+        self.version = version
+        self.variant = variant
+        self.os = platform_os
+        self.arch = platform_arch
+        self.b3sum = b3sum
+        self.commit = commit
+        self.extra = extra
+
+
+def parse_args() -> tuple[argparse.Namespace, Destination]:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--destination",
+        required=True,
+        help="Destination [examples: {}]".format(", ".join([
+            "s3://my-bucket",
+            "gcs://bucket-name",
+            "docker://docker.io",
+        ])),
+    )
     parser.add_argument(
         "--artifact-file",
         required=True,
+        type=pathlib.Path,
         help="Path to the artifact file to be actioned on.",
     )
     parser.add_argument(
         "--metadata-file",
         required=True,
+        type=pathlib.Path,
         help="Path to the metadata of the artifact to be actioned on.",
     )
     parser.add_argument(
-        "--family",
-        required=True,
-        help="Family of the artifact.",
+        "--cname",
+        help="URL hostname for artifacts references",
     )
-    parser.add_argument(
-        "--variant",
-        required=True,
-        help="Variant of the artifact.",
-    )
-    parser.add_argument(
-        "--destination",
-        required=True,
-        help="Variant of the artifact.",
-    )
-    return parser.parse_args()
 
+    args = parser.parse_args()
+    destination = None
+    for d in Destination:
+        if args.destination.startswith(f"{d.value}://"):
+            destination = d
+    if destination is None:
+        parser.error(f"destination scheme not supported: {args.destination}")
 
-def load_json_file(json_file: str) -> Dict[str, str | int | bool]:
-    with open(json_file) as file:
-        return json.load(file)
-
-
-def craft_url(bucket: str, metadata: Dict[str, str]):
-    # This avoids having to remove the last / off the end of the path, even
-    # though it's a bit awkward
-
-    crafted_url = "/".join([bucket, metadata["family"], metadata["os"], metadata["architecture"], metadata["variant"],metadata["name"]])
-    return crafted_url
+    return (args, destination)
 
 
 def main() -> int:
-    args = parse_args()
-    metadata = load_json_file(args.metadata_file)
-    url = craft_url(args.destination, metadata)
-    sync_to_s3(args.artifact_file, url)
-    sync_to_s3(args.metadata_file, url + ".metadata.json")
+    (args, destination) = parse_args()
+
+    md = load_metadata(args.metadata_file)
+
+    match destination:
+        case Destination.S3:
+            url = "/".join([args.destination, object_store_path(md)])
+            print("--- Publishing {}".format(os.path.basename(url)))
+            s3_upload(args.artifact_file, url)
+            s3_upload(args.metadata_file, url + ".metadata.json")
+            s3_report_metadata(md, url, args.cname)
+
     return 0
+
+
+def load_metadata(json_file: str) -> ArtifactMetadata:
+    with open(json_file) as file:
+        data = json.load(file)
+    return ArtifactMetadata(
+        data.pop("family"),
+        data.pop("version"),
+        Variant(data.pop("variant")),
+        PlatformOS(data.pop("os")),
+        PlatformArch(data.pop("arch")),
+        data.pop("b3sum"),
+        data.pop("commit"),
+        data,
+    )
+
+
+def s3_upload(artifact_path, s3_url):
+    cmd = [
+        "aws",
+        "s3",
+        "cp",
+        artifact_path,
+        s3_url,
+    ]
+    print(f"  - Uploading to {s3_url}")
+    subprocess.run(cmd).check_returncode()
+
+
+def s3_report_metadata(md: ArtifactMetadata, url: str, cname: str | None):
+    print("\n--- Artifact published\n")
+
+    if cname:
+        url = re.sub(r"^s3://[^/]+/", f"https://{cname}/", url)
+
+    rows = {
+        "Family": md.family,
+        "Version": md.version,
+        "Variant": md.variant.value,
+        "OS": md.os.value,
+        "Arch": md.arch.value,
+        "Blake3Sum": md.b3sum,
+        "Revision": md.commit,
+        "Artifact URL": url,
+        "Metadata URL": f"{url}.metadata.json",
+    }
+    header_max_len = max(len(name) for name in rows.keys())
+
+    for name, value in rows.items():
+        print("    {0:<{1}} : {2}".format(
+            name,
+            header_max_len,
+            value,
+        ))
+
+    return None
+
+
+def artifact_name(md: ArtifactMetadata) -> str:
+    prefix = f"{md.family}-{md.version}-{md.variant.value}-{md.os.value}-{md.arch.value}"
+
+    match md.variant:
+        case Variant.Omnibus:
+            return f"{prefix}.tar.gz"
+        case _:
+            raise TypeError(f"unsupport Variant type: {md.variant}")
+
+
+def object_store_path(md: ArtifactMetadata) -> str:
+    return "/".join([
+        md.family,
+        md.version,
+        md.variant.value,
+        md.os.value,
+        md.arch.value,
+        artifact_name(md),
+    ])
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/prelude-si/artifact/toolchain.bzl
+++ b/prelude-si/artifact/toolchain.bzl
@@ -1,15 +1,17 @@
 ArtifactToolchainInfo = provider(fields = {
+    "promote": typing.Any,
     "publish": typing.Any,
 })
 
 def artifact_toolchain_impl(ctx) -> list[[DefaultInfo, ArtifactToolchainInfo]]:
     """
     A artifact toolchain to manage a compiled or built artifact through it's lifecycle
-    This toolchain will empower targets to publish, deprecate, etc. 
+    This toolchain will empower targets to publish, deprecate, etc.
     """
     return [
         DefaultInfo(),
         ArtifactToolchainInfo(
+            promote = ctx.attrs._promote,
             publish = ctx.attrs._publish,
         ),
     ]
@@ -17,9 +19,12 @@ def artifact_toolchain_impl(ctx) -> list[[DefaultInfo, ArtifactToolchainInfo]]:
 artifact_toolchain = rule(
     impl = artifact_toolchain_impl,
     attrs = {
+        "_promote": attrs.dep(
+            default = "prelude-si//artifact:promote.py",
+        ),
         "_publish": attrs.dep(
             default = "prelude-si//artifact:publish.py",
         ),
     },
     is_toolchain_rule = True,
-) 
+)

--- a/prelude-si/git/git_info.py
+++ b/prelude-si/git/git_info.py
@@ -99,9 +99,9 @@ def finalize(data: Dict[str, Any]):
         cal_ver = dt_utc.strftime("%Y%m%d.%H%M%S.0")
         canonical_version = f"{cal_ver}-sha.{abbreviated_commit_hash}"
         if is_dirty == True:
-            canonical_version += "-dirty"
+            canonical_version += "_dirty"
             data.update({
-                COMMIT_HASH: "{}-dirty".format(data.get(COMMIT_HASH)),
+                COMMIT_HASH: "{}_dirty".format(data.get(COMMIT_HASH)),
             })
 
         data.update({

--- a/prelude-si/macros/nix.bzl
+++ b/prelude-si/macros/nix.bzl
@@ -1,4 +1,9 @@
 load(
+    "@prelude-si//:artifact.bzl",
+    _artifact_promote = "artifact_promote",
+    _artifact_publish = "artifact_publish",
+)
+load(
     "@prelude-si//:nix.bzl",
     _nix_flake_lock = "nix_flake_lock",
     _nix_omnibus_pkg = "nix_omnibus_pkg",
@@ -15,21 +20,44 @@ def nix_flake_lock(
         src = src or name,
         nix_flake = nix_flake,
         visibility = visibility,
-        **kwargs,
+        **kwargs
     )
 
 def nix_omnibus_pkg(
         name,
+        pkg_name,
         source_url = "http://github.com/systeminit/si.git",
         author = "The System Initiative <dev@systeminit.com>",
         license = "Apache-2.0",
         visibility = ["PUBLIC"],
+        publish_target = "publish-omnibus",
+        promote_target = "promote-omnibus",
+        artifact_destination = "s3://si-artifacts-prod",
+        artifact_cname = "artifacts.systeminit.com",
         **kwargs):
     _nix_omnibus_pkg(
         name = name,
+        pkg_name = pkg_name,
         source_url = source_url,
         author = author,
         license = license,
         visibility = visibility,
-        **kwargs,
+        **kwargs
+    )
+
+    _artifact_publish(
+        name = publish_target,
+        artifact = ":{}".format(name),
+        destination = artifact_destination,
+        cname = artifact_cname,
+        visibility = visibility,
+    )
+
+    _artifact_promote(
+        name = promote_target,
+        family = pkg_name,
+        variant = "omnibus",
+        destination = artifact_destination,
+        cname = artifact_cname,
+        visibility = visibility,
     )

--- a/prelude-si/nix/nix_omnibus_pkg_build.py
+++ b/prelude-si/nix/nix_omnibus_pkg_build.py
@@ -40,6 +40,9 @@ class PlatformOS(BaseEnum):
     Linux = "linux"
 
 
+VARIANT = "omnibus"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -351,29 +354,22 @@ def compute_b3sum(artifact_file: str) -> str:
 
 def compute_build_metadata(
     git_info: Dict[str, str | int | bool],
-    name: str,
-    architecture: PlatformArchitecture,
-    os: PlatformOS,
+    family: str,
+    platform_arch: PlatformArchitecture,
+    platform_os: PlatformOS,
     b3sum: str,
 ) -> Dict[str, str]:
     metadata = {
         "family":
-        name,
+        family,
         "variant":
-        "omnibus",
-        "name":
-        "{}-{}-{}-{}.tar.gz".format(
-            name,
-            git_info.get("canonical_version"),
-            os.value,
-            architecture.value,
-        ),
+        VARIANT,
         "version":
         git_info.get("canonical_version"),
-        "architecture":
-        architecture.value,
+        "arch":
+        platform_arch.value,
         "os":
-        os.value,
+        platform_os.value,
         "commit":
         git_info.get("commit_hash"),
         "b3sum":


### PR DESCRIPTION
`artifact_promote` Buck2 Rule
-----------------------------

This change adds a new Buck2 rule, `artifact_promote` which will create
or update AWS S3 [website redirect location] metadata in empty S3 objects
to serve as HTTP/301 redirects. Additionally, if the
`--cloudfront-distribution-id` option is provided or if the
`AWS_CLOUDFRONT_DISTRIBUTION_ID` environment variable is set, the
promotion will invalidate the appropriate paths in AWS CloudFront to
ensure that the redirects are up to date.

[website redirect location]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-page-redirect.html#redirect-requests-object-metadata

Updated S3 Path Strategy
------------------------

This change also updates the S3 object locations to importantly include
a version path entry. This allows us to group many different artifact
variants by a release version which may be helpful when
yanking/purging/aging out older releases. Additionally the version path
slot is used during promotion with the channel value.

Here's a more concrete example. A 64-bit ARM release of the Cylone
omnibus package for Linux would be found at:

```
/cyclone/20231206.001546.0-sha.e6ba9be23/omnibus/linux/aarch64/cyclone-20231206.001546.0-sha.e6ba9be23-omnibus-linux-aarch64.tar.gz
```

This scheme generalizes to:

```
/$family/$version/$variant/$os/$arch/$family-$version-$variant-$os-$arch.$extension
```

When being promoted to a "release channel" (in our case we use the
"stable" channel name by default), the above artifact would be found as
the current version in the "stable" channel at:

```
/cyclone/stable/omnibus/linux/aarch64/cyclone-stable-omnibus-linux-aarch64.tar.gz
```

Similar to above, this scheme generalizes to:

```
/$family/$channel/$variant/$os/$arch/$family-$version-$variant-$os-$arch.$extension
```

CloudFront Invalidation Pathing
-------------------------------

With the updated S3 path strategy, we can compute simplified [CloudFront
invalidations] that are wildcarded after the variant path segment. In
the case of the example above, and even assuming that multiple
`$os-$arch` versions are included in the promotion, only 1 CloudFront
path entry will need invalidation:

```
/cyclone/stable/omnibus/*
```

[CloudFront invalidations]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html

<img src="https://media0.giphy.com/media/Z6E5EzRex9S4hAlsUt/giphy.gif"/>
