### PR TITLE
chore(telemetry): aggressively dial back default tracing spans

### DIFF
--- a/lib/council-server/src/server.rs
+++ b/lib/council-server/src/server.rs
@@ -315,7 +315,6 @@ pub enum Error {
     UnknownNodeId,
 }
 
-#[instrument(level = "info")]
 pub async fn register_graph_from_job(
     complete_graph: &mut ChangeSetGraph,
     reply_channel: Subject,
@@ -326,7 +325,7 @@ pub async fn register_graph_from_job(
     complete_graph.merge_dependency_graph(reply_channel, new_dependency_data, change_set_id)
 }
 
-#[instrument(level = "info", skip(nats, complete_graph))]
+#[instrument(level = "debug", skip_all)]
 pub async fn job_processed_a_value(
     nats: &NatsClient,
     complete_graph: &mut ChangeSetGraph,
@@ -350,7 +349,7 @@ pub async fn job_processed_a_value(
     Ok(())
 }
 
-#[instrument(level = "info", skip(nats, complete_graph))]
+#[instrument(level = "debug", skip_all)]
 pub async fn job_failed_processing_a_value(
     nats: &NatsClient,
     complete_graph: &mut ChangeSetGraph,
@@ -377,7 +376,6 @@ pub async fn job_failed_processing_a_value(
     Ok(())
 }
 
-#[instrument(level = "info")]
 pub async fn job_is_going_away(
     complete_graph: &mut ChangeSetGraph,
     reply_channel: Subject,

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -86,7 +86,6 @@ impl_standard_model! {
 
 impl Action {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         prototype_id: ActionPrototypeId,

--- a/lib/dal/src/action_prototype.rs
+++ b/lib/dal/src/action_prototype.rs
@@ -218,8 +218,6 @@ impl_standard_model! {
 }
 
 impl ActionPrototype {
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         func_id: FuncId,

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -166,7 +166,6 @@ impl_standard_model! {
 
 impl AttributePrototype {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         func_id: FuncId,
@@ -194,7 +193,6 @@ impl AttributePrototype {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new_with_existing_value(
         ctx: &DalContext,
         func_id: FuncId,
@@ -506,7 +504,7 @@ impl AttributePrototype {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_prototype_funcs_by_context_and_backend_response_type(
         ctx: &DalContext,
         context: AttributeContext,
@@ -559,7 +557,7 @@ impl AttributePrototype {
         Ok(standard_model::objects_from_rows(rows)?)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_for_context(
         ctx: &DalContext,
         context: AttributeContext,
@@ -582,7 +580,6 @@ impl AttributePrototype {
         Ok(object)
     }
 
-    #[tracing::instrument(skip_all)]
     pub async fn find_with_parent_value_and_key_for_context(
         ctx: &DalContext,
         parent_attribute_value_id: Option<AttributeValueId>,
@@ -711,7 +708,7 @@ impl AttributePrototype {
         Ok(standard_model::objects_from_rows(rows)?)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     #[allow(clippy::too_many_arguments)]
     #[async_recursion]
     async fn create_intermediate_proxy_values(

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -97,7 +97,6 @@ impl_standard_model! {
 }
 
 impl AttributePrototypeArgument {
-    #[instrument(skip_all)]
     /// Create a new [`AttributePrototypeArgument`] for _intra_ [`Component`](crate::Component) use.
     pub async fn new_for_intra_component(
         ctx: &DalContext,
@@ -135,7 +134,6 @@ impl AttributePrototypeArgument {
     }
 
     /// Create a new [`AttributePrototypeArgument`] for _inter_ [`Component`](crate::Component) use.
-    #[instrument(skip_all)]
     pub async fn new_for_inter_component(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,
@@ -177,7 +175,6 @@ impl AttributePrototypeArgument {
     }
 
     /// Create a new [`AttributePrototypeArgument`] for _inter_ [`Component`](crate::Component) use.
-    #[instrument(skip_all)]
     pub async fn new_explicit_internal_to_explicit_internal_inter_component(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,
@@ -219,7 +216,6 @@ impl AttributePrototypeArgument {
     }
 
     /// Create a new [`AttributePrototypeArgument`] for _inter_ [`Component`](crate::Component) use.
-    #[instrument(skip_all)]
     pub async fn new_external_to_external_inter_component(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,
@@ -393,7 +389,6 @@ impl AttributePrototypeArgument {
 
     /// List all [`AttributePrototypeArguments`](Self) for a given
     /// [`AttributePrototype`](crate::AttributePrototype).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -955,7 +955,6 @@ impl AttributeValue {
                 FETCH_UPDATE_GRAPH_DATA,
                 &[&ctx.tenancy(), ctx.visibility(), &attribute_value_ids],
             )
-            .instrument(debug_span!("Graph SQL query"))
             .await?;
 
         let mut result: HashMap<AttributeValueId, Vec<AttributeValueId>> = HashMap::new();
@@ -995,13 +994,13 @@ impl AttributeValue {
     /// the "root" `Prop` of a `SchemaVariant`), then it will also enqueue a
     /// `CodeGeneration` job for the `Component`.
     #[instrument(
-    name = "attribute_value.update_from_prototype_function",
-    skip_all,
-    level = "debug",
-    fields(
-    attribute_value.id = % self.id,
-    change_set_pk = % ctx.visibility().change_set_pk,
-    )
+        name = "attribute_value.update_from_prototype_function",
+        skip_all,
+        level = "debug",
+        fields(
+            attribute_value.id = % self.id,
+            change_set_pk = % ctx.visibility().change_set_pk,
+        )
     )]
     pub async fn update_from_prototype_function(
         &mut self,

--- a/lib/dal/src/authentication_prototype.rs
+++ b/lib/dal/src/authentication_prototype.rs
@@ -115,7 +115,6 @@ impl_standard_model! {
 
 impl AuthenticationPrototype {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         func_id: FuncId,

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -93,7 +93,6 @@ pub struct ChangeSet {
 }
 
 impl ChangeSet {
-    #[instrument(skip(ctx, name, note))]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,
@@ -208,7 +207,7 @@ impl ChangeSet {
         Ok(())
     }
 
-    #[instrument(skip(ctx))]
+    #[instrument(level = "debug", skip_all)]
     pub async fn apply(&mut self, ctx: &mut DalContext) -> ChangeSetResult<()> {
         let actor = serde_json::to_value(ctx.history_actor())?;
         let row = ctx
@@ -268,7 +267,7 @@ impl ChangeSet {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_open(ctx: &DalContext) -> ChangeSetResult<Vec<Self>> {
         let rows = ctx
             .txns()
@@ -280,7 +279,6 @@ impl ChangeSet {
         Ok(results)
     }
 
-    #[instrument(skip_all)]
     pub async fn get_by_pk(
         ctx: &DalContext,
         pk: &ChangeSetPk,

--- a/lib/dal/src/change_status.rs
+++ b/lib/dal/src/change_status.rs
@@ -71,7 +71,7 @@ impl ComponentChangeStatus {
         Ok(component_stats)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_added(
         ctx: &DalContext,
     ) -> ChangeStatusResult<Vec<ComponentChangeStatusGroup>> {
@@ -87,7 +87,7 @@ impl ComponentChangeStatus {
         ComponentChangeStatusGroup::new_from_rows(rows, ChangeStatus::Added)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_deleted(
         ctx: &DalContext,
     ) -> ChangeStatusResult<Vec<ComponentChangeStatusGroup>> {
@@ -103,7 +103,7 @@ impl ComponentChangeStatus {
         ComponentChangeStatusGroup::new_from_rows(rows, ChangeStatus::Deleted)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_modified(
         ctx: &DalContext,
     ) -> ChangeStatusResult<Vec<ComponentChangeStatusGroup>> {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -267,7 +267,6 @@ impl Component {
     /// a [`Schema`](crate::Schema) rather than
     /// a specific [`SchemaVariantId`](crate::SchemaVariant), use
     /// [`Self::new_for_default_variant_from_schema()`].
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,
@@ -389,7 +388,6 @@ impl Component {
 
     /// List [`Sockets`](crate::Socket) with a given
     /// [`SocketEdgeKind`](crate::socket::SocketEdgeKind).
-    #[instrument(skip_all)]
     pub async fn list_sockets_for_kind(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -413,7 +411,6 @@ impl Component {
     }
 
     /// Find [`Self`] with a provided [`NodeId`](crate::Node).
-    #[instrument(skip_all)]
     pub async fn find_for_node(ctx: &DalContext, node_id: NodeId) -> ComponentResult<Option<Self>> {
         let row = ctx
             .txns()
@@ -434,7 +431,6 @@ impl Component {
     ///
     /// _Note:_ if the type has never been updated, this will find the _default_
     /// [`AttributeValue`](crate::AttributeValue) where the [`ComponentId`](Self) is unset.
-    #[instrument(skip_all)]
     pub async fn find_si_child_attribute_value(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -460,7 +456,6 @@ impl Component {
         Ok(object_from_row(row)?)
     }
 
-    #[instrument(skip_all)]
     pub async fn is_in_tenancy(ctx: &DalContext, id: ComponentId) -> ComponentResult<bool> {
         let row = ctx
             .txns()
@@ -477,7 +472,6 @@ impl Component {
         Ok(row.is_some())
     }
 
-    #[instrument(skip_all)]
     pub async fn list_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,
@@ -502,7 +496,6 @@ impl Component {
         Ok(results)
     }
 
-    #[instrument(skip_all)]
     pub async fn list_for_schema_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -528,7 +521,6 @@ impl Component {
     }
 
     /// Sets the "/root/si/name" for [`self`](Self).
-    #[instrument(skip_all)]
     pub async fn set_name<T: Serialize + std::fmt::Debug + std::clone::Clone>(
         &self,
         ctx: &DalContext,
@@ -582,7 +574,6 @@ impl Component {
         Ok(())
     }
 
-    #[instrument(skip_all)]
     pub async fn set_deleted_at(
         &self,
         ctx: &DalContext,
@@ -621,7 +612,6 @@ impl Component {
     }
 
     /// Return the name of the [`Component`](Self) for the provided [`ComponentId`](Self).
-    #[instrument(skip_all)]
     pub async fn find_name(ctx: &DalContext, component_id: ComponentId) -> ComponentResult<String> {
         let component_name = ComponentView::new(ctx, component_id)
             .await?
@@ -655,7 +645,6 @@ impl Component {
     /// Grabs the [`AttributeValue`](crate::AttributeValue) corresponding to the
     /// [`RootPropChild`](crate::RootPropChild) [`Prop`](crate::Prop) for the given
     /// [`Component`](Self).
-    #[instrument(skip_all)]
     pub async fn root_prop_child_attribute_value_for_component(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -703,7 +692,7 @@ impl Component {
     /// [`AttributeValueId`](crate::AttributeValue) provided has a
     /// [`context`](crate::AttributeContext) whose least specific field corresponds to a
     /// [`PropId`](crate::Prop)._
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_connected_input_sockets_for_attribute_value(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
@@ -807,7 +796,6 @@ impl Component {
 
     /// Sets the field corresponding to "/root/si/type" for the [`Component`]. Possible values
     /// are limited to variants of [`ComponentType`](crate::ComponentType).
-    #[instrument(skip(ctx))]
     pub async fn set_type(
         &self,
         ctx: &DalContext,

--- a/lib/dal/src/component/code.rs
+++ b/lib/dal/src/component/code.rs
@@ -1,7 +1,6 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use telemetry::prelude::*;
 
 use crate::attribute::value::AttributeValue;
 use crate::attribute::value::AttributeValueError;
@@ -24,7 +23,6 @@ struct CodeGenerationEntry {
 impl Component {
     /// List all [`CodeViews`](crate::CodeView) for based on the "code generation"
     /// [`leaves`](crate::schema::variant::leaves) for a given [`ComponentId`](Self).
-    #[instrument(skip_all)]
     pub async fn list_code_generated(
         ctx: &DalContext,
         component_id: ComponentId,

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
 use std::collections::HashMap;
-use telemetry::prelude::*;
 
 use crate::attribute::value::AttributeValue;
 use crate::attribute::value::AttributeValueError;
@@ -21,7 +20,6 @@ pub struct QualificationEntry {
 
 impl Component {
     // TODO(nick): big query potential here.
-    #[instrument(skip_all)]
     pub async fn list_qualifications(
         ctx: &DalContext,
         component_id: ComponentId,

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -508,7 +508,7 @@ impl DalContext {
 
     /// Copies every single row from `Self::builtin()` to our tenancy on head change-set
     /// Needed to remove universal tenancy while packages aren't a thing
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn import_builtins(&self) -> Result<(), TransactionsError> {
         self.txns()
             .await?

--- a/lib/dal/src/edge.rs
+++ b/lib/dal/src/edge.rs
@@ -181,7 +181,6 @@ impl From<ComponentId> for EdgeObjectId {
 
 impl Edge {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         kind: EdgeKind,
@@ -238,7 +237,6 @@ impl Edge {
     /// Please note that the _head_ information comes before the _tail_ information in the
     /// function parameters.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new_for_connection(
         ctx: &DalContext,
         head_node_id: NodeId,

--- a/lib/dal/src/fix.rs
+++ b/lib/dal/src/fix.rs
@@ -172,7 +172,6 @@ impl_standard_model! {
 impl Fix {
     /// Create [`Self`] and ensure it belongs to a [`FixBatch`](crate::FixBatch)
     /// since every [`fix`](Self) must belong to a [`batch`](crate::FixBatch).
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         fix_batch_id: FixBatchId,

--- a/lib/dal/src/fix/batch.rs
+++ b/lib/dal/src/fix/batch.rs
@@ -56,7 +56,7 @@ impl_standard_model! {
 }
 
 impl FixBatch {
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn new(ctx: &DalContext, author: impl AsRef<str>, actors: &str) -> FixResult<Self> {
         let author = author.as_ref();
         let row = ctx

--- a/lib/dal/src/fix/resolver.rs
+++ b/lib/dal/src/fix/resolver.rs
@@ -61,7 +61,6 @@ impl_standard_model! {
 
 impl FixResolver {
     /// Private constructor method for creating a [`FixResolver`]. Use [`Self::upsert()`] instead.
-    #[instrument(skip_all)]
     async fn new(
         ctx: &DalContext,
         action_prototype_id: ActionPrototypeId,

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -134,7 +134,6 @@ impl_standard_model! {
 }
 
 impl Func {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -243,15 +243,15 @@ pub trait FuncDispatch: std::fmt::Debug {
     }
 
     #[instrument(
-    name = "funcdispatch.execute",
-    skip_all,
-    level = "debug",
-    fields(
-    otel.kind = SpanKind::Client.as_str(),
-    otel.status_code = Empty,
-    otel.status_message = Empty,
-    si.func.result = Empty
-    )
+        name = "funcdispatch.execute",
+        skip_all,
+        level = "debug",
+        fields(
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.func.result = Empty,
+        )
     )]
     async fn execute(
         self: Box<Self>,
@@ -309,15 +309,15 @@ pub trait FuncBackend {
     }
 
     #[instrument(
-    name = "funcbackend.execute",
-    skip_all,
-    level = "debug",
-    fields(
-    otel.kind = SpanKind::Client.as_str(),
-    otel.status_code = Empty,
-    otel.status_message = Empty,
-    si.func.result = Empty
-    )
+        name = "funcbackend.execute",
+        skip_all,
+        level = "debug",
+        fields(
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.func.result = Empty,
+        )
     )]
     async fn execute(
         self: Box<Self>,

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -116,7 +116,6 @@ impl_standard_model! {
 
 impl FuncBinding {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         args: serde_json::Value,

--- a/lib/dal/src/func/binding_return_value.rs
+++ b/lib/dal/src/func/binding_return_value.rs
@@ -85,7 +85,6 @@ impl_standard_model! {
 
 impl FuncBindingReturnValue {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         unprocessed_value: Option<serde_json::Value>,

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -87,7 +87,6 @@ pub struct FuncExecution {
 
 impl FuncExecution {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         func: &Func,
@@ -239,7 +238,6 @@ impl FuncExecution {
         self.pk
     }
 
-    #[instrument(skip(ctx))]
     pub async fn get_by_pk(ctx: &DalContext, pk: &FuncExecutionPk) -> FuncExecutionResult<Self> {
         let row = ctx
             .txns()

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -68,7 +68,6 @@ pub struct HistoryEvent {
 }
 
 impl HistoryEvent {
-    #[instrument(skip(ctx, label, message))]
     pub async fn new(
         ctx: &DalContext,
         label: impl AsRef<str>,

--- a/lib/dal/src/installed_pkg.rs
+++ b/lib/dal/src/installed_pkg.rs
@@ -72,7 +72,6 @@ impl_standard_model! {
 }
 
 impl InstalledPkg {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,

--- a/lib/dal/src/installed_pkg/asset.rs
+++ b/lib/dal/src/installed_pkg/asset.rs
@@ -187,7 +187,6 @@ impl_standard_model! {
 }
 
 impl InstalledPkgAsset {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         pkg_asset: InstalledPkgAssetTyped,

--- a/lib/dal/src/job_failure.rs
+++ b/lib/dal/src/job_failure.rs
@@ -59,7 +59,6 @@ impl_standard_model! {
 }
 
 impl JobFailure {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         kind: impl AsRef<str>,

--- a/lib/dal/src/jwt_key.rs
+++ b/lib/dal/src/jwt_key.rs
@@ -126,7 +126,7 @@ impl JwtPublicSigningKey {
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip_all)]
 pub async fn validate_bearer_token(
     public_key: JwtPublicSigningKey,
     bearer_token: impl AsRef<str>,

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -204,13 +204,13 @@ pub enum ModelError {
 
 pub type ModelResult<T> = Result<T, ModelError>;
 
-#[instrument(skip_all)]
+#[instrument(level = "info", skip_all)]
 pub async fn migrate_all(services_context: &ServicesContext) -> ModelResult<()> {
     migrate(services_context.pg_pool()).await?;
     Ok(())
 }
 
-#[instrument(skip_all)]
+#[instrument(level = "info", skip_all)]
 pub async fn migrate_all_with_progress(services_context: &ServicesContext) -> ModelResult<()> {
     let mut interval = time::interval(Duration::from_secs(5));
     let instant = Instant::now();
@@ -235,13 +235,13 @@ pub async fn migrate_all_with_progress(services_context: &ServicesContext) -> Mo
     Ok(())
 }
 
-#[instrument(skip_all)]
+#[instrument(level = "info", skip_all)]
 pub async fn migrate(pg: &PgPool) -> ModelResult<()> {
     Ok(pg.migrate(embedded::migrations::runner()).await?)
 }
 
 #[allow(clippy::too_many_arguments)]
-#[instrument(skip_all)]
+#[instrument(level = "info", skip_all)]
 pub async fn migrate_local_builtins(
     pg: &PgPool,
     nats: &NatsClient,

--- a/lib/dal/src/node.rs
+++ b/lib/dal/src/node.rs
@@ -108,7 +108,6 @@ impl_standard_model! {
 }
 
 impl Node {
-    #[instrument(skip_all)]
     pub async fn new(ctx: &DalContext, kind: &NodeKind) -> NodeResult<Self> {
         let row = ctx
             .txns()
@@ -164,7 +163,6 @@ impl Node {
     }
 
     /// Find all [`NodeIds`](Self) for a given [`NodeKind`].
-    #[instrument(skip_all)]
     pub async fn list_for_kind(ctx: &DalContext, kind: NodeKind) -> NodeResult<HashSet<NodeId>> {
         let rows = ctx
             .txns()

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -294,7 +294,6 @@ impl Prop {
     /// created when the provided [`SchemaVariant`](crate::SchemaVariant) is
     /// [`finalized`](crate::SchemaVariant::finalize).
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,
@@ -422,7 +421,7 @@ impl Prop {
         Ok(objects_from_rows(rows)?)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     #[async_recursion]
     pub async fn ts_type(&self, ctx: &DalContext) -> PropResult<String> {
         // XXX: Hack! The payload prop kind is a string but we're actually storing arbitrary json

--- a/lib/dal/src/provider/external.rs
+++ b/lib/dal/src/provider/external.rs
@@ -108,7 +108,6 @@ pub struct ExternalProvider {
 impl ExternalProvider {
     /// This function will also create an _output_ [`Socket`](crate::Socket).
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(ctx, name, connection_annotations))]
     pub async fn new_with_socket(
         ctx: &DalContext,
         schema_id: SchemaId,
@@ -203,7 +202,6 @@ impl ExternalProvider {
     );
 
     /// Find all [`Self`] for a given [`SchemaVariant`](crate::SchemaVariant).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -221,7 +219,6 @@ impl ExternalProvider {
     }
 
     /// Find [`Self`] with a provided [`SocketId`](crate::Socket).
-    #[instrument(skip_all)]
     pub async fn find_for_socket(
         ctx: &DalContext,
         socket_id: SocketId,
@@ -240,7 +237,6 @@ impl ExternalProvider {
 
     /// Find [`Self`] with a provided name, which is not only the name of [`Self`], but also of the
     /// associated _output_ [`Socket`](crate::Socket).
-    #[instrument(skip_all)]
     pub async fn find_for_schema_variant_and_name(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -260,7 +256,6 @@ impl ExternalProvider {
     }
 
     /// Find all [`Self`] for a given [`AttributePrototypeId`](crate::AttributePrototype).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype_with_tail_component_id(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,
@@ -286,7 +281,6 @@ impl ExternalProvider {
     /// Find all [`Self`] that have
     /// [`AttributePrototypeArguments`](crate::AttributePrototypeArgument) referencing the provided
     /// [`InternalProviderId`](crate::InternalProvider).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_from_internal_provider_use(
         ctx: &DalContext,
         internal_provider_id: InternalProviderId,
@@ -303,7 +297,6 @@ impl ExternalProvider {
         Ok(standard_model::objects_from_rows(rows)?)
     }
 
-    #[tracing::instrument(skip(ctx))]
     pub async fn by_socket(ctx: &DalContext) -> ExternalProviderResult<HashMap<SocketId, Self>> {
         let rows = ctx
             .txns()

--- a/lib/dal/src/provider/internal.rs
+++ b/lib/dal/src/provider/internal.rs
@@ -227,7 +227,6 @@ pub struct InternalProvider {
 }
 
 impl InternalProvider {
-    #[tracing::instrument(skip(ctx))]
     pub async fn new_implicit(
         ctx: &DalContext,
         prop_id: PropId,
@@ -291,7 +290,6 @@ impl InternalProvider {
 
     /// This function will also create an _input_ [`Socket`](crate::Socket).
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(ctx, name, connection_annotations))]
     pub async fn new_explicit_with_socket(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -483,7 +481,6 @@ impl InternalProvider {
     }
 
     /// Find all [`Self`] for a given [`SchemaVariant`](crate::SchemaVariant).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_for_schema_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -501,7 +498,6 @@ impl InternalProvider {
     }
 
     /// Find all [`Self`] for a given [`SchemaVariant`](crate::SchemaVariant).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_explicit_for_schema_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -520,7 +516,6 @@ impl InternalProvider {
 
     /// Find [`Self`] with a provided name, which is not only the name of [`Self`], but also of the
     /// associated _input_ [`Socket`](crate::Socket).
-    #[instrument(skip_all)]
     pub async fn find_explicit_for_schema_variant_and_name(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -540,7 +535,6 @@ impl InternalProvider {
     }
 
     /// Find [`Self`] with a provided [`SocketId`](crate::Socket).
-    #[instrument(skip_all)]
     pub async fn find_explicit_for_socket(
         ctx: &DalContext,
         socket_id: SocketId,
@@ -558,7 +552,6 @@ impl InternalProvider {
     }
 
     /// Find all [`Self`] for a given [`AttributePrototypeId`](crate::AttributePrototype).
-    #[tracing::instrument(skip(ctx))]
     pub async fn list_for_attribute_prototype(
         ctx: &DalContext,
         attribute_prototype_id: AttributePrototypeId,
@@ -615,7 +608,6 @@ impl InternalProvider {
         Ok(object_option_from_row_option(row)?)
     }
 
-    #[tracing::instrument(skip(ctx))]
     pub async fn by_socket(ctx: &DalContext) -> InternalProviderResult<HashMap<SocketId, Self>> {
         let rows = ctx
             .txns()
@@ -638,7 +630,6 @@ impl InternalProvider {
     }
 
     /// Determines if the provided [`InternalProvider`] corresponds to a "root" [`Prop`](crate::Prop).
-    #[tracing::instrument(skip(ctx))]
     pub async fn is_for_root_prop(
         ctx: &DalContext,
         internal_provider_id: InternalProviderId,

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -50,7 +50,7 @@ pub enum QualificationSummaryError {
 pub type QualificationSummaryResult<T> = Result<T, QualificationSummaryError>;
 
 impl QualificationSummary {
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn get_summary(ctx: &DalContext) -> QualificationSummaryResult<QualificationSummary> {
         let mut components_succeeded = 0;
         let mut components_warned = 0;

--- a/lib/dal/src/reconciliation_prototype.rs
+++ b/lib/dal/src/reconciliation_prototype.rs
@@ -120,8 +120,6 @@ impl_standard_model! {
 }
 
 impl ReconciliationPrototype {
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn upsert(
         ctx: &DalContext,
         func_id: FuncId,

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -114,8 +114,6 @@ impl_standard_model! {
 }
 
 impl Schema {
-    #[instrument(skip_all)]
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,

--- a/lib/dal/src/schema/ui_menu.rs
+++ b/lib/dal/src/schema/ui_menu.rs
@@ -37,7 +37,6 @@ impl_standard_model! {
 }
 
 impl SchemaUiMenu {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         name: impl AsRef<str>,
@@ -78,7 +77,6 @@ impl SchemaUiMenu {
         result: SchemaResult,
     );
 
-    #[instrument(skip_all)]
     pub async fn find_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -203,7 +203,6 @@ impl_standard_model! {
 
 impl SchemaVariant {
     /// Create a [`SchemaVariant`](Self) with a [`RootProp`](crate::schema::RootProp).
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         schema_id: SchemaId,
@@ -523,7 +522,6 @@ impl SchemaVariant {
 
     /// List all direct child [`Props`](crate::Prop) of the [`Prop`](crate::Prop) corresponding
     /// to "/root/si".
-    #[instrument(skip_all)]
     pub async fn list_root_si_child_props(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -541,7 +539,6 @@ impl SchemaVariant {
     }
 
     /// Find all [`Props`](crate::Prop) for a given [`SchemaVariantId`](SchemaVariant).
-    #[instrument(skip_all)]
     pub async fn all_props(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -558,7 +555,6 @@ impl SchemaVariant {
         Ok(objects_from_rows(rows)?)
     }
 
-    #[instrument(skip_all)]
     pub async fn list_secret_defining(ctx: &DalContext) -> SchemaVariantResult<Vec<SchemaVariant>> {
         let rows = ctx
             .txns()
@@ -576,7 +572,6 @@ impl SchemaVariant {
     /// finds funcs connected at the schema variant context, ignoring any funcs connected to
     /// directly to components. Ignores any functions that have no code (these are typically
     /// intrinsics)
-    #[instrument(skip_all)]
     pub async fn all_funcs(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -393,7 +393,6 @@ impl From<SchemaVariantDefinition> for SchemaVariantDefinitionMetadataJson {
 }
 
 impl SchemaVariantDefinitionMetadataJson {
-    #[instrument(skip_all)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -105,7 +105,7 @@ pub struct RootProp {
 
 impl SchemaVariant {
     /// Create and set a [`RootProp`] for the [`SchemaVariant`].
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_and_set_root_prop(
         &mut self,
         ctx: &DalContext,

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -273,7 +273,6 @@ impl Socket {
 
     /// Finds the "Frame" [`Socket`] for a given [`Node`](crate::Node) and
     /// [`SocketEdgeKind`].
-    #[instrument(skip_all)]
     pub async fn find_frame_socket_for_node(
         ctx: &DalContext,
         node_id: NodeId,
@@ -296,7 +295,6 @@ impl Socket {
         Ok(standard_model::object_from_row(row)?)
     }
 
-    #[instrument(skip_all)]
     pub async fn find_for_internal_provider(
         ctx: &DalContext,
         internal_provider_id: InternalProviderId,
@@ -313,7 +311,6 @@ impl Socket {
         Ok(standard_model::objects_from_rows(rows)?)
     }
 
-    #[instrument(skip_all)]
     pub async fn find_for_external_provider(
         ctx: &DalContext,
         external_provider_id: ExternalProviderId,
@@ -331,7 +328,6 @@ impl Socket {
     }
 
     /// List all [`Sockets`](Self) for the given [`ComponentId`](crate::Component).
-    #[instrument(skip_all)]
     pub async fn list_for_component(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -350,7 +346,6 @@ impl Socket {
 
     /// Find a [`Socket`] by a provided name for a given [`SocketEdgeKind`] and
     /// a given [`NodeId`](crate::Node).
-    #[instrument(skip_all)]
     pub async fn find_by_name_for_edge_kind_and_node(
         ctx: &DalContext,
         name: impl AsRef<str>,

--- a/lib/dal/src/tasks/status_receiver/client.rs
+++ b/lib/dal/src/tasks/status_receiver/client.rs
@@ -39,7 +39,7 @@ impl StatusReceiverClient {
     /// [NATS](https://nats.io) with the appropriate subject.
     ///
     /// The request is performed in a UDP-like manner without a reply mailbox.
-    #[instrument(name = "status_receiver_client.publish", skip_all)]
+    #[instrument(name = "status_receiver_client.publish", level = "debug", skip_all)]
     pub async fn publish(&self, request: &StatusReceiverRequest) -> StatusReceiverClientResult<()> {
         self.execute_request(STATUS_RECEIVER_REQUEST_SUBJECT, request)
             .await

--- a/lib/dal/src/tenancy.rs
+++ b/lib/dal/src/tenancy.rs
@@ -31,7 +31,7 @@ impl Tenancy {
         Self { workspace_pk: None }
     }
 
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn check(&self, txn: &PgTxn, tenancy: &Tenancy) -> TenancyResult<bool> {
         let row = txn
             .query_one(

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -61,8 +61,6 @@ impl User {
     standard_model_accessor_ro!(name, String);
     standard_model_accessor_ro!(email, String);
 
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         pk: UserPk,

--- a/lib/dal/src/validation/prototype.rs
+++ b/lib/dal/src/validation/prototype.rs
@@ -81,7 +81,6 @@ impl_standard_model! {
 }
 
 impl ValidationPrototype {
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         func_id: FuncId,
@@ -129,7 +128,7 @@ impl ValidationPrototype {
     }
 
     /// List all [`ValidationPrototypes`](Self) for a given [`Prop`](crate::Prop).
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_for_prop(
         ctx: &DalContext,
         prop_id: PropId,
@@ -149,7 +148,7 @@ impl ValidationPrototype {
     ///
     /// _You can access the [`PropId`](crate::Prop) via the [`ValidationPrototypeContext`], if
     /// needed._
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_for_schema_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -168,7 +167,7 @@ impl ValidationPrototype {
     }
 
     /// List all [`ValidationPrototypes`](Self) for a [`Func`](crate::Func)
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_for_func(
         ctx: &DalContext,
         func_id: FuncId,

--- a/lib/dal/src/validation/resolver.rs
+++ b/lib/dal/src/validation/resolver.rs
@@ -96,8 +96,6 @@ impl_standard_model! {
 }
 
 impl ValidationResolver {
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &DalContext,
         validation_prototype_id: ValidationPrototypeId,

--- a/lib/dal/src/visibility.rs
+++ b/lib/dal/src/visibility.rs
@@ -30,7 +30,6 @@ pub struct Visibility {
 }
 
 impl Visibility {
-    #[instrument]
     pub fn new(change_set_pk: ChangeSetPk, deleted_at: Option<DateTime<Utc>>) -> Self {
         Visibility {
             change_set_pk,
@@ -39,7 +38,6 @@ impl Visibility {
     }
 
     /// Constructs a new head [`Visibility`].
-    #[instrument]
     pub fn new_head(deleted: bool) -> Self {
         let deleted_at = match deleted {
             true => Some(Utc::now()),
@@ -71,7 +69,6 @@ impl Visibility {
     }
 
     /// Constructs a new change set `Visibility`.
-    #[instrument]
     pub fn new_change_set(change_set_pk: ChangeSetPk, deleted: bool) -> Self {
         let deleted_at = match deleted {
             true => Some(Utc::now()),
@@ -91,7 +88,6 @@ impl Visibility {
     }
 
     /// Returns true if this [`Visibility`] is in a working changeset (and not in head)
-    #[instrument]
     pub fn in_change_set(&self) -> bool {
         self.change_set_pk != ChangeSetPk::NONE
     }
@@ -100,7 +96,6 @@ impl Visibility {
         self.deleted_at.is_some()
     }
 
-    #[instrument(skip(ctx))]
     pub async fn is_visible_to(
         &self,
         ctx: &DalContext,

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -61,7 +61,6 @@ impl Workspace {
         &self.pk
     }
 
-    #[instrument(skip_all)]
     pub async fn builtin(ctx: &DalContext) -> WorkspaceResult<Self> {
         let row = ctx
             .txns()
@@ -100,7 +99,6 @@ impl Workspace {
         Ok(standard_model::option_object_from_row(row)?)
     }
 
-    #[instrument(skip_all)]
     pub async fn new(
         ctx: &mut DalContext,
         pk: WorkspacePk,

--- a/lib/module-index-server/src/jwt_key.rs
+++ b/lib/module-index-server/src/jwt_key.rs
@@ -83,7 +83,7 @@ pub enum JwtKeyError {
     Verify(String),
 }
 
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip_all)]
 pub async fn validate_bearer_token(
     public_key: JwtPublicSigningKey,
     bearer_token: impl AsRef<str>,

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -121,7 +121,7 @@ impl Server<(), ()> {
     }
 
     // this creates our si_data_pg::PgPool, which wont work with SeaORM
-    #[instrument(name = "module-index.init.create_pg_pool", skip_all)]
+    #[instrument(name = "module-index.init.create_pg_pool", level = "info", skip_all)]
     pub async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> Result<PgPool> {
         let pool = PgPool::new(pg_pool_config).await?;
         debug!("successfully started pg pool (note that not all connections may be healthy)");
@@ -129,7 +129,11 @@ impl Server<(), ()> {
     }
 
     // this creates the sea-orm managed db connection (also a pool)
-    #[instrument(name = "module-index.init.create_db_connection", skip_all)]
+    #[instrument(
+        name = "module-index.init.create_db_connection",
+        level = "info",
+        skip_all
+    )]
     pub async fn create_db_connection(pg_pool_config: &PgPoolConfig) -> Result<DatabaseConnection> {
         let mut opt = ConnectOptions::new(format!(
             "{protocol}://{username}:{password}@{host}:{port}/{database}",
@@ -164,7 +168,11 @@ impl Server<(), ()> {
             .await?)
     }
 
-    #[instrument(name = "sdf.init.load_jwt_public_signing_key", skip_all)]
+    #[instrument(
+        name = "sdf.init.load_jwt_public_signing_key",
+        level = "info",
+        skip_all
+    )]
     pub async fn load_jwt_public_signing_key(
         path: impl AsRef<Path>,
     ) -> Result<JwtPublicSigningKey> {

--- a/lib/pinga-server/src/server.rs
+++ b/lib/pinga-server/src/server.rs
@@ -99,7 +99,7 @@ pub struct Server {
 }
 
 impl Server {
-    #[instrument(name = "pinga.init.from_config", skip_all)]
+    #[instrument(name = "pinga.init.from_config", level = "info", skip_all)]
     pub async fn from_config(config: Config) -> Result<Self> {
         dal::init()?;
 
@@ -129,7 +129,7 @@ impl Server {
         )
     }
 
-    #[instrument(name = "pinga.init.from_services", skip_all)]
+    #[instrument(name = "pinga.init.from_services", level = "info", skip_all)]
     pub fn from_services(
         instance_id: impl Into<String>,
         concurrency_limit: usize,
@@ -202,38 +202,42 @@ impl Server {
         }
     }
 
-    #[instrument(name = "pinga.init.load_encryption_key", skip_all)]
+    #[instrument(name = "pinga.init.load_encryption_key", level = "info", skip_all)]
     async fn load_encryption_key(crypto_config: CryptoConfig) -> Result<Arc<CycloneEncryptionKey>> {
         Ok(Arc::new(
             CycloneEncryptionKey::from_config(crypto_config).await?,
         ))
     }
 
-    #[instrument(name = "pinga.init.connect_to_nats", skip_all)]
+    #[instrument(name = "pinga.init.connect_to_nats", level = "info", skip_all)]
     async fn connect_to_nats(nats_config: &NatsConfig) -> Result<NatsClient> {
         let client = NatsClient::new(nats_config).await?;
         debug!("successfully connected nats client");
         Ok(client)
     }
 
-    #[instrument(name = "pinga.init.create_pg_pool", skip_all)]
+    #[instrument(name = "pinga.init.create_pg_pool", level = "info", skip_all)]
     async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> Result<PgPool> {
         let pool = PgPool::new(pg_pool_config).await?;
         debug!("successfully started pg pool (note that not all connections may be healthy)");
         Ok(pool)
     }
 
-    #[instrument(name = "pinga.init.create_veritech_client", skip_all)]
+    #[instrument(name = "pinga.init.create_veritech_client", level = "info", skip_all)]
     fn create_veritech_client(nats: NatsClient) -> VeritechClient {
         VeritechClient::new(nats)
     }
 
-    #[instrument(name = "pinga.init.create_job_processor", skip_all)]
+    #[instrument(name = "pinga.init.create_job_processor", level = "info", skip_all)]
     fn create_job_processor(nats: NatsClient) -> Box<dyn JobQueueProcessor + Send + Sync> {
         Box::new(NatsProcessor::new(nats)) as Box<dyn JobQueueProcessor + Send + Sync>
     }
 
-    #[instrument(name = "pinga.init.create_symmetric_crypto_service", skip_all)]
+    #[instrument(
+        name = "pinga.init.create_symmetric_crypto_service",
+        level = "info",
+        skip_all
+    )]
     async fn create_symmetric_crypto_service(
         config: &SymmetricCryptoServiceConfig,
     ) -> Result<SymmetricCryptoService> {
@@ -377,14 +381,17 @@ async fn process_job_requests_task(rx: UnboundedReceiver<JobItem>, concurrency_l
 #[instrument(
     name = "execute_job_task",
     parent = &request.process_span,
+    level = "info",
     skip_all,
     fields(
+        job.blocking = request.payload.blocking,
         job.id = request.payload.id,
         job.instance = metadata.job_instance,
-        job.invoked_name = request.payload.kind,
         job.invoked_args = Empty,
+        job.invoked_name = request.payload.kind,
         job.invoked_provider = metadata.job_invoked_provider,
         job.trigger = "pubsub",
+        job.visibility = ?request.payload.visibility,
         messaging.destination = Empty,
         messaging.destination_kind = "topic",
         messaging.operation = "process",
@@ -413,23 +420,6 @@ async fn execute_job_task(
         "otel.name",
         format!("{} process", &messaging_destination).as_str(),
     );
-
-    {
-        let job_info = &request.payload;
-
-        span.record("job_info.id", &job_info.id);
-        span.record("job_info.kind", &job_info.kind);
-        if let Ok(arg_str) = serde_json::to_string(&job_info.arg) {
-            span.record("job_info.arg", arg_str);
-        }
-        if let Ok(access_builder) = serde_json::to_string(&job_info.access_builder) {
-            span.record("job_info.access_builder", access_builder);
-        }
-        if let Ok(visibility) = serde_json::to_string(&job_info.visibility) {
-            span.record("job_info.visibility", visibility);
-        }
-        span.record("job_info.blocking", job_info.blocking);
-    }
 
     let maybe_reply_channel = request.reply.clone();
     let reply_message = match execute_job(ctx_builder.clone(), request.payload).await {

--- a/lib/sdf-server/src/server/nats_multiplexer.rs
+++ b/lib/sdf-server/src/server/nats_multiplexer.rs
@@ -12,7 +12,7 @@ pub const WS_MULTIPLEXER_SUBJECT: &str = "si.>";
 
 /// A grouping of multiplexer clients needed to appease the "FromRef" implementation for "AppState". Yes, really.
 #[derive(Debug, Clone)]
-pub(crate) struct NatsMultiplexerClients {
+pub struct NatsMultiplexerClients {
     pub ws: Arc<Mutex<MultiplexerClient>>,
     pub crdt: Arc<Mutex<MultiplexerClient>>,
 }

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -226,7 +226,7 @@ impl Server<(), ()> {
         Ok(posthog_client)
     }
 
-    #[instrument(name = "sdf.init.generate_cyclone_key_pair", skip_all)]
+    #[instrument(name = "sdf.init.generate_cyclone_key_pair", level = "info", skip_all)]
     pub async fn generate_cyclone_key_pair(
         secret_key_path: impl AsRef<Path>,
         public_key_path: impl AsRef<Path>,
@@ -236,7 +236,7 @@ impl Server<(), ()> {
             .map_err(Into::into)
     }
 
-    #[instrument(name = "sdf.init.generate_symmetric_key", skip_all)]
+    #[instrument(name = "sdf.init.generate_symmetric_key", level = "info", skip_all)]
     pub async fn generate_symmetric_key(symmetric_key_path: impl AsRef<Path>) -> Result<()> {
         SymmetricCryptoService::generate_key()
             .save(symmetric_key_path.as_ref())
@@ -244,17 +244,25 @@ impl Server<(), ()> {
             .map_err(Into::into)
     }
 
-    #[instrument(name = "sdf.init.load_jwt_public_signing_key", skip_all)]
+    #[instrument(
+        name = "sdf.init.load_jwt_public_signing_key",
+        level = "info",
+        skip_all
+    )]
     pub async fn load_jwt_public_signing_key(config: JwtConfig) -> Result<JwtPublicSigningKey> {
         Ok(JwtPublicSigningKey::from_config(config).await?)
     }
 
-    #[instrument(name = "sdf.init.decode_jwt_public_signing_key", skip_all)]
+    #[instrument(
+        name = "sdf.init.decode_jwt_public_signing_key",
+        level = "info",
+        skip_all
+    )]
     pub async fn decode_jwt_public_signing_key(key_string: String) -> Result<JwtPublicSigningKey> {
         Ok(JwtPublicSigningKey::decode(key_string).await?)
     }
 
-    #[instrument(name = "sdf.init.load_encryption_key", skip_all)]
+    #[instrument(name = "sdf.init.load_encryption_key", level = "info", skip_all)]
     pub async fn load_encryption_key(
         crypto_config: CryptoConfig,
     ) -> Result<Arc<CycloneEncryptionKey>> {
@@ -263,7 +271,7 @@ impl Server<(), ()> {
         ))
     }
 
-    #[instrument(name = "sdf.init.migrate_database", skip_all)]
+    #[instrument(name = "sdf.init.migrate_database", level = "info", skip_all)]
     pub async fn migrate_database(services_context: &ServicesContext) -> Result<()> {
         dal::migrate_all_with_progress(services_context).await?;
         migrate_builtins_from_module_index(services_context).await?;
@@ -288,14 +296,14 @@ impl Server<(), ()> {
         Ok(())
     }
 
-    #[instrument(name = "sdf.init.create_pg_pool", skip_all)]
+    #[instrument(name = "sdf.init.create_pg_pool", level = "info", skip_all)]
     pub async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> Result<PgPool> {
         let pool = PgPool::new(pg_pool_config).await?;
         debug!("successfully started pg pool (note that not all connections may be healthy)");
         Ok(pool)
     }
 
-    #[instrument(name = "sdf.init.connect_to_nats", skip_all)]
+    #[instrument(name = "sdf.init.connect_to_nats", level = "info", skip_all)]
     pub async fn connect_to_nats(nats_config: &NatsConfig) -> Result<NatsClient> {
         let client = NatsClient::new(nats_config).await?;
         debug!("successfully connected nats client");
@@ -306,7 +314,11 @@ impl Server<(), ()> {
         VeritechClient::new(nats)
     }
 
-    #[instrument(name = "sdf.init.create_symmetric_crypto_service", skip_all)]
+    #[instrument(
+        name = "sdf.init.create_symmetric_crypto_service",
+        level = "info",
+        skip_all
+    )]
     pub async fn create_symmetric_crypto_service(
         config: &SymmetricCryptoServiceConfig,
     ) -> Result<SymmetricCryptoService> {

--- a/lib/sdf-server/src/server/service/ws/crdt.rs
+++ b/lib/sdf-server/src/server/service/ws/crdt.rs
@@ -59,7 +59,6 @@ pub struct Id {
     id: String,
 }
 
-#[instrument(skip(wsu, nats, broadcast_groups))]
 pub async fn crdt(
     wsu: WebSocketUpgrade,
     Nats(nats): Nats,

--- a/lib/sdf-server/src/server/service/ws/workspace_updates.rs
+++ b/lib/sdf-server/src/server/service/ws/workspace_updates.rs
@@ -16,7 +16,6 @@ use crate::server::{
     state::ShutdownBroadcast,
 };
 
-#[instrument(skip(wsu, nats))]
 #[allow(clippy::unused_async)]
 pub async fn workspace_updates(
     wsu: WebSocketUpgrade,

--- a/lib/si-data-nats/examples/nats-publish/main.rs
+++ b/lib/si-data-nats/examples/nats-publish/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     run().await
 }
 
-#[instrument(name = "main", skip_all)]
+#[instrument(name = "main", level = "info", skip_all)]
 async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     let subject = env::args()
         .nth(1)

--- a/lib/si-data-nats/examples/nats-subscribe/main.rs
+++ b/lib/si-data-nats/examples/nats-subscribe/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     run().await
 }
 
-#[instrument(name = "main", skip_all)]
+#[instrument(name = "main", level = "info", skip_all)]
 async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     let subject = env::args()
         .nth(1)

--- a/lib/si-data-nats/src/lib.rs
+++ b/lib/si-data-nats/src/lib.rs
@@ -100,7 +100,7 @@ pub struct Client {
 }
 
 impl Client {
-    #[instrument(name = "client::new", skip_all, level = "debug")]
+    #[instrument(name = "client.new", skip_all, level = "debug")]
     pub async fn new(config: &NatsConfig) -> Result<Self> {
         let mut options = ConnectOptions::default();
 

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -55,7 +55,7 @@ impl Client {
         self.nats.metadata().subject_prefix()
     }
 
-    #[instrument(name = "client.execute_resolver_function", skip_all)]
+    #[instrument(name = "client.execute_resolver_function", level = "info", skip_all)]
     pub async fn execute_resolver_function(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -69,7 +69,11 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_resolver_function_with_subject", skip_all)]
+    #[instrument(
+        name = "client.execute_resolver_function_with_subject",
+        level = "info",
+        skip_all
+    )]
     pub async fn execute_resolver_function_with_subject(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -84,7 +88,7 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_validation", skip_all)]
+    #[instrument(name = "client.execute_validation", level = "info", skip_all)]
     pub async fn execute_validation(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -98,7 +102,11 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_validation_with_subject", skip_all)]
+    #[instrument(
+        name = "client.execute_validation_with_subject",
+        level = "info",
+        skip_all
+    )]
     pub async fn execute_validation_with_subject(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -113,7 +121,7 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_action_run", skip_all)]
+    #[instrument(name = "client.execute_action_run", level = "info", skip_all)]
     pub async fn execute_action_run(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -127,7 +135,11 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_action_run_with_subject", skip_all)]
+    #[instrument(
+        name = "client.execute_action_run_with_subject",
+        level = "info",
+        skip_all
+    )]
     pub async fn execute_action_run_with_subject(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -142,7 +154,7 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_reconciliation", skip_all)]
+    #[instrument(name = "client.execute_reconciliation", level = "info" skip_all)]
     pub async fn execute_reconciliation(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -156,7 +168,11 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_reconciliation_with_subject", skip_all)]
+    #[instrument(
+        name = "client.execute_reconciliation_with_subject",
+        level = "info",
+        skip_all
+    )]
     pub async fn execute_reconciliation_with_subject(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -171,7 +187,7 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_reconciliation", skip_all)]
+    #[instrument(name = "client.execute_reconciliation", level = "info", skip_all)]
     pub async fn execute_schema_variant_definition(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -185,7 +201,11 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_reconciliation_with_subject", skip_all)]
+    #[instrument(
+        name = "client.execute_reconciliation_with_subject",
+        level = "info",
+        skip_all
+    )]
     pub async fn execute_schema_variant_definition_with_subject(
         &self,
         output_tx: mpsc::Sender<OutputStream>,

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -68,7 +68,7 @@ pub struct Server {
 }
 
 impl Server {
-    #[instrument(name = "veritech.init.cyclone.http", skip(config))]
+    #[instrument(name = "veritech.init.cyclone.http", level = "info", skip_all)]
     pub async fn for_cyclone_http(config: Config) -> ServerResult<Server> {
         match config.cyclone_spec() {
             CycloneSpec::LocalHttp(_spec) => {
@@ -95,7 +95,7 @@ impl Server {
         }
     }
 
-    #[instrument(name = "veritech.init.cyclone.uds", skip(config))]
+    #[instrument(name = "veritech.init.cyclone.uds", level = "info", skip_all)]
     pub async fn for_cyclone_uds(config: Config) -> ServerResult<Server> {
         match config.cyclone_spec() {
             CycloneSpec::LocalUds(spec) => {


### PR DESCRIPTION
This change targets most of our `#[instrument]` derive macro callsites in the Rust codebase.

A default log level setting for an `#[instrument]` call is `INFO` which cause these spans to be includes in all traces at the default logging level. What we're probably wanting (in the default case) is less/higher level spans in each service, espeically spans that happen at the service boundaries (i.e. make a job call over nats, etc.).

This change gives a much higher preference to service-specific spans to be at `INFO` level, and our other supporting crates tend to be at `DEBUG` and `TRACE` levels.

Our hope is that this change may lead to a clearer high level story without having to dial up the telemetry verbosity.

<img src="https://media0.giphy.com/media/iHskdY9SMLFZuQ2u5c/giphy.gif"/>