### PR TITLE
Add delete and action generators

### DIFF
--- a/bin/si-generator/src/render.ts
+++ b/bin/si-generator/src/render.ts
@@ -11,7 +11,8 @@ import { partial as renderPropPartial } from "./templates/renderProp.ts";
 import { partial as codeGenMainPartial } from "./templates/codeGenMain.ts";
 import { partial as createMainPartial } from "./templates/createMain.ts";
 import { partial as refreshMainPartial } from "./templates/refreshMain.ts";
-import { RefreshInput, RefreshOutput } from "./resource_generator.ts";
+import { partial as deleteMainPartial } from "./templates/deleteMain.ts";
+import { ArgInput, ArgOutput } from "./resource_generator.ts";
 
 type RenderProvider = "aws";
 
@@ -31,6 +32,7 @@ export function useEta(): Eta {
   eta.loadTemplate("@codeGenMain", codeGenMainPartial);
   eta.loadTemplate("@createMain", createMainPartial);
   eta.loadTemplate("@refreshMain", refreshMainPartial);
+  eta.loadTemplate("@deleteMain", deleteMainPartial);
   return eta;
 }
 
@@ -91,13 +93,26 @@ export interface RenderRefreshOptions {
   provider: "aws";
   awsService: string;
   awsCommand: string;
-  inputs: Array<RefreshInput>;
-  outputs: Array<RefreshOutput>;
+  inputs: Array<ArgInput>;
+  outputs: Array<ArgOutput>;
 };
 
 export async function renderRefresh(options: RenderRefreshOptions): Promise<string> {
   const eta = useEta();
   const refresh = eta.render("@refreshMain", options);
   return await fmt(refresh);
+}
+
+export interface RenderDeleteOptions {
+  provider: "aws";
+  awsService: string;
+  awsCommand: string;
+  inputs: Array<ArgInput>;
+}
+
+export async function renderDelete(options: RenderDeleteOptions): Promise<string> {
+  const eta = useEta();
+  const deletetemp = eta.render("@deleteMain", options);
+  return await fmt(deletetemp);
 }
 

--- a/bin/si-generator/src/render.ts
+++ b/bin/si-generator/src/render.ts
@@ -12,6 +12,7 @@ import { partial as codeGenMainPartial } from "./templates/codeGenMain.ts";
 import { partial as createMainPartial } from "./templates/createMain.ts";
 import { partial as refreshMainPartial } from "./templates/refreshMain.ts";
 import { partial as deleteMainPartial } from "./templates/deleteMain.ts";
+import { partial as actionMainPartial } from "./templates/actionMain.ts";
 import { ArgInput, ArgOutput } from "./resource_generator.ts";
 
 type RenderProvider = "aws";
@@ -33,6 +34,7 @@ export function useEta(): Eta {
   eta.loadTemplate("@createMain", createMainPartial);
   eta.loadTemplate("@refreshMain", refreshMainPartial);
   eta.loadTemplate("@deleteMain", deleteMainPartial);
+  eta.loadTemplate("@actionMain", actionMainPartial);
   return eta;
 }
 
@@ -110,9 +112,16 @@ export interface RenderDeleteOptions {
   inputs: Array<ArgInput>;
 }
 
+export type RenderActionOptions = RenderDeleteOptions;
+
 export async function renderDelete(options: RenderDeleteOptions): Promise<string> {
   const eta = useEta();
   const deletetemp = eta.render("@deleteMain", options);
   return await fmt(deletetemp);
 }
 
+export async function renderAction(options: RenderActionOptions): Promise<string> {
+  const eta = useEta();
+  const actiontemp = eta.render("@actionMain", options);
+  return await fmt(actiontemp);
+}

