### PR TITLE
feat(sdf): add `--generate-symmetric-key-path` to SDF binary

### DIFF
--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -90,14 +90,35 @@ pub(crate) struct Args {
     /// Generates cyclone secret key file (does not run server)
     ///
     /// Will error if set when `generate_cyclone_public_key_path` is not set
-    #[arg(long, requires = "generate_cyclone_public_key_path")]
+    #[arg(
+        long,
+        requires = "generate_cyclone_public_key_path",
+        conflicts_with = "generate_symmetric_key_path"
+    )]
     pub(crate) generate_cyclone_secret_key_path: Option<PathBuf>,
 
     /// Generates cyclone public key file (does not run server)
     ///
     /// Will error if set when `generate_cyclone_secret_key_path` is not set
-    #[arg(long, requires = "generate_cyclone_secret_key_path")]
+    #[arg(
+        long,
+        requires = "generate_cyclone_secret_key_path",
+        conflicts_with = "generate_symmetric_key_path"
+    )]
     pub(crate) generate_cyclone_public_key_path: Option<PathBuf>,
+
+    /// Generates symmetric key (does not run server)
+    ///
+    /// Will error if set when cyclone key generation flags are set
+    #[arg(
+        long,
+        group = "symmetric",
+        conflicts_with_all = [
+            "generate_cyclone_secret_key_path",
+            "generate_cyclone_public_key_path",
+        ]
+    )]
+    pub(crate) generate_symmetric_key_path: Option<PathBuf>,
 
     /// Location on disk of available packages
     pub(crate) pkgs_path: Option<String>,

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -63,6 +63,15 @@ async fn async_main() -> Result<()> {
         return Ok(());
     }
 
+    if let Some(symmetric_key_path) = &args.generate_symmetric_key_path {
+        info!(
+            "Generating Symmetric key at: {}",
+            symmetric_key_path.display()
+        );
+        Server::generate_symmetric_key(symmetric_key_path).await?;
+        return Ok(());
+    }
+
     let config = Config::try_from(args)?;
 
     let encryption_key = Server::load_encryption_key(config.crypto().clone()).await?;

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -216,6 +216,14 @@ impl Server<(), ()> {
             .map_err(Into::into)
     }
 
+    #[instrument(name = "sdf.init.generate_symmetric_key", skip_all)]
+    pub async fn generate_symmetric_key(symmetric_key_path: impl AsRef<Path>) -> Result<()> {
+        SymmetricCryptoService::generate_key()
+            .save(symmetric_key_path.as_ref())
+            .await
+            .map_err(Into::into)
+    }
+
     #[instrument(name = "sdf.init.load_jwt_public_signing_key", skip_all)]
     pub async fn load_jwt_public_signing_key(config: JwtConfig) -> Result<JwtPublicSigningKey> {
         Ok(JwtPublicSigningKey::from_config(config).await?)


### PR DESCRIPTION
This new flag operates like the former Cyclone key generation flags (i.e. `--generate-cyclone-secret-key-path` and
`--generate-cyclone-public-key-path`) in that it will generate a new key, write it to the file as requested and then terminate the program.

<img src="https://media2.giphy.com/media/YnHg3U08RcCJ34OhpJ/giphy.gif"/>