### PR TITLE
feat/add e2e synthetic workflow for Production

### DIFF
--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -1,0 +1,52 @@
+name: Cypress E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '*/15 * * * *'  # Runs every 15 minutes
+
+jobs:
+  cypress-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.18.2'
+
+      - name: Setup authentication for vite & other synthetic test variables
+        working-directory: app/web
+        run: |
+          cp .env .env.local
+          echo "VITE_AUTH0_USERNAME=${{ secrets.VITE_AUTH0_USERNAME }}" >> .env.local                           # Production Synthetic User Email
+          echo "VITE_AUTH0_PASSWORD=${{ secrets.VITE_AUTH0_PASSWORD }}" >> .env.local                           # Production Synthetic User Password
+          echo "VITE_SI_WORKSPACE_URL=${{ vars.VITE_PROD_SI_WORKSPACE_URL }}" >> .env.local                     # Production Synthetic Workspace URL
+          echo "VITE_SI_WORKSPACE_ID=${{ vars.VITE_PROD_SI_WORKSPACE_ID }}" >> .env.local                       # Production Synthetic Workspace ID
+          echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
+          echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+            version: 8.10.5
+
+      - name: Run Cypress tests
+        working-directory: app/web
+        run: |
+          pnpm i
+          pnpm install cypress
+          npx cypress run --spec "cypress/e2e/4-value-propogation/value-attribute-propogation.cy.ts" --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      # TODO(johnrwatson): Enable this when we're happy with the synthetic above
+      #- name: Send PagerDuty alert on failure
+      #  if: ${{ failure() }}
+      #  uses: Entle/action-pagerduty-alert@0.2.0
+      #  with:
+      #    pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+      #    pagerduty-dedup-key: github_workflow_failed

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -1,6 +1,7 @@
 name: Cypress E2E Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/app/web/.env
+++ b/app/web/.env
@@ -9,9 +9,15 @@ VITE_AUTH_API_URL=https://auth-api.systeminit.com
 VITE_AUTH_PORTAL_URL=https://auth.systeminit.com
 VITE_AUTH0_DOMAIN=systeminit.auth0.com
 
-# Add to env.local for Cypress E2E Testing
+# Add to env.local for Cypress E2E Testing, pull out of 1 Password for the Production Synthetic Ones
 #VITE_AUTH0_USERNAME
 #VITE_AUTH0_PASSWORD
+
+# Remote Executing / E2E Specifities for Testing Production, local simply change the values to something like http://locahost:8080 & the relevant component IDs
+# VITE_SI_WORKSPACE_URL = https://app.systeminit.com/            # Production URL
+# VITE_SI_WORKSPACE_ID = 01HPMKZZ0DF54B12FNBF6Z7704              # Production Workspace URL Used for Synthetics
+# VITE_SI_PROPAGATION_COMPONENT_A = c_01HPMM4A95M2E3V6STMZZCZJRZ # Production: Used for E2E Value Propagation Test [output socket i.e. from]
+# VITE_SI_PROPAGATION_COMPONENT_B = c_01HPMM4BC682PFCYD7GE3X3AQW # Production: Used for E2E Value Propagation Test [input socket i.e. to]
 
 # TODO: point this at public/deployed module index api
 VITE_MODULE_INDEX_API_URL=https://module-index.systeminit.com

--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -2,8 +2,6 @@ import path from 'path'
 import { defineConfig } from 'cypress'
 import vitePreprocessor from 'cypress-vite'
 
-
-
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
@@ -14,6 +12,8 @@ export default defineConfig({
     chromeWebSecurity: false,
     viewportHeight: 1000,
     viewportWidth: 1500,
-  }
+  },
+  projectId: "k8tgfj",
+  video: true
 })
 

--- a/app/web/cypress/e2e/4-value-propogation/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/4-value-propogation/value-attribute-propogation.cy.ts
@@ -1,0 +1,74 @@
+// @ts-check
+///<reference path="../global.d.ts"/>
+
+describe('Value Propogation', () => {
+  beforeEach(function () {
+    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+  });
+
+  it('change value on component A and check it propogates to component B', () => {
+
+    // Go to the Synthetic Workspace
+    cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')
+
+    // Check UI has prompted for Create Change Set, this sometimes doesn't happen
+    // I have no idea why but it breaks the test [johnrwatson]
+    cy.contains('Create change set', { timeout: 10000 }).should('be.visible');
+
+    cy.url().then(currentUrl => {
+      // Construct a new URL with desired query parameters for selecting 
+      // the attribute panel for a known component
+      let newUrl = new URL(currentUrl);
+      newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_A);
+      newUrl.searchParams.set('t', 'attributes');
+    
+      // Visit the new URL
+      cy.visit(newUrl.href);
+    });
+
+    // Give the page a few seconds to load
+    cy.wait(2000);
+
+    // Generate a random number between 1 and 100 to insert into the 
+    // attribute value for Integer
+    const randomNumber = Math.floor(Math.random() * 100) + 1;
+
+    // Find the attribute for the Integer Input
+    cy.get('.attributes-panel-item__input-wrap input[type="number"]')
+    .clear()
+    .type(randomNumber.toString() + '{enter}') // type the new value
+
+    // This will have auto-directed us onto a changeset, give it a few seconds
+    // to load up
+    cy.wait(3000)
+
+    cy.url().then(currentUrl => {
+      // Construct a new URL with desired query parameters for selecting 
+      // the attribute panel for a known connected component
+      let newUrl = new URL(currentUrl);
+      newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_B);
+      newUrl.searchParams.set('t', 'attributes');
+      cy.visit(newUrl.href);
+    });
+
+    // Wait for the values to propagate
+    cy.wait(10000);
+
+    // Validate that the value has propogated through the system
+    cy.get('.attributes-panel-item__input-wrap input[type="number"]')
+    .should('have.value', randomNumber.toString());
+
+    // Click the button to destroy changeset
+    cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
+    .eq(1) // Selects the second button (index starts from 0 for create changeset button)
+    .click();
+
+    // Wait for the delete panel to appear
+    cy.wait(1000);
+
+    // Then click the agree button in the UI
+    cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
+    .click();
+
+  })
+})

