### PR TITLE
Add support for AWS session tokens

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,3 +29,4 @@ We contributors to System Initiative:
 * Luca Palmieri (@LukeMathWalker)
 * Sakshi Umredkar (@saakshii12)
 * Justin Carter (@bodymindarts)
+* Ryan Benasutti (@Octogonapus)

--- a/bin/veritech/docker-entrypoint.sh
+++ b/bin/veritech/docker-entrypoint.sh
@@ -20,6 +20,7 @@ write_aws_credentials() {
 	aws_access_key_id = ${AWS_ACCESS_KEY_ID:-}
 	aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY:-}
 	EOF
+  if [ -n "${AWS_SESSION_TOKEN:-}" ]; then echo "aws_session_token = ${AWS_SESSION_TOKEN:-}" >>"$HOME/.aws/credentials"; fi
   chmod 0600 "$HOME/.aws/credentials"
 
   # Remove environment variables from veritech's environment

--- a/lib/si-cli/src/key_management.rs
+++ b/lib/si-cli/src/key_management.rs
@@ -13,6 +13,7 @@ use std::{fs, io};
 pub struct Credentials {
     pub aws_access_key_id: String,
     pub aws_secret_access_key: String,
+    pub aws_session_token: Option<String>,
     pub aws_endpoint_url: Option<String>,
     pub docker_hub_user_name: Option<String>,
     pub docker_hub_credential: Option<String>,
@@ -117,10 +118,12 @@ pub async fn format_credentials_for_veritech() -> CliResult<Vec<String>> {
         raw_creds.aws_secret_access_key
     ));
 
-    if raw_creds.aws_endpoint_url.is_some() {
-        if let Some(url) = raw_creds.aws_endpoint_url {
-            creds.push(format!("AWS_ENDPOINT_URL={}", url));
-        }
+    if let Some(url) = raw_creds.aws_endpoint_url {
+        creds.push(format!("AWS_ENDPOINT_URL={}", url));
+    }
+
+    if let Some(token) = raw_creds.aws_session_token {
+        creds.push(format!("AWS_SESSION_TOKEN={}", token))
     }
 
     if raw_creds.docker_hub_user_name.is_some() && raw_creds.docker_hub_credential.is_some() {


### PR DESCRIPTION
This PR adds support for using an AWS session token alongside the existing AWS credentials.
This is useful for people like myself in multi-account orgs where we get credentials from SSO.

I intended to test this manually (I didn't find any existing automated tests to update), but I haven't been able to do that because I can't get the veritech container to rebuild.
Changing the `docker-entrypoint.sh` file seems to do nothing when running with `buck2 run dev:up`.
