### PR TITLE
fix: using alternative delimiter permits http-type forms

### DIFF
--- a/app/web/docker-entrypoint.sh
+++ b/app/web/docker-entrypoint.sh
@@ -2,9 +2,9 @@
 set -eu
 
 main() {
-  if [ -n "${SI__SDF__HOST:-}" ]; then
-    echo "Info: SI__SDF__HOST supplied [ $SI__SDF__HOST ]! Registering in nginx.conf"
-    sed -i "s/server sdf:5156/$SI__SDF__HOST/g" "$(find /nix/store/ -path '/nix/store/*web/conf/nginx.conf')"
+  if [ -n "${SI__WEB__SDF_HOST:-}" ]; then
+    echo "Info: SI__WEB__SDF_HOST supplied [ $SI__WEB__SDF_HOST ]! Registering in nginx.conf"
+    sed -i "s^server sdf:5156^server $SI__WEB__SDF_HOST^g" "$(find /nix/store/ -path '/nix/store/*web/conf/nginx.conf')"
   fi
   exec @@nginx@@ -c @@conf@@ -p @@prefix@@ -g "daemon off;" "$@"
 }


### PR DESCRIPTION
Using a `/` delimiter in the replace was a poor choice, as something like `https://app.systeminit.com/api` as the SI__SDF__HOST variable escapes the sed and throws a non-zero exit code, failing the replace.

Using `^` should be better as we'll need want to pass various strings in there over time