### PR TITLE
Harden council and restart running jobs with a missing dep graph (ENG-2274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-settings",
+ "strum",
  "telemetry",
  "thiserror",
  "tokio",

--- a/lib/council-server/BUCK
+++ b/lib/council-server/BUCK
@@ -11,6 +11,7 @@ rust_library(
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",
+        "//third-party/rust:strum",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:ulid",

--- a/lib/council-server/Cargo.toml
+++ b/lib/council-server/Cargo.toml
@@ -6,14 +6,16 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-settings = { path = "../../lib/si-settings" }
+telemetry = { path = "../../lib/telemetry-rs" }
+
 derive_builder = { workspace = true }
 futures = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-si-data-nats = { path = "../../lib/si-data-nats" }
-si-settings = { path = "../../lib/si-settings" }
-telemetry = { path = "../../lib/telemetry-rs" }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 ulid = { workspace = true }

--- a/lib/council-server/src/client/management.rs
+++ b/lib/council-server/src/client/management.rs
@@ -1,0 +1,57 @@
+//! This module contains [`ManagementClient`], which is used to subscribe to management-type messages from a council
+//! server (example: notify all running pinga instances that they should [`restart`](ManagementResponse::Restart)
+//! actively running jobs).
+
+use futures::StreamExt;
+use si_data_nats::{NatsClient, Subject, Subscriber};
+use std::time::Duration;
+use telemetry::prelude::*;
+
+use crate::client::{ClientError, ClientResult};
+use crate::{ManagementResponse, SubjectGenerator};
+
+#[derive(Debug)]
+pub struct ManagementClient {
+    management_channel: Subject,
+    management_subscriber: Subscriber,
+}
+
+impl ManagementClient {
+    pub async fn new(nats: &NatsClient, subject_prefix: Option<String>) -> ClientResult<Self> {
+        let management_channel = SubjectGenerator::for_management_client(subject_prefix);
+        Ok(Self {
+            management_subscriber: nats.subscribe(management_channel.clone()).await?,
+            management_channel: management_channel.into(),
+        })
+    }
+
+    // None means subscriber has been unsubscribed or that the connection has been closed
+    pub async fn fetch_response(&mut self) -> ClientResult<Option<ManagementResponse>> {
+        // TODO: timeout so we don't get stuck here forever if council goes away
+        // TODO: handle message.data() empty with Status header as 503: https://github.com/nats-io/nats.go/pull/576
+        let msg = loop {
+            let res =
+                tokio::time::timeout(Duration::from_secs(60), self.management_subscriber.next())
+                    .await;
+
+            match res {
+                Ok(msg) => break msg,
+                Err(_) => {
+                    warn!(management_channel = ?self.management_channel, "Council client waiting for response on management channel for 60 seconds");
+                }
+            }
+        };
+
+        match msg {
+            Some(msg) => {
+                if msg.payload().is_empty() {
+                    return Err(ClientError::NoListenerAvailable);
+                }
+                Ok(Some(serde_json::from_slice::<ManagementResponse>(
+                    msg.payload(),
+                )?))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/lib/council-server/src/subject_generator.rs
+++ b/lib/council-server/src/subject_generator.rs
@@ -1,0 +1,53 @@
+//! This module contains the ability to generate NATS subjects for council and users of council.
+
+use crate::Id;
+
+pub(crate) type PubChannel = String;
+pub(crate) type ReplyChannel = String;
+pub(crate) type AllChannels = String;
+pub(crate) type ManagementChannel = String;
+pub(crate) type ManagementReplyChannel = String;
+
+pub(crate) struct SubjectGenerator;
+
+impl SubjectGenerator {
+    pub fn for_client(subject_prefix: Option<String>, id: Id) -> (PubChannel, ReplyChannel) {
+        let base_subject = Self::base_subject(subject_prefix.clone());
+
+        let pub_channel = format!("{base_subject}.{id}");
+        let reply_channel = format!("{pub_channel}.reply");
+
+        (pub_channel, reply_channel)
+    }
+
+    pub fn for_management_client(subject_prefix: Option<String>) -> ManagementChannel {
+        Self::management_subject(subject_prefix)
+    }
+
+    pub fn for_server(
+        subject_prefix: Option<String>,
+    ) -> (AllChannels, ManagementChannel, ManagementReplyChannel) {
+        let all_channels = Self::all_subjects(subject_prefix.clone());
+        let management_channel = Self::management_subject(subject_prefix);
+        let management_reply_channel = format!("{management_channel}.reply");
+
+        (all_channels, management_channel, management_reply_channel)
+    }
+
+    fn management_subject(subject_prefix: Option<String>) -> String {
+        let base_subject = Self::base_subject(subject_prefix);
+        format!("{base_subject}.management")
+    }
+
+    fn all_subjects(subject_prefix: Option<String>) -> String {
+        let base_subject = Self::base_subject(subject_prefix);
+        format!("{base_subject}.*")
+    }
+
+    fn base_subject(subject_prefix: Option<String>) -> String {
+        match subject_prefix {
+            Some(provided) => format!("{provided}.council"),
+            None => "council".to_string(),
+        }
+    }
+}

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -110,7 +110,7 @@ pub enum AttributeValueError {
     #[error("component not found by id: {0}")]
     ComponentNotFoundById(ComponentId),
     #[error(transparent)]
-    Council(#[from] council_server::client::Error),
+    Council(#[from] council_server::client::ClientError),
     #[error("empty attribute prototype arguments for group name: {0}")]
     EmptyAttributePrototypeArgumentsForGroup(String),
     #[error("external provider error: {0}")]

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -38,7 +38,7 @@ pub enum JobConsumerError {
     #[error("component {0} not found")]
     ComponentNotFound(ComponentId),
     #[error(transparent)]
-    Council(#[from] council_server::client::Error),
+    CouncilClient(#[from] council_server::client::ClientError),
     #[error("Protocol error with council: {0}")]
     CouncilProtocol(String),
     #[error(transparent)]

--- a/lib/pinga-server/src/lib.rs
+++ b/lib/pinga-server/src/lib.rs
@@ -16,7 +16,7 @@ pub fn nats_jobs_subject(prefix: Option<&str>) -> String {
     nats_subject(prefix, NATS_JOBS_DEFAULT_SUBJECT)
 }
 
-pub fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
+fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
     let suffix = suffix.as_ref();
     match prefix {
         Some(prefix) => format!("{prefix}.{suffix}"),


### PR DESCRIPTION
## Summary

This PR is a first pass at hardening council. It primarily encloses
council's core loop in an infallible wrapper as well as handles
situations where we have a missing dependency graph and need to restart
all running jobs. The restart broadcast is also published whenever
council boots up in case of a panic or restart.

<img src="https://media2.giphy.com/media/JkADkL9786mQBORwCS/giphy.gif"/>

## Description

Council:
- Upon startup, council will publish a message for all subscribers (all
  running pinga instances) to restart actively running jobs
- The core loop for "bin/council" has been wrapped with an infallible
  wrapper (within our control, the only way to escape the wrapper is via
  a shutdown call or a closed connection)
- Bubbled up errors are logged in otel
- Explicit panics are now disallowed in "lib/council-server" with
  additional clippy lints
- All "unwrap" usages have been replaced and are either bubbled up or
  handled

Missing Dependency Graph:
- In the two instances where a depenendecy graph can have missing data
  within council, we need to restart the actively running job

Management Client:
- There is a new client for council exclusively for subscribing to
  management messages from council
- This is solely used for restarting actively running jobs

Subject Generation:
- For both client and server, all subject management has been
  centralized into a new module in "lib/council-server"
- There are two new subjects: "<prefix>.council.management" and
  "<prefix>.council.management.reply"