### PR TITLE
fix(sdf): make connect_component_sockets_to_frame_inner iterative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,6 @@ dependencies = [
 name = "sdf-server"
 version = "0.1.0"
 dependencies = [
- "async-recursion",
  "async-trait",
  "axum",
  "base64 0.21.7",

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -19,7 +19,6 @@ rust_library(
         "//lib/telemetry-http-rs:telemetry-http",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-client:veritech-client",
-        "//third-party/rust:async-recursion",
         "//third-party/rust:async-trait",
         "//third-party/rust:axum",
         "//third-party/rust:base64",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -23,7 +23,6 @@ telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-http = { path = "../../lib/telemetry-http-rs" }
 veritech-client = { path = "../../lib/veritech-client" }
 
-async-recursion = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }


### PR DESCRIPTION
This change converts the `connect_component_sockets_to_frame_inner` function from an async/recursive strategy to an iterative strategy. Prior to this change, when working with a large workspace containing multiple levels of nested frames (like 5 and more), calls to this function would recurse enough times that it would exhaust the stack space and cause the program to panic and abort. The iterative approach guards against an *arbitrarily* deep set of nested frames.

<img src="https://media3.giphy.com/media/eePSFNBFv2W9owZ4Sh/giphy.gif"/>