### PR TITLE
fix: add retry to firecracker connect

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -45,6 +45,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_local_firecracker: bool,
 
+    /// Cyclone firecracker connect timeout
+    #[arg(long)]
+    pub(crate) cyclone_connect_timeout: Option<u64>,
+
     /// Cyclone pool size
     #[arg(long)]
     pub(crate) cyclone_pool_size: Option<u16>,
@@ -72,6 +76,9 @@ impl TryFrom<Args> for Config {
             }
             if args.cyclone_local_process {
                 config_map.set("cyclone.runtime_strategy", "LocalProcess");
+            }
+            if let Some(timeout) = args.cyclone_connect_timeout {
+                config_map.set("cyclone.connect_timeout", timeout);
             }
             if let Some(size) = args.cyclone_pool_size {
                 config_map.set("cyclone.pool_size", size);

--- a/lib/cyclone-client/BUCK
+++ b/lib/cyclone-client/BUCK
@@ -17,6 +17,7 @@ rust_library(
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-tungstenite",
+        "//third-party/rust:tracing",
     ],
     srcs = glob(["src/**/*.rs"]),
     test_unit_deps = [

--- a/lib/cyclone-client/Cargo.toml
+++ b/lib/cyclone-client/Cargo.toml
@@ -20,6 +20,7 @@ telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/lib/cyclone-client/src/execution.rs
+++ b/lib/cyclone-client/src/execution.rs
@@ -12,9 +12,7 @@ use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::WebSocketStream;
 
-pub use tokio_tungstenite::tungstenite::{
-    protocol::frame::CloseFrame as WebSocketCloseFrame, Message as WebSocketMessage,
-};
+pub use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
 
 pub fn execute<T, Request, Success>(
     stream: WebSocketStream<T>,

--- a/lib/cyclone-client/src/lib.rs
+++ b/lib/cyclone-client/src/lib.rs
@@ -3,7 +3,7 @@ mod execution;
 mod ping;
 mod watch;
 
-pub use client::{Client, ClientError, CycloneClient, HttpClient, UdsClient};
+pub use client::{Client, ClientConfig, ClientError, CycloneClient, HttpClient, UdsClient};
 pub use cyclone_core::{
     ActionRunRequest, ActionRunResultSuccess, CycloneEncryptionKey, CycloneEncryptionKeyError,
     LivenessStatus, LivenessStatusParseError, ReadinessStatus, ReadinessStatusParseError,

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -200,6 +200,8 @@ pub enum CycloneConfig {
         action: bool,
         #[serde(default)]
         pool_size: u16,
+        #[serde(default)]
+        connect_timeout: u64,
     },
 }
 
@@ -231,6 +233,7 @@ impl CycloneConfig {
             resolver: default_enable_endpoint(),
             action: default_enable_endpoint(),
             pool_size: default_pool_size(),
+            connect_timeout: default_connect_timeout(),
         }
     }
 
@@ -360,6 +363,7 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                 resolver,
                 action,
                 pool_size,
+                connect_timeout,
             } => {
                 let mut builder = LocalUdsInstance::spec();
                 //we only need these if running local process. Maybe the builder should handle
@@ -389,6 +393,7 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                     builder.action();
                 }
                 builder.pool_size(pool_size);
+                builder.connect_timeout(connect_timeout);
 
                 Ok(Self::LocalUds(
                     builder.build().map_err(ConfigError::cyclone_spec_build)?,
@@ -462,6 +467,10 @@ fn default_runtime_strategy() -> LocalUdsRuntimeStrategy {
 
 fn default_pool_size() -> u16 {
     100
+}
+
+fn default_connect_timeout() -> u64 {
+    10
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -89,10 +89,11 @@ cyclone_args=(
   --lang-server /usr/local/bin/lang-js
   --enable-watch
   --limit-requests 1
-  --watch-timeout 10
+  --watch-timeout 30
   --enable-ping
   --enable-resolver
   --enable-action-run
+  -vvvv
 )
 
 # got get the rootfs tar and unpack it
@@ -141,6 +142,8 @@ supervisor="supervise-daemon"
 command="cyclone"
 command_args="${cyclone_args[*]}"
 pidfile="/cyclone/agent.pid"
+output_log="/var/log/cyclone.log"
+error_log="/var/log/cyclone.err"
 EOF
 
 chmod +x "/etc/init.d/cyclone"


### PR DESCRIPTION
In some cases, we fail the initial connect to Firecracker, seemingly due to a race during VM startup. This adds retries to the connect method where we bail out attempting to read bytes if we get nothing back within 10 milliseconds (by default). We then create a new stream and try again. We'll do this up to 30 times before bailing out completely. 

This timeout can be configured via the `--cyclone_connect_timeout` in Veritech.