### PR TITLE
 Stop migrating most builtins for tests 

### DIFF
--- a/docs/RUNNING_RUST_TESTS.md
+++ b/docs/RUNNING_RUST_TESTS.md
@@ -133,9 +133,9 @@ SI_TEST_BUILTIN_SCHEMAS=Schema One,Schema Two buck2 run <crate>:test-integration
 > Note: you may not want to wrap your list in `"` characters, depending on your development environment as they may
 > be unintentionally included in the list item(s).
 
-If you want migrations to run as they would by default, remove the environment variable or set it to `"all"` or `"true"`
+If you want migrations to run as they would by default, remove the environment variable or set it to `"test"` or `"true"`
 (or some variant of them).
 
 ```shell
-SI_TEST_BUILTIN_SCHEMAS=all buck2 run <crate>:test-integration -- <pattern>
+SI_TEST_BUILTIN_SCHEMAS=test buck2 run <crate>:test-integration -- <pattern>
 ```

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -591,9 +591,9 @@ fn determine_selected_test_builtin_schemas() -> SelectedTestBuiltinSchemas {
                 // If we receive any keywords indicating that we need to return early, let's do so.
                 if &cleaned == "none" || &cleaned == "false" {
                     return SelectedTestBuiltinSchemas::None;
-                } else if &cleaned == "all" || &cleaned == "true" {
+                } else if &cleaned == "all" {
                     return SelectedTestBuiltinSchemas::All;
-                } else if &cleaned == "test" {
+                } else if &cleaned == "test" || &cleaned == "true" {
                     return SelectedTestBuiltinSchemas::Test;
                 }
 
@@ -605,7 +605,7 @@ fn determine_selected_test_builtin_schemas() -> SelectedTestBuiltinSchemas {
         }
         Err(_) => {
             // If the variable is unset, then we migrate everything. This is the default behavior.
-            SelectedTestBuiltinSchemas::All
+            SelectedTestBuiltinSchemas::Test
         }
     }
 }

--- a/lib/dal/tests/integration_test/external/aws_region.rs
+++ b/lib/dal/tests/integration_test/external/aws_region.rs
@@ -4,6 +4,7 @@ use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
+#[ignore]
 async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
     let mut bagger = ComponentBagger::new();
     let ec2_bag = bagger.create_component(ctx, "server", "EC2 Instance").await;
@@ -230,6 +231,7 @@ async fn aws_region_to_aws_ec2_intelligence(ctx: &DalContext) {
 }
 
 #[test]
+#[ignore]
 async fn aws_region_to_aws_ec2_intelligence_switch_component_type(ctx: &DalContext) {
     let mut bagger = ComponentBagger::new();
     let ec2_bag = bagger.create_component(ctx, "server", "EC2 Instance").await;

--- a/lib/dal/tests/integration_test/external/coreos_butane.rs
+++ b/lib/dal/tests/integration_test/external/coreos_butane.rs
@@ -28,6 +28,7 @@ const EXPECTED_BUTANE_TO_EC2_IGNITION: &str = include_str!("ignition/butane-to-e
 const EXPECTED_DOCKER_TO_BUTANE_IGNITION: &str = include_str!("ignition/docker-to-butane.ign");
 
 #[test]
+#[ignore]
 async fn butane_to_ec2_user_data_is_valid_ignition(ctx: &DalContext) {
     let mut bagger = ComponentBagger::new();
     let butane_bag = bagger.create_component(ctx, "Mimic Tear", "Butane").await;
@@ -222,6 +223,7 @@ async fn butane_to_ec2_user_data_is_valid_ignition(ctx: &DalContext) {
 /// SI_TEST_BUILTIN_SCHEMAS=docker image,coreos butane
 /// ```
 #[test]
+#[ignore]
 async fn docker_to_butane_is_valid_ignition(ctx: &DalContext) {
     let mut bagger = ComponentBagger::new();
     let alpine_bag = bagger.create_component(ctx, "alpine", "Docker Image").await;

--- a/lib/dal/tests/integration_test/external/docker_image_intelligence.rs
+++ b/lib/dal/tests/integration_test/external/docker_image_intelligence.rs
@@ -4,6 +4,7 @@ use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
 #[test]
+#[ignore]
 async fn docker_image_intra_component_update(ctx: &DalContext) {
     let mut bagger = ComponentBagger::new();
     let soulrender_bag = bagger

--- a/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_mocked_whiskers.rs
+++ b/lib/sdf-server/tests/service_tests/scenario/model_and_fix_flow_mocked_whiskers.rs
@@ -16,6 +16,7 @@ use crate::service_tests::scenario::ScenarioHarness;
 /// SI_TEST_BUILTIN_SCHEMAS=target group,aws region,aws ami,aws keypair,aws ec2,aws securitygroup,aws ingress,docker image,coreos butane
 /// ```
 #[sdf_test]
+#[ignore]
 async fn model_and_fix_flow_mocked_whiskers(
     DalContextHead(mut ctx): DalContextHead,
     app: Router,


### PR DESCRIPTION
6 external tests disabled that basically tested the assets

We should test those assets, but the cypress baked in the package feels a better way.

Now the tests take 5 minutes instead of 20.