### PR TITLE
chore: support opt-in ANSI coloring of telemetry logging output

### DIFF
--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -19,6 +19,28 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
+
     /// NATS connection URL [example: demo.nats.io]
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
@@ -30,10 +52,6 @@ pub(crate) struct Args {
     /// NATS credentials file
     #[arg(long)]
     pub(crate) nats_creds_path: Option<String>,
-
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
 }
 
 impl TryFrom<Args> for Config {

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -24,9 +24,27 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
 
     /// Binds service to a socket address [example: 0.0.0.0:5157]
     #[arg(long, group = "bind")]

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -19,16 +19,25 @@ async fn main() -> Result<()> {
     let task_tracker = TaskTracker::new();
 
     color_eyre::install()?;
-    let config = TelemetryConfig::builder()
-        .service_name("cyclone")
-        .service_namespace("si")
-        .log_env_var_prefix("SI")
-        .app_modules(vec!["cyclone", "cyclone_server"])
-        .custom_default_tracing_level(CUSTOM_DEFAULT_TRACING_LEVEL)
-        .build()?;
-    let (mut telemetry, telemetry_shutdown) =
-        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let mut builder = TelemetryConfig::builder();
+        builder
+            .service_name("cyclone")
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec!["cyclone", "cyclone_server"])
+            .custom_default_tracing_level(CUSTOM_DEFAULT_TRACING_LEVEL);
+        if let Some(force_color) = args.force_color {
+            builder.force_color(force_color);
+        }
+        if let Some(no_color) = args.no_color {
+            builder.no_color(no_color);
+        }
+        let config = builder.build()?;
+
+        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
+    };
 
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -21,6 +21,28 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long, env)]
     pub(crate) pg_dbname: Option<String>,
@@ -80,14 +102,8 @@ pub(crate) struct Args {
     /// The path to the JWT public signing key
     #[arg(long, env)]
     pub(crate) jwt_public_key: Option<String>,
-
     // /// Database migration mode on startup
     // #[arg(long, value_parser = PossibleValuesParser::new(MigrationMode::variants()))]
-
-    // pub(crate) migration_mode: Option<String>,
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
 }
 
 impl TryFrom<Args> for Config {

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -25,15 +25,24 @@ async fn async_main() -> Result<()> {
     let task_tracker = TaskTracker::new();
 
     color_eyre::install()?;
-    let config = TelemetryConfig::builder()
-        .service_name("module-index")
-        .service_namespace("si")
-        .log_env_var_prefix("SI")
-        .app_modules(vec!["module_index", "module_index_server"])
-        .build()?;
-    let (mut telemetry, telemetry_shutdown) =
-        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let mut builder = TelemetryConfig::builder();
+        builder
+            .service_name("module-index")
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec!["module_index", "module_index_server"]);
+        if let Some(force_color) = args.force_color {
+            builder.force_color(force_color);
+        }
+        if let Some(no_color) = args.no_color {
+            builder.no_color(no_color);
+        }
+        let config = builder.build()?;
+
+        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
+    };
 
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -21,6 +21,28 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,
@@ -60,10 +82,6 @@ pub(crate) struct Args {
     /// NATS credentials file
     #[arg(long)]
     pub(crate) nats_creds_path: Option<String>,
-
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
 
     /// Cyclone encryption key file location [default: /run/pinga/cyclone_encryption.key]
     #[arg(long)]

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -25,15 +25,24 @@ async fn async_main() -> Result<()> {
     let task_tracker = TaskTracker::new();
 
     color_eyre::install()?;
-    let config = TelemetryConfig::builder()
-        .service_name("pinga")
-        .service_namespace("si")
-        .log_env_var_prefix("SI")
-        .app_modules(vec!["pinga", "pinga_server"])
-        .build()?;
-    let (mut telemetry, telemetry_shutdown) =
-        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let mut builder = TelemetryConfig::builder();
+        builder
+            .service_name("pinga")
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec!["pinga", "pinga_server"]);
+        if let Some(force_color) = args.force_color {
+            builder.force_color(force_color);
+        }
+        if let Some(no_color) = args.no_color {
+            builder.no_color(no_color);
+        }
+        let config = builder.build()?;
+
+        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
+    };
 
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -23,6 +23,28 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,
@@ -66,10 +88,6 @@ pub(crate) struct Args {
     /// Database migration mode on startup
     #[arg(long, value_parser = PossibleValuesParser::new(MigrationMode::variants()))]
     pub(crate) migration_mode: Option<String>,
-
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
 
     /// Cyclone encryption key file location [default: /run/sdf/cyclone_encryption.key]
     #[arg(long)]

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -36,15 +36,24 @@ async fn async_main() -> Result<()> {
     let task_tracker = TaskTracker::new();
 
     color_eyre::install()?;
-    let config = TelemetryConfig::builder()
-        .service_name("sdf")
-        .service_namespace("si")
-        .log_env_var_prefix("SI")
-        .app_modules(vec!["sdf", "sdf_server"])
-        .build()?;
-    let (mut telemetry, telemetry_shutdown) =
-        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let mut builder = TelemetryConfig::builder();
+        builder
+            .service_name("sdf")
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec!["sdf", "sdf_server"]);
+        if let Some(force_color) = args.force_color {
+            builder.force_color(force_color);
+        }
+        if let Some(no_color) = args.no_color {
+            builder.no_color(no_color);
+        }
+        let config = builder.build()?;
+
+        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
+    };
 
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -17,6 +17,28 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: Option<bool>,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long,
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: Option<bool>,
+
     /// NATS connection URL [example: 0.0.0.0:4222]
     #[arg(long, short = 'u')]
     pub(crate) nats_url: Option<String>,
