### PR TITLE
feat(sdf): use schema names for model name defaults

### DIFF
--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -297,6 +297,12 @@ pub fn generate_unique_id(length: usize) -> String {
         .collect()
 }
 
+pub fn generate_name_from_schema_name(schema_name: impl AsRef<str>) -> String {
+    let unique_id = generate_unique_id(4);
+    let schema_name = schema_name.as_ref();
+    format!("{schema_name} {unique_id}")
+}
+
 pub fn generate_name() -> String {
     let unique_id = generate_unique_id(4);
     format!("si-{unique_id}")

--- a/lib/sdf-server/src/server/service/diagram/create_node.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_node.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use dal::node::NodeId;
 use dal::{
-    action_prototype::ActionPrototypeContextField, generate_name, Action, ActionKind,
-    ActionPrototype, ActionPrototypeContext, ChangeSet, Component, ComponentId, Schema, SchemaId,
-    StandardModel, Visibility, WsEvent,
+    action_prototype::ActionPrototypeContextField, generate_name_from_schema_name, Action,
+    ActionKind, ActionPrototype, ActionPrototypeContext, ChangeSet, Component, ComponentId, Schema,
+    SchemaId, StandardModel, Visibility, WsEvent,
 };
 
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
@@ -57,10 +57,10 @@ pub async fn create_node(
             .await?;
     };
 
-    let name = generate_name();
     let schema = Schema::get_by_id(&ctx, &request.schema_id)
         .await?
         .ok_or(DiagramError::SchemaNotFound)?;
+    let name = generate_name_from_schema_name(schema.name());
 
     let schema_variant_id = schema
         .default_schema_variant_id()


### PR DESCRIPTION
Currently, every asset is named in a `si-1234` style. With this change, they now default to `Schema Name 1234` style, which is much nicer on the old eyeballs.

![image](https://github.com/systeminit/si/assets/4304/50b20ca2-acc2-4d6f-a651-679f6e21feba)
