### PR TITLE
Avoid blocking frontend when actions are running

### DIFF
--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -52,7 +52,8 @@ function typeDisplayName(action = "delete") {
 
 const rightClickMenuItems = computed(() => {
   const items: DropdownMenuItemObjectDef[] = [];
-  const disabled = fixesStore.fixesAreInProgress;
+  const disabled =
+    fixesStore.fixesAreInProgress && featureFlagsStore.DONT_BLOCK_ON_ACTIONS;
   if (selectedEdgeId.value) {
     // single selected edge
     if (selectedEdge.value?.changeStatus === "deleted") {

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -25,7 +25,10 @@
         variant="ghost"
         icon="git-branch-plus"
         size="sm"
-        :disabled="fixesStore.fixesAreInProgress"
+        :disabled="
+          fixesStore.fixesAreInProgress &&
+          featureFlagStore.DONT_BLOCK_ON_ACTIONS
+        "
         @click="openCreateModal"
       />
 
@@ -36,7 +39,8 @@
         icon="trash"
         size="sm"
         :disabled="
-          fixesStore.fixesAreInProgress ||
+          (fixesStore.fixesAreInProgress &&
+            featureFlagStore.DONT_BLOCK_ON_ACTIONS) ||
           !selectedChangeSetName ||
           changeSetsStore.headSelected
         "

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -16,6 +16,7 @@ const FLAG_MAPPING = {
   ABANDON_CHANGESET: "abandon_changeset",
   CONNECTION_ANNOTATIONS: "socket_connection_annotations",
   COPY_PASTE: "copy_paste",
+  DONT_BLOCK_ON_ACTIONS: "dont_block_on_actions",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;


### PR DESCRIPTION
This may trigger unexpected behavior, but it's not something we want in the long run and it's probably not needed anymore.

The only missing piece to decide is, should we block running the same action on the same component if one is running? What if the action source code changed, or if the user changed a property in between?

But if 2 create actions for the same component run in parallel they may lose the resource from the first one to finish, since it will be overwritten.