@@ -28,10 +50,6 @@ pub(crate) struct Args {
     /// NATS credentials file
     #[arg(long)]
     pub(crate) nats_creds_path: Option<String>,
-
-    /// Disable OpenTelemetry on startup
-    #[arg(long)]
-    pub(crate) disable_opentelemetry: bool,
 
     /// Cyclone runtime type: LocalProcess
     #[arg(long)]

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -11,15 +11,24 @@ async fn main() -> Result<()> {
     let task_tracker = TaskTracker::new();
 
     color_eyre::install()?;
-    let config = TelemetryConfig::builder()
-        .service_name("veritech")
-        .service_namespace("si")
-        .log_env_var_prefix("SI")
-        .app_modules(vec!["veritech", "veritech_server"])
-        .build()?;
-    let (mut telemetry, telemetry_shutdown) =
-        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?;
     let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let mut builder = TelemetryConfig::builder();
+        builder
+            .service_name("veritech")
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec!["veritech", "veritech_server"]);
+        if let Some(force_color) = args.force_color {
+            builder.force_color(force_color);
+        }
+        if let Some(no_color) = args.no_color {
+            builder.no_color(no_color);
+        }
+        let config = builder.build()?;
+
+        telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
+    };
 
     if args.verbose > 0 {
         telemetry.set_verbosity(args.verbose.into()).await?;

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -83,6 +83,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(module_index_target),
     serve_cmd = "buck2 run {}".format(module_index_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     auto_init = False,
     resource_deps = [
@@ -100,6 +101,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(council_target),
     serve_cmd = "buck2 run {}".format(council_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
         "nats",
@@ -116,6 +118,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(pinga_target),
     serve_cmd = "buck2 run {}".format(pinga_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
         "council",
@@ -134,6 +137,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(veritech_target),
     serve_cmd = "SI_LOG=debug buck2 run {}".format(veritech_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     # This is the serve command you might need if you want to execute on firecracker for 10 functione executions.
     # NB: BUCK2 MUST RUN AS ROOT OR THIS WILL NOT WORK
     # serve_cmd = "SI_LOG=debug buck2 run {} -- --cyclone-local-firecracker --cyclone-pool-size 10".format(veritech_target),
@@ -153,6 +157,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build {}".format(sdf_target),
     serve_cmd = "buck2 run {}".format(sdf_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
         "nats",


### PR DESCRIPTION
This change updates the telemetry setup and adds a couple of extra CLI arguments and environment variables to help control when it's appropriate for logging output to contain ANSI escape characters.

Each service has a new CLI argument of `--no-color` which will disable ANSI coloring of telemetry output when set. An associated environment variable of `SI_NO_COLOR` is also supported by setting the value to either `true` or `false`. Finally as a fallback of last resort, and to better support other operational ecosystems the `NO_COLOR` environment variable is also inspected and will disable coloring if this value is set to something non-empty.

In an attempt to make our services better behaved as Unix programs, they will now automatically disable ANSI coloring if the standard output of the process doesn't refer to a terminal or TTY (that is, the session is "non-interactive").

Our Tilt development environment can support output from processes with ANSI coloring, however these processes are considered "non-interactive" and thus won't be colored by default. As a consequence of this, there is one more new CLI argument of `--force-color` which will override the terminal/TTY detection logic and will unconditionally add ANSI coloring. An associated environment variable of `SI_FORCE_COLOR` will also work in place of using the `--force-color` CLI flag.

<img src="https://media4.giphy.com/media/SKGo6OYe24EBG/giphy.gif"/>