### PR TITLE
fix(si-pkg): ensure we always export invariant intrinsics

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -356,6 +356,10 @@ where
         Self(change_set_map)
     }
 
+    pub fn get_change_set_map(&self, change_set_pk: ChangeSetPk) -> Option<&HashMap<Key, Thing>> {
+        self.0.get(&change_set_pk)
+    }
+
     pub fn get(&self, change_set_pk: ChangeSetPk, key: &Key) -> Option<&Thing> {
         match self.0.get(&change_set_pk) {
             Some(change_set_map) => change_set_map.get(key).or_else(|| {

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -103,7 +103,7 @@ pub async fn exec_variant_def(
         }
 
         async fn handle_error(ctx: &DalContext, id: Ulid, err: String) {
-            error!("Unable to export workspace: {err}");
+            error!("Unable to exec variant def: {err}");
             match WsEvent::async_error(ctx, id, err).await {
                 Ok(event) => match event.publish_on_commit(ctx).await {
                     Ok(()) => {}


### PR DESCRIPTION
Some logic errors in recent changes to the import code cause us to export "intrinsic" funcs with different unique ids. Intrinsics should be considered immutable, and should only exist on head. This fixes one part of the problem by ensuring we only ever export the intrinsic as defined in the IntrinsicFuncs module.