### PR TITLE
Restore ability to update and list secrets in the new engine

### DIFF
--- a/README_NEW_ENGINE.md
+++ b/README_NEW_ENGINE.md
@@ -27,8 +27,8 @@ This guide provides the minimum steps for preparing changes for the new engine.
 1. `cargo check --all-targets --all-features`
 1. `cargo fmt`
 1. `cargo clippy --all-targets --all-features`
-1. `buck2 run //lib/dal:test-unit -- workspace_snapshot::graph`
-1. `buck2 run //lib/dal:test-integration -- new_engine`
+1. `buck2 run //lib/dal:test-unit`
+1. `buck2 run //lib/dal:test-integration` _(side note: bring back tests as they become relevant again)_
 1. `buck2 build //lib/... //bin/pinga //bin/sdf //bin/rebaser //bin/veritech //bin/council`
 1. `buck2 run dev:up` and test the application by hand
 

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -36,12 +36,13 @@ pub use color_eyre::{
     eyre::{eyre, Result, WrapErr},
 };
 pub use si_test_macros::{dal_test as test, sdf_test};
+pub use signup::WorkspaceSignup;
 pub use telemetry;
 pub use tracing_subscriber;
 
 pub mod helpers;
 mod signup;
-// pub mod test_harness;
+pub mod test_harness;
 
 const ENV_VAR_NATS_URL: &str = "SI_TEST_NATS_URL";
 const ENV_VAR_MODULE_INDEX_URL: &str = "SI_TEST_MODULE_INDEX_URL";

--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -1,14 +1,8 @@
 use dal::{
-    component::ComponentKind,
     func::{binding::FuncBinding, FuncId},
     key_pair::KeyPairPk,
-    node::NodeKind,
-    schema,
-    socket::{Socket, SocketArity, SocketEdgeKind, SocketKind},
-    ChangeSet, ChangeSetPk, Component, DalContext, DiagramKind, EncryptedSecret, Func,
-    FuncBackendKind, FuncBackendResponseType, KeyPair, Node, Prop, PropId, PropKind, Schema,
-    SchemaId, SchemaVariantId, Secret, StandardModel, User, UserPk, Visibility, Workspace,
-    WorkspacePk,
+    ChangeSet, ChangeSetPk, DalContext, EncryptedSecret, FuncBackendKind, KeyPair, Secret, User,
+    UserPk, Visibility,
 };
 use names::{Generator, Name};
 
@@ -58,115 +52,115 @@ pub async fn create_user(ctx: &DalContext) -> User {
     .expect("cannot create user")
 }
 
-pub async fn create_schema(ctx: &DalContext) -> Schema {
-    let name = generate_fake_name();
-    Schema::new(ctx, &name, &ComponentKind::Standard)
-        .await
-        .expect("cannot create schema")
-}
+// pub async fn create_schema(ctx: &DalContext) -> Schema {
+//     let name = generate_fake_name();
+//     Schema::new(ctx, &name, &ComponentKind::Standard)
+//         .await
+//         .expect("cannot create schema")
+// }
 
-pub async fn create_schema_variant(ctx: &DalContext, schema_id: SchemaId) -> schema::SchemaVariant {
-    create_schema_variant_with_root(ctx, schema_id).await.0
-}
+// pub async fn create_schema_variant(ctx: &DalContext, schema_id: SchemaId) -> schema::SchemaVariant {
+//     create_schema_variant_with_root(ctx, schema_id).await.0
+// }
 
