### PR TITLE
debounce ChangeSetWritten

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -437,6 +437,7 @@ export const useAssetStore = () => {
         realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
           {
             eventType: "ChangeSetWritten",
+            debounce: true,
             callback: (writtenChangeSetId) => {
               if (writtenChangeSetId !== changeSetId) return;
               this.LOAD_ASSET_LIST();

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -296,13 +296,12 @@ export function useChangeSetsStore() {
           },
           {
             eventType: "ChangeSetWritten",
-            callback: (cs) => {
+            debounce: true,
+            callback: (changeSetId) => {
               // we'll update a timestamp here so individual components can watch this to trigger something if necessary
               // hopefully with more targeted realtime updates we won't need this, but could be useful for now
-              this.changeSetsWrittenAtById[cs] = new Date();
+              this.changeSetsWrittenAtById[changeSetId] = new Date();
               this.FETCH_CHANGE_SETS();
-
-              // could refetch the change sets here, but not useful right now since no interesting metadata exists on the changeset itself
             },
           },
           {

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -324,6 +324,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
             {
               eventType: "ChangeSetWritten",
+              debounce: true,
               callback: (writtenChangeSetId) => {
                 if (writtenChangeSetId !== changeSetId) return;
                 this.reloadPropertyEditorData();

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1306,14 +1306,16 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           const realtimeStore = useRealtimeStore();
 
           realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
-            {
-              eventType: "ComponentCreated",
-              callback: (_update) => {
-                this.FETCH_DIAGRAM_DATA();
-              },
-            },
+            // dont need to do anything here as we will also get a ChangeSetWritten event
+            // {
+            //   eventType: "ComponentCreated",
+            //   callback: (_update) => {
+            //     this.FETCH_DIAGRAM_DATA();
+            //   },
+            // },
             {
               eventType: "ChangeSetWritten",
+              debounce: true,
               callback: (writtenChangeSetId) => {
                 // ideally we wouldn't have to check this - since the topic subscription
                 // would mean we only receive the event for this changeset already...
@@ -1327,7 +1329,11 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             {
               eventType: "CodeGenerated",
               callback: (codeGeneratedEvent) => {
-                this.FETCH_COMPONENT_CODE(codeGeneratedEvent.componentId);
+                if (
+                  this.selectedComponentId === codeGeneratedEvent.componentId
+                ) {
+                  this.FETCH_COMPONENT_CODE(codeGeneratedEvent.componentId);
+                }
               },
             },
             {

--- a/app/web/src/store/fixes.store.ts
+++ b/app/web/src/store/fixes.store.ts
@@ -117,6 +117,7 @@ export const useFixesStore = () => {
         realtimeStore.subscribe(this.$id, `workspace/${workspacePk}`, [
           {
             eventType: "ChangeSetWritten",
+            debounce: true,
             callback: (writtenChangeSetId) => {
               if (writtenChangeSetId !== nilId()) return;
               this.LOAD_FIX_BATCHES();

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -674,6 +674,7 @@ export const useFuncStore = () => {
         realtimeStore.subscribe(this.$id, `changeset/${selectedChangeSetId}`, [
           {
             eventType: "ChangeSetWritten",
+            debounce: true,
             callback: (writtenChangeSetId) => {
               if (writtenChangeSetId !== selectedChangeSetId) return;
               this.FETCH_FUNC_LIST();

--- a/app/web/src/store/qualifications.store.ts
+++ b/app/web/src/store/qualifications.store.ts
@@ -200,6 +200,7 @@ export const useQualificationsStore = () => {
             {
               // TODO(nick,theo,fletcher,wendy): replace this someday.
               eventType: "ChangeSetWritten",
+              debounce: true,
               callback: () => {
                 this.FETCH_QUALIFICATIONS_SUMMARY();
               },

--- a/app/web/src/store/reconciliations.store.ts
+++ b/app/web/src/store/reconciliations.store.ts
@@ -78,6 +78,7 @@ export const useReconciliationsStore = () => {
         realtimeStore.subscribe(this.$id, `workspace/${workspacePk}/head`, [
           {
             eventType: "ChangeSetWritten",
+            debounce: true,
             callback: (writtenChangeSetId) => {
               if (writtenChangeSetId !== nilId()) return;
               this.LOAD_RECONCILIATIONS();

--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -456,6 +456,7 @@ export function useSecretsStore() {
         realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
           {
             eventType: "ChangeSetWritten",
+            debounce: true,
             callback: (writtenChangeSetId) => {
               // ideally we wouldn't have to check this - since the topic subscription
               // would mean we only receive the event for this changeset already...


### PR DESCRIPTION
not a good longterm solution, as this actually introduces delay between receiving events and things happening... BUT this is a good fix for now until we fire off smarter events instead of refreshing everything constantly