### PR TITLE
feat(si-data-nats): update API surface coverage & add service API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.15"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9"
+checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.15"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43"
+checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4869,6 +4869,7 @@ name = "si-data-nats"
 version = "0.1.0"
 dependencies = [
  "async-nats",
+ "bytes 1.5.0",
  "crossbeam-channel",
  "futures",
  "nkeys 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 ]
 
 [workspace.dependencies]
-async-nats = "0.33.0"
+async-nats = { version = "0.33.0", features = ["service"] }
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
 axum = { version = "0.6.18", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite

--- a/lib/council-server/src/client.rs
+++ b/lib/council-server/src/client.rs
@@ -30,7 +30,7 @@ impl PubClient {
             .publish_with_reply(
                 self.pub_channel.clone(),
                 self.reply_channel.clone(),
-                message,
+                message.into(),
             )
             .await?;
         Ok(())
@@ -45,7 +45,7 @@ impl PubClient {
             .publish_with_reply(
                 self.pub_channel.clone(),
                 self.reply_channel.clone(),
-                message,
+                message.into(),
             )
             .await?;
         Ok(())
@@ -60,7 +60,7 @@ impl PubClient {
             .publish_with_reply(
                 self.pub_channel.clone(),
                 self.reply_channel.clone(),
-                message,
+                message.into(),
             )
             .await?;
         Ok(())
@@ -74,7 +74,7 @@ impl PubClient {
             .publish_with_reply(
                 self.pub_channel.clone(),
                 self.reply_channel.clone(),
-                message,
+                message.into(),
             )
             .await?;
         Ok(())

--- a/lib/council-server/src/server.rs
+++ b/lib/council-server/src/server.rs
@@ -75,7 +75,9 @@ impl Server {
                 self.nats
                     .publish(
                         reply_channel,
-                        serde_json::to_vec(&Response::OkToProcess { node_ids }).unwrap(),
+                        serde_json::to_vec(&Response::OkToProcess { node_ids })
+                            .unwrap()
+                            .into(),
                     )
                     .await
                     .unwrap();
@@ -234,7 +236,9 @@ pub async fn job_processed_a_value(
         info!(%reply_channel, ?node_id, "AttributeValue has been processed by a job");
         nats.publish(
             reply_channel,
-            serde_json::to_vec(&Response::BeenProcessed { node_id }).unwrap(),
+            serde_json::to_vec(&Response::BeenProcessed { node_id })
+                .unwrap()
+                .into(),
         )
         .await
         .unwrap();
@@ -261,7 +265,8 @@ pub async fn job_failed_processing_a_value(
             serde_json::to_vec(&Response::Failed {
                 node_id: failed_node_id,
             })
-            .unwrap(),
+            .unwrap()
+            .into(),
         )
         .await
         .unwrap();

--- a/lib/dal/src/job/processor/nats_processor.rs
+++ b/lib/dal/src/job/processor/nats_processor.rs
@@ -40,7 +40,10 @@ impl NatsProcessor {
 
             if let Err(err) = self
                 .client
-                .publish(self.pinga_subject.clone(), serde_json::to_vec(&job_info)?)
+                .publish(
+                    self.pinga_subject.clone(),
+                    serde_json::to_vec(&job_info)?.into(),
+                )
                 .await
             {
                 error!("Nats job push failed, some jobs will be dropped");
@@ -70,7 +73,8 @@ impl JobQueueProcessor for NatsProcessor {
                 self.pinga_subject.clone(),
                 job_reply_inbox,
                 serde_json::to_vec(&job_info)
-                    .map_err(|e| BlockingJobError::Serde(e.to_string()))?,
+                    .map_err(|e| BlockingJobError::Serde(e.to_string()))?
+                    .into(),
             )
             .await
             .map_err(|e| BlockingJobError::Nats(e.to_string()))?;

--- a/lib/dal/src/status.rs
+++ b/lib/dal/src/status.rs
@@ -895,7 +895,7 @@ impl StatusUpdaterInner {
         // "immediately publish" events.
         let subject = format!("si.workspace_pk.{}.event", ws_event.workspace_pk());
         let msg_bytes = serde_json::to_vec(&ws_event)?;
-        ctx.nats_conn().publish(subject, msg_bytes).await?;
+        ctx.nats_conn().publish(subject, msg_bytes.into()).await?;
         Ok(())
     }
 }

--- a/lib/dal/src/tasks/status_receiver.rs
+++ b/lib/dal/src/tasks/status_receiver.rs
@@ -217,7 +217,7 @@ impl StatusReceiver {
     async fn publish_immediately(ctx: &DalContext, ws_event: WsEvent) -> StatusReceiverResult<()> {
         let subject = format!("si.workspace_pk.{}.event", ws_event.workspace_pk());
         let msg_bytes = serde_json::to_vec(&ws_event)?;
-        ctx.nats_conn().publish(subject, msg_bytes).await?;
+        ctx.nats_conn().publish(subject, msg_bytes.into()).await?;
         Ok(())
     }
 }

--- a/lib/dal/src/tasks/status_receiver/client.rs
+++ b/lib/dal/src/tasks/status_receiver/client.rs
@@ -61,7 +61,7 @@ impl StatusReceiverClient {
             messaging.destination = &subject.as_str(),
             "publishing message"
         );
-        self.nats_client.publish(subject, msg).await?;
+        self.nats_client.publish(subject, msg.into()).await?;
         Ok(())
     }
 }

--- a/lib/pinga-server/src/server.rs
+++ b/lib/pinga-server/src/server.rs
@@ -443,7 +443,7 @@ async fn execute_job_task(
         if let Ok(message) = serde_json::to_vec(&reply_message) {
             if let Err(err) = ctx_builder
                 .nats_conn()
-                .publish(reply_channel, message)
+                .publish(reply_channel, message.into())
                 .await
             {
                 error!(error = ?err, "Unable to notify spawning job of blocking job completion");

--- a/lib/sdf-server/src/server/service/func/execute.rs
+++ b/lib/sdf-server/src/server/service/func/execute.rs
@@ -103,6 +103,6 @@ pub async fn execute(
 async fn publish_immediately(ctx: &DalContext, ws_event: WsEvent) -> FuncBindingResult<()> {
     let subject = format!("si.workspace_pk.{}.event", ws_event.workspace_pk());
     let msg_bytes = serde_json::to_vec(&ws_event)?;
-    ctx.nats_conn().publish(subject, msg_bytes).await?;
+    ctx.nats_conn().publish(subject, msg_bytes.into()).await?;
     Ok(())
 }

--- a/lib/sdf-server/src/server/service/ws/crdt.rs
+++ b/lib/sdf-server/src/server/service/ws/crdt.rs
@@ -120,7 +120,7 @@ pub async fn crdt_handle<W, R>(
     tasks.spawn(async move {
         while let Some(msg) = stream.next().await {
             if let Message::Binary(vec) = msg? {
-                ws_nats.publish(ws_channel_name.clone(), vec).await?;
+                ws_nats.publish(ws_channel_name.clone(), vec.into()).await?;
             }
         }
 

--- a/lib/sdf-server/src/server/service/ws/crdt/y.rs
+++ b/lib/sdf-server/src/server/service/ws/crdt/y.rs
@@ -34,7 +34,7 @@ impl Sink<Vec<u8>> for YSink {
     fn start_send(mut self: Pin<&mut Self>, payload: Vec<u8>) -> Result<(), Self::Error> {
         let (nats, channel) = (self.nats.clone(), self.channel.clone());
         self.future = Some(Box::pin(async move {
-            nats.publish(channel, payload)
+            nats.publish(channel, payload.into())
                 .await
                 .map_err(|err| Error::Other(err.into()))
         }));

--- a/lib/sdf-server/src/server/service/ws/workspace_updates.rs
+++ b/lib/sdf-server/src/server/service/ws/workspace_updates.rs
@@ -194,7 +194,7 @@ mod workspace_updates {
                                             container,
                                             container_key
                                         }).await?;
-                                        self.nats.publish(subject, serde_json::to_vec(&event)?).await?;
+                                        self.nats.publish(subject, serde_json::to_vec(&event)?.into()).await?;
                                     }
                                     WebsocketEventRequest::Online { user_pk, name, picture_url, change_set_pk, idle } => {
                                         let subject = format!("si.workspace_pk.{}.event", self.workspace_pk);
@@ -205,7 +205,7 @@ mod workspace_updates {
                                             change_set_pk,
                                             idle,
                                         }).await?;
-                                        self.nats.publish(subject, serde_json::to_vec(&event)?).await?;
+                                        self.nats.publish(subject, serde_json::to_vec(&event)?.into()).await?;
                                     }
                                 }
                             },

--- a/lib/si-data-nats/BUCK
+++ b/lib/si-data-nats/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "si-data-nats",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:bytes",
         "//third-party/rust:crossbeam-channel",
         "//third-party/rust:futures",
         "//third-party/rust:async-nats",

--- a/lib/si-data-nats/Cargo.toml
+++ b/lib/si-data-nats/Cargo.toml
@@ -6,9 +6,10 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+async-nats = { workspace = true }
+bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures = { workspace = true }
-async-nats = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/si-data-nats/examples/nats-publish/main.rs
+++ b/lib/si-data-nats/examples/nats-publish/main.rs
@@ -40,7 +40,7 @@ async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     let config = NatsConfig::default();
     let nats = NatsClient::new(&config).await?;
 
-    nats.publish(subject.clone(), msg.clone()).await?;
+    nats.publish(subject.clone(), msg.clone().into()).await?;
     info!(
         msg = msg.as_str(),
         subject = subject.as_str(),

--- a/lib/si-data-nats/src/service.rs
+++ b/lib/si-data-nats/src/service.rs
@@ -1,0 +1,16 @@
+use std::pin::Pin;
+
+pub use async_nats::service::*;
+use futures::Future;
+
+impl ServiceExt for crate::Client {
+    type Output = Pin<Box<dyn Future<Output = Result<Service, async_nats::Error>> + Send>>;
+
+    fn add_service(&self, config: Config) -> Self::Output {
+        self.inner.add_service(config)
+    }
+
+    fn service_builder(&self) -> ServiceBuilder {
+        self.inner.service_builder()
+    }
+}

--- a/lib/si-data-nats/src/subscriber.rs
+++ b/lib/si-data-nats/src/subscriber.rs
@@ -15,10 +15,11 @@ use super::{ConnectionMetadata, Error, Message, Result};
 /// Implements [futures::stream::Stream] for ergonomic async message processing.
 ///
 /// # Examples
+///
 /// ```
 /// # #[tokio::main]
 /// # async fn main() ->  Result<(), async_nats::Error> {
-/// let mut nc = async_nats::connect("demo.nats.io").await?;
+/// let mut nc = si_data_nats::connect("demo.nats.io").await?;
 /// # nc.publish("test".into(), "data".into()).await?;
 /// # Ok(())
 /// # }
@@ -54,11 +55,54 @@ impl Subscriber {
         }
     }
 
-    /// Unsubscribes from subscription after reaching given number of messages.
-    /// This is the total number of messages received by this subscriber in it's whole
-    /// lifespan. If it already reached or surpassed the passed value, it will immediately stop.
+    /// Unsubscribes from subscription, draining all remaining messages.
     ///
     /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), async_nats::Error> {
+    /// let client = si_data_nats::Client::connect_with_options("demo.nats.io", None, Default::default()).await?;
+    ///
+    /// let mut subscriber = client.subscribe("foo".into()).await?;
+    ///
+    /// subscriber.unsubscribe().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(
+        name = "subscriber.unsubscribe",
+        skip_all,
+        level = "debug",
+        fields(
+            messaging.protocol = %self.metadata.messaging_protocol(),
+            messaging.system = %self.metadata.messaging_system(),
+            messaging.url = %self.metadata.messaging_url(),
+            net.transport = %self.metadata.net_transport(),
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+        )
+    )]
+    pub async fn unsubscribe(mut self) -> Result<()> {
+        let span = Span::current();
+        span.follows_from(&self.sub_span);
+
+        self.inner
+            .unsubscribe()
+            .await
+            .map_err(|err| span.record_err(Error::NatsUnsubscribe(err)))?;
+
+        span.record_ok();
+        Ok(())
+    }
+
+    /// Unsubscribes from subscription after reaching given number of messages. This is the total
+    /// number of messages received by this subscriber in it's whole lifespan. If it already
+    /// reached or surpassed the passed value, it will immediately stop.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// # use futures::StreamExt;
     /// # #[tokio::main]
@@ -107,48 +151,10 @@ impl Subscriber {
         span.record_ok();
         Ok(())
     }
+}
 
-    /// Unsubscribes from subscription, draining all remaining messages.
-    ///
-    /// # Examples
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), async_nats::Error> {
-    /// let client = si_data_nats::Client::connect_with_options("demo.nats.io", None, Default::default()).await?;
-    ///
-    /// let mut subscriber = client.subscribe("foo".into()).await?;
-    ///
-    /// subscriber.unsubscribe().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[instrument(
-        name = "subscriber.unsubscribe",
-        skip_all,
-        level = "debug",
-        fields(
-            messaging.protocol = %self.metadata.messaging_protocol(),
-            messaging.system = %self.metadata.messaging_system(),
-            messaging.url = %self.metadata.messaging_url(),
-            net.transport = %self.metadata.net_transport(),
-            otel.kind = SpanKind::Client.as_str(),
-            otel.status_code = Empty,
-            otel.status_message = Empty,
-        )
-    )]
-    pub async fn unsubscribe(mut self) -> Result<()> {
-        let span = Span::current();
-        span.follows_from(&self.sub_span);
-
-        self.inner
-            .unsubscribe()
-            .await
-            .map_err(|err| span.record_err(Error::NatsUnsubscribe(err)))?;
-
-        span.record_ok();
-        Ok(())
-    }
-
+// API extensions
+impl Subscriber {
     /// Gets a reference to the subscriber's span.
     pub fn span(&self) -> &Span {
         &self.sub_span

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -250,7 +250,7 @@ impl Client {
         let mut root_subscriber = self.nats.subscribe(reply_mailbox_root.clone()).await?;
 
         self.nats
-            .publish_with_reply(subject, reply_mailbox_root.clone(), msg)
+            .publish_with_reply(subject, reply_mailbox_root.clone(), msg.into())
             .await?;
 
         tokio::select! {

--- a/lib/veritech-server/src/publisher.rs
+++ b/lib/veritech-server/src/publisher.rs
@@ -35,7 +35,7 @@ impl<'a> Publisher<'a> {
         let nats_msg = serde_json::to_string(output).map_err(PublisherError::JSONSerialize)?;
 
         self.nats
-            .publish(self.reply_mailbox_output.clone(), nats_msg)
+            .publish(self.reply_mailbox_output.clone(), nats_msg.into())
             .await
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_output.to_string()))
     }
@@ -44,7 +44,7 @@ impl<'a> Publisher<'a> {
         let mut headers = si_data_nats::HeaderMap::new();
         headers.insert(FINAL_MESSAGE_HEADER_KEY, "true");
         self.nats
-            .publish_with_headers(self.reply_mailbox_output.clone(), headers, vec![])
+            .publish_with_headers(self.reply_mailbox_output.clone(), headers, vec![].into())
             .await
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_output.to_string()))
     }
@@ -56,7 +56,7 @@ impl<'a> Publisher<'a> {
         let nats_msg = serde_json::to_string(result).map_err(PublisherError::JSONSerialize)?;
 
         self.nats
-            .publish(self.reply_mailbox_result.clone(), nats_msg)
+            .publish(self.reply_mailbox_result.clone(), nats_msg.into())
             .await
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_result.to_string()))
     }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -276,18 +276,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstream-0.6.5.crate",
-    sha256 = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6",
-    strip_prefix = "anstream-0.6.5",
-    urls = ["https://crates.io/api/v1/crates/anstream/0.6.5/download"],
+    name = "anstream-0.6.7.crate",
+    sha256 = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba",
+    strip_prefix = "anstream-0.6.7",
+    urls = ["https://crates.io/api/v1/crates/anstream/0.6.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstream-0.6.5",
-    srcs = [":anstream-0.6.5.crate"],
+    name = "anstream-0.6.7",
+    srcs = [":anstream-0.6.7.crate"],
     crate = "anstream",
-    crate_root = "anstream-0.6.5.crate/src/lib.rs",
+    crate_root = "anstream-0.6.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "auto",
@@ -528,6 +528,7 @@ cargo.rust_library(
     features = [
         "default",
         "server_2_10",
+        "service",
     ],
     visibility = [],
     deps = [
@@ -1840,23 +1841,23 @@ cargo.rust_library(
 
 alias(
     name = "clap",
-    actual = ":clap-4.4.15",
+    actual = ":clap-4.4.16",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.4.15.crate",
-    sha256 = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9",
-    strip_prefix = "clap-4.4.15",
-    urls = ["https://crates.io/api/v1/crates/clap/4.4.15/download"],
+    name = "clap-4.4.16.crate",
+    sha256 = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445",
+    strip_prefix = "clap-4.4.16",
+    urls = ["https://crates.io/api/v1/crates/clap/4.4.16/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.4.15",
-    srcs = [":clap-4.4.15.crate"],
+    name = "clap-4.4.16",
+    srcs = [":clap-4.4.16.crate"],
     crate = "clap",
-    crate_root = "clap-4.4.15.crate/src/lib.rs",
+    crate_root = "clap-4.4.16.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1872,24 +1873,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.4.15",
+        ":clap_builder-4.4.16",
         ":clap_derive-4.4.7",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.4.15.crate",
-    sha256 = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43",
-    strip_prefix = "clap_builder-4.4.15",
-    urls = ["https://crates.io/api/v1/crates/clap_builder/4.4.15/download"],
+    name = "clap_builder-4.4.16.crate",
+    sha256 = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb",
+    strip_prefix = "clap_builder-4.4.16",
+    urls = ["https://crates.io/api/v1/crates/clap_builder/4.4.16/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.4.15",
-    srcs = [":clap_builder-4.4.15.crate"],
+    name = "clap_builder-4.4.16",
+    srcs = [":clap_builder-4.4.16.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.4.15.crate/src/lib.rs",
+    crate_root = "clap_builder-4.4.16.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1903,7 +1904,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":anstream-0.6.5",
+        ":anstream-0.6.7",
         ":anstyle-1.0.4",
         ":clap_lex-0.6.0",
         ":strsim-0.10.0",
@@ -13691,7 +13692,7 @@ cargo.rust_binary(
         ":bytes-1.5.0",
         ":chrono-0.4.31",
         ":ciborium-0.2.1",
-        ":clap-4.4.15",
+        ":clap-4.4.16",
         ":color-eyre-0.6.2",
         ":colored-2.1.0",
         ":comfy-table-7.1.0",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.15"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9"
+checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.15"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43"
+checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
 dependencies = [
  "anstream",
  "anstyle",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -19,7 +19,7 @@ path = "top/main.rs"
 # BEGIN: DEPENDENCIES
 
 [dependencies]
-async-nats = "0.33.0"
+async-nats = { version = "0.33.0", features = ["service"] }
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
 axum = { version = "0.6.18", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite


### PR DESCRIPTION
This change updates our coverage over the `async-nats` library, bringing it up-to-date with the 0.33.0. Importantly, it now exposes the [Services API] which will be used in future work.

[Services API]: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-32.md

<img src="https://media2.giphy.com/media/0mGSqBuzRIVFGV2EXm/giphy.gif"/>