### PR TITLE
feat: allow passing the secret as a base64 string

### DIFF
--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -65,6 +65,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_encryption_key_base64: Option<String>,
 
+    /// Cyclone secret key as base64 string
+    #[arg(long)]
+    pub(crate) cyclone_secret_key_base64: Option<String>,
+
     /// The number of concurrent jobs that can be processed [default: 10]
     #[arg(long)]
     pub(crate) concurrency: Option<u32>,
@@ -114,6 +118,9 @@ impl TryFrom<Args> for Config {
                     "crypto.encryption_key_base64",
                     cyclone_encryption_key_base64,
                 );
+            }
+            if let Some(secret_string) = args.cyclone_secret_key_base64 {
+                config_map.set("symmetric_crypto_service.active_key_base64", secret_string);
             }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -71,6 +71,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_encryption_key_base64: Option<String>,
 
+    /// Cyclone secret key as base64 string
+    #[arg(long)]
+    pub(crate) cyclone_secret_key_base64: Option<String>,
+
     /// Generates cyclone secret key file (does not run server)
     ///
     /// Will error if set when `generate_cyclone_public_key_path` is not set
@@ -131,6 +135,9 @@ impl TryFrom<Args> for Config {
                     "crypto.encryption_key_base64",
                     cyclone_encryption_key_base64,
                 );
