### PR TITLE
window/keyboard event handling priority

### DIFF
--- a/app/web/src/components/AssetPalette.vue
+++ b/app/web/src/components/AssetPalette.vue
@@ -57,7 +57,7 @@
                       : '',
                   )
                 "
-                @mousedown.left="onSelect(schema.id, fixesAreRunning)"
+                @mousedown.left.stop="onSelect(schema.id, fixesAreRunning)"
                 @click.right.prevent
               />
             </li>
@@ -84,6 +84,7 @@ import * as _ from "lodash-es";
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import { Collapsible, Icon, ScrollArea } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { windowListenerManager } from "@si/vue-lib";
 import SiNodeSprite from "@/components/SiNodeSprite.vue";
 import {
   useComponentsStore,
@@ -166,7 +167,6 @@ const selectedSchema = computed(() => {
     return schemasById.value[componentsStore.selectedInsertSchemaId];
   return undefined;
 });
-const selecting = ref(false);
 const mouseNode = ref();
 
 const updateMouseNode = (e: MouseEvent) => {
@@ -186,23 +186,26 @@ function onSelect(schemaId: string, fixesAreRunning: boolean) {
 
   if (componentsStore.selectedInsertSchemaId === schemaId) {
     componentsStore.cancelInsert();
-    selecting.value = false;
   } else {
     componentsStore.setInsertSchema(schemaId);
-    selecting.value = true;
   }
 }
 
 const onKeyDown = (e: KeyboardEvent) => {
-  if (e.key === "Escape" || e.key === "Backspace") {
+  if (
+    (e.key === "Escape" || e.key === "Backspace") &&
+    componentsStore.selectedInsertSchemaId
+  ) {
     componentsStore.cancelInsert();
+    e.stopPropagation();
   }
 };
 
 const onMouseDown = (e: MouseEvent) => {
   updateMouseNode(e);
-  if (selecting.value) selecting.value = false;
-  else componentsStore.cancelInsert();
+  if (componentsStore.selectedInsertSchemaId) {
+    componentsStore.cancelInsert();
+  }
 };
 
 const onMouseMove = (e: MouseEvent) => {
@@ -210,14 +213,14 @@ const onMouseMove = (e: MouseEvent) => {
 };
 
 onMounted(() => {
-  window.addEventListener("mousemove", onMouseMove);
-  window.addEventListener("keydown", onKeyDown);
-  window.addEventListener("mousedown", onMouseDown);
+  windowListenerManager.addEventListener("mousemove", onMouseMove);
+  windowListenerManager.addEventListener("keydown", onKeyDown, 5);
+  windowListenerManager.addEventListener("mousedown", onMouseDown);
 });
 
 onBeforeUnmount(() => {
-  window.removeEventListener("mousemove", onMouseMove);
-  window.removeEventListener("keydown", onKeyDown);
-  window.removeEventListener("mousedown", onMouseDown);
+  windowListenerManager.removeEventListener("mousemove", onMouseMove);
+  windowListenerManager.removeEventListener("keydown", onKeyDown);
+  windowListenerManager.removeEventListener("mousedown", onMouseDown);
 });
 </script>

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -154,6 +154,7 @@ overflow hidden */
             fill: SELECTION_BOX_INNER_COLOR,
             strokeWidth: 1,
             stroke: SELECTION_COLOR,
+            listening: false,
           }"
         />
 
@@ -216,6 +217,7 @@ import {
   connectionAnnotationFitsReference,
   parseConnectionAnnotation,
 } from "@si/ts-lib/src/connection-annotations";
+import { windowListenerManager } from "@si/vue-lib";
 import { useCustomFontsLoaded } from "@/utils/useFontLoaded";
 import DiagramGroup from "@/components/ModelingDiagram/DiagramGroup.vue";
 import {
@@ -503,10 +505,11 @@ function onMountedAndReady() {
   kStage.on("wheel", onMouseWheel);
   // attach to window so we have coords even when mouse is outside bounds or on other elements
   // NOTE - mousedown is attached on the konva stage component above, since we only care about starting clicks within the diagram
-  window.addEventListener("mousemove", onMouseMove);
-  window.addEventListener("mouseup", onMouseUp);
-  window.addEventListener("keydown", onKeyDown);
-  window.addEventListener("keyup", onKeyUp);
+  windowListenerManager.addEventListener("mousemove", onMouseMove);
+  windowListenerManager.addEventListener("mouseup", onMouseUp);
+  windowListenerManager.addEventListener("keydown", onKeyDown);
+  windowListenerManager.addEventListener("keyup", onKeyUp);
+
   // window.addEventListener("pointerdown", onPointerDown);
   // window.addEventListener("pointermove", onPointerMove);
   // window.addEventListener("pointerup", onPointerUp);
@@ -517,10 +520,11 @@ function onMountedAndReady() {
 
 onBeforeUnmount(() => {
   kStage?.off("wheel", onMouseWheel);
-  window.removeEventListener("mousemove", onMouseMove);
-  window.removeEventListener("mouseup", onMouseUp);
-  window.removeEventListener("keydown", onKeyDown);
-  window.removeEventListener("keyup", onKeyUp);
+  windowListenerManager.removeEventListener("mousemove", onMouseMove);
+  windowListenerManager.removeEventListener("mouseup", onMouseUp);
+  windowListenerManager.removeEventListener("keydown", onKeyDown);
+  windowListenerManager.removeEventListener("keyup", onKeyUp);
+
   // window.removeEventListener("pointerdown", onPointerDown);
   // window.removeEventListener("pointermove", onPointerMove);
   // window.removeEventListener("pointerup", onPointerUp);

--- a/app/web/src/components/Popover.vue
+++ b/app/web/src/components/Popover.vue
@@ -27,6 +27,7 @@ import {
 } from "vue";
 import * as _ from "lodash-es";
 import clsx from "clsx";
+import { windowListenerManager } from "@si/vue-lib";
 
 const props = defineProps({
   anchorTo: { type: Object },
@@ -74,14 +75,16 @@ function onWindowMousedown(e: MouseEvent) {
 
 function onKeyboardEvent(e: KeyboardEvent) {
   if (e.key === "Escape") {
+    e.stopPropagation();
+
     if (props.noExit) return;
     close();
   }
 }
 
 function removeListeners() {
-  window.removeEventListener("click", onWindowMousedown);
-  window.removeEventListener("keydown", onKeyboardEvent);
+  windowListenerManager.removeEventListener("click", onWindowMousedown);
+  windowListenerManager.removeEventListener("keydown", onKeyboardEvent);
 }
 
 onBeforeUnmount(() => {
@@ -135,8 +138,8 @@ function finishOpening() {
 }
 
 function startListening() {
-  window.addEventListener("keydown", onKeyboardEvent);
-  window.addEventListener("mousedown", onWindowMousedown);
+  windowListenerManager.addEventListener("keydown", onKeyboardEvent, 10);
+  windowListenerManager.addEventListener("mousedown", onWindowMousedown, 10);
 }
 
 function readjustPosition() {

--- a/lib/vue-lib/src/index.ts
+++ b/lib/vue-lib/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./utils/tw-utils";
 export { default as formatters } from "./utils/formatting";
+export * from "./utils/listener-manager";

--- a/lib/vue-lib/src/utils/listener-manager.ts
+++ b/lib/vue-lib/src/utils/listener-manager.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as _ from "lodash-es";
+
+type ListenerCallback = (e: any) => any;
+type WindowListenerTypes = keyof WindowEventMap;
+
+export class WindowListenerManager {
+  private callbacksByType: Partial<
+    Record<
+      WindowListenerTypes,
+      { priority: number; callback: ListenerCallback }[]
+    >
+  > = {};
+
+  constructor(private el: Window) {}
+
+  addEventListener<ET extends WindowListenerTypes>(
+    type: ET,
+    callback: ListenerCallback,
+    priority = 1,
+  ) {
+    if (!this.callbacksByType[type]) {
+      this.callbacksByType[type] = [];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.callbacksByType[type]!.push({
+      priority,
+      callback,
+    });
+    if (this.callbacksByType[type]?.length === 1) {
+      window.addEventListener(type, this.listenerHandler);
+    }
+  }
+  removeEventListener<ET extends WindowListenerTypes>(
+    type: ET,
+    callback: ListenerCallback,
+  ) {
+    this.callbacksByType[type] = _.reject(
+      this.callbacksByType[type],
+      (c) => c.callback === callback,
+    );
+    if (this.callbacksByType[type]?.length === 0) {
+      window.removeEventListener(type, this.listenerHandler);
+    }
+  }
+
+  private listenerHandler = (e: Event) => {
+    (e as any)._isStopped = false;
+    const originalStop = e.stopPropagation;
+    const originalStopImmediate = e.stopImmediatePropagation;
+    e.stopPropagation = () => {
+      (e as any)._isStopped = true;
+      originalStop.call(e);
+    };
+    e.stopImmediatePropagation = () => {
+      (e as any)._isStopped = true;
+      originalStopImmediate.call(e);
+    };
+
+    const callbacks = _.orderBy(
+      _.filter(this.callbacksByType[e.type as WindowListenerTypes]),
+      (l) => l.priority,
+      ["desc"],
+    );
+
+    for (const callbackWithPriority of callbacks) {
+      callbackWithPriority.callback(e);
+      // check if our overridden stopPropogation methods were called so we can stop calling the next events
+      if ((e as any)._isStopped) {
+        break;
+      }
+    }
+  };
+}
+
+export const windowListenerManager = new WindowListenerManager(window);


### PR DESCRIPTION
implement event priority-aware event manager so we can still use window-bound key events, but handle them in the right order. Previously the modeling diagram component was catching all key events, so hitting escape was actually deselecting the current selection - which triggered modals/popovers to close. Now the popover/modal key handlers have a higher priority, so we can close the modal, and stop the event from triggering deselection.

Bonus - ignore mouse events on blue drag-to-select box, so that quick mouse movements dont mess with hover states