-pub async fn create_schema_variant_with_root(
-    ctx: &DalContext,
-    schema_id: SchemaId,
-) -> (schema::SchemaVariant, schema::RootProp) {
-    let name = generate_fake_name();
-    let (variant, root) = schema::SchemaVariant::new(ctx, schema_id, name)
-        .await
-        .expect("cannot create schema variant");
+// pub async fn create_schema_variant_with_root(
+//     ctx: &DalContext,
+//     schema_id: SchemaId,
+// ) -> (schema::SchemaVariant, schema::RootProp) {
+//     let name = generate_fake_name();
+//     let (variant, root) = schema::SchemaVariant::new(ctx, schema_id, name)
+//         .await
+//         .expect("cannot create schema variant");
+//
+//     let _input_socket = Socket::new(
+//         ctx,
+//         "input",
+//         connection_annotation_string!("input"),
+//         SocketKind::Standalone,
+//         &SocketEdgeKind::ConfigurationInput,
+//         &SocketArity::Many,
+//         &DiagramKind::Configuration,
+//         Some(*variant.id()),
+//     )
+//     .await
+//     .expect("Unable to create socket");
+//
+//     let _output_socket = Socket::new(
+//         ctx,
+//         "output",
+//         connection_annotation_string!("output"),
+//         SocketKind::Standalone,
+//         &SocketEdgeKind::ConfigurationOutput,
+//         &SocketArity::Many,
+//         &DiagramKind::Configuration,
+//         Some(*variant.id()),
+//     )
+//     .await
+//     .expect("Unable to create socket");
+//
+//     (variant, root)
+// }
 
-    let _input_socket = Socket::new(
-        ctx,
-        "input",
-        connection_annotation_string!("input"),
-        SocketKind::Standalone,
-        &SocketEdgeKind::ConfigurationInput,
-        &SocketArity::Many,
-        &DiagramKind::Configuration,
-        Some(*variant.id()),
-    )
-    .await
-    .expect("Unable to create socket");
+// pub async fn create_prop_without_ui_optionals(
+//     ctx: &DalContext,
+//     name: impl AsRef<str>,
+//     kind: PropKind,
+//     schema_variant_id: SchemaVariantId,
+//     parent_prop_id: Option<PropId>,
+// ) -> Prop {
+//     Prop::new_without_ui_optionals(ctx, name, kind, schema_variant_id, parent_prop_id)
+//         .await
+//         .expect("could not create prop")
+// }
 
-    let _output_socket = Socket::new(
-        ctx,
-        "output",
-        connection_annotation_string!("output"),
-        SocketKind::Standalone,
-        &SocketEdgeKind::ConfigurationOutput,
-        &SocketArity::Many,
-        &DiagramKind::Configuration,
-        Some(*variant.id()),
-    )
-    .await
-    .expect("Unable to create socket");
+// pub async fn create_component_and_schema(ctx: &DalContext) -> Component {
+//     let schema = create_schema(ctx).await;
+//     let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
+//     schema_variant
+//         .finalize(ctx, None)
+//         .await
+//         .expect("unable to finalize schema variant");
+//     let name = generate_fake_name();
+//     let (component, _) = Component::new(ctx, &name, *schema_variant.id())
+//         .await
+//         .expect("cannot create component");
+//     component
+// }
 
-    (variant, root)
-}
+// pub async fn create_component_for_schema_variant(
+//     ctx: &DalContext,
+//     schema_variant_id: &SchemaVariantId,
+// ) -> Component {
+//     let name = generate_fake_name();
+//     let (component, _) = Component::new(ctx, &name, *schema_variant_id)
+//         .await
+//         .expect("cannot create component");
+//     component
+// }
 
-pub async fn create_prop_without_ui_optionals(
-    ctx: &DalContext,
-    name: impl AsRef<str>,
-    kind: PropKind,
-    schema_variant_id: SchemaVariantId,
-    parent_prop_id: Option<PropId>,
-) -> Prop {
-    Prop::new_without_ui_optionals(ctx, name, kind, schema_variant_id, parent_prop_id)
-        .await
-        .expect("could not create prop")
-}
+// pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
+//     let name = generate_fake_name();
+//     let (component, _) = Component::new_for_default_variant_from_schema(ctx, &name, *schema_id)
+//         .await
+//         .expect("cannot create component");
+//     component
+// }
 
-pub async fn create_component_and_schema(ctx: &DalContext) -> Component {
-    let schema = create_schema(ctx).await;
-    let mut schema_variant = create_schema_variant(ctx, *schema.id()).await;
-    schema_variant
-        .finalize(ctx, None)
-        .await
-        .expect("unable to finalize schema variant");
-    let name = generate_fake_name();
-    let (component, _) = Component::new(ctx, &name, *schema_variant.id())
-        .await
-        .expect("cannot create component");
-    component
-}
+// pub async fn create_node(ctx: &DalContext, node_kind: &NodeKind) -> Node {
+//     Node::new(ctx, node_kind).await.expect("cannot create node")
+// }
 
