### PR TITLE
Fix RabbitMQ infinite hangs when it isn't ready (ENG-2214)

### DIFF
--- a/lib/si-rabbitmq/src/environment.rs
+++ b/lib/si-rabbitmq/src/environment.rs
@@ -1,10 +1,14 @@
 use rabbitmq_stream_client::error::{StreamCreateError, StreamDeleteError};
 use rabbitmq_stream_client::types::{ByteCapacity, ResponseCode};
 use rabbitmq_stream_client::Environment as UpstreamEnvironment;
+use std::time::Duration;
+use telemetry::prelude::{info, trace, warn};
 
-use crate::{config::Config, error::RabbitResult};
+use crate::{config::Config, error::RabbitResult, RabbitError};
 
 const STREAM_LENGTH_CAPACTIY_IN_MEGABYTES: u64 = 10;
+const ENVIRONMENT_CREATION_TIMEOUT_DURATION_IN_SECONDS: u64 = 4;
+const ENVIRONMENT_CREATION_RETRIES: u64 = 3;
 
 /// A connection to a RabbitMQ node.
 #[allow(missing_debug_implementations)]
@@ -15,14 +19,33 @@ pub struct Environment {
 impl Environment {
     /// Creates a new [`Environment`], which contains a connection to a RabbitMQ node.
     pub async fn new(config: &Config) -> RabbitResult<Self> {
-        let inner = UpstreamEnvironment::builder()
-            .host(config.host())
-            .username(config.username())
-            .password(config.password())
-            .port(config.port())
-            .build()
-            .await?;
-        Ok(Self { inner })
+        // Create a range starting from "1" using the retries constant.
+        let range = 1..ENVIRONMENT_CREATION_RETRIES + 1;
+
+        // Attempt to create an environment with the above range and the given timeout duration.
+        for attempt in range {
+            info!("attempt {attempt} of {ENVIRONMENT_CREATION_RETRIES} to connect to RabbitMQ...");
+            match tokio::time::timeout(
+                Duration::from_secs(ENVIRONMENT_CREATION_TIMEOUT_DURATION_IN_SECONDS),
+                UpstreamEnvironment::builder()
+                    .host(config.host())
+                    .username(config.username())
+                    .password(config.password())
+                    .port(config.port())
+                    .build(),
+            )
+            .await
+            {
+                Ok(result) => return Ok(Self { inner: result? }),
+                Err(elapsed) => {
+                    warn!("hit timeout when trying to communicate with RabbitMQ (duration: {ENVIRONMENT_CREATION_TIMEOUT_DURATION_IN_SECONDS} seconds)");
+                    trace!("{elapsed}");
+                }
+            };
+        }
+
+        // If we have exited the loop, we have hit the max number of retries.
+        Err(RabbitError::EnvironmentCreationFailed)
     }
 
     /// Returns the inner data structure handling the connection.

--- a/lib/si-rabbitmq/src/error.rs
+++ b/lib/si-rabbitmq/src/error.rs
@@ -18,6 +18,8 @@ pub enum RabbitError {
     ConsumerCreate(#[from] ConsumerCreateError),
     #[error("consumer delivery error: {0}")]
     ConsumerDelivery(#[from] ConsumerDeliveryError),
+    #[error("failed to create an environment")]
+    EnvironmentCreationFailed,
     #[error("from utf-8 error: {0}")]
     FromUtf8(#[from] FromUtf8Error),
     #[error("producer close error: {0}")]


### PR DESCRIPTION
Fix RabbitMQ infinite hangs by using a timeout-and-retry technique. When RabbitMQ is booting up and a user tries to create an "Environment" using the streams port, there can be an infinite hang. That is an issue in its own right, but this change seeks to avoid it entirely.

On macOS aarch64 with an M1 Max, it appears that RabbitMQ needs about ~3-4 seconds for the streams feature to become available. It is unclear if other RabbitMQ services need the same amount of time.
