### PR TITLE
feat: refactor application telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -578,7 +578,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
 ]
 
 [[package]]
@@ -729,9 +729,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -739,14 +739,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -755,15 +755,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -971,7 +971,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
  "tar",
@@ -995,7 +995,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
  "tar",
@@ -1044,6 +1044,7 @@ dependencies = [
  "council-server",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1248,6 +1249,7 @@ dependencies = [
  "cyclone-server",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1346,7 +1348,7 @@ dependencies = [
  "futures",
  "hex",
  "iftree",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
  "nats-subscriber",
@@ -1363,7 +1365,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
  "si-crypto",
  "si-data-nats",
  "si-data-pg",
@@ -1427,12 +1429,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.4",
+ "darling_macro 0.20.4",
 ]
 
 [[package]]
@@ -1451,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1476,11 +1478,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.4",
  "quote",
  "syn 2.0.48",
 ]
@@ -2188,7 +2190,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -2215,7 +2217,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2224,9 +2226,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2441,7 +2447,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "tokio",
 ]
 
@@ -2509,7 +2515,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2534,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2634,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2829,9 +2835,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -2898,6 +2904,7 @@ dependencies = [
  "module-index-server",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3224,7 +3231,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3350,12 +3357,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50b637ffd883b2733a8483599fb6136b9dcedaa1850f7ac08b9b6f9f2061208"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
 dependencies = [
  "aliasable",
- "ouroboros_macro 0.18.2",
+ "ouroboros_macro 0.18.3",
  "static_assertions",
 ]
 
@@ -3374,12 +3381,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3633d65683f13b9bcfaa3150880b018899fb0e5d0542f4adaea4f503fdb5eabf"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -3495,7 +3502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_derive",
 ]
@@ -3529,11 +3536,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
- "pin-project-internal 1.1.3",
+ "pin-project-internal 1.1.4",
 ]
 
 [[package]]
