### PR TITLE
Restore property editor (read-only)

### DIFF
--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -84,6 +84,7 @@ pub use attribute::{
 pub use builtins::{BuiltinsError, BuiltinsResult};
 pub use change_set::{ChangeSet, ChangeSetError, ChangeSetPk, ChangeSetStatus};
 pub use component::Component;
+pub use component::ComponentError;
 pub use component::ComponentId;
 pub use component::ComponentKind;
 pub use context::{

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -86,7 +86,7 @@ pub struct WidgetOption {
     value: String,
 }
 
-type WidgetOptions = Vec<WidgetOption>;
+pub type WidgetOptions = Vec<WidgetOption>;
 
 /// An individual "field" within the tree of a [`SchemaVariant`](crate::SchemaVariant).
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -104,6 +104,8 @@ pub struct Prop {
     pub widget_options: Option<WidgetOptions>,
     /// A link to external documentation for working with this specific [`Prop`].
     pub doc_link: Option<String>,
+    /// Embedded documentation for working with this specific [`Prop`].
+    pub documentation: Option<String>,
     /// A toggle for whether or not the [`Prop`] should be visually hidden.
     pub hidden: bool,
     /// Props can be connected to eachother to signify that they should contain the same value
@@ -131,6 +133,8 @@ pub struct PropContentV1 {
     pub widget_options: Option<WidgetOptions>,
     /// A link to external documentation for working with this specific [`Prop`].
     pub doc_link: Option<String>,
+    /// Embedded documentation for working with this specific [`Prop`].
+    pub documentation: Option<String>,
     /// A toggle for whether or not the [`Prop`] should be visually hidden.
     pub hidden: bool,
     /// Props can be connected to eachother to signify that they should contain the same value
@@ -149,6 +153,7 @@ impl From<Prop> for PropContentV1 {
             widget_kind: value.widget_kind,
             widget_options: value.widget_options,
             doc_link: value.doc_link,
+            documentation: value.documentation,
             hidden: value.hidden,
             refers_to_prop_id: value.refers_to_prop_id,
             diff_func_id: value.diff_func_id,
@@ -334,6 +339,7 @@ impl Prop {
             widget_kind: inner.widget_kind,
             widget_options: inner.widget_options,
             doc_link: inner.doc_link,
+            documentation: inner.documentation,
             hidden: inner.hidden,
             refers_to_prop_id: inner.refers_to_prop_id,
             diff_func_id: inner.diff_func_id,
@@ -421,6 +427,7 @@ impl Prop {
             widget_kind,
             widget_options,
             doc_link,
+            documentation: None,
             hidden,
             refers_to_prop_id: None,
             diff_func_id: None,

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -47,6 +47,11 @@ pub enum EdgeWeightKind {
     /// [`ExternalProvider`].
     Provider,
     Proxy,
+    /// Indicates the "root" [`AttributeValue`](crate::AttributeValue) for a [`Component`](crate::Component).
+    ///
+    /// TODO(nick): in the future, this should be used for the "root" [`Prop`](crate::Prop) for a
+    /// [`SchemaVariant`](crate::SchemaVariant) as well.
+    Root,
     /// Workspaces "use" functions, modules, schemas. Schemas "use" schema variants.
     /// Schema variants "use" props. Props "use" functions, and other props. Modules
     /// "use" functions, schemas, and eventually(?) components.

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -837,6 +837,7 @@ impl WorkspaceSnapshotGraph {
                     EdgeWeightKindDiscriminants::Provider => "red",
                     EdgeWeightKindDiscriminants::Proxy => "gray",
                     EdgeWeightKindDiscriminants::Use => "black",
+                    EdgeWeightKindDiscriminants::Root => "black",
                 };
                 format!("label = \"{discrim:?}\"\nfontcolor = {color}\ncolor = {color}")
             },
@@ -1821,6 +1822,7 @@ impl WorkspaceSnapshotGraph {
                     | EdgeWeightKind::Prop
                     | EdgeWeightKind::Prototype(None)
                     | EdgeWeightKind::Proxy
+                    | EdgeWeightKind::Root
                     | EdgeWeightKind::Use => {}
                 }
             }

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
@@ -5,5 +5,6 @@
 
 mod builtins;
 mod component;
+mod property_editor;
 mod rebaser;
 mod sdf_mock;

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/property_editor.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/property_editor.rs
@@ -1,0 +1,33 @@
+use dal::property_editor::schema::PropertyEditorSchema;
+use dal::property_editor::values::PropertyEditorValues;
+use dal::{Component, DalContext, Schema, SchemaVariant};
+use dal_test::test;
+
+#[test]
+async fn assemble(ctx: &DalContext) {
+    // List all schemas in the workspace. Pick the first one alphabetically.
+    let mut schemas: Vec<Schema> = Schema::list(ctx).await.expect("could not list schemas");
+    schemas.sort_by(|a, b| a.name.cmp(&b.name));
+    let schema = schemas.pop().expect("schemas are empty");
+
+    // Pick a schema variant.
+    let mut schema_variants = SchemaVariant::list_for_schema(ctx, schema.id())
+        .await
+        .expect("could not list schema variants for schema");
+    let schema_variant = schema_variants.pop().expect("schemas are empty");
+    let schema_variant_id = schema_variant.id();
+
+    // Create a component and set geometry.
+    let name = "steam deck";
+    let component =
+        Component::new(ctx, name, schema_variant_id, None).expect("could not create component");
+
+    // Assemble both property editor blobs.
+    let property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id)
+        .await
+        .expect("could not assemble property editor schema");
+    let property_editor_values = PropertyEditorValues::assemble(ctx, component.id())
+        .await
+        .expect("could not assemble property editor schema");
+    dbg!(property_editor_schema, property_editor_values);
+}

--- a/lib/sdf-server/src/server/routes.rs
+++ b/lib/sdf-server/src/server/routes.rs
@@ -27,20 +27,20 @@ pub fn routes(state: AppState) -> Router {
             crate::server::service::change_set::routes(),
         )
         .nest("/api/session", crate::server::service::session::routes())
-        // .nest(
-        //     "/api/component",
-        //     crate::server::service::component::routes(),
-        // )
-        // .nest("/api/fix", crate::server::service::fix::routes())
+        .nest(
+            "/api/component",
+            crate::server::service::component::routes(),
+        )
         .nest("/api/func", crate::server::service::func::routes())
-        // .nest("/api/pkg", crate::server::service::pkg::routes())
-        // .nest("/api/provider", crate::server::service::provider::routes())
-        // .nest(
-        //     "/api/qualification",
-        //     crate::server::service::qualification::routes(),
-        // )
         .nest("/api/schema", crate::server::service::schema::routes())
         .nest("/api/diagram", crate::server::service::diagram::routes());
+    // .nest("/api/fix", crate::server::service::fix::routes())
+    // .nest("/api/pkg", crate::server::service::pkg::routes())
+    // .nest("/api/provider", crate::server::service::provider::routes())
+    // .nest(
+    //     "/api/qualification",
+    //     crate::server::service::qualification::routes(),
+    // )
     // .nest("/api/secret", crate::server::service::secret::routes())
     // .nest("/api/status", crate::server::service::status::routes())
     // .nest(

--- a/lib/sdf-server/src/server/service.rs
+++ b/lib/sdf-server/src/server/service.rs
@@ -1,17 +1,18 @@
 pub mod change_set;
-// pub mod component;
+pub mod component;
 pub mod diagram;
-// pub mod fix;
 pub mod func;
+pub mod schema;
+pub mod session;
+pub mod ws;
+
+// pub mod fix;
 // pub mod pkg;
 // pub mod provider;
 // pub mod qualification;
-pub mod schema;
 // pub mod secret;
-pub mod session;
 // pub mod status;
 // pub mod variant_definition;
-pub mod ws;
 
 // /// A module containing dev routes for local development only.
 // #[cfg(debug_assertions)]

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -1,125 +1,120 @@
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::{get, post},
+    routing::get,
     Json, Router,
 };
-use dal::{change_status::ChangeStatusError, component::ComponentViewError, PropError};
-use dal::{
-    component::view::debug::ComponentDebugViewError, node::NodeError,
-    property_editor::PropertyEditorError, AttributeContextBuilderError,
-    AttributePrototypeArgumentError, AttributePrototypeError, AttributeValueError, ChangeSetError,
-    ComponentError as DalComponentError, ComponentId, DiagramError, ExternalProviderError,
-    FuncBindingError, FuncError, InternalProviderError, PropId, ReconciliationPrototypeError,
-    SchemaError as DalSchemaError, StandardModelError, TransactionsError, WsEventError,
-};
+use dal::property_editor::PropertyEditorError;
+use dal::ComponentError as DalComponentError;
+use dal::TransactionsError;
 use thiserror::Error;
 
-use crate::{server::state::AppState, service::schema::SchemaError};
+use crate::server::state::AppState;
 
-pub mod alter_simulation;
-pub mod debug;
-pub mod delete_property_editor_value;
-pub mod get_code;
-pub mod get_components_metadata;
-pub mod get_diff;
 pub mod get_property_editor_schema;
 pub mod get_property_editor_validations;
 pub mod get_property_editor_values;
-pub mod insert_property_editor_value;
-pub mod json;
-pub mod list_qualifications;
-pub mod list_resources;
-pub mod refresh;
-pub mod resource_domain_diff;
-pub mod set_type;
-pub mod update_property_editor_value;
+
+// pub mod alter_simulation;
+// pub mod debug;
+// pub mod delete_property_editor_value;
+// pub mod get_code;
+// pub mod get_components_metadata;
+// pub mod get_diff;
+// pub mod insert_property_editor_value;
+// pub mod json;
+// pub mod list_qualifications;
+// pub mod list_resources;
+// pub mod refresh;
+// pub mod resource_domain_diff;
+// pub mod set_type;
+// pub mod update_property_editor_value;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum ComponentError {
-    #[error("attribute context builder error: {0}")]
-    AttributeContextBuilder(#[from] AttributeContextBuilderError),
-    #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
-    #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
-    #[error("attribute prototype not found")]
-    AttributePrototypeNotFound,
-    #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
-    #[error("attribute value not found")]
-    AttributeValueNotFound,
-    #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
-    #[error("change status error: {0}")]
-    ChangeStatus(#[from] ChangeStatusError),
-    #[error("component error: {0}")]
-    Component(#[from] DalComponentError),
-    #[error("component debug view error: {0}")]
-    ComponentDebug(String),
-    #[error("component debug view error: {0}")]
-    ComponentDebugView(#[from] ComponentDebugViewError),
-    #[error("component name not found")]
-    ComponentNameNotFound,
-    #[error("component not found for id: {0}")]
-    ComponentNotFound(ComponentId),
-    #[error("component view error: {0}")]
-    ComponentView(#[from] ComponentViewError),
-    #[error("dal schema error: {0}")]
-    DalSchema(#[from] DalSchemaError),
-    #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
-    #[error("external provider error: {0}")]
-    ExternalProvider(#[from] ExternalProviderError),
-    #[error("func error: {0}")]
-    Func(#[from] FuncError),
-    #[error("func binding error: {0}")]
-    FuncBinding(#[from] FuncBindingError),
-    #[error("hyper error: {0}")]
-    Http(#[from] axum::http::Error),
-    #[error("identity func not found")]
-    IdentityFuncNotFound,
-    #[error("internal provider error: {0}")]
-    InternalProvider(#[from] InternalProviderError),
-    #[error("invalid request")]
-    InvalidRequest,
+    // #[error("attribute context builder error: {0}")]
+    // AttributeContextBuilder(#[from] AttributeContextBuilderError),
+    // #[error("attribute prototype error: {0}")]
+    // AttributePrototype(#[from] AttributePrototypeError),
+    // #[error("attribute prototype argument error: {0}")]
+    // AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    // #[error("attribute prototype not found")]
+    // AttributePrototypeNotFound,
+    // #[error("attribute value error: {0}")]
+    // AttributeValue(#[from] AttributeValueError),
+    // #[error("attribute value not found")]
+    // AttributeValueNotFound,
+    // #[error("change set error: {0}")]
+    // ChangeSet(#[from] ChangeSetError),
+    // #[error("change status error: {0}")]
+    // ChangeStatus(#[from] ChangeStatusError),
+    // #[error("component debug view error: {0}")]
+    // ComponentDebug(String),
+    // #[error("component debug view error: {0}")]
+    // ComponentDebugView(#[from] ComponentDebugViewError),
+    // #[error("component name not found")]
+    // ComponentNameNotFound,
+    // #[error("component not found for id: {0}")]
+    // ComponentNotFound(ComponentId),
+    // #[error("component view error: {0}")]
+    // ComponentView(#[from] ComponentViewError),
+    #[error("dal component error: {0}")]
+    DalComponent(#[from] DalComponentError),
+    // #[error("dal schema error: {0}")]
+    // DalSchema(#[from] DalSchemaError),
+    // #[error("diagram error: {0}")]
+    // Diagram(#[from] DiagramError),
+    // #[error("external provider error: {0}")]
+    // ExternalProvider(#[from] ExternalProviderError),
+    // #[error("func error: {0}")]
+    // Func(#[from] FuncError),
+    // #[error("func binding error: {0}")]
+    // FuncBinding(#[from] FuncBindingError),
+    // #[error("hyper error: {0}")]
+    // Http(#[from] axum::http::Error),
+    // #[error("identity func not found")]
+    // IdentityFuncNotFound,
+    // #[error("internal provider error: {0}")]
+    // InternalProvider(#[from] InternalProviderError),
+    // #[error("invalid request")]
+    // InvalidRequest,
     #[error("invalid visibility")]
     InvalidVisibility,
-    #[error("property value key not found")]
-    KeyNotFound,
-    #[error(transparent)]
-    Nats(#[from] si_data_nats::NatsError),
-    #[error("node error: {0}")]
-    Node(#[from] NodeError),
-    #[error(transparent)]
-    Pg(#[from] si_data_pg::PgError),
-    #[error(transparent)]
-    Prop(#[from] PropError),
+    // #[error("property value key not found")]
+    // KeyNotFound,
+    // #[error(transparent)]
+    // Nats(#[from] si_data_nats::NatsError),
+    // #[error("node error: {0}")]
+    // Node(#[from] NodeError),
+    // #[error(transparent)]
+    // Pg(#[from] si_data_pg::PgError),
+    // #[error(transparent)]
+    // Prop(#[from] PropError),
     #[error("property editor error: {0}")]
     PropertyEditor(#[from] PropertyEditorError),
-    #[error("prop not found for id: {0}")]
-    PropNotFound(PropId),
-    #[error("reconciliation prototype: {0}")]
-    ReconciliationPrototype(#[from] ReconciliationPrototypeError),
-    #[error("can't delete attribute value for root prop")]
-    RootPropAttributeValue,
-    #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    // #[error("prop not found for id: {0}")]
+    // PropNotFound(PropId),
+    // #[error("reconciliation prototype: {0}")]
+    // ReconciliationPrototype(#[from] ReconciliationPrototypeError),
+    // #[error("can't delete attribute value for root prop")]
+    // RootPropAttributeValue,
+    // #[error("schema error: {0}")]
+    // Schema(#[from] SchemaError),
     #[error("schema not found")]
     SchemaNotFound,
-    #[error("schema variant not found")]
-    SchemaVariantNotFound,
-    #[error("serde json error: {0}")]
-    SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
-    StandardModel(#[from] StandardModelError),
-    #[error("system id is required: ident_nil_v1() was provided")]
-    SystemIdRequired,
+    // #[error("schema variant not found")]
+    // SchemaVariantNotFound,
+    // #[error("serde json error: {0}")]
+    // SerdeJson(#[from] serde_json::Error),
+    // #[error(transparent)]
+    // StandardModel(#[from] StandardModelError),
+    // #[error("system id is required: ident_nil_v1() was provided")]
+    // SystemIdRequired,
     #[error(transparent)]
     Transactions(#[from] TransactionsError),
-    #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    // #[error("ws event error: {0}")]
+    // WsEvent(#[from] WsEventError),
 }
 
 pub type ComponentResult<T> = std::result::Result<T, ComponentError>;
@@ -143,17 +138,6 @@ impl IntoResponse for ComponentError {
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route(
-            "/get_components_metadata",
-            get(get_components_metadata::get_components_metadata),
-        )
-        .route(
-            "/list_qualifications",
-            get(list_qualifications::list_qualifications),
-        )
-        .route("/list_resources", get(list_resources::list_resources))
-        .route("/get_code", get(get_code::get_code))
-        .route("/get_diff", get(get_diff::get_diff))
-        .route(
             "/get_property_editor_schema",
             get(get_property_editor_schema::get_property_editor_schema),
         )
@@ -162,28 +146,39 @@ pub fn routes() -> Router<AppState> {
             get(get_property_editor_values::get_property_editor_values),
         )
         .route(
-            "/update_property_editor_value",
-            post(update_property_editor_value::update_property_editor_value),
-        )
-        .route(
-            "/insert_property_editor_value",
-            post(insert_property_editor_value::insert_property_editor_value),
-        )
-        .route(
-            "/delete_property_editor_value",
-            post(delete_property_editor_value::delete_property_editor_value),
-        )
-        .route(
             "/get_property_editor_validations",
             get(get_property_editor_validations::get_property_editor_validations),
         )
-        .route("/set_type", post(set_type::set_type))
-        .route("/refresh", post(refresh::refresh))
-        .route("/resource_domain_diff", get(resource_domain_diff::get_diff))
-        .route(
-            "/alter_simulation",
-            post(alter_simulation::alter_simulation),
-        )
-        .route("/debug", get(debug::debug_component))
-        .route("/json", get(json::json))
+    // .route(
+    //     "/get_components_metadata",
+    //     get(get_components_metadata::get_components_metadata),
+    // )
+    // .route(
+    //     "/list_qualifications",
+    //     get(list_qualifications::list_qualifications),
+    // )
+    // .route("/list_resources", get(list_resources::list_resources))
+    // .route("/get_code", get(get_code::get_code))
+    // .route("/get_diff", get(get_diff::get_diff))
+    // .route(
+    //     "/update_property_editor_value",
+    //     post(update_property_editor_value::update_property_editor_value),
+    // )
+    // .route(
+    //     "/insert_property_editor_value",
+    //     post(insert_property_editor_value::insert_property_editor_value),
+    // )
+    // .route(
+    //     "/delete_property_editor_value",
+    //     post(delete_property_editor_value::delete_property_editor_value),
+    // )
+    // .route("/set_type", post(set_type::set_type))
+    // .route("/refresh", post(refresh::refresh))
+    // .route("/resource_domain_diff", get(resource_domain_diff::get_diff))
+    // .route(
+    //     "/alter_simulation",
+    //     post(alter_simulation::alter_simulation),
+    // )
+    // .route("/debug", get(debug::debug_component))
+    // .route("/json", get(json::json))
 }

--- a/lib/sdf-server/src/server/service/component/get_property_editor_schema.rs
+++ b/lib/sdf-server/src/server/service/component/get_property_editor_schema.rs
@@ -1,10 +1,10 @@
 use axum::extract::Query;
 use axum::Json;
 use dal::property_editor::schema::PropertyEditorSchema;
-use dal::{Component, ComponentId, StandardModel, Visibility};
+use dal::{Component, ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
-use super::{ComponentError, ComponentResult};
+use super::ComponentResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -24,24 +24,18 @@ pub async fn get_property_editor_schema(
 ) -> ComponentResult<Json<GetPropertyEditorSchemaResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
-    let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .is_some();
-    if is_component_in_tenancy && !is_component_in_visibility {
-        return Err(ComponentError::InvalidVisibility);
-    }
+    // TODO(nick): restore this functionality with the new graph,
+    // let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
+    // let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
+    //     .await?
+    //     .is_some();
+    // if is_component_in_tenancy && !is_component_in_visibility {
+    //     return Err(ComponentError::InvalidVisibility);
+    // }
 
-    let component = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .ok_or(ComponentError::ComponentNotFound(request.component_id))?;
-    let schema_variant_id = *component
-        .schema_variant(&ctx)
-        .await?
-        .ok_or(ComponentError::SchemaNotFound)?
-        .id();
-    let prop_edit_schema =
-        PropertyEditorSchema::for_schema_variant(&ctx, schema_variant_id).await?;
+    let schema_variant = Component::schema_variant(&ctx, request.component_id).await?;
+
+    let prop_edit_schema = PropertyEditorSchema::assemble(&ctx, schema_variant.id()).await?;
 
     Ok(Json(prop_edit_schema))
 }

--- a/lib/sdf-server/src/server/service/component/get_property_editor_validations.rs
+++ b/lib/sdf-server/src/server/service/component/get_property_editor_validations.rs
@@ -1,9 +1,8 @@
 use axum::extract::{Json, Query};
-use dal::property_editor::validations::PropertyEditorValidations;
-use dal::{Component, ComponentId, StandardModel, Visibility};
+use dal::{ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
-use super::{ComponentError, ComponentResult};
+use super::ComponentResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -14,25 +13,31 @@ pub struct GetPropertyEditorValidationsRequest {
     pub visibility: Visibility,
 }
 
-pub type GetPropertyEditorValidationsResponse = PropertyEditorValidations;
+// TODO(nick): restore original type.
+// pub type GetPropertyEditorValidationsResponse = PropertyEditorValidations;
+
+pub type GetPropertyEditorValidationsResponse = Vec<()>;
 
 pub async fn get_property_editor_validations(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Query(request): Query<GetPropertyEditorValidationsRequest>,
 ) -> ComponentResult<Json<GetPropertyEditorValidationsResponse>> {
-    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let _ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
-    let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .is_some();
-    if is_component_in_tenancy && !is_component_in_visibility {
-        return Err(ComponentError::InvalidVisibility);
-    }
+    // let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
+    // let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
+    //     .await?
+    //     .is_some();
+    // if is_component_in_tenancy && !is_component_in_visibility {
+    //     return Err(ComponentError::InvalidVisibility);
+    // }
+    //
+    // let prop_edit_validations =
+    //     PropertyEditorValidations::for_component(&ctx, request.component_id).await?;
 
-    let prop_edit_validations =
-        PropertyEditorValidations::for_component(&ctx, request.component_id).await?;
+    // TODO(nick): restore functionality.
+    let prop_edit_validations = Vec::new();
 
     Ok(Json(prop_edit_validations))
 }

--- a/lib/sdf-server/src/server/service/component/get_property_editor_values.rs
+++ b/lib/sdf-server/src/server/service/component/get_property_editor_values.rs
@@ -1,10 +1,10 @@
 use axum::extract::Query;
 use axum::Json;
 use dal::property_editor::values::PropertyEditorValues;
-use dal::{Component, ComponentId, StandardModel, Visibility};
+use dal::{ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
-use super::{ComponentError, ComponentResult};
+use super::ComponentResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -24,15 +24,16 @@ pub async fn get_property_editor_values(
 ) -> ComponentResult<Json<GetPropertyEditorValuesResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
-    let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
-        .await?
-        .is_some();
-    if is_component_in_tenancy && !is_component_in_visibility {
-        return Err(ComponentError::InvalidVisibility);
-    }
+    // TODO(nick): restore functionality.
+    // let is_component_in_tenancy = Component::is_in_tenancy(&ctx, request.component_id).await?;
+    // let is_component_in_visibility = Component::get_by_id(&ctx, &request.component_id)
+    //     .await?
+    //     .is_some();
+    // if is_component_in_tenancy && !is_component_in_visibility {
+    //     return Err(ComponentError::InvalidVisibility);
+    // }
 
-    let prop_edit_values = PropertyEditorValues::for_component(&ctx, request.component_id).await?;
+    let prop_edit_values = PropertyEditorValues::assemble(&ctx, request.component_id).await?;
 
     Ok(Json(prop_edit_values))
 }


### PR DESCRIPTION
Primary:
- Restore PropertyEditorSchema with the new engine
- Restore PropertyEditorValues with the new engine
- Use an empty response for PropertyEditorValidations

Secondary:
- Add "EdgeWeightKind::Root" for the root AttributeValue
  - Components "use" both AttributeValues corresponding to providers as well as the root AttributeValue, so this edge indicates which one is root
  - It is possible we may want _both_ a "Use" and a "Root" edge for the root AttributeValue in the future, but until multiple edges for a given source and target is functional, this will suffice
- Add integration test for assembling the property editor
  - This test is trivial and is mostly useful for debugging output
- Restore the Prop "documentation" field
- Ensure "WidgetOptions" works with postcard
  - Postcard wants a known size, but there is potentially another solution lurking here

<img src="https://media0.giphy.com/media/CrvYx0hC04HXncghSL/giphy.gif"/>