### PR TITLE
Fix new components sometimes having a populated resource tree (BUG-60)

### DIFF
--- a/lib/dal/src/diagram/summary_diagram.rs
+++ b/lib/dal/src/diagram/summary_diagram.rs
@@ -160,8 +160,6 @@ pub async fn create_component_entry(
         }
     }
 
-    let resource_exists = component.resource(ctx).await?.payload.is_some();
-
     let _row = ctx
         .txns()
         .await?
@@ -185,7 +183,7 @@ pub async fn create_component_entry(
                 &color,
                 &node_type.to_string(),
                 &change_status.to_string(),
-                &resource_exists,
+                &false,
                 &serde_json::to_value(created_info)?,
                 &serde_json::to_value(updated_info)?,
                 &serde_json::to_value(deleted_info)?,

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -418,7 +418,7 @@ async fn update_summary_tables(
         }
     }
 
-    if let Some(_resource) = component_value_json.pointer("/resource") {
+    if let Some(_resource) = component_value_json.pointer("/resource/payload") {
         has_resource = true;
     }
 


### PR DESCRIPTION
This commit fixes a bug where new components non-deterministically have a populated resource tree.

When rapidly creating components, sometimes "has_resource" is calculated prematurely for the underlying function execution. The "/resource" field is populated as a result. This was not seen before the summary tables work because "has_resource" was always calculated on fetch.

This commit contains one quality of life improvement and one core fix to combat the issue.

The QOL improvement is to _always_ set "has_resource" to false when a component is created. This works when importing components too via the import/export feature because pre-existing resources will be set using "set_resource", which indirectly calls the
"summary_diagram::component_update" call via dependent values update.

The core fix is to check the "/resource/payload" field rather than the "/resource" field when setting "has_resource" just in case we encounter a data race. Besides, working with "/resource/payload" more accurately aligns with what "has_resource" is trying to achieve.

<img src="https://media0.giphy.com/media/I9WeMMvbg6VT0061kE/giphy-downsized-medium.gif"/>