### PR TITLE
fix: added missing scheme to otel endpoint for cyclone in firecracker

### DIFF
--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -30,6 +30,10 @@ services:
 
   otelcol:
     image: systeminit/otelcol:stable
+    # If you'd like to ship to honeycomb from your local machine, you need these two variables in the otelcol
+    #environment:
+    #  - "SI_OTEL_COL__HONEYCOMB_API_KEY=<insert key>"
+    #  - "SI_OTEL_COL__CONFIG_PATH=/etc/otelcol/honeycomb-config.yaml"
     ports:
       - "4317:4317"
       - "55679:55679"

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -142,7 +142,7 @@ supervisor="supervise-daemon"
 pidfile="/cyclone/agent.pid"
 
 start(){
-  export OTEL_EXPORTER_OTLP_ENDPOINT=1.0.0.1:4317
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4317
   cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 && reboot &
 }
 EOF


### PR DESCRIPTION
The scheme was missing for the otel ingestion for cyclone in firecracker, the remainder of the process/routes have been proven out.

I've tested this change locally using firecracker and it works! Horray!

It just needs merged into main and then revalidated on a new veritech node.