### PR TITLE
feat: convenience script for pulling logs from firecracker jails

### DIFF
--- a/bin/veritech/scripts/get_cyclone_logs.sh
+++ b/bin/veritech/scripts/get_cyclone_logs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SB_ID="${1:-0}" # Default to sb_id=0
+JAIL="/srv/jailer/firecracker/$SB_ID/root"
+MOUNT=$(mktemp -d)
+LOG_FILE="var/log/cyclone.log"
+
+function cleanup {
+  sudo umount $MOUNT
+  rm -rf $MOUNT
+}
+
+trap cleanup EXIT
+
+sudo mount $JAIL/rootfs.ext4 $MOUNT
+
+if test -f $MOUNT/$LOG_FILE ; then
+  less $MOUNT/$LOG_FILE
+else
+  echo "No logs found for $SB_ID".
+fi
+


### PR DESCRIPTION
Simple script for pulling Cyclone logs from a firecracker jail. This simply creates a temp dir, mounts the FS to it, and `less`es the log file if it is present. It cleans up after itself after it's done.