### PR TITLE
feat(telemetry): add path-filterable support into HTTP request spans

### DIFF
--- a/lib/cyclone-server/src/server.rs
+++ b/lib/cyclone-server/src/server.rs
@@ -236,7 +236,7 @@ fn build_service(
 
     let routes = routes(config, state, shutdown_tx).layer(
         TraceLayer::new_for_http()
-            .make_span_with(HttpMakeSpan::new().level(Level::INFO))
+            .make_span_with(HttpMakeSpan::builder().level(Level::INFO).build())
             .on_response(HttpOnResponse::new().level(Level::DEBUG)),
     );
 

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -535,9 +535,19 @@ fn build_service_inner(
         crdt_multiplexer_client,
     );
 
+    let path_filter = Box::new(|path: &str| match path {
+        "/api/" => Some(Level::TRACE),
+        _ => None,
+    });
+
     let routes = routes(state).layer(
         TraceLayer::new_for_http()
-            .make_span_with(HttpMakeSpan::new().level(Level::INFO))
+            .make_span_with(
+                HttpMakeSpan::builder()
+                    .level(Level::INFO)
+                    .path_filter(path_filter)
+                    .build(),
+            )
             .on_response(HttpOnResponse::new().level(Level::DEBUG)),
     );
 

--- a/lib/telemetry-http-rs/src/make_span.rs
+++ b/lib/telemetry-http-rs/src/make_span.rs
@@ -1,3 +1,5 @@
+use std::{fmt, sync::Arc};
+
 use hyper::header::USER_AGENT;
 use telemetry::prelude::*;
 use tower_http::trace::MakeSpan;
@@ -6,35 +8,55 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::propagation;
 
 /// An implementation of [`MakeSpan`] to generate [`Span`]s from incoming HTTP requests.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct HttpMakeSpan {
     level: Level,
+    path_filters: Arc<Vec<PathFilterFn>>,
 
     // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes
     network_protocol_name: &'static str,
     network_transport: NetworkTransport,
 }
 
-impl Default for HttpMakeSpan {
+impl fmt::Debug for HttpMakeSpan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpMakeSpan")
+            .field("level", &self.level)
+            .field("network_protocol_name", &self.network_protocol_name)
+            .field("network_transport", &self.network_transport)
+            .finish_non_exhaustive()
+    }
+}
+
+pub struct HttpMakeSpanBuilder {
+    level: Level,
+    path_filters: Vec<PathFilterFn>,
+    network_protocol_name: &'static str,
+    network_transport: NetworkTransport,
+}
+
+impl Default for HttpMakeSpanBuilder {
     #[inline]
     fn default() -> Self {
         Self {
             level: Level::INFO,
+            path_filters: vec![],
             network_protocol_name: "http",
             network_transport: NetworkTransport::default(),
         }
     }
 }
 
-impl HttpMakeSpan {
-    /// Creates a new `HttpMakeSpan`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
+impl HttpMakeSpanBuilder {
     /// Sets the [`Level`] used for the tracing [`Span`].
     pub fn level(mut self, level: Level) -> Self {
         self.level = level;
+        self
+    }
+
+    /// Adds a new path filter function used when creating the tracing [`Span`].
+    pub fn path_filter(mut self, filter: PathFilterFn) -> Self {
+        self.path_filters.push(filter);
         self
     }
 
@@ -56,6 +78,25 @@ impl HttpMakeSpan {
     pub fn network_transport(mut self, nt: NetworkTransport) -> Self {
         self.network_transport = nt;
         self
+    }
+
+    /// Builds and returns a new [`HttpMakeSpan`].
+    pub fn build(self) -> HttpMakeSpan {
+        HttpMakeSpan {
+            level: self.level,
+            path_filters: Arc::new(self.path_filters),
+            network_protocol_name: self.network_protocol_name,
+            network_transport: self.network_transport,
+        }
+    }
+}
+
+type PathFilterFn = Box<dyn Fn(&str) -> Option<Level> + Send + Sync + 'static>;
+
+impl HttpMakeSpan {
+    /// Creates a new `HttpMakeSpan`.
+    pub fn builder() -> HttpMakeSpanBuilder {
+        HttpMakeSpanBuilder::default()
     }
 
     fn span_from_request<B>(&mut self, request: &hyper::Request<B>) -> Span {
@@ -129,6 +170,7 @@ impl HttpMakeSpan {
         }
 
         let uri = request.uri();
+        let uri_path = uri.path();
 
         let http_request_method = InnerMethod::from(request.method().as_str());
         let network_protocol_version = HttpVersion::from(request.version());
@@ -165,7 +207,7 @@ impl HttpMakeSpan {
                     // network.local.port = Empty,
                     // server.address = Empty,
                     // server.port = Empty,
-                    url.path = uri.path(),
+                    url.path = uri_path,
                     url.query = uri.query(),
                     url.scheme = Empty,
                     user_agent.original = Empty,
@@ -195,7 +237,12 @@ impl HttpMakeSpan {
             };
         }
 
-        let span = match (InnerLevel::from(self.level), http_request_method) {
+        let level = match self.path_filters.iter().find_map(|f| f(uri_path)) {
+            Some(custom_level) => custom_level,
+            None => self.level,
+        };
+
+        let span = match (InnerLevel::from(level), http_request_method) {
             (InnerLevel::Error, InnerMethod::Options) => inner!(Level::ERROR, "OPTIONS"),
             (InnerLevel::Error, InnerMethod::Get) => inner!(Level::ERROR, "GET"),
             (InnerLevel::Error, InnerMethod::Post) => inner!(Level::ERROR, "POST"),


### PR DESCRIPTION
This change adds a general capability to "filter" HTTP requests by their URI path and change the tracing level of the request span away from its default.

In our SDF and Cyclone server setups, we're creating an HTTP request span at the `INFO` level by default, and this change alters any request in SDF at `/api/` to create an HTTP request span at the `TRACE` level, effectively disabling these spans in all but the most intense debugging scenarios.

<img src="https://media1.giphy.com/media/njYrp176NQsHS/giphy.gif"/>