--- a/app/web/cypress/support/auth-provider-commands/auth0.ts
+++ b/app/web/cypress/support/auth-provider-commands/auth0.ts
@@ -16,31 +16,28 @@ Cypress.Commands.add("loginToAuth0", (username: string, password: string) => {
   cy.session(
     `auth0-${username}`,
     () => {
+
       // App landing page redirects to Auth0.
       cy.visit("/");
+      cy.log('At homepage')
+
       cy.url().should("contain", import.meta.env.VITE_AUTH0_DOMAIN);
+
+      cy.visit("/");
+
       // Login on Auth0.
       cy.origin(import.meta.env.VITE_AUTH0_DOMAIN, { args }, ({ username, password }) => {
         cy.get("input#username").type(username);
         cy.contains('Continue').click();
         cy.get("input#password").type(password).type('{enter}');
-
       });
 
       // Ensure Auth0 has redirected us back to the auth portal.
       cy.url().should("contain", import.meta.env.VITE_AUTH_PORTAL_URL);
 
-      // click the link to go back to the local app
-      cy.origin(import.meta.env.VITE_AUTH_PORTAL_URL, () => {
+      // Push onto the workspace requested
+      cy.visit(import.meta.env.VITE_AUTH_API_URL + '/workspaces/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/go');
 
-        //todo: use a more reliable way to get the link to navigate back to
-        cy.contains('div', 'Role: Owner')
-          .parent('div').parent('a')
-          .should('exist').invoke('attr', 'href')
-          .then(($href) => {
-            cy.visit($href);
-          });
-      });
     },
     {
       validate: () => {


### PR DESCRIPTION
**Adds a new E2E Synthetic which:**
- Logs in as synthetic user
- Goes to production workspace for Synthetics
- Changes value on Attribute of Component A on a new changeset
- Validates that that property which is changes on A is propogated to Component B
- Deletes the new changeset

This uses a workspace which already has the components and "Lego" module installed within it + you're able to run and validate this flow locally by simply changing the variables.

----
Variables for env
```
# Remote Executing / E2E Specifities for Testing Production, local simply change the values to something like http://locahost:8080 & the relevant component IDs
# VITE_SI_WORKSPACE_URL = https://app.systeminit.com                         # Production URL
# VITE_SI_WORKSPACE_ID = 01HPMKZZ0DF54B12FNBF6Z7704              # Production Workspace URL Used for Synthetics
# VITE_SI_PROPAGATION_COMPONENT_A = c_01HPMM4A95M2E3V6STMZZCZJRZ # Production: Used for E2E Value Propagation Test [output socket i.e. from]
# VITE_SI_PROPAGATION_COMPONENT_B = c_01HPMM4BC682PFCYD7GE3X3AQW # Production: Used for E2E Value Propagation Test [input socket i.e. to]
```

These may drift or change over time.

----
**Maintenance**
All of the Component IDs/Workflow IDs/URLs/Credentials for the production synthetic can be changed inside github actions without having to make a PR to the repo/main. These are injected into .env.local within the pipeline from these vars:

```
      - name: Setup authentication for vite & other synthetic test variables
        working-directory: app/web
        run: |
          cp .env .env.local
          echo "VITE_AUTH0_USERNAME=${{ secrets.VITE_AUTH0_USERNAME }}" >> .env.local                           # Production Synthetic User Email
          echo "VITE_AUTH0_PASSWORD=${{ secrets.VITE_AUTH0_PASSWORD }}" >> .env.local                           # Production Synthetic User Password
          echo "VITE_SI_WORKSPACE_URL=${{ vars.VITE_PROD_SI_WORKSPACE_URL }}" >> .env.local                     # Production Synthetic Workspace URL
          echo "VITE_SI_WORKSPACE_ID=${{ vars.VITE_PROD_SI_WORKSPACE_ID }}" >> .env.local                       # Production Synthetic Workspace ID
          echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
          echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
```

It pushes the recordings + content into a new Cypress Cloud account for us to view, the links of which can be seen in the github action output log & when enabled; Slack.

We will enable the final bit of this (pagerduty/Slack link) on Monday if it proves to be stable.