### PR TITLE
[wip] feat: pass encryption key as base64 string

### DIFF
--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -29,7 +29,7 @@ pub(crate) struct Args {
 
     /// NATS credentials file
     #[arg(long)]
-    pub(crate) nats_creds_file: Option<String>,
+    pub(crate) nats_creds_path: Option<String>,
 
     /// Disable OpenTelemetry on startup
     #[arg(long)]
@@ -47,7 +47,7 @@ impl TryFrom<Args> for Config {
             if let Some(creds) = args.nats_creds {
                 config_map.set("nats.creds", creds);
             }
-            if let Some(creds_file) = args.nats_creds_file {
+            if let Some(creds_file) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_file);
             }
             config_map.set("nats.connection_name", NAME);

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -51,7 +51,7 @@ pub(crate) struct Args {
 
     /// NATS credentials file
     #[arg(long)]
-    pub(crate) nats_creds_file: Option<String>,
+    pub(crate) nats_creds_path: Option<String>,
 
     /// Disable OpenTelemetry on startup
     #[arg(long)]
@@ -60,6 +60,10 @@ pub(crate) struct Args {
     /// Cyclone encryption key file location [default: /run/pinga/cyclone_encryption.key]
     #[arg(long)]
     pub(crate) cyclone_encryption_key_path: Option<String>,
+
+    /// Cyclone encryption key file contents as a base64 encoded string
+    #[arg(long)]
+    pub(crate) cyclone_encryption_key_base64: Option<String>,
 
     /// The number of concurrent jobs that can be processed [default: 10]
     #[arg(long)]
@@ -99,11 +103,17 @@ impl TryFrom<Args> for Config {
             if let Some(creds) = args.nats_creds {
                 config_map.set("nats.creds", creds);
             }
-            if let Some(creds_file) = args.nats_creds_file {
+            if let Some(creds_file) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_file);
             }
-            if let Some(cyclone_encyption_key_path) = args.cyclone_encryption_key_path {
-                config_map.set("cyclone_encryption_key_path", cyclone_encyption_key_path);
+            if let Some(cyclone_encryption_key_file) = args.cyclone_encryption_key_path {
+                config_map.set("crypto.encryption_key_file", cyclone_encryption_key_file);
+            }
+            if let Some(cyclone_encryption_key_base64) = args.cyclone_encryption_key_base64 {
+                config_map.set(
+                    "crypto.encryption_key_base64",
+                    cyclone_encryption_key_base64,
+                );
             }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -53,7 +53,7 @@ pub(crate) struct Args {
 
     /// NATS credentials file
     #[arg(long)]
-    pub(crate) nats_creds_file: Option<String>,
+    pub(crate) nats_creds_path: Option<String>,
 
     /// Database migration mode on startup
     #[arg(long, value_parser = PossibleValuesParser::new(MigrationMode::variants()))]
@@ -66,6 +66,10 @@ pub(crate) struct Args {
     /// Cyclone encryption key file location [default: /run/sdf/cyclone_encryption.key]
     #[arg(long)]
     pub(crate) cyclone_encryption_key_path: Option<String>,
+
+    /// Cyclone encryption key file contents
+    #[arg(long)]
+    pub(crate) cyclone_encryption_key_base64: Option<String>,
 
     /// Generates cyclone secret key file (does not run server)
     ///
@@ -116,11 +120,17 @@ impl TryFrom<Args> for Config {
             if let Some(creds) = args.nats_creds {
                 config_map.set("nats.creds", creds);
             }
-            if let Some(creds_file) = args.nats_creds_file {
+            if let Some(creds_file) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_file);
             }
-            if let Some(cyclone_encyption_key_path) = args.cyclone_encryption_key_path {
-                config_map.set("cyclone_encryption_key_path", cyclone_encyption_key_path);
+            if let Some(cyclone_encryption_key_file) = args.cyclone_encryption_key_path {
+                config_map.set("crypto.encryption_key_file", cyclone_encryption_key_file);
+            }
+            if let Some(cyclone_encryption_key_base64) = args.cyclone_encryption_key_base64 {
+                config_map.set(
+                    "crypto.encryption_key_base64",
+                    cyclone_encryption_key_base64,
+                );
             }
             if let Some(pkgs_path) = args.pkgs_path {
                 config_map.set("pkgs_path", pkgs_path);

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "256"]
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use color_eyre::Result;
 use sdf_server::{
@@ -73,7 +72,7 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
 
     let config = Config::try_from(args)?;
 
-    let encryption_key = Server::load_encryption_key(config.cyclone_encryption_key_path()).await?;
+    let encryption_key = Server::load_encryption_key(config.crypto().clone()).await?;
     let jwt_public_signing_key =
         Server::load_jwt_public_signing_key(config.jwt_signing_public_key_path()).await?;
 
@@ -97,7 +96,7 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
         nats_conn,
         job_processor,
         veritech,
-        Arc::from(encryption_key),
+        encryption_key,
         Some(pkgs_path),
         Some(module_index_url),
         symmetric_crypto_service,

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -27,7 +27,7 @@ pub(crate) struct Args {
 
     /// NATS credentials file
     #[arg(long)]
-    pub(crate) nats_creds_file: Option<String>,
+    pub(crate) nats_creds_path: Option<String>,
 
     /// Disable OpenTelemetry on startup
     #[arg(long)]
@@ -61,7 +61,7 @@ impl TryFrom<Args> for Config {
             if let Some(creds) = args.nats_creds {
                 config_map.set("nats.creds", creds);
             }
-            if let Some(creds_file) = args.nats_creds_file {
+            if let Some(creds_file) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_file);
             }
             if args.cyclone_local_firecracker {

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -3,10 +3,10 @@ use std::{env, path::Path};
 use buck2_resources::Buck2Resources;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use si_crypto::{SymmetricCryptoServiceConfig, SymmetricCryptoServiceConfigFile};
+use si_crypto::{CryptoConfig, SymmetricCryptoServiceConfig, SymmetricCryptoServiceConfigFile};
 use si_data_nats::NatsConfig;
 use si_data_pg::PgPoolConfig;
-use si_std::{CanonicalFile, CanonicalFileError};
+use si_std::CanonicalFileError;
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -45,7 +45,8 @@ pub struct Config {
     #[builder(default = "NatsConfig::default()")]
     nats: NatsConfig,
 
-    cyclone_encryption_key_path: CanonicalFile,
+    #[builder(default = "CryptoConfig::default()")]
+    crypto: CryptoConfig,
 
     #[builder(default = "default_concurrency_limit()")]
     concurrency: usize,
@@ -78,10 +79,10 @@ impl Config {
         self.nats.subject_prefix.as_deref()
     }
 
-    /// Gets a reference to the config's cyclone public key path.
+    /// Gets a reference to the config's crypto config.
     #[must_use]
-    pub fn cyclone_encryption_key_path(&self) -> &Path {
-        self.cyclone_encryption_key_path.as_path()
+    pub fn crypto(&self) -> &CryptoConfig {
+        &self.crypto
     }
 
     pub fn symmetric_crypto_service(&self) -> &SymmetricCryptoServiceConfig {
@@ -105,8 +106,8 @@ pub struct ConfigFile {
     pg: PgPoolConfig,
     #[serde(default)]
     nats: NatsConfig,
-    #[serde(default = "default_cyclone_encryption_key_path")]
-    cyclone_encryption_key_path: String,
+    #[serde(default)]
+    crypto: CryptoConfig,
     #[serde(default = "default_concurrency_limit")]
     concurrency_limit: usize,
     #[serde(default = "random_instance_id")]
@@ -120,8 +121,8 @@ impl Default for ConfigFile {
         Self {
             pg: Default::default(),
             nats: Default::default(),
-            cyclone_encryption_key_path: default_cyclone_encryption_key_path(),
             concurrency_limit: default_concurrency_limit(),
+            crypto: Default::default(),
             instance_id: random_instance_id(),
             symmetric_crypto_service: default_symmetric_crypto_config(),
         }
@@ -141,7 +142,7 @@ impl TryFrom<ConfigFile> for Config {
         let mut config = Config::builder();
         config.pg_pool(value.pg);
         config.nats(value.nats);
-        config.cyclone_encryption_key_path(value.cyclone_encryption_key_path.try_into()?);
+        config.crypto(value.crypto);
         config.concurrency(value.concurrency_limit);
         config.instance_id(value.instance_id);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
@@ -151,10 +152,6 @@ impl TryFrom<ConfigFile> for Config {
 
 fn random_instance_id() -> String {
     Ulid::new().to_string()
-}
-
-fn default_cyclone_encryption_key_path() -> String {
-    "/run/pinga/cyclone_encryption.key".to_string()
 }
 
 fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
@@ -199,7 +196,7 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
         "detected development run",
     );
 
-    config.cyclone_encryption_key_path = cyclone_encryption_key_path;
+    config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
         active_key: symmetric_crypto_service_key,
         extra_keys: vec![],
@@ -224,7 +221,7 @@ fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
         "detected development run",
     );
 
-    config.cyclone_encryption_key_path = cyclone_encryption_key_path;
+    config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
         active_key: symmetric_crypto_service_key,
         extra_keys: vec![],

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -1,5 +1,6 @@
+use si_crypto::CryptoConfig;
 use std::time::Duration;
-use std::{io, net::SocketAddr, path::Path, path::PathBuf};
+use std::{io, net::SocketAddr, path::Path, path::PathBuf, sync::Arc};
 
 use axum::routing::IntoMakeService;
 use axum::Router;
@@ -219,8 +220,12 @@ impl Server<(), ()> {
     }
 
     #[instrument(name = "sdf.init.load_encryption_key", skip_all)]
-    pub async fn load_encryption_key(path: impl AsRef<Path>) -> Result<CycloneEncryptionKey> {
-        Ok(CycloneEncryptionKey::load(path).await?)
+    pub async fn load_encryption_key(
+        crypto_config: CryptoConfig,
+    ) -> Result<Arc<CycloneEncryptionKey>> {
+        Ok(Arc::new(
+            CycloneEncryptionKey::from_config(crypto_config).await?,
+        ))
     }
 
     #[instrument(name = "sdf.init.migrate_database", skip_all)]

--- a/lib/si-crypto/src/cyclone.rs
+++ b/lib/si-crypto/src/cyclone.rs
@@ -1,3 +1,4 @@
+pub(crate) mod config;
 pub(crate) mod decryption_key;
 pub(crate) mod encryption_key;
 pub(crate) mod key_pair;

--- a/lib/si-crypto/src/cyclone/config.rs
+++ b/lib/si-crypto/src/cyclone/config.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use si_std::CanonicalFile;
+
+/// Configuration for how to load the key for [`CryptoConfig`].
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CryptoConfig {
+    /// Key file encoded as a base64 string
+    pub encryption_key_base64: Option<String>,
+    /// Key file on disk
+    pub encryption_key_file: Option<CanonicalFile>,
+}

--- a/lib/si-crypto/src/lib.rs
+++ b/lib/si-crypto/src/lib.rs
@@ -19,6 +19,7 @@
 mod cyclone;
 mod symmetric;
 
+pub use cyclone::config::CryptoConfig;
 pub use cyclone::decryption_key::{CycloneDecryptionKey, CycloneDecryptionKeyError};
 pub use cyclone::encryption_key::{CycloneEncryptionKey, CycloneEncryptionKeyError};
 pub use cyclone::key_pair::{CycloneKeyPair, CycloneKeyPairError};


### PR DESCRIPTION
Needs a bunch of clean up, but it works!

```bash
./buck-out/v2/gen/root/524f8da68ea2a374/bin/pinga/__pinga__/static_pic/pinga --cyclone-encryption-key-base64 $(cat lib/cyclone-server/src/dev.encryption.key | base64) -vvvv

2023-12-19T02:49:41.677935Z  INFO ThreadId(61) telemetry_application: updated tracing levels to: "trace,pinga=trace,pinga_server=trace"
2023-12-19T02:49:41.679335Z TRACE ThreadId(02) config_file::layered_load: merging defaults config for defaults=SerdeSource { source: ConfigFile { pg: PgPoolConfig { user: "si", password: ..., dbname: "si", application_name: "si-unknown-app", hostname: "localhost", port: 5432, pool_max_size: 128, pool_timeout_wait_secs: None, pool_timeout_create_secs: None, pool_timeout_recycle_secs: None }, nats: NatsConfig { connection_name: None, creds: None, creds_file: None, subject_prefix: None, url: "localhost" }, crypto: CryptoConfig { encryption_key_base64: None, encryption_key_file: None }, concurrency_limit: 5, instance_id: "01HHZZN91FYRAR148C6YDVM4M5", symmetric_crypto_service: SymmetricCryptoServiceConfigFile { active_key: "/run/pinga/donkey.key", extra_keys: [] } } }
...
si_crypto::cyclone::encryption_key: loading cyclone encryption key from base64 string vpq8omDdnI0Ar0KGLRRvXoYK+2sm6FjdiPdnAQGWt3I=
```