### PR TITLE
fix(dal,web,sdf) - fix up component created event firing and handling

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1401,6 +1401,16 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               },
             },
             {
+              eventType: "ComponentCreated",
+              debounce: true,
+              callback: (data) => {
+                // If the component that updated wasn't in this change set,
+                // don't update
+                if (data.changeSetPk !== changeSetId) return;
+                this.FETCH_DIAGRAM_DATA();
+              },
+            },
+            {
               eventType: "ChangeSetApplied",
               callback: () => {
                 this.FETCH_DIAGRAM_DATA();

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -151,6 +151,8 @@ export type WsEventPayloadMap = {
   };
   ComponentCreated: {
     success: boolean;
+    componentId: string;
+    changeSetPk: string;
   };
   ComponentUpdated: {
     componentId: string;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1295,13 +1295,22 @@ impl Component {
 #[serde(rename_all = "camelCase")]
 pub struct ComponentCreatedPayload {
     success: bool,
+    component_id: ComponentId,
+    change_set_pk: ChangeSetPk,
 }
 
 impl WsEvent {
-    pub async fn component_created(ctx: &DalContext) -> WsEventResult<Self> {
+    pub async fn component_created(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
-            WsPayload::ComponentCreated(ComponentCreatedPayload { success: true }),
+            WsPayload::ComponentCreated(ComponentCreatedPayload {
+                success: true,
+                change_set_pk: ctx.visibility().change_set_pk,
+                component_id,
+            }),
         )
         .await
     }

--- a/lib/sdf-server/src/server/service/diagram/create_node.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_node.rs
@@ -117,7 +117,7 @@ pub async fn create_node(
         .await?;
     }
 
-    WsEvent::component_created(&ctx)
+    WsEvent::component_created(&ctx, *component.id())
         .await?
         .publish_on_commit(&ctx)
         .await?;

--- a/lib/sdf-server/src/server/service/diagram/paste_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/paste_component.rs
@@ -132,7 +132,7 @@ async fn paste_single_component(
         }),
     );
 
-    WsEvent::component_created(&ctx)
+    WsEvent::component_created(&ctx, *pasted_comp.id())
         .await?
         .publish_on_commit(&ctx)
         .await?;


### PR DESCRIPTION
This PR modifies the ComponentCreated event to pass along the changeset pk and component id, which is used by the front end to re-fetch the diagram when components are created