### PR TITLE
show loader until new components appear when pasting

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1078,7 +1078,13 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
             const tempInsertId = _.uniqueId("temp-insert-component");
 
-            return new ApiRequest({
+            return new ApiRequest<
+              {
+                copiedComponentId: ComponentId;
+                pastedComponentId: ComponentId;
+                pastedNodeId: ComponentNodeId;
+              }[]
+            >({
               method: "post",
               url: "diagram/paste_components",
               keyRequestStatusBy: componentIds,
@@ -1099,7 +1105,14 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 };
               },
               onSuccess: (response) => {
-                delete this.pendingInsertedComponents[tempInsertId];
+                // following CREATE_COMPONENT's strategy here
+                // but matching up the loader to the first id in the list...
+                // not ideal but should help avoid the delay between the loader disappearing and the new things appearing
+                const pendingInsert =
+                  this.pendingInsertedComponents[tempInsertId];
+                if (pendingInsert && response[0]?.pastedComponentId) {
+                  pendingInsert.componentId = response[0]?.pastedComponentId;
+                }
               },
             });
           },

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -101,6 +101,8 @@ pub enum DiagramError {
     ParentNodeNotFound(NodeId),
     #[error("parse int: {0}")]
     ParseFloat(#[from] ParseFloatError),
+    #[error("paste failed")]
+    PasteError,
     #[error(transparent)]
     Pg(#[from] si_data_pg::PgError),
     #[error(transparent)]


### PR DESCRIPTION
uses same strategy that insert currently uses, which is very imperfect, but works ok until we rearchitect the realtime stuff to just push new components right away. This means

- on paste, we optimistically add show a loader at a certain position tracked under a temporary id
- when paste api request returns, we attach a new component id to the temporary loader (in this case we just use the first one if there are multiple components pasted)
- whenever we fetch the diagram, we look through any temporary loaders that are showing and if we find the new component id in the data fetched, we hide the loader