### PR TITLE
Add instance timeout to poolnoodle

### DIFF
--- a/lib/deadpool-cyclone/src/instance.rs
+++ b/lib/deadpool-cyclone/src/instance.rs
@@ -17,7 +17,7 @@ pub trait Spec {
     type Error;
 
     /// Performs setup activities to prepare the host to create [Instance]s.
-    async fn setup(&self) -> result::Result<(), Self::Error>;
+    async fn setup(&mut self) -> result::Result<(), Self::Error>;
     /// Creates and launches an [`Instance`].
     ///
     /// NOTE: the method is non-consuming so that multiple Instances can be spawned from the same
@@ -79,12 +79,7 @@ pub trait Spec {
     /// # });
     /// # Ok::<(), SpawnError>(())
     /// ```
-    async fn spawn(&self, id: u32) -> result::Result<Self::Instance, Self::Error>;
-
-    /// whether to enable pool_noodle when using this spec
-    fn use_pool_noodle(&self) -> bool;
-    /// the size of the pool
-    fn pool_size(&self) -> u16;
+    async fn spawn(&self) -> result::Result<Self::Instance, Self::Error>;
 }
 
 /// A type which implements the [Builder pattern] and builds a [`Spec`].

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_http.rs
@@ -296,17 +296,10 @@ impl Spec for LocalHttpInstanceSpec {
     type Instance = LocalHttpInstance;
     type Error = LocalHttpInstanceError;
 
-    fn use_pool_noodle(&self) -> bool {
-        false
-    }
-    fn pool_size(&self) -> u16 {
-        0
-    }
-
-    async fn setup(&self) -> result::Result<(), Self::Error> {
+    async fn setup(&mut self) -> result::Result<(), Self::Error> {
         Ok(())
     }
-    async fn spawn(&self, _id: u32) -> result::Result<Self::Instance, Self::Error> {
+    async fn spawn(&self) -> result::Result<Self::Instance, Self::Error> {
         let socket_addr = socket_addr_from(&self.socket_strategy).await?;
         let mut cmd = self.build_command(&socket_addr);
 

--- a/lib/deadpool-cyclone/src/pool_noodle/pool_noodle.rs
+++ b/lib/deadpool-cyclone/src/pool_noodle/pool_noodle.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
-use tokio::process::Command;
+
 use tokio::sync::Mutex;
 use tokio::time::Duration;
+use tokio::{process::Command, time::Instant};
 use tracing::{debug, trace, warn};
 
 use std::{collections::VecDeque, result};
@@ -9,6 +11,7 @@ use thiserror::Error;
 use tokio::time;
 
 const MINUMUM_JAIL_PERCENTAGE: f32 = 0.25;
+const CYCLONE_EXECUTION_TIMEOUT: u64 = 3600;
 
 type Result<T> = result::Result<T, PoolNoodleError>;
 ///---------------------------------------------------------------------
@@ -48,10 +51,6 @@ type Result<T> = result::Result<T, PoolNoodleError>;
 ///----------:::::::::::::::::::::::::::-#*****#######%%%%%-:+#=::::----
 ///:------------:::::::::::::::::::::::::##****#######%%%%%+:::::::-----
 ///=:----------::::::::::::::::::::::::::*#***########%%%%%*::::::------
-/// Pool Noodle is a tool for ensuring that we maintain a bare minimum number of Firecracker Jails
-/// for function execution. We wrap it in an Arc Mutex so we can update the queues it manages
-/// across threads.
-pub struct PoolNoodle(Arc<Mutex<PoolNoodleInner>>);
 
 /// Error type for [`PoolNoodle`].
 #[remain::sorted]
@@ -71,17 +70,31 @@ pub enum PoolNoodleError {
     SetClean,
 }
 
+/// Pool Noodle is a tool for ensuring that we maintain a bare minimum number of Firecracker Jails
+/// for function execution. We wrap it in an Arc Mutex so we can update the queues it manages
+/// across threads.
+#[derive(Debug, Clone)]
+pub struct PoolNoodle(pub Arc<Mutex<PoolNoodleInner>>);
+
 /// Inner struct to excpsulate the queues of jails in different states.
 ///
 /// pool_size: the total number of jails we want to manage
 /// ready: jails that can currently be used to run functions
 /// to_be_cleaned: jails that have been used and must be cleaned up
 /// unprepared: jails that are available to be prepared and moved into a ready state
+#[derive(Debug)]
 pub struct PoolNoodleInner {
     pool_size: u32,
+    active: BTreeMap<u32, Instant>,
     ready: Vec<u32>,
     to_be_cleaned: VecDeque<u32>,
     unprepared: VecDeque<u32>,
+}
+
+impl Default for PoolNoodle {
+    fn default() -> Self {
+        Self::new(0)
+    }
 }
 
 impl PoolNoodle {
@@ -90,6 +103,7 @@ impl PoolNoodle {
         PoolNoodle(Arc::new(
             PoolNoodleInner {
                 pool_size,
+                active: BTreeMap::new(),
                 ready: Vec::new(),
                 to_be_cleaned: VecDeque::new(),
                 unprepared: VecDeque::from_iter(0..pool_size),
@@ -103,7 +117,9 @@ impl PoolNoodle {
     /// 2. If so, go get an unprepared jail and prepare it!
     /// 3. If not, check if there are any jails that need to be cleaned.
     /// 4. If so, clean them and move them to `[unprepared]` so they can be made ready.
-    /// 5. If not, do nothing!
+    /// 5. If not, let's go check if our oldest active jail is older than the timeout
+    /// 6. If so, push it to to_be_cleaned
+    /// 7. If not, do nothing!
     ///
     /// todo(scott): this is a brute force approach. I deally moving this to be event driving and
     /// talking over channels will lets us simplify the cross-thread vec fun and the forver-looping
@@ -116,61 +132,73 @@ impl PoolNoodle {
 
             loop {
                 interval.tick().await;
+
                 let mut me = me.lock().await;
+                let active_len = me.active.len();
                 let ready_len = me.ready.len() as f32;
                 let to_be_cleaned_len = me.to_be_cleaned.len();
                 let unprepared_len = me.unprepared.len();
                 let target = me.pool_size as f32 * MINUMUM_JAIL_PERCENTAGE;
 
                 trace!(
-                    "PoolNoodle Stats -- desired ready: {}, ready: {}, to be cleaned: {}, unprepared: {}",
+                    "PoolNoodle Stats -- desired ready: {}, ready: {}, active: {}, to be cleaned: {}, unprepared: {}",
                     target,
                     ready_len,
+                    active_len,
                     to_be_cleaned_len,
                     unprepared_len,
                 );
 
                 // we're at fewer than 25% of the total, let's make more jails
                 if ready_len < target && unprepared_len != 0 {
-                    let id = match me.unprepared.pop_back() {
-                        Some(id) => id,
-                        None => {
-                            warn!("PoolNoodle: failed to pop_back() unprepared when it should not be empty!");
-                            continue;
+                    if let Some(id) = me.unprepared.pop_back() {
+                        match PoolNoodle::prepare_jail(id).await {
+                            Ok(_) => {
+                                debug!("PoolNoodle: jail readied: {}", id);
+                                me.ready.push(id);
+                            }
+                            Err(_) => {
+                                warn!("PoolNoodle: failed to ready jail: {}", id);
+                                me.unprepared.push_front(id);
+                            }
                         }
                     };
 
-                    match PoolNoodle::prepare_jail(id).await {
-                        Ok(_) => {
-                            debug!("PoolNoodle: jail readied: {}", id);
-                            me.ready.push(id);
-                        }
-                        Err(_) => {
-                            warn!("PoolNoodle: failed to ready jail: {}", id);
-                            me.unprepared.push_front(id);
-                        }
-                    }
                 // let's go clean some dead jails!
                 } else if to_be_cleaned_len != 0 {
                     // go get a jail that needs to be cleaned
-                    let id = match me.to_be_cleaned.pop_back() {
-                        Some(id) => id,
-                        None => {
-                            warn!("PoolNoodle: failed to pop_back() to_be_cleaned when it should not be empty!");
-                            continue;
-                        }
+                    if let Some(id) = me.to_be_cleaned.pop_back() {
+                        // attempt to clean it
+                        match PoolNoodle::clean_jail(id).await {
+                            // it worked!
+                            Ok(_) => {
+                                debug!("PoolNoodle: jail cleaned: {}", id);
+                                me.unprepared.push_back(id);
+                                // this jail should no longer be active, so let's make sure we
+                                // remove it
+                                me.active.remove(&id);
+                            }
+                            // it did not work. We should move on to a different jail. This one will be
+                            // abandoned.
+                            Err(_) => {
+                                warn!("PoolNoodle: failed to clean jail: {}", id);
+                            }
+                        };
                     };
-                    // attempt to clean it
-                    match PoolNoodle::clean_jail(id).await {
-                        // it worked!
-                        Ok(_) => {
-                            debug!("PoolNoodle: jail cleaned: {}", id);
-                            me.unprepared.push_back(id);
-                        }
-                        // it did not work. We should move on to a different jail. This one will be
-                        // abandoned.
-                        Err(_) => {
-                            warn!("PoolNoodle: failed to clean jail: {}", id);
+
+                // let's go see if any of our active jails have timed out
+                } else if active_len != 0 {
+                    // peak at the top jail to see if it needs to be cleaned
+                    if let Some((id, start_time)) = me.active.last_key_value() {
+                        let elapsed = start_time.elapsed();
+                        if elapsed >= Duration::from_secs(CYCLONE_EXECUTION_TIMEOUT) {
+                            debug!(
+                                "PoolNoodle: jail active for {:?}, more than timeout of {}s: {}",
+                                elapsed, CYCLONE_EXECUTION_TIMEOUT, id
+                            );
+                            if let Some((id, _)) = me.active.pop_last() {
+                                me.set_as_to_be_cleaned(id).await;
+                            }
                         }
                     };
                 } else {
@@ -208,14 +236,16 @@ impl PoolNoodle {
 
         Ok(())
     }
+}
 
+impl PoolNoodleInner {
     /// This pops a ready jail from the stack and returns its Id so it can be executed.
     /// If there are no ready jails, it will retry until it either gets one or retries out.
     pub async fn get_ready_jail(&mut self) -> Result<u32> {
         let mut retries = 30;
         loop {
             trace!("PoolNoodle: getting a ready jail.");
-            match self.0.lock().await.ready.pop() {
+            match self.ready.pop() {
                 Some(id) => {
                     debug!("PoolNoodle: got ready jail: {}", id);
                     break Ok(id);
@@ -233,8 +263,15 @@ impl PoolNoodle {
         }
     }
 
+    /// This marks a jail as active
+    pub async fn set_as_active(&mut self, id: u32, start_time: Instant) -> Result<Instant> {
+        self.active
+            .insert(id, start_time)
+            .ok_or(PoolNoodleError::ExecutionPoolStarved)
+    }
+
     /// This marks a jail as needing to be cleaned
     pub async fn set_as_to_be_cleaned(&mut self, id: u32) {
-        self.0.lock().await.to_be_cleaned.push_front(id)
+        self.to_be_cleaned.push_front(id)
     }
 }

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -1,3 +1,4 @@
+use deadpool_cyclone::PoolNoodle;
 use std::{
     env,
     net::{SocketAddr, ToSocketAddrs},
@@ -394,6 +395,7 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                 }
                 builder.pool_size(pool_size);
                 builder.connect_timeout(connect_timeout);
+                builder.pool_noodle(PoolNoodle::new(pool_size.into()));
 
                 Ok(Self::LocalUds(
                     builder.build().map_err(ConfigError::cyclone_spec_build)?,


### PR DESCRIPTION
* moves the PoolNoodle invocation to inside of local_uds instead of at the manager level to avoid repeating decision logic  specific to firecracker
* adds an `active` pool when we start an instance that keeps track of the start_time
* we now check if the pools are timed out and move them to the `to_be_cleaned` pool
* this check is pretty lazy and only happens if we don't have new jails to make or old jails to clean. Given that the timeout is 60 minutes, another few seconds should be fine
