### PR TITLE
bug(geometry): this fixes the geometry upsert

### DIFF
--- a/lib/dal/src/migrations/U2412__summary_diagram_update_geometry_insert_row.sql
+++ b/lib/dal/src/migrations/U2412__summary_diagram_update_geometry_insert_row.sql
@@ -52,7 +52,7 @@ BEGIN
                size,
                color,
                node_type,
-               this_change_status,
+               change_status,
                has_resource,
                created_info,
                updated_info,


### PR DESCRIPTION
Fixes the issue where 'this_change_status' is seen as not existing as a column, because it's not set as a variable. We actually don't want to update the change status when you move the geometry anyway, so easy fix.