### PR TITLE
feat: refactor rootfs to not use docker

### DIFF
--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -4,7 +4,7 @@
 # components we need rootfs' for but there are some cyclone-specifics bits that
 # will cause us problems
 
-set -euo pipefail
+set -euxo pipefail
 
 # TODO(johnrwatson): We need to port this to python or similar, and check for
 # OS-dependencies that are required. i.e. docker and basic priviledged
@@ -44,11 +44,12 @@ GITROOT="$(pwd)"
 BUCKROOT="$BUCK_SCRATCH_PATH" # This is provided by buck2
 
 BIN=cyclone
-PACKAGEDIR="$BUCKROOT/cyclone-pkg"
+PACKAGEDIR=$(realpath "$BUCKROOT/cyclone-pkg")
 ROOTFS="$PACKAGEDIR/cyclone-rootfs.ext4"
 ROOTFSMOUNT="$PACKAGEDIR/rootfs"
-GUESTDISK="/rootfs"
+ROOTFS_TAR="rootfs.tar.gz"
 INITSCRIPT="$PACKAGEDIR/init.sh"
+ALPINE_VERSION=3.18
 
 # Vendored from https://github.com/fnichol/libsh/blob/main/lib/setup_traps.sh
 setup_traps() {
@@ -71,16 +72,16 @@ cleanup() {
   # cleanup the PACKAGEDIR
   sudo umount -fv "$ROOTFSMOUNT"
 
-  rm -rfv "$ROOTFSMOUNT" "$INITSCRIPT"
+  rm -rfv "$ROOTFSMOUNT" "$INITSCRIPT" "$ROOTFS_TAR"
 }
+
+setup_traps cleanup
 
 # create disk and mount to a known location
 mkdir -pv "$ROOTFSMOUNT"
 dd if=/dev/zero of="$ROOTFS" bs=1M count=2048
 mkfs.ext4 -v "$ROOTFS"
 sudo mount -v "$ROOTFS" "$ROOTFSMOUNT"
-
-setup_traps cleanup
 
 cyclone_args=(
   --bind-vsock 3:52
@@ -94,6 +95,74 @@ cyclone_args=(
   --enable-action-run
 )
 
+# got get the rootfs tar and unpack it
+curl "https://dl-cdn.alpinelinux.org/alpine/v$ALPINE_VERSION/releases/$(arch)/alpine-minirootfs-$ALPINE_VERSION.0-$(arch).tar.gz" -o $ROOTFS_TAR
+sudo tar xf rootfs.tar.gz -C "$ROOTFSMOUNT"
+
+#ENTER CHROOT
+sudo chroot "$ROOTFSMOUNT" sh <<EOL
+
+# Set up DNS resolution
+echo "nameserver 8.8.8.8" >"/etc/resolv.conf"
+
+apk update
+apk add openrc openssh mingetty runuser
+
+adduser -D app
+for dir in / run etc usr/local/etc home/app/.config; do
+    mkdir -pv "/\$dir/$BIN"
+done
+
+# create /dev/null
+mknod /dev/null c 1 3
+chmod 666 /dev/null
+
+ssh-keygen -A
+
+# Make sure special file systems are mounted on boot:
+rc-update add devfs boot
+rc-update add procfs boot
+rc-update add sysfs boot
+rc-update add networking boot
+rc-update add local default
+rc-update add sshd
+
+# autologin
+echo "ttyS0::respawn:/sbin/mingetty --autologin root --noclear ttyS0" >> /etc/inittab
+sed -i 's/root:*::0:::::/root:::0:::::/g' /etc/shadow
+
+# autostart cyclone
+cat <<EOF >"/etc/init.d/cyclone"
+#!/sbin/openrc-run
+
+name="cyclone"
+description="Cyclone"
+supervisor="supervise-daemon"
+command="cyclone"
+command_args="${cyclone_args[*]}"
+pidfile="/cyclone/agent.pid"
+EOF
+
+chmod +x "/etc/init.d/cyclone"
+
+rc-update add cyclone boot
+
+# Set up TAP device route/escape
+cat <<EOZ >"/etc/network/interfaces"
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+        address 10.0.0.1/30
+        gateway 10.0.0.2
+EOZ
+
+EOL
+# LEAVE CHROOT
+
+# For each tar.gz, copy the contents into the rootfs into the rootfs partition
+# we created above. This will cumulatively stack the content of each.
 for binary_input in "${binary_inputs[@]}"; do
   sudo tar -xpf "$binary_input" -C "$ROOTFSMOUNT"
 
@@ -108,84 +177,6 @@ for binary_input in "${binary_inputs[@]}"; do
       "$ROOTFSMOUNT/cyclone/decryption.key"
   fi
 done
-
-# create our script to add an init system to our container image
-cat <<EOL >"$INITSCRIPT"
-set -e
-
-apk update
-apk add openrc openssh mingetty runuser
-
-adduser -D app
-for dir in / run etc usr/local/etc home/app/.config; do
-    mkdir -pv "${GUESTDISK}/\$dir/$BIN"
-done
-
-ssh-keygen -A
-
-# Make sure special file systems are mounted on boot:
-rc-update add devfs boot
-rc-update add procfs boot
-rc-update add sysfs boot
-rc-update add networking boot
-rc-update add local default
-rc-update add sshd
-
-# Then, copy the newly configured system to the rootfs image:
-for dir in bin dev etc lib root sbin usr; do
-  tar cp "/\${dir}" | tar xp -C "${GUESTDISK}"
-done
-for dir in proc run sys var; do
-  mkdir -pv "${GUESTDISK}/\${dir}"
-done
-
-# autologin
-echo "ttyS0::respawn:/sbin/mingetty --autologin root --noclear ttyS0" >> ${GUESTDISK}/etc/inittab
-sed -i 's/root:*::0:::::/root:::0:::::/g' $GUESTDISK/etc/shadow
-
-# autostart cyclone
-cat <<EOF >"${GUESTDISK}/etc/init.d/cyclone"
-#!/sbin/openrc-run
-
-name="cyclone"
-description="Cyclone"
-supervisor="supervise-daemon"
-command="cyclone"
-command_args="${cyclone_args[*]}"
-pidfile="/cyclone/agent.pid"
-EOF
-
-chmod +x "${GUESTDISK}/etc/init.d/cyclone"
-
-chroot "${GUESTDISK}" rc-update add cyclone boot
-
-# Set up DNS resolution
-echo "nameserver 8.8.8.8" >"${GUESTDISK}/etc/resolv.conf"
-
-# Set up TAP device route/escape
-cat <<EOZ >"${GUESTDISK}/etc/network/interfaces"
-auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet static
-        address 10.0.0.1/30
-        gateway 10.0.0.2
-EOZ
-
-EOL
-
-# run the script, mounting the disk so we can create a rootfs
-docker run \
-  -v "$(pwd)/$ROOTFSMOUNT:$GUESTDISK" \
-  -v "$(pwd)/$INITSCRIPT:/init.sh" \
-  --rm \
-  --entrypoint sh \
-  alpine:3.18 \
-  /init.sh
-
-# For each tar.gz, copy the contents into the rootfs into the rootfs partition
-# we created above. This will cumulatively stack the content of each.
 # Must be unmounted then moved with sudo or permission issues will prevent all directories
 # from copying over for some mysterious reason.
 sudo umount -fv "$ROOTFSMOUNT"


### PR DESCRIPTION
This changes the rootfs build from using the alpine docker image to downloading the rootfs directly and `chroot`ing it into the right shape. The docker path works fine locally, but fails in CI due running this as docker in docker, which makes bind mounting the scripts and directories fraught with peril as it tries to mount from the **host**, not the local container. This should make this process more reliable in general and a little faster. @fnichol I think you made changes to make docker in docker work correctly. I'm not sure if we should go back and remove those, I'm not sure exactly where they live.