### PR TITLE
feat(nats): add connection name to nats connection

### DIFF
--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -50,6 +50,7 @@ impl TryFrom<Args> for Config {
             if let Some(creds_file) = args.nats_creds_file {
                 config_map.set("nats.creds_file", creds_file);
             }
+            config_map.set("nats.connection_name", NAME);
         })?
         .try_into()
     }

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -111,7 +111,7 @@ impl TryFrom<Args> for Config {
             if let Some(instance_id) = args.instance_id {
                 config_map.set("instance_id", instance_id);
             }
-
+            config_map.set("nats.connection_name", NAME);
             config_map.set("pg.application_name", NAME);
         })?
         .try_into()

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -129,6 +129,7 @@ impl TryFrom<Args> for Config {
                 config_map.set("module_index_url", module_index_url);
             }
 
+            config_map.set("nats.connection_name", NAME);
             config_map.set("pg.application_name", NAME);
         })?
         .try_into()

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -76,6 +76,7 @@ impl TryFrom<Args> for Config {
             if let Some(size) = args.cyclone_pool_size {
                 config_map.set("cyclone.pool_size", size);
             }
+            config_map.set("nats.connection_name", NAME);
         })?
         .try_into()
     }

--- a/lib/si-data-nats/src/lib.rs
+++ b/lib/si-data-nats/src/lib.rs
@@ -53,19 +53,21 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NatsConfig {
-    pub url: String,
-    pub subject_prefix: Option<String>,
+    pub connection_name: Option<String>,
     pub creds: Option<String>,
     pub creds_file: Option<String>,
+    pub subject_prefix: Option<String>,
+    pub url: String,
 }
 
 impl Default for NatsConfig {
     fn default() -> Self {
         Self {
-            url: "localhost".to_string(),
-            subject_prefix: None,
+            connection_name: None,
             creds: None,
             creds_file: None,
+            subject_prefix: None,
+            url: "localhost".to_string(),
         }
     }
 }
@@ -105,6 +107,9 @@ impl Client {
         }
         if let Some(creds_file) = &config.creds_file {
             options = options.credentials_file(creds_file.into()).await?;
+        }
+        if let Some(connection_name) = &config.connection_name {
+            options = options.name(connection_name);
         }
         Self::connect_with_options(&config.url, config.subject_prefix.clone(), options).await
     }


### PR DESCRIPTION
This allows giving a connection name to nats. This makes it easier to identify who is connecting to nats. We're considering using a managed nats solution and without this the UI shows all of the connections as `unknown` . Here's a before and after:
![image](https://github.com/systeminit/si/assets/3621657/7a85f47d-1274-4573-8601-52b64338e653)
![image](https://github.com/systeminit/si/assets/3621657/cf2d9aaa-5fbd-4dae-a709-2631b9141e2e)
