### PR TITLE
feat(dal,web) Make secrets work inside the dependency reactivity system

### DIFF
--- a/app/web/src/components/FuncEditor/LeafInputs.vue
+++ b/app/web/src/components/FuncEditor/LeafInputs.vue
@@ -4,21 +4,31 @@
       Function inputs
     </h2>
     <Stack spacing="sm">
-      <VormInput v-model="codeSelected" type="checkbox"> Code </VormInput>
+      <VormInput v-model="codeSelected" type="checkbox"> Code</VormInput>
       <VormInput v-model="deletedAtSelected" type="checkbox">
         Deleted At
       </VormInput>
-      <VormInput v-model="domainSelected" type="checkbox"> Domain </VormInput>
+      <VormInput v-model="domainSelected" type="checkbox"> Domain</VormInput>
       <VormInput v-model="resourceSelected" type="checkbox">
         Resource
       </VormInput>
+      <VormInput
+        v-model="secretsSelected"
+        label="Function Depends on Secrets"
+        prompt="Run the authentication function first, to make sure the secret is applied?"
+        type="radio"
+        :options="[
+          { value: true, label: 'Yes' },
+          { value: false, label: 'No' },
+        ]"
+      />
     </Stack>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref, watch } from "vue";
-import { VormInput, Stack } from "@si/vue-lib/design-system";
+import { Stack, VormInput } from "@si/vue-lib/design-system";
 import { LeafInputLocation } from "@/store/func/types";
 
 const props = defineProps<{
@@ -30,6 +40,7 @@ const codeSelected = ref(props.modelValue.includes("code"));
 const deletedAtSelected = ref(props.modelValue.includes("deletedAt"));
 const domainSelected = ref(props.modelValue.includes("domain"));
 const resourceSelected = ref(props.modelValue.includes("resource"));
+const secretsSelected = ref(props.modelValue.includes("secrets"));
 
 watch(
   () => props.modelValue,
@@ -38,12 +49,19 @@ watch(
     deletedAtSelected.value = inputs.includes("deletedAt");
     domainSelected.value = inputs.includes("domain");
     resourceSelected.value = inputs.includes("resource");
+    secretsSelected.value = inputs.includes("secrets");
   },
 );
 
 watch(
-  [codeSelected, deletedAtSelected, domainSelected, resourceSelected],
-  ([code, deletedAt, domain, resource]) => {
+  [
+    codeSelected,
+    deletedAtSelected,
+    domainSelected,
+    resourceSelected,
+    secretsSelected,
+  ],
+  ([code, deletedAt, domain, resource, secrets]) => {
     const leafInputLocations: LeafInputLocation[] = [];
 
     if (code) {
@@ -57,6 +75,9 @@ watch(
     }
     if (resource) {
       leafInputLocations.push("resource");
+    }
+    if (secrets) {
+      leafInputLocations.push("secrets");
     }
 
     emit("update:modelValue", leafInputLocations);

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -8,7 +8,12 @@ export interface ActionAssociations {
   kind?: ActionKind;
 }
 
-export type LeafInputLocation = "code" | "deletedAt" | "domain" | "resource";
+export type LeafInputLocation =
+  | "code"
+  | "deletedAt"
+  | "domain"
+  | "resource"
+  | "secrets";
 
 export interface AuthenticationAssociations {
   type: "authentication";

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1073,12 +1073,22 @@ impl AttributeValue {
             AttributeValueError::AttributePrototypeNotFound(self.id, *ctx.visibility())
         })?;
 
+        // Note(victor): Secrets should never be passed to functions as arguments directly.
+        // We detect if they're set as dependencies and later fetch before functions to execute
+        // This is so secret values still trigger the dependent values system,
+        // and before functions are only called when necessary
+        let mut has_secrets_as_arg = false;
         let mut func_binding_args: HashMap<String, Option<serde_json::Value>> = HashMap::new();
         for mut argument_data in attribute_prototype
             .argument_values(ctx, self.context)
             .await
             .map_err(|e| AttributeValueError::AttributePrototype(e.to_string()))?
         {
+            if argument_data.argument_name == "secrets" {
+                has_secrets_as_arg = true;
+                continue;
+            }
+
             match argument_data.values.len() {
                 1 => {
                     let argument = argument_data.values.pop().ok_or_else(|| {
@@ -1110,12 +1120,14 @@ impl AttributeValue {
 
         let func_id = attribute_prototype.func_id();
 
-        let before = {
+        let before = if has_secrets_as_arg {
             // We need the associated [`ComponentId`] for this function--this is how we resolve and
             // prepare before functions
-            let asssociated_component_id = self.context.component_id();
+            let associated_component_id = self.context.component_id();
 
-            before_funcs_for_component(ctx, &asssociated_component_id).await?
+            before_funcs_for_component(ctx, &associated_component_id).await?
+        } else {
+            vec![]
         };
 
         let (func_binding, mut func_binding_return_value) = match FuncBinding::create_and_execute(

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -68,6 +68,8 @@ pub enum LeafInputLocation {
     Domain,
     /// The input location corresponding to "/root/resource".
     Resource,
+    /// The input location corresponding to "/root/secrets".
+    Secrets,
 }
 
 // We only want to allow converting an input location into a root prop child and root the other
@@ -80,6 +82,7 @@ impl Into<RootPropChild> for LeafInputLocation {
             LeafInputLocation::Domain => RootPropChild::Domain,
             LeafInputLocation::Resource => RootPropChild::Resource,
             LeafInputLocation::DeletedAt => RootPropChild::DeletedAt,
+            LeafInputLocation::Secrets => RootPropChild::Secrets,
         }
     }
 }
@@ -91,6 +94,7 @@ impl From<&PkgLeafInputLocation> for LeafInputLocation {
             PkgLeafInputLocation::Domain => Self::Domain,
             PkgLeafInputLocation::Resource => Self::Resource,
             PkgLeafInputLocation::DeletedAt => Self::DeletedAt,
+            PkgLeafInputLocation::Secrets => Self::Secrets,
         }
     }
 }
@@ -102,6 +106,7 @@ impl From<LeafInputLocation> for PkgLeafInputLocation {
             LeafInputLocation::Domain => Self::Domain,
             LeafInputLocation::Resource => Self::Resource,
             LeafInputLocation::DeletedAt => Self::DeletedAt,
+            LeafInputLocation::Secrets => Self::Secrets,
         }
     }
 }
@@ -119,6 +124,7 @@ impl LeafInputLocation {
             LeafInputLocation::Domain => "domain",
             LeafInputLocation::Resource => "resource",
             LeafInputLocation::DeletedAt => "deleted_at",
+            LeafInputLocation::Secrets => "secrets",
         }
     }
 
@@ -132,15 +138,17 @@ impl LeafInputLocation {
             "code" => LeafInputLocation::Code,
             "resource" => LeafInputLocation::Resource,
             "deleted_at" => LeafInputLocation::DeletedAt,
+            "secrets" => LeafInputLocation::Secrets,
             _ => return None,
         })
     }
 
     pub fn arg_kind(&self) -> FuncArgumentKind {
         match self {
-            LeafInputLocation::Code | LeafInputLocation::Domain | LeafInputLocation::Resource => {
-                FuncArgumentKind::Object
-            }
+            LeafInputLocation::Code
+            | LeafInputLocation::Domain
+            | LeafInputLocation::Resource
+            | LeafInputLocation::Secrets => FuncArgumentKind::Object,
             LeafInputLocation::DeletedAt => FuncArgumentKind::String,
         }
     }

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -31,6 +31,8 @@ pub enum RootPropChild {
     Qualification,
     /// Corresponds to the "/root/resource" subtree.
     Resource,
+    /// Corresponds to the "/root/secrets" subtree.
+    Secrets,
     /// Corresponds to the "/root/si" subtree.
     Si,
 }
@@ -44,6 +46,7 @@ impl RootPropChild {
             Self::Code => "code",
             Self::Qualification => "qualification",
             Self::DeletedAt => "deleted_at",
+            Self::Secrets => "secrets",
         }
     }
 }

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -33,27 +33,13 @@ pub async fn update_property_editor_value(
 ) -> ComponentResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut force_changeset_pk = None;
-    if ctx.visibility().is_head() {
-        let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
-
-        let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
-
-        ctx.update_visibility(new_visibility);
-
-        force_changeset_pk = Some(change_set.pk);
-
-        WsEvent::change_set_created(&ctx, change_set.pk)
-            .await?
-            .publish_on_commit(&ctx)
-            .await?;
-    };
+    let force_changeset_pk = ChangeSet::force_new(&mut ctx).await?;
 
     let attribute_context = AttributeContext::builder()
         .set_prop_id(request.prop_id)
         .set_component_id(request.component_id)
         .to_context()?;
-    let (_, _) = AttributeValue::update_for_context(
+    AttributeValue::update_for_context(
         &ctx,
         request.attribute_value_id,
         request.parent_attribute_value_id,
@@ -63,45 +49,48 @@ pub async fn update_property_editor_value(
     )
     .await?;
 
-    let component = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .ok_or(ComponentError::ComponentNotFound(request.component_id))?;
+    // Track
+    {
+        let component = Component::get_by_id(&ctx, &request.component_id)
+            .await?
+            .ok_or(ComponentError::ComponentNotFound(request.component_id))?;
 
-    let component_schema = component
-        .schema(&ctx)
-        .await?
-        .ok_or(ComponentError::SchemaNotFound)?;
+        let component_schema = component
+            .schema(&ctx)
+            .await?
+            .ok_or(ComponentError::SchemaNotFound)?;
 
-    let prop = Prop::get_by_id(&ctx, &request.prop_id)
-        .await?
-        .ok_or(ComponentError::PropNotFound(request.prop_id))?;
+        let prop = Prop::get_by_id(&ctx, &request.prop_id)
+            .await?
+            .ok_or(ComponentError::PropNotFound(request.prop_id))?;
 
-    // In this context, there will always be a parent attribute value id
-    let parent_prop = if let Some(att_val_id) = request.parent_attribute_value_id {
-        Some(AttributeValue::find_prop_for_value(&ctx, att_val_id).await?)
-    } else {
-        None
-    };
+        // In this context, there will always be a parent attribute value id
+        let parent_prop = if let Some(att_val_id) = request.parent_attribute_value_id {
+            Some(AttributeValue::find_prop_for_value(&ctx, att_val_id).await?)
+        } else {
+            None
+        };
+
+        track(
+            &posthog_client,
+            &ctx,
+            &original_uri,
+            "property_value_updated",
+            serde_json::json!({
+                "component_id": component.id(),
+                "component_schema_name": component_schema.name(),
+                "prop_id": prop.id(),
+                "prop_name": prop.name(),
+                "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id()),
+                "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name()),
+            }),
+        );
+    }
 
     WsEvent::change_set_written(&ctx)
         .await?
         .publish_on_commit(&ctx)
         .await?;
-
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "property_value_updated",
-        serde_json::json!({
-            "component_id": component.id(),
-            "component_schema_name": component_schema.name(),
-            "prop_id": prop.id(),
-            "prop_name": prop.name(),
-            "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id()),
-            "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name()),
-        }),
-    );
 
     ctx.commit().await?;
 

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -738,6 +738,7 @@ pub async fn save_func<'a>(
     let request_associations = request.associations.clone();
     let (save_response, _) = do_save_func(&ctx, request).await?;
 
+    // Track
     {
         let func = Func::get_by_id(&ctx, &request_id)
             .await?

--- a/lib/si-pkg/src/spec/leaf_function.rs
+++ b/lib/si-pkg/src/spec/leaf_function.rs
@@ -44,6 +44,7 @@ pub enum LeafInputLocation {
     DeletedAt,
     Domain,
     Resource,
+    Secrets,
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
<img width="601" alt="image" src="https://github.com/systeminit/si/assets/6564471/9ac78854-ef60-415f-875e-460d271a1565">

By setting the toggle above, `root/secrets` will be set as input to the function. At runtime, the system will detect the dependency on secrets, wipe that from the args of the main function to be executed and trigger fetching the before functions.

As a corollary, auth functions now  will only run when explicitly set by the user