### PR TITLE
feat(veritech): add service-spanning telemetry to/from Veritech

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6429,6 +6429,7 @@ dependencies = [
  "si-crypto",
  "si-data-nats",
  "telemetry",
+ "telemetry-nats",
  "test-log",
  "thiserror",
  "tokio",
@@ -6459,8 +6460,10 @@ dependencies = [
  "si-data-nats",
  "si-settings",
  "telemetry",
+ "telemetry-nats",
  "thiserror",
  "tokio",
+ "ulid",
  "veritech-core",
 ]
 

--- a/lib/veritech-client/BUCK
+++ b/lib/veritech-client/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-crypto:si-crypto",
         "//lib/telemetry-rs:telemetry",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/veritech-core:veritech-core",
         "//third-party/rust:futures",
         "//third-party/rust:remain",

--- a/lib/veritech-client/Cargo.toml
+++ b/lib/veritech-client/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 si-crypto = { path = "../../lib/si-crypto" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 veritech-core = { path = "../../lib/veritech-core" }

--- a/lib/veritech-server/BUCK
+++ b/lib/veritech-server/BUCK
@@ -8,6 +8,7 @@ rust_library(
         "//lib/nats-subscriber:nats-subscriber",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-settings:si-settings",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-core:veritech-core",
         "//third-party/rust:chrono",
@@ -18,6 +19,7 @@ rust_library(
         "//third-party/rust:serde_json",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
+        "//third-party/rust:ulid",
     ],
     srcs = glob(["src/**/*.rs"]),
 )

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -18,6 +18,8 @@ serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-settings = { path = "../../lib/si-settings" }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+ulid = { workspace = true }
 veritech-core = { path = "../../lib/veritech-core" }

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
+use ulid::Ulid;
 
 use buck2_resources::Buck2Resources;
 use deadpool_cyclone::{
@@ -51,6 +52,9 @@ pub struct Config {
     nats: NatsConfig,
 
     cyclone_spec: CycloneSpec,
+
+    #[builder(default = "random_instance_id()")]
+    instance_id: String,
 }
 
 #[remain::sorted]
@@ -118,6 +122,11 @@ impl Config {
     /// Gets a reference to the config's subject prefix.
     pub fn subject_prefix(&self) -> Option<&str> {
         self.nats.subject_prefix.as_deref()
+    }
+
+    /// Gets the config's instance ID.
+    pub fn instance_id(&self) -> &str {
+        self.instance_id.as_ref()
     }
 
     // Consumes into a [`CycloneSpec`].
@@ -473,6 +482,10 @@ fn default_pool_size() -> u16 {
 
 fn default_connect_timeout() -> u64 {
     10
+}
+
+fn random_instance_id() -> String {
+    Ulid::new().to_string()
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development


### PR DESCRIPTION
This change adds tracing context propagation between the Veritech client and server code (in `lib/veritech-client` and `lib/veritech-server` respectively). With this change, you can now track each incoming function request into the Veritech server and see the corresponding output and result messaging between client and server. Very cool!

<img src="https://media3.giphy.com/media/2bUpP71bbVnZ3x7lgQ/giphy.gif"/>