### PR TITLE
chore(ci): set OpenTelemetry environment varible in integration tests

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - "SI_TEST_PG_HOSTNAME=postgres"
       - "SI_TEST_NATS_URL=nats"
+      - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     depends_on:
       - postgres
       - nats


### PR DESCRIPTION
This change configures the OpenTelemetry collector endpoint for any Cyclone servers running as part of an integration test. Prior to this change (and given past work), Cyclone servers try in vain to connect to a localhost collector only to fail. This causes a *lot* of stderr output in the CI logs, even though this is not a failure at all.