### PR TITLE
feat(si-pkg,dal,sdf-server): multi variant editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
 ]
 
 [[package]]
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -781,22 +781,22 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -806,19 +806,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
+checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
 dependencies = [
  "libc",
- "once_cell",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasix",
  "wasm-bindgen",
 ]
 
@@ -1217,9 +1216,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1369,7 +1368,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
  "si-crypto",
  "si-data-nats",
  "si-data-pg",
@@ -1452,7 +1451,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1466,7 +1465,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -1785,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519 2.2.3",
@@ -2660,18 +2659,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jwt-simple"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89159de5f0e8a07eb345e6a9ee6cfd1195585eb0f43ee1face42c0dc4968f0f9"
+checksum = "bc9355eabbe26435645b794e0f351150b9a35d03539f1e28742b3642b5587628"
 dependencies = [
  "anyhow",
  "binstring",
@@ -3175,19 +3174,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3196,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -4527,7 +4525,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_url_params",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
  "si-crypto",
  "si-data-nats",
  "si-data-pg",
@@ -4822,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -4832,8 +4830,9 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.0",
+ "serde_with_macros 3.6.1",
  "time",
 ]
 
@@ -4851,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling 0.20.5",
  "proc-macro2",
@@ -5033,6 +5032,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "derive_builder",
+ "indexmap 2.2.2",
  "object-tree",
  "petgraph",
  "remain",
@@ -5079,7 +5079,7 @@ version = "0.1.0"
 dependencies = [
  "remain",
  "serde",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
  "thiserror",
 ]
 
