### PR TITLE
frame attach/detach improvements

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -85,6 +85,7 @@ import {
   useTheme,
   getToneColorHex,
 } from "@si/vue-lib/design-system";
+import { useComponentsStore } from "@/store/components.store";
 import { SOCKET_SIZE, SELECTION_COLOR } from "./diagram_constants";
 import { DiagramEdgeData } from "./diagram_types";
 import { pointAlongLinePct, pointAlongLinePx } from "./utils/math";
@@ -168,12 +169,13 @@ const mainLineOpacity = computed(() => {
   return 1;
 });
 
-function onMouseOver(_e: KonvaEventObject<MouseEvent>) {
-  emit("hover:start");
+const componentsStore = useComponentsStore();
+function onMouseOver() {
+  componentsStore.setHoveredEdgeId(props.edge.def.id);
 }
 
 function onMouseOut(_e: KonvaEventObject<MouseEvent>) {
-  emit("hover:end");
+  componentsStore.setHoveredEdgeId(null);
 }
 
 function onMouseDown(_e: KonvaEventObject<MouseEvent>) {

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -9,65 +9,39 @@
     @mouseover="onMouseOver"
     @mouseout="onMouseOut"
   >
-    <!-- selection box outline -->
-    <v-rect
-      v-if="isHovered || isSelected"
-      :config="{
-        width: nodeWidth + 8,
-        height: nodeHeight + 8,
-        x: -halfWidth - 4,
-        y: -4,
-        cornerRadius: CORNER_RADIUS + 3,
-        stroke: SELECTION_COLOR,
-        strokeWidth: isSelected ? 3 : 1,
-        listening: false,
-      }"
-    />
-
     <v-group :config="{ opacity: isDeleted ? 0.5 : 1 }">
-      <template v-if="edgeDisplayMode === 'EDGES_UNDER'">
-        <v-rect
-          :config="{
-            width: nodeWidth,
-            height: nodeHeaderHeight,
-            x: -halfWidth,
-            y: 0,
-            fill: colors.bodyBg,
-            opacity: 0.9,
-          }"
-        />
-        <v-rect
-          :config="{
-            width: nodeWidth,
-            height: nodeHeight - nodeHeaderHeight,
-            x: -halfWidth,
-            y: nodeHeaderHeight,
-            cornerRadius: CORNER_RADIUS,
-            fill: colors.bodyBg,
-            opacity: 0.7,
-          }"
-        />
-      </template>
+      <!-- drop shadow -->
+      <!-- <v-rect
+        :config="{
+          width: nodeWidth,
+          height: nodeHeight,
+          x: -halfWidth - 10,
+          y: 10,
+          cornerRadius: CORNER_RADIUS,
+          fill: colors.bodyBg,
+          fillAfterStrokeEnabled: true,
+        }"
+      /> -->
 
       <!-- box background - also used by layout manager to figure out nodes location and size -->
       <v-rect
         :config="{
           id: `${node.uniqueKey}--bg`,
-          width: nodeWidth + (edgeDisplayMode === 'EDGES_UNDER' ? 2 : 0),
-          height: nodeHeight + (edgeDisplayMode === 'EDGES_UNDER' ? 2 : 0),
-          x: -halfWidth + (edgeDisplayMode === 'EDGES_UNDER' ? -1 : 0),
-          y: 0 + (edgeDisplayMode === 'EDGES_UNDER' ? -1 : 0),
-          cornerRadius:
-            CORNER_RADIUS + (edgeDisplayMode === 'EDGES_UNDER' ? 1 : 0),
-          fill: edgeDisplayMode === 'EDGES_OVER' ? colors.bodyBg : null,
-          fillAfterStrokeEnabled: edgeDisplayMode === 'EDGES_OVER',
+          width: nodeWidth,
+          height: nodeHeight,
+          x: -halfWidth,
+          y: 0,
+          cornerRadius: CORNER_RADIUS,
+          fill: colors.bodyBg,
           stroke: colors.border,
-          strokeWidth: edgeDisplayMode === 'EDGES_OVER' ? 4 : 2,
+          strokeWidth: 2,
+          shadowForStrokeEnabled: false,
+          hitStrokeWidth: 0,
           shadowColor: 'black',
-          shadowBlur: 8,
-          shadowOffset: { x: 3, y: 3 },
-          shadowOpacity: 0.4,
-          shadowEnabled: false,
+          shadowBlur: 3,
+          shadowOffset: { x: 8, y: 8 },
+          shadowOpacity: 0.3,
+          shadowEnabled: !parentComponentId,
         }"
       />
 
@@ -118,6 +92,18 @@
         }"
       />
 
+      <!-- parent frame attachment indicator -->
+      <DiagramIcon
+        v-if="parentComponentId"
+        icon="frame"
+        :size="16"
+        :x="-halfWidth + 12"
+        :y="nodeHeaderHeight + nodeBodyHeight - 12"
+        :color="colors.parentColor"
+        @mouseover="(e) => onMouseOver(e, 'parent')"
+        @mouseout="onMouseOut"
+      />
+
       <!-- header bottom border -->
       <v-line
         :config="{
