### PR TITLE
fix: jail clean flakiness

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -13,7 +13,7 @@ function retry() {
   do
      $1 && break
      n=$((n+1))
-     sleep 5
+     sleep 1
   done
 }
 

--- a/bin/veritech/scripts/stop.sh
+++ b/bin/veritech/scripts/stop.sh
@@ -4,33 +4,23 @@ set -euo pipefail
 
 SB_ID="${1:-null}"
 
-JAILER_BINARY="/usr/bin/jailer"
-TAP_DEV="fc-${SB_ID}-tap0"
-
-# Kill the firecracker process
-ps aux | grep "firecracke[r] --id $SB_ID" | awk '{ print $2 }' | xargs kill -9 || true
-
-# Remove TAP device
-ip link del "$TAP_DEV" 2> /dev/null || true
-
-# Remove veth devices
-ip link del veth-main$SB_ID 2> /dev/null || true
-ip link del veth-jailer$SB_ID 2> /dev/null || true
-
-# Remove iptables rules
-ip netns exec jailer-$SB_ID iptables -t nat -D POSTROUTING -o veth-jailer$SB_ID -j MASQUERADE || true
-ip netns exec jailer-$SB_ID iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
-ip netns exec jailer-$SB_ID iptables -D FORWARD -i fc-$SB_ID-tap0 -o veth-jailer$SB_ID -j ACCEPT || true
-
-# Remove network namespace
-ip netns del jailer-$SB_ID || true
-
-# Remove user and group
-userdel jailer-$SB_ID || true
+# Kill the firecracker process if it exists
+FIRECRACKER_PID=$(pgrep -f "firecracker --id $SB_ID") || true
+if [ -n "${FIRECRACKER_PID}" ]; then
+  kill -9 $FIRECRACKER_PID
+fi
 
 # Remove directories and files
-umount /srv/jailer/firecracker/$SB_ID/root/rootfs.ext4 || true
-dmsetup remove --retry rootfs-overlay-$SB_ID
+DISK="/srv/jailer/firecracker/$SB_ID/root/rootfs.ext4"
+OVERLAY="rootfs-overlay-$SB_ID"
+
+until ! $(mount | grep -q $DISK); do
+  umount -dl "$DISK"
+done
+
+until ! dmsetup status "$OVERLAY" &> /dev/null; do
+  dmsetup remove --force --retry $OVERLAY
+done
 
 # We are not currently creating these.
 # umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true


### PR DESCRIPTION
In some cases, jails were failing to clean and we were swallowing the error, meaning the jail would still be marked as clean. This would cause subsequent function calls using that jail to fail.

* Change `stop.sh` to only swap out the rootfs to remove some points of failure
  * It also checks for the existence of things before trying to kill/remove and will retry if things fail
* Ensure that all jails are actually cleaned on Veritech startup
* Capture script errors and log them appropriately. In every case I've seen, a failure is due to a device not unmounting in a timely fashion. Therefore, if we fail we push that jail back onto the to-be-cleaned stack, but to the front  so we don't immediately try to clean it again. This is kind of weak, but I've not seen a jail fail to clean twice in a row in my tests

The result here should be that we no longer mark uncleaned jails as clean. We will also bubble up more errors as they occur, so we should be able to more easily track these issues.