### PR TITLE
Remove unused frame sockets and add multiple frames test (ENG-2325,ENG-2327)

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -118,8 +118,11 @@ pub async fn migrate_local(
 
     // FIXME(nick): restore builtin migration functionality for all variants.
     info!("migrate minimal number of schemas for testing the new engine");
+
     schema::migrate_pkg(ctx, SI_DOCKER_IMAGE_PKG, None).await?;
     schema::migrate_pkg(ctx, SI_COREOS_PKG, None).await?;
+    schema::migrate_pkg(ctx, SI_AWS_EC2_PKG, None).await?;
+    schema::migrate_pkg(ctx, SI_AWS_PKG, None).await?;
     schema::migrate_test_exclusive_schema_starfield(ctx).await?;
     schema::migrate_test_exclusive_schema_fallout(ctx).await?;
 

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -103,7 +103,7 @@ struct GridPoint {
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-struct Size2D {
+pub struct Size2D {
     pub width: isize,
     pub height: isize,
 }
@@ -111,60 +111,46 @@ struct Size2D {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct SummaryDiagramComponent {
-    id: ComponentId,
-    component_id: ComponentId,
-    schema_name: String,
-    schema_id: SchemaId,
-    schema_variant_id: SchemaVariantId,
-    schema_variant_name: String,
-    schema_category: String,
-    sockets: serde_json::Value,
-    node_id: NodeId,
-    display_name: String,
-    position: GridPoint,
-    size: Size2D,
-    color: String,
-    node_type: String,
-    change_status: String,
-    has_resource: bool,
-    parent_node_id: Option<NodeId>,
-    child_node_ids: serde_json::Value,
-    created_info: serde_json::Value,
-    updated_info: serde_json::Value,
-    deleted_info: serde_json::Value,
-}
-
-impl SummaryDiagramComponent {
-    pub fn has_resource(&self) -> bool {
-        self.has_resource
-    }
-
-    pub fn parent_node_id(&self) -> Option<NodeId> {
-        self.parent_node_id
-    }
-
-    pub fn schema_name(&self) -> &str {
-        &self.schema_name
-    }
+    pub id: ComponentId,
+    pub component_id: ComponentId,
+    pub schema_name: String,
+    pub schema_id: SchemaId,
+    pub schema_variant_id: SchemaVariantId,
+    pub schema_variant_name: String,
+    pub schema_category: String,
+    pub sockets: serde_json::Value,
+    pub node_id: NodeId,
+    pub display_name: String,
+    pub position: GridPoint,
+    pub size: Size2D,
+    pub color: String,
+    pub node_type: String,
+    pub change_status: String,
+    pub has_resource: bool,
+    pub parent_node_id: Option<NodeId>,
+    pub child_node_ids: serde_json::Value,
+    pub created_info: serde_json::Value,
+    pub updated_info: serde_json::Value,
+    pub deleted_info: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct SummaryDiagramEdge {
-    id: EdgeId,
-    edge_id: EdgeId,
-    from_node_id: NodeId,
-    from_socket_id: ExternalProviderId,
-    to_node_id: NodeId,
-    to_socket_id: InternalProviderId,
-    change_status: String,
-    created_info: serde_json::Value,
-    deleted_info: serde_json::Value,
+    pub id: EdgeId,
+    pub edge_id: EdgeId,
+    pub from_node_id: NodeId,
+    pub from_socket_id: ExternalProviderId,
+    pub to_node_id: NodeId,
+    pub to_socket_id: InternalProviderId,
+    pub change_status: String,
+    pub created_info: serde_json::Value,
+    pub deleted_info: serde_json::Value,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-struct DiagramSocket {
+pub struct DiagramSocket {
     pub id: String,
     pub label: String,
     pub connection_annotations: Vec<String>,

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -194,26 +194,6 @@ impl SchemaVariant {
         let root_prop = RootProp::new(ctx, schema_variant_id).await?;
         let func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity).await?;
 
-        InternalProvider::new_explicit(
-            ctx,
-            schema_variant_id,
-            "Frame",
-            func_id,
-            ProviderArity::Many,
-            ProviderKind::Frame,
-        )
-        .await?;
-        ExternalProvider::new(
-            ctx,
-            schema_variant_id,
-            "Frame",
-            None,
-            func_id,
-            ProviderArity::Many,
-            ProviderKind::Frame,
-        )
-        .await?;
-
         let schema_variant = Self::assemble(id.into(), content);
         Ok((schema_variant, root_prop))
     }

--- a/lib/dal/tests/integration_test/internal/new_engine/frame.rs
+++ b/lib/dal/tests/integration_test/internal/new_engine/frame.rs
@@ -1,23 +1,26 @@
 use dal::component::frame::{Frame, FrameError, FrameResult};
-use dal::diagram::Diagram;
-use dal::{AttributeValue, Component, DalContext, Schema, SchemaVariant};
+use dal::diagram::{
+    Diagram, DiagramResult, DiagramSocket, EdgeId, NodeId, Size2D, SummaryDiagramComponent,
+    SummaryDiagramEdge,
+};
+use dal::{
+    AttributeValue, Component, ComponentId, DalContext, ExternalProvider, ExternalProviderId,
+    InternalProvider, InternalProviderId, Schema, SchemaId, SchemaVariant, SchemaVariantId,
+};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
+use std::collections::HashMap;
 
 #[test]
-async fn convert_component_to_frame_and_attach(ctx: &mut DalContext) {
-    // Collect the test exclusive schemas that we need.
-    let mut starfield_schema = None;
-    let mut fallout_schema = None;
-    for schema in Schema::list(ctx).await.expect("list schemas") {
-        match schema.name.as_str() {
-            "starfield" => starfield_schema = Some(schema),
-            "fallout" => fallout_schema = Some(schema),
-            _ => {}
-        }
-    }
-    let starfield_schema = starfield_schema.expect("could not find starfield schema");
-    let fallout_schema = fallout_schema.expect("could not find fallout schema");
+async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) {
+    let starfield_schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found by name");
+    let fallout_schema = Schema::find_by_name(ctx, "fallout")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found by name");
 
     // Create components using the test exclusive schemas. Neither of them should be frames.
     let starfield_schema_variant = SchemaVariant::list_for_schema(ctx, starfield_schema.id())
@@ -85,9 +88,9 @@ async fn convert_component_to_frame_and_attach(ctx: &mut DalContext) {
     let mut starfield_parent_node_id = None;
     let mut fallout_parent_node_id = None;
     for component in diagram.components {
-        match component.schema_name() {
-            "starfield" => starfield_parent_node_id = Some(component.parent_node_id()),
-            "fallout" => fallout_parent_node_id = Some(component.parent_node_id()),
+        match component.schema_name.as_str() {
+            "starfield" => starfield_parent_node_id = Some(component.parent_node_id),
+            "fallout" => fallout_parent_node_id = Some(component.parent_node_id),
             schema_name => panic!(
                 "unexpected schema name for diagram component: {0}",
                 schema_name
@@ -105,4 +108,770 @@ async fn convert_component_to_frame_and_attach(ctx: &mut DalContext) {
         starfield_component.id(),
         fallout_parent_node_id.expect("no parent node id for fallout component")
     );
+}
+
+#[test]
+async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContext) {
+    let region_schema = Schema::find_by_name(ctx, "Region")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found by name");
+    let ec2_schema = Schema::find_by_name(ctx, "EC2 Instance")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found by name");
+    let ami_schema = Schema::find_by_name(ctx, "AMI")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found by name");
+
+    // Collect schema variants.
+    let region_schema_variant_id = SchemaVariant::list_for_schema(ctx, region_schema.id())
+        .await
+        .expect("could not list schema variants")
+        .pop()
+        .expect("no schema variants found")
+        .id();
+    let ec2_schema_variant_id = SchemaVariant::list_for_schema(ctx, ec2_schema.id())
+        .await
+        .expect("could not list schema variants")
+        .pop()
+        .expect("no schema variants found")
+        .id();
+    let ami_schema_variant_id = SchemaVariant::list_for_schema(ctx, ami_schema.id())
+        .await
+        .expect("could not list schema variants")
+        .pop()
+        .expect("no schema variants found")
+        .id();
+
+    // Scenario 1: create an AWS region frame.
+    let first_region_frame_name = "first region frame";
+    let first_region_frame =
+        Component::new(ctx, first_region_frame_name, region_schema_variant_id, None)
+            .await
+            .expect("could not create component");
+
+    // Validate Scenario 1
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            1,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert!(diagram.edges.is_empty());
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+    }
+
+    // Scenario 2: create an AMI and attach to region frame
+    let first_ami_component_name = "first ami component";
+    let first_ami_component =
+        Component::new(ctx, first_ami_component_name, ami_schema_variant_id, None)
+            .await
+            .expect("could not create component");
+    Frame::attach_child_to_parent(&ctx, first_region_frame.id(), first_ami_component.id())
+        .await
+        .expect("could not attach child to parent");
+
+    // Validate Scenario 2
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            2,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            1,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+    }
+
+    // Scenario 3: add another aws region frame on its own.
+    let second_region_frame_name = "second region frame";
+    let second_region_frame = Component::new(
+        ctx,
+        second_region_frame_name,
+        region_schema_variant_id,
+        None,
+    )
+    .await
+    .expect("could not create component");
+
+    // Validate Scenario 3
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            3,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            1,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+    }
+
+    // Scenarios 4 and 5: create another ami, but place it outside of both frames. Then, drag it onto the second region
+    // frame. Since we are working with dal integration tests and not sdf routes, we combine these two scenarios.
+    let second_ami_component_name = "second ami component";
+    let second_ami_component =
+        Component::new(ctx, second_ami_component_name, ami_schema_variant_id, None)
+            .await
+            .expect("could not create component");
+    Frame::attach_child_to_parent(&ctx, second_region_frame.id(), second_ami_component.id())
+        .await
+        .expect("could not attach child to parent");
+
+    // Validate Scenarios 4 and 5
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            4,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            2,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+        let second_ami_component_assembled = diagram
+            .components
+            .get(second_ami_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_ami_component.id(),                   // expected
+            second_ami_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(), // expected
+            second_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+    }
+
+    // Scenarios 6 and 7: create an ec2 instance, but place it outside of both frames. Then, drag it onto the first
+    // region frame. Since we are working with dal integration tests and not sdf routes, we combine these two scenarios.
+    let first_ec2_instance_component_name = "first ec2 instance component";
+    let first_ec2_instance_component = Component::new(
+        ctx,
+        first_ec2_instance_component_name,
+        ec2_schema_variant_id,
+        None,
+    )
+    .await
+    .expect("could not create component");
+    Frame::attach_child_to_parent(
+        &ctx,
+        first_region_frame.id(),
+        first_ec2_instance_component.id(),
+    )
+    .await
+    .expect("could not attach child to parent");
+
+    // Validate Scenarios 6 and 7
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            5,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            3,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+        let second_ami_component_assembled = diagram
+            .components
+            .get(second_ami_component_name)
+            .expect("could not get component by name");
+        let first_ec2_instance_component_assembled = diagram
+            .components
+            .get(first_ec2_instance_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_ami_component.id(),                   // expected
+            second_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                   // expected
+            first_ec2_instance_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(), // expected
+            second_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ec2_instance_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+    }
+
+    // Scenario 8: draw an edge between the first ami and the first ec2 using the "Image ID" sockets. Both should exist
+    // within the first region frame.
+    let image_id_socket_name = "Image ID";
+    let image_id_ami_external_provider_id =
+        ExternalProvider::find_with_name(ctx, image_id_socket_name, ami_schema_variant_id)
+            .await
+            .expect("could not perform find by name")
+            .expect("no external provider found")
+            .id();
+    let image_id_ec2_instance_internal_provider_id =
+        InternalProvider::find_explicit_with_name(ctx, image_id_socket_name, ec2_schema_variant_id)
+            .await
+            .expect("could not perform find by name")
+            .expect("no internal provider found")
+            .id();
+    let image_id_ami_to_ec2_instance_attribute_prototype_argument_id = Component::connect(
+        ctx,
+        first_ami_component.id(),
+        image_id_ami_external_provider_id,
+        first_ec2_instance_component.id(),
+        image_id_ec2_instance_internal_provider_id,
+    )
+    .await
+    .expect("could not perform connection");
+
+    // Validate Scenario 8
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            5,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            4,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+        let second_ami_component_assembled = diagram
+            .components
+            .get(second_ami_component_name)
+            .expect("could not get component by name");
+        let first_ec2_instance_component_assembled = diagram
+            .components
+            .get(first_ec2_instance_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_ami_component.id(),                   // expected
+            second_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                   // expected
+            first_ec2_instance_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(), // expected
+            second_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ec2_instance_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+
+        let image_id_ami_to_ec2_instance_edge_assembled = diagram
+            .edges
+            .get(&image_id_ami_to_ec2_instance_attribute_prototype_argument_id)
+            .expect("could not get edge by id");
+        assert_eq!(
+            first_ami_component.id(),                                 // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ami_external_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_socket_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                      // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ec2_instance_internal_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_socket_id  // actual
+        );
+    }
+
+    // Scenario 9: create a third AMI outside of both frames.
+    let third_ami_component_name = "third ami component";
+    let third_ami_component =
+        Component::new(ctx, third_ami_component_name, ami_schema_variant_id, None)
+            .await
+            .expect("could not create component");
+
+    // Validate Scenario 9
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            6,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            4,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+        let second_ami_component_assembled = diagram
+            .components
+            .get(second_ami_component_name)
+            .expect("could not get component by name");
+        let first_ec2_instance_component_assembled = diagram
+            .components
+            .get(first_ec2_instance_component_name)
+            .expect("could not get component by name");
+        let third_ami_component_assembled = diagram
+            .components
+            .get(third_ami_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_ami_component.id(),                   // expected
+            second_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                   // expected
+            first_ec2_instance_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            third_ami_component.id(),                   // expected
+            third_ami_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert!(third_ami_component_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(), // expected
+            second_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ec2_instance_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+
+        let image_id_ami_to_ec2_instance_edge_assembled = diagram
+            .edges
+            .get(&image_id_ami_to_ec2_instance_attribute_prototype_argument_id)
+            .expect("could not get edge by id");
+        assert_eq!(
+            first_ami_component.id(),                                 // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ami_external_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_socket_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                      // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ec2_instance_internal_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_socket_id  // actual
+        );
+    }
+
+    // Scenario 10: draw an edge (do not drag the component or place it onto a frame) between the "Region" socket of the
+    // second region frame and the "Region" socket of the third ami.
+    let region_socket_name = "Region";
+    let region_region_external_provider_id =
+        ExternalProvider::find_with_name(ctx, region_socket_name, region_schema_variant_id)
+            .await
+            .expect("could not perform find by name")
+            .expect("no external provider found")
+            .id();
+    let region_ami_internal_provider_id =
+        InternalProvider::find_explicit_with_name(ctx, region_socket_name, ami_schema_variant_id)
+            .await
+            .expect("could not perform find by name")
+            .expect("no internal provider found")
+            .id();
+    let region_region_to_ami_attribute_prototype_argument_id = Component::connect(
+        ctx,
+        second_region_frame.id(),
+        region_region_external_provider_id,
+        third_ami_component.id(),
+        region_ami_internal_provider_id,
+    )
+    .await
+    .expect("could not perform connection");
+
+    // Validate Scenario 10
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            6,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            5,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let first_region_frame_assembled = diagram
+            .components
+            .get(first_region_frame_name)
+            .expect("could not get component by name");
+        let first_ami_component_assembled = diagram
+            .components
+            .get(first_ami_component_name)
+            .expect("could not get component by name");
+        let second_region_frame_assembled = diagram
+            .components
+            .get(second_region_frame_name)
+            .expect("could not get component by name");
+        let second_ami_component_assembled = diagram
+            .components
+            .get(second_ami_component_name)
+            .expect("could not get component by name");
+        let first_ec2_instance_component_assembled = diagram
+            .components
+            .get(first_ec2_instance_component_name)
+            .expect("could not get component by name");
+        let third_ami_component_assembled = diagram
+            .components
+            .get(third_ami_component_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            first_region_frame.id(),                   // expected
+            first_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ami_component.id(),                   // expected
+            first_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(),                   // expected
+            second_region_frame_assembled.component_id  // actual
+        );
+        assert_eq!(
+            second_ami_component.id(),                   // expected
+            second_ami_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                   // expected
+            first_ec2_instance_component_assembled.component_id  // actual
+        );
+        assert_eq!(
+            third_ami_component.id(),                   // expected
+            third_ami_component_assembled.component_id  // actual
+        );
+
+        assert!(first_region_frame_assembled.parent_node_id.is_none());
+        assert!(second_region_frame_assembled.parent_node_id.is_none());
+        assert!(third_ami_component_assembled.parent_node_id.is_none());
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            second_region_frame.id(), // expected
+            second_ami_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            first_region_frame.id(), // expected
+            first_ec2_instance_component_assembled
+                .parent_node_id
+                .expect("no parent node id")  // actual
+        );
+
+        let image_id_ami_to_ec2_instance_edge_assembled = diagram
+            .edges
+            .get(&image_id_ami_to_ec2_instance_attribute_prototype_argument_id)
+            .expect("could not get edge by id");
+        assert_eq!(
+            first_ami_component.id(),                                 // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ami_external_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.from_socket_id  // actual
+        );
+        assert_eq!(
+            first_ec2_instance_component.id(),                      // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_node_id  // actual
+        );
+        assert_eq!(
+            image_id_ec2_instance_internal_provider_id, // expected
+            image_id_ami_to_ec2_instance_edge_assembled.to_socket_id  // actual
+        );
+
+        let region_region_to_ami_edge_assembled = diagram
+            .edges
+            .get(&region_region_to_ami_attribute_prototype_argument_id)
+            .expect("could not get edge by id");
+        assert_eq!(
+            second_region_frame.id(),                         // expected
+            region_region_to_ami_edge_assembled.from_node_id  // actual
+        );
+        assert_eq!(
+            region_region_external_provider_id,                 // expected
+            region_region_to_ami_edge_assembled.from_socket_id  // actual
+        );
+        assert_eq!(
+            third_ami_component.id(),                       // expected
+            region_region_to_ami_edge_assembled.to_node_id  // actual
+        );
+        assert_eq!(
+            region_ami_internal_provider_id,                  // expected
+            region_region_to_ami_edge_assembled.to_socket_id  // actual
+        );
+    }
+}
+
+struct DiagramByKey {
+    pub components: HashMap<String, SummaryDiagramComponent>,
+    pub edges: HashMap<EdgeId, SummaryDiagramEdge>,
+}
+
+impl DiagramByKey {
+    pub async fn assemble(ctx: &DalContext) -> DiagramResult<Self> {
+        let diagram = Diagram::assemble(ctx).await?;
+
+        let mut components = HashMap::new();
+        for component in &diagram.components {
+            components.insert(component.display_name.clone(), component.to_owned());
+        }
+
+        let mut edges = HashMap::new();
+        for edge in &diagram.edges {
+            edges.insert(edge.edge_id, edge.to_owned());
+        }
+
+        Ok(Self { components, edges })
+    }
 }


### PR DESCRIPTION
## Description

Remove unused frame sockets (external provider and explicit internal provider) when creating schema variants. Add an extended test with not only multiple frames, but also a connection from a frame to an unattached component.

Misc change: now we import AWS EC2 PKG and AWS PKG for integration tests (again).

## Test Contents

The test runs through a few non-trivial scenarios when working with multiple, non-nested frames. They are include, but are not limited to, the following:

- Ensure multiple frames with multiple connections work
- Ensure connections within frames work
  - Example: two components are placed within a frame. They have an edge between one another for a given set of sockets.
- Ensure edges from frame sockets to unattached components work
  - Example: create an AWS Region and create a AWS AMI outside of the frame. Draw an edge between the AWS Region's "region" socket to the AWS AMI's "region" socket. The AMI should remain unattached.

The test does not check for values propagation, but it does check for data setup and potential drift.

## GIF

<img src="https://media1.giphy.com/media/l41YvOZhFqjJjCmY0/giphy.gif"/>