### PR TITLE
chore: revisit telemetry tracing levels to make debugging easier

### DIFF
--- a/bin/council/src/args.rs
+++ b/bin/council/src/args.rs
@@ -15,7 +15,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/council/src/main.rs
+++ b/bin/council/src/main.rs
@@ -39,6 +39,7 @@ async fn async_main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["council", "council_server"])
+            .interesting_modules(vec!["si_data_nats"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -20,7 +20,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -33,6 +33,7 @@ async fn main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["cyclone", "cyclone_server"])
+            .interesting_modules(vec!["cyclone_core"])
             .custom_default_tracing_level(CUSTOM_DEFAULT_TRACING_LEVEL)
             .build()?;
 

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -17,7 +17,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -39,6 +39,7 @@ async fn async_main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["module_index", "module_index_server"])
+            .interesting_modules(vec!["si_data_pg"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -17,7 +17,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -39,6 +39,7 @@ async fn async_main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["pinga", "pinga_server"])
+            .interesting_modules(vec!["si_data_nats", "si_data_pg"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -19,7 +19,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -50,6 +50,7 @@ async fn async_main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["sdf", "sdf_server"])
+            .interesting_modules(vec!["si_data_nats", "si_data_pg"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -13,7 +13,7 @@ pub(crate) fn parse() -> Args {
 pub(crate) struct Args {
     /// Sets the verbosity mode.
     ///
-    /// Multiple -v options increase verbosity. The maximum is 4.
+    /// Multiple -v options increase verbosity. The maximum is 6.
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["veritech", "veritech_server"])
+            .interesting_modules(vec!["si_data_nats"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?


### PR DESCRIPTION
This change updates the tracing from 5 prescribed levels to 7. This means that before there were a max of 4 `-v` levels and now there are 6.

Additionally, the `TelemetryConfig` has 2 new values that influence the tracing levels in addition to `app_modules`:

- `interesting_modules`: a `Vec` of Rust crate/module names that are not strictly the server's library code but rather "crates of interest" the application. For example, we care about `si-data-nats` when looking at the Veritech server as it's driven primarily via NATS. The default is an empty collection of modules.
- `never_modules`: a `Vec` of Rust crate/module names that will never be logged/transmitted/considered when setting levels. In other words, these modules are always set to `NAME=off` at any verbosity level. After operating our services several Rust crates demonstrated themselves to be extremely chatty at `DEBUG` and `TRACE` levels and the value we derive from this logging is low to nothing. By default a couple of initial crates are supplied here, namely `h2` and `hyper`.

So now there are 4 groups of modules to consider:

1. app modules
2. interesting modules
3. never modules
4. all other modules

The updated tracing level increases work as follows:

1. `INFO` for all modules (the default for all services)
2. `DEBUG` for app modules and `INFO` for all others
3. `DEBUG` for app and interesting modules, and `INFO` for all others
4. `TRACE` for app modules, `DEBUG` for interesting modules, and `INFO` for all others
5. `TRACE` for app modules, `TRACE` for interesting modules, and `INFO` for all others
6. `TRACE` for app and interesting modules, and `DEBUG` for all others
7. `TRACE` for all modules

<img src="https://media4.giphy.com/media/10koGH0aisNoli/giphy.gif"/>