### PR TITLE
feat: added drive-ability to web in docker for sdf route

### DIFF
--- a/app/web/docker-entrypoint.sh
+++ b/app/web/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 set -eu
 
 main() {
+  if [ -n "${SI__SDF__HOST:-}" ]; then
+    echo "Info: SI__SDF__HOST supplied [ $SI__SDF__HOST ]! Registering in nginx.conf"
+    sed -i "s/server sdf:5156/$SI__SDF__HOST/g" "$(find /nix/store/ -path '/nix/store/*web/conf/nginx.conf')"
+  fi
   exec @@nginx@@ -c @@conf@@ -p @@prefix@@ -g "daemon off;" "$@"
 }
 


### PR DESCRIPTION
This is a feature change fix to allow us to deploy + drive web api requests to a custom sdf endpoint/dns entry (whilst still hosted in dockerised nginx).

For Production, we are going to host the web docker image in ECS and front it with an ALB Cloudfront (excluding /api for the cache layer) and route the traffic via an ALB either to either the SDF service or web depending on route.

A bit like this:

```
      Cloudfront (app.systeminit.com) <---------> WAF Association
      <excluding /api/* from cache>
             |
            ALB 
             | ___alb_________  / ________ web
                      |________ /api ______ sdf
```

So a user session will look like:
```
  browser -----> api.systeminit.com/index.html 
  *browser loads javascript/page*
  browser -----> api.systeminit.com/api #for dynamic page content
 ```
 
 This should be non-breaking throughout uses of `web` as the environment variable SI__SDF__HOST does not exist anywhere else in the stack
 
 I've checked this by building the image with buck2, tagging it stable in my local docker registry then running it:
 ```
 ┌────────────────────────────┬────────────┬─────────────────────────────────────────────┐
│ Container Image            ┆ State      ┆ Container Version                           │
systeminit/jaeger:stable   ┆     ✅     ┆ 20231109.180504.0-sha.c18a66aea             │
systeminit/postgres:stable ┆     ✅     ┆ 20231109.180504.0-sha.c18a66aea             │
systeminit/nats:stable     ┆     ✅     ┆ 20231109.180504.0-sha.c18a66aea             │
systeminit/otelcol:stable  ┆     ✅     ┆ 20231109.180504.0-sha.c18a66aea             │
systeminit/council:stable  ┆     ✅     ┆ 20231214.165340.0-sha.feed3be7a             │
systeminit/veritech:stable ┆     ✅     ┆ 20231214.211001.0-sha.bf0a03419             │
systeminit/pinga:stable    ┆     ✅     ┆ 20231214.234307.0-sha.36e2875a4             │
systeminit/sdf:stable      ┆     ✅     ┆ 20231214.234307.0-sha.36e2875a4             │
systeminit/web:stable      ┆     ✅     ┆ 20231219.223504.0-sha.2d8ef6e20_dirty-dirty 
```

Then the same image but driving the variable:
```
docker run --env SI__SDF__HOST=johnwatson systeminit/web:20231219.223504.0-sha.2d8ef6e20_dirty-dirty-amd64
Info: SI__SDF__HOST supplied [ johnwatson ]! Registering in nginx.conf
nginx: [emerg] unknown directive "johnwatson" in /nix/store/ab5rz8ii51yngkv25akcyfric6hlbppf-web/conf/nginx.conf:14
```