### PR TITLE
Convert ephemeral Secret object to graph node in the new engine

### DIFF
--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -11,14 +11,14 @@ use crate::attribute::prototype::argument::{
 };
 use crate::attribute::value::AttributeValueError;
 use crate::change_status::ChangeStatus;
-use crate::component::{ComponentError, IncomingConnection};
+use crate::component::ComponentError;
 use crate::history_event::HistoryEventMetadata;
 use crate::provider::external::ExternalProviderError;
 use crate::provider::internal::InternalProviderError;
 use crate::schema::variant::SchemaVariantError;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    history_event, AttributePrototypeId, Component, ComponentId, DalContext, ExternalProviderId,
+    AttributePrototypeId, Component, ComponentId, DalContext, ExternalProviderId,
     HistoryEventError, InternalProviderId, ProviderArity, SchemaId, SchemaVariant, SchemaVariantId,
     StandardModelError,
 };

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -71,11 +71,12 @@ pub mod node_menu;
 // pub mod prototype_list_for_func;
 pub mod qualification;
 // pub mod reconciliation_prototype;
-// pub mod secret;
+pub mod secret;
 // pub mod status;
 //pub mod tasks;
 
 pub use action_prototype::{ActionKind, ActionPrototype, ActionPrototypeId};
+pub use actor_view::ActorView;
 pub use attribute::{
     prototype::{AttributePrototype, AttributePrototypeId},
     value::{AttributeValue, AttributeValueId},
@@ -107,6 +108,10 @@ pub use provider::ProviderArity;
 pub use provider::ProviderKind;
 pub use schema::variant::root_prop::component_type::ComponentType;
 pub use schema::{Schema, SchemaError, SchemaId, SchemaVariant, SchemaVariantId};
+pub use secret::SecretError;
+pub use secret::SecretId;
+pub use secret::SecretView;
+pub use secret::{EncryptedSecret, SecretAlgorithm, SecretVersion};
 pub use standard_model::{StandardModel, StandardModelError, StandardModelResult};
 pub use tenancy::{Tenancy, TenancyError};
 pub use timestamp::{Timestamp, TimestampError};

--- a/lib/dal/src/node_menu.rs
+++ b/lib/dal/src/node_menu.rs
@@ -4,12 +4,12 @@
 
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use std::collections::{hash_map, HashMap};
+use std::collections::HashMap;
 use thiserror::Error;
 
 use crate::schema::variant::SchemaVariantError;
 use crate::{DalContext, Schema, SchemaVariant};
-use crate::{SchemaError, SchemaId, StandardModel, StandardModelError};
+use crate::{SchemaError, SchemaId, StandardModelError};
 
 #[allow(clippy::large_enum_variant)]
 #[remain::sorted]
@@ -104,7 +104,7 @@ pub struct GenerateMenuItem {
 
 impl GenerateMenuItem {
     /// Generates raw items and initializes menu items as an empty vec.
-    pub async fn new(ctx: &DalContext, include_ui_hidden: bool) -> NodeMenuResult<Self> {
+    pub async fn new(ctx: &DalContext, _include_ui_hidden: bool) -> NodeMenuResult<Self> {
         let mut item_map: HashMap<String, Vec<MenuItem>> = HashMap::new();
 
         for schema in Schema::list(ctx).await? {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -35,8 +35,8 @@ use crate::{
     pk,
     schema::variant::leaves::{LeafInput, LeafInputLocation, LeafKind},
     AttributePrototype, AttributePrototypeId, ComponentId, DalContext, ExternalProvider,
-    ExternalProviderId, Func, FuncId, InternalProvider, Prop, PropId, PropKind, ProviderArity,
-    ProviderKind, Schema, SchemaError, SchemaId, Timestamp, TransactionsError,
+    ExternalProviderId, Func, FuncId, InternalProvider, Prop, PropId, PropKind, Schema,
+    SchemaError, SchemaId, Timestamp, TransactionsError,
 };
 use crate::{FuncBackendResponseType, InternalProviderId};
 
@@ -192,7 +192,7 @@ impl SchemaVariant {
 
         let schema_variant_id: SchemaVariantId = id.into();
         let root_prop = RootProp::new(ctx, schema_variant_id).await?;
-        let func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity).await?;
+        let _func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity).await?;
 
         let schema_variant = Self::assemble(id.into(), content);
         Ok((schema_variant, root_prop))

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -156,6 +156,8 @@ impl WorkspaceSnapshot {
         let func_node_index = graph.add_category_node(change_set, CategoryNodeKind::Func)?;
         let schema_node_index = graph.add_category_node(change_set, CategoryNodeKind::Schema)?;
 
+        let secret_node_index = graph.add_category_node(change_set, CategoryNodeKind::Secret)?;
+
         // Connect them to root.
         graph.add_edge(
             graph.root(),
@@ -171,6 +173,11 @@ impl WorkspaceSnapshot {
             graph.root(),
             EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
             schema_node_index,
+        )?;
+        graph.add_edge(
+            graph.root(),
+            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            secret_node_index,
         )?;
 
         // We do not care about any field other than "working_copy" because "write" will populate

--- a/lib/dal/src/workspace_snapshot/content_address.rs
+++ b/lib/dal/src/workspace_snapshot/content_address.rs
@@ -22,6 +22,7 @@ pub enum ContentAddress {
     Root,
     Schema(ContentHash),
     SchemaVariant(ContentHash),
+    Secret(ContentHash),
     StaticArgumentValue(ContentHash),
     ValidationPrototype(ContentHash),
 }
@@ -41,6 +42,7 @@ impl ContentAddress {
             | ContentAddress::Prop(id)
             | ContentAddress::Schema(id)
             | ContentAddress::SchemaVariant(id)
+            | ContentAddress::Secret(id)
             | ContentAddress::StaticArgumentValue(id)
             | ContentAddress::ValidationPrototype(id) => Some(*id),
         }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -953,6 +953,7 @@ impl WorkspaceSnapshotGraph {
                             ContentAddressDiscriminants::Root => "black",
                             ContentAddressDiscriminants::Schema => "black",
                             ContentAddressDiscriminants::SchemaVariant => "black",
+                            ContentAddressDiscriminants::Secret => "black",
                             ContentAddressDiscriminants::StaticArgumentValue => "green",
                             ContentAddressDiscriminants::ValidationPrototype => "black",
                         };
@@ -978,6 +979,7 @@ impl WorkspaceSnapshotGraph {
                         }
                         CategoryNodeKind::Func => ("Funcs (Category)".to_string(), "black"),
                         CategoryNodeKind::Schema => ("Schemas (Category)".to_string(), "black"),
+                        CategoryNodeKind::Secret => ("Secrets (Category)".to_string(), "black"),
                     },
                     NodeWeight::Func(func_node_weight) => {
                         (format!("Func\n{}", func_node_weight.name()), "black")
@@ -1533,6 +1535,7 @@ impl WorkspaceSnapshotGraph {
         algo::toposort(&self.graph, None).is_ok()
     }
 
+    #[allow(dead_code)]
     fn is_on_path_between(&self, start: NodeIndex, end: NodeIndex, node: NodeIndex) -> bool {
         algo::has_path_connecting(&self.graph, start, node, None)
             && algo::has_path_connecting(&self.graph, node, end, None)

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -13,6 +13,7 @@ pub enum CategoryNodeKind {
     Component,
     Func,
     Schema,
+    Secret,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -139,6 +139,7 @@ impl ContentNodeWeight {
             ContentAddress::Root => return Err(NodeWeightError::CannotUpdateRootNodeContentHash),
             ContentAddress::Schema(_) => ContentAddress::Schema(content_hash),
             ContentAddress::SchemaVariant(_) => ContentAddress::SchemaVariant(content_hash),
+            ContentAddress::Secret(_) => ContentAddress::Secret(content_hash),
             ContentAddress::StaticArgumentValue(_) => {
                 ContentAddress::StaticArgumentValue(content_hash)
             }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -7,6 +7,7 @@ use ulid::Ulid;
 use crate::change_set::{ChangeSetActorPayload, ChangeSetMergeVotePayload};
 use crate::component::{ComponentCreatedPayload, ComponentUpdatedPayload};
 use crate::qualification::QualificationCheckPayload;
+use crate::secret::{SecretCreatedPayload, SecretUpdatedPayload};
 use crate::user::OnlinePayload;
 use crate::{
     func::binding::LogLinePayload, pkg::ModuleImportedPayload, user::CursorPayload, ChangeSetPk,
@@ -71,8 +72,8 @@ pub enum WsPayload {
     // SchemaVariantDefinitionCreated(SchemaVariantDefinitionCreatedPayload),
     // SchemaVariantDefinitionFinished(FinishSchemaVariantDefinitionPayload),
     // SchemaVariantDefinitionSaved(SchemaVariantDefinitionSavedPayload),
-    // SecretCreated(SecretCreatedPayload),
-    // SecretUpdated(SecretUpdatedPayload),
+    SecretCreated(SecretCreatedPayload),
+    SecretUpdated(SecretUpdatedPayload),
     // StatusUpdate(StatusMessage),
     // WorkspaceExported(WorkspaceExportPayload),
     // WorkspaceImportBeginApprovalProcess(WorkspaceImportApprovalActorPayload),

--- a/lib/sdf-server/src/server/service.rs
+++ b/lib/sdf-server/src/server/service.rs
@@ -11,7 +11,7 @@ pub mod ws;
 // pub mod pkg;
 // pub mod provider;
 pub mod qualification;
-// pub mod secret;
+pub mod secret;
 // pub mod status;
 // pub mod variant_definition;
 

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -3,7 +3,6 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
-use dal::component::frame::FrameError;
 use dal::component::ComponentError;
 use dal::node_menu::NodeMenuError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;

--- a/lib/sdf-server/src/server/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/server/service/diagram/set_component_position.rs
@@ -1,5 +1,5 @@
 use axum::Json;
-use dal::{Component, ComponentId, SchemaVariant, Visibility, WsEvent};
+use dal::{Component, ComponentId, SchemaVariant, Visibility};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;

--- a/lib/sdf-server/src/server/service/func/create_func.rs
+++ b/lib/sdf-server/src/server/service/func/create_func.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use dal::authentication_prototype::{AuthenticationPrototype, AuthenticationPrototypeContext};
 use dal::{
     generate_name, ActionKind, ChangeSetPk, DalContext, ExternalProviderId, Func,
-    FuncBackendResponseType, FuncId, PropId, SchemaVariantId, Visibility, WsEvent,
+    FuncBackendResponseType, FuncId, PropId, SchemaVariantId, Visibility,
 };
 use serde::{Deserialize, Serialize};
 

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -1,9 +1,7 @@
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 use base64::{engine::general_purpose, Engine};
-use dal::{
-    func::argument::FuncArgument, DalContext, Func, FuncBackendKind, FuncId, Visibility, WsEvent,
-};
+use dal::{func::argument::FuncArgument, DalContext, Func, FuncBackendKind, FuncId, Visibility};
 use dal::{ChangeSetPk, FuncBackendResponseType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;

--- a/lib/sdf-server/src/server/service/schema/create_schema.rs
+++ b/lib/sdf-server/src/server/service/schema/create_schema.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use dal::ComponentKind;
-use dal::{Schema, Visibility, WsEvent};
+use dal::{Schema, Visibility};
 use serde::{Deserialize, Serialize};
 
 use super::SchemaResult;

--- a/lib/sdf-server/src/server/service/secret.rs
+++ b/lib/sdf-server/src/server/service/secret.rs
@@ -1,12 +1,13 @@
+use axum::routing::get;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::{get, patch, post},
+    routing::post,
     Json, Router,
 };
 use dal::{
-    ChangeSetError, DiagramError, KeyPairError, SecretId, StandardModelError, TransactionsError,
-    UserError, WorkspacePk, WsEventError,
+    ChangeSetError, KeyPairError, StandardModelError, TransactionsError, UserError, WorkspacePk,
+    WsEventError,
 };
 use thiserror::Error;
 
@@ -14,8 +15,8 @@ use crate::server::state::AppState;
 
 pub mod create_secret;
 pub mod get_public_key;
-pub mod list_secrets;
-pub mod update_secret;
+// pub mod list_secrets;
+// pub mod update_secret;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -24,8 +25,8 @@ pub enum SecretError {
     ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ContextTransactions(#[from] TransactionsError),
-    #[error(transparent)]
-    Diagram(#[from] DiagramError),
+    // #[error(transparent)]
+    // Diagram(#[from] DiagramError),
     #[error("Hyper error: {0}")]
     Hyper(#[from] hyper::http::Error),
     #[error(transparent)]
@@ -36,8 +37,8 @@ pub enum SecretError {
     Pg(#[from] si_data_pg::PgError),
     #[error(transparent)]
     Secret(#[from] dal::SecretError),
-    #[error("definition not found for secret: {0}")]
-    SecretWithInvalidDefinition(SecretId),
+    // #[error("definition not found for secret: {0}")]
+    // SecretWithInvalidDefinition(SecretId),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]
@@ -73,6 +74,6 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/get_public_key", get(get_public_key::get_public_key))
         .route("/", post(create_secret::create_secret))
-        .route("/", get(list_secrets::list_secrets))
-        .route("/", patch(update_secret::update_secret))
+    // .route("/", get(list_secrets::list_secrets))
+    // .route("/", patch(update_secret::update_secret))
 }


### PR DESCRIPTION
## Description

This PR converts the ephemeral `Secret` object to a graph node. It remains purely referential to the underlying `encrypted_secrets` table, but now persists to the workspace under a new "Secrets" category node.

This PR also restores the `create_secret` and `get_public_key` routes. Finally, it contains some lint fixes.

## GIF

<img src="https://media2.giphy.com/media/k0S9HVeQvlniHogBVt/giphy.gif"/>