### PR TITLE
fix: hardcode the baseurl as it isn't working in CI

### DIFF
--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
       on('file:preprocessor', vitePreprocessor(path.resolve('./vite.config.ts'),
       ))
     },
-    baseUrl: 'http://localhost:8080',
+    // Hotfix, needs amended
+    baseUrl: 'https://app.systeminit.com',
     chromeWebSecurity: false,
     viewportHeight: 1000,
     viewportWidth: 1500,


### PR DESCRIPTION
Compatibility with local runs `must` be retained but without this it isn't passing in CI (even if without it it passes locally against remote) 

Temporarily hardcoding this to give us stability coverage over the weekend + will amend properly config-wise next week when we are up and running.