### PR TITLE
bug: stop trying to find the span in our transaction libs

### DIFF
--- a/lib/si-data-nats/src/lib.rs
+++ b/lib/si-data-nats/src/lib.rs
@@ -87,12 +87,8 @@ impl Default for NatsConfig {
 // "transaction span" might be an ancestor span unless we're really careful.
 macro_rules! current_span_for_debug {
     () => {
-        if span_enabled!(target: "si_data_nats", Level::DEBUG) {
-            Span::current()
-        } else {
-            Span::none()
-        }
-    }
+        Span::none()
+    };
 }
 
 pub type NatsClient = Client;

--- a/lib/si-data-pg/src/lib.rs
+++ b/lib/si-data-pg/src/lib.rs
@@ -459,12 +459,8 @@ impl PgPool {
 // "transaction span" might be an ancestor span unless we're really careful.
 macro_rules! current_span_for_debug {
     () => {
-        if span_enabled!(target: "si_data_pg", Level::DEBUG) {
-            Span::current()
-        } else {
-            Span::none()
-        }
-    }
+        Span::none()
+    };
 }
 
 /// An instrumented wrapper for `deadpool::managed::Object<deadpool_postgres::Manager>`


### PR DESCRIPTION
This is a brutal hammer that disables some logic that tried to find the correct span for a transaction. It should make the spans a little weirder, but we think it will fix our performance problem.

<img src="https://media0.giphy.com/media/vTW5G6EWsymtO/giphy.gif"/>