-pub async fn create_component_for_schema_variant(
-    ctx: &DalContext,
-    schema_variant_id: &SchemaVariantId,
-) -> Component {
-    let name = generate_fake_name();
-    let (component, _) = Component::new(ctx, &name, *schema_variant_id)
-        .await
-        .expect("cannot create component");
-    component
-}
-
-pub async fn create_component_for_schema(ctx: &DalContext, schema_id: &SchemaId) -> Component {
-    let name = generate_fake_name();
-    let (component, _) = Component::new_for_default_variant_from_schema(ctx, &name, *schema_id)
-        .await
-        .expect("cannot create component");
-    component
-}
-
-pub async fn create_node(ctx: &DalContext, node_kind: &NodeKind) -> Node {
-    Node::new(ctx, node_kind).await.expect("cannot create node")
-}
-
-pub async fn create_func(ctx: &DalContext) -> Func {
-    let name = generate_fake_name();
-    Func::new(
-        ctx,
-        name,
-        FuncBackendKind::String,
-        FuncBackendResponseType::String,
-    )
-    .await
-    .expect("cannot create func")
-}
+// pub async fn create_func(ctx: &DalContext) -> Func {
+//     let name = generate_fake_name();
+//     Func::new(
+//         ctx,
+//         name,
+//         FuncBackendKind::String,
+//         FuncBackendResponseType::String,
+//     )
+//     .await
+//     .expect("cannot create func")
+// }
 
 pub async fn create_func_binding(
     ctx: &DalContext,

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -108,6 +108,7 @@ pub use provider::ProviderArity;
 pub use provider::ProviderKind;
 pub use schema::variant::root_prop::component_type::ComponentType;
 pub use schema::{Schema, SchemaError, SchemaId, SchemaVariant, SchemaVariantId};
+pub use secret::Secret;
 pub use secret::SecretError;
 pub use secret::SecretId;
 pub use secret::SecretView;

--- a/lib/dal/tests/integration_test/internal/mod.rs
+++ b/lib/dal/tests/integration_test/internal/mod.rs
@@ -18,7 +18,7 @@ mod new_engine;
 // mod property_editor;
 // mod provider;
 // mod schema;
-// mod secret;
+mod secret;
 // mod socket;
 // mod standard_model;
 // mod status_update;

--- a/lib/sdf-server/src/server/routes.rs
+++ b/lib/sdf-server/src/server/routes.rs
@@ -27,32 +27,30 @@ pub fn routes(state: AppState) -> Router {
             "/api/change_set",
             crate::server::service::change_set::routes(),
         )
-        .nest("/api/session", crate::server::service::session::routes())
         .nest(
             "/api/component",
             crate::server::service::component::routes(),
         )
-        .nest("/api/func", crate::server::service::func::routes())
-        .nest("/api/schema", crate::server::service::schema::routes())
         .nest("/api/diagram", crate::server::service::diagram::routes())
+        .nest("/api/func", crate::server::service::func::routes())
         .nest("/api/graphviz", crate::server::service::graphviz::routes())
-        .nest("/api/ws", crate::server::service::ws::routes())
         .nest(
             "/api/qualification",
             crate::server::service::qualification::routes(),
         )
+        .nest("/api/schema", crate::server::service::schema::routes())
+        .nest("/api/secret", crate::server::service::secret::routes())
+        .nest("/api/session", crate::server::service::session::routes())
+        .nest("/api/ws", crate::server::service::ws::routes())
+        // .nest("/api/fix", crate::server::service::fix::routes())
+        // .nest("/api/pkg", crate::server::service::pkg::routes())
+        // .nest("/api/provider", crate::server::service::provider::routes())
+        // .nest("/api/status", crate::server::service::status::routes())
+        // .nest(
+        //     "/api/variant_def",
+        //     crate::server::service::variant_definition::routes(),
+        // )
         .layer(CompressionLayer::new());
-
-    // .nest("/api/fix", crate::server::service::fix::routes())
-    // .nest("/api/pkg", crate::server::service::pkg::routes())
-    // .nest("/api/provider", crate::server::service::provider::routes())
-    // .nest("/api/secret", crate::server::service::secret::routes())
-    // .nest("/api/status", crate::server::service::status::routes())
-    // .nest(
-    //     "/api/variant_def",
-    //     crate::server::service::variant_definition::routes(),
-    // )
-    // .nest("/api/ws", crate::server::service::ws::routes());
 
     // Load dev routes if we are in dev mode (decided by "opt-level" at the moment).
     // router = dev_routes(router);

--- a/lib/sdf-server/src/server/service/secret.rs
+++ b/lib/sdf-server/src/server/service/secret.rs
@@ -1,4 +1,4 @@
-use axum::routing::get;
+use axum::routing::{get, patch};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -6,8 +6,8 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    ChangeSetError, KeyPairError, StandardModelError, TransactionsError, UserError, WorkspacePk,
-    WsEventError,
+    ChangeSetError, KeyPairError, SecretId, StandardModelError, TransactionsError, UserError,
+    WorkspacePk, WsEventError,
 };
 use thiserror::Error;
 