@@ -5508,6 +5508,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -6039,7 +6045,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.2",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -6077,9 +6083,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -6348,9 +6354,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -6572,10 +6578,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.90"
+name = "wasix"
+version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+dependencies = [
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6583,9 +6598,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -6598,9 +6613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6610,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6620,9 +6635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6633,15 +6648,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6857,9 +6872,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,11 @@ members = [
 async-nats = { version = "0.33.0", features = ["service"] }
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
-axum = { version = "0.6.18", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
+axum = { version = "0.6.18", features = [
+    "macros",
+    "multipart",
+    "ws",
+] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
 base64 = "0.21.0"
 blake3 = "1.3.3"
 bollard = "0.15.0"
@@ -63,7 +67,11 @@ ciborium = "0.2.1"
 clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.2"
 colored = "2.0.4"
-comfy-table = { version = "7.0.1", features = ["crossterm", "tty", "custom_styling"] }
+comfy-table = { version = "7.0.1", features = [
+    "crossterm",
+    "tty",
+    "custom_styling",
+] }
 config = { version = "0.13.4", default-features = false, features = ["toml"] }
 console = "0.15.7"
 convert_case = "0.6.0"
@@ -81,14 +89,24 @@ futures = "0.3.28"
 futures-lite = "2.1.0"
 hex = "0.4.3"
 http = "0.2.9" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
-hyper = { version = "0.14.26", features = ["client", "http1", "runtime", "server"] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
-hyperlocal = { version = "0.8.0", default-features = false, features = ["client"] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
+hyper = { version = "0.14.26", features = [
+    "client",
+    "http1",
+    "runtime",
+    "server",
+] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
+hyperlocal = { version = "0.8.0", default-features = false, features = [
+    "client",
+] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.4"
 indicatif = "0.17.5"
+indexmap = "2.2.2"
 indoc = "2.0.1"
 inquire = "0.6.2"
 itertools = "0.12.0"
-jwt-simple = { version = "0.12.6", default-features = false, features = ["pure-rust"] }
+jwt-simple = { version = "0.12.6", default-features = false, features = [
+    "pure-rust",
+] }
 lazy_static = "1.4.0"
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }
@@ -114,12 +132,24 @@ rand = "0.8.5"
 refinery = { version = "0.8.9", features = ["tokio-postgres"] }
 regex = "1.8.1"
 remain = "0.2.8"
-reqwest = { version = "0.11.17", default-features = false, features = ["rustls-tls", "json", "multipart"] }
+reqwest = { version = "0.11.17", default-features = false, features = [
+    "rustls-tls",
+    "json",
+    "multipart",
+] }
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
 rustls = { version = "0.22.2" }
 rustls-pemfile = { version = "2.0.0" }
-rust-s3 = { version = "0.34.0-rc4", default-features = false, features = ["tokio-rustls-tls"] }
-sea-orm = { version = "0.12.0", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "debug-print"] }
+rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
+    "tokio-rustls-tls",
+] }
+sea-orm = { version = "0.12.0", features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+    "macros",
+    "with-chrono",
+    "debug-print",
+] }
 self-replace = "1.3.7"
 serde = { version = "1.0.160", features = ["derive", "rc"] }
 serde-aux = "4.2.0"
@@ -133,10 +163,16 @@ strum = { version = "0.25.0", features = ["derive"] }
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 tar = "0.4.38"
 tempfile = "3.5.0"
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+test-log = { version = "0.2.11", default-features = false, features = [
+    "trace",
+] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.0", features = ["full"] }
-tokio-postgres = { version = "0.7.8", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7.8", features = [
+    "runtime",
+    "with-chrono-0_4",
+    "with-serde_json-1",
+] }
 tokio-postgres-rustls = { version = "0.11.0" }
 tokio-serde = { version = "0.8.0", features = ["json"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
@@ -146,10 +182,20 @@ tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
 toml = { version = "0.8.8" }
 tower = "0.4.13"
-tower-http = { version = "0.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
+tower-http = { version = "0.4", features = [
+    "compression-br",
+    "compression-deflate",
+    "compression-gzip",
+    "cors",
+    "trace",
+] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.22.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
+tracing-subscriber = { version = "0.3.18", features = [
+    "env-filter",
+    "json",
+    "std",
+] }
 ulid = { version = "1.0.0", features = ["serde"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -182,6 +182,7 @@ import { FuncVariant } from "@/api/sdf/dal/func";
 import { useAssetStore } from "@/store/asset.store";
 import { FuncId } from "@/store/func/funcs.store";
 import { ComponentType } from "@/components/ModelingDiagram/diagram_types";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import ColorPicker from "./ColorPicker.vue";
 import AssetFuncAttachModal from "./AssetFuncAttachModal.vue";
 
@@ -195,6 +196,8 @@ const loadAssetReqStatus = assetStore.getRequestStatus(
   props.assetId,
 );
 const executeAssetModalRef = ref();
+
+const featureFlagStore = useFeatureFlagsStore();
 
 const openAttachModal = (warning: {
   variant?: FuncVariant;
@@ -244,10 +247,16 @@ const updateAsset = async () => {
   }
 };
 
-const disabled = computed(() => !!(editingAsset.value?.hasComponents ?? false));
+const disabled = computed(() => {
+  if (featureFlagStore.MULTI_VARIANT_EDITING) {
+    return false;
+  }
+
+  return !!(editingAsset.value?.hasComponents ?? false);
+});
 
 const disabledWarning = computed(() => {
-  if (editingAsset.value?.hasComponents) {
+  if (disabled.value) {
     return `This asset cannot be edited because it is in use by components.`;
   }
 

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -52,6 +52,7 @@ import {
 } from "@si/vue-lib/design-system";
 import { useAssetStore, assetDisplayName } from "@/store/asset.store";
 import SiChip from "@/components/SiChip.vue";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import CodeEditor from "./CodeEditor.vue";
 import NodeSkeleton from "./NodeSkeleton.vue";
 
@@ -59,12 +60,18 @@ const props = defineProps<{
   assetId?: string;
 }>();
 
+const featureFlagStore = useFeatureFlagsStore();
 const assetStore = useAssetStore();
 const selectedAsset = computed(() =>
   props.assetId ? assetStore.assetsById[props.assetId] : undefined,
 );
 
-const isReadOnly = computed(() => !!selectedAsset.value?.hasComponents);
+const isReadOnly = computed(() => {
+  if (featureFlagStore.MULTI_VARIANT_EDITING) {
+    return false;
+  }
+  return !!selectedAsset.value?.hasComponents;
+});
 
 const editingAsset = ref<string>(selectedAsset.value?.code ?? "");
 

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -96,10 +96,15 @@ export type Asset = VariantDef;
 export type AssetListEntry = ListedVariantDef;
 export type AssetSaveRequest = Visibility & {
   overrideBuiltinSchemaFeatureFlag: boolean;
+  multiVariantEditingFlag: boolean;
 } & Omit<Asset, "createdAt" | "updatedAt" | "variantExists" | "hasComponents">;
 export type AssetCreateRequest = Omit<
   AssetSaveRequest,
-  "id" | "definition" | "variantExists" | "overrideBuiltinSchemaFeatureFlag"
+  | "id"
+  | "definition"
+  | "variantExists"
+  | "overrideBuiltinSchemaFeatureFlag"
+  | "multiVariantEditingFlag"
 >;
 export type AssetCloneRequest = Visibility & { id: AssetId };
 
@@ -350,6 +355,7 @@ export const useAssetStore = () => {
             params: {
               overrideBuiltinSchemaFeatureFlag:
                 featureFlagsStore.OVERRIDE_SCHEMA,
+              multiVariantEditingFlag: featureFlagsStore.MULTI_VARIANT_EDITING,
               ...visibility,
               ..._.omit(asset, [
                 "schemaVariantId",
@@ -414,6 +420,7 @@ export const useAssetStore = () => {
             params: {
               overrideBuiltinSchemaFeatureFlag:
                 featureFlagsStore.OVERRIDE_SCHEMA,
+              multiVariantEditingFlag: featureFlagsStore.MULTI_VARIANT_EDITING,
               ...visibility,
               ..._.omit(asset, [
                 "schemaVariantId",

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -6,17 +6,19 @@ import { posthog } from "@/utils/posthog";
 // translation from store key to posthog feature flag name
 const FLAG_MAPPING = {
   // STORE_FLAG_NAME: "posthogFlagName",
-  MODULES_TAB: "modules_tab",
-  SECRETS: "secrets",
-  INVITE_USER: "invite_user",
-  WORKSPACE_BACKUPS: "workspaceBackups",
+  // STORE_FLAG_NAME: "posthogFlagName",
   COPY_PASTE: "copy_paste",
   DONT_BLOCK_ON_ACTIONS: "dont_block_on_actions",
-  OVERRIDE_SCHEMA: "override_schema",
+  INVITE_USER: "invite_user",
   JOI_VALIDATIONS: "joi_validations",
-  SHOW_EDGES_ON_SELECT: "show_edges_on_select",
+  MODULES_TAB: "modules_tab",
+  MULTI_VARIANT_EDITING: "multiVariantEditing",
+  OVERRIDE_SCHEMA: "override_schema",
   REMOVE_COMPONENT_ICONS: "remove_component_icons",
   RESIZABLE_PANEL_UPGRADE: "resizable-panel-upgrade",
+  SECRETS: "secrets",
+  SHOW_EDGES_ON_SELECT: "show_edges_on_select",
+  WORKSPACE_BACKUPS: "workspaceBackups",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;
@@ -41,6 +43,8 @@ export function useFeatureFlagsStore() {
           });
         });
         // You can override feature flags while working on a feature by setting them to true here
+
+        // this.MULTI_VARIANT_EDITING = true;
 
         // Make sure to remove the override before committing your code!
       },

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -33,8 +33,8 @@ use crate::{
     WsEvent, WsEventResult, WsPayload,
 };
 
-mod export;
-mod import;
+pub mod export;
+pub mod import;
 
 #[remain::sorted]
 #[derive(Debug, Error)]

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -499,9 +499,9 @@ impl SchemaVariantDefinitionJson {
         metadata: SchemaVariantDefinitionMetadataJson,
         identity_func_unique_id: &str,
         asset_func_spec_unique_id: &str,
+        name: &str,
     ) -> SchemaVariantDefinitionResult<SchemaVariantSpec> {
         let mut builder = SchemaVariantSpec::builder();
-        let name = "v0";
         builder.name(name);
 
         let mut data_builder = SchemaVariantSpecData::builder();

--- a/lib/dal/tests/integration_test/internal/func.rs
+++ b/lib/dal/tests/integration_test/internal/func.rs
@@ -199,7 +199,10 @@ async fn duplicate(ctx: &DalContext) {
         .await
         .expect("could not set handler");
 
-    let new_func = func.duplicate(ctx).await.expect("could not duplicate func");
+    let new_func = func
+        .duplicate(ctx, None)
+        .await
+        .expect("could not duplicate func");
 
     // Ensure the ID is new.
     assert_ne!(

--- a/lib/sdf-server/src/server/service/variant_definition.rs
+++ b/lib/sdf-server/src/server/service/variant_definition.rs
@@ -110,6 +110,10 @@ pub enum SchemaVariantDefinitionError {
     PgPool(#[from] si_data_pg::PgPoolError),
     #[error(transparent)]
     Pkg(#[from] PkgError),
+    #[error("constructed package has no schema node")]
+    PkgMissingSchema,
+    #[error("constructed package has no schema variant node")]
+    PkgMissingSchemaVariant,
     #[error(transparent)]
     Prop(#[from] PropError),
     #[error(transparent)]

--- a/lib/sdf-server/src/server/service/variant_definition/clone_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/clone_variant_def.rs
@@ -81,7 +81,7 @@ pub async fn clone_variant_def(
     let func = Func::get_by_id(&ctx, &variant_def.func_id()).await?.ok_or(
         SchemaVariantDefinitionError::FuncNotFound(variant_def.func_id()),
     )?;
-    let duplicated_func = func.duplicate(&ctx).await?;
+    let duplicated_func = func.duplicate(&ctx, None).await?;
 
     let variant_def = SchemaVariantDefinition::new(
         &ctx,

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -4,6 +4,9 @@ use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 use chrono::Utc;
 use convert_case::{Case, Casing};
+use dal::component::ComponentKind;
+use dal::pkg::import::{clone_and_import_funcs, import_schema_variant};
+use dal::pkg::PkgExporter;
 use hyper::Uri;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
@@ -19,7 +22,8 @@ use dal::{
     SchemaVariantId, StandardModel, User, WsEvent,
 };
 use si_pkg::{
-    FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, PkgSpec, SiPkg,
+    FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, MergeSkip, PkgSpec,
+    SchemaVariantSpec, SiPkg,
 };
 use telemetry::prelude::*;
 
@@ -135,6 +139,148 @@ fn generate_scaffold_func_name(name: String) -> String {
     generated_name
 }
 
+async fn execute_asset_func(
+    ctx: &DalContext,
+    asset_func: &Func,
+) -> SchemaVariantDefinitionResult<SchemaVariantDefinitionJson> {
+    let (_, return_value) =
+        FuncBinding::create_and_execute(ctx, serde_json::Value::Null, *asset_func.id(), vec![])
+            .await?;
+
+    if let Some(error) = return_value
+        .value()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .as_object()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .get("error")
+        .and_then(|e| e.as_str())
+    {
+        return Err(SchemaVariantDefinitionError::FuncExecutionFailure(
+            error.to_owned(),
+        ));
+    }
+
+    let func_resp = return_value
+        .value()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .as_object()
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?
+        .get("definition")
+        .ok_or(SchemaVariantDefinitionError::FuncExecution(
+            *asset_func.id(),
+        ))?;
+
+    Ok(serde_json::from_value::<SchemaVariantDefinitionJson>(
+        func_resp.to_owned(),
+    )?)
+}
+
+#[allow(clippy::result_large_err)]
+fn build_asset_func_spec(asset_func: &Func) -> SchemaVariantDefinitionResult<FuncSpec> {
+    let mut schema_variant_func_spec = FuncSpec::builder();
+    schema_variant_func_spec.name(asset_func.name());
+    schema_variant_func_spec.unique_id(asset_func.id().to_string());
+    let mut func_spec_data_builder = FuncSpecData::builder();
+    func_spec_data_builder
+        .name(asset_func.name())
+        .backend_kind(FuncSpecBackendKind::JsSchemaVariantDefinition)
+        .response_type(FuncSpecBackendResponseType::SchemaVariantDefinition)
+        .hidden(asset_func.hidden());
+    if let Some(code) = asset_func.code_plaintext()? {
+        func_spec_data_builder.code_plaintext(code);
+    }
+    if let Some(handler) = asset_func.handler() {
+        func_spec_data_builder.handler(handler.to_string());
+    }
+    if let Some(description) = asset_func.description() {
+        func_spec_data_builder.description(description.to_string());
+    }
+    if let Some(display_name) = asset_func.display_name() {
+        func_spec_data_builder.display_name(display_name.to_string());
+    }
+
+    Ok(schema_variant_func_spec
+        .data(func_spec_data_builder.build()?)
+        .build()?)
+}
+
+fn inc_variant_name(name: &str) -> String {
+    let (prefix, suffix) = name.split_at(1);
+
+    let new_suffix = match suffix.parse::<i64>() {
+        Ok(number) => (number + 1).to_string(),
+        Err(_) => format!("{}_new", suffix),
+    };
+
+    format!("{}{}", prefix, new_suffix)
+}
+
+async fn build_variant_spec_based_on_existing_variant(
+    ctx: &DalContext,
+    definition: SchemaVariantDefinitionJson,
+    asset_func_spec: &FuncSpec,
+    metadata: &SchemaVariantDefinitionMetadataJson,
+    existing_variant_id: SchemaVariantId,
+) -> SchemaVariantDefinitionResult<(SchemaVariantSpec, Vec<MergeSkip>, Vec<FuncSpec>)> {
+    let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
+
+    let existing_variant = SchemaVariant::get_by_id(ctx, &existing_variant_id)
+        .await?
+        .ok_or(SchemaVariantError::NotFound(existing_variant_id))?;
+
+    let new_name = inc_variant_name(existing_variant.name());
+
+    let variant_spec = definition.to_spec(
+        metadata.clone(),
+        &identity_func_spec.unique_id,
+        &asset_func_spec.unique_id,
+        &new_name,
+    )?;
+
+    let (existing_variant_spec, variant_funcs) =
+        PkgExporter::export_variant_standalone(ctx, &existing_variant).await?;
+
+    let (merged_variant, skips) = variant_spec.merge_prototypes_from(&existing_variant_spec);
+
+    Ok((merged_variant, skips, variant_funcs))
+}
+
+#[allow(clippy::result_large_err)]
+fn build_pkg_spec_for_variant(
+    definition: SchemaVariantDefinitionJson,
+    asset_func_spec: &FuncSpec,
+    metadata: &SchemaVariantDefinitionMetadataJson,
+    user_email: &str,
+) -> SchemaVariantDefinitionResult<PkgSpec> {
+    // we need to change this to use the PkgImport
+    let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
+
+    let variant_spec = definition.to_spec(
+        metadata.clone(),
+        &identity_func_spec.unique_id,
+        &asset_func_spec.unique_id,
+        "v0",
+    )?;
+    let schema_spec = metadata.to_spec(variant_spec)?;
+
+    Ok(PkgSpec::builder()
+        .name(metadata.clone().name)
+        .created_by(user_email)
+        .func(identity_func_spec)
+        .func(asset_func_spec.clone())
+        .schema(schema_spec)
+        .version("0.0.1")
+        .build()?)
+}
+
 #[instrument(name = "async_task.exec_variant_def", level = "info", skip_all)]
 pub async fn exec_variant_def_inner(
     ctx: &DalContext,
@@ -143,29 +289,49 @@ pub async fn exec_variant_def_inner(
     PosthogClient(posthog_client): PosthogClient,
     request_span: Span,
 ) -> SchemaVariantDefinitionResult<(SchemaVariantId, Vec<AttributePrototypeView>)> {
-    Span::current().follows_from(request_span.id());
+    let current_span = Span::current();
+    let span = current_span.follows_from(request_span.id());
 
-    let scaffold_func_name = generate_scaffold_func_name(request.name.clone());
-
-    // Ensure we save all details before "exec"
-    super::save_variant_def(ctx, request, Some(scaffold_func_name)).await?;
-
-    let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk).await?,
+    let user_email = match ctx.history_actor() {
+        HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk)
+            .await?
+            .map(|user| user.email().to_owned()),
         _ => None,
-    };
-    let user_email = user
-        .map(|user| user.email().to_owned())
-        .unwrap_or("unauthenticated user email".into());
+    }
+    .unwrap_or("unauthenticated user email".into());
 
-    let mut variant_def = SchemaVariantDefinition::get_by_id(ctx, &request.id)
+    let current_variant_def = SchemaVariantDefinition::get_by_id(ctx, &request.id)
         .await?
         .ok_or(SchemaVariantDefinitionError::VariantDefinitionNotFound(
             request.id,
         ))?;
 
-    let (maybe_previous_variant_id, leaf_funcs_to_migrate, attribute_prototypes) =
-        maybe_delete_schema_variant_connected_to_variant_def(ctx, &mut variant_def).await?;
+    // Exec forks here if the multi variant editing flag is on and the definition is for an existing asset
+    if let Some(&current_schema_variant_id) = current_variant_def.schema_variant_id() {
+        if request.multi_variant_editing_flag {
+            return exec_variant_def_multi_variant_editing(
+                ctx,
+                request.to_owned(),
+                original_uri,
+                posthog_client,
+                span,
+                user_email,
+                current_variant_def,
+                current_schema_variant_id,
+            )
+            .await;
+        }
+    }
+
+    let scaffold_func_name = generate_scaffold_func_name(request.name.clone());
+
+    // Ensure we save all details before "exec"
+    super::save_variant_def(ctx, request, Some(scaffold_func_name)).await?;
+    let mut variant_def = SchemaVariantDefinition::get_by_id(ctx, &request.id)
+        .await?
+        .ok_or(SchemaVariantDefinitionError::VariantDefinitionNotFound(
+            request.id,
+        ))?;
 
     let asset_func = Func::get_by_id(ctx, &variant_def.func_id()).await?.ok_or(
         SchemaVariantDefinitionError::FuncNotFound(variant_def.func_id()),
@@ -173,95 +339,14 @@ pub async fn exec_variant_def_inner(
 
     let metadata: SchemaVariantDefinitionMetadataJson = variant_def.clone().into();
 
-    // Execute asset function
-    let (definition, _) = {
-        let (_, return_value) =
-            FuncBinding::create_and_execute(ctx, serde_json::Value::Null, *asset_func.id(), vec![])
-                .await?;
+    let (maybe_previous_variant_id, leaf_funcs_to_migrate, attribute_prototypes) =
+        maybe_delete_schema_variant_connected_to_variant_def(ctx, &mut variant_def).await?;
 
-        if let Some(error) = return_value
-            .value()
-            .ok_or(SchemaVariantDefinitionError::FuncExecution(
-                *asset_func.id(),
-            ))?
-            .as_object()
-            .ok_or(SchemaVariantDefinitionError::FuncExecution(
-                *asset_func.id(),
-            ))?
-            .get("error")
-            .and_then(|e| e.as_str())
-        {
-            return Err(SchemaVariantDefinitionError::FuncExecutionFailure(
-                error.to_owned(),
-            ));
-        }
-
-        let func_resp = return_value
-            .value()
-            .ok_or(SchemaVariantDefinitionError::FuncExecution(
-                *asset_func.id(),
-            ))?
-            .as_object()
-            .ok_or(SchemaVariantDefinitionError::FuncExecution(
-                *asset_func.id(),
-            ))?
-            .get("definition")
-            .ok_or(SchemaVariantDefinitionError::FuncExecution(
-                *asset_func.id(),
-            ))?;
-
-        (
-            serde_json::from_value::<SchemaVariantDefinitionJson>(func_resp.to_owned())?,
-            func_resp.to_owned(),
-        )
-    };
-
-    let asset_func_built = {
-        let mut schema_variant_func_spec = FuncSpec::builder();
-        schema_variant_func_spec.name(asset_func.name());
-        schema_variant_func_spec.unique_id(asset_func.id().to_string());
-        let mut func_spec_data_builder = FuncSpecData::builder();
-        func_spec_data_builder
-            .name(asset_func.name())
-            .backend_kind(FuncSpecBackendKind::JsSchemaVariantDefinition)
-            .response_type(FuncSpecBackendResponseType::SchemaVariantDefinition)
-            .hidden(asset_func.hidden());
-        if let Some(code) = asset_func.code_plaintext()? {
-            func_spec_data_builder.code_plaintext(code);
-        }
-        if let Some(handler) = asset_func.handler() {
-            func_spec_data_builder.handler(handler.to_string());
-        }
-        if let Some(description) = asset_func.description() {
-            func_spec_data_builder.description(description.to_string());
-        }
-        if let Some(display_name) = asset_func.display_name() {
-            func_spec_data_builder.display_name(display_name.to_string());
-        }
-        schema_variant_func_spec
-            .data(func_spec_data_builder.build()?)
-            .build()?
-    };
-
-    let pkg_spec = {
-        // we need to change this to use the PkgImport
-        let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
-
-        let variant_spec = definition.to_spec(
-            metadata.clone(),
-            &identity_func_spec.unique_id,
-            &asset_func_built.unique_id,
-        )?;
-        let schema_spec = metadata.to_spec(variant_spec)?;
-        PkgSpec::builder()
-            .name(metadata.clone().name)
-            .created_by(&user_email)
-            .func(identity_func_spec)
-            .func(asset_func_built.clone())
-            .schema(schema_spec)
-            .version("0.0.1")
-            .build()?
-    };
+    // Execute asset function to get schema variant definition
+    let asset_func_built = build_asset_func_spec(&asset_func)?;
+    let definition = execute_asset_func(ctx, &asset_func).await?;
+    let pkg_spec =
+        build_pkg_spec_for_variant(definition, &asset_func_built, &metadata, &user_email)?;
 
     let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
 
@@ -352,10 +437,145 @@ pub async fn exec_variant_def_inner(
                     "variant_def_category": metadata.clone().category,
                     "variant_def_name": metadata.clone().name,
                     "variant_def_version": pkg_spec.clone().version,
-                    "variant_def_schema_count":  pkg_spec.clone().schemas.len(),
                     "variant_def_function_count":  pkg_spec.clone().funcs.len(),
+                    "multi_variant_editing": false,
         }),
     );
 
     Ok((schema_variant_id, detached_attribute_prototypes))
+}
+
+#[instrument(
+    name = "async_task.exec_variant_def_multi_variant_editing",
+    level = "info",
+    skip_all
+)]
+#[allow(clippy::too_many_arguments)]
+pub async fn exec_variant_def_multi_variant_editing(
+    ctx: &DalContext,
+    request: ExecVariantDefRequest,
+    original_uri: &Uri,
+    posthog_client: crate::server::state::PosthogClient,
+    span: &Span,
+    user_email: String,
+    current_variant_def: SchemaVariantDefinition,
+    current_schema_variant_id: SchemaVariantId,
+) -> SchemaVariantDefinitionResult<(SchemaVariantId, Vec<AttributePrototypeView>)> {
+    Span::current().follows_from(span.id());
+
+    // we need asset func drafts or some similar concept so that we don't write
+    // to the last asset func before we get here
+    let current_asset_func = Func::get_by_id(ctx, &current_variant_def.func_id())
+        .await?
+        .ok_or(SchemaVariantDefinitionError::FuncNotFound(
+            current_variant_def.func_id(),
+        ))?;
+
+    let scaffold_func_name = generate_scaffold_func_name(request.name.clone());
+    let new_asset_func = current_asset_func
+        .duplicate(ctx, Some(scaffold_func_name))
+        .await?;
+
+    let mut new_definition = SchemaVariantDefinition::new(
+        ctx,
+        request.name,
+        request.menu_name,
+        request.category,
+        request.link,
+        request.color,
+        ComponentKind::Standard,
+        request.description,
+        *new_asset_func.id(),
+    )
+    .await?;
+
+    let metadata = new_definition.clone().into();
+
+    // Execute asset function to get schema variant prop tree etc
+    let definition = execute_asset_func(ctx, &new_asset_func).await?;
+    let asset_func_built = build_asset_func_spec(&new_asset_func)?;
+    let (new_variant_spec, skips, variant_funcs) = build_variant_spec_based_on_existing_variant(
+        ctx,
+        definition,
+        &asset_func_built,
+        &metadata,
+        current_schema_variant_id,
+    )
+    .await?;
+
+    dbg!(skips);
+
+    let schema_spec = metadata.to_spec(new_variant_spec)?;
+    let pkg_spec = PkgSpec::builder()
+        .name(&metadata.name)
+        .created_by(user_email)
+        .funcs(variant_funcs.clone())
+        .func(asset_func_built)
+        .schema(schema_spec)
+        .version("0")
+        .build()?;
+
+    // Copy some data here for sending to posthog track
+    let variant_def_version = pkg_spec.version.to_owned();
+    let variant_def_function_count = pkg_spec.funcs.len();
+    let variant_def_category = metadata.category.to_owned();
+    let variant_def_name = metadata.name.to_owned();
+
+    let pkg = SiPkg::load_from_spec(pkg_spec)?;
+
+    let mut schema = SchemaVariant::get_by_id(ctx, &current_schema_variant_id)
+        .await?
+        .ok_or(SchemaVariantError::NotFound(current_schema_variant_id))?
+        .schema(ctx)
+        .await?
+        .ok_or(SchemaVariantError::MissingSchema(current_schema_variant_id))?;
+
+    let pkg_variant = pkg
+        .schemas()?
+        .into_iter()
+        .next()
+        .ok_or(SchemaVariantDefinitionError::PkgMissingSchema)?
+        .variants()?
+        .into_iter()
+        .next()
+        .ok_or(SchemaVariantDefinitionError::PkgMissingSchemaVariant)?;
+
+    let mut thing_map = clone_and_import_funcs(ctx, variant_funcs).await?;
+    let new_schema_variant = import_schema_variant(
+        ctx,
+        ctx.visibility().change_set_pk,
+        &mut schema,
+        &pkg_variant,
+        None,
+        &mut thing_map,
+        &pkg.metadata()?,
+    )
+    .await?
+    .ok_or(SchemaVariantDefinitionError::NoAssetCreated)?;
+
+    let schema_variant_id = *new_schema_variant.id();
+
+    new_definition
+        .set_schema_variant_id(ctx, Some(schema_variant_id))
+        .await?;
+
+    schema
+        .set_default_schema_variant_id(ctx, Some(schema_variant_id))
+        .await?;
+
+    track(
+        &posthog_client,
+        ctx,
+        original_uri,
+        "exec_variant_def",
+        serde_json::json!({
+                    "variant_def_category": variant_def_category,
+                    "variant_def_name": variant_def_name,
+                    "variant_def_version": variant_def_version,
+                    "variant_def_function_count": variant_def_function_count,
+                    "multi_variant_editing": true,
+        }),
+    );
+
+    Ok((schema_variant_id, vec![]))
 }

--- a/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
@@ -7,7 +7,7 @@ use dal::ComponentType;
 use dal::{schema::variant::definition::SchemaVariantDefinitionId, ChangeSet, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveVariantDefRequest {
     pub id: SchemaVariantDefinitionId,
@@ -20,6 +20,7 @@ pub struct SaveVariantDefRequest {
     pub description: Option<String>,
     pub component_type: ComponentType,
     pub override_builtin_schema_feature_flag: bool,
+    pub multi_variant_editing_flag: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -427,6 +427,7 @@ impl ScenarioHarness {
             description: None,
             visibility: *visibility,
             override_builtin_schema_feature_flag: true,
+            multi_variant_editing_flag: false,
         };
 
         let response: ExecVariantDefResponse = self
@@ -455,6 +456,7 @@ impl ScenarioHarness {
             description: None,
             visibility: *visibility,
             override_builtin_schema_feature_flag: true,
+            multi_variant_editing_flag: true,
         };
         let response: SaveVariantDefResponse = self
             .query_post("/api/variant_def/save_variant_def", &request)

--- a/lib/si-pkg/BUCK
+++ b/lib/si-pkg/BUCK
@@ -7,6 +7,7 @@ rust_library(
         "//third-party/rust:base64",
         "//third-party/rust:chrono",
         "//third-party/rust:derive_builder",
+        "//third-party/rust:indexmap",
         "//third-party/rust:petgraph",
         "//third-party/rust:remain",
         "//third-party/rust:serde",

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 base64.workspace = true
 chrono = { workspace = true }
 derive_builder = { workspace = true }
+indexmap = { workspace = true }
 object-tree = { path = "../../lib/object-tree" }
 petgraph = { workspace = true }
 remain = { workspace = true }

--- a/lib/si-pkg/src/spec/attr_func_input.rs
+++ b/lib/si-pkg/src/spec/attr_func_input.rs
@@ -26,7 +26,7 @@ pub enum AttrFuncInputSpecKind {
 }
 
 #[remain::sorted]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum AttrFuncInputSpec {
     InputSocket {
@@ -75,6 +75,13 @@ impl AttrFuncInputSpec {
             Self::InputSocket { name, .. } => name.as_str(),
             Self::OutputSocket { name, .. } => name.as_str(),
             Self::Prop { name, .. } => name.as_str(),
+        }
+    }
+
+    pub fn prop_path(&self) -> Option<&str> {
+        match self {
+            Self::Prop { prop_path, .. } => Some(prop_path.as_str()),
+            _ => None,
         }
     }
 }

--- a/lib/si-pkg/src/spec/prop.rs
+++ b/lib/si-pkg/src/spec/prop.rs
@@ -396,25 +396,23 @@ impl PropSpec {
                         other_kind,
                         self_kind,
                     });
-                } else {
-                    if let (Some(func_unique_id), Some(other_inputs)) =
-                        (other_prop_spec.func_unique_id(), other_prop_spec.inputs())
-                    {
-                        let mismatches = Self::get_input_mismatches(
-                            &current_path,
-                            InputMismatchTruth::PropSpecMap(&self_map),
-                            other_inputs.as_slice(),
-                            func_unique_id,
-                            input_sockets,
-                            output_sockets,
-                        );
+                } else if let (Some(func_unique_id), Some(other_inputs)) =
+                    (other_prop_spec.func_unique_id(), other_prop_spec.inputs())
+                {
+                    let mismatches = Self::get_input_mismatches(
+                        current_path,
+                        InputMismatchTruth::PropSpecMap(&self_map),
+                        other_inputs.as_slice(),
+                        func_unique_id,
+                        input_sockets,
+                        output_sockets,
+                    );
 
-                        if mismatches.is_empty() {
-                            current_prop_spec_builder.func_unique_id(func_unique_id);
-                            current_prop_spec_builder.inputs(other_inputs.to_owned());
-                        } else {
-                            merge_skips.extend(mismatches);
-                        }
+                    if mismatches.is_empty() {
+                        current_prop_spec_builder.func_unique_id(func_unique_id);
+                        current_prop_spec_builder.inputs(other_inputs.to_owned());
+                    } else {
+                        merge_skips.extend(mismatches);
                     }
                 }
             }
@@ -453,7 +451,7 @@ impl PropSpec {
         }
 
         // unreachable, but the compiler doesn't know this
-        return (self.to_owned(), vec![]);
+        (self.to_owned(), vec![])
     }
 }
 

--- a/lib/si-pkg/src/spec/socket.rs
+++ b/lib/si-pkg/src/spec/socket.rs
@@ -98,4 +98,8 @@ impl SocketSpec {
     pub fn builder() -> SocketSpecBuilder {
         SocketSpecBuilder::default()
     }
+
+    pub fn kind(&self) -> Option<SocketSpecKind> {
+        self.data.as_ref().map(|data| data.kind)
+    }
 }

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -1,9 +1,13 @@
+use std::collections::HashSet;
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use strum::{AsRefStr, Display, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString, IntoEnumIterator};
 use url::Url;
 
-use crate::spec::authentication_func::AuthenticationFuncSpec;
+use crate::{
+    spec::authentication_func::AuthenticationFuncSpec, MergeSkip, PropSpecKind, SocketSpecKind,
+};
 
 use super::{
     ActionFuncSpec, LeafFunctionSpec, PropSpec, PropSpecData, PropSpecWidgetKind, RootPropFuncSpec,
@@ -74,6 +78,16 @@ impl SchemaVariantSpecPropRoot {
             Self::ResourceValue => &["root", "resource_value"],
             Self::SecretDefinition => &["root", "secret_definition"],
             Self::Secrets => &["root", "secrets"],
+        }
+    }
+
+    pub fn maybe_from_str(leaf_name: &str) -> Option<SchemaVariantSpecPropRoot> {
+        match leaf_name {
+            "domain" => Some(SchemaVariantSpecPropRoot::Domain),
+            "resource_value" => Some(SchemaVariantSpecPropRoot::ResourceValue),
+            "secret_definition" => Some(SchemaVariantSpecPropRoot::SecretDefinition),
+            "secrets" => Some(SchemaVariantSpecPropRoot::Secrets),
+            _ => None,
         }
     }
 }
@@ -165,6 +179,159 @@ pub struct SchemaVariantSpec {
 impl SchemaVariantSpec {
     pub fn builder() -> SchemaVariantSpecBuilder {
         SchemaVariantSpecBuilder::default()
+    }
+
+    fn get_root_prop(&self, root: SchemaVariantSpecPropRoot) -> Option<&PropSpec> {
+        match root {
+            SchemaVariantSpecPropRoot::Domain => Some(&self.domain),
+            SchemaVariantSpecPropRoot::ResourceValue => Some(&self.resource_value),
+            SchemaVariantSpecPropRoot::SecretDefinition => self.secret_definition.as_ref(),
+            SchemaVariantSpecPropRoot::Secrets => Some(&self.secrets),
+        }
+    }
+
+    fn input_sockets(&self) -> Vec<String> {
+        self.sockets
+            .iter()
+            .filter_map(|socket_spec| match socket_spec.kind() {
+                Some(SocketSpecKind::Input) => Some(socket_spec.name.to_owned()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn output_sockets(&self) -> Vec<String> {
+        self.sockets
+            .iter()
+            .filter_map(|socket_spec| match socket_spec.kind() {
+                Some(SocketSpecKind::Output) => Some(socket_spec.name.to_owned()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn make_fake_root_prop(&self) -> PropSpec {
+        let mut root = PropSpec::builder();
+        root.kind(PropSpecKind::Object).name("root");
+        for root_prop_kind in SchemaVariantSpecPropRoot::iter() {
+            if let Some(prop_spec) = self.get_root_prop(root_prop_kind) {
+                root.entry(prop_spec.clone());
+            }
+        }
+
+        root.build().expect("failure to build is a logic error")
+    }
+
+    /// Makes a best effort to merge the prototypes of `other_spec` into `self`,
+    /// producing a new `SchemaVariantSpec`. The prop tree for `self` is taken as
+    /// the source of truth. Props present in `other_spec` but not present in
+    /// `self` are considered removed, and the types from `self` take priority.
+    /// This works by walking the prop tree in self and trying to find the
+    /// equivalent prop in other. If an equivalent prop in other is found, the
+    /// attribute functions for that prop are copied over to self. Then, all
+    /// other functions are copied over, if they have matching props (or
+    /// providers) in self.
+    pub fn merge_prototypes_from(&self, other_spec: &Self) -> (Self, Vec<MergeSkip>) {
+        let mut schema_variant_builder = SchemaVariantSpec::builder();
+        schema_variant_builder.name(&self.name);
+        schema_variant_builder.data = Some(self.data.to_owned());
+
+        let self_input_sockets = self.input_sockets();
+        let self_output_sockets = self.output_sockets();
+
+        // The inputs to these prototypes will always be available so we just copy
+        schema_variant_builder.action_funcs = Some(other_spec.action_funcs.clone());
+        schema_variant_builder.auth_funcs = Some(other_spec.auth_funcs.clone());
+        schema_variant_builder.leaf_functions = Some(other_spec.leaf_functions.clone());
+
+        // These are fake root props that include all the "root prop children"
+        // (domain, resource_value, etc) as entries
+        let self_root_prop = self.make_fake_root_prop();
+        let other_root_prop = other_spec.make_fake_root_prop();
+
+        let (new_root, mut merge_skips) =
+            self_root_prop.merge_with(&other_root_prop, &self_input_sockets, &self_output_sockets);
+
+        schema_variant_builder.replace_roots(new_root);
+
+        let missing_props: HashSet<String> = merge_skips
+            .iter()
+            .filter_map(|skip| match skip {
+                MergeSkip::PropMissing(path) => Some(path.to_owned()),
+                _ => None,
+            })
+            .collect();
+
+        for si_prop_func in &other_spec.si_prop_funcs {
+            let path = PropSpec::make_path(&si_prop_func.kind.prop_path(), None);
+            let si_prop_skips = PropSpec::get_input_mismatches(
+                &path,
+                crate::InputMismatchTruth::MissingPropSet(&missing_props),
+                &si_prop_func.inputs,
+                &si_prop_func.func_unique_id,
+                &self_input_sockets,
+                &self_output_sockets,
+            );
+
+            if si_prop_skips.is_empty() {
+                schema_variant_builder.si_prop_func(si_prop_func.to_owned());
+            } else {
+                merge_skips.extend(si_prop_skips);
+            }
+        }
+
+        for root_prop_func in &other_spec.root_prop_funcs {
+            let path = PropSpec::make_path(root_prop_func.prop.path_parts(), None);
+            let root_prop_skips = PropSpec::get_input_mismatches(
+                &path,
+                crate::InputMismatchTruth::MissingPropSet(&missing_props),
+                &root_prop_func.inputs,
+                &root_prop_func.func_unique_id,
+                &self_input_sockets,
+                &self_output_sockets,
+            );
+
+            if root_prop_skips.is_empty() {
+                schema_variant_builder.root_prop_func(root_prop_func.to_owned());
+            } else {
+                merge_skips.extend(root_prop_skips);
+            }
+        }
+
+        merge_skips.extend(
+            other_spec
+                .input_sockets()
+                .iter()
+                .filter_map(|input_socket| {
+                    if !self_input_sockets.contains(&input_socket) {
+                        Some(MergeSkip::InputSocketMissing {
+                            socket_name: input_socket.to_owned(),
+                        })
+                    } else {
+                        None
+                    }
+                }),
+        );
+
+        merge_skips.extend(
+            other_spec
+                .output_sockets()
+                .iter()
+                .filter_map(|output_socket| {
+                    if !self_output_sockets.contains(&output_socket) {
+                        Some(MergeSkip::OutputSocketMissing {
+                            socket_name: output_socket.to_owned(),
+                        })
+                    } else {
+                        None
+                    }
+                }),
+        );
+
+        (
+            schema_variant_builder.build().expect("should build"),
+            merge_skips,
+        )
     }
 }
 
@@ -266,6 +433,28 @@ impl SchemaVariantSpecBuilder {
         self.prop(SchemaVariantSpecPropRoot::ResourceValue, item)
     }
 
+    pub fn replace_roots(&mut self, new_root: PropSpec) -> &mut Self {
+        for child in new_root.direct_children() {
+            match SchemaVariantSpecPropRoot::maybe_from_str(child.name()) {
+                Some(SchemaVariantSpecPropRoot::Domain) => {
+                    self.domain = Some(child.to_owned());
+                }
+                Some(SchemaVariantSpecPropRoot::ResourceValue) => {
+                    self.resource_value = Some(child.to_owned());
+                }
+                Some(SchemaVariantSpecPropRoot::SecretDefinition) => {
+                    self.secret_definition = Some(Some(child.to_owned()));
+                }
+                Some(SchemaVariantSpecPropRoot::Secrets) => {
+                    self.secrets = Some(child.to_owned());
+                }
+                None => {}
+            }
+        }
+
+        self
+    }
+
     #[allow(unused_mut)]
     pub fn prop(
         &mut self,
@@ -321,5 +510,210 @@ impl SchemaVariantSpecBuilder {
             ),
         };
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ActionFuncSpecKind, AttrFuncInputSpec, LeafInputLocation, LeafKind};
+
+    use super::*;
+
+    #[test]
+    fn test_schema_variant_merge() {
+        let mercedes_dantes_beloved_path =
+            PropSpec::make_path(&["root", "domain", "mercedes", "dantes_beloved"], None);
+        let si_name_path = PropSpec::make_path(&["root", "si", "name"], None);
+
+        let sv_1 = SchemaVariantSpec::builder()
+            .name("v0")
+            .unique_id("monte_cristo_sv_1")
+            .data(
+                SchemaVariantSpecData::builder()
+                    .name("v0")
+                    .color("#ffff00")
+                    .func_unique_id("cristo_1")
+                    .build()
+                    .expect("build variant spec data"),
+            )
+            .domain_prop(
+                PropSpec::builder()
+                    .name("edmond_dantes")
+                    .kind(PropSpecKind::String)
+                    .func_unique_id("set_edmond_dantes")
+                    .input(
+                        AttrFuncInputSpec::builder()
+                            .kind(crate::AttrFuncInputSpecKind::Prop)
+                            .name("beloved")
+                            .prop_path(mercedes_dantes_beloved_path.clone())
+                            .build()
+                            .expect("func input"),
+                    )
+                    .build()
+                    .expect("build prop"),
+            )
+            .domain_prop(
+                PropSpec::builder()
+                    .name("mercedes")
+                    .kind(PropSpecKind::Object)
+                    .entry(
+                        PropSpec::builder()
+                            .name("dantes_beloved")
+                            .kind(PropSpecKind::Boolean)
+                            .func_unique_id("set_dantes_beloved")
+                            .input(
+                                AttrFuncInputSpec::builder()
+                                    .kind(crate::AttrFuncInputSpecKind::Prop)
+                                    .name("si_name")
+                                    .prop_path(si_name_path.clone())
+                                    .build()
+                                    .expect("beloved input from si name"),
+                            )
+                            .build()
+                            .expect("build prop"),
+                    )
+                    .entry(
+                        PropSpec::builder()
+                            .name("mother_of")
+                            .kind(PropSpecKind::Object)
+                            .entry(
+                                PropSpec::builder()
+                                    .name("albert_de_morcef")
+                                    .kind(PropSpecKind::Number)
+                                    .build()
+                                    .expect("brop puild"),
+                            )
+                            .build()
+                            .expect("prop build"),
+                    )
+                    .build()
+                    .expect("build prop"),
+            )
+            .action_func(
+                ActionFuncSpec::builder()
+                    .kind(ActionFuncSpecKind::Create)
+                    .func_unique_id("create_monte_cristo")
+                    .build()
+                    .expect("action func spec"),
+            )
+            .action_func(
+                ActionFuncSpec::builder()
+                    .kind(ActionFuncSpecKind::Refresh)
+                    .func_unique_id("refresh_monte_cristo")
+                    .build()
+                    .expect("action func spec"),
+            )
+            .leaf_function(
+                LeafFunctionSpec::builder()
+                    .func_unique_id("qualify_cristo")
+                    .leaf_kind(LeafKind::Qualification)
+                    .inputs(vec![LeafInputLocation::Domain])
+                    .build()
+                    .expect("build leaf func"),
+            )
+            .build()
+            .expect("build sv");
+
+        let sv_2 = SchemaVariantSpec::builder()
+            .name("v1")
+            .unique_id("monte_cristo_sv_1")
+            .data(
+                SchemaVariantSpecData::builder()
+                    .name("v0")
+                    .color("#ffff00")
+                    .func_unique_id("cristo_2")
+                    .build()
+                    .expect("build variant spec data"),
+            )
+            .domain_prop(
+                PropSpec::builder()
+                    .name("edmond_dantes")
+                    .kind(PropSpecKind::String)
+                    .build()
+                    .expect("build prop"),
+            )
+            .domain_prop(
+                PropSpec::builder()
+                    .name("mercedes")
+                    .kind(PropSpecKind::Object)
+                    .entry(
+                        PropSpec::builder()
+                            .name("dantes_beloved")
+                            .kind(PropSpecKind::Boolean)
+                            .build()
+                            .expect("build prop"),
+                    )
+                    .build()
+                    .expect("build prop"),
+            )
+            .build()
+            .expect("build sv");
+
+        let (merged_sv, skips) = sv_2.merge_prototypes_from(&sv_1);
+
+        assert_eq!(
+            &[
+                MergeSkip::PropMissing(PropSpec::make_path(
+                    &["root", "domain", "mercedes", "mother_of"],
+                    None
+                )),
+                MergeSkip::PropMissing(PropSpec::make_path(
+                    &[
+                        "root",
+                        "domain",
+                        "mercedes",
+                        "mother_of",
+                        "albert_de_morcef"
+                    ],
+                    None
+                ))
+            ],
+            skips.as_slice()
+        );
+
+        assert_eq!(2, merged_sv.action_funcs.len());
+        assert_eq!(1, merged_sv.leaf_functions.len());
+
+        let edmond_dantes_path = PropSpec::make_path(&["domain", "edmond_dantes"], None);
+
+        let dantes_prop_spec = merged_sv
+            .domain
+            .build_prop_spec_index_map()
+            .get(&edmond_dantes_path)
+            .expect("should exist in the map")
+            .0;
+
+        assert_eq!(Some("set_edmond_dantes"), dantes_prop_spec.func_unique_id());
+        assert_eq!(
+            Some(mercedes_dantes_beloved_path.as_str()),
+            dantes_prop_spec
+                .inputs()
+                .expect("has inputs")
+                .iter()
+                .next()
+                .expect("has an input")
+                .prop_path()
+        );
+
+        let mercedes_path_under_domain =
+            PropSpec::make_path(&["domain", "mercedes", "dantes_beloved"], None);
+        let beloved_spec = merged_sv
+            .domain
+            .build_prop_spec_index_map()
+            .get(&mercedes_path_under_domain)
+            .expect("should exist in the map")
+            .0;
+
+        assert_eq!(Some("set_dantes_beloved"), beloved_spec.func_unique_id());
+        assert_eq!(
+            Some(si_name_path.as_str()),
+            beloved_spec
+                .inputs()
+                .expect("has inputs")
+                .iter()
+                .next()
+                .expect("has an input")
+                .prop_path()
+        );
     }
 }

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -234,7 +234,8 @@ impl SchemaVariantSpec {
     pub fn merge_prototypes_from(&self, other_spec: &Self) -> (Self, Vec<MergeSkip>) {
         let mut schema_variant_builder = SchemaVariantSpec::builder();
         schema_variant_builder.name(&self.name);
-        schema_variant_builder.data = Some(self.data.to_owned());
+        schema_variant_builder.data = Some(self.data.clone());
+        schema_variant_builder.sockets = Some(self.sockets.clone());
 
         let self_input_sockets = self.input_sockets();
         let self_output_sockets = self.output_sockets();
@@ -303,7 +304,7 @@ impl SchemaVariantSpec {
                 .input_sockets()
                 .iter()
                 .filter_map(|input_socket| {
-                    if !self_input_sockets.contains(&input_socket) {
+                    if !self_input_sockets.contains(input_socket) {
                         Some(MergeSkip::InputSocketMissing {
                             socket_name: input_socket.to_owned(),
                         })
@@ -318,7 +319,7 @@ impl SchemaVariantSpec {
                 .output_sockets()
                 .iter()
                 .filter_map(|output_socket| {
-                    if !self_output_sockets.contains(&output_socket) {
+                    if !self_output_sockets.contains(output_socket) {
                         Some(MergeSkip::OutputSocketMissing {
                             socket_name: output_socket.to_owned(),
                         })

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -708,7 +708,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":num-traits-0.2.17"],
+    deps = [":num-traits-0.2.18"],
 )
 
 http_archive(
@@ -1141,8 +1141,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-bigint-0.4.4",
-        ":num-integer-0.1.45",
-        ":num-traits-0.2.17",
+        ":num-integer-0.1.46",
+        ":num-traits-0.2.18",
     ],
 )
 
@@ -1525,7 +1525,7 @@ cargo.rust_library(
     deps = [
         ":serde-1.0.196",
         ":serde_repr-0.1.18",
-        ":serde_with-3.6.0",
+        ":serde_with-3.6.1",
     ],
 )
 
@@ -1782,7 +1782,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":num-traits-0.2.17",
+        ":num-traits-0.2.18",
         ":serde-1.0.196",
     ],
 )
@@ -1863,23 +1863,23 @@ cargo.rust_library(
 
 alias(
     name = "clap",
-    actual = ":clap-4.4.18",
+    actual = ":clap-4.5.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.4.18.crate",
-    sha256 = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c",
-    strip_prefix = "clap-4.4.18",
-    urls = ["https://crates.io/api/v1/crates/clap/4.4.18/download"],
+    name = "clap-4.5.0.crate",
+    sha256 = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f",
+    strip_prefix = "clap-4.5.0",
+    urls = ["https://crates.io/api/v1/crates/clap/4.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.4.18",
-    srcs = [":clap-4.4.18.crate"],
+    name = "clap-4.5.0",
+    srcs = [":clap-4.5.0.crate"],
     crate = "clap",
-    crate_root = "clap-4.4.18.crate/src/lib.rs",
+    crate_root = "clap-4.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1895,24 +1895,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.4.18",
-        ":clap_derive-4.4.7",
+        ":clap_builder-4.5.0",
+        ":clap_derive-4.5.0",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.4.18.crate",
-    sha256 = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7",
-    strip_prefix = "clap_builder-4.4.18",
-    urls = ["https://crates.io/api/v1/crates/clap_builder/4.4.18/download"],
+    name = "clap_builder-4.5.0.crate",
+    sha256 = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99",
+    strip_prefix = "clap_builder-4.5.0",
+    urls = ["https://crates.io/api/v1/crates/clap_builder/4.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.4.18",
-    srcs = [":clap_builder-4.4.18.crate"],
+    name = "clap_builder-4.5.0",
+    srcs = [":clap_builder-4.5.0.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.4.18.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1928,25 +1928,25 @@ cargo.rust_library(
     deps = [
         ":anstream-0.6.11",
         ":anstyle-1.0.6",
-        ":clap_lex-0.6.0",
-        ":strsim-0.10.0",
+        ":clap_lex-0.7.0",
+        ":strsim-0.11.0",
         ":terminal_size-0.3.0",
     ],
 )
 
 http_archive(
-    name = "clap_derive-4.4.7.crate",
-    sha256 = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442",
-    strip_prefix = "clap_derive-4.4.7",
-    urls = ["https://crates.io/api/v1/crates/clap_derive/4.4.7/download"],
+    name = "clap_derive-4.5.0.crate",
+    sha256 = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47",
+    strip_prefix = "clap_derive-4.5.0",
+    urls = ["https://crates.io/api/v1/crates/clap_derive/4.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_derive-4.4.7",
-    srcs = [":clap_derive-4.4.7.crate"],
+    name = "clap_derive-4.5.0",
+    srcs = [":clap_derive-4.5.0.crate"],
     crate = "clap_derive",
-    crate_root = "clap_derive-4.4.7.crate/src/lib.rs",
+    crate_root = "clap_derive-4.5.0.crate/src/lib.rs",
     edition = "2021",
     features = ["default"],
     proc_macro = True,
@@ -1960,35 +1960,35 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "clap_lex-0.6.0.crate",
-    sha256 = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1",
-    strip_prefix = "clap_lex-0.6.0",
-    urls = ["https://crates.io/api/v1/crates/clap_lex/0.6.0/download"],
+    name = "clap_lex-0.7.0.crate",
+    sha256 = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce",
+    strip_prefix = "clap_lex-0.7.0",
+    urls = ["https://crates.io/api/v1/crates/clap_lex/0.7.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_lex-0.6.0",
-    srcs = [":clap_lex-0.6.0.crate"],
+    name = "clap_lex-0.7.0",
+    srcs = [":clap_lex-0.7.0.crate"],
     crate = "clap_lex",
-    crate_root = "clap_lex-0.6.0.crate/src/lib.rs",
+    crate_root = "clap_lex-0.7.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
 
 http_archive(
-    name = "coarsetime-0.1.33.crate",
-    sha256 = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a",
-    strip_prefix = "coarsetime-0.1.33",
-    urls = ["https://crates.io/api/v1/crates/coarsetime/0.1.33/download"],
+    name = "coarsetime-0.1.34.crate",
+    sha256 = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d",
+    strip_prefix = "coarsetime-0.1.34",
+    urls = ["https://crates.io/api/v1/crates/coarsetime/0.1.34/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "coarsetime-0.1.33",
-    srcs = [":coarsetime-0.1.33.crate"],
+    name = "coarsetime-0.1.34",
+    srcs = [":coarsetime-0.1.34.crate"],
     crate = "coarsetime",
-    crate_root = "coarsetime-0.1.33.crate/src/lib.rs",
+    crate_root = "coarsetime-0.1.34.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "linux-arm64": dict(
@@ -2011,7 +2011,6 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":once_cell-1.19.0"],
 )
 
 alias(
@@ -2477,7 +2476,7 @@ cargo.rust_library(
     crate_root = "convert_case-0.6.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":unicode-segmentation-1.10.1"],
+    deps = [":unicode-segmentation-1.11.0"],
 )
 
 http_archive(
@@ -2999,18 +2998,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "curve25519-dalek-4.1.1.crate",
-    sha256 = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c",
-    strip_prefix = "curve25519-dalek-4.1.1",
-    urls = ["https://crates.io/api/v1/crates/curve25519-dalek/4.1.1/download"],
+    name = "curve25519-dalek-4.1.2.crate",
+    sha256 = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348",
+    strip_prefix = "curve25519-dalek-4.1.2",
+    urls = ["https://crates.io/api/v1/crates/curve25519-dalek/4.1.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "curve25519-dalek-4.1.1",
-    srcs = [":curve25519-dalek-4.1.1.crate"],
+    name = "curve25519-dalek-4.1.2",
+    srcs = [":curve25519-dalek-4.1.2.crate"],
     crate = "curve25519_dalek",
-    crate_root = "curve25519-dalek-4.1.1.crate/src/lib.rs",
+    crate_root = "curve25519-dalek-4.1.2.crate/src/lib.rs",
     edition = "2021",
     features = ["digest"],
     platform = {
@@ -3039,7 +3038,7 @@ cargo.rust_library(
             ],
         ),
     },
-    rustc_flags = ["@$(location :curve25519-dalek-4.1.1-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :curve25519-dalek-4.1.2-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
@@ -3049,10 +3048,10 @@ cargo.rust_library(
 )
 
 cargo.rust_binary(
-    name = "curve25519-dalek-4.1.1-build-script-build",
-    srcs = [":curve25519-dalek-4.1.1.crate"],
+    name = "curve25519-dalek-4.1.2-build-script-build",
+    srcs = [":curve25519-dalek-4.1.2.crate"],
     crate = "build_script_build",
-    crate_root = "curve25519-dalek-4.1.1.crate/build.rs",
+    crate_root = "curve25519-dalek-4.1.2.crate/build.rs",
     edition = "2021",
     features = ["digest"],
     visibility = [],
@@ -3063,11 +3062,11 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "curve25519-dalek-4.1.1-build-script-run",
+    name = "curve25519-dalek-4.1.2-build-script-run",
     package_name = "curve25519-dalek",
-    buildscript_rule = ":curve25519-dalek-4.1.1-build-script-build",
+    buildscript_rule = ":curve25519-dalek-4.1.2-build-script-build",
     features = ["digest"],
-    version = "4.1.1",
+    version = "4.1.2",
 )
 
 http_archive(
@@ -3946,18 +3945,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ed25519-dalek-2.1.0.crate",
-    sha256 = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0",
-    strip_prefix = "ed25519-dalek-2.1.0",
-    urls = ["https://crates.io/api/v1/crates/ed25519-dalek/2.1.0/download"],
+    name = "ed25519-dalek-2.1.1.crate",
+    sha256 = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871",
+    strip_prefix = "ed25519-dalek-2.1.1",
+    urls = ["https://crates.io/api/v1/crates/ed25519-dalek/2.1.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ed25519-dalek-2.1.0",
-    srcs = [":ed25519-dalek-2.1.0.crate"],
+    name = "ed25519-dalek-2.1.1",
+    srcs = [":ed25519-dalek-2.1.1.crate"],
     crate = "ed25519_dalek",
-    crate_root = "ed25519-dalek-2.1.0.crate/src/lib.rs",
+    crate_root = "ed25519-dalek-2.1.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "digest",
@@ -3965,7 +3964,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":curve25519-dalek-4.1.1",
+        ":curve25519-dalek-4.1.2",
         ":ed25519-2.2.3",
         ":sha2-0.10.8",
         ":signature-2.2.0",
@@ -4130,7 +4129,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-bigint-0.4.4",
-        ":num-traits-0.2.17",
+        ":num-traits-0.2.18",
         ":proc-macro2-1.0.78",
         ":quote-1.0.35",
         ":syn-2.0.48",
@@ -5229,7 +5228,7 @@ cargo.rust_library(
         "unicode-segmentation",
     ],
     visibility = [],
-    deps = [":unicode-segmentation-1.10.1"],
+    deps = [":unicode-segmentation-1.11.0"],
 )
 
 alias(
@@ -5834,6 +5833,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "indexmap",
+    actual = ":indexmap-2.2.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "indexmap-2.2.2.crate",
     sha256 = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520",
@@ -5975,7 +5980,7 @@ cargo.rust_library(
         ":lazy_static-1.4.0",
         ":newline-converter-0.2.2",
         ":thiserror-1.0.56",
-        ":unicode-segmentation-1.10.1",
+        ":unicode-segmentation-1.11.0",
         ":unicode-width-0.1.11",
     ],
 )
@@ -6107,23 +6112,23 @@ cargo.rust_library(
 
 alias(
     name = "jwt-simple",
-    actual = ":jwt-simple-0.12.7",
+    actual = ":jwt-simple-0.12.8",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "jwt-simple-0.12.7.crate",
-    sha256 = "89159de5f0e8a07eb345e6a9ee6cfd1195585eb0f43ee1face42c0dc4968f0f9",
-    strip_prefix = "jwt-simple-0.12.7",
-    urls = ["https://crates.io/api/v1/crates/jwt-simple/0.12.7/download"],
+    name = "jwt-simple-0.12.8.crate",
+    sha256 = "bc9355eabbe26435645b794e0f351150b9a35d03539f1e28742b3642b5587628",
+    strip_prefix = "jwt-simple-0.12.8",
+    urls = ["https://crates.io/api/v1/crates/jwt-simple/0.12.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "jwt-simple-0.12.7",
-    srcs = [":jwt-simple-0.12.7.crate"],
+    name = "jwt-simple-0.12.8",
+    srcs = [":jwt-simple-0.12.8.crate"],
     crate = "jwt_simple",
-    crate_root = "jwt-simple-0.12.7.crate/src/lib.rs",
+    crate_root = "jwt-simple-0.12.8.crate/src/lib.rs",
     edition = "2018",
     features = [
         "pure-rust",
@@ -6154,7 +6159,7 @@ cargo.rust_library(
         ":anyhow-1.0.79",
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
-        ":coarsetime-0.1.33",
+        ":coarsetime-0.1.34",
         ":ct-codecs-1.1.1",
         ":ed25519-compact-2.1.1",
         ":hmac-sha1-compact-1.1.4",
@@ -7311,7 +7316,7 @@ cargo.rust_library(
     crate_root = "newline-converter-0.2.2.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":unicode-segmentation-1.10.1"],
+    deps = [":unicode-segmentation-1.11.0"],
 )
 
 http_archive(
@@ -7447,7 +7452,7 @@ cargo.rust_library(
         ":byteorder-1.5.0",
         ":data-encoding-2.5.0",
         ":ed25519-2.2.3",
-        ":ed25519-dalek-2.1.0",
+        ":ed25519-dalek-2.1.1",
         ":log-0.4.20",
         ":rand-0.8.5",
         ":signatory-0.27.1",
@@ -7479,7 +7484,7 @@ cargo.rust_library(
         ":byteorder-1.5.0",
         ":data-encoding-2.5.0",
         ":ed25519-2.2.3",
-        ":ed25519-dalek-2.1.0",
+        ":ed25519-dalek-2.1.1",
         ":log-0.4.20",
         ":rand-0.8.5",
         ":signatory-0.27.1",
@@ -7580,8 +7585,8 @@ cargo.rust_library(
     rustc_flags = ["@$(location :num-bigint-0.4.4-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
-        ":num-integer-0.1.45",
-        ":num-traits-0.2.17",
+        ":num-integer-0.1.46",
+        ":num-traits-0.2.18",
     ],
 )
 
@@ -7637,9 +7642,9 @@ cargo.rust_library(
         ":byteorder-1.5.0",
         ":lazy_static-1.4.0",
         ":libm-0.2.8",
-        ":num-integer-0.1.45",
-        ":num-iter-0.1.43",
-        ":num-traits-0.2.17",
+        ":num-integer-0.1.46",
+        ":num-iter-0.1.44",
+        ":num-traits-0.2.18",
         ":rand-0.8.5",
         ":smallvec-1.13.1",
         ":zeroize-1.7.0",
@@ -7694,108 +7699,62 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "num-integer-0.1.45.crate",
-    sha256 = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
-    strip_prefix = "num-integer-0.1.45",
-    urls = ["https://crates.io/api/v1/crates/num-integer/0.1.45/download"],
+    name = "num-integer-0.1.46.crate",
+    sha256 = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
+    strip_prefix = "num-integer-0.1.46",
+    urls = ["https://crates.io/api/v1/crates/num-integer/0.1.46/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "num-integer-0.1.45",
-    srcs = [":num-integer-0.1.45.crate"],
+    name = "num-integer-0.1.46",
+    srcs = [":num-integer-0.1.46.crate"],
     crate = "num_integer",
-    crate_root = "num-integer-0.1.45.crate/src/lib.rs",
-    edition = "2015",
-    features = [
-        "default",
-        "i128",
-        "std",
-    ],
-    rustc_flags = ["@$(location :num-integer-0.1.45-build-script-run[rustc_flags])"],
-    visibility = [],
-    deps = [":num-traits-0.2.17"],
-)
-
-cargo.rust_binary(
-    name = "num-integer-0.1.45-build-script-build",
-    srcs = [":num-integer-0.1.45.crate"],
-    crate = "build_script_build",
-    crate_root = "num-integer-0.1.45.crate/build.rs",
-    edition = "2015",
+    crate_root = "num-integer-0.1.46.crate/src/lib.rs",
+    edition = "2018",
     features = [
         "default",
         "i128",
         "std",
     ],
     visibility = [],
-    deps = [":autocfg-1.1.0"],
-)
-
-buildscript_run(
-    name = "num-integer-0.1.45-build-script-run",
-    package_name = "num-integer",
-    buildscript_rule = ":num-integer-0.1.45-build-script-build",
-    features = [
-        "default",
-        "i128",
-        "std",
-    ],
-    version = "0.1.45",
+    deps = [":num-traits-0.2.18"],
 )
 
 http_archive(
-    name = "num-iter-0.1.43.crate",
-    sha256 = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
-    strip_prefix = "num-iter-0.1.43",
-    urls = ["https://crates.io/api/v1/crates/num-iter/0.1.43/download"],
+    name = "num-iter-0.1.44.crate",
+    sha256 = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9",
+    strip_prefix = "num-iter-0.1.44",
+    urls = ["https://crates.io/api/v1/crates/num-iter/0.1.44/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "num-iter-0.1.43",
-    srcs = [":num-iter-0.1.43.crate"],
+    name = "num-iter-0.1.44",
+    srcs = [":num-iter-0.1.44.crate"],
     crate = "num_iter",
-    crate_root = "num-iter-0.1.43.crate/src/lib.rs",
-    edition = "2015",
-    rustc_flags = ["@$(location :num-iter-0.1.43-build-script-run[rustc_flags])"],
+    crate_root = "num-iter-0.1.44.crate/src/lib.rs",
+    edition = "2018",
     visibility = [],
     deps = [
-        ":num-integer-0.1.45",
-        ":num-traits-0.2.17",
+        ":num-integer-0.1.46",
+        ":num-traits-0.2.18",
     ],
 )
 
-cargo.rust_binary(
-    name = "num-iter-0.1.43-build-script-build",
-    srcs = [":num-iter-0.1.43.crate"],
-    crate = "build_script_build",
-    crate_root = "num-iter-0.1.43.crate/build.rs",
-    edition = "2015",
-    visibility = [],
-    deps = [":autocfg-1.1.0"],
-)
-
-buildscript_run(
-    name = "num-iter-0.1.43-build-script-run",
-    package_name = "num-iter",
-    buildscript_rule = ":num-iter-0.1.43-build-script-build",
-    version = "0.1.43",
-)
-
 http_archive(
-    name = "num-traits-0.2.17.crate",
-    sha256 = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c",
-    strip_prefix = "num-traits-0.2.17",
-    urls = ["https://crates.io/api/v1/crates/num-traits/0.2.17/download"],
+    name = "num-traits-0.2.18.crate",
+    sha256 = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a",
+    strip_prefix = "num-traits-0.2.18",
+    urls = ["https://crates.io/api/v1/crates/num-traits/0.2.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "num-traits-0.2.17",
-    srcs = [":num-traits-0.2.17.crate"],
+    name = "num-traits-0.2.18",
+    srcs = [":num-traits-0.2.18.crate"],
     crate = "num_traits",
-    crate_root = "num-traits-0.2.17.crate/src/lib.rs",
+    crate_root = "num-traits-0.2.18.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -7803,16 +7762,16 @@ cargo.rust_library(
         "libm",
         "std",
     ],
-    rustc_flags = ["@$(location :num-traits-0.2.17-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :num-traits-0.2.18-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":libm-0.2.8"],
 )
 
 cargo.rust_binary(
-    name = "num-traits-0.2.17-build-script-build",
-    srcs = [":num-traits-0.2.17.crate"],
+    name = "num-traits-0.2.18-build-script-build",
+    srcs = [":num-traits-0.2.18.crate"],
     crate = "build_script_build",
-    crate_root = "num-traits-0.2.17.crate/build.rs",
+    crate_root = "num-traits-0.2.18.crate/build.rs",
     edition = "2018",
     features = [
         "default",
@@ -7825,16 +7784,16 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "num-traits-0.2.17-build-script-run",
+    name = "num-traits-0.2.18-build-script-run",
     package_name = "num-traits",
-    buildscript_rule = ":num-traits-0.2.17-build-script-build",
+    buildscript_rule = ":num-traits-0.2.18-build-script-build",
     features = [
         "default",
         "i128",
         "libm",
         "std",
     ],
-    version = "0.2.17",
+    version = "0.2.18",
 )
 
 alias(
@@ -8266,7 +8225,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":num-traits-0.2.17"],
+    deps = [":num-traits-0.2.18"],
 )
 
 http_archive(
@@ -8284,7 +8243,7 @@ cargo.rust_library(
     crate_root = "ordered-float-3.9.2.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":num-traits-0.2.17"],
+    deps = [":num-traits-0.2.18"],
 )
 
 http_archive(
@@ -8306,7 +8265,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":num-traits-0.2.17"],
+    deps = [":num-traits-0.2.18"],
 )
 
 http_archive(
@@ -11090,8 +11049,8 @@ cargo.rust_library(
     deps = [
         ":const-oid-0.9.6",
         ":digest-0.10.7",
-        ":num-integer-0.1.45",
-        ":num-traits-0.2.17",
+        ":num-integer-0.1.46",
+        ":num-traits-0.2.18",
         ":pkcs1-0.7.5",
         ":pkcs8-0.10.2",
         ":rand_core-0.6.4",
@@ -11209,7 +11168,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":arrayvec-0.7.4",
-        ":num-traits-0.2.17",
+        ":num-traits-0.2.18",
         ":serde-1.0.196",
     ],
 )
@@ -12410,23 +12369,23 @@ cargo.rust_library(
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.6.0",
+    actual = ":serde_with-3.6.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.6.0.crate",
-    sha256 = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981",
-    strip_prefix = "serde_with-3.6.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with/3.6.0/download"],
+    name = "serde_with-3.6.1.crate",
+    sha256 = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270",
+    strip_prefix = "serde_with-3.6.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with/3.6.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.6.0",
-    srcs = [":serde_with-3.6.0.crate"],
+    name = "serde_with-3.6.1",
+    srcs = [":serde_with-3.6.1.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.6.0.crate/src/lib.rs",
+    crate_root = "serde_with-3.6.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12445,8 +12404,9 @@ cargo.rust_library(
         ":base64-0.21.7",
         ":hex-0.4.3",
         ":serde-1.0.196",
+        ":serde_derive-1.0.196",
         ":serde_json-1.0.113",
-        ":serde_with_macros-3.6.0",
+        ":serde_with_macros-3.6.1",
     ],
 )
 
@@ -12475,18 +12435,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "serde_with_macros-3.6.0.crate",
-    sha256 = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15",
-    strip_prefix = "serde_with_macros-3.6.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.6.0/download"],
+    name = "serde_with_macros-3.6.1.crate",
+    sha256 = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d",
+    strip_prefix = "serde_with_macros-3.6.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.6.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.6.0",
-    srcs = [":serde_with_macros-3.6.0.crate"],
+    name = "serde_with_macros-3.6.1",
+    srcs = [":serde_with_macros-3.6.1.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.6.0.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.6.1.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
@@ -13348,6 +13308,23 @@ cargo.rust_library(
     visibility = [],
 )
 
+http_archive(
+    name = "strsim-0.11.0.crate",
+    sha256 = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01",
+    strip_prefix = "strsim-0.11.0",
+    urls = ["https://crates.io/api/v1/crates/strsim/0.11.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "strsim-0.11.0",
+    srcs = [":strsim-0.11.0.crate"],
+    crate = "strsim",
+    crate_root = "strsim-0.11.0.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+)
+
 alias(
     name = "strum",
     actual = ":strum-0.25.0",
@@ -13820,7 +13797,7 @@ cargo.rust_binary(
         ":bytes-1.5.0",
         ":chrono-0.4.33",
         ":ciborium-0.2.2",
-        ":clap-4.4.18",
+        ":clap-4.5.0",
         ":color-eyre-0.6.2",
         ":colored-2.1.0",
         ":comfy-table-7.1.0",
@@ -13844,11 +13821,12 @@ cargo.rust_binary(
         ":hyper-0.14.28",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.4",
+        ":indexmap-2.2.2",
         ":indicatif-0.17.7",
         ":indoc-2.0.4",
         ":inquire-0.6.2",
         ":itertools-0.12.1",
-        ":jwt-simple-0.12.7",
+        ":jwt-simple-0.12.8",
         ":lazy_static-1.4.0",
         ":names-0.14.0",
         ":nix-0.27.1",
@@ -13885,7 +13863,7 @@ cargo.rust_binary(
         ":serde-aux-4.4.0",
         ":serde_json-1.0.113",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.6.0",
+        ":serde_with-3.6.1",
         ":serde_yaml-0.9.31",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
@@ -14729,7 +14707,7 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":toml_edit-0.22.2",
+        ":toml_edit-0.22.4",
     ],
 )
 
@@ -14776,23 +14754,23 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.37",
+        ":winnow-0.5.39",
     ],
 )
 
 http_archive(
-    name = "toml_edit-0.22.2.crate",
-    sha256 = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704",
-    strip_prefix = "toml_edit-0.22.2",
-    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.2/download"],
+    name = "toml_edit-0.22.4.crate",
+    sha256 = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951",
+    strip_prefix = "toml_edit-0.22.4",
+    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.22.2",
-    srcs = [":toml_edit-0.22.2.crate"],
+    name = "toml_edit-0.22.4",
+    srcs = [":toml_edit-0.22.4.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.22.2.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "display",
@@ -14805,7 +14783,7 @@ cargo.rust_library(
         ":serde-1.0.196",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.5.37",
+        ":winnow-0.5.39",
     ],
 )
 
@@ -15502,18 +15480,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "unicode-segmentation-1.10.1.crate",
-    sha256 = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
-    strip_prefix = "unicode-segmentation-1.10.1",
-    urls = ["https://crates.io/api/v1/crates/unicode-segmentation/1.10.1/download"],
+    name = "unicode-segmentation-1.11.0.crate",
+    sha256 = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202",
+    strip_prefix = "unicode-segmentation-1.11.0",
+    urls = ["https://crates.io/api/v1/crates/unicode-segmentation/1.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "unicode-segmentation-1.10.1",
-    srcs = [":unicode-segmentation-1.10.1.crate"],
+    name = "unicode-segmentation-1.11.0",
+    srcs = [":unicode-segmentation-1.11.0.crate"],
     crate = "unicode_segmentation",
-    crate_root = "unicode-segmentation-1.10.1.crate/src/lib.rs",
+    crate_root = "unicode-segmentation-1.11.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -16325,18 +16303,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.5.37.crate",
-    sha256 = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5",
-    strip_prefix = "winnow-0.5.37",
-    urls = ["https://crates.io/api/v1/crates/winnow/0.5.37/download"],
+    name = "winnow-0.5.39.crate",
+    sha256 = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29",
+    strip_prefix = "winnow-0.5.39",
+    urls = ["https://crates.io/api/v1/crates/winnow/0.5.39/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.5.37",
-    srcs = [":winnow-0.5.37.crate"],
+    name = "winnow-0.5.39",
+    srcs = [":winnow-0.5.39.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.5.37.crate/src/lib.rs",
+    crate_root = "winnow-0.5.39.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
 ]
 
 [[package]]
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -744,22 +744,22 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -769,19 +769,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
+checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
 dependencies = [
  "libc",
- "once_cell",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasix",
  "wasm-bindgen",
 ]
 
@@ -1129,9 +1128,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1184,7 +1183,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1198,7 +1197,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -1490,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519 2.2.3",
@@ -2365,18 +2364,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jwt-simple"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89159de5f0e8a07eb345e6a9ee6cfd1195585eb0f43ee1face42c0dc4968f0f9"
+checksum = "bc9355eabbe26435645b794e0f351150b9a35d03539f1e28742b3642b5587628"
 dependencies = [
  "anyhow",
  "binstring",
@@ -2755,19 +2754,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2776,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -4275,9 +4273,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -4285,8 +4283,9 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.0",
+ "serde_with_macros 3.6.1",
  "time",
 ]
 
@@ -4304,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling 0.20.5",
  "proc-macro2",
@@ -4776,6 +4775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4984,6 +4989,7 @@ dependencies = [
  "hyper",
  "hyperlocal",
  "iftree",
+ "indexmap 2.2.2",
  "indicatif",
  "indoc",
  "inquire",
@@ -5025,7 +5031,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_url_params",
- "serde_with 3.6.0",
+ "serde_with 3.6.1",
  "serde_yaml",
  "sodiumoxide",
  "stream-cancel",
@@ -5367,7 +5373,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.2",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -5405,9 +5411,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fdc42b34281459f8223cd861512dcdc19bd272fcc73308d7235ff615b76704"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -5676,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -5834,10 +5840,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.90"
+name = "wasix"
+version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+dependencies = [
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5845,9 +5860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -5860,9 +5875,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5872,9 +5887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5882,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5895,15 +5910,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6119,9 +6134,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -22,7 +22,11 @@ path = "top/main.rs"
 async-nats = { version = "0.33.0", features = ["service"] }
 async-recursion = "1.0.4"
 async-trait = "0.1.68"
-axum = { version = "0.6.18", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
+axum = { version = "0.6.18", features = [
+    "macros",
+    "multipart",
+    "ws",
+] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
 base64 = "0.21.0"
 blake3 = "1.3.3"
 bollard = "0.15.0"
@@ -32,7 +36,11 @@ ciborium = "0.2.1"
 clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.2"
 colored = "2.0.4"
-comfy-table = { version = "7.0.1", features = ["crossterm", "tty", "custom_styling"] }
+comfy-table = { version = "7.0.1", features = [
+    "crossterm",
+    "tty",
+    "custom_styling",
+] }
 config = { version = "0.13.4", default-features = false, features = ["toml"] }
 console = "0.15.7"
 convert_case = "0.6.0"
@@ -50,14 +58,24 @@ futures = "0.3.28"
 futures-lite = "2.1.0"
 hex = "0.4.3"
 http = "0.2.9" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
-hyper = { version = "0.14.26", features = ["client", "http1", "runtime", "server"] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
-hyperlocal = { version = "0.8.0", default-features = false, features = ["client"] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
+hyper = { version = "0.14.26", features = [
+    "client",
+    "http1",
+    "runtime",
+    "server",
+] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
+hyperlocal = { version = "0.8.0", default-features = false, features = [
+    "client",
+] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.4"
 indicatif = "0.17.5"
+indexmap = "2.2.2"
 indoc = "2.0.1"
 inquire = "0.6.2"
 itertools = "0.12.0"
-jwt-simple = { version = "0.12.6", default-features = false, features = ["pure-rust"] }
+jwt-simple = { version = "0.12.6", default-features = false, features = [
+    "pure-rust",
+] }
 lazy_static = "1.4.0"
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }
@@ -83,12 +101,24 @@ rand = "0.8.5"
 refinery = { version = "0.8.9", features = ["tokio-postgres"] }
 regex = "1.8.1"
 remain = "0.2.8"
-reqwest = { version = "0.11.17", default-features = false, features = ["rustls-tls", "json", "multipart"] }
+reqwest = { version = "0.11.17", default-features = false, features = [
+    "rustls-tls",
+    "json",
+    "multipart",
+] }
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
 rustls = { version = "0.22.2" }
 rustls-pemfile = { version = "2.0.0" }
-rust-s3 = { version = "0.34.0-rc4", default-features = false, features = ["tokio-rustls-tls"] }
-sea-orm = { version = "0.12.0", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "debug-print"] }
+rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
+    "tokio-rustls-tls",
+] }
+sea-orm = { version = "0.12.0", features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+    "macros",
+    "with-chrono",
+    "debug-print",
+] }
 self-replace = "1.3.7"
 serde = { version = "1.0.160", features = ["derive", "rc"] }
 serde-aux = "4.2.0"
@@ -102,10 +132,16 @@ strum = { version = "0.25.0", features = ["derive"] }
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 tar = "0.4.38"
 tempfile = "3.5.0"
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+test-log = { version = "0.2.11", default-features = false, features = [
+    "trace",
+] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.0", features = ["full"] }
-tokio-postgres = { version = "0.7.8", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7.8", features = [
+    "runtime",
+    "with-chrono-0_4",
+    "with-serde_json-1",
+] }
 tokio-postgres-rustls = { version = "0.11.0" }
 tokio-serde = { version = "0.8.0", features = ["json"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
@@ -115,10 +151,20 @@ tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
 toml = { version = "0.8.8" }
 tower = "0.4.13"
-tower-http = { version = "0.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
+tower-http = { version = "0.4", features = [
+    "compression-br",
+    "compression-deflate",
+    "compression-gzip",
+    "cors",
+    "trace",
+] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.22.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
+tracing-subscriber = { version = "0.3.18", features = [
+    "env-filter",
+    "json",
+    "std",
+] }
 ulid = { version = "1.0.0", features = ["serde"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.2", features = ["serde", "v4"] }


### PR DESCRIPTION
Instead of deleting the old schema variant and creating a new one, then attempting to migrate components, we just create a new schema variant on exec_variant_def and mark it as the default variant. Existing components are unchanged.

Component upgrades are coming next.

This is controlled by the "multiVariantEditing" flag, which is not yet in posthog (but can be easily turned on in the feature flags store).
