### PR TITLE
Fix Module Index Server Startup

### DIFF
--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -117,7 +117,7 @@ pub(crate) struct Args {
 
     /// The path to the JWT public signing key
     #[arg(long, env)]
-    pub(crate) jwt_public_key: Option<SensitiveString>,
+    pub(crate) jwt_public_key: Option<String>,
     // /// Database migration mode on startup
     // #[arg(long, value_parser = PossibleValuesParser::new(MigrationMode::variants()))]
 }


### PR DESCRIPTION
We can't load a path from a SensitiveString so needed to change the path back to a string