### PR TITLE
fix(web): calculate ancestry in frontend to ignore parentId stored for get_diagram

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -343,18 +343,26 @@ const titleTextRef = ref();
 const subtitleTextRef = ref();
 const groupRef = ref();
 
+const actualSockets = computed(() =>
+  _.filter(props.node.sockets, (s) => {
+    const should_skip = s.def.label === "Frame";
+
+    return !should_skip;
+  }),
+);
+
 const leftSockets = computed(() => {
   const leftSockets = _.filter(
-    props.node.sockets,
-    (s) => s.def.nodeSide === "left" && s.def.label !== "Frame",
+    actualSockets.value,
+    (s) => s.def.nodeSide === "left",
   );
 
   return _.sortBy(leftSockets, (s) => s.def.label);
 });
 const rightSockets = computed(() => {
   const rightSockets = _.filter(
-    props.node.sockets,
-    (s) => s.def.nodeSide === "right" && s.def.label !== "Frame",
+    actualSockets.value,
+    (s) => s.def.nodeSide === "right",
   );
 
   return _.sortBy(rightSockets, (s) => s.def.label);

--- a/lib/dal/src/diagram/summary_diagram.rs
+++ b/lib/dal/src/diagram/summary_diagram.rs
@@ -382,6 +382,10 @@ pub async fn create_edge_entry(ctx: &DalContext, edge: &Edge) -> SummaryDiagramR
         .await?;
 
     // If this is a symbolic edge, we need to set the relevant summary diagram component row's parent node id.
+    // NOTE(victor): This will store the wrong parent ID if parent has parents, since they get connected via symbolic edge,
+    // implicitly, later.
+    // TODO Store parent_node_id as data on the component itself, making sure to store only the direct parent
+    // so data survives export and import too
     if edge.kind() == &EdgeKind::Symbolic {
         let _row = ctx
             .txns()


### PR DESCRIPTION
Fixes bug in which we were showing implicit frame edges

<img width="847" alt="image" src="https://github.com/systeminit/si/assets/6564471/2e9085db-2bd9-4839-bee2-412f57caa0c8">
