### PR TITLE
fix(web): Ensure that the right func is called for changeset abandon

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -31,7 +31,7 @@
           icon="trash"
           size="sm"
           :disabled="fixesStore.fixesAreInProgress || !selectedChangeSetName"
-          @click="abandonConfirmationModalRef.open"
+          @click="abandonConfirmationModalRef.open()"
         />
       </div>
     </div>


### PR DESCRIPTION
Without this change, the following error fires starting the site and it just crashes:

```
Uncaught (in promise) TypeError: $setup.abandonConfirmationModalRef is undefined
    _sfc_render ChangeSetPanel.vue:34
    renderComponentRoot runtime-core.esm-bundler.js:816
    componentUpdateFn runtime-core.esm-bundler.js:5701
    run reactivity.esm-bundler.js:178
    update runtime-core.esm-bundler.js:5814
    setupRenderEffect runtime-core.esm-bundler.js:5822
    mountComponent runtime-core.esm-bundler.js:5612
    processComponent runtime-core.esm-bundler.js:5565
    patch runtime-core.esm-bundler.js:5040
    mountChildren runtime-core.esm-bundler.js:5284

```