### PR TITLE
feat: save recordings to github artifacts

### DIFF
--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -44,6 +44,13 @@ jobs:
           pnpm install cypress
           npx cypress run --spec "cypress/e2e/**"
 
+      - name: 'Upload Cypress Recordings to Github'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-recordings
+          path: app/web/cypress/videos/**/*.mp4
+          retention-days: 5
+
       # TODO(johnrwatson): Enable this when we're happy with the synthetic above
       #- name: Send PagerDuty alert on failure
       #  if: ${{ failure() }}


### PR DESCRIPTION
Save the cypress recordings for easy access/allowing you to see what didn't work during any run without having to re-run it to try and understand what went wrong.

**Example here**
https://github.com/systeminit/si/actions/runs/8005441473

See Artifacts: Produced during runtime