### PR TITLE
chore: use a dedicated postgres db for testing using `fsync=off`

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -6,6 +6,10 @@ services:
     image: systeminit/ci-base:stable
     environment:
       - "SI_TEST_PG_HOSTNAME=postgres"
+      # NOTE: We want to set this to the default postgres port as the tests run
+      # in *this* container and we're accessing postgres in a peer container
+      # and not using the external port mapping.
+      - "SI_TEST_PG_PORT=5432"
       - "SI_TEST_NATS_URL=nats"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     depends_on:
@@ -14,14 +18,23 @@ services:
       - jaeger
       - otelcol
 
+  # NOTE: this db is the same configuration as `postgres-test` under
+  # `dev/docker-compose.platform.yml`. In the CI environment, there should be
+  # *no* need for the `postgres` service as we aren't running the full service
+  # stack.
   postgres:
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
       - "PGPASSWORD=bugbear"
-      - "POSTGRES_USER=si"
-      - "POSTGRES_DB=si"
-      - "POSTGRES_MULTIPLE_DBS=si_test,si_test_dal,si_test_sdf_server,si_auth,si_module_index"
+      - "POSTGRES_USER=si_test"
+      - "POSTGRES_DB=si_test"
+      - "POSTGRES_MULTIPLE_DBS=si_test_dal,si_test_sdf_server"
+    command:
+      - "-c"
+      - "fsync=off"
+    ports:
+      - "6432:5432"
 
   nats:
     image: systeminit/nats:stable

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -8,6 +8,7 @@ groups = {
         "nats",
         "otelcol",
         "postgres",
+        "postgres-test",
     ],
     "backend": [
         "council",
@@ -66,7 +67,7 @@ allow_k8s_contexts(k8s_context())
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test"]
 for service in compose_services:
     if service == "jaeger":
         links = [

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -9,9 +9,23 @@ services:
       - "PGPASSWORD=bugbear"
       - "POSTGRES_USER=si"
       - "POSTGRES_DB=si"
-      - "POSTGRES_MULTIPLE_DBS=si_test,si_test_dal,si_test_sdf_server,si_auth,si_module_index"
+      - "POSTGRES_MULTIPLE_DBS=si_auth,si_module_index"
     ports:
       - "5432:5432"
+
+  postgres-test:
+    image: systeminit/postgres:stable
+    environment:
+      - "POSTGRES_PASSWORD=bugbear"
+      - "PGPASSWORD=bugbear"
+      - "POSTGRES_USER=si_test"
+      - "POSTGRES_DB=si_test"
+      - "POSTGRES_MULTIPLE_DBS=si_test_dal,si_test_sdf_server"
+    command:
+      - "-c"
+      - "fsync=off"
+    ports:
+      - "6432:5432"
 
   nats:
     image: systeminit/nats:stable

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -40,10 +40,15 @@ pub use tracing_subscriber;
 pub mod helpers;
 pub mod test_harness;
 
+const DEFAULT_TEST_PG_USER: &str = "si_test";
+const DEFAULT_TEST_PG_PORT_STR: &str = "6432";
+
 const ENV_VAR_NATS_URL: &str = "SI_TEST_NATS_URL";
 const ENV_VAR_MODULE_INDEX_URL: &str = "SI_TEST_MODULE_INDEX_URL";
 const ENV_VAR_PG_HOSTNAME: &str = "SI_TEST_PG_HOSTNAME";
 const ENV_VAR_PG_DBNAME: &str = "SI_TEST_PG_DBNAME";
+const ENV_VAR_PG_USER: &str = "SI_TEST_PG_USER";
+const ENV_VAR_PG_PORT: &str = "SI_TEST_PG_PORT";
 const ENV_VAR_BUILTIN_SCHEMAS: &str = "SI_TEST_BUILTIN_SCHEMAS";
 
 pub static COLOR_EYRE_INIT: Once = Once::new();
@@ -113,12 +118,19 @@ impl Config {
             config.pg.hostname = value;
         }
         config.pg.dbname = env::var(ENV_VAR_PG_DBNAME).unwrap_or_else(|_| pg_dbname.to_string());
+        config.pg.user =
+            env::var(ENV_VAR_PG_USER).unwrap_or_else(|_| DEFAULT_TEST_PG_USER.to_string());
+        config.pg.port = env::var(ENV_VAR_PG_PORT)
+            .unwrap_or_else(|_| DEFAULT_TEST_PG_PORT_STR.to_string())
+            .parse()?;
         config.pg.pool_max_size *= 32;
         config.pg.certificate_path = Some(config.postgres_key_path.clone().try_into()?);
 
         if let Ok(value) = env::var(ENV_VAR_MODULE_INDEX_URL) {
             config.module_index_url = value;
         }
+
+        debug!(?config, "test config");
 
         Ok(config)
     }


### PR DESCRIPTION
This change adds another running Postgres service in our Tilt/dev environment which is used exclusively by the DAL/SDF integration tests. This database is configured with `fsync=off` and greatly speeds up the database copy-from-template activity that happens in the integration test setup.

Reference: https://www.postgresql.org/message-id/CA%2BhUKGJwuVCJ7JYWchv1kFzRZO57_WChgsrzLmM9PeZTfo_bEQ%40mail.gmail.com