### PR TITLE
fix: remove extra retry from stop script

### DIFF
--- a/bin/veritech/scripts/stop.sh
+++ b/bin/veritech/scripts/stop.sh
@@ -30,11 +30,6 @@ userdel jailer-$SB_ID || true
 
 # Remove directories and files
 umount /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4 || true
-until ! mountpoint -q /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4
-do
-  echo "waiting for unmount"
-  sleep .1
-done
 dmsetup remove --retry rootfs-overlay-$SB_ID
 
 # We are not currently creating these.


### PR DESCRIPTION
This retry can possibly hang forever and is unnecessary with the `--retry` flag on dmsetup