### PR TITLE
feat: veritech flags to configure runtime

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -24,6 +24,22 @@ pub(crate) struct Args {
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
+
+    /// Cyclone runtime type: LocalProcess
+    #[arg(long)]
+    pub(crate) cyclone_local_process: bool,
+
+    /// Cyclone runtime type: LocalDocker
+    #[arg(long)]
+    pub(crate) cyclone_local_docker: bool,
+
+    /// Cyclone runtime type: LocalFirecracker
+    #[arg(long)]
+    pub(crate) cyclone_local_firecracker: bool,
+
+    /// Cyclone pool size
+    #[arg(long)]
+    pub(crate) cyclone_pool_size: Option<u16>,
 }
 
 impl TryFrom<Args> for Config {
@@ -33,6 +49,18 @@ impl TryFrom<Args> for Config {
         ConfigFile::layered_load(NAME, move |config_map| {
             if let Some(url) = args.nats_url {
                 config_map.set("nats.url", url);
+            }
+            if args.cyclone_local_firecracker {
+                config_map.set("cyclone.runtime_strategy", "LocalFirecracker");
+            }
+            if args.cyclone_local_docker {
+                config_map.set("cyclone.runtime_strategy", "LocalDocker");
+            }
+            if args.cyclone_local_process {
+                config_map.set("cyclone.runtime_strategy", "LocalProcess");
+            }
+            if let Some(size) = args.cyclone_pool_size {
+                config_map.set("cyclone.pool_size", size);
             }
         })?
         .try_into()


### PR DESCRIPTION
This adds flags to veritech to configure the runtime type and the size of the pool. These flags are passed down into cyclone-server/client to configure the respective settings.  As an example, to tell Veritech to use Firecracker:
```bash
$ buck2 run bin/veritech -- --cyclone-local-firecracker --cyclone-pool-size 500
```
