### PR TITLE
fix: use debian for vector

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
 
   vector:
     container_name: vector
-    image: timberio/vector:0.X-alpine
+    image: timberio/vector:0.X-debian
     profiles: [council, pinga, sdf, veritech]
     ports:
       - 8686:8686


### PR DESCRIPTION
The vector container should use Debian so it can run journalctl for the host's systemd logs.