### PR TITLE
fix: prevent error on empty modules page

### DIFF
--- a/app/web/src/components/modules/ModuleDisplay.vue
+++ b/app/web/src/components/modules/ModuleDisplay.vue
@@ -125,7 +125,11 @@
       <!-- this else means the module does not exist locally -->
       <template v-else>
         <!-- deal with showing an error message if name is totally bogus -->
-        <template v-if="loadRemoteModulesReqStatus.isSuccess && !remoteSummary">
+        <template
+          v-if="
+            loadRemoteModulesReqStatus.isSuccess && !remoteSummary && moduleSlug
+          "
+        >
           <ErrorMessage>
             Could not find module with hash {{ moduleSlug }}
           </ErrorMessage>


### PR DESCRIPTION
Delicious Food!

Fixes the error where the Modules panel in the Customize tab would complain about a module not existing for a hash when you first navigate to it. We haven't selected one yet, so of course it's missing. There shouldn't be a module slug in this case, so checking for that makes this go away.