### PR TITLE
fix: amend download link on artifacts.systeminit.com static site

### DIFF
--- a/app/artifact-status/index.html
+++ b/app/artifact-status/index.html
@@ -262,11 +262,18 @@ permissions and limitations under the License.
     function object2hrefvirt(bucket, key) {
         var enckey = key.split('/').map(function(x) { return encodeURIComponent(x); }).join('/');
 
-        if (AWS.config.region === "us-east-1") {
-            return document.location.protocol + '//' + bucket + '.s3.amazonaws.com/' + enckey;
+        // If it's a folder, return the nested folder key as the html a ref
+        if (key.endsWith("/")) {
+            if (AWS.config.region === "us-east-1") {
+                return document.location.protocol + '//' + bucket + '.s3.amazonaws.com/' + enckey;
+            } else {
+                return document.location.protocol + '//' + bucket + '.s3-' + AWS.config.region + '.amazonaws.com/' + enckey;
+            }
         } else {
-            return document.location.protocol + '//' + bucket + '.s3-' + AWS.config.region + '.amazonaws.com/' + enckey;
+            // Otherwise return the CDN link to the artifact for better cache performance
+            return 'https://artifacts.systeminit.com/' + enckey;
         }
+
     }
 
     function object2hrefpath(bucket, key) {


### PR DESCRIPTION
Amends the download link in the https://artifacts.systeminit.com webpage for the final objects in the S3 store to redirect the user back through the CDN for better cache performance on download.

Noted as a fix because previously the `stable` object pointers would never resolve/follow the S3 metadata redirects because it would be trying to resolve the redirect directly on the bucket, which never worked.

I.e. previously
```
# Get the latest version of cyclone rootfs on arrch64
curl https://si-artifacts-prod.s3.amazonaws.com/cyclone/stable/rootfs/linux/aarch64/cyclone-stable-rootfs-linux-aarch64.ext4

# Metadata/redirect on this object pointer points to  cyclone-20231209.044841.0-sha.e84c47e4e-rootfs-linux-x86_64.ext4
# Therefore the curl is redirected through:
# https://si-artifacts-prod.s3.amazonaws.com/cyclone/20231209.044841.0-sha.e84c47e4e/rootfs/linux/aarch64/cyclone-20231209.044841.0-sha.e84c47e4e-rootfs-linux-aarch64.ext4
# which would never resolve to the actual object as it would just directly download the 0B pointer

# Now it's redirected through the root CDN of https://artifacts.systeminit.com which firstly will work, but also will cache the result on the CDN, which should give better overall download performance
```