### PR TITLE
bug (sdf): fix default validation function message to be accurate

### DIFF
--- a/lib/sdf-server/src/server/service/func/defaults/validation.ts
+++ b/lib/sdf-server/src/server/service/func/defaults/validation.ts
@@ -1,6 +1,6 @@
 async function main(value: Input): Promise<Output> {
   return {
     valid: true,
-    message: "validation error message",
+    message: "validation successful",
   };
 }


### PR DESCRIPTION
The default message for a validation function was the opposite of what was intended. This fixes it.

I have rebuilt my local sdf after this change and the default function behaves as expected.