### PR TITLE
feat: support telemetry logging option as JSON lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -652,9 +652,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -907,7 +907,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "toml 0.8.9",
+ "toml 0.8.10",
  "tracing",
 ]
 
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-compact"
-version = "2.0.6"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a667e6426df16c2ac478efa4a439d0e674cba769c5556e8cf221739251640c8c"
+checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
  "ct-codecs",
  "getrandom 0.2.12",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "filetime"
@@ -2283,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -2457,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2880,9 +2880,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -3164,6 +3164,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -4055,7 +4061,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.9",
+ "toml 0.8.10",
  "url",
  "walkdir",
 ]
@@ -4130,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -4205,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -4223,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4301,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.0"
+version = "1.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de2711cae7bdec993f4d2319352599ceb0d003e9f7900ea7c6ef4c5fc16831"
+checksum = "755392e1a2f77afd95580d3f0d0e94ac83eeeb7167552c9b5bca549e61a94d83"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4332,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -4364,7 +4370,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.1",
+ "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
 ]
@@ -4402,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 
 [[package]]
 name = "rustls-webpki"
@@ -4418,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.1"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4557,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d"
+checksum = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4585,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555"
+checksum = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4944,7 +4950,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.8.9",
+ "toml 0.8.10",
 ]
 
 [[package]]
@@ -5680,13 +5686,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5754,12 +5759,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -5774,10 +5780,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -5807,9 +5814,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -6020,14 +6027,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.2",
 ]
 
 [[package]]
@@ -6057,6 +6064,17 @@ name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.2",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -6220,6 +6238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,12 +6257,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -6270,9 +6301,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ulid"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3c3b4dcec1e4729aab50688a1a0631483d79e65b194851425e7748287715a6"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
  "getrandom 0.2.12",
  "rand 0.8.5",
@@ -6632,9 +6663,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
@@ -6820,9 +6851,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.36"
+version = "0.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
+checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ tower = "0.4.13"
 tower-http = { version = "0.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.22.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }

--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -43,6 +43,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// NATS connection URL [example: demo.nats.io]
     #[arg(long)]
     pub(crate) nats_url: Option<String>,

--- a/bin/council/src/main.rs
+++ b/bin/council/src/main.rs
@@ -30,6 +30,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("council")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -48,6 +48,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// Binds service to a socket address [example: 0.0.0.0:5157]
     #[arg(long, group = "bind")]
     pub(crate) bind_addr: Option<SocketAddr>,

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -24,6 +24,11 @@ async fn main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("cyclone")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -45,6 +45,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long, env)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -30,6 +30,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("module-index")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -45,6 +45,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -30,6 +30,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("pinga")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -47,6 +47,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -41,6 +41,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("sdf")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -41,6 +41,17 @@ pub(crate) struct Args {
     )]
     pub(crate) force_color: bool,
 
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// NATS connection URL [example: 0.0.0.0:4222]
     #[arg(long, short = 'u')]
     pub(crate) nats_url: Option<String>,

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -16,6 +16,11 @@ async fn main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("veritech")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -304,7 +304,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anstyle-1.0.5",
+        ":anstyle-1.0.6",
         ":anstyle-parse-0.2.3",
         ":anstyle-query-1.0.2",
         ":colorchoice-1.0.0",
@@ -313,18 +313,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstyle-1.0.5.crate",
-    sha256 = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220",
-    strip_prefix = "anstyle-1.0.5",
-    urls = ["https://crates.io/api/v1/crates/anstyle/1.0.5/download"],
+    name = "anstyle-1.0.6.crate",
+    sha256 = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc",
+    strip_prefix = "anstyle-1.0.6",
+    urls = ["https://crates.io/api/v1/crates/anstyle/1.0.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-1.0.5",
-    srcs = [":anstyle-1.0.5.crate"],
+    name = "anstyle-1.0.6",
+    srcs = [":anstyle-1.0.6.crate"],
     crate = "anstyle",
-    crate_root = "anstyle-1.0.5.crate/src/lib.rs",
+    crate_root = "anstyle-1.0.6.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -403,7 +403,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":anstyle-1.0.5"],
+    deps = [":anstyle-1.0.6"],
 )
 
 http_archive(
@@ -490,7 +490,7 @@ cargo.rust_library(
         ":futures-core-0.3.30",
         ":memchr-2.7.1",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -552,8 +552,8 @@ cargo.rust_library(
         ":serde_nanos-0.1.3",
         ":serde_repr-0.1.18",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
-        ":tokio-1.35.1",
+        ":time-0.3.34",
+        ":tokio-1.36.0",
         ":tokio-retry-0.3.0",
         ":tokio-rustls-0.24.1",
         ":tracing-0.1.40",
@@ -774,7 +774,7 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_json-1.0.113",
         ":url-2.5.0",
-        ":webpki-roots-0.25.3",
+        ":webpki-roots-0.25.4",
     ],
 )
 
@@ -815,7 +815,7 @@ cargo.rust_library(
         ":rust-ini-0.19.0",
         ":serde-1.0.196",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
+        ":time-0.3.34",
         ":url-2.5.0",
     ],
 )
