### PR TITLE
chore: amend wording in new change set dropdown

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -249,7 +249,7 @@ export function useChangeSetsStore() {
               latestNum = labelNum;
             }
           });
-          return `Demo ${latestNum + 1}`;
+          return `Change Set ${latestNum + 1}`;
         },
       },
       onActivated() {


### PR DESCRIPTION
Amends the wording to reflect "Change Set <number>" rather than "Demo <number>" as it's more appropriate as we move towards Production.