### PR TITLE
chore/unset-aws-session-token (Veritech)

### DIFF
--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -77,3 +77,4 @@ nix_omnibus_pkg(
     pkg_name = "veritech",
     build_dep = "//bin/veritech:veritech",
 )
+

--- a/bin/veritech/docker-entrypoint.sh
+++ b/bin/veritech/docker-entrypoint.sh
@@ -24,7 +24,8 @@ write_aws_credentials() {
   chmod 0600 "$HOME/.aws/credentials"
 
   # Remove environment variables from veritech's environment
-  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  # AWS_SESSION_TOKEN is optional, but `unset` returns 0 for any variable, whether it exists or not
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 }
 
 write_docker_credentials() {


### PR DESCRIPTION
Adds unsetting of AWS_SESSION_TOKEN too to ensure it's not included after it's used in the docker container. The container will need fully rotated between tokens anyway, so this just prevents environment variable bleed.

NB: For some reason modifying the `docker-entrypoint.sh` within `bin/veritech` doesn't trigger a promote of the container or omnibus when merged into main, it's likely that this file is mistakenly considered a non-func change during calculation of targets in si-ci. This is a separate problem to the omnibus-overwriting issue documented in https://github.com/systeminit/si-ci/pull/99 which can be engaged after this is merged.

BUCK is considered a critical file (understandably) to the build of the binary or folder, so I've made a new line change there to trigger the downstream process correctly, see output below from si-ci's perspective:

```
...
    command:
      - apk add git github-cli python3
      - git config --global --add safe.directory /workdir
      - "echo '{\"groups\":{\"artifacts\":{\"name\":\"artifacts\",\"tasks\":[{\"name\":\":package: promote-omnibus (root//bin/veritech:promote-omnibus 20231208.153753.0-sha.6140793a3)\",\"commands\":[{\"type\":\"shell\",\"code\":\"eval $(buck2 run .ci:generate-creds-from-iam-role -- buildkite-x86-64-Role 2> /dev/null)\"},{\"type\":\"buck2_run\",\"target\":\"root//bin/veritech:promote-omnibus\",\"args\":[\"--target\",\"linux-aarch64\",\"--target\",\"linux-x86_64\"]}]}]},\"docker_images\":{\"name\":\"docker_images\",\"tasks\":[{\"name\":\":docker: promote-docker (root//bin/veritech:promote sha-6140793a3cdb94660476e35bcc67ebd673c2d270)\",\"commands\":[{\"type\":\"buck2_run\",\"target\":\"root//bin/veritech:promote\",\"args\":[\"sha-6140793a3cdb94660476e35bcc67ebd673c2d270\"]}]},{\"name\":\":docker: promote-docker (root//bin/veritech:promote 20231208.153753.0-sha.6140793a3)\",\"commands\":[{\"type\":\"buck2_run\",\"target\":\"root//bin/veritech:promote\",\"args\":[\"--update-stable-tag\",\"20231208.153753.0-sha.6140793a3\"]}]}]},\"git_tags\":{\"name\":\"git_tags\",\"tasks\":[{\"name\":\":git: tag-git (bin/veritech/image/20231208.153753.0-sha.6140793a3)\",\"commands\":[{\"type\":\"shell\",\"code\":\"git tag --annotate \\\"bin/veritech/image/20231208.153753.0-sha.6140793a3\\\" --message \\\"release: bin/veritech/image/20231208.153753.0-sha.6140793a3\\\"\"},{\"type\":\"shell\",\"code\":\"git push origin \\\"bin/veritech/image/20231208.153753.0-sha.6140793a3\\\"\"}]}]}}}'"
...
```

*Critically, it has both omnibus and docker promote tasks*