### PR TITLE
fix(sdf): async routes should not commit on error by default

### DIFF
--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -170,11 +170,32 @@ impl WsEvent {
         self.workspace_pk
     }
 
+    fn workspace_subject(&self) -> String {
+        format!("si.workspace_pk.{}.event", self.workspace_pk)
+    }
+
     /// Publishes the [`event`](Self) to the [`NatsTxn`](si_data_nats::NatsTxn). When the
     /// transaction is committed, the [`event`](Self) will be published for external use.
     pub async fn publish_on_commit(&self, ctx: &DalContext) -> WsEventResult<()> {
-        let subject = format!("si.workspace_pk.{}.event", self.workspace_pk);
-        ctx.txns().await?.nats().publish(subject, &self).await?;
+        ctx.txns()
+            .await?
+            .nats()
+            .publish(self.workspace_subject(), &self)
+            .await?;
+        Ok(())
+    }
+
+    /// Publishes the [`event`](Self) immediately to the Nats stream, without
+    /// waiting for the transactions to commit. Care should be taken to avoid
+    /// sending data to the frontend, such as object ids, that will only be
+    /// valid if the transaction commits successfully.
+    pub async fn publish_immediately(&self, ctx: &DalContext) -> WsEventResult<()> {
+        ctx.txns()
+            .await?
+            .nats()
+            .publish_immediately(self.workspace_subject(), &self)
+            .await?;
+
         Ok(())
     }
 }

--- a/lib/sdf-server/src/server/service.rs
+++ b/lib/sdf-server/src/server/service.rs
@@ -1,3 +1,4 @@
+pub mod async_route;
 pub mod change_set;
 pub mod component;
 pub mod diagram;

--- a/lib/sdf-server/src/server/service/async_route.rs
+++ b/lib/sdf-server/src/server/service/async_route.rs
@@ -1,0 +1,27 @@
+use dal::{DalContext, WsEvent};
+use hyper::Uri;
+use telemetry::prelude::*;
+
+pub type TaskId = ulid::Ulid;
+
+/// Handler for any fatal error condition in an "async" SDF route (one that does
+/// work on a background thread and returns the result via a WsEvent)
+pub async fn handle_error(
+    ctx: &DalContext,
+    uri: Uri,
+    task_id: TaskId,
+    err: impl std::error::Error,
+) {
+    let err_string = err.to_string();
+    error!("async route '{}' error: {}", uri.to_string(), err_string);
+    match WsEvent::async_error(ctx, task_id, err_string).await {
+        Ok(event) => {
+            if let Err(commit_err) = event.publish_immediately(ctx).await {
+                error!("Unable to publish ws event for async error: {commit_err}");
+            }
+        }
+        Err(creation_err) => {
+            error!("Unable to create ws event for async error: {creation_err}")
+        }
+    }
+}


### PR DESCRIPTION
Committing in the error handler for async tasks means we are not rolling our transactions back when a fatal error occurs. In the case of workspace import, this is catastrophic, since we begin import by clearing out the workspace entirely. A failed workspace import then leaves the user with an empty workspace, destroying any data they currently had.

Adds the ability to publish a WsEvent immediately, without requiring the commit to drain the pending event queue.

Adds a standardized error handler function `handle_error` which publishes the error event immediately and produces error telemetry.

The telemetry message for a failed async task looks like this now:

```
2024-02-22T17:18:10.901152Z ERROR ThreadId(47) sdf_server::server::service::async_route: async route '/api/pkg/install_pkg' error: could not find schema Docker Image with variant v1 for package component mysql
```

We should probably abstract more of the async behavior with a function that takes an async `FnOnce() -> Result<T, E>` spawns the tokio task, and handles the error itself. This will allow us to use the try (`?`) operator in the async code.