### PR TITLE
feat: add trace logs for cyclone function execution

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -173,7 +173,7 @@ cat << EOF > $JAIL/firecracker.conf
     }
   ],
   "machine-config": {
-    "vcpu_count": 1,
+    "vcpu_count": 4,
     "mem_size_mib": 512
   },
   "network-interfaces": [{


### PR DESCRIPTION
This adds some simple trace logs to deadpool execution steps so we can capture some basic metrics around how long we spend spinning up firecracker VMs vs just running tokio processes