### PR TITLE
chore(tilt): add labelled link to Jaeger' UI for jaeger service

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -68,7 +68,13 @@ allow_k8s_contexts(k8s_context())
 docker_compose("./docker-compose.platform.yml")
 compose_services = ["jaeger", "nats", "otelcol", "postgres"]
 for service in compose_services:
-    dc_resource(service, labels = ["platform"])
+    if service == "jaeger":
+        links = [
+            link("http://localhost:16686", "ui"),
+        ]
+    else:
+        links = []
+    dc_resource(service, links = links, labels = ["platform"])
 
 # Locally build and run `module-index`
 module_index_target = "//bin/module-index:module-index"

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -20,12 +20,13 @@ groups = {
         "web",
     ],
 }
+
 # Add "all" group as a sorted set of all services
 _all = {}
 for group_values in groups.values():
     for value in group_values:
-        _all.update({ value: True })
-groups.update({ "all": sorted(_all.keys()) })
+        _all.update({value: True})
+groups.update({"all": sorted(_all.keys())})
 
 # Parse the CLI args to enable group names and/or individual service names
 enabled_resources = []
@@ -80,10 +81,10 @@ local_resource(
     auto_init = False,
     resource_deps = [
         "otelcol",
-        "postgres"
+        "postgres",
     ],
     deps = _buck2_dep_inputs(module_index_target),
-    trigger_mode = trigger_mode
+    trigger_mode = trigger_mode,
 )
 
 # Locally build and run `council`
@@ -154,10 +155,10 @@ local_resource(
     deps = _buck2_dep_inputs(sdf_target),
     trigger_mode = trigger_mode,
     readiness_probe = probe(
-        period_secs  = 5,
+        period_secs = 5,
         http_get = http_get_action(
             port = 5156,
-            path = "/api/"
+            path = "/api/",
         ),
     ),
     links = [
@@ -177,7 +178,7 @@ local_resource(
         "sdf",
     ],
     readiness_probe = probe(
-        period_secs  = 5,
+        period_secs = 5,
         http_get = http_get_action(
             port = 8080,
         ),


### PR DESCRIPTION
There was already 2 endpoint links provided automatically by Docker
Compose, but at least for this author, I kept clicking the "other" link
first which is the gRPC OpenTelemetry endpoint. Yeesh.

<img src="https://media0.giphy.com/media/K25PVRA032Ues/giphy.gif"/>