### PR TITLE
feat(web) snap frame attach/detach with snapping

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -12,7 +12,7 @@
   >
     <!-- selection box outline -->
     <v-rect
-      v-if="isHovered || isSelected || highlightParent"
+      v-if="isHovered || isSelected || highlightParent || highlightAsNewParent"
       :config="{
         width: nodeWidth + 8,
         height: nodeHeight + 8,
@@ -35,6 +35,22 @@
       }"
     /> -->
 
+    <v-rect
+      :config="{
+        id: `${group.uniqueKey}--bg`,
+        width: nodeWidth,
+        height: nodeBodyHeight,
+        x: -halfWidth,
+        y: 0,
+        cornerRadius: CORNER_RADIUS,
+        fill: colors.bodyBg,
+        fillAfterStrokeEnabled: true,
+        stroke: colors.headerBg,
+        strokeWidth: 3,
+        dash: [8, 8],
+      }"
+    />
+
     <!--  Node Body  -->
     <v-rect
       :config="{
@@ -48,8 +64,15 @@
         fillAfterStrokeEnabled: true,
         stroke: colors.headerBg,
         strokeWidth: 3,
-        hitStrokeWidth: 0,
         dash: [8, 8],
+
+        shadowForStrokeEnabled: false,
+        hitStrokeWidth: 0,
+        shadowColor: 'black',
+        shadowBlur: 3,
+        shadowOffset: { x: 8, y: 8 },
+        shadowOpacity: 0.3,
+        shadowEnabled: !parentComponentId,
       }"
     />
 
@@ -388,6 +411,7 @@ import {
   SideAndCornerIdentifiers,
   Size2D,
 } from "./diagram_types";
