### PR TITLE
fix(web) url issues when switching change sets

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -106,7 +106,6 @@ const fixesAreRunning = computed(
 );
 
 const openCollapsible = ref(true);
-
 onMounted(() => {
   if (changeSetStore.headSelected) {
     openCollapsible.value = !!window.localStorage.getItem("applied-changes");

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -418,12 +418,16 @@ function onSelectChangeSet(newVal: string) {
 
   if (newVal && route.name) {
     if (newVal === nilId()) newVal = "head";
+
+    // keep everything in the current route except the change set id
+    // note - we use push here, so there is a new browser history entry
     router.push({
       name: route.name,
       params: {
         ...route.params,
         changeSetId: newVal,
       },
+      query: route.query,
     });
   }
 }


### PR DESCRIPTION
we were running into issues sometimes when swapping change sets

This stuff gets pretty gnarly since we are keeping some state in sync between the URL, the store, and the tabs.
Unfortunately, there's not a good way out to make it much cleaner...