@@ -128,47 +114,6 @@
           opacity: 1,
         }"
       />
-
-      <!-- sockets -->
-      <v-group
-        :config="{
-          x: -halfWidth,
-          y: nodeHeaderHeight + subtitleTextHeight + SOCKET_MARGIN_TOP,
-        }"
-      >
-        <DiagramNodeSocket
-          v-for="(socket, i) in leftSockets"
-          :key="socket.uniqueKey"
-          :socket="socket"
-          :y="i * SOCKET_GAP"
-          :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
-          :nodeWidth="nodeWidth"
-          @hover:start="onSocketHoverStart(socket)"
-          @hover:end="onSocketHoverEnd(socket)"
-        />
-      </v-group>
-
-      <v-group
-        :config="{
-          x: halfWidth,
-          y:
-            nodeHeaderHeight +
-            SOCKET_MARGIN_TOP +
-            subtitleTextHeight +
-            SOCKET_GAP * leftSockets.length,
-        }"
-      >
-        <DiagramNodeSocket
-          v-for="(socket, i) in rightSockets"
-          :key="socket.uniqueKey"
-          :socket="socket"
-          :y="i * SOCKET_GAP"
-          :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
-          :nodeWidth="nodeWidth"
-          @hover:start="onSocketHoverStart(socket)"
-          @hover:end="onSocketHoverEnd(socket)"
-        />
-      </v-group>
 
       <!-- status icons -->
       <v-group
@@ -256,6 +201,64 @@
       /> -->
     </v-group>
 
+    <!-- selection box outline -->
+    <v-rect
+      v-if="isHovered || isSelected"
+      :config="{
+        width: nodeWidth + 8,
+        height: nodeHeight + 8,
+        x: -halfWidth - 4,
+        y: -4,
+        cornerRadius: CORNER_RADIUS + 3,
+        stroke: SELECTION_COLOR,
+        strokeWidth: isSelected ? 3 : 1,
+        listening: false,
+      }"
+    />
+
+    <!-- sockets -->
+    <v-group :config="{ opacity: isDeleted ? 0.5 : 1 }">
+      <v-group
+        :config="{
+          x: -halfWidth,
+          y: nodeHeaderHeight + subtitleTextHeight + SOCKET_MARGIN_TOP,
+        }"
+      >
+        <DiagramNodeSocket
+          v-for="(socket, i) in leftSockets"
+          :key="socket.uniqueKey"
+          :socket="socket"
+          :y="i * SOCKET_GAP"
+          :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+          :nodeWidth="nodeWidth"
+          @hover:start="onSocketHoverStart(socket)"
+          @hover:end="onSocketHoverEnd(socket)"
+        />
+      </v-group>
+
+      <v-group
+        :config="{
+          x: halfWidth,
+          y:
+            nodeHeaderHeight +
+            SOCKET_MARGIN_TOP +
+            subtitleTextHeight +
+            SOCKET_GAP * leftSockets.length,
+        }"
+      >
+        <DiagramNodeSocket
+          v-for="(socket, i) in rightSockets"
+          :key="socket.uniqueKey"
+          :socket="socket"
+          :y="i * SOCKET_GAP"
+          :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+          :nodeWidth="nodeWidth"
+          @hover:start="onSocketHoverStart(socket)"
+          @hover:end="onSocketHoverEnd(socket)"
+        />
+      </v-group>
+    </v-group>
+
     <!-- change status indicators -->
     <!-- deleted icon overlay (large centered) -->
     <DiagramIcon
@@ -285,7 +288,6 @@ import {
   DiagramElementUniqueKey,
   DiagramNodeData,
   DiagramSocketData,
-  ElementHoverMeta,
 } from "./diagram_types";
 import DiagramNodeSocket from "./DiagramNodeSocket.vue";
 
@@ -320,10 +322,11 @@ const props = defineProps({
 });
 
 const emit = defineEmits<{
-  (e: "hover:start", meta?: ElementHoverMeta): void;
-  (e: "hover:end"): void;
   (e: "resize"): void;
 }>();
