### PR TITLE
feat: added otelcol to cyclone within firecracker

### DIFF
--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
         .build()?;
     let telemetry = telemetry_application::init(config)?;
     let args = args::parse();
+
     run(args, telemetry).await
 }
 

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<()> {
         .build()?;
     let telemetry = telemetry_application::init(config)?;
     let args = args::parse();
-
     run(args, telemetry).await
 }
 

--- a/bin/veritech/scripts/userdata.sh
+++ b/bin/veritech/scripts/userdata.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 
-POOL_SIZE=${1:-100}
-NATS=${2:-nats.si-tools-prod.systeminit.info:4222}
+POOL_SIZE=${1:-1000}
+NATS=${2:-tls://connect.ngs.global}
 
 wget https://artifacts.systeminit.com/veritech/stable/omnibus/linux/$(arch)/veritech-stable-omnibus-linux-$(arch).tar.gz -O - | tar -xzvf - -C /
+
+# Awkward install of the aws cli
+sudo apt update
+sudo apt install unzip jq -y
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+aws secretsmanager get-secret-value --region us-east-1 --secret-id si-nats-creds | jq -r '.SecretString' >> /tmp/nats-creds
+
+# Install + run docker with otel on 4317 on the host interface
+curl -fsSL get.docker.com | bash
+
+docker run \
+ --restart always \
+ --env SI_OTEL_COL__CONFIG_PATH=/etc/otelcol/honeycomb-config.yaml \
+ --env SI_OTEL_COL__HONEYCOMB_API_KEY=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id si-honeycomb-api-key | jq -r '.SecretString') \
+ -p 4317:4317 \
+ systeminit/otelcol:stable
 
 cat << EOF > /etc/systemd/system/veritech.service
 
@@ -12,7 +31,7 @@ Description=Veritech Server
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/veritech --cyclone-local-firecracker --cyclone-pool-size $POOL_SIZE --nats-url $NATS
+ExecStart=/usr/local/bin/veritech --cyclone-local-firecracker --cyclone-pool-size $POOL_SIZE --nats-url $NATS --nats-creds-path /tmp/nats-creds --cyclone-connect-timeout 100
 Type=exec
 Restart=always
 
@@ -21,4 +40,4 @@ WantedBy=default.target
 RequiredBy=network.target
 EOF
 
-systemctl enable –now veritech
+systemctl enable --now veritech

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -127,6 +127,9 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(veritech_target),
     serve_cmd = "SI_LOG=debug buck2 run {}".format(veritech_target),
+    # This is the serve command you might need if you want to execute on firecracker for 10 functione executions.
+    # NB: BUCK2 MUST RUN AS ROOT OR THIS WILL NOT WORK
+    # serve_cmd = "SI_LOG=debug buck2 run {} -- --cyclone-local-firecracker --cyclone-pool-size 10".format(veritech_target),
     allow_parallel = True,
     resource_deps = [
         "nats",

--- a/lib/deadpool-cyclone/src/instance/cyclone/firecracker-setup.sh
+++ b/lib/deadpool-cyclone/src/instance/cyclone/firecracker-setup.sh
@@ -218,6 +218,13 @@ execute_configuration_management() {
         # Adjust MTU to make it consistent
         ip link set dev $(ip route get 8.8.8.8 | awk -- '{printf $5}') mtu 1500
 
+        # This permits NAT from within the Jail to access the otelcol running on the external interface of the machine. Localhost is `not` resolveable from
+        # within the jail or the micro-vm directly due to /etc/hosts misalignment. Hardcoding the destination to 12.0.0.1 for the otel endpoint allows us to
+        # ship a static copy of the rootfs but allow us to keep the dynamic nature of the machine hosting. 
+        if ! iptables -t nat -C PREROUTING -p tcp --dport 4317 -d 10.0.0.3 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317; then
+          iptables -t nat -A PREROUTING -p tcp --dport 4317 -d 10.0.0.3 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317
+        fi
+
     else
         echo "Error: Unsupported or unknown configuration management tool specified, exiting."
         exit 1

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -84,16 +84,16 @@ mkfs.ext4 -v "$ROOTFS"
 sudo mount -v "$ROOTFS" "$ROOTFSMOUNT"
 
 cyclone_args=(
-  --bind-vsock 3:52
-  --decryption-key /cyclone/decryption.key
-  --lang-server /usr/local/bin/lang-js
-  --enable-watch
-  --limit-requests 1
-  --watch-timeout 30
-  --enable-ping
-  --enable-resolver
-  --enable-action-run
-  -vvvv
+--bind-vsock 3:52
+--decryption-key /cyclone/decryption.key
+--lang-server /usr/local/bin/lang-js
+--enable-watch
+--limit-requests 1
+--watch-timeout 30
+--enable-ping
+--enable-resolver
+--enable-action-run
+-vvvv
 )
 
 # got get the rootfs tar and unpack it
@@ -140,11 +140,10 @@ name="cyclone"
 description="Cyclone"
 supervisor="supervise-daemon"
 pidfile="/cyclone/agent.pid"
-output_log="/var/log/cyclone.log"
-error_log="/var/log/cyclone.err"
 
 start(){
-  cyclone ${cyclone_args[*]} && reboot &
+  export OTEL_EXPORTER_OTLP_ENDPOINT=10.0.0.3:4317
+  cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 && reboot &
 }
 EOF
 

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -84,16 +84,16 @@ mkfs.ext4 -v "$ROOTFS"
 sudo mount -v "$ROOTFS" "$ROOTFSMOUNT"
 
 cyclone_args=(
---bind-vsock 3:52
---decryption-key /cyclone/decryption.key
---lang-server /usr/local/bin/lang-js
---enable-watch
---limit-requests 1
---watch-timeout 30
---enable-ping
---enable-resolver
---enable-action-run
--vvvv
+  --bind-vsock 3:52
+  --decryption-key /cyclone/decryption.key
+  --lang-server /usr/local/bin/lang-js
+  --enable-watch
+  --limit-requests 1
+  --watch-timeout 30
+  --enable-ping
+  --enable-resolver
+  --enable-action-run
+  -vvvv
 )
 
 # got get the rootfs tar and unpack it


### PR DESCRIPTION
Adds a static route from cyclone into 10.0.0.3 which is then picked up via a NAT iptables route to push it into the otelcollector running on the veritech host on 4317.

This includes:
- Amendments to the rootfs for cyclone
- Adds docker to the veritech node
- Pulls & runs our otelcol container with the relevant honeycomb configuration