+            }
+            if let Some(secret_string) = args.cyclone_secret_key_base64 {
+                config_map.set("symmetric_crypto_service.active_key_base64", secret_string);
             }
             if let Some(pkgs_path) = args.pkgs_path {
                 config_map.set("pkgs_path", pkgs_path);

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -679,7 +679,8 @@ fn detect_and_configure_testing_for_buck2(builder: &mut ConfigBuilder) -> Result
     builder.jwt_signing_private_key_path(jwt_signing_private_key_path);
     builder.symmetric_crypto_service_config(
         SymmetricCryptoServiceConfigFile {
-            active_key: symmetric_crypto_service_key,
+            active_key: Some(symmetric_crypto_service_key),
+            active_key_base64: None,
             extra_keys: vec![],
         }
         .try_into()?,
@@ -725,7 +726,8 @@ fn detect_and_configure_testing_for_cargo(dir: String, builder: &mut ConfigBuild
     builder.jwt_signing_private_key_path(jwt_signing_private_key_path);
     builder.symmetric_crypto_service_config(
         SymmetricCryptoServiceConfigFile {
-            active_key: symmetric_crypto_service_key,
+            active_key: Some(symmetric_crypto_service_key),
+            active_key_base64: None,
             extra_keys: vec![],
         }
         .try_into()?,

--- a/lib/dal/examples/dal-pkg-export/main.rs
+++ b/lib/dal/examples/dal-pkg-export/main.rs
@@ -130,7 +130,8 @@ async fn create_symmetric_crypto_service() -> Result<SymmetricCryptoService> {
 
     SymmetricCryptoService::from_config(
         &SymmetricCryptoServiceConfigFile {
-            active_key: active_key.to_string_lossy().into_owned(),
+            active_key: Some(active_key.to_string_lossy().into_owned()),
+            active_key_base64: None,
             extra_keys: Default::default(),
         }
         .try_into()?,

--- a/lib/dal/examples/dal-pkg-import/main.rs
+++ b/lib/dal/examples/dal-pkg-import/main.rs
@@ -119,7 +119,8 @@ async fn create_symmetric_crypto_service() -> Result<SymmetricCryptoService> {
 
     SymmetricCryptoService::from_config(
         &SymmetricCryptoServiceConfigFile {
-            active_key: active_key.to_string_lossy().into_owned(),
+            active_key: Some(active_key.to_string_lossy().into_owned()),
+            active_key_base64: None,
             extra_keys: Default::default(),
         }
         .try_into()?,

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -54,6 +54,7 @@ pub struct Config {
     #[builder(default = "random_instance_id()")]
     instance_id: String,
 
+    #[builder(default = "SymmetricCryptoServiceConfig::default()")]
     symmetric_crypto_service: SymmetricCryptoServiceConfig,
 }
 
@@ -156,7 +157,8 @@ fn random_instance_id() -> String {
 
 fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
     SymmetricCryptoServiceConfigFile {
-        active_key: "/run/pinga/donkey.key".into(),
+        active_key: None,
+        active_key_base64: None,
         extra_keys: vec![],
     }
 }
@@ -198,7 +200,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
 
     config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
-        active_key: symmetric_crypto_service_key,
+        active_key: Some(symmetric_crypto_service_key),
+        active_key_base64: None,
         extra_keys: vec![],
     };
 
@@ -223,7 +226,8 @@ fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
 
     config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
-        active_key: symmetric_crypto_service_key,
+        active_key: Some(symmetric_crypto_service_key),
+        active_key_base64: None,
         extra_keys: vec![],
     };
 

--- a/lib/sdf-server/src/server/config.rs
+++ b/lib/sdf-server/src/server/config.rs
@@ -65,6 +65,7 @@ pub struct Config {
     #[builder(default = "PosthogConfig::default()")]
     posthog: PosthogConfig,
 
+    #[builder(default = "SymmetricCryptoServiceConfig::default()")]
     symmetric_crypto_service: SymmetricCryptoServiceConfig,
 
     #[builder(default = "MigrationMode::default()")]
@@ -268,7 +269,8 @@ fn default_pkgs_path() -> String {
 
 fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
     SymmetricCryptoServiceConfigFile {
-        active_key: "/run/sdf/donkey.key".into(),
+        active_key: None,
+        active_key_base64: None,
         extra_keys: vec![],
     }
 }
@@ -335,7 +337,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
     config.jwt_signing_public_key_path = jwt_signing_public_key_path;
     config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
-        active_key: symmetric_crypto_service_key,
+        active_key: Some(symmetric_crypto_service_key),
+        active_key_base64: None,
         extra_keys: vec![],
     };
     config.pkgs_path = pkgs_path;
@@ -383,7 +386,8 @@ fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
     config.jwt_signing_public_key_path = jwt_signing_public_key_path;
     config.crypto.encryption_key_file = cyclone_encryption_key_path.parse().ok();
     config.symmetric_crypto_service = SymmetricCryptoServiceConfigFile {
-        active_key: symmetric_crypto_service_key,
+        active_key: Some(symmetric_crypto_service_key),
+        active_key_base64: None,
         extra_keys: vec![],
     };
     config.pkgs_path = pkgs_path;

--- a/lib/si-cli/src/engine/docker_engine.rs
+++ b/lib/si-cli/src/engine/docker_engine.rs
@@ -422,6 +422,7 @@ impl ContainerEngine for DockerEngine {
                 "SI_PINGA__CRYPTO__ENCRYPTION_KEY_FILE=/run/pinga/cyclone_encryption.key",
                 "SI_PINGA__NATS__URL=nats",
                 "SI_PINGA__PG__HOSTNAME=postgres",
+                "SI_PINGA__SYMMETRIC_CRYPTO_SERVICE__ACTIVE_KEY=/run/pinga/donkey.key",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
             ])
             .volumes([format!("{}:/run/pinga:z", data_dir.display())])
@@ -452,6 +453,7 @@ impl ContainerEngine for DockerEngine {
                 "SI_SDF__CRYPTO__ENCRYPTION_KEY_FILE=/run/sdf/cyclone_encryption.key",
                 "SI_SDF__NATS__URL=nats",
                 "SI_SDF__PG__HOSTNAME=postgres",
+                "SI_SDF__SYMMETRIC_CRYPTO_SERVICE__ACTIVE_KEY=/run/sdf/donkey.key",
                 "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317",
             ])
             .network_mode("bridge")

--- a/lib/si-cli/src/engine/podman_engine.rs
+++ b/lib/si-cli/src/engine/podman_engine.rs
@@ -605,6 +605,10 @@ impl ContainerEngine for PodmanEngine {
                 ),
                 ("SI_PINGA__NATS__URL", "nats"),
                 ("SI_PINGA__PG__HOSTNAME", "postgres"),
+                (
+                    "SI_PINGA__SYMMETRIC_CRYPTO_SERVICE__ACTIVE_KEY",
+                    "/run/pinga/donkey.key",
+                ),
                 ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317"),
             ]))
             .mounts(vec![ContainerMount {
@@ -657,6 +661,10 @@ impl ContainerEngine for PodmanEngine {
                 ),
                 ("SI_SDF__NATS__URL", "nats"),
                 ("SI_SDF__PG__HOSTNAME", "postgres"),
+                (
+                    "SI_SDF__SYMMETRIC_CRYPTO_SERVICE__ACTIVE_KEY",
+                    "/run/sdf/donkey.key",
+                ),
                 ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317"),
             ]))
             .portmappings(vec![PortMapping {


### PR DESCRIPTION
This lets us pass the cbor encoded key that we use to encrypt secrets as a base64 string so we can host in ECS. This was a bit more surgery than the last one, but we got there in the end.