### PR TITLE
chore: add optional API to make tracing level changes "wait-able"

### DIFF
--- a/bin/council/src/main.rs
+++ b/bin/council/src/main.rs
@@ -46,7 +46,9 @@ async fn async_main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -41,7 +41,9 @@ async fn main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -46,7 +46,9 @@ async fn async_main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -46,7 +46,9 @@ async fn async_main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -57,7 +57,9 @@ async fn async_main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -32,7 +32,9 @@ async fn main() -> Result<()> {
     };
 
     if args.verbose > 0 {
-        telemetry.set_verbosity(args.verbose.into()).await?;
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
     }
     trace!(arguments =?args, "parsed cli arguments");
 


### PR DESCRIPTION
This change adds several `*_and_wait()` method options to the `ApplicationTelemetryClient` type. When our services boot up we check the parsed CLI argument for verbosity flags. If there are more than one set then we issue a command to raise the tracing level but prior to this change, this operation was non-blocking/async. That means that the level may not have raised by the time the next line of code executes resulting in potential missing log messages.

<img src="https://media2.giphy.com/media/l0HlKrB02QY0f1mbm/giphy.gif"/>