### PR TITLE
chore(cyclone): revert cyclone's default tracing level to `INFO`

### DIFF
--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -5,14 +5,6 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 mod args;
 
-// Override the default tracing level of `info` to warn.
-//
-// Note: Cyclone servers are spawned as child processes (or managed processes) of a Veritech server
-// instance so in many cases the logging output of a Cyclone server is written to the same output
-// stream (i.e. terminal, console) as the Veritech server's logging output. This higher threshold
-// is an attempt to reduce the amount of "normal" logging that is emited for Cyclone instances.
-const CUSTOM_DEFAULT_TRACING_LEVEL: &str = "warn";
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let shutdown_token = CancellationToken::new();
@@ -34,7 +26,6 @@ async fn main() -> Result<()> {
             .log_env_var_prefix("SI")
             .app_modules(vec!["cyclone", "cyclone_server"])
             .interesting_modules(vec!["cyclone_core"])
-            .custom_default_tracing_level(CUSTOM_DEFAULT_TRACING_LEVEL)
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?


### PR DESCRIPTION
This change helps to support Cyclone server spans being emitted by default in development and production. Long prior to this change, the output from a Cyclone instance was so chatty that we dialed down the default log level but this has since been remedied. To further muddy the waters, the Tilt configuration has been running with `SI_LOG=debug` for the Veritech service meaning that all Cyclone server instances were also being hard-coded into running a `DEBUG` level. This development setting should eventually be removed as it widens the gap between development and production and should be increasingly less desirable under normal circumstances.

<img src="https://media1.giphy.com/media/yQbzE3pbJhcSk/giphy.gif"/>