### PR TITLE
chore(cyclone): refactor `Server` to not require generics externally

### DIFF
--- a/lib/cyclone-server/src/lib.rs
+++ b/lib/cyclone-server/src/lib.rs
@@ -16,7 +16,7 @@ mod watch;
 
 pub use axum::extract::ws::Message as WebSocketMessage;
 pub use config::{Config, ConfigBuilder, ConfigError, IncomingStream};
-pub use server::{Server, ShutdownSource};
+pub use server::{Runnable, Server, ShutdownSource};
 pub use timestamp::timestamp;
 #[cfg(target_os = "linux")]
 pub use tokio_vsock::VsockAddr;


### PR DESCRIPTION
This change is pretty exciting (for me, hey I've been working with this code for a while now) as it delivers a `cyclone_server::Server` which has no external generic types while still supporting the various incoming streams internally.

The key insight was to create a `Runnable` trait which is implemented by an `InnerServer` which has all the trait-bound generics, but stored in a `Box` making an inner field of `inner: Box<dyn Runnable + Send>`.

<img src="https://media1.giphy.com/media/aR6JyO12RkwE5P7lxb/giphy.gif"/>