### PR TITLE
feat: terminate on recycle, startup fixes

### DIFF
--- a/component/firecracker-base/stop.sh
+++ b/component/firecracker-base/stop.sh
@@ -29,10 +29,13 @@ ip netns del jailer-$SB_ID || true
 userdel jailer-$SB_ID || true
 
 # Remove directories and files
-umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true
 umount /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4 || true
 dmsetup remove rootfs-overlay-$SB_ID || true
-dmsetup remove kernel-overlay-$SB_ID || true
+
+# We are not currently creating these.
+# umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true
+# dmsetup remove kernel-overlay-$SB_ID || true
+
 # TODO(scott): figure out a better way to do this.
 # this will only detach devices removed from device-mapper
 # but it still feels bad

--- a/lib/deadpool-cyclone/src/instance.rs
+++ b/lib/deadpool-cyclone/src/instance.rs
@@ -310,7 +310,7 @@ pub trait Instance {
     /// # });
     /// # Ok::<(), TerminationError>(())
     /// ```
-    async fn terminate(mut self) -> result::Result<(), Self::Error>;
+    async fn terminate(&mut self) -> result::Result<(), Self::Error>;
 }
 
 // async fn spawn<B, E, I, S>(builder: &B) -> Result<impl Instance<Error = E>, E>

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
@@ -83,10 +83,7 @@ impl Instance for LocalHttpInstance {
     type SpecBuilder = LocalHttpInstanceSpecBuilder;
     type Error = LocalHttpInstanceError;
 
-    async fn terminate(mut self) -> result::Result<(), Self::Error> {
-        if !self.watch_shutdown_tx.is_closed() && self.watch_shutdown_tx.send(()).is_err() {
-            debug!("sent watch shutdown but receiver was already closed");
-        }
+    async fn terminate(&mut self) -> result::Result<(), Self::Error> {
         process::child_shutdown(&mut self.child, Some(process::Signal::SIGTERM), None).await?;
 
         Ok(())


### PR DESCRIPTION
This adds some robustness to our startup script so that we can dynamically choose whether to do things like download new rootfs or kernel images. It also adds force recreating jails if necessary (such as if you download a new rootfs). I added some flags to make this easier to use on the command line and a help block.

I also made it so we actually call `terminate()` when when recycling the pool. In the case of Firecracker, we will clean the jail and set it up again. I think a better way to do this would be just clean replace the rootfs and remove the jailer bits, but this is fine for now.