### PR TITLE
feat: add veritech service file

### DIFF
--- a/bin/veritech/veritech.service
+++ b/bin/veritech/veritech.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Veritech Server
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/veritech --cyclone-local-firecracker --cyclone-pool-size 1000
+Type=exec
+Restart=always
+
+
+[Install]
+WantedBy=default.target
+RequiredBy=network.target

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -276,15 +276,15 @@ impl LocalUdsInstance {
 #[derive(Builder, Clone, Debug)]
 pub struct LocalUdsInstanceSpec {
     /// Canonical path to the `cyclone` program.
-    #[builder(try_setter, setter(into))]
+    #[builder(try_setter, setter(into), default)]
     cyclone_cmd_path: CanonicalCommand,
 
     /// Canonical path to Cyclone's secret key file.
-    #[builder(setter(into))]
+    #[builder(setter(into), default)]
     cyclone_decryption_key_path: String,
 
     /// Canonical path to the language server program.
-    #[builder(try_setter, setter(into))]
+    #[builder(try_setter, setter(into), default)]
     lang_server_cmd_path: CanonicalCommand,
 
     /// Socket strategy for a spawned Cyclone server.

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -362,13 +362,17 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                 pool_size,
             } => {
                 let mut builder = LocalUdsInstance::spec();
-                builder
-                    .try_cyclone_cmd_path(cyclone_cmd_path)
-                    .map_err(ConfigError::cyclone_spec_build)?;
-                builder.cyclone_decryption_key_path(cyclone_decryption_key_path);
-                builder
-                    .try_lang_server_cmd_path(lang_server_cmd_path)
-                    .map_err(ConfigError::cyclone_spec_build)?;
+                //we only need these if running local process. Maybe the builder should handle
+                //this?
+                if matches!(runtime_strategy, LocalUdsRuntimeStrategy::LocalProcess) {
+                    builder
+                        .try_cyclone_cmd_path(cyclone_cmd_path)
+                        .map_err(ConfigError::cyclone_spec_build)?;
+                    builder.cyclone_decryption_key_path(cyclone_decryption_key_path);
+                    builder
+                        .try_lang_server_cmd_path(lang_server_cmd_path)
+                        .map_err(ConfigError::cyclone_spec_build)?;
+                }
                 builder.socket_strategy(socket_strategy);
                 builder.runtime_strategy(runtime_strategy);
                 if let Some(watch_timeout) = watch_timeout {


### PR DESCRIPTION
Adds the systemd service file for veritech. Ideally we ship this as an artifact along with veritech itself so we can version it with the binary. We can then just grab both in user data and `systemctl daemon-reload && systemctl enable veritech --now`