### PR TITLE
Add the ability to create inter-component edges with the new engine (ENG-2202)

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -117,8 +117,9 @@ pub async fn migrate(
     // func::migrate(ctx).await?;
 
     // FIXME(nick): restore builtin migration functionality for all variants.
-    info!("migrate schema for docker image package");
+    info!("migrate minimal number of schemas for testing the new engine");
     schema::migrate_pkg(ctx, SI_DOCKER_IMAGE_PKG, None).await?;
+    schema::migrate_pkg(ctx, SI_COREOS_PKG, None).await?;
 
     // match selected_test_builtin_schemas {
     //     Some(found_selected_test_builtin_schemas) => {

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -339,7 +339,22 @@ impl NodeWeight {
         }
     }
 
-    // NOTE(nick): individual node weight funcs below.
+    pub fn get_option_content_node_weight_of_kind(
+        &self,
+        content_addr_discrim: ContentAddressDiscriminants,
+    ) -> Option<ContentNodeWeight> {
+        match self {
+            NodeWeight::Content(inner) => {
+                let inner_addr_discrim: ContentAddressDiscriminants =
+                    inner.content_address().into();
+                if inner_addr_discrim != content_addr_discrim {
+                    return None;
+                }
+                Some(inner.to_owned())
+            }
+            _other => None,
+        }
+    }
 
     pub fn new_content(
         change_set: &ChangeSetPointer,

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge.rs
@@ -5,6 +5,7 @@
 
 mod builtins;
 mod component;
+mod connection;
 mod property_editor;
 mod rebaser;
 mod sdf_mock;

--- a/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/connection.rs
+++ b/lib/dal/tests/integration_test/internal/mostly_everything_is_a_node_or_an_edge/connection.rs
@@ -1,0 +1,71 @@
+use dal::{Component, DalContext, ExternalProvider, InternalProvider, Schema, SchemaVariant};
+use dal_test::test;
+
+#[test]
+async fn connect_components_simple(ctx: &DalContext) {
+    // Get the source schema variant id.
+    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let mut docker_image_schema_variants =
+        SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
+            .await
+            .expect("could not list schema variants for schema");
+    let docker_image_schema_variant = docker_image_schema_variants
+        .pop()
+        .expect("schema variants are empty");
+    let docker_image_schema_variant_id = docker_image_schema_variant.id();
+
+    // Get the destination schema variant id.
+    let butane_schema = Schema::find_by_name(ctx, "Butane")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
+        .await
+        .expect("could not list schema variants for schema");
+    let butane_schema_variant = butane_schema_variants
+        .pop()
+        .expect("schema variants are empty");
+    let butane_schema_variant_id = butane_schema_variant.id();
+
+    // Find the providers we want to use.
+    let docker_image_external_providers =
+        ExternalProvider::list(ctx, docker_image_schema_variant_id)
+            .await
+            .expect("could not list external providers");
+    let external_provider = docker_image_external_providers
+        .iter()
+        .find(|e| e.name() == "Container Image")
+        .expect("could not find external provider");
+    let butane_explicit_internal_providers =
+        InternalProvider::list_explicit(ctx, butane_schema_variant_id)
+            .await
+            .expect("could not list explicit internal providers");
+    let explicit_internal_provider = butane_explicit_internal_providers
+        .iter()
+        .find(|e| e.name() == "Container Image")
+        .expect("could not find explicit internal provider");
+
+    // Create a component for both the source and the destination
+    let oysters_component = Component::new(
+        ctx,
+        "oysters in my pocket",
+        docker_image_schema_variant_id,
+        None,
+    )
+    .expect("could not create component");
+    let royel_component = Component::new(ctx, "royel otis", butane_schema_variant_id, None)
+        .expect("could not create component");
+
+    // Connect the components!
+    Component::connect(
+        ctx,
+        oysters_component.id(),
+        external_provider.id(),
+        royel_component.id(),
+        explicit_internal_provider.id(),
+    )
+    .expect("could not connect components");
+}


### PR DESCRIPTION
- Add the ability to create inter-Component edges with the new engine
  - These are called "connections"
- Extend AttributePrototypeArgument to hold side effect metadata for a given connection
- Add the ability to find the AttributeValue corresponding to a Component and an explicit InternalProvider
- Add an integration test to test the new functionality

<img src="https://media1.giphy.com/media/jPGWvQM7IKGTYz67Jf/giphy.gif"/>