### PR TITLE
feat(si-generator): add codegen and create funcs

### DIFF
--- a/bin/si-generator/src/render.ts
+++ b/bin/si-generator/src/render.ts
@@ -10,6 +10,8 @@ import { partial as stringPartial } from "./templates/string.ts";
 import { partial as renderPropPartial } from "./templates/renderProp.ts";
 import { partial as codeGenMainPartial } from "./templates/codeGenMain.ts";
 import { partial as createMainPartial } from "./templates/createMain.ts";
+import { partial as refreshMainPartial } from "./templates/refreshMain.ts";
+import { RefreshInput, RefreshOutput } from "./resource_generator.ts";
 
 type RenderProvider = "aws";
 
@@ -28,6 +30,7 @@ export function useEta(): Eta {
   eta.loadTemplate("@renderPropPartial", renderPropPartial);
   eta.loadTemplate("@codeGenMain", codeGenMainPartial);
   eta.loadTemplate("@createMain", createMainPartial);
+  eta.loadTemplate("@refreshMain", refreshMainPartial);
   return eta;
 }
 
@@ -82,5 +85,19 @@ export async function renderCreate(options: RenderCreateOptions): Promise<string
   const eta = useEta();
   const create = eta.render("@createMain", { options });
   return await fmt(create);
+}
+
+export interface RenderRefreshOptions {
+  provider: "aws";
+  awsService: string;
+  awsCommand: string;
+  inputs: Array<RefreshInput>;
+  outputs: Array<RefreshOutput>;
+};
+
+export async function renderRefresh(options: RenderRefreshOptions): Promise<string> {
+  const eta = useEta();
+  const refresh = eta.render("@refreshMain", options);
+  return await fmt(refresh);
 }
 

--- a/bin/si-generator/src/render.ts
+++ b/bin/si-generator/src/render.ts
@@ -8,10 +8,12 @@ import { partial as numberPartial } from "./templates/number.ts";
 import { partial as objectPartial } from "./templates/object.ts";
 import { partial as stringPartial } from "./templates/string.ts";
 import { partial as renderPropPartial } from "./templates/renderProp.ts";
+import { partial as codeGenMainPartial } from "./templates/codeGenMain.ts";
+import { partial as createMainPartial } from "./templates/createMain.ts";
 
 type RenderProvider = "aws";
 
