### PR TITLE
build(deps): upgrade to NATS 2.10.10

### DIFF
--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -9,7 +9,7 @@ docker_image(
         "nats-server.conf": "component/nats",
     },
     build_args = {
-        "BASE_VERSION": "2.3.4",
+        "BASE_VERSION": "2.10.10",
     },
     run_docker_args = [
         "--publish",

--- a/component/nats/nats-server.conf
+++ b/component/nats/nats-server.conf
@@ -1,4 +1,16 @@
-port: 4222
-monitor_port: 8222
+# See: https://docs.nats.io/running-a-nats-service/configuration
+
+# Maximum number of bytes in a message payload. It is not recommended to use
+# values over 8MB but `max_payload` can be set up to 64MB. The max payload must
+# be equal to or smaller than the `max_pending` value.
+#
+# Default: 1MB
 max_payload: 8MB
+
+# Maximum number of bytes buffered for a connection.
+#
+# Default: 64MB
 max_pending: 128MB
+
+# JetStream configuration
+jetstream {}


### PR DESCRIPTION
Confirmed we're good to upgrade--this also brings our development environments to closer parity with our production environment.

<img src="https://media1.giphy.com/media/ckB9wvcONerp73fvkQ/giphy.gif"/>