### PR TITLE
chore: inject otel ctx when dal submits jobs to pinga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "sodiumoxide",
  "strum",
  "telemetry",
+ "telemetry-nats",
  "tempfile",
  "thiserror",
  "tokio",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -17,6 +17,7 @@ rust_library(
         "//lib/si-pkg:si-pkg",
         "//lib/si-std:si-std",
         "//lib/telemetry-rs:telemetry",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/veritech-client:veritech-client",
         "//third-party/rust:async-recursion",
         "//third-party/rust:async-trait",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -46,6 +46,7 @@ si-std = { path = "../../lib/si-std" }
 sodiumoxide = { workspace = true }
 strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -791,6 +791,12 @@ impl Transactions {
 
     /// Consumes all inner transactions, committing all changes made within them, and returns
     /// underlying connections.
+    #[instrument(
+        name = "transactions.commit_into_conns",
+        level = "info",
+        skip_all,
+        fields()
+    )]
     pub async fn commit_into_conns(self) -> Result<Connections, TransactionsError> {
         let pg_conn = self.pg_txn.commit_into_conn().await?;
         let nats_conn = self.nats_txn.commit_into_conn().await?;
@@ -802,6 +808,12 @@ impl Transactions {
 
     /// Consumes all inner transactions, committing all changes made within them, and returns
     /// underlying connections. Blocking until all queued jobs have reported as finishing.
+    #[instrument(
+        name = "transactions.blocking_commit_into_conns",
+        level = "info",
+        skip_all,
+        fields()
+    )]
     pub async fn blocking_commit_into_conns(self) -> Result<Connections, TransactionsError> {
         let pg_conn = self.pg_txn.commit_into_conn().await?;
         let nats_conn = self.nats_txn.commit_into_conn().await?;

--- a/lib/dal/src/job/processor/nats_processor.rs
+++ b/lib/dal/src/job/processor/nats_processor.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use futures::StreamExt;
-use si_data_nats::{NatsClient, Subject};
+use si_data_nats::{HeaderMap, NatsClient, Subject};
 use telemetry::prelude::*;
+use telemetry_nats::inject_headers;
 use tokio::task::JoinSet;
 
 use crate::job::{
@@ -34,14 +35,24 @@ impl NatsProcessor {
         }
     }
 
+    #[instrument(
+        name = "nats_processor.push_all_jobs",
+        level = "debug",
+        skip_all,
+        fields()
+    )]
     async fn push_all_jobs(&self, queue: JobQueue) -> JobQueueProcessorResult<()> {
+        let mut headers = HeaderMap::new();
+        inject_headers(&mut headers);
+
         while let Some(element) = queue.fetch_job().await {
             let job_info = JobInfo::new(element)?;
 
             if let Err(err) = self
                 .client
-                .publish(
+                .publish_with_headers(
                     self.pinga_subject.clone(),
+                    headers.clone(),
                     serde_json::to_vec(&job_info)?.into(),
                 )
                 .await
@@ -62,6 +73,9 @@ impl JobQueueProcessor for NatsProcessor {
 
         job_info.blocking = true;
 
+        let mut headers = HeaderMap::new();
+        inject_headers(&mut headers);
+
         let job_reply_inbox = Subject::from(self.client.new_inbox());
         let mut reply_subscriber = self
             .client
@@ -69,9 +83,10 @@ impl JobQueueProcessor for NatsProcessor {
             .await
             .map_err(|e| BlockingJobError::Nats(e.to_string()))?;
         self.client
-            .publish_with_reply(
+            .publish_with_reply_and_headers(
                 self.pinga_subject.clone(),
                 job_reply_inbox,
+                headers,
                 serde_json::to_vec(&job_info)
                     .map_err(|e| BlockingJobError::Serde(e.to_string()))?
                     .into(),
@@ -92,12 +107,21 @@ impl JobQueueProcessor for NatsProcessor {
         &self,
         jobs: Vec<Box<dyn JobProducer + Send + Sync>>,
     ) -> BlockingJobResult {
+        let span = Span::current();
+
         let mut dispatched_jobs = JoinSet::new();
 
         // Fan out, dispatching all queued jobs to pinga over nats.
         for job in jobs {
             let job_processor = Self::new(self.client.clone());
-            dispatched_jobs.spawn(async move { job_processor.block_on_job(job).await });
+            let parent_span = span.clone();
+
+            dispatched_jobs.spawn(async move {
+                job_processor
+                    .block_on_job(job)
+                    .instrument(info_span!(parent: parent_span, "job_processor.block_on_job"))
+                    .await
+            });
         }
 
         let mut results = Vec::new();
@@ -129,19 +153,38 @@ impl JobQueueProcessor for NatsProcessor {
         }
     }
 
+    #[instrument(
+        name = "nats_processor.process_queue",
+        level = "info",
+        skip_all,
+        fields(
+            queue.size = Empty,
+        )
+    )]
     async fn process_queue(&self, queue: JobQueue) -> JobQueueProcessorResult<()> {
-        let processor = self.clone();
-        tokio::spawn(async move {
-            if let Err(err) = processor.push_all_jobs(queue).await {
-                error!("Unable to push jobs to nats: {err}");
-            }
-        });
+        let span = Span::current();
+        span.record("queue.size", queue.size().await);
+
+        self.push_all_jobs(queue).await?;
 
         Ok(())
     }
 
+    #[instrument(
+        name = "nats_processor.blocking_process_queue",
+        level = "info",
+        skip_all,
+        fields(
+            queue.size = Empty,
+        )
+    )]
     async fn blocking_process_queue(&self, queue: JobQueue) -> JobQueueProcessorResult<()> {
-        self.block_on_jobs(queue.drain().await).await?;
+        let span = Span::current();
+        span.record("queue.size", queue.size().await);
+
+        self.block_on_jobs(queue.drain().await)
+            .instrument(info_span!("nats_processor.block_on_jobs"))
+            .await?;
 
         Ok(())
     }

--- a/lib/dal/src/job/queue.rs
+++ b/lib/dal/src/job/queue.rs
@@ -32,6 +32,10 @@ impl JobQueue {
         self.queue.lock().await.is_empty()
     }
 
+    pub async fn size(&self) -> usize {
+        self.queue.lock().await.len()
+    }
+
     pub async fn drain(&self) -> Vec<Box<dyn JobProducer + Send + Sync>> {
         self.queue.lock().await.drain(0..).collect()
     }

--- a/lib/telemetry-nats-rs/src/lib.rs
+++ b/lib/telemetry-nats-rs/src/lib.rs
@@ -16,4 +16,7 @@ mod make_span;
 mod propagation;
 
 pub use make_span::NatsMakeSpan;
-pub use propagation::{extract_opentelemetry_context, inject_opentelemetry_context};
+pub use propagation::{
+    empty_injected_headers, extract_opentelemetry_context, inject_headers,
+    inject_opentelemetry_context,
+};

--- a/lib/telemetry-nats-rs/src/propagation.rs
+++ b/lib/telemetry-nats-rs/src/propagation.rs
@@ -1,5 +1,24 @@
 use si_data_nats::HeaderMap;
-use telemetry::opentelemetry::{global, Context};
+use telemetry::{
+    opentelemetry::{global, Context},
+    tracing::Span,
+};
+
+/// Injects propagation telemetry into a [`HeaderMap`].
+pub fn inject_headers(headers: &mut HeaderMap) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let ctx = Span::current().context();
+    inject_opentelemetry_context(&ctx, headers)
+}
+
+/// Creates a [`HeaderMap`] containing propagation telemetry.
+pub fn empty_injected_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    inject_headers(&mut headers);
+
+    headers
+}
 
 /// Extracts an OpenTelemetry [`Context`] from a [`HeaderMap`].
 pub fn extract_opentelemetry_context(headers: &HeaderMap) -> Context {


### PR DESCRIPTION
This change marks the first transmission of OpenTelemetry trace metadata between 2 service components. In this case, from a `NatsProcessor` (in the DAL) to a Pinga job. Future work will connect more. Yay!

<img src="https://media4.giphy.com/media/x7wP4RGKkY2x1TMfVC/giphy.gif"/>