### PR TITLE
feat(dal): restore edges on component upgrade

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -988,6 +988,18 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             });
           },
 
+          async MIGRATE_COMPONENT(componentId: ComponentId) {
+            return new ApiRequest({
+              url: "component/migrate_to_default_variant",
+              keyRequestStatusBy: componentId,
+              method: "post",
+              params: {
+                componentId,
+                ...visibilityParams,
+              },
+            });
+          },
+
           async DELETE_EDGE(edgeId: EdgeId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -17,6 +17,7 @@ use crate::attribute::context::AttributeContextBuilder;
 use crate::attribute::value::AttributeValue;
 use crate::attribute::value::AttributeValueError;
 use crate::code_view::CodeViewError;
+use crate::diagram::summary_diagram::update_socket_summary;
 use crate::edge::EdgeKind;
 use crate::func::binding::FuncBindingError;
 use crate::func::binding_return_value::{FuncBindingReturnValueError, FuncBindingReturnValueId};
@@ -376,6 +377,10 @@ impl Component {
             .await?;
 
         let component: Component = standard_model::finish_create_from_row(ctx, row).await?;
+        // TODO: we may also need to do an update to the `has_resource` property of the summary
+        update_socket_summary(ctx, &component)
+            .await
+            .map_err(|err| ComponentError::SummaryDiagram(err.to_string()))?;
 
         Ok(component)
     }

--- a/lib/dal/src/component/migrate.rs
+++ b/lib/dal/src/component/migrate.rs
@@ -1,12 +1,13 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::{
-    AttributePrototype, AttributePrototypeArgumentError, AttributePrototypeError, AttributeValue,
-    AttributeValueError, AttributeValueId, Component, ComponentError, ComponentId, ComponentView,
-    DalContext, PropError, PropKind, SchemaVariant, SchemaVariantId, StandardModel,
-    StandardModelError,
+    socket::SocketError, AttributePrototype, AttributePrototypeArgumentError,
+    AttributePrototypeError, AttributeValue, AttributeValueError, AttributeValueId, Component,
+    ComponentError, ComponentId, ComponentView, Connection, DalContext, DiagramError, Edge,
+    EdgeError, PropError, PropKind, SchemaVariant, SchemaVariantId, Socket, SocketId,
+    StandardModel, StandardModelError,
 };
 
 use super::{ComponentResult, ComponentViewError};
@@ -26,6 +27,12 @@ pub enum ComponentMigrateError {
     Component(#[from] ComponentError),
     #[error("component view error: {0}")]
     ComponentView(#[from] ComponentViewError),
+    #[error("diagram error: {0}")]
+    Diagram(#[from] DiagramError),
+    #[error("edge error: {0}")]
+    Edge(#[from] EdgeError),
+    #[error("socket error: {0}")]
+    Socket(#[from] SocketError),
     #[error("standard model error: {0}")]
     StandardModel(#[from] StandardModelError),
 }
@@ -37,16 +44,34 @@ pub async fn migrate_component_to_schema_variant(
     component_id: ComponentId,
     schema_variant_id: SchemaVariantId,
 ) -> ComponentMigrateResult<()> {
+    // Gather up the original socket map so we can migrate to new edges
+    let original_sockets: HashMap<SocketId, String> = Socket::list_for_component(ctx, component_id)
+        .await?
+        .iter()
+        .map(|socket| (*socket.id(), socket.name().into()))
+        .collect();
+
+    let original_edges = Edge::list_for_component(ctx, component_id).await?;
+
+    // Delete all the original edges
+    for edge in &original_edges {
+        edge.clone().delete_and_propagate(ctx).await?;
+    }
+
     let original_component_view = ComponentView::new(ctx, component_id).await?.properties;
 
     // Respin the component, this deletes all the attribute values for the
     // component so we have to gather up the prototype info *before* we do
     // this
     let new_component = Component::respin(ctx, component_id, schema_variant_id).await?;
+    let new_sockets: HashMap<String, SocketId> = Socket::list_for_component(ctx, component_id)
+        .await?
+        .iter()
+        .map(|socket| (socket.name().into(), *socket.id()))
+        .collect();
 
     let mut json_for_new_sv = build_empty_json_for_prop_tree(ctx, schema_variant_id).await?;
     serde_value_merge_in_place_recursive(&mut json_for_new_sv, original_component_view);
-    dbg!(&json_for_new_sv);
 
     // Call update for context on the root attribute value of the new
     // component with the constructed attribute view. We use
@@ -84,6 +109,43 @@ pub async fn migrate_component_to_schema_variant(
                     .set_attribute_prototype(ctx, variant_prototype.id())
                     .await?;
             }
+        }
+    }
+
+    // Restore edges if matching sockets exist in the migrated component This
+    // should probably use the connection annotation for matching, instead of
+    // socket name?
+    for edge in original_edges {
+        let tail_component_id = edge.tail_component_id();
+        let tail_socket_id = if tail_component_id == component_id {
+            original_sockets
+                .get(&edge.tail_socket_id())
+                .and_then(|socket_name| new_sockets.get(socket_name))
+                .copied()
+        } else {
+            Some(edge.tail_socket_id())
+        };
+
+        let head_component_id = edge.head_component_id();
+        let head_socket_id = if head_component_id == component_id {
+            original_sockets
+                .get(&edge.head_socket_id())
+                .and_then(|socket_name| new_sockets.get(socket_name))
+                .copied()
+        } else {
+            Some(edge.head_socket_id())
+        };
+
+        if let (Some(tail_socket_id), Some(head_socket_id)) = (tail_socket_id, head_socket_id) {
+            Connection::new(
+                ctx,
+                edge.tail_node_id(),
+                tail_socket_id,
+                edge.head_node_id(),
+                head_socket_id,
+                *edge.kind(),
+            )
+            .await?;
         }
     }
 

--- a/lib/dal/src/diagram/summary_diagram.rs
+++ b/lib/dal/src/diagram/summary_diagram.rs
@@ -2,7 +2,9 @@ use std::num::{ParseFloatError, ParseIntError};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use strum::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
 use thiserror::Error;
 
 use si_data_pg::PgError;
@@ -13,12 +15,13 @@ use crate::edge::{EdgeId, EdgeKind};
 use crate::history_event::HistoryEventMetadata;
 use crate::schema::SchemaUiMenu;
 use crate::socket::SocketEdgeKind;
-use crate::standard_model::objects_from_rows;
+use crate::standard_model::{self, objects_from_rows};
 use crate::{
-    history_event, impl_standard_model, pk, ActorView, Component, ComponentError, ComponentId,
-    ComponentStatus, DalContext, DiagramError, Edge, EdgeError, HistoryActor, Node, NodeId, Schema,
-    SchemaError, SchemaId, SchemaVariant, SchemaVariantId, SocketArity, SocketId, StandardModel,
-    StandardModelError, Tenancy, Timestamp, TransactionsError, Visibility,
+    history_event, impl_standard_model, pk, standard_model_accessor, ActorView, Component,
+    ComponentError, ComponentId, ComponentStatus, DalContext, DiagramError, Edge, EdgeError,
+    HistoryActor, HistoryEventError, Node, NodeId, Schema, SchemaError, SchemaId, SchemaVariant,
+    SchemaVariantId, SocketArity, SocketId, StandardModel, StandardModelError, Tenancy, Timestamp,
+    TransactionsError, Visibility,
 };
 
 const LIST_SUMMARY_DIAGRAM_COMPONENTS: &str =
@@ -37,6 +40,8 @@ pub enum SummaryDiagramError {
     Diagram(#[from] DiagramError),
     #[error(transparent)]
     Edge(#[from] EdgeError),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
     #[error("no timestamp for deleting an edge when one was expected; bug!")]
     NoTimestamp,
     #[error(transparent)]
@@ -104,6 +109,46 @@ impl SummaryDiagramComponent {
     pub fn has_resource(&self) -> bool {
         self.has_resource
     }
+
+    pub async fn get_for_component_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> SummaryDiagramResult<Option<Self>> {
+        let maybe_row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                "SELECT DISTINCT ON (sdc.id)
+            row_to_json(sdc.*) AS object
+            FROM summary_diagram_components_v1($1, $2) AS sdc
+            WHERE component_id=$3 LIMIT 1",
+                &[ctx.tenancy(), ctx.visibility(), &component_id],
+            )
+            .await?;
+
+        Ok(standard_model::option_object_from_row(maybe_row)?)
+    }
+
+    standard_model_accessor!(sockets, Json<JsonValue>, SummaryDiagramResult);
+}
+
+pub async fn update_socket_summary(
+    ctx: &DalContext,
+    component: &Component,
+) -> SummaryDiagramResult<()> {
+    if let Some(mut summary_component) =
+        SummaryDiagramComponent::get_for_component_id(ctx, *component.id()).await?
+    {
+        if let Some(schema_variant) = component.schema_variant(ctx).await? {
+            let sockets = DiagramSocket::list(ctx, &schema_variant).await?;
+            summary_component
+                .set_sockets(ctx, serde_json::to_value(sockets)?)
+                .await?;
+        }
+    }
+
+    Ok(())
 }
 
 pub async fn create_component_entry(


### PR DESCRIPTION
When a component is upgraded to a different schema variant, we need to recreate all the edges (if possible). This attempts to do that, and also updates the component diagram summary row to have the new sockets.