### PR TITLE
feat: only reload properties and schema for impacted components

### DIFF
--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -339,6 +339,10 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
                 ...removePayload,
                 ...visibilityParams,
               },
+              onSuccess() {
+                const store = useComponentAttributesStore(componentId);
+                store.reloadPropertyEditorData();
+              },
             });
           },
 
@@ -381,7 +385,10 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
                 ...(isInsert ? updatePayload.insert : updatePayload.update),
                 ...visibilityParams,
               },
-              // onSuccess() {},
+              onSuccess() {
+                const store = useComponentAttributesStore(componentId);
+                store.reloadPropertyEditorData();
+              },
               onFail() {
                 // may not work exactly right with concurrent updates... but I dont think will be a problem
                 statusStore.cancelUpdateStarted();
@@ -395,10 +402,11 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           const realtimeStore = useRealtimeStore();
           realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
             {
-              eventType: "ChangeSetWritten",
+              eventType: "ComponentUpdated",
               debounce: true,
-              callback: (writtenChangeSetId) => {
-                if (writtenChangeSetId !== changeSetId) return;
+              callback: (updated) => {
+                if (updated.changeSetPk !== changeSetId) return;
+                if (updated.componentId !== this.selectedComponentId) return;
                 this.reloadPropertyEditorData();
               },
             },

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -147,6 +147,10 @@ export type WsEventPayloadMap = {
   ComponentCreated: {
     success: boolean;
   };
+  ComponentUpdated: {
+    componentId: string;
+    changeSetPk: string;
+  };
   ModuleImported: {
     schemaVariantIds: string[];
   };

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -23,6 +23,7 @@ use crate::schema::SchemaVariant;
 use crate::socket::{SocketEdgeKind, SocketError};
 use crate::standard_model::object_from_row;
 use crate::ws_event::WsEventError;
+use crate::ChangeSetPk;
 use crate::{
     diagram, impl_standard_model, node::NodeId, pk, provider::internal::InternalProviderError,
     standard_model, standard_model_accessor, standard_model_belongs_to, standard_model_has_many,
@@ -1279,6 +1280,29 @@ impl WsEvent {
         WsEvent::new(
             ctx,
             WsPayload::ComponentCreated(ComponentCreatedPayload { success: true }),
+        )
+        .await
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentUpdatedPayload {
+    component_id: ComponentId,
+    change_set_pk: ChangeSetPk,
+}
+
+impl WsEvent {
+    pub async fn component_updated(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::ComponentUpdated(ComponentUpdatedPayload {
+                component_id,
+                change_set_pk: ctx.visibility().change_set_pk,
+            }),
         )
         .await
     }

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -476,6 +476,12 @@ async fn update_summary_tables(
         deleted_at,
     )
     .await?;
+
+    WsEvent::component_updated(ctx, component_id)
+        .await?
+        .publish_on_commit(ctx)
+        .await?;
+
     Ok(())
 }
 

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use ulid::Ulid;
 
 use crate::change_set::{ChangeSetActorPayload, ChangeSetMergeVotePayload};
-use crate::component::ComponentCreatedPayload;
+use crate::component::{ComponentCreatedPayload, ComponentUpdatedPayload};
 use crate::pkg::{
     ImportWorkspaceVotePayload, ModuleImportedPayload, WorkspaceActorPayload,
     WorkspaceExportPayload, WorkspaceImportApprovalActorPayload, WorkspaceImportPayload,
@@ -63,6 +63,7 @@ pub enum WsPayload {
     CheckedQualifications(QualificationCheckPayload),
     CodeGenerated(CodeGeneratedPayload),
     ComponentCreated(ComponentCreatedPayload),
+    ComponentUpdated(ComponentUpdatedPayload),
     Cursor(CursorPayload),
     FixBatchReturn(FixBatchReturn),
     FixReturn(FixReturn),


### PR DESCRIPTION
This PR makes it so that we only re-load the properties and schema for impacted components. It adds a new WsEvent called "ComponentUpdated", which provides the component id and change set id. The component_attributes store then uses that event to trigger its update, rather than the raw ChangeSetUpdated event.

<img src="https://media2.giphy.com/media/3o85xwxr06YNoFdSbm/giphy.gif"/>