### PR TITLE
WorkspaceSnapshoGraph cleanup speedup

### DIFF
--- a/lib/rebaser-server/src/server/change_set_loop.rs
+++ b/lib/rebaser-server/src/server/change_set_loop.rs
@@ -170,15 +170,20 @@ async fn process_delivery(
             &mut onto_workspace_snapshot,
             updates.as_slice(),
         )?;
+        info!("Updates complete: {:?}", start.elapsed());
 
-        // Once all updates have been performed, we can write out, mark everything as recently seen
-        // and update the pointer.
-        to_rebase_workspace_snapshot
-            .write(ctx, to_rebase_change_set.vector_clock_id())
-            .await?;
-        to_rebase_change_set
-            .update_pointer(ctx, to_rebase_workspace_snapshot.id())
-            .await?;
+        if !updates.is_empty() {
+            // Once all updates have been performed, we can write out, mark everything as recently seen
+            // and update the pointer.
+            to_rebase_workspace_snapshot
+                .write(ctx, to_rebase_change_set.vector_clock_id())
+                .await?;
+            info!("Snapshot written: {:?}", start.elapsed());
+            to_rebase_change_set
+                .update_pointer(ctx, to_rebase_workspace_snapshot.id())
+                .await?;
+            info!("Pointer updated: {:?}", start.elapsed());
+        }
 
         ChangeSetReplyMessage::Success {
             updates_performed: serde_json::to_value(updates)?,


### PR DESCRIPTION
* Only prune & write out new workspace snapshot graph if there have been changes in rebaser
* Speed up garbage collection of un-referenced nodes in WorkspaceSnapshotGraph

    We want to remove all of the "garbage" we've accumulated while operating on the graph.
    Anything that is no longer reachable from the current `self.root_index` should be
    removed as it is no longer referenced by anything in the current version of the graph.

    Fortunately, we don't need to walk the graph to find out if something is reachable from
    the root, since `has_path_connecting` is slow (depth-first search). Any node that does
    *NOT* have any incoming edges (aside from the `self.root_index` node) is not reachable,
    by definition. Finding the list of nodes with no incoming edges is very fast.

    If we remove all nodes (that are not the `self.root_index` node) that do
    not have any incoming edges, and we keep doing this until the only one
    left is the `self.root_index` node, then all remaining nodes are
    reachable from `self.root_index`.
