### PR TITLE
feat: get_diagram is now a summary table

### DIFF
--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -2,28 +2,26 @@ use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
 use std::num::{ParseFloatError, ParseIntError};
 use strum::{AsRefStr, Display, EnumString};
-use telemetry::prelude::debug;
+
 use thiserror::Error;
 
-use crate::change_status::{
-    ChangeStatus, ChangeStatusError, ComponentChangeStatus, EdgeChangeStatus,
-};
-use crate::diagram::connection::{Connection, DiagramEdgeView};
-use crate::diagram::node::{DiagramComponentView, SocketDirection, SocketView};
-use crate::edge::EdgeKind;
+use crate::change_status::ChangeStatusError;
+
+use crate::diagram::summary_diagram::{SummaryDiagramComponent, SummaryDiagramEdge};
+
 use crate::provider::external::ExternalProviderError;
 use crate::provider::internal::InternalProviderError;
 use crate::schema::variant::SchemaVariantError;
 use crate::socket::SocketError;
 use crate::{
     ActionPrototypeError, AttributeContextBuilderError, AttributePrototypeArgumentError,
-    AttributeValueError, ChangeSetPk, ComponentError, ComponentId, DalContext, Edge, EdgeError,
-    Node, NodeError, NodeId, NodeKind, PropError, SchemaError, SocketId, StandardModel,
-    StandardModelError,
+    AttributeValueError, ComponentError, ComponentId, DalContext, EdgeError, NodeError, NodeId,
+    NodeKind, PropError, SchemaError, SocketId, StandardModelError,
 };
 
 pub mod connection;
 pub mod node;
