### PR TITLE
fix: pass the encryption key path for the launcher

### DIFF
--- a/lib/si-cli/src/engine/docker_engine.rs
+++ b/lib/si-cli/src/engine/docker_engine.rs
@@ -419,6 +419,7 @@ impl ContainerEngine for DockerEngine {
                 "local-otelcol-1:otelcol",
             ])
             .env(vec![
+                "SI_PINGA__CRYPTO__ENCRYPTION_KEY_FILE=/run/pinga/cyclone_encryption.key",
                 "SI_PINGA__NATS__URL=nats",
                 "SI_PINGA__PG__HOSTNAME=postgres",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
@@ -448,6 +449,7 @@ impl ContainerEngine for DockerEngine {
                 "local-otelcol-1:otelcol",
             ])
             .env(vec![
+                "SI_SDF__CRYPTO__ENCRYPTION_KEY_FILE=/run/sdf/cyclone_encryption.key",
                 "SI_SDF__NATS__URL=nats",
                 "SI_SDF__PG__HOSTNAME=postgres",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",

--- a/lib/si-cli/src/engine/podman_engine.rs
+++ b/lib/si-cli/src/engine/podman_engine.rs
@@ -599,6 +599,10 @@ impl ContainerEngine for PodmanEngine {
                 },
             )]))
             .env(HashMap::from([
+                (
+                    "SI_PINGA__CRYPTO__ENCRYPTION_KEY_FILE",
+                    "/run/pinga/cyclone_encryption.key",
+                ),
                 ("SI_PINGA__NATS__URL", "nats"),
                 ("SI_PINGA__PG__HOSTNAME", "postgres"),
                 ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317"),
@@ -647,6 +651,10 @@ impl ContainerEngine for PodmanEngine {
                 },
             )]))
             .env(HashMap::from([
+                (
+                    "SI_SDF__CRYPTO__ENCRYPTION_KEY_FILE",
+                    "/run/sdf/cyclone_encryption.key",
+                ),
                 ("SI_SDF__NATS__URL", "nats"),
                 ("SI_SDF__PG__HOSTNAME", "postgres"),
                 ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317"),


### PR DESCRIPTION
I changed how the defaults work so I could pass this as a base64 encrypted string. This adds the path to the containers directly.

Verified on both linux and macos. 