--- a/bin/si-generator/src/resource_generator.ts
+++ b/bin/si-generator/src/resource_generator.ts
@@ -49,7 +49,7 @@ export function makeRefreshOptions(options: { input: Array<string>, output: Arra
   return refreshOptions;
 }
 
-export function makeDeleteOptions(options: { input: Array<string> }): DeleteOptions {
+export function makeDeleteOrActionOptions(options: { input: Array<string> }): DeleteOptions {
   const deleteOptions: RefreshOptions = { inputs: [], outputs: [] };
   for (const input of options.input) {
     const argInput = parseInputOption(input);
@@ -57,4 +57,3 @@ export function makeDeleteOptions(options: { input: Array<string> }): DeleteOpti
   }
   return deleteOptions;
 }
-

--- a/bin/si-generator/src/resource_generator.ts
+++ b/bin/si-generator/src/resource_generator.ts
@@ -1,35 +1,60 @@
-export interface RefreshInput {
+export interface ArgInput {
   toSet: string,
   readFrom: string,
 }
 
-export interface RefreshOutput {
+export interface ArgOutput {
   toSet?: string,
   readFrom: string,
 }
 
 export interface RefreshOptions {
-  inputs: Array<RefreshInput>;
-  outputs: Array<RefreshOutput>;
+  inputs: Array<ArgInput>;
+  outputs: Array<ArgOutput>;
 }
+
+export interface DeleteOptions {
+  inputs: Array<ArgInput>;
+}
+
+export function parseInputOption(input: string): ArgInput {
+    const [toSet, readFrom] = input.split(':');
+    if (toSet && readFrom) {
+    return { toSet, readFrom };
+    } else {
+      throw new Error(`Invalid input specifier; must be 'awsInputPath:siPropertiesPath': ${input}`);
+    }
+}
+
+export function parseOutputOption(output: string): ArgOutput {
+    if (output.includes(':')) {
+      const [toSet, readFrom] = output.split(':');
+      return { toSet, readFrom };
+    } else {
+      return { readFrom: output };
+    }
+}
+
 
 export function makeRefreshOptions(options: { input: Array<string>, output: Array<string> }): RefreshOptions {
   const refreshOptions: RefreshOptions = { inputs: [], outputs: [] };
   for (const input of options.input) {
-    const [toSet, readFrom] = input.split(':');
-    if (toSet && readFrom) {
-      refreshOptions.inputs.push({ toSet, readFrom });
-    } else {
-      throw new Error(`Invalid input specifier; must be 'awsInputPath:siPropertiesPath': ${input}`);
-    }
+    const argInput = parseInputOption(input);
+    refreshOptions.inputs.push(argInput);
   }
   for (const output of options.output) {
-    if (output.includes(':')) {
-      const [toSet, readFrom] = output.split(':');
-      refreshOptions.outputs.push({ toSet, readFrom });
-    } else {
-      refreshOptions.outputs.push({ readFrom: output });
-    }
+    const argOutput = parseOutputOption(output);
+    refreshOptions.outputs.push(argOutput);
   }
   return refreshOptions;
 }
+
+export function makeDeleteOptions(options: { input: Array<string> }): DeleteOptions {
+  const deleteOptions: RefreshOptions = { inputs: [], outputs: [] };
+  for (const input of options.input) {
+    const argInput = parseInputOption(input);
+    deleteOptions.inputs.push(argInput);
+  }
+  return deleteOptions;
+}
+

--- a/bin/si-generator/src/run.ts
+++ b/bin/si-generator/src/run.ts
@@ -1,7 +1,8 @@
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { awsGenerate } from "./asset_generator.ts";
 import { makeRefreshOptions } from "./resource_generator.ts";
-import { renderAsset, renderCodeGen, renderCreate, renderRefresh } from "./render.ts";
+import { renderAsset, renderCodeGen, renderCreate, renderDelete, renderRefresh } from "./render.ts";
+import { makeDeleteOptions } from "./resource_generator.ts";
 
 export async function run() {
   const command = new Command()
@@ -44,7 +45,18 @@ export async function run() {
       const refreshOptions = makeRefreshOptions(options);
       const result = await renderRefresh({ provider: "aws", awsService, awsCommand, inputs: refreshOptions.inputs, outputs: refreshOptions.outputs });
       console.log(result);
+    })
+    .command("delete")
+    .description("generate a delete function from an aws cli skeleton")
+    .arguments("<awsService:string> <awsCommand:string>")
+    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
+    .action(async (options, awsService, awsCommand) => {
+      const deleteOptions = makeDeleteOptions(options);
+      const result = await renderDelete({ provider: "aws", awsService, awsCommand, inputs: deleteOptions.inputs });
+      console.log(result);
     });
+
+  ;
 
   ;
 

--- a/bin/si-generator/src/run.ts
+++ b/bin/si-generator/src/run.ts
@@ -1,8 +1,8 @@
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { awsGenerate } from "./asset_generator.ts";
 import { makeRefreshOptions } from "./resource_generator.ts";
-import { renderAsset, renderCodeGen, renderCreate, renderDelete, renderRefresh } from "./render.ts";
-import { makeDeleteOptions } from "./resource_generator.ts";
+import { renderAction, renderAsset, renderCodeGen, renderCreate, renderDelete, renderRefresh } from "./render.ts";
+import { makeDeleteOrActionOptions } from "./resource_generator.ts";
 
 export async function run() {
   const command = new Command()
@@ -51,14 +51,19 @@ export async function run() {
     .arguments("<awsService:string> <awsCommand:string>")
     .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
     .action(async (options, awsService, awsCommand) => {
-      const deleteOptions = makeDeleteOptions(options);
+      const deleteOptions = makeDeleteOrActionOptions(options);
       const result = await renderDelete({ provider: "aws", awsService, awsCommand, inputs: deleteOptions.inputs });
       console.log(result);
+    })
+    .command("action")
+    .description("generate an action function from an aws cli skeleton")
+    .arguments("<awsService:string> <awsCommand:string>")
+    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
+    .action(async (options, awsService, awsCommand) => {
+      const deleteOptions = makeDeleteOrActionOptions(options);
+      const result = await renderAction({ provider: "aws", awsService, awsCommand, inputs: deleteOptions.inputs });
+      console.log(result);
     });
-
-  ;
-
-  ;
 
   const _result = await command.parse(Deno.args);
 }

--- a/bin/si-generator/src/templates/actionMain.ts
+++ b/bin/si-generator/src/templates/actionMain.ts
@@ -1,0 +1,38 @@
+export const partial = `
+async function main(component: Input): Promise < Output > {
+  const cliArguments = {};
+<% for (const input of it.inputs) { %>
+  _.set(cliArguments, '<%= input.toSet %>', _.get(component, '<%= input.readFrom %>'));
+<% } %>
+
+  const child = await siExec.waitUntilEnd("aws", [
+    "<%= it.awsService %>",
+    "<%= it.awsCommand %>",
+    "--region",
+    _.get(component, 'properties.domain.extra.Region', ''),
+    "--cli-input-json",
+    JSON.stringify(cliArguments),
+  ]);
+
+  const payload = _.get(component, 'properties.resource.payload');
+  if (child.exitCode !== 0) {
+    if (payload) {
+      return {
+        status: "error",
+        payload,
+        message: \`Action error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    } else {
+      return {
+        status: "error",
+        message: \`Action error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    }
+  }
+
+  return {
+    payload,
+    status: "ok"
+  }
+}
+`

--- a/bin/si-generator/src/templates/deleteMain.ts
+++ b/bin/si-generator/src/templates/deleteMain.ts
@@ -1,0 +1,39 @@
+export const partial = `
+async function main(component: Input): Promise < Output > {
+  const cliArguments = {};
+<% for (const input of it.inputs) { %>
+  _.set(cliArguments, '<%= input.toSet %>', _.get(component, '<%= input.readFrom %>'));
+<% } %>
+
+  const child = await siExec.waitUntilEnd("aws", [
+    "<%= it.awsService %>",
+    "<%= it.awsCommand %>",
+    "--region",
+    _.get(component, 'properties.domain.extra.Region', ''),
+    "--cli-input-json",
+    JSON.stringify(cliArguments),
+  ]);
+
+  if (child.exitCode !== 0) {
+    const payload = _.get(component, 'properties.resource.payload');
+    if (payload) {
+      return {
+        status: "error",
+        payload,
+        message: \`Delete error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    } else {
+      return {
+        status: "error",
+        message: \`Delete error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+      }
+    }
+  }
+
+  return {
+    payload: null,
+    status: "ok"
+  }
+}
+`
+


### PR DESCRIPTION
Adds a 'delete' and 'action' generator.

Like the refresh generator, they essentially construct the arugments for the cli skeleton from 'input' arguments that specify the AWS Input path on the left, and the property to set it from on the right. Then it calls the API and checks the exit code. 

Delete should work for any AWS API - actions should work for anything except tagging, which is just fraught with peril.

<img src="https://media3.giphy.com/media/l2YWs1NexTst9YmFG/giphy.gif"/>