### PR TITLE
fix(web): Mark the applied history as collapsed by default 

### DIFF
--- a/app/web/src/components/ApplyHistory.vue
+++ b/app/web/src/components/ApplyHistory.vue
@@ -19,6 +19,7 @@
       v-for="(fixBatch, index) in fixBatches"
       :key="index"
       :fixBatch="fixBatch"
+      :collapse="index !== 0"
     />
   </ScrollArea>
 </template>

--- a/app/web/src/components/ApplyHistoryItem.vue
+++ b/app/web/src/components/ApplyHistoryItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <Collapsible v-if="fixBatch" hideBottomBorder>
+  <Collapsible v-if="fixBatch" :defaultOpen="!props.collapse" hideBottomBorder>
     <template #label>
       <div class="flex flex-row flex-wrap items-center gap-1">
         <div class="font-bold flex flex-row items-center">
@@ -73,7 +73,6 @@
           <Timestamp size="long" :date="new Date(fixBatch.finishedAt)" />
         </div>
       </div>
-
       <ul class="pl-5 mt-2">
         <Collapsible
           v-for="(fix, fix_index) of fixBatch.fixes"
@@ -170,7 +169,10 @@ import CodeViewer from "./CodeViewer.vue";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
 import FixDetails from "./FixDetails.vue";
 
-const props = defineProps<{ fixBatch: FixBatch }>();
+const props = defineProps<{
+  fixBatch: FixBatch;
+  collapse: boolean;
+}>();
 
 const hasCollaborators = computed(
   () => props.fixBatch.actors && props.fixBatch.actors.length > 0,

--- a/app/web/src/components/AssetActionsDetails.vue
+++ b/app/web/src/components/AssetActionsDetails.vue
@@ -52,7 +52,7 @@
             :key="index"
             class="bg-black p-xs"
           >
-            <ApplyHistoryItem :fixBatch="fixBatch" />
+            <ApplyHistoryItem :fixBatch="fixBatch" :collapse="false" />
           </li>
         </ul>
       </TabGroupItem>


### PR DESCRIPTION
<img width="525" alt="Screenshot 2023-12-18 at 23 02 22" src="https://github.com/systeminit/si/assets/227823/6fede16c-fe86-4eb9-9247-4c6d798c79f8">