@@ -15,8 +15,8 @@ use crate::server::state::AppState;
 
 pub mod create_secret;
 pub mod get_public_key;
-// pub mod list_secrets;
-// pub mod update_secret;
+pub mod list_secrets;
+pub mod update_secret;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -37,8 +37,8 @@ pub enum SecretError {
     Pg(#[from] si_data_pg::PgError),
     #[error(transparent)]
     Secret(#[from] dal::SecretError),
-    // #[error("definition not found for secret: {0}")]
-    // SecretWithInvalidDefinition(SecretId),
+    #[error("definition not found for secret: {0}")]
+    SecretWithInvalidDefinition(SecretId),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]
@@ -74,6 +74,6 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/get_public_key", get(get_public_key::get_public_key))
         .route("/", post(create_secret::create_secret))
-    // .route("/", get(list_secrets::list_secrets))
-    // .route("/", patch(update_secret::update_secret))
+        .route("/", get(list_secrets::list_secrets))
+        .route("/", patch(update_secret::update_secret))
 }

--- a/lib/sdf-server/src/server/service/secret/list_secrets.rs
+++ b/lib/sdf-server/src/server/service/secret/list_secrets.rs
@@ -5,7 +5,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use dal::secret::{SecretDefinitionView, SecretView};
-use dal::{Secret, StandardModel, Visibility};
+use dal::{Secret, Visibility};
 
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use crate::service::secret::SecretError;
@@ -54,7 +54,7 @@ pub async fn list_secrets(
     for secret in Secret::list(&ctx).await? {
         hash_map
             .get_mut(secret.definition())
-            .ok_or(SecretError::SecretWithInvalidDefinition(*secret.id()))?
+            .ok_or(SecretError::SecretWithInvalidDefinition(secret.id()))?
             .secrets
             .push(SecretView::from_secret(&ctx, secret).await?);
     }

--- a/lib/sdf-server/src/server/service/secret/update_secret.rs
+++ b/lib/sdf-server/src/server/service/secret/update_secret.rs
@@ -2,8 +2,8 @@ use axum::response::IntoResponse;
 use axum::Json;
 use dal::secret::SecretView;
 use dal::{
-    key_pair::KeyPairPk, ChangeSet, EncryptedSecret, SecretAlgorithm, SecretVersion, Visibility,
-    WsEvent,
+    key_pair::KeyPairPk, ChangeSet, EncryptedSecret, Secret, SecretAlgorithm, SecretVersion,
+    Visibility, WsEvent,
 };
 use dal::{HistoryActor, SecretError, SecretId, StandardModel};
 use serde::{Deserialize, Serialize};
@@ -66,6 +66,10 @@ pub async fn update_secret(
         secret.set_version(&ctx, new_data.version).await?;
         secret.set_algorithm(&ctx, new_data.algorithm).await?;
     }
+
+    // TODO(nick): unify this with the encrypted secrets stuff. For now, let's update the referential secret
+    // as a side effect.
+    Secret::update(&ctx, &secret).await?;
 
     WsEvent::secret_updated(&ctx, *secret.id())
         .await?


### PR DESCRIPTION
## Description

This PR restores the ability to update and list secrets. Updating secrets remains the same, but now the referential secrets on the snapshot are updated. Listing secrets uses the same interfaces, but now the graph is purely used and mimics the original logic (this first pass is likely unoptimized as a result).

This is also the first time integration tests have been restored that aren't part of the `new_engine` module! The secrets tests return. We needed to expose `WorkspaceSignup` from the `dal-test` crate as a result, since `WorkspaceSignup` is still in the `dal` on main. The `test_harness` module has been partially restored as well.

## Disclaimer

We need to figure out the long term shape and relationship between referential secrets and encrypted secrets. The `update_secrets` route contains side effect logic for updating the referential secret. This is brittle, but will work for the first pass. However, it is unlikely to work in the long term.

## GIF

<img src="https://media2.giphy.com/media/8HcT5UwUTT0XtlIvmc/giphy.gif"/>