### PR TITLE
feat: add configuration option for otel + new honeycomb trace option

### DIFF
--- a/component/otelcol/BUCK
+++ b/component/otelcol/BUCK
@@ -7,6 +7,8 @@ docker_image(
     name = "otelcol",
     srcs = {
         "config.yaml": "component/otelcol",
+        "honeycomb-config.yaml": ".",
+        "docker-entrypoint.sh": ".",
     },
     build_args = {
         "BASE_VERSION": "0.74.0",

--- a/component/otelcol/BUCK
+++ b/component/otelcol/BUCK
@@ -7,8 +7,8 @@ docker_image(
     name = "otelcol",
     srcs = {
         "config.yaml": "component/otelcol",
-        "honeycomb-config.yaml": ".",
-        "docker-entrypoint.sh": ".",
+        "honeycomb-config.yaml": "component/otelcol",
+        "docker-entrypoint.sh": "component/otelcol",
     },
     build_args = {
         "BASE_VERSION": "0.74.0",

--- a/component/otelcol/Dockerfile
+++ b/component/otelcol/Dockerfile
@@ -1,12 +1,15 @@
 ARG BASE_VERSION
 
-FROM otel/opentelemetry-collector:$BASE_VERSION AS otelcol
+FROM otel/opentelemetry-collector:latest AS otelcol
+
+ENV SI_OTEL_COL__CONFIG_PATH=/etc/otelcol/config.yaml
+ENV SI_OTEL_COL__HONEYCOMB_API_KEY=""
 
 # We're going to base our image on a non-scratch image which should allow us to
 # `docker exec` into a running instance for debugging
 FROM alpine:3 AS final
 COPY --from=otelcol /otelcol /bin/otelcol
-COPY component/otelcol/config.yaml /etc/otelcol/config.yaml
+COPY ./*config.yaml /etc/otelcol/
+COPY ./docker-entrypoint.sh /etc/otelcol/docker-entrypoint.sh
 
-ENTRYPOINT ["/bin/otelcol"]
-CMD ["--config", "/etc/otelcol/config.yaml"]
+ENTRYPOINT ["sh", "-c", "/etc/otelcol/docker-entrypoint.sh"]

--- a/component/otelcol/Dockerfile
+++ b/component/otelcol/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_VERSION
 
-FROM otel/opentelemetry-collector:latest AS otelcol
+FROM otel/opentelemetry-collector:$BASE_VERSION AS otelcol
 
 ENV SI_OTEL_COL__CONFIG_PATH=/etc/otelcol/config.yaml
 ENV SI_OTEL_COL__HONEYCOMB_API_KEY=""
@@ -9,7 +9,7 @@ ENV SI_OTEL_COL__HONEYCOMB_API_KEY=""
 # `docker exec` into a running instance for debugging
 FROM alpine:3 AS final
 COPY --from=otelcol /otelcol /bin/otelcol
-COPY ./*config.yaml /etc/otelcol/
-COPY ./docker-entrypoint.sh /etc/otelcol/docker-entrypoint.sh
+COPY component/otelcol/*config.yaml /etc/otelcol/
+COPY component/otelcol/docker-entrypoint.sh /etc/otelcol/docker-entrypoint.sh
 
 ENTRYPOINT ["sh", "-c", "/etc/otelcol/docker-entrypoint.sh"]

--- a/component/otelcol/docker-entrypoint.sh
+++ b/component/otelcol/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+sed -i "s/SI_OTEL_COL__HONEYCOMB_API_KEY/$SI_OTEL_COL__HONEYCOMB_API_KEY/g" ${SI_OTEL_COL__CONFIG_PATH-/etc/otelcol/config.yaml}
+
+/bin/otelcol --config ${SI_OTEL_COL__CONFIG_PATH-/etc/otelcol/config.yaml}

--- a/component/otelcol/honeycomb-config.yaml
+++ b/component/otelcol/honeycomb-config.yaml
@@ -1,0 +1,31 @@
+---
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    verbosity: normal
+  otlp:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": "SI_OTEL_COL__HONEYCOMB_API_KEY"
+
+extensions:
+  zpages:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlp]
+  extensions: [zpages]


### PR DESCRIPTION
Adds a basic docker environment variable method of driving the configuration file to use for the otelcol docker image.

The environment variable changes are as below:
```
SI_OTEL_COL__CONFIG_PATH # Allows driving the specific config file in the build to use
SI_OTEL_COL__HONEYCOMB_API_KEY # Allows driving the API key for honeycomb
```