### PR TITLE
Add ability to attach components to frames in the new engine (ENG-2316)

### DIFF
--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -1,0 +1,113 @@
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumString};
+use telemetry::prelude::*;
+use thiserror::Error;
+use ulid::Ulid;
+
+use crate::diagram::{EdgeId, NodeId};
+use crate::workspace_snapshot::edge_weight::{EdgeWeight, EdgeWeightError, EdgeWeightKind};
+use crate::workspace_snapshot::WorkspaceSnapshotError;
+use crate::{
+    Component, ComponentError, ComponentId, ComponentType, DalContext, TransactionsError, User,
+};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum FrameError {
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
+    #[error("edge weight error: {0}")]
+    EdgeWeight(#[from] EdgeWeightError),
+    #[error("parent is not a frame (child id: {0}) (parent id: {1})")]
+    ParentIsNotAFrame(ComponentId, ComponentId),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+}
+
+pub type FrameResult<T> = Result<T, FrameError>;
+
+/// A unit struct containing logic for working with frames.
+pub struct Frame;
+
+impl Frame {
+    /// Provides the ability to attach a child [`Component`] to a parent frame.
+    pub async fn attach_child_to_parent(
+        ctx: &DalContext,
+        parent_id: ComponentId,
+        child_id: ComponentId,
+    ) -> FrameResult<()> {
+        let parent = Component::get_by_id(ctx, parent_id).await?;
+        let parent_type = parent.get_type(ctx).await?;
+
+        let (source_id, destination_id) = match parent_type {
+            ComponentType::AggregationFrame => {
+                unimplemented!("aggregation frames are untested in the new engine")
+            }
+            ComponentType::Component => {
+                return Err(FrameError::ParentIsNotAFrame(child_id, parent_id))
+            }
+            ComponentType::ConfigurationFrameDown => (parent_id, child_id),
+            ComponentType::ConfigurationFrameUp => (child_id, parent_id),
+        };
+
+        Self::attach_child_to_parent_symbolic(ctx, parent_id, child_id).await?;
+
+        Component::connect_all(ctx, source_id, destination_id).await?;
+
+        Ok(())
+    }
+
+    async fn attach_child_to_parent_symbolic(
+        ctx: &DalContext,
+        parent_id: ComponentId,
+        child_id: ComponentId,
+    ) -> FrameResult<()> {
+        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
+        let change_set = ctx.change_set_pointer()?;
+
+        workspace_snapshot.add_edge(
+            parent_id,
+            EdgeWeight::new(change_set, EdgeWeightKind::FrameContains)?,
+            child_id,
+        )?;
+
+        Ok(())
+    }
+}
+
+// TODO(nick): replace once the switchover is complete.
+#[remain::sorted]
+#[derive(
+    Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Display, EnumString, AsRefStr, Copy,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum EdgeKind {
+    Configuration,
+    Symbolic,
+}
+
+// TODO(nick): replace once the switchover is complete.
+pub type SocketId = Ulid;
+
+// TODO(nick): replace once the switchover is complete.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Vertex {
+    pub node_id: NodeId,
+    pub socket_id: SocketId,
+}
+
+// TODO(nick): replace once the switchover is complete.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Connection {
+    pub id: EdgeId,
+    pub classification: EdgeKind,
+    pub source: Vertex,
+    pub destination: Vertex,
+    pub created_by: Option<User>,
+    pub deleted_by: Option<User>,
+}

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -138,6 +138,14 @@ impl SummaryDiagramComponent {
     pub fn has_resource(&self) -> bool {
         self.has_resource
     }
+
+    pub fn parent_node_id(&self) -> Option<NodeId> {
+        self.parent_node_id
+    }
+
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -344,7 +352,7 @@ impl Diagram {
                 change_status: ChangeStatus::Added.to_string(),
                 has_resource: false,
                 sockets,
-                parent_node_id: None,
+                parent_node_id: component.parent(ctx).await?,
                 child_node_ids: serde_json::to_value::<Vec<String>>(vec![])?,
                 updated_info,
                 created_info,

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -28,6 +28,11 @@ pub enum EdgeWeightKind {
     /// array/map, or a field of an object. The optional [`String`] represents the key of the entry
     /// in a map.
     Contain(Option<String>),
+    /// Used to indicate parentage within frames. It does not dictate data flow. That is provided via
+    /// [`ComponentType`](crate::ComponentType).
+    ///
+    /// This replaces "Symbolic" edges and "Frame" sockets from the old engine.
+    FrameContains,
     /// Used to record the order that the elements of a container should be presented in.
     Ordering,
     /// Connects the node at the Ordering edge directly to the things it orders.

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -909,6 +909,7 @@ impl WorkspaceSnapshotGraph {
                 let color = match discrim {
                     EdgeWeightKindDiscriminants::ActionPrototype => "black",
                     EdgeWeightKindDiscriminants::Contain => "blue",
+                    EdgeWeightKindDiscriminants::FrameContains => "black",
                     EdgeWeightKindDiscriminants::Ordering => "gray",
                     EdgeWeightKindDiscriminants::Ordinal => "gray",
                     EdgeWeightKindDiscriminants::Prop => "orange",
@@ -1923,6 +1924,7 @@ impl WorkspaceSnapshotGraph {
                     // Nothing to do, as these EdgeWeightKind do not encode extra information
                     // in the edge itself.
                     EdgeWeightKind::Contain(None)
+                    | EdgeWeightKind::FrameContains
                     | EdgeWeightKind::PrototypeArgument
                     | EdgeWeightKind::PrototypeArgumentValue
                     | EdgeWeightKind::Provider

--- a/lib/dal/tests/integration_test/internal/new_engine.rs
+++ b/lib/dal/tests/integration_test/internal/new_engine.rs
@@ -1,11 +1,13 @@
 //! This is a temporary module to co-locate all tests for the new engine layer. Once everything is
 //! working, this module will go away and the tests will be moved or removed.
 //!
-//! For all tests in this module, provide "SI_TEST_BUILTIN_SCHEMAS=none" as an environment variable.
+//! For all tests in this module, provide "SI_TEST_BUILTIN_SCHEMAS=none" or "SI_TEST_BUILTIN_SCHEMAS=test" as an
+//! environment variable.
 
 mod builtins;
 mod component;
 mod connection;
+mod frame;
 mod prop;
 mod property_editor;
 mod rebaser;

--- a/lib/dal/tests/integration_test/internal/new_engine/frame.rs
+++ b/lib/dal/tests/integration_test/internal/new_engine/frame.rs
@@ -1,0 +1,108 @@
+use dal::component::frame::{Frame, FrameError, FrameResult};
+use dal::diagram::Diagram;
+use dal::{AttributeValue, Component, DalContext, Schema, SchemaVariant};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn convert_component_to_frame_and_attach(ctx: &mut DalContext) {
+    // Collect the test exclusive schemas that we need.
+    let mut starfield_schema = None;
+    let mut fallout_schema = None;
+    for schema in Schema::list(ctx).await.expect("list schemas") {
+        match schema.name.as_str() {
+            "starfield" => starfield_schema = Some(schema),
+            "fallout" => fallout_schema = Some(schema),
+            _ => {}
+        }
+    }
+    let starfield_schema = starfield_schema.expect("could not find starfield schema");
+    let fallout_schema = fallout_schema.expect("could not find fallout schema");
+
+    // Create components using the test exclusive schemas. Neither of them should be frames.
+    let starfield_schema_variant = SchemaVariant::list_for_schema(ctx, starfield_schema.id())
+        .await
+        .expect("could not list schema variants")
+        .pop()
+        .expect("no schema variants found");
+    let fallout_schema_variant = SchemaVariant::list_for_schema(ctx, fallout_schema.id())
+        .await
+        .expect("could not list schema variants")
+        .pop()
+        .expect("no schema variants found");
+    let starfield_component = Component::new(ctx, "parent", starfield_schema_variant.id(), None)
+        .await
+        .expect("could not create component");
+    let fallout_component = Component::new(ctx, "child", fallout_schema_variant.id(), None)
+        .await
+        .expect("could not create component");
+
+    // Attempt to attach a child to a parent that is a not a frame.
+    match Frame::attach_child_to_parent(ctx, starfield_component.id(), fallout_component.id()).await
+    {
+        Ok(()) => panic!("attaching child to parent should fail if parent is not a frame"),
+        Err(FrameError::ParentIsNotAFrame(..)) => {}
+        Err(other_error) => panic!("unexpected error: {0}", other_error),
+    }
+
+    // Change the parent to become a frame.
+    let type_attribute_value_id = starfield_component
+        .attribute_values_for_prop(ctx, &["root", "si", "type"])
+        .await
+        .expect("could not find attribute values for prop")
+        .into_iter()
+        .next()
+        .expect("could not get type attribute value id");
+
+    AttributeValue::update(
+        &ctx,
+        type_attribute_value_id,
+        Some(serde_json::json!["ConfigurationFrameDown"]),
+    )
+    .await
+    .expect("could not update attribute value");
+
+    ctx.blocking_commit()
+        .await
+        .expect("could not perform blocking commit");
+
+    // Now that the parent is a frame, attempt to attach the child.
+    Frame::attach_child_to_parent(ctx, starfield_component.id(), fallout_component.id())
+        .await
+        .expect("could not attach child to parent");
+
+    ctx.blocking_commit()
+        .await
+        .expect("could not perform blocking commit");
+
+    // Assemble the diagram and ensure we see the right number of components.
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(2, diagram.components.len());
+
+    // Collect the parent ids for the components on the diagram.
+    let mut starfield_parent_node_id = None;
+    let mut fallout_parent_node_id = None;
+    for component in diagram.components {
+        match component.schema_name() {
+            "starfield" => starfield_parent_node_id = Some(component.parent_node_id()),
+            "fallout" => fallout_parent_node_id = Some(component.parent_node_id()),
+            schema_name => panic!(
+                "unexpected schema name for diagram component: {0}",
+                schema_name
+            ),
+        }
+    }
+    let starfield_parent_node_id =
+        starfield_parent_node_id.expect("could not find starfield parent node id");
+    let fallout_parent_node_id =
+        fallout_parent_node_id.expect("could not find fallout parent node id");
+
+    // Ensure the frame does not have a parent and the child's parent is the frame.
+    assert!(starfield_parent_node_id.is_none());
+    assert_eq!(
+        starfield_component.id(),
+        fallout_parent_node_id.expect("no parent node id for fallout component")
+    );
+}

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -3,6 +3,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
+use dal::component::frame::FrameError;
 use dal::component::ComponentError;
 use dal::node_menu::NodeMenuError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
@@ -14,6 +15,7 @@ use crate::server::state::AppState;
 
 use self::get_node_add_menu::get_node_add_menu;
 
+mod connect_component_to_frame_new_engine;
 pub mod create_component;
 pub mod create_connection;
 pub mod get_diagram;
@@ -43,6 +45,8 @@ pub enum DiagramError {
     ContextTransaction(#[from] TransactionsError),
     #[error("dal diagram error: {0}")]
     DalDiagram(#[from] dal::diagram::DiagramError),
+    #[error("dal frame error: {0}")]
+    DalFrame(#[from] dal::component::frame::FrameError),
     #[error("dal schema error: {0}")]
     DalSchema(#[from] dal::SchemaError),
     #[error("dal schema variant error: {0}")]
@@ -130,10 +134,10 @@ pub fn routes() -> Router<AppState> {
         //     "/restore_components",
         //     post(restore_component::restore_components),
         // )
-        // .route(
-        //     "/connect_component_to_frame",
-        //     post(connect_component_to_frame::connect_component_to_frame),
-        // )
+        .route(
+            "/connect_component_to_frame",
+            post(connect_component_to_frame_new_engine::connect_component_to_frame),
+        )
         .route("/get_node_add_menu", post(get_node_add_menu))
         .route(
             "/create_connection",

--- a/lib/sdf-server/src/server/service/diagram/connect_component_to_frame_new_engine.rs
+++ b/lib/sdf-server/src/server/service/diagram/connect_component_to_frame_new_engine.rs
@@ -1,0 +1,49 @@
+use axum::extract::OriginalUri;
+use axum::{response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+use dal::component::frame::{Connection, Frame};
+use dal::diagram::NodeId;
+use dal::Visibility;
+
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+
+use super::DiagramResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateFrameConnectionRequest {
+    pub child_node_id: NodeId,
+    pub parent_node_id: NodeId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateFrameConnectionResponse {
+    pub connection: Connection,
+}
+
+/// Create a [`Connection`](dal::Connection) with a _to_ [`Socket`](dal::Socket) and
+/// [`Node`](dal::Node) and a _from_ [`Socket`](dal::Socket) and [`Node`](dal::Node).
+/// Creating a change set if on head.
+pub async fn connect_component_to_frame(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Json(request): Json<CreateFrameConnectionRequest>,
+) -> DiagramResult<impl IntoResponse> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    // Connect children to parent through frame edge
+    Frame::attach_child_to_parent(&ctx, request.parent_node_id, request.child_node_id).await?;
+
+    ctx.commit().await?;
+
+    let response = axum::response::Response::builder();
+    Ok(response
+        .header("content-type", "application/json")
+        .body("{}".to_owned())?)
+}

--- a/lib/sdf-server/src/server/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_component.rs
@@ -2,11 +2,9 @@ use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
+use dal::component::frame::Frame;
 use dal::component::{DEFAULT_COMPONENT_HEIGHT, DEFAULT_COMPONENT_WIDTH};
-use dal::{
-    generate_name, Component, ComponentId, SchemaId, SchemaVariant, SchemaVariantId, Visibility,
-    WsEvent,
-};
+use dal::{generate_name, Component, ComponentId, SchemaId, SchemaVariant, Visibility, WsEvent};
 
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::service::diagram::DiagramResult;
@@ -107,7 +105,11 @@ pub async fn create_component(
         )
         .await?;
 
-    // TODO(nick): restore frames.
+    if let Some(frame_id) = request.parent_id {
+        Frame::attach_child_to_parent(&ctx, frame_id, component.id()).await?;
+    }
+
+    // TODO(nick): restore posthog logic and other potential missing frame logic.
     // if let Some(frame_id) = request.parent_id {
     //     let component_socket = Socket::find_frame_socket_for_node(
     //         &ctx,


### PR DESCRIPTION
## Description

This is the first pass at adding frames to the new engine. This PR is primarily focused on restoring the ability to place a new component or an existing component onto an existing frame in the frontend.

Relevant changes:
- Restore ability to place a new component into a frame in the frontend
- Add `EdgeWeightKind::FrameContains` to replace symbolic edge functionality seen on main
- Add ability for Components to determine their parent
- Add integration test for converting a component into a frame and
  attaching a component to that frame

## Disclaimer

This commit does not guarantee that nested frames, aggregation frames, and "up" frames will work. It is only concerned with components within "down" frames (without nesting).

## Example

This is an example of what happens when you place a new component onto an existing frame:

![image](https://github.com/systeminit/si/assets/39320683/fb27bbde-1334-4488-8aad-4a953468868b)

## Known Bug

When there is already a component (A) connected to a parent (A) in the diagram, and then you connect another component (B) to another frame (B), an unexpected edge will exist from the other frame (B) to the original component (A). It is unclear if this is caused by diagram assembly or at "write time".

![image](https://github.com/systeminit/si/assets/39320683/78698d0b-b82c-4473-9952-b6d7a0cae906)