+import { useDiagramContext } from "./ModelingDiagram.vue";
 import DiagramIcon from "./DiagramIcon.vue";
 
 const props = defineProps({
@@ -412,6 +436,8 @@ const props = defineProps({
   isHovered: Boolean,
   isSelected: Boolean,
 });
+
+const diagramContext = useDiagramContext();
 
 const componentId = computed(() => props.group.def.componentId);
 const parentComponentId = computed(() => _.last(props.group.def.ancestorIds));
@@ -592,6 +618,14 @@ const highlightParent = computed(() => {
   return (
     componentsStore.hoveredComponent.ancestorIds?.includes(componentId.value) ||
     false
+  );
+});
+
+const highlightAsNewParent = computed(() => {
+  return (
+    diagramContext.moveElementsState.value.active &&
+    diagramContext.moveElementsState.value.intoNewParentKey ===
+      props.group.uniqueKey
   );
 });
 </script>

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -35,13 +35,7 @@
           fill: colors.bodyBg,
           stroke: colors.border,
           strokeWidth: 2,
-          shadowForStrokeEnabled: false,
           hitStrokeWidth: 0,
-          shadowColor: 'black',
-          shadowBlur: 3,
-          shadowOffset: { x: 8, y: 8 },
-          shadowOpacity: 0.3,
-          shadowEnabled: !parentComponentId,
         }"
       />
 
@@ -494,8 +488,6 @@ function onSocketHoverStart(socket: DiagramSocketData) {
 function onSocketHoverEnd(_socket: DiagramSocketData) {
   componentsStore.setHoveredComponentId(null);
 }
-
-// TODO: not sure if want to communicate with the store here or send the message up to the diagram...
 
 function onClick(detailsTabSlug: string) {
   componentsStore.setSelectedComponentId(componentId.value, {

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -175,6 +175,8 @@ export type DiagramNodeDef = {
   componentId: ComponentId;
   /** parent frame (or whatever) id */
   parentNodeId?: DiagramElementId;
+  /** parent frame (or whatever) id */
+  parentComponentId?: ComponentId;
   /** list of ancestor component ids */
   ancestorIds?: ComponentId[];
   /** node type within the context of the diagram */
@@ -256,6 +258,11 @@ export type DiagramDrawEdgeState = {
   toSocketKey?: DiagramElementUniqueKey;
   possibleTargetSocketKeys: DiagramElementUniqueKey[];
   edgeKeysToDelete: DiagramElementUniqueKey[];
+};
+
+export type MoveElementsState = {
+  active: boolean;
+  intoNewParentKey: DiagramElementUniqueKey | undefined;
 };
 
 // Event payloads - emitted by generic diagram //////////////////////////////////

--- a/app/web/src/components/ModelingDiagram/utils/math.ts
+++ b/app/web/src/components/ModelingDiagram/utils/math.ts
@@ -20,13 +20,28 @@ export function vectorBetween(v1: Vector2d, v2: Vector2d) {
   } as Vector2d;
 }
 
+export function pointsToRect(v1: Vector2d, v2: Vector2d) {
+  return {
+    x: v1.x,
+    y: v1.y,
+    width: v2.x - v1.x,
+    height: v2.y - v1.y,
+  };
+}
+
 /** check if 2 rectangles overlap, each rect defined by 2 opposite corner points */
-export function checkRectanglesOverlap(
-  r1v1: Vector2d,
-  r1v2: Vector2d,
-  r2v1: Vector2d,
-  r2v2: Vector2d,
-) {
+export function checkRectanglesOverlap(rect1: IRect, rect2: IRect) {
+  const r1v1: Vector2d = { x: rect1.x, y: rect1.y };
+  const r1v2: Vector2d = {
+    x: rect1.x + rect1.width,
+    y: rect1.y + rect1.height,
+  };
+  const r2v1: Vector2d = { x: rect2.x, y: rect2.y };
+  const r2v2: Vector2d = {
+    x: rect2.x + rect2.width,
+    y: rect2.y + rect2.height,
+  };
+
   // we allow any 2 points to be passed in, but we need the points in a sorted order for this algorithm
   // so we use min/max to make sure we're getting the bottom left and top right of each rect
   const r1x1 = Math.min(r1v1.x, r1v2.x);
@@ -88,12 +103,23 @@ export function rectContainsAnother(container: IRect, object: IRect) {
 
   return insideX && insideY;
 }
+
+export function rectContainsPoint(rect: IRect, point: Vector2d) {
+  return (
+    point.x >= rect.x &&
+    point.x <= rect.x + rect.width &&
+    point.y >= rect.y &&
+    point.y <= rect.y + rect.height
+  );
+}
+
 export function getRectCenter(rect: IRect) {
   return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
 }
 export function getAdjustmentRectToContainAnother(
   container: IRect,
   object: IRect,
+  paddingPx = 0,
 ) {
   const cMinX = container.x;
   const cMaxX = container.x + container.width;
@@ -109,15 +135,15 @@ export function getAdjustmentRectToContainAnother(
   let moveY = 0;
 
   if (oMinX < cMinX) {
-    moveX = oMinX - cMinX - container.width * 0.05;
+    moveX = oMinX - cMinX - paddingPx;
   } else if (oMaxX > cMaxX) {
-    moveX = oMaxX - cMaxX + container.width * 0.05;
+    moveX = oMaxX - cMaxX + paddingPx;
   }
 
   if (oMinY < cMinY) {
-    moveY = oMinY - cMinY - container.width * 0.05;
+    moveY = oMinY - cMinY - paddingPx;
   } else if (oMaxY > cMaxY) {
-    moveY = oMaxY - cMaxY + container.height * 0.05;
+    moveY = oMaxY - cMaxY + paddingPx;
   }
 
   return {

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -442,11 +442,12 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               ]);
 
               return {
-                ...component,
+                ..._.omit(component, "parentId"),
                 // swapping "id" to be node id and passing along component id separately for the diagram
                 // this is gross and needs to go, but will happen later
                 id: component.nodeId,
                 componentId: component.id,
+                parentComponentId: component.parentId,
                 title: component.displayName,
                 subtitle: component.schemaName,
                 isLoading:


### PR DESCRIPTION
probably needs some cleanup, but this is feeling pretty good!

- you can now drag items in/out of frames to attach/detach
- New parent is based on cursor position rather than what each component is hovering over
- we highlight the new parent so you can see what it will be attached to
- we optimistically update parent id so it feels snappy
- there is logic that bumps children into the new parent if they are outside, which means things sort of snap into the parent...

It's not perfect, but it feels pretty good!

Main issue is that when snapping things into place, you can still end up with items hovering over each other that are not actually attached.
