### PR TITLE
fix: docker + iptables conflicting rules amendment

### DIFF
--- a/lib/deadpool-cyclone/src/instance/cyclone/firecracker-setup.sh
+++ b/lib/deadpool-cyclone/src/instance/cyclone/firecracker-setup.sh
@@ -221,8 +221,8 @@ execute_configuration_management() {
         # This permits NAT from within the Jail to access the otelcol running on the external interface of the machine. Localhost is `not` resolveable from
         # within the jail or the micro-vm directly due to /etc/hosts misalignment. Hardcoding the destination to 12.0.0.1 for the otel endpoint allows us to
         # ship a static copy of the rootfs but allow us to keep the dynamic nature of the machine hosting. 
-        if ! iptables -t nat -C PREROUTING -p tcp --dport 4317 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317; then
-          iptables -t nat -A PREROUTING -p tcp --dport 4317 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317
+        if ! iptables -t nat -C PREROUTING -p tcp --dport 4316 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317; then
+          iptables -t nat -A PREROUTING -p tcp --dport 4316 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317
         fi
 
     else

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -142,7 +142,7 @@ supervisor="supervise-daemon"
 pidfile="/cyclone/agent.pid"
 
 start(){
-  export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4317
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4316
   cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 && reboot &
 }
 EOF


### PR DESCRIPTION
TLDR: Docker was being a pain

These were the existing rules in the iptables nat table regarding otel:
```
-A PREROUTING -d 1.0.0.1/32 -p tcp -m tcp --dport 4317 -j DNAT --to-destination 10.1.151.8:4317
-A DOCKER ! -i docker0 -p tcp -m tcp --dport 4317 -j DNAT --to-destination 172.17.0.2:4317
```

The two iptables rules used are for different scenarios, but there is a potential conflict depending on the specific use case. In our case, they were conflicting causing irrational packet loss.

If there is a possibility that packets can match both rules, there might be a conflict. The conflict arises because both rules are trying to DNAT packets with the same destination port (4317) but to different destination addresses (10.1.151.8:4317 and 172.17.0.2:4317).

To avoid conflicts, make sure that the conditions for each rule are mutually exclusive. If you have specific criteria to distinguish between the scenarios these rules are meant for, you should adjust the rules accordingly. Additionally, you may want to consider the order of the rules and how they interact with other rules in your iptables configuration.