### PR TITLE
feat(dal,sdf): upgrade components to new schema variants

### DIFF
--- a/lib/dal/src/attribute/context.rs
+++ b/lib/dal/src/attribute/context.rs
@@ -157,6 +157,17 @@ impl AttributeContext {
         AttributeContextBuilder::new()
     }
 
+    /// Use this when you want this exact context but with the provided
+    /// component id instead
+    pub fn clone_with_component_id(&self, component_id: ComponentId) -> Self {
+        Self {
+            prop_id: self.prop_id,
+            internal_provider_id: self.internal_provider_id,
+            external_provider_id: self.external_provider_id,
+            component_id,
+        }
+    }
+
     pub fn prop_id(&self) -> PropId {
         self.prop_id
     }

--- a/lib/dal/src/component/migrate.rs
+++ b/lib/dal/src/component/migrate.rs
@@ -1,0 +1,154 @@
+use std::collections::VecDeque;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{
+    AttributePrototype, AttributePrototypeArgumentError, AttributePrototypeError, AttributeValue,
+    AttributeValueError, AttributeValueId, Component, ComponentError, ComponentId, ComponentView,
+    DalContext, PropError, PropKind, SchemaVariant, SchemaVariantId, StandardModel,
+    StandardModelError,
+};
+
+use super::{ComponentResult, ComponentViewError};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum ComponentMigrateError {
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] AttributePrototypeError),
+    #[error("attribute prototype argument error: {0}")]
+    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    #[error("attribute value error: {0}")]
+    AttributeValue(#[from] AttributeValueError),
+    #[error("attribute value view of {0} is not associated with a prop or provider!")]
+    AttributeValueViewNoPropOrProvider(AttributeValueId),
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
+    #[error("component view error: {0}")]
+    ComponentView(#[from] ComponentViewError),
+    #[error("standard model error: {0}")]
+    StandardModel(#[from] StandardModelError),
+}
+
+pub type ComponentMigrateResult<T> = Result<T, ComponentMigrateError>;
+
+pub async fn migrate_component_to_schema_variant(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    schema_variant_id: SchemaVariantId,
+) -> ComponentMigrateResult<()> {
+    let original_component_view = ComponentView::new(ctx, component_id).await?.properties;
+
+    // Respin the component, this deletes all the attribute values for the
+    // component so we have to gather up the prototype info *before* we do
+    // this
+    let new_component = Component::respin(ctx, component_id, schema_variant_id).await?;
+
+    let mut json_for_new_sv = build_empty_json_for_prop_tree(ctx, schema_variant_id).await?;
+    serde_value_merge_in_place_recursive(&mut json_for_new_sv, original_component_view);
+    dbg!(&json_for_new_sv);
+
+    // Call update for context on the root attribute value of the new
+    // component with the constructed attribute view. We use
+    // update_for_context because it will populate all the nested values
+    // for the tree and recalculate all the implicit attribute values
+    // from root to leaf.
+    if json_for_new_sv != serde_json::Value::Null {
+        let root_attribute_value = new_component.root_attribute_value(ctx).await?;
+        AttributeValue::update_for_context_without_propagating_dependent_values(
+            ctx,
+            *root_attribute_value.id(),
+            None,
+            root_attribute_value.context,
+            Some(json_for_new_sv),
+            None,
+        )
+        .await?;
+
+        // If a schema variant level prototype exists for this value's context, just reset the
+        // value to use that prototype and we're done
+        for value in AttributeValue::find_all_values_for_component_id(ctx, component_id).await? {
+            let value_context = value.attribute_value.context;
+            let variant_context = value_context.clone_with_component_id(ComponentId::NONE);
+            if let Some(variant_prototype) = AttributePrototype::find_for_context_and_key(
+                ctx,
+                variant_context,
+                &value.attribute_value.key,
+            )
+            .await?
+            .into_iter()
+            .next()
+            {
+                value
+                    .attribute_value
+                    .set_attribute_prototype(ctx, variant_prototype.id())
+                    .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn build_empty_json_for_prop_tree(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> ComponentResult<serde_json::Value> {
+    // This should fetch the entire prop tree in the correct order in a single query.
+    let mut result = serde_json::json!({});
+
+    let root_prop = SchemaVariant::find_root_prop(ctx, schema_variant_id)
+        .await?
+        .ok_or(PropError::NotFoundAtPath("root".into(), *ctx.visibility()))?;
+
+    let mut work_queue = VecDeque::from([root_prop]);
+
+    while let Some(prop) = work_queue.pop_front() {
+        if matches!(prop.kind(), PropKind::Object) {
+            work_queue.extend(prop.child_props(ctx).await?);
+        }
+
+        let path = prop.path();
+        let mut parts = path.as_parts();
+        if parts.len() <= 1 {
+            continue;
+        }
+
+        parts[0] = "";
+        let parent_path = parts[..parts.len() - 1].join("/");
+        let last_part = parts[parts.len() - 1].to_string();
+
+        if let Some(value) = result.pointer_mut(&parent_path) {
+            if let Some(object) = value.as_object_mut() {
+                object.insert(
+                    last_part,
+                    match prop.kind() {
+                        PropKind::String => serde_json::Value::Null,
+                        PropKind::Boolean => serde_json::Value::Null,
+                        PropKind::Integer => serde_json::Value::Null,
+                        PropKind::Array => serde_json::json!([]),
+                        PropKind::Map => serde_json::json!({}),
+                        PropKind::Object => serde_json::json!({}),
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn serde_value_merge_in_place_recursive(a: &mut serde_json::Value, b: serde_json::Value) {
+    match (a, b) {
+        (a @ &mut serde_json::Value::Object(_), serde_json::Value::Object(b)) => {
+            let a = a.as_object_mut().unwrap();
+            for (k, v) in b {
+                serde_value_merge_in_place_recursive(
+                    a.entry(k).or_insert(serde_json::Value::Null),
+                    v,
+                );
+            }
+        }
+        (a, b) => *a = b,
+    }
+}

--- a/lib/dal/src/migrations/U2422__respin_component.sql
+++ b/lib/dal/src/migrations/U2422__respin_component.sql
@@ -1,0 +1,365 @@
+-- Recreate a component's attribute value tree from scratch for a given
+-- schema_variant_id. this does not handle edges, which you'll need to delete as
+-- well.
+CREATE OR REPLACE FUNCTION component_respin_v1(
+    this_tenancy jsonb,
+    this_visibility jsonb,
+    this_component_id ident,
+    this_schema_variant_id ident,
+    OUT object JSON) 
+AS
+$$
+DECLARE
+    this_tenancy_record                     tenancy_record_v1;
+    this_visibility_record                  visibility_record_v1;
+    this_attribute_context                  jsonb;
+    this_attribute_prototype                RECORD;
+    this_attribute_value_id                 ident;
+    this_external_provider                  RECORD;
+    this_internal_provider                  RECORD;
+    this_new_attribute_value                jsonb;
+    this_parent_attribute_value_id          ident;
+    this_prop_attribute_value               RECORD;
+    this_schema_id                          ident;
+    this_unset_func_binding_id              ident;
+    this_unset_func_binding_return_value_id ident;
+    this_unset_func_id                      ident;
+    this_component_row                      components%ROWTYPE;
+BEGIN
+    this_tenancy_record := tenancy_json_to_columns_v1(this_tenancy);
+    this_visibility_record := visibility_json_to_columns_v1(this_visibility);
+
+    -- Delete all attribute values 
+    FOR this_attribute_value_id IN
+        SELECT id FROM attribute_values_v1(this_tenancy, this_visibility) AS avs
+        WHERE attribute_context_component_id = this_component_id
+    LOOP
+        PERFORM delete_by_id_v1(
+            'attribute_values',
+            this_tenancy,
+            this_visibility,
+            this_attribute_value_id
+        );
+    END LOOP;
+    
+    -- Create unset AttributeValues for the ExternalProviders, InternalProviders,
+    -- and for the Props starting at the root prop, up until (and including) the
+    -- first Array/Map that is encountered. These will be place holders for
+    -- when we set values (such as the root.si.name), and do function evaluation
+    -- later on.
+    SELECT belongs_to_id
+    INTO STRICT this_schema_id
+    FROM schema_variant_belongs_to_schema
+    WHERE in_tenancy_and_visible_v1(this_tenancy, this_visibility, schema_variant_belongs_to_schema)
+        AND object_id = this_schema_variant_id;
+
+    PERFORM unset_all_belongs_to_v1(
+        'component_belongs_to_schema',
+        this_tenancy,
+        this_visibility,
+        this_component_id
+    );
+    PERFORM set_belongs_to_v1(
+      'component_belongs_to_schema',
+      this_tenancy,
+      this_visibility,
+      this_component_id,
+      this_schema_id
+    );
+    PERFORM unset_all_belongs_to_v1(
+        'component_belongs_to_schema_variant',
+        this_tenancy,
+        this_visibility,
+        this_component_id
+    );
+    PERFORM set_belongs_to_v1(
+      'component_belongs_to_schema_variant',
+      this_tenancy,
+      this_visibility,
+      this_component_id,
+      this_schema_variant_id
+    );
+
+    -- Find the "si:unset" Func Binding, and Func Binding Return Value to use
+    -- when creating the Attribute Values for the External & Internal Providers.
+    SELECT id
+    INTO this_unset_func_id
+    FROM find_by_attr_v1('funcs',
+                         this_tenancy,
+                         this_visibility,
+                         'name',
+                         'si:unset');
+    IF this_unset_func_id IS NULL THEN
+        RAISE 'attribute_value_insert_for_context_raw_v1: Unable to find Func(%) in Tenancy(%), Visibility(%)',
+              'si:unset',
+              this_tenancy,
+              this_visibility;
+    END IF;
+    SELECT new_func_binding_id, new_func_binding_return_value_id
+    INTO this_unset_func_binding_id, this_unset_func_binding_return_value_id
+    FROM func_binding_create_and_execute_v1(
+      this_tenancy,
+      this_visibility,
+      'null'::jsonb,
+      this_unset_func_id
+    );
+
+    -- External Providers
+    FOR this_external_provider IN
+        SELECT *
+        FROM external_providers_v1(this_tenancy, this_visibility)
+        WHERE schema_variant_id = this_schema_variant_id
+    LOOP
+        this_attribute_context := attribute_context_build_from_parts_v1(
+            ident_nil_v1(), -- Prop ID
+            ident_nil_v1(), -- Internal Provider ID
+            this_external_provider.id, -- External Provider ID
+            -- We won't find a component-specific prototype, since the component
+            -- didn't exist before calling this function, but we'll want the
+            -- component ID set when we go to create the Attribute Value.
+            this_component_id -- Component ID
+        );
+
+        SELECT *
+        INTO STRICT this_attribute_prototype
+        FROM attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+        WHERE in_attribute_context_v1(this_attribute_context, ap);
+
+        SELECT av.object
+        INTO this_new_attribute_value
+        FROM attribute_value_create_v1(
+            this_tenancy,
+            this_visibility,
+            this_attribute_context,
+            this_unset_func_binding_id,
+            this_unset_func_binding_return_value_id,
+            NULL
+        ) AS av;
+
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_prototype',
+            this_tenancy,
+            this_visibility,
+            this_new_attribute_value ->> 'id',
+            this_attribute_prototype.id
+        );
+    END LOOP;
+
+    -- Explicit Internal Providers
+    FOR this_internal_provider IN
+        SELECT *
+        FROM internal_providers_v1(this_tenancy, this_visibility)
+        WHERE schema_variant_id = this_schema_variant_id
+    LOOP
+        this_attribute_context := attribute_context_build_from_parts_v1(
+            ident_nil_v1(), -- Prop ID
+            this_internal_provider.id, -- Internal Provider ID
+            ident_nil_v1(), -- External Provider ID
+            this_component_id -- Component ID
+        );
+
+        SELECT *
+        INTO STRICT this_attribute_prototype
+        FROM attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+        WHERE in_attribute_context_v1(this_attribute_context, ap);
+
+        SELECT av.object
+        INTO this_new_attribute_value
+        FROM attribute_value_create_v1(
+            this_tenancy,
+            this_visibility,
+            this_attribute_context,
+            this_unset_func_binding_id,
+            this_unset_func_binding_return_value_id,
+            NULL
+        ) AS av;
+
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_prototype',
+            this_tenancy,
+            this_visibility,
+            this_new_attribute_value ->> 'id',
+            this_attribute_prototype.id
+        );
+    END LOOP;
+
+    -- Implicit Internal Providers
+    FOR this_internal_provider IN
+        SELECT ip.*
+        FROM internal_providers_v1(this_tenancy, this_visibility) AS ip
+            INNER JOIN props_v1(this_tenancy, this_visibility) AS props
+              ON ip.prop_id = props.id
+        WHERE props.schema_variant_id = this_schema_variant_id
+    LOOP
+        -- Create an Attribute Value for the Internal Provider
+        this_attribute_context := attribute_context_build_from_parts_v1(
+            ident_nil_v1(), -- Prop ID
+            this_internal_provider.id, -- Internal Provider ID
+            ident_nil_v1(), -- External Provider ID
+            this_component_id -- Component ID
+        );
+
+        SELECT *
+        INTO STRICT this_attribute_prototype
+        FROM attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+        WHERE in_attribute_context_v1(this_attribute_context, ap);
+
+        SELECT av.object
+        INTO this_new_attribute_value
+        FROM attribute_value_create_v1(
+            this_tenancy,
+            this_visibility,
+            this_attribute_context,
+            this_unset_func_binding_id,
+            this_unset_func_binding_return_value_id,
+            NULL
+        ) AS av;
+
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_prototype',
+            this_tenancy,
+            this_visibility,
+            this_new_attribute_value ->> 'id',
+            this_attribute_prototype.id
+        );
+
+        -- Create an Attribute Value for the Prop.
+        this_attribute_context := attribute_context_build_from_parts_v1(
+            this_internal_provider.prop_id, -- Prop ID
+            ident_nil_v1(), -- Internal Provider ID
+            ident_nil_v1(), -- External Provider ID
+            this_component_id -- Component ID
+        );
+
+        SELECT *
+        INTO this_attribute_prototype
+        FROM attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+        WHERE in_attribute_context_v1(this_attribute_context, ap)
+        ORDER BY id DESC
+        LIMIT 1;
+
+        -- See what the func_binding & func_binding_return_value are on the
+        -- prop-specific Attribute Value, and copy those over.
+        SELECT *
+        INTO STRICT this_prop_attribute_value
+        FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+        WHERE in_attribute_context_v1(
+            attribute_context_build_from_parts_v1(
+                this_internal_provider.prop_id,
+                ident_nil_v1(),
+                ident_nil_v1(),
+                ident_nil_v1()
+            ),
+            av
+        );
+
+
+        SELECT av.object
+        INTO this_new_attribute_value
+        FROM attribute_value_create_v1(
+            this_tenancy,
+            this_visibility,
+            this_attribute_context,
+            this_prop_attribute_value.func_binding_id,
+            this_prop_attribute_value.func_binding_return_value_id,
+            NULL
+        ) AS av;
+
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_prototype',
+            this_tenancy,
+            this_visibility,
+            this_new_attribute_value ->> 'id',
+            this_attribute_prototype.id
+        );
+    END LOOP;
+
+    -- Some map Props have entries for specific keys as part of the Schema
+    -- Variant's definition. This should only be happening for things like
+    -- qualifications, and code-gen, which means that it should only ever be
+    -- happening for the first-level map encountered from the root, when it
+    -- happens at all.
+    FOR this_prop_attribute_value IN
+        SELECT av.*
+        FROM attribute_values_v1(this_tenancy, this_visibility) AS av
+            INNER JOIN props_v1(this_tenancy, this_visibility) AS props
+                ON av.attribute_context_prop_id = props.id
+        WHERE props.schema_variant_id = this_schema_variant_id
+            AND av.key IS NOT NULL
+            AND av.attribute_context_component_id = ident_nil_v1()
+    LOOP
+        this_attribute_context := attribute_context_build_from_parts_v1(
+            this_prop_attribute_value.attribute_context_prop_id,
+            ident_nil_v1(),
+            ident_nil_v1(),
+            this_component_id
+        );
+
+        SELECT ap.*
+        INTO STRICT this_attribute_prototype
+        FROM attribute_prototypes_v1(this_tenancy, this_visibility) AS ap
+            INNER JOIN attribute_value_belongs_to_attribute_prototype_v1(this_tenancy, this_visibility) AS avbtap
+                ON ap.id = avbtap.belongs_to_id
+        WHERE avbtap.object_id = this_prop_attribute_value.id;
+
+        SELECT av.object
+        INTO this_new_attribute_value
+        FROM attribute_value_create_v1(
+            this_tenancy,
+            this_visibility,
+            this_attribute_context,
+            this_prop_attribute_value.func_binding_id,
+            this_prop_attribute_value.func_binding_return_value_id,
+            this_prop_attribute_value.key
+        ) AS av;
+
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_prototype',
+            this_tenancy,
+            this_visibility,
+            this_new_attribute_value ->> 'id',
+            this_attribute_prototype.id
+        );
+    END LOOP;
+
+    -- We need to create the attribute_value_belongs_to_attribute_value
+    -- relationship for the Prop Attribute Values of the Component. We are doing
+    -- this after all of the Attribute Values have been created because we're
+    -- guaranteeing that they're created in topographical order, which prevents
+    -- us from setting the belongs_to relationship as we go along.
+    this_attribute_context := attribute_context_build_from_parts_v1(
+        NULL, -- Prop ID
+        ident_nil_v1(), -- Internal Provider ID
+        ident_nil_v1(), -- External Provider ID
+        this_component_id -- Component ID
+    );
+    FOR this_parent_attribute_value_id, this_attribute_value_id IN
+        WITH RECURSIVE avbtav(parent_av_id, av_id) AS (
+            SELECT parent_av.id, av.id
+            FROM prop_belongs_to_prop AS pbtp
+            INNER JOIN attribute_values_v1(this_tenancy, this_visibility) AS av
+                ON av.attribute_context_prop_id = pbtp.object_id
+            INNER JOIN attribute_values_v1(this_tenancy, this_visibility) AS parent_av
+                ON parent_av.attribute_context_prop_id = pbtp.belongs_to_id
+            WHERE in_attribute_context_v1(this_attribute_context, av)
+                AND av.attribute_context_component_id = this_component_id
+                AND in_attribute_context_v1(this_attribute_context, parent_av)
+                AND parent_av.attribute_context_component_id = this_component_id
+        )
+        SELECT * FROM avbtav
+    LOOP
+        PERFORM set_belongs_to_v1(
+            'attribute_value_belongs_to_attribute_value',
+            this_tenancy,
+            this_visibility,
+            this_attribute_value_id,
+            this_parent_attribute_value_id
+        );
+    END LOOP;
+
+    SELECT row_to_json(component.*) 
+    INTO object 
+    FROM components_v1(this_tenancy, this_visibility) AS component 
+    WHERE id=this_component_id;
+END;
+$$ LANGUAGE PLPGSQL VOLATILE;

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -215,7 +215,7 @@ impl PkgExporter {
         let mut exporter = Self::new_standalone_variant_exporter();
 
         exporter
-            .export_funcs_for_variant(ctx, Some(ChangeSetPk::NONE), *variant.id())
+            .export_funcs_for_variant(ctx, None, *variant.id())
             .await?;
         let variant_spec = exporter.export_variant(ctx, None, variant).await?;
 

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -5,8 +5,9 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    change_status::ChangeStatusError, component::ComponentViewError, ActionPrototypeError,
-    PropError,
+    change_status::ChangeStatusError,
+    component::{migrate::ComponentMigrateError, ComponentViewError},
+    ActionPrototypeError, PropError,
 };
 use dal::{
     component::view::debug::ComponentDebugViewError, node::NodeError,
@@ -35,6 +36,7 @@ pub mod get_resource;
 pub mod insert_property_editor_value;
 pub mod json;
 pub mod list_qualifications;
+pub mod migrate_to_default_variant;
 pub mod refresh;
 pub mod resource_domain_diff;
 pub mod set_type;
@@ -67,6 +69,8 @@ pub enum ComponentError {
     ComponentDebug(String),
     #[error("component debug view error: {0}")]
     ComponentDebugView(#[from] ComponentDebugViewError),
+    #[error("component migration error: {0}")]
+    ComponentMigrate(#[from] ComponentMigrateError),
     #[error("component name not found")]
     ComponentNameNotFound,
     #[error("component not found for id: {0}")]
@@ -196,4 +200,8 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/debug", get(debug::debug_component))
         .route("/json", get(json::json))
+        .route(
+            "/migrate_to_default_variant",
+            post(migrate_to_default_variant::migrate_to_default_variant),
+        )
 }

--- a/lib/sdf-server/src/server/service/component/migrate_to_default_variant.rs
+++ b/lib/sdf-server/src/server/service/component/migrate_to_default_variant.rs
@@ -1,0 +1,49 @@
+use axum::extract::OriginalUri;
+use axum::{response::IntoResponse, Json};
+use dal::{Component, ComponentId, StandardModel, Visibility, WsEvent};
+use serde::{Deserialize, Serialize};
+
+use super::ComponentResult;
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use dal::component::migrate::migrate_component_to_schema_variant;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MigrateToDefaultVariantRequest {
+    pub component_id: ComponentId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn migrate_to_default_variant(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Json(request): Json<MigrateToDefaultVariantRequest>,
+) -> ComponentResult<impl IntoResponse> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    if let Some(component) = Component::get_by_id(&ctx, &request.component_id).await? {
+        if let Some(schema) = component.schema(&ctx).await? {
+            if let Some(default_variant_id) = schema.default_schema_variant_id() {
+                migrate_component_to_schema_variant(
+                    &ctx,
+                    request.component_id,
+                    *default_variant_id,
+                )
+                .await?;
+
+                WsEvent::component_updated(&ctx, request.component_id)
+                    .await?
+                    .publish_on_commit(&ctx)
+                    .await?;
+
+                ctx.commit().await?;
+            }
+        }
+    }
+
+    let response = axum::response::Response::builder();
+    Ok(response.body(axum::body::Empty::new())?)
+}

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -400,10 +400,10 @@ impl SchemaVariantSpecBuilder {
 
     fn default_resource_value() -> PropSpec {
         PropSpec::Object {
-            name: "value".to_string(),
+            name: "resource_value".to_string(),
             unique_id: None,
             data: Some(PropSpecData {
-                name: "value".to_string(),
+                name: "resource_value".to_string(),
                 default_value: None,
                 func_unique_id: None,
                 inputs: None,


### PR DESCRIPTION
Adds the ability to take a component based on one schema variant and
migrate it to another schema variant without component deletion. Adds an
sdf route that facilitates this.

Frontend code not commited, resources have not been tested, and one
important feature is missing from this: the deletion and restoration of
edges to the new providers if they are compatible. But otherwise this
reliably "respins" a component onto a new variant.