-export async function renderAsset(props: Array<Prop>, provider: RenderProvider): Promise<string> {
+export function useEta(): Eta {
   const eta = new Eta({
     debug: true,
     autoEscape: false,
@@ -24,8 +26,12 @@ export async function renderAsset(props: Array<Prop>, provider: RenderProvider):
   eta.loadTemplate("@objectPartial", objectPartial);
   eta.loadTemplate("@stringPartial", stringPartial);
   eta.loadTemplate("@renderPropPartial", renderPropPartial);
-  const assetDefinition = eta.render("@assetMain", { props, provider });
+  eta.loadTemplate("@codeGenMain", codeGenMainPartial);
+  eta.loadTemplate("@createMain", createMainPartial);
+  return eta;
+}
 
+export async function fmt(ts: string): Promise<string> {
   const command = new Deno.Command("deno", {
     args: ["fmt", "-"],
     stdin: "piped",
@@ -34,7 +40,7 @@ export async function renderAsset(props: Array<Prop>, provider: RenderProvider):
   });
   const running = command.spawn();
   const writer = running.stdin.getWriter();
-  await writer.write(new TextEncoder().encode(assetDefinition));
+  await writer.write(new TextEncoder().encode(ts));
   writer.releaseLock();
   await running.stdin.close();
 
@@ -44,6 +50,37 @@ export async function renderAsset(props: Array<Prop>, provider: RenderProvider):
   if (result.success) {
     return stdout;
   } else {
-    return assetDefinition;
+    return ts;
   }
 }
+
+export async function renderAsset(props: Array<Prop>, provider: RenderProvider): Promise<string> {
+  const eta = useEta();
+  const assetDefinition = eta.render("@assetMain", { props, provider });
+  return await fmt(assetDefinition);
+}
+
+export async function renderCodeGen(provider: RenderProvider): Promise<string> {
+  const eta = useEta();
+  const codeGen = eta.render("@codeGenMain", { provider });
+  return await fmt(codeGen);
+}
+
+export interface RenderCreateBase {
+  provider: RenderProvider
+}
+
+export interface RenderCreateAws extends RenderCreateBase {
+  provider: "aws";
+  awsService: string;
+  awsCommand: string;
+}
+
+export type RenderCreateOptions = RenderCreateAws;
+
+export async function renderCreate(options: RenderCreateOptions): Promise<string> {
+  const eta = useEta();
+  const create = eta.render("@createMain", { options });
+  return await fmt(create);
+}
+

--- a/bin/si-generator/src/resource_generator.ts
+++ b/bin/si-generator/src/resource_generator.ts
@@ -1,0 +1,35 @@
+export interface RefreshInput {
+  toSet: string,
+  readFrom: string,
+}
+
+export interface RefreshOutput {
+  toSet?: string,
+  readFrom: string,
+}
+
+export interface RefreshOptions {
+  inputs: Array<RefreshInput>;
+  outputs: Array<RefreshOutput>;
+}
+
+export function makeRefreshOptions(options: { input: Array<string>, output: Array<string> }): RefreshOptions {
+  const refreshOptions: RefreshOptions = { inputs: [], outputs: [] };
+  for (const input of options.input) {
+    const [toSet, readFrom] = input.split(':');
+    if (toSet && readFrom) {
+      refreshOptions.inputs.push({ toSet, readFrom });
+    } else {
+      throw new Error(`Invalid input specifier; must be 'awsInputPath:siPropertiesPath': ${input}`);
+    }
+  }
+  for (const output of options.output) {
+    if (output.includes(':')) {
+      const [toSet, readFrom] = output.split(':');
+      refreshOptions.outputs.push({ toSet, readFrom });
+    } else {
+      refreshOptions.outputs.push({ readFrom: output });
+    }
+  }
+  return refreshOptions;
+}

--- a/bin/si-generator/src/run.ts
+++ b/bin/si-generator/src/run.ts
@@ -1,6 +1,7 @@
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { awsGenerate } from "./asset_generator.ts";
-import { renderAsset, renderCodeGen, renderCreate } from "./render.ts";
+import { makeRefreshOptions } from "./resource_generator.ts";
+import { renderAsset, renderCodeGen, renderCreate, renderRefresh } from "./render.ts";
 
 export async function run() {
   const command = new Command()
@@ -33,7 +34,19 @@ export async function run() {
     .action(async (_options, awsService, awsCommand) => {
       const result = await renderCreate({ provider: "aws", awsService, awsCommand });
       console.log(result);
+    })
+    .command("refresh")
+    .description("generate a refresh function from an aws cli skeleton")
+    .arguments("<awsService:string> <awsCommand:string>")
+    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
+    .option("--output <output:string>", "[siResourcePath:]awsOutputPath; constructs resource object", { collect: true, required: true })
+    .action(async (options, awsService, awsCommand) => {
+      const refreshOptions = makeRefreshOptions(options);
+      const result = await renderRefresh({ provider: "aws", awsService, awsCommand, inputs: refreshOptions.inputs, outputs: refreshOptions.outputs });
+      console.log(result);
     });
+
+  ;
 
   const _result = await command.parse(Deno.args);
 }

--- a/bin/si-generator/src/run.ts
+++ b/bin/si-generator/src/run.ts
@@ -1,6 +1,6 @@
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { awsGenerate } from "./asset_generator.ts";
-import { renderAsset } from "./render.ts";
+import { renderAsset, renderCodeGen, renderCreate } from "./render.ts";
 
 export async function run() {
   const command = new Command()
@@ -20,6 +20,20 @@ export async function run() {
       const props = awsGenerate(awsService, awsCommand);
       const result = await renderAsset(props, "aws");
       console.log(result);
+    })
+    .command("codeGen")
+    .description("generate a codeGen definition for an aws asset to create")
+    .action(async (_options) => {
+      const result = await renderCodeGen("aws");
+      console.log(result);
+    })
+    .command("create")
+    .description("generate a create function from an aws cli skeleton")
+    .arguments("<awsService:string> <awsCommand:string>")
+    .action(async (_options, awsService, awsCommand) => {
+      const result = await renderCreate({ provider: "aws", awsService, awsCommand });
+      console.log(result);
     });
+
   const _result = await command.parse(Deno.args);
 }

--- a/bin/si-generator/src/templates/assetMain.ts
+++ b/bin/si-generator/src/templates/assetMain.ts
@@ -19,15 +19,24 @@ function main() {
       .build();
   asset.addInputSocket(regionSocket);
 
-  const regionProp = new PropBuilder()
-      .setKind("string")
-      .setName("region")
-      .setValueFrom(new ValueFromBuilder()
-          .setKind("inputSocket")
-          .setSocketName("Region")
-          .build())
+  // Add any props needed for information that isn't
+  // strictly part of the object domain here.
+  const extraProp = new PropBuilder()
+      .setKind("object")
+      .setName("extra")
+      .addChild(
+         new PropBuilder()
+        .setKind("string")
+        .setName("Region")
+        .setValueFrom(new ValueFromBuilder()
+            .setKind("inputSocket")
+            .setSocketName("Region")
+            .build()
+        ).build()
+      )
       .build();
-  asset.addProp(regionProp);
+
+  asset.addProp(extraProp);
 <% } %>
 
   return asset.build();

--- a/bin/si-generator/src/templates/codeGenMain.ts
+++ b/bin/si-generator/src/templates/codeGenMain.ts
@@ -1,0 +1,11 @@
+export const partial = `
+async function main(input: Input): Promise < Output > {
+    if (input.domain?.extra) {
+        delete input.domain.extra;
+    }
+  return {
+    format: "json",
+    code: JSON.stringify(input.domain || {}, null, 2),
+  }
+}
+`

--- a/bin/si-generator/src/templates/createMain.ts
+++ b/bin/si-generator/src/templates/createMain.ts
@@ -1,0 +1,37 @@
+export const partial = `
+async function main(component: Input): Promise < Output > {
+    if (component.properties.resource?.payload) {
+        return {
+            status: "error",
+            message: "Resource already exists",
+            payload: component.properties.resource.payload,
+        };
+    }
+
+    const code = component.properties.code?.["si:genericAwsCreate"]?.code;
+    const domain = component.properties?.domain;
+
+    const child = await siExec.waitUntilEnd("aws", [
+        "<%= it.options.awsService %>",
+        "<%= it.options.awsCommand %>",
+        "--region",
+        domain?.extra?.Region || "",
+        "--cli-input-json",
+        code || "",
+    ]);
+
+    if (child.exitCode !== 0) {
+        console.error(child.stderr);
+        return {
+            status: "error",
+            message: \`Unable to create; AWS CLI 2 exited with non zero code: \${child.exitCode}\`,
+        };
+    }
+
+    const response = JSON.parse(child.stdout);
+
+    return {
+        payload: response,
+        status: "ok"
+    };
+}`

--- a/bin/si-generator/src/templates/refreshMain.ts
+++ b/bin/si-generator/src/templates/refreshMain.ts
@@ -1,0 +1,53 @@
+export const partial = `
+async function main(component: Input): Promise < Output > {
+  const cliArguments = {};
+<% for (const input of it.inputs) { %>
+  _.set(cliArguments, '<%= input.toSet %>', _.get(component, '<%= input.readFrom %>'));
+<% } %>
+
+  const child = await siExec.waitUntilEnd("aws", [
+    "<%= it.awsService %>",
+    "<%= it.awsCommand %>",
+    "--region",
+    _.get(component, 'properties.domain.extra.Region', ''),
+    "--cli-input-json",
+    JSON.stringify(cliArguments),
+  ]);
+
+  if (child.exitCode !== 0) {
+    const payload = _.get(component, 'properties.resource.payload');
+    if (payload) {
+      return {
+        status: "error",
+        payload,
+        message: \`Refresh error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    } else {
+      return {
+        status: "error",
+        message: \`Refresh error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    }
+  }
+
+  const response = JSON.parse(child.stdout);
+  const resource = {};
+<% for (const output of it.outputs) { %>
+<% if (output.toSet) { %>
+  _.set(resource, <%= output.toSet %>, _.get(response, '<%= output.readFrom %>');
+<% } else { %>
+  _.merge(resource, _.get(response, '<%= output.readFrom %>'));
+<% } %>
+<% } %>
+  if (!resource) {
+    return {
+      status: "error",
+      message: \`Resource not found in payload.\\n\\nResponse:\\n\\n\${child.stdout}\`
+    }
+  }
+  return {
+    payload: resource,
+    status: "ok"
+  }
+}
+`


### PR DESCRIPTION
The generator can now produce codeGen and createFuncs.

In theory, there should only need to be 1 codeGen func created, and it should just be re-used across every asset. It should be named 'si:genericAwsCreate', which will then be re-used in the create functions.