### PR TITLE
Ensure content store works with TLS config (ENG-2315)

### DIFF
--- a/bin/rebaser/BUCK
+++ b/bin/rebaser/BUCK
@@ -18,6 +18,7 @@ rust_binary(
     resources = {
         "dev.encryption.key": "//lib/cyclone-server:dev.encryption.key",
         "dev.donkey.key": "//lib/dal:dev.donkey.key",
+        "dev.postgres.root.crt": "//config/keys:dev.postgres.root.crt",
     },
 )
 

--- a/lib/sdf-server/src/server/config.rs
+++ b/lib/sdf-server/src/server/config.rs
@@ -176,6 +176,8 @@ impl ConfigBuilder {
 pub struct ConfigFile {
     #[serde(default)]
     pub pg: PgPoolConfig,
+    #[serde(default = "PgStoreTools::default_pool_config")]
+    pub content_store_pg: PgPoolConfig,
     #[serde(default)]
     pub nats: NatsConfig,
     #[serde(default)]
@@ -200,6 +202,7 @@ impl Default for ConfigFile {
     fn default() -> Self {
         Self {
             pg: Default::default(),
+            content_store_pg: PgStoreTools::default_pool_config(),
             nats: Default::default(),
             migration_mode: Default::default(),
             jwt_signing_public_key: Default::default(),
@@ -225,6 +228,7 @@ impl TryFrom<ConfigFile> for Config {
 
         let mut config = Config::builder();
         config.pg_pool(value.pg);
+        config.content_store_pg_pool(value.content_store_pg);
         config.nats(value.nats);
         config.migration_mode(value.migration_mode);
         config.jwt_signing_public_key(value.jwt_signing_public_key);
@@ -358,7 +362,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
         active_key_base64: None,
         extra_keys: vec![],
     };
-    config.pg.certificate_path = Some(postgres_cert.try_into()?);
+    config.pg.certificate_path = Some(postgres_cert.clone().try_into()?);
+    config.content_store_pg.certificate_path = Some(postgres_cert.try_into()?);
     config.pkgs_path = pkgs_path;
 
     Ok(())
@@ -416,7 +421,8 @@ fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
         active_key_base64: None,
         extra_keys: vec![],
     };
-    config.pg.certificate_path = Some(postgres_cert.try_into()?);
+    config.pg.certificate_path = Some(postgres_cert.clone().try_into()?);
+    config.content_store_pg.certificate_path = Some(postgres_cert.try_into()?);
     config.pkgs_path = pkgs_path;
 
     Ok(())


### PR DESCRIPTION
Now that the content store (Pg) has been moved to the ServicesContext, it must also use the TLS config that the regular "PgPoolConfig" uses.

<img src="https://media3.giphy.com/media/jbKbdoKJOFusHTjl80/giphy-downsized-medium.gif"/>