### PR TITLE
fix(sdf): only list schema variant definitions for default variants

### DIFF
--- a/lib/dal/src/queries/defs_for_default_variants.sql
+++ b/lib/dal/src/queries/defs_for_default_variants.sql
@@ -1,0 +1,5 @@
+SELECT DISTINCT on (svds.id)
+  row_to_json(svds.*) as object
+FROM schema_variant_definitions_v1($1, $2) AS svds
+WHERE schema_variant_id IS NULL OR schema_variant_id in
+  (SELECT default_schema_variant_id FROM schemas_v1($1, $2))

--- a/lib/dal/src/schema/variant/definition.rs
+++ b/lib/dal/src/schema/variant/definition.rs
@@ -28,6 +28,8 @@ use si_pkg::{
     SocketSpecData, SocketSpecKind, SpecError,
 };
 
+const DEFS_FOR_DEFAULT_VARIANTS: &str = include_str!("../../queries/defs_for_default_variants.sql");
+
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SchemaVariantDefinitionError {
@@ -197,6 +199,22 @@ impl SchemaVariantDefinition {
             .await?;
 
         Ok(standard_model::finish_create_from_row(ctx, row).await?)
+    }
+
+    pub async fn list_for_default_variants(
+        ctx: &DalContext,
+    ) -> SchemaVariantDefinitionResult<Vec<Self>> {
+        let rows = ctx
+            .txns()
+            .await?
+            .pg()
+            .query(
+                DEFS_FOR_DEFAULT_VARIANTS,
+                &[ctx.tenancy(), ctx.visibility()],
+            )
+            .await?;
+
+        Ok(standard_model::objects_from_rows(rows)?)
     }
 
     pub async fn get_by_func_id(

--- a/lib/sdf-server/src/server/service/variant_definition/list_variant_defs.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/list_variant_defs.rs
@@ -43,19 +43,20 @@ pub async fn list_variant_defs(
 ) -> SchemaVariantDefinitionResult<Json<ListVariantDefsResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let variant_defs: Vec<ListedVariantDef> = SchemaVariantDefinition::list(&ctx)
-        .await?
-        .iter()
-        .map(|def| ListedVariantDef {
-            // TODO: Ensure we pass an actor for created / updated / deleted to the frontend
-            id: def.id().to_owned(),
-            name: def.name().to_owned(),
-            menu_name: def.menu_name().map(|menu_name| menu_name.to_owned()),
-            category: def.category().to_owned(),
-            color: def.color().to_owned(),
-            timestamp: def.timestamp().to_owned(),
-        })
-        .collect();
+    let variant_defs: Vec<ListedVariantDef> =
+        SchemaVariantDefinition::list_for_default_variants(&ctx)
+            .await?
+            .iter()
+            .map(|def| ListedVariantDef {
+                // TODO: Ensure we pass an actor for created / updated / deleted to the frontend
+                id: def.id().to_owned(),
+                name: def.name().to_owned(),
+                menu_name: def.menu_name().map(|menu_name| menu_name.to_owned()),
+                category: def.category().to_owned(),
+                color: def.color().to_owned(),
+                timestamp: def.timestamp().to_owned(),
+            })
+            .collect();
 
     track(
         &posthog_client,


### PR DESCRIPTION
Ensure we only list one definition per schema in the asset editing panel by restricting to default schema variant ids (or NULL, for variant defs that have not yet been executed)