### PR TITLE
feat: serialize jail usage

### DIFF
--- a/bin/veritech/scripts/stop.sh
+++ b/bin/veritech/scripts/stop.sh
@@ -4,40 +4,5 @@ set -euo pipefail
 
 SB_ID="${1:-null}"
 
-JAILER_BINARY="/usr/bin/jailer"
-TAP_DEV="fc-${SB_ID}-tap0"
-
 # Kill the firecracker process
 ps aux | grep "firecracke[r] --id $SB_ID" | awk '{ print $2 }' | xargs kill -9 || true
-
-# Remove TAP device
-ip link del "$TAP_DEV" 2> /dev/null || true
-
-# Remove veth devices
-ip link del veth-main$SB_ID 2> /dev/null || true
-ip link del veth-jailer$SB_ID 2> /dev/null || true
-
-# Remove iptables rules
-ip netns exec jailer-$SB_ID iptables -t nat -D POSTROUTING -o veth-jailer$SB_ID -j MASQUERADE || true
-ip netns exec jailer-$SB_ID iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
-ip netns exec jailer-$SB_ID iptables -D FORWARD -i fc-$SB_ID-tap0 -o veth-jailer$SB_ID -j ACCEPT || true
-
-# Remove network namespace
-ip netns del jailer-$SB_ID || true
-
-# Remove user and group
-userdel jailer-$SB_ID || true
-
-# Remove directories and files
-umount /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4 || true
-dmsetup remove rootfs-overlay-$SB_ID || true
-
-# We are not currently creating these.
-# umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true
-# dmsetup remove kernel-overlay-$SB_ID || true
-
-# TODO(scott): figure out a better way to do this.
-# this will only detach devices removed from device-mapper
-# but it still feels bad
-losetup --detach-all
-rm -rf /srv/jailer/firecracker/$SB_ID

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -67,6 +67,15 @@ pub enum LocalUdsInstanceError {
     /// Docker api not found
     #[error("no docker api")]
     DockerAPINotFound,
+    /// Failed to parse the Firecracker PID file.
+    #[error("failed to parse the firecracker pid file")]
+    FirecrackerPidParse(#[source] std::num::ParseIntError),
+    /// Failed to read the Firecracker PID file.
+    #[error("failed to open the firecracker pid file")]
+    FirecrackerPidRead(#[source] io::Error),
+    /// Failed to write the Firecracker PID file.
+    #[error("failed to write the firecracker pid file")]
+    FirecrackerPidWrite(#[source] io::Error),
     /// Failed to create firecracker-setup file.
     #[error("failed to create firecracker-setup file")]
     FirecrackerSetupCreate(#[source] io::Error),
@@ -715,22 +724,46 @@ impl LocalInstanceRuntime for LocalDockerRuntime {
 
 #[derive(Debug)]
 struct LocalFirecrackerRuntime {
-    vm_id: String,
+    cmd: Command,
+    child: Option<Child>,
     socket: PathBuf,
 }
 
 impl LocalFirecrackerRuntime {
-    async fn build(spec: LocalUdsInstanceSpec) -> Result<Box<dyn LocalInstanceRuntime>> {
-        // TODO(johnwatson): Run some checks against the ID to see if it's been used before
-        // Calculate it instead of random? Or have an incrementing pool 1..5000 that we loop
-        // over, ensuring that we do cleanup along the way
-        // Obviously this has the potential to clash, but overall the risk here is fairly low
-        // assuming that cleanup works as expected ;)
-        let vm_id: String = thread_rng().gen_range(0..spec.pool_size).to_string();
-        let sock = PathBuf::from(&format!("/srv/jailer/firecracker/{}/root/v.sock", vm_id));
+    async fn build() -> Result<Box<dyn LocalInstanceRuntime>> {
+        // todo(scott): the pid is a naive method for removing serially creating jails.
+        // we read the pid, use that as the vm_id, and then increment it.
+        // There are obvious contention problems here, but we should address
+        // this within deadpool itself.
+        let pid = Path::new("/firecracker-data/pid");
+        let vm_id = &std::fs::read_to_string(pid)
+            .map_err(LocalUdsInstanceError::FirecrackerPidRead)?
+            .parse::<i32>()
+            .map_err(LocalUdsInstanceError::FirecrackerPidParse)?;
+        std::fs::write(pid, format!("{}", vm_id + 1))
+            .map_err(LocalUdsInstanceError::FirecrackerPidWrite)?;
 
+        let mut cmd = Command::new("/usr/bin/jailer");
+        cmd.arg("--cgroup-version")
+            .arg("2")
+            .arg("--id")
+            .arg(vm_id.to_string())
+            .arg("--exec-file")
+            .arg("/usr/bin/firecracker")
+            .arg("--uid")
+            .arg(format!("10000{}", vm_id))
+            .arg("--gid")
+            .arg("10000")
+            .arg("--netns")
+            .arg(format!("/var/run/netns/jailer-{}", vm_id))
+            .arg("--")
+            .arg("--config-file")
+            .arg("./firecracker.conf");
+
+        let sock = PathBuf::from(&format!("/srv/jailer/firecracker/{}/root/v.sock", vm_id));
         Ok(Box::new(LocalFirecrackerRuntime {
-            vm_id,
+            cmd,
+            child: None,
             socket: sock,
         }))
     }
@@ -743,41 +776,22 @@ impl LocalInstanceRuntime for LocalFirecrackerRuntime {
     }
 
     async fn spawn(&mut self) -> result::Result<(), LocalUdsInstanceError> {
-        let command = "/firecracker-data/start.sh ".to_owned() + &self.vm_id;
-
-        // Spawn the shell process
-        let _status = Command::new("sudo")
-            .arg("bash")
-            .arg("-c")
-            .arg(command)
-            .status()
-            .await;
-
+        self.child = Some(
+            self.cmd
+                .spawn()
+                .map_err(LocalUdsInstanceError::ChildSpawn)?,
+        );
         Ok(())
     }
 
     async fn terminate(&mut self) -> result::Result<(), LocalUdsInstanceError> {
-        let stop_command = format!("/firecracker-data/stop.sh {}", &self.vm_id);
-
-        // Spawn the stop script
-        let _status = Command::new("sudo")
-            .arg("bash")
-            .arg("-c")
-            .arg(stop_command)
-            .status()
-            .await;
-
-        let prepare_command = format!("/firecracker-data/prepare_jailer.sh {}", &self.vm_id);
-
-        // Re-setup the jail so it can be resued
-        let _status = Command::new("sudo")
-            .arg("bash")
-            .arg("-c")
-            .arg(prepare_command)
-            .status()
-            .await;
-
-        Ok(())
+        match self.child.as_mut() {
+            Some(c) => {
+                process::child_shutdown(c, Some(process::Signal::SIGTERM), None).await?;
+                Ok(())
+            }
+            None => Ok(()),
+        }
     }
 }
 
@@ -792,15 +806,14 @@ async fn runtime_instance_from_spec(
         LocalUdsRuntimeStrategy::LocalDocker => {
             LocalDockerRuntime::build(socket, spec.clone()).await
         }
-        LocalUdsRuntimeStrategy::LocalFirecracker => {
-            LocalFirecrackerRuntime::build(spec.clone()).await
-        }
+        LocalUdsRuntimeStrategy::LocalFirecracker => LocalFirecrackerRuntime::build().await,
     }
 }
 
 async fn setup_firecracker(spec: &LocalUdsInstanceSpec) -> Result<()> {
     let script_bytes = include_bytes!("firecracker-setup.sh");
     let command = Path::new("/firecracker-data/firecracker-setup.sh");
+    let pid = Path::new("/firecracker-data/pid");
 
     // we need to ensure the file is in the correct location with the correct permissions
     std::fs::create_dir_all(
@@ -813,6 +826,13 @@ async fn setup_firecracker(spec: &LocalUdsInstanceSpec) -> Result<()> {
     std::fs::set_permissions(command, std::fs::Permissions::from_mode(0o755))
         .map_err(LocalUdsInstanceError::FirecrackerSetupPermissions)?;
 
+    // firecracker pid is used to serialize jail creation
+    std::fs::create_dir_all(
+        pid.parent()
+            .expect("This should never happen. Did you remove the path from the string above?"),
+    )
+    .map_err(LocalUdsInstanceError::FirecrackerSetupCreate)?;
+    std::fs::write(pid, "0").map_err(LocalUdsInstanceError::FirecrackerSetupWrite)?;
     // Spawn the shell process
     let _status = Command::new("sudo")
         .arg(command)


### PR DESCRIPTION
This does two things:

1. We now manage a small file that is used to keep track of jail ids. We want to never reuse jails, the overhead of repreparing them is too much and the risk of failure is too high. We cannot rely on random id generation as the jails must exist on disk at a known path. This will (mostly) ensure that we use the next available jail and that jails are not reused. There are really big contention problems with this approach, but it should be enough to get us by until we can build a proper pool management suite.
2. This change means that our stop/start processes for jails is down to only interacting with the jailer process itself. Therefore, we can remove the `{start,stop}.sh` scripts from the path and manage the jailer process directly in rust. Hurray!