### PR TITLE
Restore "force new" for change sets in the new engine

### DIFF
--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -1,6 +1,6 @@
 use color_eyre::Result;
 use dal::change_set_pointer::{ChangeSetPointer, ChangeSetPointerId};
-use dal::{DalContext, UserClaim, Visibility};
+use dal::{DalContext, UserClaim};
 use jwt_simple::algorithms::RSAKeyPairLike;
 use jwt_simple::{claims::Claims, reexports::coarsetime::Duration};
 use names::{Generator, Name};
@@ -80,7 +80,7 @@ pub async fn create_change_set_and_update_ctx(
         )
         .await
         .expect("could not update pointer");
-    ctx.update_visibility(Visibility::new_for_change_set_pointer(change_set.id));
+    ctx.update_visibility_v2(&change_set);
     ctx.update_snapshot_to_visibility()
         .await
         .expect("could not update snapshot to visibility");

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -21,7 +21,6 @@ use crate::workspace_snapshot::conflict::Conflict;
 use crate::workspace_snapshot::update::Update;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::workspace_snapshot::WorkspaceSnapshotId;
-use crate::Workspace;
 use crate::{
     change_set_pointer::{ChangeSetPointer, ChangeSetPointerId},
     job::{
@@ -32,6 +31,7 @@ use crate::{
     workspace_snapshot::WorkspaceSnapshotError,
     HistoryActor, StandardModel, Tenancy, TenancyError, Visibility, WorkspacePk, WorkspaceSnapshot,
 };
+use crate::{ChangeSetPk, Workspace};
 
 /// A context type which contains handles to common core service dependencies.
 ///
@@ -565,6 +565,14 @@ impl DalContext {
     /// Updates this context with a new [`Visibility`].
     pub fn update_visibility(&mut self, visibility: Visibility) {
         self.visibility = visibility;
+    }
+
+    /// Updates this context with a new [`Visibility`], specific to the new engine.
+    pub fn update_visibility_v2(&mut self, change_set_v2: &ChangeSetPointer) {
+        self.update_visibility(Visibility::new(
+            ChangeSetPk::from(Ulid::from(change_set_v2.id)),
+            None,
+        ));
     }
 
     /// Runs a block of code with "deleted" [`Visibility`] DalContext using the same transactions

--- a/lib/dal/src/visibility.rs
+++ b/lib/dal/src/visibility.rs
@@ -1,13 +1,11 @@
-use crate::{ChangeSetPk, DalContext, TransactionsError};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_aux::field_attributes::deserialize_number_from_string;
 use si_data_pg::PgError;
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::change_set_pointer::ChangeSetPointerId;
-use serde_aux::field_attributes::deserialize_number_from_string;
-use ulid::Ulid;
+use crate::{ChangeSetPk, DalContext, TransactionsError};
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -46,14 +44,6 @@ impl Visibility {
             false => None,
         };
         Visibility::new(ChangeSetPk::NONE, deleted_at)
-    }
-
-    // TODO(nick,zack,jacob): remove this once the old change set dies.
-    pub fn new_for_change_set_pointer(change_set_pointer_id: ChangeSetPointerId) -> Self {
-        Visibility {
-            change_set_pk: ChangeSetPk::from(Ulid::from(change_set_pointer_id)),
-            deleted_at: None,
-        }
     }
 
     pub fn to_deleted(&self) -> Self {

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -4,14 +4,13 @@ use si_data_nats::NatsError;
 use si_data_pg::{PgError, PgRow};
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::change_set_pointer::{ChangeSetPointer, ChangeSetPointerError, ChangeSetPointerId};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    pk, standard_model, standard_model_accessor_ro, ChangeSetPk, DalContext, HistoryActor,
-    HistoryEvent, HistoryEventError, KeyPairError, StandardModelError, Tenancy, Timestamp,
-    TransactionsError, UserError, Visibility, WorkspaceSnapshot,
+    pk, standard_model, standard_model_accessor_ro, DalContext, HistoryActor, HistoryEvent,
+    HistoryEventError, KeyPairError, StandardModelError, Tenancy, Timestamp, TransactionsError,
+    UserError, WorkspaceSnapshot,
 };
 
 const WORKSPACE_GET_BY_PK: &str = include_str!("queries/workspace/get_by_pk.sql");
@@ -208,10 +207,7 @@ impl Workspace {
 
         // TODO(nick,zack,jacob): convert visibility (or get rid of it?) to use our the new change set id.
         // should set_change_set_pointer and set_workspace_snapshot happen in update_visibility?
-        ctx.update_visibility(Visibility::new(
-            ChangeSetPk::from(Ulid::from(change_set_id)),
-            None,
-        ));
+        ctx.update_visibility_v2(&change_set);
         ctx.update_snapshot_to_visibility().await?;
 
         let _history_event = HistoryEvent::new(

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -8,7 +8,7 @@ use dal::attribute::value::AttributeValueError;
 use dal::component::ComponentId;
 use dal::property_editor::PropertyEditorError;
 use dal::validation::resolver::ValidationResolverError;
-use dal::TransactionsError;
+use dal::{ChangeSetError, TransactionsError};
 use dal::{ComponentError as DalComponentError, StandardModelError};
 use thiserror::Error;
 
@@ -49,8 +49,8 @@ pub enum ComponentError {
     AttributeValue(#[from] AttributeValueError),
     // #[error("attribute value not found")]
     // AttributeValueNotFound,
-    // #[error("change set error: {0}")]
-    // ChangeSet(#[from] ChangeSetError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     // #[error("change status error: {0}")]
     // ChangeStatus(#[from] ChangeStatusError),
     // #[error("component debug view error: {0}")]

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -5,11 +5,11 @@ use axum::{
 };
 use dal::authentication_prototype::AuthenticationPrototypeError;
 use dal::func::argument::{FuncArgument, FuncArgumentError, FuncArgumentId, FuncArgumentKind};
-use dal::WsEventError;
 use dal::{
     workspace_snapshot::WorkspaceSnapshotError, DalContext, Func, FuncBackendKind,
     FuncBackendResponseType, FuncId, TransactionsError,
 };
+use dal::{ChangeSetError, WsEventError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -66,8 +66,8 @@ pub enum FuncError {
     AuthenticationPrototype(#[from] AuthenticationPrototypeError),
     //     #[error("attribute value missing")]
     //     AttributeValueMissing,
-    //     #[error("change set error: {0}")]
-    //     ChangeSet(#[from] ChangeSetError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     //     #[error("component error: {0}")]
     //     Component(#[from] ComponentError),
     //     #[error("component missing schema variant")]

--- a/lib/sdf-server/src/server/service/func/create_func.rs
+++ b/lib/sdf-server/src/server/service/func/create_func.rs
@@ -4,7 +4,7 @@ use base64::engine::general_purpose;
 use base64::Engine;
 use dal::authentication_prototype::{AuthenticationPrototype, AuthenticationPrototypeContext};
 use dal::{
-    generate_name, ActionKind, ChangeSetPk, DalContext, ExternalProviderId, Func,
+    generate_name, ActionKind, ChangeSet, DalContext, ExternalProviderId, Func,
     FuncBackendResponseType, FuncId, PropId, SchemaVariantId, Visibility,
 };
 use serde::{Deserialize, Serialize};
@@ -301,7 +301,7 @@ pub async fn create_func(
     OriginalUri(original_uri): OriginalUri,
     Json(request): Json<CreateFuncRequest>,
 ) -> FuncResult<impl IntoResponse> {
-    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     if let Some(name) = request.name.as_deref() {
         if dal::func::is_intrinsic(name)
@@ -311,8 +311,7 @@ pub async fn create_func(
         }
     }
 
-    // let force_changeset_pk = ChangeSet::force_new(&mut ctx).await?;
-    let force_changeset_pk: Option<ChangeSetPk> = None;
+    let force_changeset_pk = ChangeSet::force_new(&mut ctx).await?;
 
     let func = match request.variant {
         FuncVariant::Attribute => {

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -1,8 +1,10 @@
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 use base64::{engine::general_purpose, Engine};
-use dal::{func::argument::FuncArgument, DalContext, Func, FuncBackendKind, FuncId, Visibility};
-use dal::{ChangeSetPk, FuncBackendResponseType};
+use dal::FuncBackendResponseType;
+use dal::{
+    func::argument::FuncArgument, ChangeSet, DalContext, Func, FuncBackendKind, FuncId, Visibility,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use telemetry::prelude::*;
@@ -729,25 +731,9 @@ pub async fn save_func<'a>(
     OriginalUri(original_uri): OriginalUri,
     Json(request): Json<SaveFuncRequest>,
 ) -> FuncResult<impl IntoResponse> {
-    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    // let force_changeset_pk = ChangeSet::force_new(&mut ctx).await?;
-
-    let force_changeset_pk: Option<ChangeSetPk> = None;
-    // if ctx.visibility().is_head() {
-    //     let change_set = ChangeSet::new(&ctx, ChangeSet::generate_name(), None).await?;
-
-    //     let new_visibility = Visibility::new(change_set.pk, request.visibility.deleted_at);
-
-    //     ctx.update_visibility(new_visibility);
-
-    //     force_changeset_pk = Some(change_set.pk);
-
-    //     WsEvent::change_set_created(&ctx, change_set.pk)
-    //         .await?
-    //         .publish_on_commit(&ctx)
-    //         .await?;
-    // };
+    let force_changeset_pk = ChangeSet::force_new(&mut ctx).await?;
 
     let request_id = request.id;
     let _request_associations = request.associations.clone();


### PR DESCRIPTION
## Description

This PR restores the "force new" functionality for change sets in the new engine. It uses the same interface through the existing `ChangeSet` struct, but goes through the new `ChangeSetPointer` interface under the hood.

As a result of this change, existing logic attempting to coerce change set pointer data into visibility has been unified to one method.

## Reminder

The `ChangeSetPointer` struct will eventually replace the existing `ChangeSet` struct. After or during replacement, it will likely be renamed to `ChangeSet`. Both will likely happen once the existing `ChangeSet` struct is no longer used and the new engine reaches near feature parity with `main`.

## GIF

<img src="https://media2.giphy.com/media/wf2R8k4FLxauSkD91G/giphy.gif"/>