+
+const componentsStore = useComponentsStore();
+const componentId = computed(() => props.node.def.componentId);
 
 const diffIconHover = ref(false);
 const statusIconHovers = ref(
@@ -424,6 +427,8 @@ const nodeHeight = computed(
   () => nodeHeaderHeight.value + nodeBodyHeight.value,
 );
 
+const parentComponentId = computed(() => _.last(props.node.def.ancestorIds));
+
 const position = computed(() => props.tempPosition || props.node.def.position);
 
 watch([nodeWidth, nodeHeight, position], () => {
@@ -440,6 +445,8 @@ const colors = computed(() => {
   bodyBgHsl.l = theme.value === "dark" ? 0.08 : 0.95;
   const bodyBg = tinycolor(bodyBgHsl);
 
+  if (edgeDisplayMode.value === "EDGES_UNDER") bodyBg.setAlpha(0.5);
+
   const bodyText = theme.value === "dark" ? "#FFF" : "#000";
   return {
     border: primaryColor.toRgbString(),
@@ -447,6 +454,9 @@ const colors = computed(() => {
     headerText: bodyText,
     bodyBg: bodyBg.toRgbString(),
     bodyText,
+    parentColor:
+      componentsStore.componentsById[parentComponentId.value || ""]?.color ||
+      "#FFF",
   };
 });
 
@@ -462,26 +472,33 @@ watch([() => props.node.def.isLoading, overlay], () => {
   transition.play();
 });
 
-function onMouseOver(_e: KonvaEventObject<MouseEvent>) {
-  emit("hover:start");
+function onMouseOver(evt: KonvaEventObject<MouseEvent>, type?: "parent") {
+  evt.cancelBubble = true;
+  componentsStore.setHoveredComponentId(
+    componentId.value,
+    type ? { type } : undefined,
+  );
 }
 
-function onMouseOut(_e: KonvaEventObject<MouseEvent>) {
-  emit("hover:end");
+function onMouseOut() {
+  componentsStore.setHoveredComponentId(null);
 }
 
 function onSocketHoverStart(socket: DiagramSocketData) {
-  emit("hover:start", { type: "socket", socket });
+  componentsStore.setHoveredComponentId(componentId.value, {
+    type: "socket",
+    socket,
+  });
 }
 
 function onSocketHoverEnd(_socket: DiagramSocketData) {
-  emit("hover:end");
+  componentsStore.setHoveredComponentId(null);
 }
 
 // TODO: not sure if want to communicate with the store here or send the message up to the diagram...
-const componentsStore = useComponentsStore();
+
 function onClick(detailsTabSlug: string) {
-  componentsStore.setSelectedComponentId(props.node.def.componentId, {
+  componentsStore.setSelectedComponentId(componentId.value, {
     detailsTab: detailsTabSlug,
   });
 }

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -250,7 +250,8 @@ export type DiagramDrawEdgeState = {
 // Event payloads - emitted by generic diagram //////////////////////////////////
 export type ElementHoverMeta =
   | { type: "resize"; direction: SideAndCornerIdentifiers }
-  | { type: "socket"; socket: DiagramSocketData };
+  | { type: "socket"; socket: DiagramSocketData }
+  | { type: "parent" };
 
 export type RightClickElementEvent = {
   element: DiagramElementData;

--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script setup lang="ts">
+import * as _ from "lodash-es";
 import {
   DropdownMenuItemObjectDef,
   DropdownMenu,
@@ -24,6 +25,7 @@ const {
   selectedComponentId,
   selectedComponentIds,
   selectedComponent,
+  selectedComponents,
   deletableSelectedComponents,
   restorableSelectedComponents,
   selectedEdgeId,
@@ -136,6 +138,21 @@ const rightClickMenuItems = computed(() => {
     }
   }
 
+  if (
+    _.every(selectedComponents.value, (c) => (c.ancestorIds?.length || 0) > 0)
+  ) {
+    items.push({
+      label: "Detach from parent(s)",
+      icon: "frame",
+      onSelect: () => {
+        // TODO: we likely want an endpoint that handles multiple?
+        _.each(selectedComponentIds.value, (id) => {
+          componentsStore.DETACH_COMPONENT(id);
+        });
+      },
+      disabled,
+    });
+  }
   if (selectedComponent.value?.hasResource) {
     items.push({
       label: "Refresh resource",

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -92,6 +92,7 @@ import Docs from "~icons/fluent/book-question-mark-20-filled";
 import Password from "~icons/material-symbols-light/password";
 import Key from "~icons/material-symbols/key";
 import Scissors from "~icons/clarity/scissors-solid";
+import Frame from "~icons/iconamoon/frame-light";
 
 import BracketsCurly from "~icons/ph/brackets-curly";
 import BracketsSquare from "~icons/ph/brackets-square";
@@ -206,6 +207,7 @@ export const ICONS = Object.freeze({
   "external-link": ExternalLink,
   eye: Eye,
   filter: Filter,
+  frame: Frame,
   "git-branch": GitBranch,
   "git-branch-plus": GitBranchPlus,
   "git-commit": GitCommit,


### PR DESCRIPTION
still wip but coming together

- show visual indicator of whether components are attached to their parent
- hovering that indicator highlights the parent frame(s)
- add "detach from parent(s)" to right click context menu and wire up (backend bug)

dragging components into frame behaviour still needs to be adjusted
- show indicator that an attachment is about to happen depending on mouse position
- determine attachment based on _mouse position_ rather than component bounds
- on attaching, we should bump components inside of frame bounds (or expand frame?) so we dont end up with components that are attached but outside the frame

BONUS
- small konva perf tweaks
- hover meta info moved to the store
- refactor hover handling - components now talk directly to the store rather than emitting events to ModelingDiagram