### PR TITLE
feat: add cred string and file options for NATs auth.

### DIFF
--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -23,6 +23,14 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
 
+    /// NATS credentials string
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) nats_creds: Option<String>,
+
+    /// NATS credentials file
+    #[arg(long)]
+    pub(crate) nats_creds_file: Option<String>,
+
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
@@ -35,6 +43,12 @@ impl TryFrom<Args> for Config {
         ConfigFile::layered_load(NAME, |config_map| {
             if let Some(url) = args.nats_url {
                 config_map.set("nats.url", url);
+            }
+            if let Some(creds) = args.nats_creds {
+                config_map.set("nats.creds", creds);
+            }
+            if let Some(creds_file) = args.nats_creds_file {
+                config_map.set("nats.creds_file", creds_file);
             }
         })?
         .try_into()

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -45,6 +45,14 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
 
+    /// NATS credentials string
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) nats_creds: Option<String>,
+
+    /// NATS credentials file
+    #[arg(long)]
+    pub(crate) nats_creds_file: Option<String>,
+
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
@@ -87,6 +95,12 @@ impl TryFrom<Args> for Config {
             }
             if let Some(url) = args.nats_url {
                 config_map.set("nats.url", url);
+            }
+            if let Some(creds) = args.nats_creds {
+                config_map.set("nats.creds", creds);
+            }
+            if let Some(creds_file) = args.nats_creds_file {
+                config_map.set("nats.creds_file", creds_file);
             }
             if let Some(cyclone_encyption_key_path) = args.cyclone_encryption_key_path {
                 config_map.set("cyclone_encryption_key_path", cyclone_encyption_key_path);

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -47,6 +47,14 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
 
+    /// NATS credentials string
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) nats_creds: Option<String>,
+
+    /// NATS credentials file
+    #[arg(long)]
+    pub(crate) nats_creds_file: Option<String>,
+
     /// Database migration mode on startup
     #[arg(long, value_parser = PossibleValuesParser::new(MigrationMode::variants()))]
     pub(crate) migration_mode: Option<String>,
@@ -104,6 +112,12 @@ impl TryFrom<Args> for Config {
             }
             if let Some(url) = args.nats_url {
                 config_map.set("nats.url", url);
+            }
+            if let Some(creds) = args.nats_creds {
+                config_map.set("nats.creds", creds);
+            }
+            if let Some(creds_file) = args.nats_creds_file {
+                config_map.set("nats.creds_file", creds_file);
             }
             if let Some(cyclone_encyption_key_path) = args.cyclone_encryption_key_path {
                 config_map.set("cyclone_encryption_key_path", cyclone_encyption_key_path);

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -21,6 +21,14 @@ pub(crate) struct Args {
     #[arg(long, short = 'u')]
     pub(crate) nats_url: Option<String>,
 
+    /// NATS credentials string
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) nats_creds: Option<String>,
+
+    /// NATS credentials file
+    #[arg(long)]
+    pub(crate) nats_creds_file: Option<String>,
+
     /// Disable OpenTelemetry on startup
     #[arg(long)]
     pub(crate) disable_opentelemetry: bool,
@@ -49,6 +57,12 @@ impl TryFrom<Args> for Config {
         ConfigFile::layered_load(NAME, move |config_map| {
             if let Some(url) = args.nats_url {
                 config_map.set("nats.url", url);
+            }
+            if let Some(creds) = args.nats_creds {
+                config_map.set("nats.creds", creds);
+            }
+            if let Some(creds_file) = args.nats_creds_file {
+                config_map.set("nats.creds_file", creds_file);
             }
             if args.cyclone_local_firecracker {
                 config_map.set("cyclone.runtime_strategy", "LocalFirecracker");

--- a/lib/si-data-nats/src/connect_options.rs
+++ b/lib/si-data-nats/src/connect_options.rs
@@ -205,6 +205,25 @@ impl ConnectOptions {
             .into())
     }
 
+    /// Use a builder to authenticate with NATS using a `.creds` file.
+    /// Open the provided file, load its creds,
+    /// and perform the desired authentication
+    ///
+    /// # Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), si_data_nats::Error> {
+    /// let nc = si_data_nats::ConnectOptions::new()
+    ///     .credentials("path/to/my.creds".into())
+    ///     .await?
+    ///     .connect("connect.ngs.global")
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn credentials_file(self, path: PathBuf) -> Result<Self> {
+        Ok(self.inner.credentials_file(path).await?.into())
+    }
     /// Authenticate with NATS using a credential str, in the creds file format.
     ///
     /// # Example


### PR DESCRIPTION
This adds the ability to authenticate with nats using either a credential file or a credential string. These credentials must follow the format defined [here](https://docs.nats.io/using-nats/developer/connecting/creds). 

This is only required if the NATs server is using authentication, such as if you are using [NGS](https://app.ngs.global/).