+pub(crate) mod summary_diagram;
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -92,6 +90,8 @@ pub enum DiagramError {
     SocketNotFound,
     #[error("standard model error: {0}")]
     StandardModel(#[from] StandardModelError),
+    #[error("summary diagram error: {0}")]
+    SummaryDiagram(String),
 }
 
 pub type DiagramResult<T> = Result<T, DiagramError>;
@@ -114,194 +114,30 @@ pub enum DiagramKind {
 #[serde(rename_all = "camelCase")]
 pub struct Diagram {
     /// The shape of assembled [`Node`](crate::Node) information to render graphical/visual nodes.
-    components: Vec<DiagramComponentView>,
+    components: Vec<SummaryDiagramComponent>,
     /// The shape of assembled [`Edge`](crate::Edge) information to render graphical/visual edges.
-    edges: Vec<DiagramEdgeView>,
+    edges: Vec<SummaryDiagramEdge>,
 }
 
 impl Diagram {
     /// Assemble a [`Diagram`](Self) based on existing [`Nodes`](crate::Node) and
     /// [`Connections`](crate::Connection).
     pub async fn assemble(ctx: &DalContext) -> DiagramResult<Self> {
-        let ctx_with_deleted = &ctx.clone_with_delete_visibility();
+        let components = summary_diagram::component_list(ctx)
+            .await
+            .map_err(|e| DiagramError::SummaryDiagram(e.to_string()))?;
+        let edges = summary_diagram::edge_list(ctx)
+            .await
+            .map_err(|e| DiagramError::SummaryDiagram(e.to_string()))?;
 
-        let modified = ComponentChangeStatus::list_modified(ctx).await?;
-        debug!("modified component change status: {modified:#?}");
-
-        let mut diagram_edges = Vec::new();
-        let edges = Edge::list(ctx).await?;
-        for edge in &edges {
-            if *edge.kind() == EdgeKind::Configuration {
-                let change_status = match edge.visibility().change_set_pk {
-                    ChangeSetPk::NONE => ChangeStatus::Unmodified,
-                    _ => ChangeStatus::Added,
-                };
-                let conn = Connection::from_edge(edge);
-                let mut diagram_edge_view =
-                    DiagramEdgeView::from_with_change_status(conn, change_status);
-                diagram_edge_view.set_actor_details(ctx, edge).await?;
-                diagram_edges.push(diagram_edge_view);
-            }
-        }
-
-        let deleted_edges: Vec<Edge> = EdgeChangeStatus::list_deleted(ctx).await?;
-
-        let deleted_diagram_edges = ctx
-            .run_with_deleted_visibility(|ctx_with_deleted| async move {
-                let mut deleted_diagram_edges = Vec::new();
-
-                for deleted_edge in deleted_edges {
-                    if *deleted_edge.kind() == EdgeKind::Configuration {
-                        let conn = Connection::from_edge(&deleted_edge);
-                        let mut diagram_edge_view =
-                            DiagramEdgeView::from_with_change_status(conn, ChangeStatus::Deleted);
-                        diagram_edge_view
-                            .set_actor_details(&ctx_with_deleted, &deleted_edge)
-                            .await?;
-                        deleted_diagram_edges.push(diagram_edge_view);
-                    }
-                }
-
-                Ok::<_, DiagramError>(deleted_diagram_edges)
-            })
-            .await?;
-
-        diagram_edges.extend(deleted_diagram_edges);
-
-        let nodes = ctx
-            .run_with_deleted_visibility(|ctx_with_deleted| async move {
-                Node::list_live(&ctx_with_deleted, NodeKind::Configuration).await
-            })
-            .await?;
-
-        let mut component_views = Vec::with_capacity(nodes.len());
-        for node in &nodes {
-            let component = node
-                .component(ctx_with_deleted)
-                .await?
-                .ok_or(DiagramError::ComponentNotFound)?;
-            if component.hidden() {
-                continue;
-            }
-
-            let schema_variant = match node.kind() {
-                NodeKind::Configuration => component
-                    .schema_variant(ctx_with_deleted)
-                    .await?
-                    .ok_or(DiagramError::SchemaVariantNotFound)?,
-            };
-
-            let is_modified = modified
-                .clone()
-                .iter()
-                .any(|s| s.component_id == *component.id());
-
-            // Get Parent Id
-            let sockets = SocketView::list(ctx, &schema_variant).await?;
-            let maybe_socket_to_parent = sockets.iter().find(|socket| {
-                socket.label == "Frame" && socket.direction == SocketDirection::Output
-            });
-
-            let edges_with_deleted =
-                Edge::list_for_component(ctx_with_deleted, *component.id()).await?;
-
-            let mut parent_node_ids = Vec::new();
-
-            if let Some(socket_to_parent) = maybe_socket_to_parent {
-                for edge in &edges_with_deleted {
-                    if edge.tail_node_id() == *node.id()
-                        && edge.tail_socket_id().to_string() == socket_to_parent.id
-                        && (edge.visibility().deleted_at.is_none() || edge.deleted_implicitly())
-                    {
-                        let parents =
-                            Edge::list_parents_for_component(ctx, edge.head_component_id()).await?;
-                        parent_node_ids.push((edge.head_node_id(), parents.len()));
-                    }
-                }
-            };
-
-            let parent_node_id = parent_node_ids
-                .into_iter()
-                .max_by_key(|(_, parents)| *parents)
-                .map(|(id, _)| id);
-
-            // Get Child Ids
-            let maybe_socket_from_children = sockets.iter().find(|socket| {
-                socket.label == "Frame" && socket.direction == SocketDirection::Input
-            });
-
-            let mut child_node_ids = vec![];
-            if let Some(socket_from_children) = maybe_socket_from_children {
-                for edge in &edges_with_deleted {
-                    if edge.head_node_id() == *node.id()
-                        && edge.head_socket_id().to_string() == socket_from_children.id
-                        && (edge.visibility().deleted_at.is_none()
-                            || (edge.deleted_implicitly() && edge.visibility().in_change_set()))
-                    {
-                        let child_node = Node::get_by_id(ctx_with_deleted, &edge.tail_node_id())
-                            .await?
-                            .ok_or(DiagramError::NodeNotFound)?;
-
-                        // This is a node in the current changeset and it is not deleted
-                        if child_node.visibility().in_change_set()
-                            && child_node.visibility().deleted_at.is_none()
-                        {
-                            child_node_ids.push(edge.tail_node_id());
-                            continue;
-                        }
-
-                        // this is a node in the current changeset that has been marked as deleted
-                        // now we need to check to see if it is exists in head
-                        // if it does, then it's a ghosted node and should be included as a child
-                        if child_node.visibility().in_change_set()
-                            && child_node.visibility().deleted_at.is_some()
-                        {
-                            let head_ctx = &ctx.clone_with_head();
-                            let head_node = Node::get_by_id(head_ctx, &edge.tail_node_id()).await?;
-                            if head_node.is_some() {
-                                child_node_ids.push(edge.tail_node_id());
-                                continue;
-                            }
-                        }
-
-                        // if the node is in head, doesn't exist directly on the changeset
-                        // and not marked as deleted in head, then it's also a valid child
-                        // *Remember*: a node won't exist in the changeset until a change is
-                        // made to a node!!
-                        if child_node.visibility().is_head()
-                            && child_node.visibility().deleted_at.is_none()
-                        {
-                            child_node_ids.push(edge.tail_node_id());
-                            continue;
-                        }
-                    }
-                }
-            };
-
-            let view = DiagramComponentView::new(
-                ctx_with_deleted,
-                &component,
-                node,
-                parent_node_id,
-                child_node_ids,
-                is_modified,
-                &schema_variant,
-            )
-            .await?;
-            component_views.push(view);
-        }
-
-        Ok(Self {
-            edges: diagram_edges,
-            components: component_views,
-        })
+        Ok(Self { edges, components })
     }
 
-    pub fn components(&self) -> &[DiagramComponentView] {
+    pub fn components(&self) -> &[SummaryDiagramComponent] {
         &self.components
     }
 
-    pub fn edges(&self) -> &[DiagramEdgeView] {
+    pub fn edges(&self) -> &[SummaryDiagramEdge] {
         &self.edges
     }
 }

--- a/lib/dal/src/diagram/summary_diagram.rs
+++ b/lib/dal/src/diagram/summary_diagram.rs
@@ -1,0 +1,485 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use si_data_pg::PgError;
+use std::num::{ParseFloatError, ParseIntError};
+use thiserror::Error;
+
+use crate::change_status::ChangeStatus;
+use crate::diagram::node::{GridPoint, HistoryEventMetadata, Size2D, SocketView};
+
+use crate::edge::{EdgeId, EdgeKind};
+use crate::schema::SchemaUiMenu;
+use crate::standard_model::objects_from_rows;
+use crate::{
+    history_event, impl_standard_model, pk, ActorView, Component, ComponentError, ComponentId,
+    ComponentStatus, DalContext, DiagramError, Edge, EdgeError, HistoryActor, Node, NodeId, Schema,
+    SchemaError, SchemaId, SchemaVariant, SchemaVariantId, SocketId, StandardModel,
+    StandardModelError, Tenancy, Timestamp, TransactionsError, Visibility,
+};
+
+const LIST_SUMMARY_DIAGRAM_COMPONENTS: &str =
+    include_str!("../queries/summary_diagram/list_summary_diagram_components.sql");
+const LIST_SUMMARY_DIAGRAM_EDGES: &str =
+    include_str!("../queries/summary_diagram/list_summary_diagram_edges.sql");
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum SummaryDiagramError {
+    #[error(transparent)]
+    ChronoParse(#[from] chrono::ParseError),
+    #[error(transparent)]
+    Component(#[from] ComponentError),
+    #[error(transparent)]
+    Diagram(#[from] DiagramError),
+    #[error(transparent)]
+    Edge(#[from] EdgeError),
+    #[error("no timestamp for deleting an edge when one was expected; bug!")]
+    NoTimestamp,
+    #[error(transparent)]
+    ParseFloat(#[from] ParseFloatError),
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+    #[error(transparent)]
+    PgError(#[from] PgError),
+    #[error(transparent)]
+    Schema(#[from] SchemaError),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    StandardModel(#[from] StandardModelError),
+    #[error(transparent)]
+    Transactions(#[from] TransactionsError),
+}
+
+pub type SummaryDiagramResult<T> = Result<T, SummaryDiagramError>;
+
+pk!(SummaryDiagramComponentPk);
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct SummaryDiagramComponent {
+    pk: SummaryDiagramComponentPk,
+    id: ComponentId,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+    component_id: ComponentId,
+    schema_name: String,
+    schema_id: SchemaId,
+    schema_variant_id: SchemaVariantId,
+    schema_variant_name: String,
+    schema_category: String,
+    sockets: serde_json::Value,
+    node_id: NodeId,
+    display_name: String,
+    position: GridPoint,
+    size: Size2D,
+    color: String,
+    node_type: String,
+    change_status: String,
+    has_resource: bool,
+    parent_node_id: Option<NodeId>,
+    child_node_ids: serde_json::Value,
+    created_info: serde_json::Value,
+    updated_info: serde_json::Value,
+    deleted_info: serde_json::Value,
+}
+
+impl_standard_model! {
+    model: SummaryDiagramComponent,
+    pk: SummaryDiagramComponentPk,
+    id: ComponentId,
+    table_name: "summary_diagram_components",
+    history_event_label_base: "summary_diagram_components",
+    history_event_message_name: "Summary Diagram Components"
+}
+
+impl SummaryDiagramComponent {
+    pub fn has_resource(&self) -> bool {
+        self.has_resource
+    }
+}
+
+pub async fn create_component_entry(
+    ctx: &DalContext,
+    component: &Component,
+    node: &Node,
+    schema: &Schema,
+    schema_variant: &SchemaVariant,
+) -> SummaryDiagramResult<()> {
+    let schema_category_name = SchemaUiMenu::find_for_schema(ctx, *schema.id())
+        .await?
+        .map_or("None".to_string(), |um| um.category().to_string());
+    let sockets = SocketView::list(ctx, schema_variant).await?;
+    let display_name = component.name(ctx).await?;
+    let position = GridPoint {
+        x: node.x().parse::<f64>()?.round() as isize,
+        y: node.y().parse::<f64>()?.round() as isize,
+    };
+    let size = if let (Some(w), Some(h)) = (node.width(), node.height()) {
+        Size2D {
+            height: h.parse()?,
+            width: w.parse()?,
+        }
+    } else {
+        Size2D {
+            height: 500,
+            width: 500,
+        }
+    };
+    let color = component.color(ctx).await?.unwrap_or("#111111".to_string());
+    let node_type = component.get_type(ctx).await?;
+
+    let change_status = ChangeStatus::Added;
+
+    // This could also be refactored away from hisotry actors
+    let component_status = ComponentStatus::get_by_id(ctx, component.id())
+        .await?
+        .ok_or_else(|| DiagramError::ComponentStatusNotFound(*component.id()))?;
+    let created_info =
+        HistoryEventMetadata::from_history_actor_timestamp(ctx, component_status.creation())
+            .await?;
+    let updated_info =
+        HistoryEventMetadata::from_history_actor_timestamp(ctx, component_status.update()).await?;
+    let mut deleted_info: Option<HistoryEventMetadata> = None;
+    {
+        if let Some(deleted_at) = ctx.visibility().deleted_at {
+            if let Some(deletion_user_pk) = component.deletion_user_pk() {
+                let history_actor = history_event::HistoryActor::User(*deletion_user_pk);
+                let actor = ActorView::from_history_actor(ctx, history_actor).await?;
+
+                deleted_info = Some(HistoryEventMetadata {
+                    actor,
+                    timestamp: deleted_at,
+                });
+            }
+        }
+    }
+
+    let resource_exists = component.resource(ctx).await?.payload.is_some();
+
+    let _row = ctx
+        .txns()
+        .await?
+        .pg()
+        .query_one(
+            "SELECT object FROM summary_diagram_component_create_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
+            &[
+                ctx.tenancy(),
+                ctx.visibility(),
+                component.id(),
+                &schema.name(),
+                schema.id(),
+                schema_variant.id(),
+                &schema_variant.name(),
+                &schema_category_name,
+                &serde_json::to_value(sockets)?,
+                node.id(),
+                &display_name,
+                &serde_json::to_value(position)?,
+                &serde_json::to_value(size)?,
+                &color,
+                &node_type.to_string(),
+                &change_status.to_string(),
+                &resource_exists,
+                &serde_json::to_value(created_info)?,
+                &serde_json::to_value(updated_info)?,
+                &serde_json::to_value(deleted_info)?,
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn component_update_geometry(
+    ctx: &DalContext,
+    node_id: &NodeId,
+    x: impl AsRef<str>,
+    y: impl AsRef<str>,
+    width: Option<impl AsRef<str>>,
+    height: Option<impl AsRef<str>>,
+) -> SummaryDiagramResult<()> {
+    let position = GridPoint {
+        x: x.as_ref().parse::<f64>()?.round() as isize,
+        y: y.as_ref().parse::<f64>()?.round() as isize,
+    };
+    let size = if let (Some(w), Some(h)) = (width, height) {
+        Size2D {
+            height: h.as_ref().parse()?,
+            width: w.as_ref().parse()?,
+        }
+    } else {
+        Size2D {
+            height: 500,
+            width: 500,
+        }
+    };
+
+    let _row = ctx
+        .txns()
+        .await?
+        .pg()
+        .query_one(
+            "SELECT object FROM summary_diagram_component_update_geometry_v1($1, $2, $3, $4, $5)",
+            &[
+                ctx.tenancy(),
+                ctx.visibility(),
+                &node_id,
+                &serde_json::to_value(position)?,
+                &serde_json::to_value(size)?,
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn component_update(
+    ctx: &DalContext,
+    component_id: &ComponentId,
+    name: impl AsRef<str>,
+    color: impl AsRef<str>,
+    component_type: impl AsRef<str>,
+    has_resource: bool,
+    deleted_at: Option<String>,
+) -> SummaryDiagramResult<()> {
+    let component_status = ComponentStatus::get_by_id(ctx, component_id)
+        .await?
+        .ok_or_else(|| DiagramError::ComponentStatusNotFound(*component_id))?;
+
+    let updated_info =
+        HistoryEventMetadata::from_history_actor_timestamp(ctx, component_status.update()).await?;
+
+    // We really have to clean up how we keep summaries of history events, which will make it so
+    // we no longer need to fetch the full component in order to pull this off. It's a bit insane.
+    // But it is what it is, for now. -- Adam
+    let mut deleted_info = None;
+    let mut deleted_at_datetime: Option<DateTime<Utc>> = None;
+    if let Some(ref deleted_at) = deleted_at {
+        let deleted_at_datetime_inner: DateTime<Utc> = deleted_at.parse()?;
+        deleted_at_datetime = Some(deleted_at_datetime_inner);
+        let new_ctx = ctx.clone_with_delete_visibility();
+        if let Some(component) = Component::get_by_id(&new_ctx, component_id).await? {
+            if let Some(deletion_user_pk) = component.deletion_user_pk() {
+                let history_actor = HistoryActor::User(*deletion_user_pk);
+                let actor = ActorView::from_history_actor(ctx, history_actor).await?;
+                deleted_info = Some(HistoryEventMetadata {
+                    actor,
+                    timestamp: deleted_at_datetime_inner,
+                });
+            }
+        }
+    }
+
+    // Set the change_status to deleted if we are adding the delete data
+    let _row = ctx
+        .txns()
+        .await?
+        .pg()
+        .query_one(
+            "SELECT object FROM summary_diagram_component_update_v1($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+            &[
+                ctx.tenancy(),
+                ctx.visibility(),
+                &component_id,
+                &name.as_ref(),
+                &color.as_ref(),
+                &component_type.as_ref(),
+                &has_resource,
+                &serde_json::to_value(updated_info)?,
+                &deleted_at_datetime,
+                &serde_json::to_value(deleted_info)?,
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn component_list(
+    ctx: &DalContext,
+) -> SummaryDiagramResult<Vec<SummaryDiagramComponent>> {
+    let rows = ctx
+        .txns()
+        .await?
+        .pg()
+        .query(
+            LIST_SUMMARY_DIAGRAM_COMPONENTS,
+            &[ctx.tenancy(), &ctx.visibility().change_set_pk],
+        )
+        .await?;
+    let objects: Vec<SummaryDiagramComponent> = objects_from_rows(rows)?;
+    Ok(objects)
+}
+
+pk!(SummaryDiagramEdgePk);
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct SummaryDiagramEdge {
+    pk: SummaryDiagramEdgePk,
+    id: EdgeId,
+    #[serde(flatten)]
+    tenancy: Tenancy,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    #[serde(flatten)]
+    visibility: Visibility,
+    edge_id: EdgeId,
+    from_node_id: NodeId,
+    from_socket_id: SocketId,
+    to_node_id: NodeId,
+    to_socket_id: SocketId,
+    change_status: String,
+    created_info: serde_json::Value,
+    deleted_info: serde_json::Value,
+}
+
+impl_standard_model! {
+    model: SummaryDiagramEdge,
+    pk: SummaryDiagramEdgePk,
+    id: EdgeId,
+    table_name: "summary_diagram_edges",
+    history_event_label_base: "summary_diagram_edges",
+    history_event_message_name: "Summary Diagram Edges"
+}
+
+impl SummaryDiagramEdge {
+    pub fn edge_id(&self) -> EdgeId {
+        self.edge_id
+    }
+}
+
+pub async fn create_edge_entry(ctx: &DalContext, edge: &Edge) -> SummaryDiagramResult<()> {
+    let mut created_info: Option<HistoryEventMetadata> = None;
+    if let Some(user_pk) = edge.creation_user_pk() {
+        let history_actor = HistoryActor::User(*user_pk);
+        let actor = ActorView::from_history_actor(ctx, history_actor).await?;
+        created_info = Some(HistoryEventMetadata {
+            actor,
+            timestamp: edge.timestamp().created_at,
+        })
+    }
+
+    let _row = ctx
+        .txns()
+        .await?
+        .pg()
+        .query_one(
+            "SELECT object FROM summary_diagram_edge_create_v1($1, $2, $3, $4, $5, $6, $7, $8)",
+            &[
+                ctx.tenancy(),
+                ctx.visibility(),
+                &edge.id(),
+                &edge.tail_node_id(),
+                &edge.tail_socket_id(),
+                &edge.head_node_id(),
+                &edge.head_socket_id(),
+                &serde_json::to_value(created_info)?,
+            ],
+        )
+        .await?;
+
+    // If this is a symbolic edge, we need to set the relevant summary diagram component row's parent node id.
+    if edge.kind() == &EdgeKind::Symbolic {
+        let _row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_one(
+                "SELECT object FROM summary_diagram_component_set_parent_node_id_v1($1, $2, $3, $4)",
+                &[
+                    ctx.tenancy(),
+                    ctx.visibility(),
+                    &edge.tail_component_id(),
+                    &edge.head_node_id(),
+                ],
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub async fn delete_edge_entry(ctx: &DalContext, edge: &Edge) -> SummaryDiagramResult<()> {
+    let mut deleted_info = None;
+    let new_ctx = ctx.clone_with_delete_visibility();
+    let mut deleted_timestamp = None;
+    // I hate how this makes me feel inside my heart. -- Adam
+    if let Some(deleted_edge) = Edge::get_by_id(&new_ctx, edge.id()).await? {
+        if let Some(deletion_user_pk) = deleted_edge.deletion_user_pk() {
+            let history_actor = HistoryActor::User(*deletion_user_pk);
+            let actor = ActorView::from_history_actor(ctx, history_actor).await?;
+            deleted_timestamp = Some(
+                deleted_edge
+                    .visibility()
+                    .deleted_at
+                    .ok_or_else(|| SummaryDiagramError::NoTimestamp)?,
+            );
+
+            deleted_info = Some(HistoryEventMetadata {
+                actor,
+                timestamp: deleted_timestamp
+                    .expect("we know we have a deleted timestamp, but... we don't. Bug!"),
+            });
+        } else {
+            let history_actor = HistoryActor::SystemInit;
+            let actor = ActorView::from_history_actor(ctx, history_actor).await?;
+            deleted_timestamp = Some(
+                deleted_edge
+                    .visibility()
+                    .deleted_at
+                    .ok_or_else(|| SummaryDiagramError::NoTimestamp)?,
+            );
+
+            deleted_info = Some(HistoryEventMetadata {
+                actor,
+                timestamp: deleted_timestamp
+                    .expect("we know we have a deleted timestamp, but... we don't. Bug!"),
+            });
+        }
+    }
+
+    let _row = ctx
+        .txns()
+        .await?
+        .pg()
+        .query_one(
+            "SELECT object FROM summary_diagram_edge_delete_v1($1, $2, $3, $4, $5)",
+            &[
+                ctx.tenancy(),
+                ctx.visibility(),
+                &edge.id(),
+                &deleted_timestamp,
+                &serde_json::to_value(deleted_info)?,
+            ],
+        )
+        .await?;
+
+    // If this is a symbolic edge, we need to unset the relevant summary diagram component row's parent node id.
+    if edge.kind() == &EdgeKind::Symbolic {
+        let _row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_one(
+                "SELECT object FROM summary_diagram_component_unset_parent_node_id_v1($1, $2, $3)",
+                &[ctx.tenancy(), ctx.visibility(), &edge.tail_component_id()],
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn edge_list(ctx: &DalContext) -> SummaryDiagramResult<Vec<SummaryDiagramEdge>> {
+    let rows = ctx
+        .txns()
+        .await?
+        .pg()
+        .query(
+            LIST_SUMMARY_DIAGRAM_EDGES,
+            &[ctx.tenancy(), &ctx.visibility().change_set_pk],
+        )
+        .await?;
+    let objects: Vec<SummaryDiagramEdge> = objects_from_rows(rows)?;
+    Ok(objects)
+}

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -7,6 +7,7 @@ use si_data_pg::{PgError, PgPoolError};
 use thiserror::Error;
 use tokio::task::JoinError;
 
+use crate::diagram::summary_diagram::SummaryDiagramError;
 use crate::{
     fix::FixError, func::binding_return_value::FuncBindingReturnValueError,
     job::producer::BlockingJobError, job::producer::JobProducerError, status::StatusUpdaterError,
@@ -72,6 +73,8 @@ pub enum JobConsumerError {
     StandardModel(#[from] StandardModelError),
     #[error(transparent)]
     StatusUpdaterError(#[from] StatusUpdaterError),
+    #[error(transparent)]
+    SummaryDiagram(#[from] SummaryDiagramError),
     #[error(transparent)]
     TokioTask(#[from] JoinError),
     #[error(transparent)]

--- a/lib/dal/src/migrations/U2411__summary_diagram.sql
+++ b/lib/dal/src/migrations/U2411__summary_diagram.sql
@@ -1,0 +1,494 @@
+CREATE TABLE summary_diagram_components
+(
+    pk                       ident primary key                 default ident_create_v1(),
+    id                       ident                    not null default ident_create_v1(),
+    tenancy_workspace_pk     ident,
+    visibility_change_set_pk ident                    NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at    timestamp with time zone,
+    created_at               timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at               timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    component_id             ident                    NOT NULL,
+    display_name             text                     NOT NULL,
+    node_id                  ident                    NOT NULL,
+    parent_node_id           ident,
+    child_node_ids           jsonb,
+    schema_name              text                     NOT NULL,
+    schema_id                ident                    NOT NULL,
+    schema_variant_id        ident                    NOT NULL,
+    schema_variant_name      text                     NOT NULL,
+    schema_category          text                     NOT NULL,
+    position                 jsonb                    NOT NULL,
+    size                     jsonb                    NOT NULL,
+    color                    text                     NOT NULL,
+    node_type                text                     NOT NULL,
+    change_status            text                     NOT NULL,
+    has_resource             boolean                  NOT NULL,
+    created_info             jsonb                    NOT NULL,
+    updated_info             jsonb                    NOT NULL,
+    deleted_info             jsonb                    NOT NULL,
+    sockets                  jsonb                    NOT NULL
+);
+
+SELECT standard_model_table_constraints_v1('summary_diagram_components');
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('summary_diagram_components', 'model', 'summary_diagram_components', 'Summary Diagram Components');
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_id ident,
+    this_schema_name text,
+    this_schema_id ident,
+    this_schema_variant_id ident,
+    this_schema_variant_name text,
+    this_schema_category text,
+    this_sockets jsonb,
+    this_node_id ident,
+    this_display_name text,
+    this_position jsonb,
+    this_size jsonb,
+    this_color text,
+    this_node_type text,
+    this_change_status text,
+    this_has_resource boolean,
+    this_created_info jsonb,
+    this_updated_info jsonb,
+    this_deleted_info jsonb,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO summary_diagram_components (id, tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at,
+                                            component_id, display_name, node_id, schema_name,
+                                            schema_id, schema_variant_id, schema_variant_name, schema_category,
+                                            position, size, color, node_type, change_status, has_resource, created_info,
+                                            updated_info, deleted_info, sockets, child_node_ids)
+    VALUES (this_id, this_tenancy_record.tenancy_workspace_pk, this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at,
+            this_id, this_display_name, this_node_id, this_schema_name, this_schema_id, this_schema_variant_id,
+            this_schema_variant_name,
+            this_schema_category, this_position, this_size, this_color, this_node_type, this_change_status,
+            this_has_resource, this_created_info, this_updated_info, this_deleted_info,
+            this_sockets, jsonb_build_array())
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_update_geometry_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_node_id ident,
+    this_position jsonb,
+    this_size jsonb,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    UPDATE summary_diagram_components
+    SET position=this_position,
+        size=this_size
+    WHERE node_id = this_node_id
+      AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+      AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_set_parent_node_id_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id ident,
+    this_parent_node_id ident,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    UPDATE summary_diagram_components
+    SET parent_node_id=this_parent_node_id
+    WHERE component_id = this_component_id
+      AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+      AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_unset_parent_node_id_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id ident,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    UPDATE summary_diagram_components
+    SET parent_node_id=NULL
+    WHERE component_id = this_component_id
+      AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+      AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_update_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id ident,
+    this_name text,
+    this_color text,
+    this_component_type text,
+    this_has_resource bool,
+    this_updated_info jsonb,
+    this_deleted_at timestamp with time zone,
+    this_deleted_info jsonb,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_components%ROWTYPE;
+    this_change_status     text;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+    IF this_deleted_at IS NOT NULL then
+        this_change_status := 'deleted';
+    ELSE
+        this_change_status := 'modified';
+    END IF;
+
+    -- First, we check to see if there is a row already for this change set. If there isn't, we copy the HEAD
+    -- row with a few changes.
+    IF NOT EXISTS (SELECT
+                   FROM summary_diagram_components
+                   WHERE component_id = this_component_id
+                     AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+                     AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk) THEN
+        INSERT INTO summary_diagram_components (id, tenancy_workspace_pk, visibility_change_set_pk,
+                                                visibility_deleted_at, created_at, component_id,
+                                                display_name, node_id, schema_name,
+                                                schema_id, schema_variant_id,
+                                                schema_variant_name, schema_category, position, size, color, node_type,
+                                                change_status, has_resource, created_info, updated_info, deleted_info,
+                                                sockets, parent_node_id, child_node_ids)
+        SELECT id,
+               tenancy_workspace_pk,
+               this_visibility_record.visibility_change_set_pk AS visibility_change_set_pk,
+               this_visibility_record.visibility_deleted_at    AS visibility_deleted_at,
+               created_at,
+               component_id,
+               display_name,
+               node_id,
+               schema_name,
+               schema_id,
+               schema_variant_id,
+               schema_variant_name,
+               schema_category,
+               position,
+               size,
+               color,
+               node_type,
+               this_change_status,
+               has_resource,
+               created_info,
+               updated_info,
+               deleted_info,
+               sockets,
+               parent_node_id,
+               child_node_ids
+        FROM summary_diagram_components
+        WHERE id = this_component_id
+          AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+          AND visibility_change_set_pk = '00000000000000000000000000';
+    END IF;
+    UPDATE summary_diagram_components
+    SET display_name=this_name,
+        color=this_color,
+        node_type=this_component_type,
+        has_resource=this_has_resource,
+        updated_info=this_updated_info,
+        visibility_deleted_at = this_deleted_at,
+        deleted_info=this_deleted_info
+    WHERE component_id = this_component_id
+      AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+      AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk
+    -- AND in_tenancy_and_visible_v1(this_tenancy, this_visibility, summary_diagram_components)
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_change_status_trigger_v1() RETURNS trigger AS
+$$
+BEGIN
+    IF NEW.change_status != 'deleted' THEN
+        NEW.change_status := 'unmodified';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER summary_diagram_component_change_status
+    BEFORE INSERT OR UPDATE
+    ON summary_diagram_components
+    FOR EACH ROW
+    WHEN (NEW.visibility_change_set_pk = '00000000000000000000000000')
+EXECUTE FUNCTION summary_diagram_component_change_status_trigger_v1();
+
+CREATE OR REPLACE FUNCTION summary_diagram_component_child_node_ids_trigger_v1() RETURNS trigger AS
+$$
+BEGIN
+    IF NEW.parent_node_id IS NULL THEN
+        IF OLD.parent_node_id IS NOT NULL THEN
+            UPDATE summary_diagram_components
+            SET child_node_ids = (SELECT COALESCE(json_agg(s1ni.node_id), json_build_array())
+                                  FROM (SELECT DISTINCT ON (id) sdc1.node_id
+                                        FROM summary_diagram_components as sdc1
+                                        WHERE sdc1.tenancy_workspace_pk = NEW.tenancy_workspace_pk
+                                          AND sdc1.parent_node_id = OLD.parent_node_id
+                                          AND (sdc1.visibility_change_set_pk = NEW.visibility_change_set_pk
+                                            AND (sdc1.visibility_deleted_at IS NULL OR
+                                                 EXISTS (SELECT 1
+                                                         FROM summary_diagram_components AS sdc2
+                                                         WHERE sdc2.component_id = sdc1.component_id
+                                                           AND sdc2.visibility_change_set_pk = ident_nil_v1()
+                                                           AND sdc2.visibility_deleted_at IS NULL))
+                                            )
+                                        ORDER BY sdc1.id, sdc1.visibility_change_set_pk DESC,
+                                                 sdc1.visibility_deleted_at DESC) as s1ni)
+            WHERE node_id = OLD.parent_node_id;
+        END IF;
+    ELSE
+        UPDATE summary_diagram_components
+        SET child_node_ids = (SELECT COALESCE(json_agg(s1ni.node_id), json_build_array())
+                              FROM (SELECT DISTINCT ON (id) sdc1.node_id
+                                    FROM summary_diagram_components as sdc1
+                                    WHERE sdc1.tenancy_workspace_pk = NEW.tenancy_workspace_pk
+                                      AND sdc1.parent_node_id = NEW.parent_node_id
+                                      AND (sdc1.visibility_change_set_pk = NEW.visibility_change_set_pk
+                                        AND (sdc1.visibility_deleted_at IS NULL OR
+                                             EXISTS (SELECT 1
+                                                     FROM summary_diagram_components AS sdc2
+                                                     WHERE sdc2.component_id = sdc1.component_id
+                                                       AND sdc2.visibility_change_set_pk = ident_nil_v1()
+                                                       AND sdc2.visibility_deleted_at IS NULL))
+                                        )
+                                    ORDER BY sdc1.id, sdc1.visibility_change_set_pk DESC,
+                                             sdc1.visibility_deleted_at DESC) as s1ni)
+        WHERE node_id = NEW.parent_node_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER summary_diagram_component_child_node_ids
+    AFTER INSERT OR UPDATE
+    ON summary_diagram_components
+    FOR EACH ROW
+EXECUTE FUNCTION summary_diagram_component_child_node_ids_trigger_v1();
+
+CREATE TABLE summary_diagram_edges
+(
+    pk                       ident primary key                 default ident_create_v1(),
+    id                       ident                    not null default ident_create_v1(),
+    tenancy_workspace_pk     ident,
+    visibility_change_set_pk ident                    NOT NULL DEFAULT ident_nil_v1(),
+    visibility_deleted_at    timestamp with time zone,
+    created_at               timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at               timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    edge_id                  ident                    NOT NULL,
+    from_node_id             ident                    NOT NULL,
+    from_socket_id           ident                    NOT NULL,
+    to_node_id               ident                    NOT NULL,
+    to_socket_id             ident                    NOT NULL,
+    change_status            text                     NOT NULL,
+    created_info             jsonb                    NOT NULL,
+    deleted_info             jsonb
+);
+
+SELECT standard_model_table_constraints_v1('summary_diagram_edges');
+INSERT INTO standard_models (table_name, table_type, history_event_label_base, history_event_message_name)
+VALUES ('summary_diagram_edges', 'model', 'summary_diagram_edges', 'Summary Diagram Edges');
+
+CREATE OR REPLACE FUNCTION summary_diagram_edge_create_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_id ident,
+    this_from_node_id ident,
+    this_from_socket_id ident,
+    this_to_node_id ident,
+    this_to_socket_id ident,
+    this_created_info jsonb,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_edges%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    INSERT INTO summary_diagram_edges (id, tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at,
+                                       edge_id, from_node_id, from_socket_id, to_node_id,
+                                       to_socket_id, change_status, created_info)
+    VALUES (this_id, this_tenancy_record.tenancy_workspace_pk, this_visibility_record.visibility_change_set_pk,
+            this_visibility_record.visibility_deleted_at, this_id, this_from_node_id, this_from_socket_id,
+            this_to_node_id, this_to_socket_id, 'added', this_created_info)
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION summary_diagram_edge_change_status_trigger_v1() RETURNS trigger AS
+$$
+BEGIN
+    IF NEW.change_status != 'deleted' THEN
+        NEW.change_status := 'unmodified';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER summary_diagram_edge_change_status
+    BEFORE INSERT OR UPDATE
+    ON summary_diagram_edges
+    FOR EACH ROW
+    WHEN (NEW.visibility_change_set_pk = '00000000000000000000000000')
+EXECUTE FUNCTION summary_diagram_edge_change_status_trigger_v1();
+
+CREATE OR REPLACE FUNCTION summary_diagram_edge_delete_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_id ident,
+    this_visibility_deleted_at timestamp with time zone,
+    this_deleted_info jsonb,
+    OUT object json) AS
+$$
+DECLARE
+    this_tenancy_record    tenancy_record_v1;
+    this_visibility_record visibility_record_v1;
+    this_new_row           summary_diagram_edges%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    -- First, we check to see if there is a row already for this change set. If there isn't, we copy the HEAD
+    -- row with a few changes.
+    IF NOT EXISTS (SELECT
+                   FROM summary_diagram_edges
+                   WHERE id = this_id
+                     AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+                     AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk) THEN
+        INSERT INTO summary_diagram_edges
+        (id, tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at, created_at, updated_at, edge_id,
+         from_node_id, from_socket_id, to_node_id, to_socket_id, change_status, created_info, deleted_info)
+        SELECT id,
+               tenancy_workspace_pk,
+               this_visibility_record.visibility_change_set_pk AS visibility_change_set_pk,
+               this_visibility_deleted_at,
+               created_at,
+               updated_at,
+               edge_id,
+               from_node_id,
+               from_socket_id,
+               to_node_id,
+               to_socket_id,
+               change_status,
+               created_info,
+               deleted_info
+        FROM summary_diagram_edges
+        WHERE id = this_id
+          AND tenancy_workspace_pk = this_tenancy_record.tenancy_workspace_pk
+          AND visibility_change_set_pk = ident_nil_v1();
+    END IF;
+
+    UPDATE summary_diagram_edges
+    SET visibility_deleted_at = this_visibility_deleted_at,
+        deleted_info          = this_deleted_info,
+        change_status         = 'deleted'
+    WHERE id = this_id
+      AND visibility_change_set_pk = this_visibility_record.visibility_change_set_pk
+    RETURNING * INTO this_new_row;
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION edge_delete_updates_summaries_trigger_v1() RETURNS trigger AS
+$$
+DECLARE
+    this_deleted_info json;
+BEGIN
+    IF NEW.visibility_deleted_at IS NOT NULL THEN
+        IF NOT EXISTS (SELECT
+                       FROM summary_diagram_edges
+                       WHERE id = NEW.id
+                         AND tenancy_workspace_pk = NEW.tenancy_workspace_pk
+                         AND visibility_change_set_pk = NEW.visibility_change_set_pk) THEN
+            INSERT INTO summary_diagram_edges
+            (id, tenancy_workspace_pk, visibility_change_set_pk, visibility_deleted_at, created_at, updated_at, edge_id,
+             from_node_id, from_socket_id, to_node_id, to_socket_id, change_status, created_info, deleted_info)
+            SELECT id,
+                   tenancy_workspace_pk,
+                   NEW.visibility_change_set_pk,
+                   NEW.visibility_deleted_at,
+                   created_at,
+                   updated_at,
+                   edge_id,
+                   from_node_id,
+                   from_socket_id,
+                   to_node_id,
+                   to_socket_id,
+                   change_status,
+                   created_info,
+                   deleted_info
+            FROM summary_diagram_edges
+            WHERE id = NEW.id
+              AND tenancy_workspace_pk = NEW.tenancy_workspace_pk
+              AND visibility_change_set_pk = ident_nil_v1();
+        END IF;
+        this_deleted_info := jsonb_build_object(
+                'actor', jsonb_build_object(
+                        'pk', COALESCE(NEW.deletion_user_pk, ident_nil_v1()),
+                        'kind', 'system',
+                        'email', 'system@systeminit.com',
+                        'label', 'System Initiative'
+                         ),
+                'timestamp', NEW.visibility_deleted_at);
+        UPDATE summary_diagram_edges
+        SET visibility_deleted_at = NEW.visibility_deleted_at,
+            change_status         = 'deleted',
+            deleted_info          = this_deleted_info
+        WHERE id = NEW.id
+          AND tenancy_workspace_pk = NEW.tenancy_workspace_pk
+          AND visibility_change_set_pk = NEW.visibility_change_set_pk;
+    END IF;
+    RETURN NEW;
+END ;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER edge_delete_trigger
+    AFTER INSERT OR UPDATE
+    ON edges
+    FOR EACH ROW
+EXECUTE FUNCTION edge_delete_updates_summaries_trigger_v1();

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -99,6 +99,7 @@ const FIND_EXPLICIT_FOR_SCHEMA_VARIANT_AND_NAME: &str =
 const FIND_FOR_PROP: &str = include_str!("../queries/internal_provider/find_for_prop.sql");
 const FIND_EXPLICIT_FOR_SOCKET: &str =
     include_str!("../queries/internal_provider/find_explicit_for_socket.sql");
+const IS_FOR_ROOT_PROP: &str = include_str!("../queries/internal_provider/is_for_root_prop.sql");
 const LIST_FOR_SCHEMA_VARIANT: &str =
     include_str!("../queries/internal_provider/list_for_schema_variant.sql");
 const LIST_EXPLICIT_FOR_SCHEMA_VARIANT: &str =
@@ -634,5 +635,23 @@ impl InternalProvider {
         }
 
         Ok(objects.into_iter().collect())
+    }
+
+    /// Determines if the provided [`InternalProvider`] corresponds to a "root" [`Prop`](crate::Prop).
+    #[tracing::instrument(skip(ctx))]
+    pub async fn is_for_root_prop(
+        ctx: &DalContext,
+        internal_provider_id: InternalProviderId,
+    ) -> InternalProviderResult<bool> {
+        let maybe_row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                IS_FOR_ROOT_PROP,
+                &[ctx.tenancy(), ctx.visibility(), &internal_provider_id],
+            )
+            .await?;
+        Ok(maybe_row.is_some())
     }
 }

--- a/lib/dal/src/queries/attribute_value/is_for_internal_provider_of_root_prop.sql
+++ b/lib/dal/src/queries/attribute_value/is_for_internal_provider_of_root_prop.sql
@@ -1,6 +1,0 @@
-SELECT
-    pbtp.belongs_to_id IS NULL AS is_for_root_prop
-FROM internal_providers_v1($1, $2) AS ip
-LEFT JOIN prop_belongs_to_prop_v1($1, $2) AS pbtp
-    ON ip.id = pbtp.object_id
-WHERE ip.id = ($3::jsonb ->> 'attribute_context_internal_provider_id')::ident

--- a/lib/dal/src/queries/internal_provider/is_for_root_prop.sql
+++ b/lib/dal/src/queries/internal_provider/is_for_root_prop.sql
@@ -1,0 +1,4 @@
+SELECT 1 FROM schema_variants_v1($1, $2) AS schema_variants
+    JOIN internal_providers_v1($1, $2) AS internal_providers
+        ON schema_variants.root_prop_id = internal_providers.prop_id
+        AND internal_providers.id = $3;

--- a/lib/dal/src/queries/summary_diagram/list_summary_diagram_components.sql
+++ b/lib/dal/src/queries/summary_diagram/list_summary_diagram_components.sql
@@ -1,0 +1,13 @@
+SELECT DISTINCT ON (id) row_to_json(sdc1.*) AS object
+FROM summary_diagram_components AS sdc1
+WHERE in_tenancy_v1($1, sdc1)
+  AND ((sdc1.visibility_change_set_pk = $2
+    AND (sdc1.visibility_deleted_at IS NULL OR
+         EXISTS (SELECT 1
+                 FROM summary_diagram_components AS sdc2
+                 WHERE sdc2.component_id = sdc1.component_id
+                   AND sdc2.visibility_change_set_pk = ident_nil_v1()
+                   AND sdc2.visibility_deleted_at IS NULL))
+           )
+    OR sdc1.visibility_change_set_pk = ident_nil_v1() AND sdc1.visibility_deleted_at IS NULL)
+ORDER BY sdc1.id, sdc1.visibility_change_set_pk DESC, sdc1.visibility_deleted_at DESC;

--- a/lib/dal/src/queries/summary_diagram/list_summary_diagram_edges.sql
+++ b/lib/dal/src/queries/summary_diagram/list_summary_diagram_edges.sql
@@ -1,0 +1,13 @@
+SELECT DISTINCT ON (id) row_to_json(sde1.*) AS object
+FROM summary_diagram_edges AS sde1
+WHERE in_tenancy_v1($1, sde1)
+  AND ((sde1.visibility_change_set_pk = $2
+    AND (sde1.visibility_deleted_at IS NULL OR
+         EXISTS (SELECT 1
+                 FROM summary_diagram_edges AS sde2
+                 WHERE sde2.edge_id = sde1.edge_id
+                   AND sde2.visibility_change_set_pk = ident_nil_v1()
+                   AND sde2.visibility_deleted_at IS NULL))
+           )
+    OR sde1.visibility_change_set_pk = ident_nil_v1() AND sde1.visibility_deleted_at IS NULL)
+ORDER BY sde1.id, sde1.visibility_change_set_pk DESC, sde1.visibility_deleted_at DESC;

--- a/lib/dal/src/queries/summary_qualification/get_summary_qualifications.sql
+++ b/lib/dal/src/queries/summary_qualification/get_summary_qualifications.sql
@@ -1,5 +1,6 @@
 SELECT row_to_json(a) AS object
-FROM (SELECT DISTINCT ON (components.id) components.id AS component_id,
+FROM (
+SELECT DISTINCT ON (components.id) components.id AS component_id,
                                          summary_qualifications.component_name,
                                          summary_qualifications.total,
                                          summary_qualifications.warned,

--- a/lib/dal/tests/integration_test/internal/diagram.rs
+++ b/lib/dal/tests/integration_test/internal/diagram.rs
@@ -125,8 +125,8 @@ async fn get_diagram_and_create_and_delete_connection(ctx: &DalContext) {
     // Check the connection on the diagram.
     assert_eq!(diagram.edges().len(), 1);
     assert_eq!(
-        diagram.edges()[0],
-        DiagramEdgeView::from_with_change_status(connection.clone(), ChangeStatus::Added)
+        DiagramEdgeView::from_with_change_status(connection.clone(), ChangeStatus::Added).id(),
+        diagram.edges()[0].edge_id().to_string()
     );
 
     // Check the connection itself.


### PR DESCRIPTION
Creating a summary table for get_diagram, in two parts - one for components, and one for edges. This one is a bit more complicated than the qualification summary table, as it has more spots where the data needs to be updated.

Add summary edges and collect parentNodeIds for components

Summary edges are now deleted and created automatically. The migration for summary diagram tables and functions has been incremented due to a conflict when rebasing with main. "ChildNodeIds" are now collected within the frontend and only "parentNodeId" is collected for summary components.

Correctly determine if the attribute value being processed in dependent values update corresponds to a root prop and a component. Fix integration tests broken by changing the diagram edges and nodes types.