@@ -3549,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3579,6 +3586,7 @@ dependencies = [
  "pinga-server",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3803,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3984,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529664dbccc0a296947615c997a857912d72d1c44be1fafb7bae54ecfa7a8c24"
+checksum = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -3994,13 +4002,12 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e895cb870cf06e92318cbbeb701f274d022d5ca87a16fa8244e291cd035ef954"
+checksum = "08d6c80329c0455510a8d42fce286ecb4b6bcd8c57e1816d9f2d6bd7379c2cc8"
 dependencies = [
  "async-trait",
  "cfg-if",
- "lazy_static",
  "log",
  "regex",
  "serde",
@@ -4009,16 +4016,16 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.7.8",
+ "toml 0.8.8",
  "url",
  "walkdir",
 ]
 
 [[package]]
 name = "refinery-macros"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123e8b80f8010c3ae38330c81e76938fc7adf6cdbfbaad20295bb8c22718b4f1"
+checksum = "6ab6e31e166a49d55cb09b62639e5ab9ba2e73f2f124336b06f6c321dc602779"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4029,13 +4036,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -4050,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4435,6 +4442,7 @@ dependencies = [
  "sdf-server",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4466,7 +4474,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_url_params",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
  "si-crypto",
  "si-data-nats",
  "si-data-pg",
@@ -4505,9 +4513,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f66e2129991acd51fcad7b59da1edd862edca69773cc9a19cb17b967fae2fb"
+checksum = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4533,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03da1864306242678ac3b6567e69f70dd1252a72742baa23a4d92d2d45da3fc"
+checksum = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4640,9 +4648,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -4660,9 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4671,11 +4679,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "itoa",
  "ryu",
  "serde",
@@ -4760,18 +4768,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros 3.5.1",
  "time",
 ]
 
@@ -4781,7 +4789,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -4789,11 +4797,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -4801,11 +4809,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "itoa",
  "ryu",
  "serde",
@@ -4856,6 +4864,7 @@ dependencies = [
  "strum",
  "telemetry-application",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4940,7 +4949,7 @@ dependencies = [
  "deadpool-postgres",
  "futures",
  "num_cpus",
- "ouroboros 0.18.2",
+ "ouroboros 0.18.3",
  "refinery",
  "remain",
  "rustls 0.22.2",
@@ -5017,7 +5026,7 @@ version = "0.1.0"
 dependencies = [
  "remain",
  "serde",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
  "thiserror",
 ]
 
@@ -5126,9 +5135,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -5183,7 +5192,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -5225,7 +5234,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "log",
  "memchr",
  "once_cell",
@@ -5426,7 +5435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
 dependencies = [
  "futures-core",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "tokio",
 ]
 
@@ -5599,6 +5608,7 @@ dependencies = [
  "telemetry",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -5836,7 +5846,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "rand 0.8.5",
  "tokio",
 ]
@@ -5872,7 +5882,7 @@ dependencies = [
  "educe",
  "futures-core",
  "futures-sink",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
 ]
@@ -5922,6 +5932,8 @@ dependencies = [
  "bytes 1.5.0",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -5988,7 +6000,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6001,7 +6013,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6026,7 +6038,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost",
  "tokio",
  "tokio-stream",
@@ -6045,7 +6057,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -6325,9 +6337,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
@@ -6353,6 +6365,7 @@ dependencies = [
  "color-eyre",
  "telemetry-application",
  "tokio",
+ "tokio-util",
  "veritech-server",
 ]
 
@@ -6747,9 +6760,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]
@@ -6838,9 +6851,9 @@ checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "yrs"
-version = "0.17.2"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aea14c6c33f2edd8a5ff9415360cfa5b98d90cce30c5ee3be59a8419fb15a9"
+checksum = "c4830316bfee4bec0044fe34a001cda783506d5c4c0852f8433c6041dfbfce51"
 dependencies = [
  "atomic_refcell",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ tokio-serde = { version = "0.8.0", features = ["json"] }
 tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
-tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0"}
 toml = { version = "0.8.8" }
 tower = "0.4.13"

--- a/bin/council/BUCK
+++ b/bin/council/BUCK
@@ -13,6 +13,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
 )

--- a/bin/council/Cargo.toml
+++ b/bin/council/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { workspace = true }
 council-server = { path = "../../lib/council-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/council/src/main.rs
+++ b/bin/council/src/main.rs
@@ -1,32 +1,29 @@
 use color_eyre::Result;
-use telemetry_application::{
-    prelude::*, ApplicationTelemetryClient, TelemetryClient, TelemetryConfig,
-};
+use telemetry_application::prelude::*;
 use tokio::sync::watch;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 mod args;
 
 const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
 
-fn main() {
-    std::thread::Builder::new()
-        .stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
-        .name("bin/council-std::thread".to_owned())
-        .spawn(move || {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
-                .thread_name("bin/council-tokio::runtime".to_owned())
-                .enable_all()
-                .build()?;
-            runtime.block_on(async_main())
-        })
-        .expect("council thread failed")
-        .join()
-        .expect("council thread panicked")
-        .expect("council thread join failed");
+fn main() -> Result<()> {
+    let thread_builder = ::std::thread::Builder::new().stack_size(RT_DEFAULT_THREAD_STACK_SIZE);
+    let thread_handler = thread_builder.spawn(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
+            .thread_name("bin/council-tokio::runtime")
+            .enable_all()
+            .build()?
+            .block_on(async_main())
+    })?;
+    thread_handler.join().unwrap()
 }
 
 async fn async_main() -> Result<()> {
+    let shutdown_token = CancellationToken::new();
+    let task_tracker = TaskTracker::new();
+
     color_eyre::install()?;
     let config = TelemetryConfig::builder()
         .service_name("council")
@@ -34,28 +31,17 @@ async fn async_main() -> Result<()> {
         .log_env_var_prefix("SI")
         .app_modules(vec!["council", "council_server"])
         .build()?;
-    let telemetry = telemetry_application::init(config)?;
+    let mut telemetry = telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
 
     let (_shutdown_request_tx, shutdown_request_rx) = watch::channel(());
-    tokio::task::spawn(run(args, telemetry, shutdown_request_rx)).await??;
 
-    Ok(())
-}
-
-async fn run(
-    args: args::Args,
-    mut telemetry: ApplicationTelemetryClient,
-    shutdown_request_rx: watch::Receiver<()>,
-) -> Result<()> {
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;
     }
     debug!(arguments =?args, "parsed cli arguments");
 
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
+    task_tracker.close();
 
     let config = council_server::server::Config::try_from(args)?;
     let server = council_server::Server::new_with_config(config).await?;
@@ -63,5 +49,16 @@ async fn run(
     server
         .run(subscriber_started_tx, shutdown_request_rx.clone())
         .await?;
+
+    // TODO(fnichol): this will eventually go into the signal handler code but at the moment in
+    // council's case, this is embedded in server library code which is incorrect. At this moment
+    // in the program however, the main council server has shut down so it's an appropriate time to
+    // cancel other remaining tasks and wait on their graceful shutdowns
+    {
+        shutdown_token.cancel();
+        task_tracker.wait().await;
+    }
+
+    info!("graceful shutdown complete.");
     Ok(())
 }

--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -35,6 +35,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
 )

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { version = "0.6.1" }
 cyclone-server = { path = "../../lib/cyclone-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/module-index/BUCK
+++ b/bin/module-index/BUCK
@@ -13,6 +13,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
     resources = {

--- a/bin/module-index/Cargo.toml
+++ b/bin/module-index/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { workspace = true }
 module-index-server = { path = "../../lib/module-index-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/pinga/BUCK
+++ b/bin/pinga/BUCK
@@ -13,6 +13,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
     resources = {

--- a/bin/pinga/Cargo.toml
+++ b/bin/pinga/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { workspace = true }
 pinga-server = { path = "../../lib/pinga-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -1,9 +1,7 @@
 use color_eyre::Result;
 use pinga_server::{Config, Server};
-use telemetry_application::{
-    prelude::*, start_tracing_level_signal_handler_task, ApplicationTelemetryClient,
-    TelemetryClient, TelemetryConfig,
-};
+use telemetry_application::prelude::*;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 mod args;
 
@@ -23,6 +21,9 @@ fn main() -> Result<()> {
 }
 
 async fn async_main() -> Result<()> {
+    let shutdown_token = CancellationToken::new();
+    let task_tracker = TaskTracker::new();
+
     color_eyre::install()?;
     let config = TelemetryConfig::builder()
         .service_name("pinga")
@@ -30,28 +31,29 @@ async fn async_main() -> Result<()> {
         .log_env_var_prefix("SI")
         .app_modules(vec!["pinga", "pinga_server"])
         .build()?;
-    let telemetry = telemetry_application::init(config)?;
-
+    let mut telemetry = telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
 
-    run(args, telemetry).await
-}
-
-async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Result<()> {
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;
     }
     debug!(arguments =?args, "parsed cli arguments");
 
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
-
     let config = Config::try_from(args)?;
 
-    start_tracing_level_signal_handler_task(&telemetry)?;
+    task_tracker.close();
 
     Server::from_config(config).await?.run().await?;
 
+    // TODO(fnichol): this will eventually go into the signal handler code but at the moment in
+    // sdf's case, this is embedded in server library code which is incorrect. At this moment in
+    // the program however, axum has shut down so it's an appropriate time to cancel other
+    // remaining tasks and wait on their graceful shutdowns
+    {
+        shutdown_token.cancel();
+        task_tracker.wait().await;
+    }
+
+    info!("graceful shutdown complete.");
     Ok(())
 }

--- a/bin/sdf/BUCK
+++ b/bin/sdf/BUCK
@@ -13,6 +13,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
     resources = {

--- a/bin/sdf/Cargo.toml
+++ b/bin/sdf/Cargo.toml
@@ -15,3 +15,4 @@ color-eyre = { workspace = true }
 sdf-server = { path = "../../lib/sdf-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -7,10 +7,8 @@ use sdf_server::{
     Config, IncomingStream, JobProcessorClientCloser, JobProcessorConnector, MigrationMode, Server,
     ServicesContext,
 };
-use telemetry_application::{
-    prelude::*, start_tracing_level_signal_handler_task, ApplicationTelemetryClient,
-    TelemetryClient, TelemetryConfig,
-};
+use telemetry_application::prelude::*;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 mod args;
 
@@ -32,6 +30,9 @@ fn main() -> Result<()> {
 }
 
 async fn async_main() -> Result<()> {
+    let shutdown_token = CancellationToken::new();
+    let task_tracker = TaskTracker::new();
+
     color_eyre::install()?;
     let config = TelemetryConfig::builder()
         .service_name("sdf")
@@ -39,21 +40,13 @@ async fn async_main() -> Result<()> {
         .log_env_var_prefix("SI")
         .app_modules(vec!["sdf", "sdf_server"])
         .build()?;
-    let telemetry = telemetry_application::init(config)?;
+    let mut telemetry = telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
 
-    run(args, telemetry).await
-}
-
-async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Result<()> {
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;
     }
     debug!(arguments =?args, "parsed cli arguments");
-
-    if args.disable_opentelemetry {
-        telemetry.disable_opentelemetry().await?;
-    }
 
     Server::init()?;
 
@@ -115,9 +108,9 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
         trace!("migration mode is skip, not running migrations");
     }
 
-    start_tracing_level_signal_handler_task(&telemetry)?;
-
     let posthog_client = Server::start_posthog(config.posthog()).await?;
+
+    task_tracker.close();
 
     match config.incoming_stream() {
         IncomingStream::HTTPSocket(_) => {
@@ -161,10 +154,20 @@ async fn run(args: args::Args, mut telemetry: ApplicationTelemetryClient) -> Res
         }
     }
 
+    // TODO(fnichol): this will eventually go into the signal handler code but at the moment in
+    // sdf's case, this is embedded in server library code which is incorrect. At this moment in
+    // the program however, axum has shut down so it's an appropriate time to cancel other
+    // remaining tasks and wait on their graceful shutdowns
+    {
+        shutdown_token.cancel();
+        task_tracker.wait().await;
+    }
+
     info!("Shutting down the job processor client");
     if let Err(err) = (&job_client as &dyn JobProcessorClientCloser).close().await {
         error!("Failed to close job client: {err}");
     }
 
+    info!("graceful shutdown complete.");
     Ok(())
 }

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -163,7 +163,6 @@ async fn async_main() -> Result<()> {
         task_tracker.wait().await;
     }
 
-    info!("Shutting down the job processor client");
     if let Err(err) = (&job_client as &dyn JobProcessorClientCloser).close().await {
         error!("Failed to close job client: {err}");
     }

--- a/bin/si/BUCK
+++ b/bin/si/BUCK
@@ -7,15 +7,16 @@ load(
 rust_binary(
     name = "si",
     deps = [
-        "//third-party/rust:clap",
-        "//third-party/rust:color-eyre",
-        "//third-party/rust:tokio",
-        "//third-party/rust:strum",
-        "//third-party/rust:derive_builder",
-        "//third-party/rust:serde_json",
         "//lib/si-cli:si-cli",
         "//lib/si-posthog-rs:si-posthog",
         "//lib/telemetry-application-rs:telemetry-application",
+        "//third-party/rust:clap",
+        "//third-party/rust:color-eyre",
+        "//third-party/rust:derive_builder",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:strum",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs", "src/version.txt"]),
 )

--- a/bin/si/Cargo.toml
+++ b/bin/si/Cargo.toml
@@ -19,3 +19,4 @@ si-posthog = { path = "../../lib/si-posthog-rs" }
 strum = { workspace = true }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -35,6 +35,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
     resources = {

--- a/bin/veritech/Cargo.toml
+++ b/bin/veritech/Cargo.toml
@@ -14,4 +14,5 @@ clap = { workspace = true }
 color-eyre = { workspace = true }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 veritech-server = { path = "../../lib/veritech-server" }

--- a/lib/sdf-server/src/server/job_processor.rs
+++ b/lib/sdf-server/src/server/job_processor.rs
@@ -2,6 +2,7 @@ use crate::{server::server::ServerError, Config, Server};
 use async_trait::async_trait;
 use dal::{JobQueueProcessor, NatsProcessor};
 use si_data_nats::NatsClient;
+use telemetry::prelude::*;
 
 #[async_trait]
 pub trait JobProcessorClientCloser {
@@ -11,7 +12,8 @@ pub trait JobProcessorClientCloser {
 #[async_trait]
 impl JobProcessorClientCloser for NatsClient {
     async fn close(&self) -> Result<(), ServerError> {
-        Ok(self.close().await?)
+        debug!("shutting down the job processor client");
+        self.flush().await.map_err(Into::into)
     }
 }
 

--- a/lib/telemetry-application-rs/BUCK
+++ b/lib/telemetry-application-rs/BUCK
@@ -11,6 +11,7 @@ rust_library(
         "//third-party/rust:remain",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
         "//third-party/rust:tracing-opentelemetry",
         "//third-party/rust:tracing-subscriber",
     ],

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -14,5 +14,6 @@ remain = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -304,7 +304,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anstyle-1.0.4",
+        ":anstyle-1.0.5",
         ":anstyle-parse-0.2.3",
         ":anstyle-query-1.0.2",
         ":colorchoice-1.0.0",
@@ -313,18 +313,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstyle-1.0.4.crate",
-    sha256 = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87",
-    strip_prefix = "anstyle-1.0.4",
-    urls = ["https://crates.io/api/v1/crates/anstyle/1.0.4/download"],
+    name = "anstyle-1.0.5.crate",
+    sha256 = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220",
+    strip_prefix = "anstyle-1.0.5",
+    urls = ["https://crates.io/api/v1/crates/anstyle/1.0.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-1.0.4",
-    srcs = [":anstyle-1.0.4.crate"],
+    name = "anstyle-1.0.5",
+    srcs = [":anstyle-1.0.5.crate"],
     crate = "anstyle",
-    crate_root = "anstyle-1.0.4.crate/src/lib.rs",
+    crate_root = "anstyle-1.0.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -403,7 +403,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":anstyle-1.0.4"],
+    deps = [":anstyle-1.0.5"],
 )
 
 http_archive(
@@ -541,14 +541,14 @@ cargo.rust_library(
         ":nuid-0.5.0",
         ":once_cell-1.19.0",
         ":rand-0.8.5",
-        ":regex-1.10.2",
+        ":regex-1.10.3",
         ":ring-0.17.5",
         ":rustls-0.21.10",
         ":rustls-native-certs-0.6.3",
         ":rustls-pemfile-1.0.4",
         ":rustls-webpki-0.101.7",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_nanos-0.1.3",
         ":serde_repr-0.1.18",
         ":thiserror-1.0.56",
@@ -584,7 +584,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -629,7 +629,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -658,7 +658,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -771,8 +771,8 @@ cargo.rust_library(
     deps = [
         ":http-0.2.11",
         ":log-0.4.20",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":url-2.5.0",
         ":webpki-roots-0.25.3",
     ],
@@ -813,7 +813,7 @@ cargo.rust_library(
         ":log-0.4.20",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":thiserror-1.0.56",
         ":time-0.3.31",
         ":url-2.5.0",
@@ -883,8 +883,8 @@ cargo.rust_library(
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.13",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_path_to_error-0.1.15",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
@@ -943,7 +943,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -1120,7 +1120,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.5.0",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
     ],
 )
 
@@ -1200,7 +1200,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -1495,9 +1495,9 @@ cargo.rust_library(
         ":hyper-0.14.28",
         ":log-0.4.20",
         ":pin-project-lite-0.2.13",
-        ":serde-1.0.195",
-        ":serde_derive-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_derive-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_repr-0.1.18",
         ":serde_urlencoded-0.7.1",
         ":thiserror-1.0.56",
@@ -1523,9 +1523,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":serde_repr-0.1.18",
-        ":serde_with-3.4.0",
+        ":serde_with-3.5.1",
     ],
 )
 
@@ -1601,7 +1601,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.1",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -1673,7 +1673,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -1726,23 +1726,23 @@ cargo.rust_library(
 
 alias(
     name = "chrono",
-    actual = ":chrono-0.4.31",
+    actual = ":chrono-0.4.33",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "chrono-0.4.31.crate",
-    sha256 = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38",
-    strip_prefix = "chrono-0.4.31",
-    urls = ["https://crates.io/api/v1/crates/chrono/0.4.31/download"],
+    name = "chrono-0.4.33.crate",
+    sha256 = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb",
+    strip_prefix = "chrono-0.4.33",
+    urls = ["https://crates.io/api/v1/crates/chrono/0.4.33/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "chrono-0.4.31",
-    srcs = [":chrono-0.4.31.crate"],
+    name = "chrono-0.4.33",
+    srcs = [":chrono-0.4.33.crate"],
     crate = "chrono",
-    crate_root = "chrono-0.4.31.crate/src/lib.rs",
+    crate_root = "chrono-0.4.33.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -1751,6 +1751,7 @@ cargo.rust_library(
         "default",
         "iana-time-zone",
         "js-sys",
+        "now",
         "oldtime",
         "serde",
         "std",
@@ -1773,38 +1774,38 @@ cargo.rust_library(
             deps = [":iana-time-zone-0.1.59"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-targets-0.48.5"],
+            deps = [":windows-targets-0.52.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-targets-0.48.5"],
+            deps = [":windows-targets-0.52.0"],
         ),
     },
     visibility = [],
     deps = [
         ":num-traits-0.2.17",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
 alias(
     name = "ciborium",
-    actual = ":ciborium-0.2.1",
+    actual = ":ciborium-0.2.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "ciborium-0.2.1.crate",
-    sha256 = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926",
-    strip_prefix = "ciborium-0.2.1",
-    urls = ["https://crates.io/api/v1/crates/ciborium/0.2.1/download"],
+    name = "ciborium-0.2.2.crate",
+    sha256 = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e",
+    strip_prefix = "ciborium-0.2.2",
+    urls = ["https://crates.io/api/v1/crates/ciborium/0.2.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ciborium-0.2.1",
-    srcs = [":ciborium-0.2.1.crate"],
+    name = "ciborium-0.2.2",
+    srcs = [":ciborium-0.2.2.crate"],
     crate = "ciborium",
-    crate_root = "ciborium-0.2.1.crate/src/lib.rs",
+    crate_root = "ciborium-0.2.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -1812,25 +1813,25 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":ciborium-io-0.2.1",
-        ":ciborium-ll-0.2.1",
-        ":serde-1.0.195",
+        ":ciborium-io-0.2.2",
+        ":ciborium-ll-0.2.2",
+        ":serde-1.0.196",
     ],
 )
 
 http_archive(
-    name = "ciborium-io-0.2.1.crate",
-    sha256 = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656",
-    strip_prefix = "ciborium-io-0.2.1",
-    urls = ["https://crates.io/api/v1/crates/ciborium-io/0.2.1/download"],
+    name = "ciborium-io-0.2.2.crate",
+    sha256 = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757",
+    strip_prefix = "ciborium-io-0.2.2",
+    urls = ["https://crates.io/api/v1/crates/ciborium-io/0.2.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ciborium-io-0.2.1",
-    srcs = [":ciborium-io-0.2.1.crate"],
+    name = "ciborium-io-0.2.2",
+    srcs = [":ciborium-io-0.2.2.crate"],
     crate = "ciborium_io",
-    crate_root = "ciborium-io-0.2.1.crate/src/lib.rs",
+    crate_root = "ciborium-io-0.2.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -1840,23 +1841,23 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ciborium-ll-0.2.1.crate",
-    sha256 = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b",
-    strip_prefix = "ciborium-ll-0.2.1",
-    urls = ["https://crates.io/api/v1/crates/ciborium-ll/0.2.1/download"],
+    name = "ciborium-ll-0.2.2.crate",
+    sha256 = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9",
+    strip_prefix = "ciborium-ll-0.2.2",
+    urls = ["https://crates.io/api/v1/crates/ciborium-ll/0.2.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ciborium-ll-0.2.1",
-    srcs = [":ciborium-ll-0.2.1.crate"],
+    name = "ciborium-ll-0.2.2",
+    srcs = [":ciborium-ll-0.2.2.crate"],
     crate = "ciborium_ll",
-    crate_root = "ciborium-ll-0.2.1.crate/src/lib.rs",
+    crate_root = "ciborium-ll-0.2.2.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
-        ":ciborium-io-0.2.1",
-        ":half-1.8.2",
+        ":ciborium-io-0.2.2",
+        ":half-2.3.1",
     ],
 )
 
@@ -1926,7 +1927,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":anstream-0.6.11",
-        ":anstyle-1.0.4",
+        ":anstyle-1.0.5",
         ":clap_lex-0.6.0",
         ":strsim-0.10.0",
         ":terminal_size-0.3.0",
@@ -1952,7 +1953,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -2207,7 +2208,7 @@ cargo.rust_library(
         ":lazy_static-1.4.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":toml-0.5.11",
     ],
 )
@@ -2368,7 +2369,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
         ":http-0.2.11",
@@ -2376,9 +2377,9 @@ cargo.rust_library(
         ":log-0.4.20",
         ":mime-0.3.17",
         ":paste-1.0.14",
-        ":pin-project-1.1.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":pin-project-1.1.4",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
         ":tokio-1.35.1",
@@ -2420,7 +2421,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
         ":http-0.2.11",
@@ -2428,9 +2429,9 @@ cargo.rust_library(
         ":log-0.4.20",
         ":mime-0.3.17",
         ":paste-1.0.14",
-        ":pin-project-1.1.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":pin-project-1.1.4",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
         ":tokio-1.35.1",
@@ -3086,7 +3087,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -3118,18 +3119,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "darling-0.20.3.crate",
-    sha256 = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e",
-    strip_prefix = "darling-0.20.3",
-    urls = ["https://crates.io/api/v1/crates/darling/0.20.3/download"],
+    name = "darling-0.20.4.crate",
+    sha256 = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454",
+    strip_prefix = "darling-0.20.4",
+    urls = ["https://crates.io/api/v1/crates/darling/0.20.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "darling-0.20.3",
-    srcs = [":darling-0.20.3.crate"],
+    name = "darling-0.20.4",
+    srcs = [":darling-0.20.4.crate"],
     crate = "darling",
-    crate_root = "darling-0.20.3.crate/src/lib.rs",
+    crate_root = "darling-0.20.4.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -3137,8 +3138,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":darling_core-0.20.3",
-        ":darling_macro-0.20.3",
+        ":darling_core-0.20.4",
+        ":darling_macro-0.20.4",
     ],
 )
 
@@ -3164,7 +3165,7 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":strsim-0.10.0",
         ":syn-1.0.109",
@@ -3172,18 +3173,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "darling_core-0.20.3.crate",
-    sha256 = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621",
-    strip_prefix = "darling_core-0.20.3",
-    urls = ["https://crates.io/api/v1/crates/darling_core/0.20.3/download"],
+    name = "darling_core-0.20.4.crate",
+    sha256 = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a",
+    strip_prefix = "darling_core-0.20.4",
+    urls = ["https://crates.io/api/v1/crates/darling_core/0.20.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "darling_core-0.20.3",
-    srcs = [":darling_core-0.20.3.crate"],
+    name = "darling_core-0.20.4",
+    srcs = [":darling_core-0.20.4.crate"],
     crate = "darling_core",
-    crate_root = "darling_core-0.20.3.crate/src/lib.rs",
+    crate_root = "darling_core-0.20.4.crate/src/lib.rs",
     edition = "2018",
     features = [
         "strsim",
@@ -3193,7 +3194,7 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":strsim-0.10.0",
         ":syn-2.0.48",
@@ -3224,23 +3225,23 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "darling_macro-0.20.3.crate",
-    sha256 = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5",
-    strip_prefix = "darling_macro-0.20.3",
-    urls = ["https://crates.io/api/v1/crates/darling_macro/0.20.3/download"],
+    name = "darling_macro-0.20.4.crate",
+    sha256 = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd",
+    strip_prefix = "darling_macro-0.20.4",
+    urls = ["https://crates.io/api/v1/crates/darling_macro/0.20.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "darling_macro-0.20.3",
-    srcs = [":darling_macro-0.20.3.crate"],
+    name = "darling_macro-0.20.4",
+    srcs = [":darling_macro-0.20.4.crate"],
     crate = "darling_macro",
-    crate_root = "darling_macro-0.20.3.crate/src/lib.rs",
+    crate_root = "darling_macro-0.20.4.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":darling_core-0.20.3",
+        ":darling_core-0.20.4",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -3433,7 +3434,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -3454,7 +3455,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -3505,7 +3506,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.14.4",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -3585,7 +3586,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -3751,7 +3752,7 @@ cargo.rust_library(
         ":base64-0.13.1",
         ":byteorder-1.5.0",
         ":bytes-1.5.0",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":containers-api-0.9.0",
         ":docker-api-stubs-0.6.0",
         ":futures-util-0.3.30",
@@ -3759,8 +3760,8 @@ cargo.rust_library(
         ":hyper-0.14.28",
         ":log-0.4.20",
         ":paste-1.0.14",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
         ":url-2.5.0",
@@ -3775,9 +3776,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":chrono-0.4.31",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":chrono-0.4.33",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_with-2.3.3",
     ],
 )
@@ -3994,7 +3995,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-3.1.15",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -4020,7 +4021,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -4130,7 +4131,7 @@ cargo.rust_library(
     deps = [
         ":num-bigint-0.4.4",
         ":num-traits-0.2.17",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -4742,7 +4743,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -5045,7 +5046,7 @@ cargo.rust_library(
         ":aho-corasick-1.1.2",
         ":bstr-1.9.0",
         ":log-0.4.20",
-        ":regex-automata-0.4.3",
+        ":regex-automata-0.4.5",
         ":regex-syntax-0.8.2",
     ],
 )
@@ -5095,7 +5096,7 @@ cargo.rust_library(
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":http-0.2.11",
-        ":indexmap-2.1.0",
+        ":indexmap-2.2.1",
         ":slab-0.4.9",
         ":tokio-1.35.1",
         ":tokio-util-0.7.10",
@@ -5104,20 +5105,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "half-1.8.2.crate",
-    sha256 = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7",
-    strip_prefix = "half-1.8.2",
-    urls = ["https://crates.io/api/v1/crates/half/1.8.2/download"],
+    name = "half-2.3.1.crate",
+    sha256 = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872",
+    strip_prefix = "half-2.3.1",
+    urls = ["https://crates.io/api/v1/crates/half/2.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "half-1.8.2",
-    srcs = [":half-1.8.2.crate"],
+    name = "half-2.3.1",
+    srcs = [":half-2.3.1.crate"],
     crate = "half",
-    crate_root = "half-1.8.2.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "half-2.3.1.crate/src/lib.rs",
+    edition = "2021",
     visibility = [],
+    deps = [":cfg-if-1.0.0"],
 )
 
 http_archive(
@@ -5640,7 +5642,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":hex-0.4.3",
         ":hyper-0.14.28",
-        ":pin-project-1.1.3",
+        ":pin-project-1.1.4",
         ":tokio-1.35.1",
     ],
 )
@@ -5744,9 +5746,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.22",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":syn-1.0.109",
         ":toml-0.7.8",
         ":unicode-xid-0.2.4",
@@ -5781,7 +5783,7 @@ cargo.rust_library(
         ":globset-0.4.14",
         ":log-0.4.20",
         ":memchr-2.7.1",
-        ":regex-automata-0.4.3",
+        ":regex-automata-0.4.5",
         ":same-file-1.0.6",
         ":walkdir-2.4.0",
     ],
@@ -5828,23 +5830,23 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
 http_archive(
-    name = "indexmap-2.1.0.crate",
-    sha256 = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
-    strip_prefix = "indexmap-2.1.0",
-    urls = ["https://crates.io/api/v1/crates/indexmap/2.1.0/download"],
+    name = "indexmap-2.2.1.crate",
+    sha256 = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b",
+    strip_prefix = "indexmap-2.2.1",
+    urls = ["https://crates.io/api/v1/crates/indexmap/2.2.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "indexmap-2.1.0",
-    srcs = [":indexmap-2.1.0.crate"],
+    name = "indexmap-2.2.1",
+    srcs = [":indexmap-2.2.1.crate"],
     crate = "indexmap",
-    crate_root = "indexmap-2.1.0.crate/src/lib.rs",
+    crate_root = "indexmap-2.2.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -5856,7 +5858,7 @@ cargo.rust_library(
     deps = [
         ":equivalent-1.0.1",
         ":hashbrown-0.14.3",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -5934,7 +5936,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -6059,23 +6061,23 @@ cargo.rust_library(
 
 alias(
     name = "itertools",
-    actual = ":itertools-0.12.0",
+    actual = ":itertools-0.12.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "itertools-0.12.0.crate",
-    sha256 = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0",
-    strip_prefix = "itertools-0.12.0",
-    urls = ["https://crates.io/api/v1/crates/itertools/0.12.0/download"],
+    name = "itertools-0.12.1.crate",
+    sha256 = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
+    strip_prefix = "itertools-0.12.1",
+    urls = ["https://crates.io/api/v1/crates/itertools/0.12.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "itertools-0.12.0",
-    srcs = [":itertools-0.12.0.crate"],
+    name = "itertools-0.12.1",
+    srcs = [":itertools-0.12.1.crate"],
     crate = "itertools",
-    crate_root = "itertools-0.12.0.crate/src/lib.rs",
+    crate_root = "itertools-0.12.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -6162,8 +6164,8 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":thiserror-1.0.56",
         ":zeroize-1.7.0",
     ],
@@ -6935,7 +6937,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -7010,18 +7012,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "memmap2-0.9.3.crate",
-    sha256 = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92",
-    strip_prefix = "memmap2-0.9.3",
-    urls = ["https://crates.io/api/v1/crates/memmap2/0.9.3/download"],
+    name = "memmap2-0.9.4.crate",
+    sha256 = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322",
+    strip_prefix = "memmap2-0.9.4",
+    urls = ["https://crates.io/api/v1/crates/memmap2/0.9.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "memmap2-0.9.3",
-    srcs = [":memmap2-0.9.3.crate"],
+    name = "memmap2-0.9.4",
+    srcs = [":memmap2-0.9.4.crate"],
     crate = "memmap2",
-    crate_root = "memmap2-0.9.3.crate/src/lib.rs",
+    crate_root = "memmap2-0.9.4.crate/src/lib.rs",
     edition = "2018",
     features = ["stable_deref_trait"],
     platform = {
@@ -7639,7 +7641,7 @@ cargo.rust_library(
         ":num-iter-0.1.43",
         ":num-traits-0.2.17",
         ":rand-0.8.5",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":zeroize-1.7.0",
     ],
 )
@@ -8030,7 +8032,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
-        ":indexmap-2.1.0",
+        ":indexmap-2.2.1",
         ":once_cell-1.19.0",
         ":pin-project-lite-0.2.13",
         ":thiserror-1.0.56",
@@ -8339,23 +8341,23 @@ cargo.rust_library(
 
 alias(
     name = "ouroboros",
-    actual = ":ouroboros-0.18.2",
+    actual = ":ouroboros-0.18.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "ouroboros-0.18.2.crate",
-    sha256 = "a50b637ffd883b2733a8483599fb6136b9dcedaa1850f7ac08b9b6f9f2061208",
-    strip_prefix = "ouroboros-0.18.2",
-    urls = ["https://crates.io/api/v1/crates/ouroboros/0.18.2/download"],
+    name = "ouroboros-0.18.3.crate",
+    sha256 = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c",
+    strip_prefix = "ouroboros-0.18.3",
+    urls = ["https://crates.io/api/v1/crates/ouroboros/0.18.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ouroboros-0.18.2",
-    srcs = [":ouroboros-0.18.2.crate"],
+    name = "ouroboros-0.18.3",
+    srcs = [":ouroboros-0.18.3.crate"],
     crate = "ouroboros",
-    crate_root = "ouroboros-0.18.2.crate/src/lib.rs",
+    crate_root = "ouroboros-0.18.3.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -8364,7 +8366,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aliasable-0.1.3",
-        ":ouroboros_macro-0.18.2",
+        ":ouroboros_macro-0.18.3",
         ":static_assertions-1.1.0",
     ],
 )
@@ -8388,33 +8390,33 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
 )
 
 http_archive(
-    name = "ouroboros_macro-0.18.2.crate",
-    sha256 = "3633d65683f13b9bcfaa3150880b018899fb0e5d0542f4adaea4f503fdb5eabf",
-    strip_prefix = "ouroboros_macro-0.18.2",
-    urls = ["https://crates.io/api/v1/crates/ouroboros_macro/0.18.2/download"],
+    name = "ouroboros_macro-0.18.3.crate",
+    sha256 = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33",
+    strip_prefix = "ouroboros_macro-0.18.3",
+    urls = ["https://crates.io/api/v1/crates/ouroboros_macro/0.18.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ouroboros_macro-0.18.2",
-    srcs = [":ouroboros_macro-0.18.2.crate"],
+    name = "ouroboros_macro-0.18.3",
+    srcs = [":ouroboros_macro-0.18.3.crate"],
     crate = "ouroboros_macro",
-    crate_root = "ouroboros_macro-0.18.2.crate/src/lib.rs",
+    crate_root = "ouroboros_macro-0.18.3.crate/src/lib.rs",
     edition = "2018",
     features = ["std"],
     proc_macro = True,
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":itertools-0.12.0",
-        ":proc-macro2-1.0.76",
+        ":itertools-0.12.1",
+        ":proc-macro2-1.0.78",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.35",
         ":syn-2.0.48",
@@ -8608,7 +8610,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
     ],
 )
 
@@ -8680,7 +8682,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.21.7",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -8757,9 +8759,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":fixedbitset-0.4.2",
-        ":indexmap-2.1.0",
-        ":serde-1.0.195",
-        ":serde_derive-1.0.195",
+        ":indexmap-2.2.1",
+        ":serde-1.0.196",
+        ":serde_derive-1.0.196",
     ],
 )
 
@@ -8823,21 +8825,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "pin-project-1.1.3.crate",
-    sha256 = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422",
-    strip_prefix = "pin-project-1.1.3",
-    urls = ["https://crates.io/api/v1/crates/pin-project/1.1.3/download"],
+    name = "pin-project-1.1.4.crate",
+    sha256 = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0",
+    strip_prefix = "pin-project-1.1.4",
+    urls = ["https://crates.io/api/v1/crates/pin-project/1.1.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-1.1.3",
-    srcs = [":pin-project-1.1.3.crate"],
+    name = "pin-project-1.1.4",
+    srcs = [":pin-project-1.1.4.crate"],
     crate = "pin_project",
-    crate_root = "pin-project-1.1.3.crate/src/lib.rs",
+    crate_root = "pin-project-1.1.4.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":pin-project-internal-1.1.3"],
+    deps = [":pin-project-internal-1.1.4"],
 )
 
 http_archive(
@@ -8857,30 +8859,30 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
 )
 
 http_archive(
-    name = "pin-project-internal-1.1.3.crate",
-    sha256 = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405",
-    strip_prefix = "pin-project-internal-1.1.3",
-    urls = ["https://crates.io/api/v1/crates/pin-project-internal/1.1.3/download"],
+    name = "pin-project-internal-1.1.4.crate",
+    sha256 = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690",
+    strip_prefix = "pin-project-internal-1.1.4",
+    urls = ["https://crates.io/api/v1/crates/pin-project-internal/1.1.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-internal-1.1.3",
-    srcs = [":pin-project-internal-1.1.3.crate"],
+    name = "pin-project-internal-1.1.4",
+    srcs = [":pin-project-internal-1.1.4.crate"],
     crate = "pin_project_internal",
-    crate_root = "pin-project-internal-1.1.3.crate/src/lib.rs",
+    crate_root = "pin-project-internal-1.1.4.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -9048,7 +9050,7 @@ cargo.rust_library(
         ":base64-0.13.1",
         ":byteorder-1.5.0",
         ":bytes-1.5.0",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":containers-api-0.8.0",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
@@ -9056,8 +9058,8 @@ cargo.rust_library(
         ":log-0.4.20",
         ":paste-1.0.14",
         ":podman-api-stubs-0.9.0",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
         ":tokio-1.35.1",
@@ -9081,9 +9083,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":chrono-0.4.31",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":chrono-0.4.33",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
     ],
 )
 
@@ -9173,7 +9175,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -9239,9 +9241,9 @@ cargo.rust_library(
         "with-serde_json-1",
     ],
     named_deps = {
-        "chrono_04": ":chrono-0.4.31",
-        "serde_1": ":serde-1.0.195",
-        "serde_json_1": ":serde_json-1.0.111",
+        "chrono_04": ":chrono-0.4.33",
+        "serde_1": ":serde-1.0.196",
+        "serde_json_1": ":serde_json-1.0.113",
     },
     visibility = [],
     deps = [
@@ -9383,7 +9385,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -9433,45 +9435,45 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
     ],
 )
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.76",
+    actual = ":proc-macro2-1.0.78",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.76.crate",
-    sha256 = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c",
-    strip_prefix = "proc-macro2-1.0.76",
-    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.76/download"],
+    name = "proc-macro2-1.0.78.crate",
+    sha256 = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae",
+    strip_prefix = "proc-macro2-1.0.78",
+    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.78/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.76",
-    srcs = [":proc-macro2-1.0.76.crate"],
+    name = "proc-macro2-1.0.78",
+    srcs = [":proc-macro2-1.0.78.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.76.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.78.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.76-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.78-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.12"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.76-build-script-build",
-    srcs = [":proc-macro2-1.0.76.crate"],
+    name = "proc-macro2-1.0.78-build-script-build",
+    srcs = [":proc-macro2-1.0.78.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.76.crate/build.rs",
+    crate_root = "proc-macro2-1.0.78.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -9481,14 +9483,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.76-build-script-run",
+    name = "proc-macro2-1.0.78-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.76-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.78-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.76",
+    version = "1.0.78",
 )
 
 http_archive(
@@ -9512,7 +9514,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
         ":yansi-1.0.0-rc.1",
@@ -9564,7 +9566,7 @@ cargo.rust_library(
     deps = [
         ":anyhow-1.0.79",
         ":itertools-0.10.5",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -9592,7 +9594,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.1",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -9621,7 +9623,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.76"],
+    deps = [":proc-macro2-1.0.78"],
 )
 
 http_archive(
@@ -9829,23 +9831,23 @@ cargo.rust_library(
 
 alias(
     name = "refinery",
-    actual = ":refinery-0.8.11",
+    actual = ":refinery-0.8.12",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "refinery-0.8.11.crate",
-    sha256 = "529664dbccc0a296947615c997a857912d72d1c44be1fafb7bae54ecfa7a8c24",
-    strip_prefix = "refinery-0.8.11",
-    urls = ["https://crates.io/api/v1/crates/refinery/0.8.11/download"],
+    name = "refinery-0.8.12.crate",
+    sha256 = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e",
+    strip_prefix = "refinery-0.8.12",
+    urls = ["https://crates.io/api/v1/crates/refinery/0.8.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "refinery-0.8.11",
-    srcs = [":refinery-0.8.11.crate"],
+    name = "refinery-0.8.12",
+    srcs = [":refinery-0.8.12.crate"],
     crate = "refinery",
-    crate_root = "refinery-0.8.11.crate/src/lib.rs",
+    crate_root = "refinery-0.8.12.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -9853,24 +9855,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":refinery-core-0.8.11",
-        ":refinery-macros-0.8.11",
+        ":refinery-core-0.8.12",
+        ":refinery-macros-0.8.12",
     ],
 )
 
 http_archive(
-    name = "refinery-core-0.8.11.crate",
-    sha256 = "e895cb870cf06e92318cbbeb701f274d022d5ca87a16fa8244e291cd035ef954",
-    strip_prefix = "refinery-core-0.8.11",
-    urls = ["https://crates.io/api/v1/crates/refinery-core/0.8.11/download"],
+    name = "refinery-core-0.8.12.crate",
+    sha256 = "08d6c80329c0455510a8d42fce286ecb4b6bcd8c57e1816d9f2d6bd7379c2cc8",
+    strip_prefix = "refinery-core-0.8.12",
+    urls = ["https://crates.io/api/v1/crates/refinery-core/0.8.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "refinery-core-0.8.11",
-    srcs = [":refinery-core-0.8.11.crate"],
+    name = "refinery-core-0.8.12",
+    srcs = [":refinery-core-0.8.12.crate"],
     crate = "refinery_core",
-    crate_root = "refinery-core-0.8.11.crate/src/lib.rs",
+    crate_root = "refinery-core-0.8.12.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -9881,65 +9883,64 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.77",
         ":cfg-if-1.0.0",
-        ":lazy_static-1.4.0",
         ":log-0.4.20",
-        ":regex-1.10.2",
-        ":serde-1.0.195",
+        ":regex-1.10.3",
+        ":serde-1.0.196",
         ":siphasher-1.0.0",
         ":thiserror-1.0.56",
         ":time-0.3.31",
         ":tokio-1.35.1",
         ":tokio-postgres-0.7.10",
-        ":toml-0.7.8",
+        ":toml-0.8.8",
         ":url-2.5.0",
         ":walkdir-2.4.0",
     ],
 )
 
 http_archive(
-    name = "refinery-macros-0.8.11.crate",
-    sha256 = "123e8b80f8010c3ae38330c81e76938fc7adf6cdbfbaad20295bb8c22718b4f1",
-    strip_prefix = "refinery-macros-0.8.11",
-    urls = ["https://crates.io/api/v1/crates/refinery-macros/0.8.11/download"],
+    name = "refinery-macros-0.8.12.crate",
+    sha256 = "6ab6e31e166a49d55cb09b62639e5ab9ba2e73f2f124336b06f6c321dc602779",
+    strip_prefix = "refinery-macros-0.8.12",
+    urls = ["https://crates.io/api/v1/crates/refinery-macros/0.8.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "refinery-macros-0.8.11",
-    srcs = [":refinery-macros-0.8.11.crate"],
+    name = "refinery-macros-0.8.12",
+    srcs = [":refinery-macros-0.8.12.crate"],
     crate = "refinery_macros",
-    crate_root = "refinery-macros-0.8.11.crate/src/lib.rs",
+    crate_root = "refinery-macros-0.8.12.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
-        ":refinery-core-0.8.11",
-        ":regex-1.10.2",
+        ":refinery-core-0.8.12",
+        ":regex-1.10.3",
         ":syn-2.0.48",
     ],
 )
 
 alias(
     name = "regex",
-    actual = ":regex-1.10.2",
+    actual = ":regex-1.10.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "regex-1.10.2.crate",
-    sha256 = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343",
-    strip_prefix = "regex-1.10.2",
-    urls = ["https://crates.io/api/v1/crates/regex/1.10.2/download"],
+    name = "regex-1.10.3.crate",
+    sha256 = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15",
+    strip_prefix = "regex-1.10.3",
+    urls = ["https://crates.io/api/v1/crates/regex/1.10.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-1.10.2",
-    srcs = [":regex-1.10.2.crate"],
+    name = "regex-1.10.3",
+    srcs = [":regex-1.10.3.crate"],
     crate = "regex",
-    crate_root = "regex-1.10.2.crate/src/lib.rs",
+    crate_root = "regex-1.10.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -9964,7 +9965,7 @@ cargo.rust_library(
     deps = [
         ":aho-corasick-1.1.2",
         ":memchr-2.7.1",
-        ":regex-automata-0.4.3",
+        ":regex-automata-0.4.5",
         ":regex-syntax-0.8.2",
     ],
 )
@@ -9993,18 +9994,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "regex-automata-0.4.3.crate",
-    sha256 = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f",
-    strip_prefix = "regex-automata-0.4.3",
-    urls = ["https://crates.io/api/v1/crates/regex-automata/0.4.3/download"],
+    name = "regex-automata-0.4.5.crate",
+    sha256 = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd",
+    strip_prefix = "regex-automata-0.4.5",
+    urls = ["https://crates.io/api/v1/crates/regex-automata/0.4.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-automata-0.4.3",
-    srcs = [":regex-automata-0.4.3.crate"],
+    name = "regex-automata-0.4.5",
+    srcs = [":regex-automata-0.4.5.crate"],
     crate = "regex_automata",
-    crate_root = "regex-automata-0.4.3.crate/src/lib.rs",
+    crate_root = "regex-automata-0.4.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -10120,7 +10121,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -10295,8 +10296,8 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-0.2.11",
         ":mime_guess-2.0.4",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_urlencoded-0.7.1",
         ":tower-service-0.3.2",
         ":url-2.5.0",
@@ -11152,9 +11153,9 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rustls-0.21.10",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.195",
-        ":serde_derive-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_derive-1.0.196",
+        ":serde_json-1.0.113",
         ":sha2-0.10.8",
         ":thiserror-1.0.56",
         ":time-0.3.31",
@@ -11192,7 +11193,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.4",
         ":num-traits-0.2.17",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -11750,7 +11751,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -11758,23 +11759,23 @@ cargo.rust_library(
 
 alias(
     name = "sea-orm",
-    actual = ":sea-orm-0.12.11",
+    actual = ":sea-orm-0.12.12",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "sea-orm-0.12.11.crate",
-    sha256 = "59f66e2129991acd51fcad7b59da1edd862edca69773cc9a19cb17b967fae2fb",
-    strip_prefix = "sea-orm-0.12.11",
-    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.11/download"],
+    name = "sea-orm-0.12.12.crate",
+    sha256 = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d",
+    strip_prefix = "sea-orm-0.12.12",
+    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-0.12.11",
-    srcs = [":sea-orm-0.12.11.crate"],
+    name = "sea-orm-0.12.12",
+    srcs = [":sea-orm-0.12.12.crate"],
     crate = "sea_orm",
-    crate_root = "sea-orm-0.12.11.crate/src/lib.rs",
+    crate_root = "sea-orm-0.12.12.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bigdecimal",
@@ -11805,39 +11806,39 @@ cargo.rust_library(
         ":async-stream-0.3.5",
         ":async-trait-0.1.77",
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":futures-0.3.30",
         ":log-0.4.20",
         ":ouroboros-0.17.2",
         ":rust_decimal-1.33.1",
-        ":sea-orm-macros-0.12.11",
+        ":sea-orm-macros-0.12.12",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":sqlx-0.7.3",
         ":strum-0.25.0",
         ":thiserror-1.0.56",
         ":time-0.3.31",
         ":tracing-0.1.40",
         ":url-2.5.0",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
     ],
 )
 
 http_archive(
-    name = "sea-orm-macros-0.12.11.crate",
-    sha256 = "b03da1864306242678ac3b6567e69f70dd1252a72742baa23a4d92d2d45da3fc",
-    strip_prefix = "sea-orm-macros-0.12.11",
-    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.11/download"],
+    name = "sea-orm-macros-0.12.12.crate",
+    sha256 = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555",
+    strip_prefix = "sea-orm-macros-0.12.12",
+    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-macros-0.12.11",
-    srcs = [":sea-orm-macros-0.12.11.crate"],
+    name = "sea-orm-macros-0.12.12",
+    srcs = [":sea-orm-macros-0.12.12.crate"],
     crate = "sea_orm_macros",
-    crate_root = "sea-orm-macros-0.12.11.crate/src/lib.rs",
+    crate_root = "sea-orm-macros-0.12.12.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bae",
@@ -11852,7 +11853,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
         ":unicode-ident-1.0.12",
@@ -11898,14 +11899,14 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":derivative-2.2.0",
         ":inherent-1.0.11",
         ":ordered-float-3.9.2",
         ":rust_decimal-1.33.1",
-        ":serde_json-1.0.111",
+        ":serde_json-1.0.113",
         ":time-0.3.31",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
     ],
 )
 
@@ -11944,13 +11945,13 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":rust_decimal-1.33.1",
         ":sea-query-0.30.7",
-        ":serde_json-1.0.111",
+        ":serde_json-1.0.113",
         ":sqlx-0.7.3",
         ":time-0.3.31",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
     ],
 )
 
@@ -12101,23 +12102,23 @@ cargo.rust_library(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.195",
+    actual = ":serde-1.0.196",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.195.crate",
-    sha256 = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02",
-    strip_prefix = "serde-1.0.195",
-    urls = ["https://crates.io/api/v1/crates/serde/1.0.195/download"],
+    name = "serde-1.0.196.crate",
+    sha256 = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32",
+    strip_prefix = "serde-1.0.196",
+    urls = ["https://crates.io/api/v1/crates/serde/1.0.196/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.195",
-    srcs = [":serde-1.0.195.crate"],
+    name = "serde-1.0.196",
+    srcs = [":serde-1.0.196.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.195.crate/src/lib.rs",
+    crate_root = "serde-1.0.196.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -12128,7 +12129,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.195"],
+    deps = [":serde_derive-1.0.196"],
 )
 
 alias(
@@ -12157,31 +12158,31 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":chrono-0.4.31",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":chrono-0.4.33",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.195.crate",
-    sha256 = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c",
-    strip_prefix = "serde_derive-1.0.195",
-    urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.195/download"],
+    name = "serde_derive-1.0.196.crate",
+    sha256 = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67",
+    strip_prefix = "serde_derive-1.0.196",
+    urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.196/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.195",
-    srcs = [":serde_derive-1.0.195.crate"],
+    name = "serde_derive-1.0.196",
+    srcs = [":serde_derive-1.0.196.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.195.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.196.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -12189,23 +12190,23 @@ cargo.rust_library(
 
 alias(
     name = "serde_json",
-    actual = ":serde_json-1.0.111",
+    actual = ":serde_json-1.0.113",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_json-1.0.111.crate",
-    sha256 = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4",
-    strip_prefix = "serde_json-1.0.111",
-    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.111/download"],
+    name = "serde_json-1.0.113.crate",
+    sha256 = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79",
+    strip_prefix = "serde_json-1.0.113",
+    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.113/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_json-1.0.111",
-    srcs = [":serde_json-1.0.111.crate"],
+    name = "serde_json-1.0.113",
+    srcs = [":serde_json-1.0.113.crate"],
     crate = "serde_json",
-    crate_root = "serde_json-1.0.111.crate/src/lib.rs",
+    crate_root = "serde_json-1.0.113.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12217,10 +12218,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.1.0",
+        ":indexmap-2.2.1",
         ":itoa-1.0.10",
         ":ryu-1.0.16",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -12239,7 +12240,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.3.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -12259,7 +12260,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.10",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -12280,7 +12281,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -12302,7 +12303,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 alias(
@@ -12327,7 +12328,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":url-2.5.0",
     ],
 )
@@ -12351,7 +12352,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.10",
         ":ryu-1.0.16",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -12376,7 +12377,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "chrono_0_4": ":chrono-0.4.31",
+        "chrono_0_4": ":chrono-0.4.33",
         "indexmap_1": ":indexmap-1.9.3",
         "time_0_3": ":time-0.3.31",
     },
@@ -12384,31 +12385,31 @@ cargo.rust_library(
     deps = [
         ":base64-0.13.1",
         ":hex-0.4.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":serde_with_macros-2.3.3",
     ],
 )
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.4.0",
+    actual = ":serde_with-3.5.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.4.0.crate",
-    sha256 = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23",
-    strip_prefix = "serde_with-3.4.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with/3.4.0/download"],
+    name = "serde_with-3.5.1.crate",
+    sha256 = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c",
+    strip_prefix = "serde_with-3.5.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with/3.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.4.0",
-    srcs = [":serde_with-3.4.0.crate"],
+    name = "serde_with-3.5.1",
+    srcs = [":serde_with-3.5.1.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.4.0.crate/src/lib.rs",
+    crate_root = "serde_with-3.5.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12417,18 +12418,18 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "chrono_0_4": ":chrono-0.4.31",
+        "chrono_0_4": ":chrono-0.4.33",
         "indexmap_1": ":indexmap-1.9.3",
-        "indexmap_2": ":indexmap-2.1.0",
+        "indexmap_2": ":indexmap-2.2.1",
         "time_0_3": ":time-0.3.31",
     },
     visibility = [],
     deps = [
         ":base64-0.21.7",
         ":hex-0.4.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
-        ":serde_with_macros-3.4.0",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
+        ":serde_with_macros-3.5.1",
     ],
 )
 
@@ -12449,32 +12450,32 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":darling-0.20.3",
-        ":proc-macro2-1.0.76",
+        ":darling-0.20.4",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
 )
 
 http_archive(
-    name = "serde_with_macros-3.4.0.crate",
-    sha256 = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788",
-    strip_prefix = "serde_with_macros-3.4.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.4.0/download"],
+    name = "serde_with_macros-3.5.1.crate",
+    sha256 = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298",
+    strip_prefix = "serde_with_macros-3.5.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.4.0",
-    srcs = [":serde_with_macros-3.4.0.crate"],
+    name = "serde_with_macros-3.5.1",
+    srcs = [":serde_with_macros-3.5.1.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.4.0.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.5.1.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":darling-0.20.3",
-        ":proc-macro2-1.0.76",
+        ":darling-0.20.4",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -12482,30 +12483,30 @@ cargo.rust_library(
 
 alias(
     name = "serde_yaml",
-    actual = ":serde_yaml-0.9.30",
+    actual = ":serde_yaml-0.9.31",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_yaml-0.9.30.crate",
-    sha256 = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38",
-    strip_prefix = "serde_yaml-0.9.30",
-    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.30/download"],
+    name = "serde_yaml-0.9.31.crate",
+    sha256 = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e",
+    strip_prefix = "serde_yaml-0.9.31",
+    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_yaml-0.9.30",
-    srcs = [":serde_yaml-0.9.30.crate"],
+    name = "serde_yaml-0.9.31",
+    srcs = [":serde_yaml-0.9.31.crate"],
     crate = "serde_yaml",
-    crate_root = "serde_yaml-0.9.30.crate/src/lib.rs",
+    crate_root = "serde_yaml-0.9.31.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
-        ":indexmap-2.1.0",
+        ":indexmap-2.2.1",
         ":itoa-1.0.10",
         ":ryu-1.0.16",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":unsafe-libyaml-0.2.10",
     ],
 )
@@ -12841,22 +12842,22 @@ cargo.rust_library(
     edition = "2018",
     features = ["union"],
     visibility = [],
-    deps = [":smallvec-1.13.0"],
+    deps = [":smallvec-1.13.1"],
 )
 
 http_archive(
-    name = "smallvec-1.13.0.crate",
-    sha256 = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8",
-    strip_prefix = "smallvec-1.13.0",
-    urls = ["https://crates.io/api/v1/crates/smallvec/1.13.0/download"],
+    name = "smallvec-1.13.1.crate",
+    sha256 = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7",
+    strip_prefix = "smallvec-1.13.1",
+    urls = ["https://crates.io/api/v1/crates/smallvec/1.13.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "smallvec-1.13.0",
-    srcs = [":smallvec-1.13.0.crate"],
+    name = "smallvec-1.13.1",
+    srcs = [":smallvec-1.13.1.crate"],
     crate = "smallvec",
-    crate_root = "smallvec-1.13.0.crate/src/lib.rs",
+    crate_root = "smallvec-1.13.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "const_generics",
@@ -12934,7 +12935,7 @@ cargo.rust_library(
         ":ed25519-1.5.3",
         ":libc-0.2.152",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -13028,7 +13029,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":itertools-0.12.0",
+        ":itertools-0.12.1",
         ":nom-7.1.3",
         ":unicode_categories-0.1.1",
     ],
@@ -13113,7 +13114,7 @@ cargo.rust_library(
         ":bigdecimal-0.3.1",
         ":byteorder-1.5.0",
         ":bytes-1.5.0",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":crc-3.0.1",
         ":crossbeam-queue-0.3.11",
         ":dotenvy-0.15.7",
@@ -13126,7 +13127,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":hashlink-0.8.4",
         ":hex-0.4.3",
-        ":indexmap-2.1.0",
+        ":indexmap-2.2.1",
         ":log-0.4.20",
         ":memchr-2.7.1",
         ":once_cell-1.19.0",
@@ -13135,10 +13136,10 @@ cargo.rust_library(
         ":rust_decimal-1.33.1",
         ":rustls-0.21.10",
         ":rustls-pemfile-1.0.4",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":sha2-0.10.8",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":sqlformat-0.2.3",
         ":thiserror-1.0.56",
         ":time-0.3.31",
@@ -13146,7 +13147,7 @@ cargo.rust_library(
         ":tokio-stream-0.1.14",
         ":tracing-0.1.40",
         ":url-2.5.0",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
         ":webpki-roots-0.25.3",
     ],
 )
@@ -13190,7 +13191,7 @@ cargo.rust_library(
         ":bigdecimal-0.3.1",
         ":bitflags-2.4.2",
         ":byteorder-1.5.0",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":crc-3.0.1",
         ":dotenvy-0.15.7",
         ":futures-channel-0.3.30",
@@ -13209,17 +13210,17 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":rand-0.8.5",
         ":rust_decimal-1.33.1",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":sha1-0.10.6",
         ":sha2-0.10.8",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":sqlx-core-0.7.3",
         ":stringprep-0.1.4",
         ":thiserror-1.0.56",
         ":time-0.3.31",
         ":tracing-0.1.40",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
         ":whoami-1.4.1",
     ],
 )
@@ -13286,7 +13287,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-core-0.3.30",
-        ":pin-project-1.1.3",
+        ":pin-project-1.1.4",
         ":tokio-1.35.1",
     ],
 )
@@ -13378,7 +13379,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":rustversion-1.0.14",
         ":syn-2.0.48",
@@ -13465,7 +13466,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":unicode-ident-1.0.12",
     ],
@@ -13507,7 +13508,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":unicode-ident-1.0.12",
     ],
@@ -13778,7 +13779,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -13800,8 +13801,8 @@ cargo.rust_binary(
         ":blake3-1.5.0",
         ":bollard-0.15.0",
         ":bytes-1.5.0",
-        ":chrono-0.4.31",
-        ":ciborium-0.2.1",
+        ":chrono-0.4.33",
+        ":ciborium-0.2.2",
         ":clap-4.4.18",
         ":color-eyre-0.6.2",
         ":colored-2.1.0",
@@ -13829,7 +13830,7 @@ cargo.rust_binary(
         ":indicatif-0.17.7",
         ":indoc-2.0.4",
         ":inquire-0.6.2",
-        ":itertools-0.12.0",
+        ":itertools-0.12.1",
         ":jwt-simple-0.12.7",
         ":lazy_static-1.4.0",
         ":names-0.14.0",
@@ -13842,7 +13843,7 @@ cargo.rust_binary(
         ":opentelemetry-otlp-0.14.0",
         ":opentelemetry-semantic-conventions-0.13.0",
         ":opentelemetry_sdk-0.21.2",
-        ":ouroboros-0.18.2",
+        ":ouroboros-0.18.3",
         ":paste-1.0.14",
         ":pathdiff-0.2.1",
         ":petgraph-0.6.4",
@@ -13850,25 +13851,25 @@ cargo.rust_binary(
         ":podman-api-0.10.0",
         ":postgres-types-0.2.6",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":rand-0.8.5",
-        ":refinery-0.8.11",
-        ":regex-1.10.2",
+        ":refinery-0.8.12",
+        ":regex-1.10.3",
         ":remain-0.2.12",
         ":reqwest-0.11.23",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.22.2",
         ":rustls-pemfile-2.0.0",
-        ":sea-orm-0.12.11",
+        ":sea-orm-0.12.12",
         ":self-replace-1.3.7",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":serde-aux-4.4.0",
-        ":serde_json-1.0.111",
+        ":serde_json-1.0.113",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.4.0",
-        ":serde_yaml-0.9.30",
+        ":serde_with-3.5.1",
+        ":serde_yaml-0.9.31",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
         ":strum-0.25.0",
@@ -13894,12 +13895,12 @@ cargo.rust_binary(
         ":tracing-subscriber-0.3.18",
         ":ulid-1.1.0",
         ":url-2.5.0",
-        ":uuid-1.6.1",
+        ":uuid-1.7.0",
         ":vfs-0.10.0",
         ":vfs-tar-0.4.1",
         ":webpki-roots-0.25.3",
         ":y-sync-0.4.0",
-        ":yrs-0.17.2",
+        ":yrs-0.17.4",
     ],
 )
 
@@ -13944,7 +13945,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -14000,7 +14001,7 @@ cargo.rust_library(
         ":deranged-0.3.11",
         ":itoa-1.0.10",
         ":powerfmt-0.2.0",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":time-core-0.1.2",
         ":time-macros-0.2.16",
     ],
@@ -14251,7 +14252,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -14364,7 +14365,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":pin-project-1.1.3",
+        ":pin-project-1.1.4",
         ":rand-0.8.5",
         ":tokio-1.35.1",
     ],
@@ -14452,9 +14453,9 @@ cargo.rust_library(
         ":educe-0.4.23",
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
-        ":pin-project-1.1.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":pin-project-1.1.4",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
     ],
 )
 
@@ -14579,7 +14580,10 @@ cargo.rust_library(
     features = [
         "codec",
         "default",
+        "futures-util",
+        "hashbrown",
         "io",
+        "rt",
         "tracing",
     ],
     visibility = [],
@@ -14587,6 +14591,7 @@ cargo.rust_library(
         ":bytes-1.5.0",
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
+        ":futures-util-0.3.30",
         ":pin-project-lite-0.2.13",
         ":tokio-1.35.1",
         ":tracing-0.1.40",
@@ -14639,7 +14644,7 @@ cargo.rust_library(
     edition = "2018",
     features = ["default"],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -14663,7 +14668,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
         ":toml_edit-0.19.15",
@@ -14697,7 +14702,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.195",
+        ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
         ":toml_edit-0.21.0",
@@ -14720,7 +14725,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.195"],
+    deps = [":serde-1.0.196"],
 )
 
 http_archive(
@@ -14743,11 +14748,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.1.0",
-        ":serde-1.0.195",
+        ":indexmap-2.2.1",
+        ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.34",
+        ":winnow-0.5.35",
     ],
 )
 
@@ -14773,11 +14778,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.1.0",
-        ":serde-1.0.195",
+        ":indexmap-2.2.1",
+        ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.34",
+        ":winnow-0.5.35",
     ],
 )
 
@@ -14827,7 +14832,7 @@ cargo.rust_library(
         ":hyper-0.14.28",
         ":hyper-timeout-0.4.1",
         ":percent-encoding-2.3.1",
-        ":pin-project-1.1.3",
+        ":pin-project-1.1.4",
         ":prost-0.11.9",
         ":tokio-1.35.1",
         ":tokio-stream-0.1.14",
@@ -14887,7 +14892,7 @@ cargo.rust_library(
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
         ":indexmap-1.9.3",
-        ":pin-project-1.1.3",
+        ":pin-project-1.1.4",
         ":pin-project-lite-0.2.13",
         ":rand-0.8.5",
         ":slab-0.4.9",
@@ -15037,7 +15042,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],
@@ -15160,7 +15165,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":opentelemetry-0.21.0",
         ":opentelemetry_sdk-0.21.2",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
         ":tracing-log-0.2.0",
@@ -15211,9 +15216,9 @@ cargo.rust_library(
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
-        ":regex-1.10.2",
+        ":regex-1.10.3",
         ":sharded-slab-0.1.7",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":thread_local-1.1.7",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
@@ -15344,7 +15349,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -15578,7 +15583,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-0.5.0",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -15653,27 +15658,26 @@ cargo.rust_library(
 
 alias(
     name = "uuid",
-    actual = ":uuid-1.6.1",
+    actual = ":uuid-1.7.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "uuid-1.6.1.crate",
-    sha256 = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560",
-    strip_prefix = "uuid-1.6.1",
-    urls = ["https://crates.io/api/v1/crates/uuid/1.6.1/download"],
+    name = "uuid-1.7.0.crate",
+    sha256 = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a",
+    strip_prefix = "uuid-1.7.0",
+    urls = ["https://crates.io/api/v1/crates/uuid/1.7.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "uuid-1.6.1",
-    srcs = [":uuid-1.6.1.crate"],
+    name = "uuid-1.7.0",
+    srcs = [":uuid-1.7.0.crate"],
     crate = "uuid",
-    crate_root = "uuid-1.6.1.crate/src/lib.rs",
+    crate_root = "uuid-1.7.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
-        "getrandom",
         "rng",
         "serde",
         "std",
@@ -15682,7 +15686,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.12",
-        ":serde-1.0.195",
+        ":serde-1.0.196",
     ],
 )
 
@@ -15752,7 +15756,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":memmap2-0.9.3",
+        ":memmap2-0.9.4",
         ":stable_deref_trait-1.2.0",
         ":tar-parser2-0.9.1",
         ":vfs-0.10.0",
@@ -16270,18 +16274,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.5.34.crate",
-    sha256 = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16",
-    strip_prefix = "winnow-0.5.34",
-    urls = ["https://crates.io/api/v1/crates/winnow/0.5.34/download"],
+    name = "winnow-0.5.35.crate",
+    sha256 = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d",
+    strip_prefix = "winnow-0.5.35",
+    urls = ["https://crates.io/api/v1/crates/winnow/0.5.35/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.5.34",
-    srcs = [":winnow-0.5.34.crate"],
+    name = "winnow-0.5.35",
+    srcs = [":winnow-0.5.35.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.5.34.crate/src/lib.rs",
+    crate_root = "winnow-0.5.35.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -16331,7 +16335,7 @@ cargo.rust_library(
     deps = [
         ":bcder-0.7.4",
         ":bytes-1.5.0",
-        ":chrono-0.4.31",
+        ":chrono-0.4.33",
         ":der-0.7.8",
         ":hex-0.4.3",
         ":pem-3.0.3",
@@ -16399,7 +16403,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":thiserror-1.0.56",
         ":tokio-1.35.1",
-        ":yrs-0.17.2",
+        ":yrs-0.17.4",
     ],
 )
 
@@ -16444,32 +16448,32 @@ cargo.rust_library(
 
 alias(
     name = "yrs",
-    actual = ":yrs-0.17.2",
+    actual = ":yrs-0.17.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "yrs-0.17.2.crate",
-    sha256 = "68aea14c6c33f2edd8a5ff9415360cfa5b98d90cce30c5ee3be59a8419fb15a9",
-    strip_prefix = "yrs-0.17.2",
-    urls = ["https://crates.io/api/v1/crates/yrs/0.17.2/download"],
+    name = "yrs-0.17.4.crate",
+    sha256 = "c4830316bfee4bec0044fe34a001cda783506d5c4c0852f8433c6041dfbfce51",
+    strip_prefix = "yrs-0.17.4",
+    urls = ["https://crates.io/api/v1/crates/yrs/0.17.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "yrs-0.17.2",
-    srcs = [":yrs-0.17.2.crate"],
+    name = "yrs-0.17.4",
+    srcs = [":yrs-0.17.4.crate"],
     crate = "yrs",
-    crate_root = "yrs-0.17.2.crate/src/lib.rs",
+    crate_root = "yrs-0.17.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.195",
-        ":serde_json-1.0.111",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":smallstr-0.3.0",
-        ":smallvec-1.13.0",
+        ":smallvec-1.13.1",
         ":thiserror-1.0.56",
     ],
 )
@@ -16544,7 +16548,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.76",
+        ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
     ],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -562,7 +562,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
 ]
 
 [[package]]
@@ -692,9 +692,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -702,14 +702,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -718,15 +718,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -915,7 +915,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
  "tar",
@@ -939,7 +939,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
  "tar",
@@ -1166,12 +1166,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.4",
+ "darling_macro 0.20.4",
 ]
 
 [[package]]
@@ -1190,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1215,11 +1215,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.4",
  "quote",
  "syn 2.0.48",
 ]
@@ -1900,7 +1900,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -1927,7 +1927,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1936,9 +1936,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2153,7 +2157,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "tokio",
 ]
 
@@ -2221,7 +2225,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2246,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2346,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2535,9 +2539,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -2830,7 +2834,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2956,12 +2960,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50b637ffd883b2733a8483599fb6136b9dcedaa1850f7ac08b9b6f9f2061208"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
 dependencies = [
  "aliasable",
- "ouroboros_macro 0.18.2",
+ "ouroboros_macro 0.18.3",
  "static_assertions",
 ]
 
@@ -2980,12 +2984,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3633d65683f13b9bcfaa3150880b018899fb0e5d0542f4adaea4f503fdb5eabf"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -3101,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_derive",
 ]
@@ -3135,11 +3139,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
- "pin-project-internal 1.1.3",
+ "pin-project-internal 1.1.4",
 ]
 
 [[package]]
@@ -3155,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3372,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3553,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529664dbccc0a296947615c997a857912d72d1c44be1fafb7bae54ecfa7a8c24"
+checksum = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -3563,13 +3567,12 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e895cb870cf06e92318cbbeb701f274d022d5ca87a16fa8244e291cd035ef954"
+checksum = "08d6c80329c0455510a8d42fce286ecb4b6bcd8c57e1816d9f2d6bd7379c2cc8"
 dependencies = [
  "async-trait",
  "cfg-if",
- "lazy_static",
  "log",
  "regex",
  "serde",
@@ -3578,16 +3581,16 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.7.8",
+ "toml 0.8.8",
  "url",
  "walkdir",
 ]
 
 [[package]]
 name = "refinery-macros"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123e8b80f8010c3ae38330c81e76938fc7adf6cdbfbaad20295bb8c22718b4f1"
+checksum = "6ab6e31e166a49d55cb09b62639e5ab9ba2e73f2f124336b06f6c321dc602779"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3598,13 +3601,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -3619,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4010,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f66e2129991acd51fcad7b59da1edd862edca69773cc9a19cb17b967fae2fb"
+checksum = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4038,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03da1864306242678ac3b6567e69f70dd1252a72742baa23a4d92d2d45da3fc"
+checksum = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4145,9 +4148,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -4165,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4176,11 +4179,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "itoa",
  "ryu",
  "serde",
@@ -4265,18 +4268,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros 3.5.1",
  "time",
 ]
 
@@ -4286,7 +4289,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -4294,11 +4297,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -4306,11 +4309,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "itoa",
  "ryu",
  "serde",
@@ -4444,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -4501,7 +4504,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -4543,7 +4546,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "log",
  "memchr",
  "once_cell",
@@ -4744,7 +4747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
 dependencies = [
  "futures-core",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "tokio",
 ]
 
@@ -4978,7 +4981,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "inquire",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
  "names",
@@ -4991,7 +4994,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "ouroboros 0.18.2",
+ "ouroboros 0.18.3",
  "paste",
  "pathdiff",
  "petgraph",
@@ -5016,7 +5019,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_url_params",
- "serde_with 3.4.0",
+ "serde_with 3.5.1",
  "serde_yaml",
  "sodiumoxide",
  "stream-cancel",
@@ -5219,7 +5222,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "rand 0.8.5",
  "tokio",
 ]
@@ -5255,7 +5258,7 @@ dependencies = [
  "educe",
  "futures-core",
  "futures-sink",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "serde",
  "serde_json",
 ]
@@ -5305,6 +5308,8 @@ dependencies = [
  "bytes 1.5.0",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -5371,7 +5376,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5384,7 +5389,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5409,7 +5414,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "prost",
  "tokio",
  "tokio-stream",
@@ -5428,7 +5433,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project 1.1.3",
+ "pin-project 1.1.4",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -5708,9 +5713,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
@@ -6069,9 +6074,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]
@@ -6151,9 +6156,9 @@ checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "yrs"
-version = "0.17.2"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aea14c6c33f2edd8a5ff9415360cfa5b98d90cce30c5ee3be59a8419fb15a9"
+checksum = "c4830316bfee4bec0044fe34a001cda783506d5c4c0852f8433c6041dfbfce51"
 dependencies = [
  "atomic_refcell",
  "rand 0.7.3",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -111,7 +111,7 @@ tokio-serde = { version = "0.8.0", features = ["json"] }
 tokio-stream = "0.1.14"
 tokio-test = "0.4.2"
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
-tokio-util = { version = "0.7.8", features = ["codec"] }
+tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0"}
 toml = { version = "0.8.8" }
 tower = "0.4.13"


### PR DESCRIPTION
This change aggresively refactors the telemetry setup for all services.
The enabling/disabling of OpenTelemetry has been removed and is now
*always* active and set up.

The dynamic tracing level functionality remains but its approach is
different. In this current iteration, both the console logger and the
OpenTelemetry layer have their own reloadable `EnvFilter` layer on top,
whereas before the `EnvFilter` layer was its own third layer in the
`Registry` stack. That is:

```
- Registry
  - console_log
    - env_filter
  - otel
    - env_filter
```

At the moment both of the `EnvFilter`s are updated identically and at
the same time, but these may become more independent in future work.

Additionally, long-running the signal handling and level-updating tasks
have been re-written to be their own structs.

Finally, a new pattern is introduced into each of the service binary
crates which make use of 2 types from the `tokio-util` crate:
`TaskTracker` and `CancellationToken`. These 2 types work extremely well
together and make cancellation/shutown signalling and waiting (i.e. a
process-wide graceful shutdown) much more straight forward. Future work
will embed this idea further down into each service, allowing much of
the existing shutdown channel infrastructure to be pulled out.
