### PR TITLE
feat: summary table for qualifications

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -922,8 +922,7 @@ impl AttributeValue {
     /// [`Component`](crate::Component). This means that the [`Prop`](crate::Prop) that the
     /// [`InternalProvider`](crate::InternalProvider) is sourcing its data from does not have a
     /// parent [`Prop`](crate::Prop).
-    #[allow(unused)]
-    async fn is_for_internal_provider_of_root_prop(
+    pub async fn is_for_internal_provider_of_root_prop(
         &mut self,
         ctx: &DalContext,
     ) -> AttributeValueResult<bool> {

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_data_nats::NatsError;
-use si_data_pg::PgPoolError;
+use si_data_pg::{PgError, PgPoolError};
 use thiserror::Error;
 use tokio::task::JoinError;
 
@@ -62,6 +62,8 @@ pub enum JobConsumerError {
     NoSchemaFound(ComponentId),
     #[error("no schema variant found for component {0}")]
     NoSchemaVariantFound(ComponentId),
+    #[error(transparent)]
+    PgError(#[from] PgError),
     #[error(transparent)]
     PgPool(#[from] PgPoolError),
     #[error(transparent)]

--- a/lib/dal/src/migrations/U2409__summary_qualifications.sql
+++ b/lib/dal/src/migrations/U2409__summary_qualifications.sql
@@ -1,0 +1,50 @@
+CREATE TABLE summary_qualifications
+(
+    pk                          ident primary key default ident_create_v1(),
+    id                          ident not null default ident_create_v1(),
+    component_id                ident NOT NULL,
+    component_name              text NOT NULL,
+    tenancy_workspace_pk        ident,
+    visibility_change_set_pk    ident NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at       timestamp with time zone,
+    created_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                  timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    total                       bigint,
+    warned                      bigint,
+    succeeded                   bigint,
+    failed                      bigint
+);
+
+SELECT standard_model_table_constraints_v1('summary_qualifications');
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('summary_qualifications', 'model', 'summary_qualifications', 'Summary Qualifications');
+
+CREATE OR REPLACE FUNCTION summary_qualification_update_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id ident,
+    this_component_name text,
+    this_total bigint,
+    this_warned bigint,
+    this_succeeded bigint,
+    this_failed bigint,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_qualifications%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO summary_qualifications
+        (id, component_id, component_name, tenancy_workspace_pk, visibility_change_set_pk, total, warned, succeeded, failed)
+    VALUES
+        (this_component_id, this_component_id, this_component_name, this_tenancy_record.tenancy_workspace_pk, this_visibility_record.visibility_change_set_pk,
+         this_total, this_warned, this_succeeded, this_failed)
+    ON CONFLICT (id, tenancy_workspace_pk, visibility_change_set_pk)
+    DO UPDATE SET component_name = this_component_name, total = this_total, warned = this_warned, succeeded = this_succeeded, failed = this_failed
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/queries/summary_qualification/get_summary_qualifications.sql
+++ b/lib/dal/src/queries/summary_qualification/get_summary_qualifications.sql
@@ -1,0 +1,11 @@
+SELECT row_to_json(a) AS object
+FROM (SELECT DISTINCT ON (components.id) components.id AS component_id,
+                                         summary_qualifications.component_name,
+                                         summary_qualifications.total,
+                                         summary_qualifications.warned,
+                                         summary_qualifications.succeeded,
+                                         summary_qualifications.failed
+      FROM components
+               INNER JOIN summary_qualifications ON components.id = summary_qualifications.component_id AND components.visibility_change_set_pk = summary_qualifications.visibility_change_set_pk
+      WHERE in_tenancy_and_visible_v1($1, $2, components)
+      ORDER BY components.id, components.visibility_change_set_pk DESC, components.visibility_deleted_at DESC) AS a

--- a/lib/sdf-server/src/server/service/qualification/get_summary.rs
+++ b/lib/sdf-server/src/server/service/qualification/get_summary.rs
@@ -2,8 +2,8 @@ use axum::extract::Query;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use dal::qualification::QualificationSummary;
-use dal::Visibility;
+use dal::qualification::{QualificationSummary, QualificationSummaryForComponent};
+use dal::{ComponentId, Visibility};
 
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use crate::service::qualification::QualificationResult;
@@ -15,16 +15,60 @@ pub struct GetSummaryRequest {
     pub visibility: Visibility,
 }
 
-pub type GetSummaryResponse = QualificationSummary;
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QualificationSummaryForComponentResponse {
+    component_id: ComponentId,
+    component_name: String,
+    total: i64,
+    warned: i64,
+    succeeded: i64,
+    failed: i64,
+}
+
+impl From<QualificationSummaryForComponent> for QualificationSummaryForComponentResponse {
+    fn from(q: QualificationSummaryForComponent) -> Self {
+        QualificationSummaryForComponentResponse {
+            component_id: q.component_id,
+            component_name: q.component_name,
+            total: q.total,
+            warned: q.warned,
+            succeeded: q.succeeded,
+            failed: q.failed,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QualificationSummaryResponse {
+    total: i64,
+    succeeded: i64,
+    warned: i64,
+    failed: i64,
+    components: Vec<QualificationSummaryForComponentResponse>,
+}
+
+impl From<QualificationSummary> for QualificationSummaryResponse {
+    fn from(s: QualificationSummary) -> Self {
+        QualificationSummaryResponse {
+            total: s.total,
+            succeeded: s.succeeded,
+            warned: s.warned,
+            failed: s.failed,
+            components: s.components.into_iter().map(|c| c.into()).collect(),
+        }
+    }
+}
 
 pub async fn get_summary(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Query(request): Query<GetSummaryRequest>,
-) -> QualificationResult<Json<GetSummaryResponse>> {
+) -> QualificationResult<Json<QualificationSummaryResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let qual_summary = QualificationSummary::get_summary(&ctx).await?;
 
-    Ok(Json(qual_summary))
+    Ok(Json(qual_summary.into()))
 }


### PR DESCRIPTION
The get_summary endpoint was taking 30+ seconds to respond in production. This commit introduces the idea of 'summary tables', which get updated when the internal provider for the root prop is updated. We take the raw data, and then compute custom tables that cache the data, getting rid of the need to do the complex queries to get the information.

This is in a pretty raw state - if we decide that summary tables like this are a pattern we want more broadly, it'll certainly need some refactoring (like moving the summary table code into a single module, etc.)

<img src="https://media4.giphy.com/media/NFA61GS9qKZ68/giphy.gif"/>