### PR TITLE
chore: revert "build(deps): upgrade to NATS 2.10.9"

### DIFF
--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -9,7 +9,7 @@ docker_image(
         "nats-server.conf": "component/nats",
     },
     build_args = {
-        "BASE_VERSION": "2.10.9",
+        "BASE_VERSION": "2.3.4",
     },
     run_docker_args = [
         "--publish",


### PR DESCRIPTION
This reverts commit b9f26c80506f7883297832888132493bd9f3b951.

I would like to better understand if there is a change in the connection details between these versions of NATS. Granted I made a massive jump and over 2 years of upstream releases :)