@@ -889,7 +889,7 @@ cargo.rust_library(
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.2",
@@ -973,7 +973,7 @@ cargo.rust_library(
             deps = [
                 ":addr2line-0.21.0",
                 ":libc-0.2.153",
-                ":miniz_oxide-0.7.1",
+                ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
         ),
@@ -981,7 +981,7 @@ cargo.rust_library(
             deps = [
                 ":addr2line-0.21.0",
                 ":libc-0.2.153",
-                ":miniz_oxide-0.7.1",
+                ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
         ),
@@ -989,7 +989,7 @@ cargo.rust_library(
             deps = [
                 ":addr2line-0.21.0",
                 ":libc-0.2.153",
-                ":miniz_oxide-0.7.1",
+                ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
         ),
@@ -997,7 +997,7 @@ cargo.rust_library(
             deps = [
                 ":addr2line-0.21.0",
                 ":libc-0.2.153",
-                ":miniz_oxide-0.7.1",
+                ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
         ),
@@ -1005,7 +1005,7 @@ cargo.rust_library(
             deps = [
                 ":addr2line-0.21.0",
                 ":libc-0.2.153",
-                ":miniz_oxide-0.7.1",
+                ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
         ),
@@ -1501,7 +1501,7 @@ cargo.rust_library(
         ":serde_repr-0.1.18",
         ":serde_urlencoded-0.7.1",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":url-2.5.0",
     ],
@@ -1762,16 +1762,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":iana-time-zone-0.1.59"],
+            deps = [":iana-time-zone-0.1.60"],
         ),
         "linux-x86_64": dict(
-            deps = [":iana-time-zone-0.1.59"],
+            deps = [":iana-time-zone-0.1.60"],
         ),
         "macos-arm64": dict(
-            deps = [":iana-time-zone-0.1.59"],
+            deps = [":iana-time-zone-0.1.60"],
         ),
         "macos-x86_64": dict(
-            deps = [":iana-time-zone-0.1.59"],
+            deps = [":iana-time-zone-0.1.60"],
         ),
         "windows-gnu": dict(
             deps = [":windows-targets-0.52.0"],
@@ -1927,7 +1927,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":anstream-0.6.11",
-        ":anstyle-1.0.5",
+        ":anstyle-1.0.6",
         ":clap_lex-0.6.0",
         ":strsim-0.10.0",
         ":terminal_size-0.3.0",
@@ -2382,7 +2382,7 @@ cargo.rust_library(
         ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":url-2.5.0",
     ],
 )
@@ -2434,7 +2434,7 @@ cargo.rust_library(
         ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":url-2.5.0",
     ],
 )
@@ -3324,7 +3324,7 @@ cargo.rust_library(
         ":async-trait-0.1.77",
         ":deadpool-runtime-0.1.3",
         ":num_cpus-1.16.0",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -3355,7 +3355,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":deadpool-0.10.0",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
         ":tracing-0.1.40",
     ],
@@ -3377,7 +3377,7 @@ cargo.rust_library(
     edition = "2018",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.35.1",
+        "tokio_1": ":tokio-1.36.0",
     },
     visibility = [],
 )
@@ -3899,18 +3899,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ed25519-compact-2.0.6.crate",
-    sha256 = "a667e6426df16c2ac478efa4a439d0e674cba769c5556e8cf221739251640c8c",
-    strip_prefix = "ed25519-compact-2.0.6",
-    urls = ["https://crates.io/api/v1/crates/ed25519-compact/2.0.6/download"],
+    name = "ed25519-compact-2.1.1.crate",
+    sha256 = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190",
+    strip_prefix = "ed25519-compact-2.1.1",
+    urls = ["https://crates.io/api/v1/crates/ed25519-compact/2.1.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ed25519-compact-2.0.6",
-    srcs = [":ed25519-compact-2.0.6.crate"],
+    name = "ed25519-compact-2.1.1",
+    srcs = [":ed25519-compact-2.1.1.crate"],
     crate = "ed25519_compact",
-    crate_root = "ed25519-compact-2.0.6.crate/src/lib.rs",
+    crate_root = "ed25519-compact-2.1.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "ct-codecs",
@@ -4452,7 +4452,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":crc32fast-1.3.2",
-        ":miniz_oxide-0.7.1",
+        ":miniz_oxide-0.7.2",
     ],
 )
 
@@ -5098,7 +5098,7 @@ cargo.rust_library(
         ":http-0.2.11",
         ":indexmap-2.2.2",
         ":slab-0.4.9",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":tracing-0.1.40",
     ],
@@ -5565,7 +5565,7 @@ cargo.rust_library(
         ":itoa-1.0.10",
         ":pin-project-lite-0.2.13",
         ":socket2-0.5.5",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tower-service-0.3.2",
         ":tracing-0.1.40",
         ":want-0.3.1",
@@ -5592,7 +5592,7 @@ cargo.rust_library(
         ":http-0.2.11",
         ":hyper-0.14.28",
         ":rustls-0.21.10",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-rustls-0.24.1",
     ],
 )
@@ -5615,7 +5615,7 @@ cargo.rust_library(
     deps = [
         ":hyper-0.14.28",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-io-timeout-1.2.0",
     ],
 )
@@ -5643,23 +5643,23 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-0.14.28",
         ":pin-project-1.1.4",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
 http_archive(
-    name = "iana-time-zone-0.1.59.crate",
-    sha256 = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539",
-    strip_prefix = "iana-time-zone-0.1.59",
-    urls = ["https://crates.io/api/v1/crates/iana-time-zone/0.1.59/download"],
+    name = "iana-time-zone-0.1.60.crate",
+    sha256 = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141",
+    strip_prefix = "iana-time-zone-0.1.60",
+    urls = ["https://crates.io/api/v1/crates/iana-time-zone/0.1.60/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "iana-time-zone-0.1.59",
-    srcs = [":iana-time-zone-0.1.59.crate"],
+    name = "iana-time-zone-0.1.60",
+    srcs = [":iana-time-zone-0.1.60.crate"],
     crate = "iana_time_zone",
-    crate_root = "iana-time-zone-0.1.59.crate/src/lib.rs",
+    crate_root = "iana-time-zone-0.1.60.crate/src/lib.rs",
     edition = "2018",
     features = ["fallback"],
     platform = {
@@ -6156,7 +6156,7 @@ cargo.rust_library(
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.33",
         ":ct-codecs-1.1.1",
-        ":ed25519-compact-2.0.6",
+        ":ed25519-compact-2.1.1",
         ":hmac-sha1-compact-1.1.4",
         ":hmac-sha256-1.1.7",
         ":hmac-sha512-1.1.5",
@@ -7139,18 +7139,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "miniz_oxide-0.7.1.crate",
-    sha256 = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
-    strip_prefix = "miniz_oxide-0.7.1",
-    urls = ["https://crates.io/api/v1/crates/miniz_oxide/0.7.1/download"],
+    name = "miniz_oxide-0.7.2.crate",
+    sha256 = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
+    strip_prefix = "miniz_oxide-0.7.2",
+    urls = ["https://crates.io/api/v1/crates/miniz_oxide/0.7.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "miniz_oxide-0.7.1",
-    srcs = [":miniz_oxide-0.7.1.crate"],
+    name = "miniz_oxide-0.7.2",
+    srcs = [":miniz_oxide-0.7.2.crate"],
     crate = "miniz_oxide",
-    crate_root = "miniz_oxide-0.7.1.crate/src/lib.rs",
+    crate_root = "miniz_oxide-0.7.2.crate/src/lib.rs",
     edition = "2018",
     features = ["with-alloc"],
     visibility = [],
@@ -7677,6 +7677,23 @@ buildscript_run(
 )
 
 http_archive(
+    name = "num-conv-0.1.0.crate",
+    sha256 = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+    strip_prefix = "num-conv-0.1.0",
+    urls = ["https://crates.io/api/v1/crates/num-conv/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "num-conv-0.1.0",
+    srcs = [":num-conv-0.1.0.crate"],
+    crate = "num_conv",
+    crate_root = "num-conv-0.1.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+)
+
+http_archive(
     name = "num-integer-0.1.45.crate",
     sha256 = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
     strip_prefix = "num-integer-0.1.45",
@@ -8091,7 +8108,7 @@ cargo.rust_library(
         ":opentelemetry_sdk-0.21.2",
         ":prost-0.11.9",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tonic-0.9.2",
     ],
 )
@@ -8208,7 +8225,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-stream-0.1.14",
     ],
 )
@@ -9062,7 +9079,7 @@ cargo.rust_library(
         ":serde_json-1.0.113",
         ":tar-0.4.40",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":url-2.5.0",
     ],
 )
@@ -9888,10 +9905,10 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":siphasher-1.0.0",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
-        ":tokio-1.35.1",
+        ":time-0.3.34",
+        ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
-        ":toml-0.8.9",
+        ":toml-0.8.10",
         ":url-2.5.0",
         ":walkdir-2.4.0",
     ],
@@ -10177,9 +10194,9 @@ cargo.rust_library(
                 ":pin-project-lite-0.2.13",
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
             ],
         ),
         "linux-x86_64": dict(
@@ -10197,9 +10214,9 @@ cargo.rust_library(
                 ":pin-project-lite-0.2.13",
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
             ],
         ),
         "macos-arm64": dict(
@@ -10218,9 +10235,9 @@ cargo.rust_library(
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
                 ":system-configuration-0.5.1",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
             ],
         ),
         "macos-x86_64": dict(
@@ -10239,9 +10256,9 @@ cargo.rust_library(
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
                 ":system-configuration-0.5.1",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
             ],
         ),
         "windows-gnu": dict(
@@ -10259,9 +10276,9 @@ cargo.rust_library(
                 ":pin-project-lite-0.2.13",
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
                 ":winreg-0.50.0",
             ],
         ),
@@ -10280,9 +10297,9 @@ cargo.rust_library(
                 ":pin-project-lite-0.2.13",
                 ":rustls-0.21.10",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.35.1",
+                ":tokio-1.36.0",
                 ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.3",
+                ":webpki-roots-0.25.4",
                 ":winreg-0.50.0",
             ],
         ),
@@ -11158,8 +11175,8 @@ cargo.rust_library(
         ":serde_json-1.0.113",
         ":sha2-0.10.8",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
-        ":tokio-1.35.1",
+        ":time-0.3.34",
+        ":tokio-1.36.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.14",
         ":url-2.5.0",
@@ -11167,21 +11184,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rust_decimal-1.34.0.crate",
-    sha256 = "d7de2711cae7bdec993f4d2319352599ceb0d003e9f7900ea7c6ef4c5fc16831",
-    strip_prefix = "rust_decimal-1.34.0",
-    urls = ["https://crates.io/api/v1/crates/rust_decimal/1.34.0/download"],
+    name = "rust_decimal-1.34.2.crate",
+    sha256 = "755392e1a2f77afd95580d3f0d0e94ac83eeeb7167552c9b5bca549e61a94d83",
+    strip_prefix = "rust_decimal-1.34.2",
+    urls = ["https://crates.io/api/v1/crates/rust_decimal/1.34.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rust_decimal-1.34.0",
-    srcs = [":rust_decimal-1.34.0.crate"],
+    name = "rust_decimal-1.34.2",
+    srcs = [":rust_decimal-1.34.2.crate"],
     crate = "rust_decimal",
-    crate_root = "rust_decimal-1.34.0.crate/src/lib.rs",
+    crate_root = "rust_decimal-1.34.2.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "OUT_DIR": "$(location :rust_decimal-1.34.0-build-script-run[out_dir])",
+        "OUT_DIR": "$(location :rust_decimal-1.34.2-build-script-run[out_dir])",
     },
     features = [
         "default",
@@ -11198,10 +11215,10 @@ cargo.rust_library(
 )
 
 cargo.rust_binary(
-    name = "rust_decimal-1.34.0-build-script-build",
-    srcs = [":rust_decimal-1.34.0.crate"],
+    name = "rust_decimal-1.34.2-build-script-build",
+    srcs = [":rust_decimal-1.34.2.crate"],
     crate = "build_script_build",
-    crate_root = "rust_decimal-1.34.0.crate/build.rs",
+    crate_root = "rust_decimal-1.34.2.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -11213,16 +11230,16 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rust_decimal-1.34.0-build-script-run",
+    name = "rust_decimal-1.34.2-build-script-run",
     package_name = "rust_decimal",
-    buildscript_rule = ":rust_decimal-1.34.0-build-script-build",
+    buildscript_rule = ":rust_decimal-1.34.2-build-script-build",
     features = [
         "default",
         "maths",
         "serde",
         "std",
     ],
-    version = "1.34.0",
+    version = "1.34.2",
 )
 
 http_archive(
@@ -11261,18 +11278,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustix-0.38.30.crate",
-    sha256 = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca",
-    strip_prefix = "rustix-0.38.30",
-    urls = ["https://crates.io/api/v1/crates/rustix/0.38.30/download"],
+    name = "rustix-0.38.31.crate",
+    sha256 = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949",
+    strip_prefix = "rustix-0.38.31",
+    urls = ["https://crates.io/api/v1/crates/rustix/0.38.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustix-0.38.30",
-    srcs = [":rustix-0.38.30.crate"],
+    name = "rustix-0.38.31",
+    srcs = [":rustix-0.38.31.crate"],
     crate = "rustix",
-    crate_root = "rustix-0.38.30.crate/src/lib.rs",
+    crate_root = "rustix-0.38.31.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -11326,16 +11343,16 @@ cargo.rust_library(
             deps = [":windows-sys-0.52.0"],
         ),
     },
-    rustc_flags = ["@$(location :rustix-0.38.30-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :rustix-0.38.31-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":bitflags-2.4.2"],
 )
 
 cargo.rust_binary(
-    name = "rustix-0.38.30-build-script-build",
-    srcs = [":rustix-0.38.30.crate"],
+    name = "rustix-0.38.31-build-script-build",
+    srcs = [":rustix-0.38.31.crate"],
     crate = "build_script_build",
-    crate_root = "rustix-0.38.30.crate/build.rs",
+    crate_root = "rustix-0.38.31.crate/build.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -11349,9 +11366,9 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rustix-0.38.30-build-script-run",
+    name = "rustix-0.38.31-build-script-run",
     package_name = "rustix",
-    buildscript_rule = ":rustix-0.38.30-build-script-build",
+    buildscript_rule = ":rustix-0.38.31-build-script-build",
     features = [
         "alloc",
         "default",
@@ -11360,7 +11377,7 @@ buildscript_run(
         "termios",
         "use-libc-auxv",
     ],
-    version = "0.38.30",
+    version = "0.38.31",
 )
 
 http_archive(
@@ -11421,13 +11438,13 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.1.0",
+        "pki_types": ":rustls-pki-types-1.2.0",
     },
     visibility = [],
     deps = [
         ":log-0.4.20",
         ":ring-0.17.5",
-        ":rustls-webpki-0.102.1",
+        ":rustls-webpki-0.102.2",
         ":subtle-2.5.0",
         ":zeroize-1.7.0",
     ],
@@ -11514,25 +11531,25 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.1.0",
+        "pki_types": ":rustls-pki-types-1.2.0",
     },
     visibility = [],
     deps = [":base64-0.21.7"],
 )
 
 http_archive(
-    name = "rustls-pki-types-1.1.0.crate",
-    sha256 = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a",
-    strip_prefix = "rustls-pki-types-1.1.0",
-    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.1.0/download"],
+    name = "rustls-pki-types-1.2.0.crate",
+    sha256 = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf",
+    strip_prefix = "rustls-pki-types-1.2.0",
+    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.2.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pki-types-1.1.0",
-    srcs = [":rustls-pki-types-1.1.0.crate"],
+    name = "rustls-pki-types-1.2.0",
+    srcs = [":rustls-pki-types-1.2.0.crate"],
     crate = "rustls_pki_types",
-    crate_root = "rustls-pki-types-1.1.0.crate/src/lib.rs",
+    crate_root = "rustls-pki-types-1.2.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -11569,18 +11586,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustls-webpki-0.102.1.crate",
-    sha256 = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b",
-    strip_prefix = "rustls-webpki-0.102.1",
-    urls = ["https://crates.io/api/v1/crates/rustls-webpki/0.102.1/download"],
+    name = "rustls-webpki-0.102.2.crate",
+    sha256 = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610",
+    strip_prefix = "rustls-webpki-0.102.2",
+    urls = ["https://crates.io/api/v1/crates/rustls-webpki/0.102.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-webpki-0.102.1",
-    srcs = [":rustls-webpki-0.102.1.crate"],
+    name = "rustls-webpki-0.102.2",
+    srcs = [":rustls-webpki-0.102.2.crate"],
     crate = "webpki",
-    crate_root = "rustls-webpki-0.102.1.crate/src/lib.rs",
+    crate_root = "rustls-webpki-0.102.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -11588,7 +11605,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.1.0",
+        "pki_types": ":rustls-pki-types-1.2.0",
     },
     visibility = [],
     deps = [
@@ -11759,23 +11776,23 @@ cargo.rust_library(
 
 alias(
     name = "sea-orm",
-    actual = ":sea-orm-0.12.12",
+    actual = ":sea-orm-0.12.14",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "sea-orm-0.12.12.crate",
-    sha256 = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d",
-    strip_prefix = "sea-orm-0.12.12",
-    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.12/download"],
+    name = "sea-orm-0.12.14.crate",
+    sha256 = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe",
+    strip_prefix = "sea-orm-0.12.14",
+    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-0.12.12",
-    srcs = [":sea-orm-0.12.12.crate"],
+    name = "sea-orm-0.12.14",
+    srcs = [":sea-orm-0.12.14.crate"],
     crate = "sea_orm",
-    crate_root = "sea-orm-0.12.12.crate/src/lib.rs",
+    crate_root = "sea-orm-0.12.14.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bigdecimal",
@@ -11810,8 +11827,8 @@ cargo.rust_library(
         ":futures-0.3.30",
         ":log-0.4.20",
         ":ouroboros-0.17.2",
-        ":rust_decimal-1.34.0",
-        ":sea-orm-macros-0.12.12",
+        ":rust_decimal-1.34.2",
+        ":sea-orm-macros-0.12.14",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
         ":serde-1.0.196",
@@ -11819,7 +11836,7 @@ cargo.rust_library(
         ":sqlx-0.7.3",
         ":strum-0.25.0",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
+        ":time-0.3.34",
         ":tracing-0.1.40",
         ":url-2.5.0",
         ":uuid-1.7.0",
@@ -11827,18 +11844,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "sea-orm-macros-0.12.12.crate",
-    sha256 = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555",
-    strip_prefix = "sea-orm-macros-0.12.12",
-    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.12/download"],
+    name = "sea-orm-macros-0.12.14.crate",
+    sha256 = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa",
+    strip_prefix = "sea-orm-macros-0.12.14",
+    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-macros-0.12.12",
-    srcs = [":sea-orm-macros-0.12.12.crate"],
+    name = "sea-orm-macros-0.12.14",
+    srcs = [":sea-orm-macros-0.12.14.crate"],
     crate = "sea_orm_macros",
-    crate_root = "sea-orm-macros-0.12.12.crate/src/lib.rs",
+    crate_root = "sea-orm-macros-0.12.14.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bae",
@@ -11903,9 +11920,9 @@ cargo.rust_library(
         ":derivative-2.2.0",
         ":inherent-1.0.11",
         ":ordered-float-3.9.2",
-        ":rust_decimal-1.34.0",
+        ":rust_decimal-1.34.2",
         ":serde_json-1.0.113",
-        ":time-0.3.31",
+        ":time-0.3.34",
         ":uuid-1.7.0",
     ],
 )
@@ -11946,11 +11963,11 @@ cargo.rust_library(
     deps = [
         ":bigdecimal-0.3.1",
         ":chrono-0.4.33",
-        ":rust_decimal-1.34.0",
+        ":rust_decimal-1.34.2",
         ":sea-query-0.30.7",
         ":serde_json-1.0.113",
         ":sqlx-0.7.3",
-        ":time-0.3.31",
+        ":time-0.3.34",
         ":uuid-1.7.0",
     ],
 )
@@ -12076,7 +12093,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":tempfile-3.9.0"],
+    deps = [":tempfile-3.10.0"],
 )
 
 http_archive(
@@ -12379,7 +12396,7 @@ cargo.rust_library(
     named_deps = {
         "chrono_0_4": ":chrono-0.4.33",
         "indexmap_1": ":indexmap-1.9.3",
-        "time_0_3": ":time-0.3.31",
+        "time_0_3": ":time-0.3.34",
     },
     visibility = [],
     deps = [
@@ -12421,7 +12438,7 @@ cargo.rust_library(
         "chrono_0_4": ":chrono-0.4.33",
         "indexmap_1": ":indexmap-1.9.3",
         "indexmap_2": ":indexmap-2.2.2",
-        "time_0_3": ":time-0.3.31",
+        "time_0_3": ":time-0.3.34",
     },
     visibility = [],
     deps = [
@@ -13133,7 +13150,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":paste-1.0.14",
         ":percent-encoding-2.3.1",
-        ":rust_decimal-1.34.0",
+        ":rust_decimal-1.34.2",
         ":rustls-0.21.10",
         ":rustls-pemfile-1.0.4",
         ":serde-1.0.196",
@@ -13142,13 +13159,13 @@ cargo.rust_library(
         ":smallvec-1.13.1",
         ":sqlformat-0.2.3",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
-        ":tokio-1.35.1",
+        ":time-0.3.34",
+        ":tokio-1.36.0",
         ":tokio-stream-0.1.14",
         ":tracing-0.1.40",
         ":url-2.5.0",
         ":uuid-1.7.0",
-        ":webpki-roots-0.25.3",
+        ":webpki-roots-0.25.4",
     ],
 )
 
@@ -13209,7 +13226,7 @@ cargo.rust_library(
         ":num-bigint-0.4.4",
         ":once_cell-1.19.0",
         ":rand-0.8.5",
-        ":rust_decimal-1.34.0",
+        ":rust_decimal-1.34.2",
         ":serde-1.0.196",
         ":serde_json-1.0.113",
         ":sha1-0.10.6",
@@ -13218,7 +13235,7 @@ cargo.rust_library(
         ":sqlx-core-0.7.3",
         ":stringprep-0.1.4",
         ":thiserror-1.0.56",
-        ":time-0.3.31",
+        ":time-0.3.34",
         ":tracing-0.1.40",
         ":uuid-1.7.0",
         ":whoami-1.4.1",
@@ -13288,7 +13305,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-1.1.4",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -13648,36 +13665,36 @@ cargo.rust_library(
 
 alias(
     name = "tempfile",
-    actual = ":tempfile-3.9.0",
+    actual = ":tempfile-3.10.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tempfile-3.9.0.crate",
-    sha256 = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa",
-    strip_prefix = "tempfile-3.9.0",
-    urls = ["https://crates.io/api/v1/crates/tempfile/3.9.0/download"],
+    name = "tempfile-3.10.0.crate",
+    sha256 = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67",
+    strip_prefix = "tempfile-3.10.0",
+    urls = ["https://crates.io/api/v1/crates/tempfile/3.10.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tempfile-3.9.0",
-    srcs = [":tempfile-3.9.0.crate"],
+    name = "tempfile-3.10.0",
+    srcs = [":tempfile-3.10.0.crate"],
     crate = "tempfile",
-    crate_root = "tempfile-3.9.0.crate/src/lib.rs",
+    crate_root = "tempfile-3.10.0.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -13709,16 +13726,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.30"],
+            deps = [":rustix-0.38.31"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -13862,7 +13879,7 @@ cargo.rust_binary(
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.22.2",
         ":rustls-pemfile-2.0.0",
-        ":sea-orm-0.12.12",
+        ":sea-orm-0.12.14",
         ":self-replace-1.3.7",
         ":serde-1.0.196",
         ":serde-aux-4.4.0",
@@ -13875,10 +13892,10 @@ cargo.rust_binary(
         ":strum-0.25.0",
         ":syn-2.0.48",
         ":tar-0.4.40",
-        ":tempfile-3.9.0",
+        ":tempfile-3.10.0",
         ":test-log-0.2.14",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
         ":tokio-postgres-rustls-0.11.1",
         ":tokio-serde-0.8.0",
@@ -13887,18 +13904,18 @@ cargo.rust_binary(
         ":tokio-tungstenite-0.20.1",
         ":tokio-util-0.7.10",
         ":tokio-vsock-0.4.0",
-        ":toml-0.8.9",
+        ":toml-0.8.10",
         ":tower-0.4.13",
         ":tower-http-0.4.4",
         ":tracing-0.1.40",
         ":tracing-opentelemetry-0.22.0",
         ":tracing-subscriber-0.3.18",
-        ":ulid-1.1.1",
+        ":ulid-1.1.2",
         ":url-2.5.0",
         ":uuid-1.7.0",
         ":vfs-0.10.0",
         ":vfs-tar-0.4.1",
-        ":webpki-roots-0.25.3",
+        ":webpki-roots-0.25.4",
         ":y-sync-0.4.0",
         ":yrs-0.17.4",
     ],
@@ -13973,18 +13990,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "time-0.3.31.crate",
-    sha256 = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e",
-    strip_prefix = "time-0.3.31",
-    urls = ["https://crates.io/api/v1/crates/time/0.3.31/download"],
+    name = "time-0.3.34.crate",
+    sha256 = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749",
+    strip_prefix = "time-0.3.34",
+    urls = ["https://crates.io/api/v1/crates/time/0.3.34/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-0.3.31",
-    srcs = [":time-0.3.31.crate"],
+    name = "time-0.3.34",
+    srcs = [":time-0.3.34.crate"],
     crate = "time",
-    crate_root = "time-0.3.31.crate/src/lib.rs",
+    crate_root = "time-0.3.34.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -14000,10 +14017,11 @@ cargo.rust_library(
     deps = [
         ":deranged-0.3.11",
         ":itoa-1.0.10",
+        ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
         ":serde-1.0.196",
         ":time-core-0.1.2",
-        ":time-macros-0.2.16",
+        ":time-macros-0.2.17",
     ],
 )
 
@@ -14025,18 +14043,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "time-macros-0.2.16.crate",
-    sha256 = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f",
-    strip_prefix = "time-macros-0.2.16",
-    urls = ["https://crates.io/api/v1/crates/time-macros/0.2.16/download"],
+    name = "time-macros-0.2.17.crate",
+    sha256 = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774",
+    strip_prefix = "time-macros-0.2.17",
+    urls = ["https://crates.io/api/v1/crates/time-macros/0.2.17/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-macros-0.2.16",
-    srcs = [":time-macros-0.2.16.crate"],
+    name = "time-macros-0.2.17",
+    srcs = [":time-macros-0.2.17.crate"],
     crate = "time_macros",
-    crate_root = "time-macros-0.2.16.crate/src/lib.rs",
+    crate_root = "time-macros-0.2.17.crate/src/lib.rs",
     edition = "2021",
     features = [
         "formatting",
@@ -14045,7 +14063,10 @@ cargo.rust_library(
     ],
     proc_macro = True,
     visibility = [],
-    deps = [":time-core-0.1.2"],
+    deps = [
+        ":num-conv-0.1.0",
+        ":time-core-0.1.2",
+    ],
 )
 
 http_archive(
@@ -14112,23 +14133,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.35.1",
+    actual = ":tokio-1.36.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.35.1.crate",
-    sha256 = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104",
-    strip_prefix = "tokio-1.35.1",
-    urls = ["https://crates.io/api/v1/crates/tokio/1.35.1/download"],
+    name = "tokio-1.36.0.crate",
+    sha256 = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931",
+    strip_prefix = "tokio-1.36.0",
+    urls = ["https://crates.io/api/v1/crates/tokio/1.36.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.35.1",
-    srcs = [":tokio-1.35.1.crate"],
+    name = "tokio-1.36.0",
+    srcs = [":tokio-1.36.0.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.35.1.crate/src/lib.rs",
+    crate_root = "tokio-1.36.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -14231,7 +14252,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -14320,7 +14341,7 @@ cargo.rust_library(
         ":postgres-protocol-0.6.6",
         ":postgres-types-0.2.6",
         ":rand-0.8.5",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":whoami-1.4.1",
     ],
@@ -14342,7 +14363,7 @@ cargo.rust_library(
     deps = [
         ":ring-0.17.5",
         ":rustls-0.22.2",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
         ":tokio-rustls-0.25.0",
         ":x509-certificate-0.23.1",
@@ -14367,7 +14388,7 @@ cargo.rust_library(
     deps = [
         ":pin-project-1.1.4",
         ":rand-0.8.5",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -14393,7 +14414,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.10",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -14412,12 +14433,12 @@ cargo.rust_library(
     crate_root = "tokio-rustls-0.25.0.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.1.0",
+        "pki_types": ":rustls-pki-types-1.2.0",
     },
     visibility = [],
     deps = [
         ":rustls-0.22.2",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
     ],
 )
 
@@ -14490,7 +14511,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
     ],
 )
@@ -14520,7 +14541,7 @@ cargo.rust_library(
         ":async-stream-0.3.5",
         ":bytes-1.5.0",
         ":futures-core-0.3.30",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-stream-0.1.14",
     ],
 )
@@ -14555,7 +14576,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":log-0.4.20",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tungstenite-0.20.1",
     ],
 )
@@ -14596,7 +14617,7 @@ cargo.rust_library(
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tracing-0.1.40",
     ],
 )
@@ -14626,7 +14647,7 @@ cargo.rust_library(
         ":bytes-1.5.0",
         ":futures-0.3.30",
         ":libc-0.2.153",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":vsock-0.3.0",
     ],
 )
@@ -14680,23 +14701,23 @@ cargo.rust_library(
 
 alias(
     name = "toml",
-    actual = ":toml-0.8.9",
+    actual = ":toml-0.8.10",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "toml-0.8.9.crate",
-    sha256 = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325",
-    strip_prefix = "toml-0.8.9",
-    urls = ["https://crates.io/api/v1/crates/toml/0.8.9/download"],
+    name = "toml-0.8.10.crate",
+    sha256 = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
+    strip_prefix = "toml-0.8.10",
+    urls = ["https://crates.io/api/v1/crates/toml/0.8.10/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml-0.8.9",
-    srcs = [":toml-0.8.9.crate"],
+    name = "toml-0.8.10",
+    srcs = [":toml-0.8.10.crate"],
     crate = "toml",
-    crate_root = "toml-0.8.9.crate/src/lib.rs",
+    crate_root = "toml-0.8.10.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -14708,7 +14729,7 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":toml_edit-0.21.1",
+        ":toml_edit-0.22.2",
     ],
 )
 
@@ -14755,26 +14776,25 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.36",
+        ":winnow-0.5.37",
     ],
 )
 
 http_archive(
-    name = "toml_edit-0.21.1.crate",
-    sha256 = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1",
-    strip_prefix = "toml_edit-0.21.1",
-    urls = ["https://crates.io/api/v1/crates/toml_edit/0.21.1/download"],
+    name = "toml_edit-0.22.2.crate",
+    sha256 = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704",
+    strip_prefix = "toml_edit-0.22.2",
+    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.21.1",
-    srcs = [":toml_edit-0.21.1.crate"],
+    name = "toml_edit-0.22.2",
+    srcs = [":toml_edit-0.22.2.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.21.1.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.2.crate/src/lib.rs",
     edition = "2021",
     features = [
-        "default",
         "display",
         "parse",
         "serde",
@@ -14785,7 +14805,7 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.36",
+        ":winnow-0.5.37",
     ],
 )
 
@@ -14837,7 +14857,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.4",
         ":prost-0.11.9",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-stream-0.1.14",
         ":tower-0.4.13",
         ":tower-layer-0.3.2",
@@ -14899,7 +14919,7 @@ cargo.rust_library(
         ":pin-project-lite-0.2.13",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":tower-layer-0.3.2",
         ":tower-service-0.3.2",
@@ -14950,7 +14970,7 @@ cargo.rust_library(
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":tower-layer-0.3.2",
         ":tower-service-0.3.2",
@@ -15176,6 +15196,27 @@ cargo.rust_library(
     ],
 )
 
+http_archive(
+    name = "tracing-serde-0.1.3.crate",
+    sha256 = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1",
+    strip_prefix = "tracing-serde-0.1.3",
+    urls = ["https://crates.io/api/v1/crates/tracing-serde/0.1.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-serde-0.1.3",
+    srcs = [":tracing-serde-0.1.3.crate"],
+    crate = "tracing_serde",
+    crate_root = "tracing-serde-0.1.3.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":serde-1.0.196",
+        ":tracing-core-0.1.32",
+    ],
+)
+
 alias(
     name = "tracing-subscriber",
     actual = ":tracing-subscriber-0.3.18",
@@ -15202,17 +15243,21 @@ cargo.rust_library(
         "default",
         "env-filter",
         "fmt",
+        "json",
         "matchers",
         "nu-ansi-term",
         "once_cell",
         "regex",
         "registry",
+        "serde",
+        "serde_json",
         "sharded-slab",
         "smallvec",
         "std",
         "thread_local",
         "tracing",
         "tracing-log",
+        "tracing-serde",
     ],
     visibility = [],
     deps = [
@@ -15220,12 +15265,15 @@ cargo.rust_library(
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
         ":regex-1.10.3",
+        ":serde-1.0.196",
+        ":serde_json-1.0.113",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.1",
         ":thread_local-1.1.7",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
         ":tracing-log-0.2.0",
+        ":tracing-serde-0.1.3",
     ],
 )
 
@@ -15325,23 +15373,23 @@ buildscript_run(
 
 alias(
     name = "ulid",
-    actual = ":ulid-1.1.1",
+    actual = ":ulid-1.1.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "ulid-1.1.1.crate",
-    sha256 = "7e3c3b4dcec1e4729aab50688a1a0631483d79e65b194851425e7748287715a6",
-    strip_prefix = "ulid-1.1.1",
-    urls = ["https://crates.io/api/v1/crates/ulid/1.1.1/download"],
+    name = "ulid-1.1.2.crate",
+    sha256 = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259",
+    strip_prefix = "ulid-1.1.2",
+    urls = ["https://crates.io/api/v1/crates/ulid/1.1.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ulid-1.1.1",
-    srcs = [":ulid-1.1.1.crate"],
+    name = "ulid-1.1.2",
+    srcs = [":ulid-1.1.2.crate"],
     crate = "ulid",
-    crate_root = "ulid-1.1.1.crate/src/lib.rs",
+    crate_root = "ulid-1.1.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -15833,23 +15881,23 @@ cargo.rust_library(
 
 alias(
     name = "webpki-roots",
-    actual = ":webpki-roots-0.25.3",
+    actual = ":webpki-roots-0.25.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "webpki-roots-0.25.3.crate",
-    sha256 = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10",
-    strip_prefix = "webpki-roots-0.25.3",
-    urls = ["https://crates.io/api/v1/crates/webpki-roots/0.25.3/download"],
+    name = "webpki-roots-0.25.4.crate",
+    sha256 = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1",
+    strip_prefix = "webpki-roots-0.25.4",
+    urls = ["https://crates.io/api/v1/crates/webpki-roots/0.25.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "webpki-roots-0.25.3",
-    srcs = [":webpki-roots-0.25.3.crate"],
+    name = "webpki-roots-0.25.4",
+    srcs = [":webpki-roots-0.25.4.crate"],
     crate = "webpki_roots",
-    crate_root = "webpki-roots-0.25.3.crate/src/lib.rs",
+    crate_root = "webpki-roots-0.25.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -16277,18 +16325,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.5.36.crate",
-    sha256 = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249",
-    strip_prefix = "winnow-0.5.36",
-    urls = ["https://crates.io/api/v1/crates/winnow/0.5.36/download"],
+    name = "winnow-0.5.37.crate",
+    sha256 = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5",
+    strip_prefix = "winnow-0.5.37",
+    urls = ["https://crates.io/api/v1/crates/winnow/0.5.37/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.5.36",
-    srcs = [":winnow-0.5.36.crate"],
+    name = "winnow-0.5.37",
+    srcs = [":winnow-0.5.37.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.5.36.crate/src/lib.rs",
+    crate_root = "winnow-0.5.37.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -16377,7 +16425,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":rustix-0.38.30"],
+    deps = [":rustix-0.38.31"],
 )
 
 alias(
@@ -16405,7 +16453,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":thiserror-1.0.56",
-        ":tokio-1.35.1",
+        ":tokio-1.36.0",
         ":yrs-0.17.4",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -628,9 +628,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-compact"
-version = "2.0.6"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a667e6426df16c2ac478efa4a439d0e674cba769c5556e8cf221739251640c8c"
+checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
  "ct-codecs",
  "getrandom 0.2.12",
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "filetime"
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2580,9 +2580,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -2746,6 +2746,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -3581,7 +3587,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.9",
+ "toml 0.8.10",
  "url",
  "walkdir",
 ]
@@ -3656,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -3731,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -3749,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3827,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.0"
+version = "1.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de2711cae7bdec993f4d2319352599ceb0d003e9f7900ea7c6ef4c5fc16831"
+checksum = "755392e1a2f77afd95580d3f0d0e94ac83eeeb7167552c9b5bca549e61a94d83"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3858,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -3890,7 +3896,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.1",
+ "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
 ]
@@ -3928,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 
 [[package]]
 name = "rustls-webpki"
@@ -3944,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.1"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4014,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbf88748872fa54192476d6d49d0775e208566a72656e267e45f6980b926c8d"
+checksum = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4042,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dbc880d47aa53c6a572e39c99402c7fad59b50766e51e0b0fc1306510b0555"
+checksum = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4899,13 +4905,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5039,7 +5044,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tokio-vsock",
- "toml 0.8.9",
+ "toml 0.8.10",
  "tower",
  "tower-http",
  "tracing",
@@ -5087,12 +5092,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -5107,10 +5113,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -5140,9 +5147,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -5353,14 +5360,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.2",
 ]
 
 [[package]]
@@ -5390,6 +5397,17 @@ name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.2",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -5553,6 +5571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,12 +5590,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5603,9 +5634,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ulid"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3c3b4dcec1e4729aab50688a1a0631483d79e65b194851425e7748287715a6"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
  "getrandom 0.2.12",
  "rand 0.8.5",
@@ -5900,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
@@ -6088,9 +6119,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.36"
+version = "0.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
+checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
 dependencies = [
  "memchr",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -118,7 +118,7 @@ tower = "0.4.13"
 tower-http = { version = "0.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.22.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }


### PR DESCRIPTION
This change adds a new `--log-json` flag to all services which will configure the telemetry to output logging as JSON objects, one per line. An associated environment variable of `SI_LOG_JSON` is also supported to enable this output mode.

<img src="https://media2.giphy.com/media/xT9KVn8tApfgnNLpL2/giphy.gif"/>