### PR TITLE
feat: allow mounting cyclone decryption key into jails

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -28,6 +28,7 @@ JAILER_DIR="/srv/jailer/firecracker"
 JAILER_BINARY="/usr/bin/jailer"
 
 ROOTFS="rootfs.ext4"
+DKEYFS="decrypt_key.ext4"
 KERNEL="image-kernel.bin"
 
 RO_DRIVE="$DATA_DIR/$ROOTFS"
@@ -65,6 +66,7 @@ mkdir -p "$JAIL/"
 
 touch $JAIL/logs
 touch $JAIL/metrics
+cp $DATA_DIR/$DKEYFS $JAIL
 
 function kernel_prep() {
   cp $KERNEL_IMG "$JAIL/$KERNEL"
@@ -170,6 +172,12 @@ cat << EOF > $JAIL/firecracker.conf
       "is_root_device": true,
       "is_read_only": false,
       "path_on_host": "./rootfs.ext4"
+    },
+    {
+      "drive_id": "2",
+      "is_root_device": false,
+      "is_read_only": true,
+      "path_on_host": "./decrypt_key.ext4"
     }
   ],
   "machine-config": {

--- a/bin/veritech/scripts/userdata.sh
+++ b/bin/veritech/scripts/userdata.sh
@@ -1,7 +1,71 @@
 #!/bin/bash
 
-POOL_SIZE=${1:-1000}
+# Detects all ssd devices present on the machine,
+function detect_devices {
+  local block_devices=$(ls /dev | grep nvme[1-9]*n[0-9]*$)
+  local result=""
+  for device_name in $block_devices
+  do
+    device="/dev/$device_name"
+    # if it is a block device and not a root volume
+    if [[ -b $device ]] && [[ ! "$(file -b -s $device)" == *"boot sector"* ]]
+    then
+      result+=" $device"
+    fi
+  done
+  echo $result
+}
+
+# create RAID array
+function create_md_array {
+  local devices="$(detect_devices)"
+  local dev_count=$(echo $devices | wc -w)
+
+  echo "Total devices: $dev_count"
+  echo "Devices found: $devices"
+
+  if $(mdadm --assemble /dev/md0 $devices)
+  then
+    echo "Found previously created Raid0 array, assembling as /dev/md0"
+  else
+    echo "Raid0 array not found, creating..."
+    mdadm --create --verbose /dev/md0 --level raid0 --force --raid-devices=$dev_count --chunk=64K $devices
+  fi
+
+  mdadm --examine --scan
+  cat /proc/mdstat
+  # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disk-performance.html
+  echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min
+}
+
+# create raid array from local volumes
+VOLUME="/dev/md0"
+create_md_array
+mkfs -t xfs -f $VOLUME
+mkdir -p /srv/jailer
+mount $VOLUME /srv/jailer
+
+###################################################################
+################       Application Start           ################
+###################################################################
+
+POOL_SIZE=${1:-500}
 NATS=${2:-tls://connect.ngs.global}
+CYCLONE_ENCRYPTION_KEY_SECRET=${3:-tools-encryption-key}
+NATS_CREDS_SECRET=${3:-tools-prod-nats-creds}
+HONEYCOMB_API_SECRET=${4:-tools-honeycomb-api-key}
+
+# create a volume for our friend the decryption key
+KEY_VOLUME=/firecracker-data/decrypt_key.ext4
+KEY_MOUNT=/firecracker-data/key
+mkdir -p $KEY_MOUNT
+dd if=/dev/zero of="$KEY_VOLUME" bs=1M count=1
+mkfs.ext4 -v $KEY_VOLUME
+e2label $KEY_VOLUME dkey
+mount $KEY_VOLUME $KEY_MOUNT
+aws secretsmanager get-secret-value --region us-east-1 --secret-id $CYCLONE_ENCRYPTION_KEY_SECRET | jq -r '.SecretString' > $KEY_MOUNT/decryption.key
+chmod 777 $KEY_MOUNT/decryption.key
+umount $KEY_VOLUME
 
 wget https://artifacts.systeminit.com/veritech/stable/omnibus/linux/$(arch)/veritech-stable-omnibus-linux-$(arch).tar.gz -O - | tar -xzvf - -C /
 
@@ -12,7 +76,7 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 sudo ./aws/install
 
-aws secretsmanager get-secret-value --region us-east-1 --secret-id si-nats-creds | jq -r '.SecretString' >> /tmp/nats-creds
+aws secretsmanager get-secret-value --region us-east-1 --secret-id $NATS_CREDS_SECRET | jq -r '.SecretString' >> /tmp/nats-creds
 
 # Install + run docker with otel on 4317 on the host interface
 curl -fsSL get.docker.com | bash
@@ -20,9 +84,9 @@ curl -fsSL get.docker.com | bash
 docker run \
  --restart always \
  --env SI_OTEL_COL__CONFIG_PATH=/etc/otelcol/honeycomb-config.yaml \
- --env SI_OTEL_COL__HONEYCOMB_API_KEY=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id si-honeycomb-api-key | jq -r '.SecretString') \
+ --env SI_OTEL_COL__HONEYCOMB_API_KEY=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id $HONEYCOMB_API_SECRET | jq -r '.SecretString') \
  -p 4317:4317 \
- systeminit/otelcol:stable
+ -d systeminit/otelcol:stable
 
 cat << EOF > /etc/systemd/system/veritech.service
 


### PR DESCRIPTION
This adds a volume to the firecracker jails that is expected to include the cyclone decryption key. This volume must be present in the `/firecracker-data` directory when preparing the jail. The volume is teeny, one whole megabyte, so I thought it would be fine to just copy it around.

I also updated the userdata script to match what we have in the tools env plus having it pull the key from an aws secret, make the volume, and place it where it should go. 

I am removing the dev key from the rootfs entirely so this will break local development until I figure out how to add this to buck2. It's an easy fix, just create the volume with the dev key in it and put it where it goes.


<img src="https://media4.giphy.com/media/N8k6u4e4w0qWs6Spma/giphy-downsized-medium.gif"/>