### PR TITLE
feat: close the firecracker VM when cyclone exits

### DIFF
--- a/lib/deadpool-cyclone/src/lib.rs
+++ b/lib/deadpool-cyclone/src/lib.rs
@@ -106,13 +106,7 @@ where
         obj: &mut Self::Type,
         _: &Metrics,
     ) -> managed::RecycleResult<Self::Error> {
-        match obj.ensure_healthy().await {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                obj.terminate().await?;
-                Result::map_err(Err(err), Into::into)
-            }
-        }
+        obj.ensure_healthy().await.map_err(Into::into)
     }
 }
 

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -139,11 +139,13 @@ cat <<EOF >"/etc/init.d/cyclone"
 name="cyclone"
 description="Cyclone"
 supervisor="supervise-daemon"
-command="cyclone"
-command_args="${cyclone_args[*]}"
 pidfile="/cyclone/agent.pid"
 output_log="/var/log/cyclone.log"
 error_log="/var/log/cyclone.err"
+
+start(){
+  cyclone ${cyclone_args[*]} && reboot &
+}
 EOF
 
 chmod +x "/etc/init.d/cyclone"


### PR DESCRIPTION
Ok, here me out. This reverts us back to the old behavior of never calling the `terminate()` methods and instead relying on cyclone exiting by itself. I figured out I can replicate this in Firecracker by simply following the cyclone call with `&& reboot`, which will kill the firecracker VM. This whole thing feels weird to me as we define terminate methods that are never used, but I think this method may be better as it's currently possible that we'll call terminate on a running VM because the healthcheck will return unhealthy if it's already (or currently) running one. I think this may be leading to some strange performance issues that are difficult to diagnose, but I'm not entirely sure.

@fnichol at some point I'd love to talk to you about this and how deadpool works. I'm not sure I entirely understand the recycle semantics and what you were planning here.