### PR TITLE
feat(telemetry-http): add "matched" path to HTTP span names

### DIFF
--- a/lib/telemetry-http-rs/BUCK
+++ b/lib/telemetry-http-rs/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "telemetry-http",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:axum",
         "//third-party/rust:http",
         "//third-party/rust:hyper",
         "//third-party/rust:remain",

--- a/lib/telemetry-http-rs/Cargo.toml
+++ b/lib/telemetry-http-rs/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+axum = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 remain = { workspace = true }


### PR DESCRIPTION
Yay! There is an extension on the Axum request type that returns the router matching string. This means that if the request path in the Axum router was `/api/summary/:workspace_id`, then a related request span name would now be `GET /api/summary/:workspace_id`.

With this implementation detail sorted we can now include the request path without matched ids and other path variables in the span name. This keeps the number of span names lower (in OpenTelemetry jargon "low cardinality") and thus helps to increase the power of querying later on.

<img src="https://media2.giphy.com/media/wt2ZDTyc7jYA9OwpI2/giphy.gif"/>