### PR TITLE
bug(dal): fix some deadlocks

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -611,6 +611,29 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 ...visibilityParams,
               },
               onSuccess: (response) => {
+                // This is us calculating the childNodeIds
+                for (let x = 0; x < response.components.length; x++) {
+                  const c = response.components[x];
+                  if (c?.parentNodeId) {
+                    for (let y = 0; y < response.components.length; y++) {
+                      if (response.components[y]?.nodeId === c.parentNodeId) {
+                        if (
+                          response.components[y]?.childNodeIds.indexOf(
+                            c.nodeId,
+                          ) === -1
+                        ) {
+                          response.components[y]?.childNodeIds.push(c.nodeId);
+                        } else {
+                          if (_.isEmpty(response.components[y]?.childNodeIds)) {
+                            // @ts-ignore - we know this exists, we just checked
+                            response.components[y].childNodeIds = [c.nodeId];
+                          }
+                        }
+                        break;
+                      }
+                    }
+                  }
+                }
                 this.rawComponentsById = _.keyBy(response.components, "id");
                 this.edgesById = _.keyBy(response.edges, "id");
 

--- a/lib/dal/src/migrations/U2415__summary_diagram_update_fix_deadlock.sql
+++ b/lib/dal/src/migrations/U2415__summary_diagram_update_fix_deadlock.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS summary_diagram_component_child_node_ids ON summary_diagram_components;


### PR DESCRIPTION
This fixes deadlocks relating to the calculation of child_node_ids by the backend. We remove the trigger that calcualtes them, and now the summary tables always return an empty array. The frontend then calculates the correct child node ids itself by manipulating the raw response.

CC: Victor!

<img src="https://media0.giphy.com/media/W5wopTDMkNugyRGNrj/giphy.gif"/>