### PR TITLE
feat: run workflow with option for multiple executions, improve cypress execution logic

### DIFF
--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup authentication for vite & other synthetic test variables
         working-directory: app/web
         run: |
-          apt update
-          apt install uuid -y
+          sudo apt update
+          sudo apt install uuid -y
           cp .env .env.local
           echo "VITE_AUTH0_USERNAME=${{ secrets.VITE_AUTH0_USERNAME }}" >> .env.local                           # Production Synthetic User Email
           echo "VITE_AUTH0_PASSWORD=${{ secrets.VITE_AUTH0_PASSWORD }}" >> .env.local                           # Production Synthetic User Password

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - feat/add-more-synthetics
   schedule:
-    - cron: '*/5 * * * *'  # Runs every 5 minutes
+    - cron: '*/15 * * * *'  # Runs every 5 minutes
 
 jobs:
   cypress-tests:
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        containers: [1, 2] #, 3, 4, 5, 6, 7, 8, 9, 10] - temp disabled mass
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -4,14 +4,19 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - feat/add-more-synthetics
   schedule:
-    - cron: '*/15 * * * *'  # Runs every 15 minutes
+    - cron: '*/5 * * * *'  # Runs every 5 minutes
 
 jobs:
   cypress-tests:
     runs-on: ubuntu-latest
-
+    strategy:
+      # don't fail the entire matrix on failure
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,7 +36,8 @@ jobs:
           echo "VITE_SI_WORKSPACE_ID=${{ vars.VITE_PROD_SI_WORKSPACE_ID }}" >> .env.local                       # Production Synthetic Workspace ID
           echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
           echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
-          
+          echo "VITE_SI_CYPRESS_MULTIPLIER=${{ vars.VITE_PROD_SI_CYPRESS_MULTIPLIER }}" >> .env.local                                                    # Set Execution to 10 iterations
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -46,8 +52,9 @@ jobs:
 
       - name: 'Upload Cypress Recordings to Github'
         uses: actions/upload-artifact@v4
+        if: always()
         with:
-          name: cypress-recordings
+          name: cypress-recordings-run-${{ matrix.containers }}
           path: app/web/cypress/videos/**/*.mp4
           retention-days: 5
 

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Setup authentication for vite & other synthetic test variables
         working-directory: app/web
         run: |
+          apt update
+          apt install uuid -y
           cp .env .env.local
           echo "VITE_AUTH0_USERNAME=${{ secrets.VITE_AUTH0_USERNAME }}" >> .env.local                           # Production Synthetic User Email
           echo "VITE_AUTH0_PASSWORD=${{ secrets.VITE_AUTH0_PASSWORD }}" >> .env.local                           # Production Synthetic User Password
@@ -33,7 +35,8 @@ jobs:
           echo "VITE_SI_WORKSPACE_ID=${{ vars.VITE_PROD_SI_WORKSPACE_ID }}" >> .env.local                       # Production Synthetic Workspace ID
           echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
           echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
-          echo "VITE_SI_CYPRESS_MULTIPLIER=${{ vars.VITE_PROD_SI_CYPRESS_MULTIPLIER }}" >> .env.local                                                    # Set Execution to 10 iterations
+          echo "VITE_SI_CYPRESS_MULTIPLIER=${{ vars.VITE_PROD_SI_CYPRESS_MULTIPLIER }}" >> .env.local           # Set Execution to 10 iterations
+          echo "VITE_UUID="$(uuid)"                                                                             # UUID for test validation
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -2,9 +2,6 @@ name: Cypress E2E Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - feat/add-more-synthetics
   schedule:
     - cron: '*/15 * * * *'  # Runs every 5 minutes
 
@@ -16,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2] #, 3, 4, 5, 6, 7, 8, 9, 10] - temp disabled mass
+        containers: [1] # , 2, 3, 4, 5, 6, 7, 8, 9, 10] - temp disabled mass
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -36,7 +36,7 @@ jobs:
           echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
           echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
           echo "VITE_SI_CYPRESS_MULTIPLIER=${{ vars.VITE_PROD_SI_CYPRESS_MULTIPLIER }}" >> .env.local           # Set Execution to 10 iterations
-          echo "VITE_UUID="$(uuid)"                                                                             # UUID for test validation
+          echo "VITE_UUID=$(uuid)"                                                                              # UUID for test validation
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -36,7 +36,7 @@ jobs:
           echo "VITE_SI_PROPAGATION_COMPONENT_A=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_A }}" >> .env.local # Production Propagation Test Component A [from]
           echo "VITE_SI_PROPAGATION_COMPONENT_B=${{ vars.VITE_PROD_SI_PROPAGATION_COMPONENT_B }}" >> .env.local # Production Propagation Test Component B [to]
           echo "VITE_SI_CYPRESS_MULTIPLIER=${{ vars.VITE_PROD_SI_CYPRESS_MULTIPLIER }}" >> .env.local           # Set Execution to 10 iterations
-          echo "VITE_UUID=$(uuid)"                                                                              # UUID for test validation
+          echo "VITE_UUID=$(uuid)" >> .env.local                                                                # UUID for test validation
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/app/web/.env
+++ b/app/web/.env
@@ -18,6 +18,8 @@ VITE_AUTH0_DOMAIN=systeminit.auth0.com
 # VITE_SI_WORKSPACE_ID = 01HPMKZZ0DF54B12FNBF6Z7704              # Production Workspace URL Used for Synthetics
 # VITE_SI_PROPAGATION_COMPONENT_A = c_01HPMM4A95M2E3V6STMZZCZJRZ # Production: Used for E2E Value Propagation Test [output socket i.e. from]
 # VITE_SI_PROPAGATION_COMPONENT_B = c_01HPMM4BC682PFCYD7GE3X3AQW # Production: Used for E2E Value Propagation Test [input socket i.e. to]
+# VITE_SI_CYPRESS_MULTIPLIER=1                                   # How many times to run each test in cypress, only changes modelling tests
+
 
 # TODO: point this at public/deployed module index api
 VITE_MODULE_INDEX_API_URL=https://module-index.systeminit.com

--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -15,6 +15,6 @@ export default defineConfig({
     viewportWidth: 1500,
   },
   projectId: "k8tgfj",
-  video: true
+  video: true,
 })
 

--- a/app/web/cypress/e2e/authentication/login.cy.ts
+++ b/app/web/cypress/e2e/authentication/login.cy.ts
@@ -1,11 +1,11 @@
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe("Login", () => {
+  describe("login", () => {
     beforeEach(() => {
       cy.visit("/");
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it("Log In", () => {
+    it("log_in", () => {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.visit("/");
       // check that you're on head i.e. that you were redirected correctly

--- a/app/web/cypress/e2e/authentication/login.cy.ts
+++ b/app/web/cypress/e2e/authentication/login.cy.ts
@@ -2,9 +2,10 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
   describe("Login", () => {
     beforeEach(() => {
       cy.visit("/");
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it("lets the user log in", () => {
+    it("Log In", () => {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.visit("/");
       // check that you're on head i.e. that you were redirected correctly

--- a/app/web/cypress/e2e/authentication/login.cy.ts
+++ b/app/web/cypress/e2e/authentication/login.cy.ts
@@ -1,13 +1,15 @@
-describe("Login", () => {
-  beforeEach(() => {
-    cy.visit("/");
-  });
+Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+  describe("Login", () => {
+    beforeEach(() => {
+      cy.visit("/");
+    });
 
-  it("lets the user log in", () => {
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-    cy.visit("/");
-    // check that you're on head i.e. that you were redirected correctly
-    cy.url().should("contain", "head");
-  });
+    it("lets the user log in", () => {
+      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.visit("/");
+      // check that you're on head i.e. that you were redirected correctly
+      cy.url().should("contain", "head");
+    });
 
+  });
 });

--- a/app/web/cypress/e2e/authentication/logout.cy.ts
+++ b/app/web/cypress/e2e/authentication/logout.cy.ts
@@ -1,18 +1,20 @@
-describe("Logout", () => {
-  beforeEach(() => {
-    cy.visit("/");
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-  });
+Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+  describe("Logout", () => {
+    beforeEach(() => {
+      cy.visit("/");
+      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+    });
 
-  it("lets the user log out", () => {
-    cy.visit("/");
-    cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
-    cy.get('[aria-label="Profile"]').should('exist').click();
-    cy.get('#dropdown-menu-item-1').should('exist').should('be.visible').click({ force: true });
+    it("lets the user log out", () => {
+      cy.visit("/");
+      cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
+      cy.get('[aria-label="Profile"]').should('exist').click();
+      cy.get('#dropdown-menu-item-1').should('exist').should('be.visible').click({ force: true });
 
-    // There is a bug currently where you log out of the product & it just logs you out to the dashboard page
-    // of the UI in auth portal
-    cy.url().should("contain", import.meta.env.VITE_AUTH_PORTAL_URL + '/dashboard');
+      // There is a bug currently where you log out of the product & it just logs you out to the dashboard page
+      // of the UI in auth portal
+      cy.url().should("contain", import.meta.env.VITE_AUTH_PORTAL_URL + '/dashboard');
 
+    });
   });
 });

--- a/app/web/cypress/e2e/authentication/logout.cy.ts
+++ b/app/web/cypress/e2e/authentication/logout.cy.ts
@@ -3,9 +3,10 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
     beforeEach(() => {
       cy.visit("/");
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it("lets the user log out", () => {
+    it("Log Out", () => {
       cy.visit("/");
       cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
       cy.get('[aria-label="Profile"]').should('exist').click();

--- a/app/web/cypress/e2e/authentication/logout.cy.ts
+++ b/app/web/cypress/e2e/authentication/logout.cy.ts
@@ -1,12 +1,12 @@
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe("Logout", () => {
+  describe("logout", () => {
     beforeEach(() => {
       cy.visit("/");
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it("Log Out", () => {
+    it("log_out", () => {
       cy.visit("/");
       cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
       cy.get('[aria-label="Profile"]').should('exist').click();

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -2,13 +2,13 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Create Component', () => {
+  describe('component', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it('should pick up an AWS Credential and move it onto the diagram', () => {
+    it('create', () => {
       cy.visit('/')
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -1,39 +1,40 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Create Components', () => {
-  beforeEach(function () {
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-  });
+Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+  describe('Create Components', () => {
+    beforeEach(function () {
+      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+    });
 
-  it('should pick up an AWS Credential and move it onto the diagram', () => {
-    cy.visit('/')
-    cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
+    it('should pick up an AWS Credential and move it onto the diagram', () => {
+      cy.visit('/')
+      cy.contains('Create change set', { timeout: 30000 }).should('be.visible').click();
 
-    // Find the AWS Credential
-    cy.get('[data-cy="asset_card', { timeout: 10000 }).contains('AWS Credential').should('be.visible').as('awsCred')
+      // Find the AWS Credential
+      cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential').should('be.visible').as('awsCred')
 
-    // Find the canvas to get a location to drag to
-    cy.get('canvas').first().as('konvaStage');
+      // Find the canvas to get a location to drag to
+      cy.get('canvas').first().as('konvaStage');
 
-    // drag to the canvas
-    cy.dragTo('@awsCred', '@konvaStage');
+      // drag to the canvas
+      cy.dragTo('@awsCred', '@konvaStage');
 
-    //check to make sure a component has been added to the outliner
-    cy.get('[class="component-outline-node"]', { timeout: 10000 }).contains('AWS Credential', { timeout: 10000 }).should('be.visible');
+      //check to make sure a component has been added to the outliner
+      cy.get('[class="component-outline-node"]', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible');
 
-    // Click the button to destroy changeset
-    cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
-    .eq(1) // Selects the second button (index starts from 0 for create changeset button)
-    .click();
+      // Click the button to destroy changeset
+      cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
+      .eq(1) // Selects the second button (index starts from 0 for create changeset button)
+      .click();
 
-    // Wait for the delete panel to appear
-    cy.wait(1000);
+      // Wait for the delete panel to appear
+      cy.wait(1000);
 
-    // Then click the agree button in the UI
-    cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
-    .click();
+      // Then click the agree button in the UI
+      cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
+      .click();
 
+    })
   })
-})
-
+});

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -9,7 +9,10 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
 
     it('should pick up an AWS Credential and move it onto the diagram', () => {
       cy.visit('/')
-      cy.contains('Create change set', { timeout: 30000 }).should('be.visible').click();
+
+      cy.get('#vorm-input-3', { timeout: 30000 }).clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+
+      cy.contains('Create change set', { timeout: 30000 }).click();
 
       // Find the AWS Credential
       cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential').should('be.visible').as('awsCred')

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -2,9 +2,10 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Create Components', () => {
+  describe('Create Component', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
     it('should pick up an AWS Credential and move it onto the diagram', () => {
@@ -47,4 +48,5 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
 
     })
   })
+
 });

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -10,9 +10,16 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
     it('should pick up an AWS Credential and move it onto the diagram', () => {
       cy.visit('/')
 
-      cy.get('#vorm-input-3', { timeout: 30000 }).clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
+      
+      cy.get('#vorm-input-3').clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
 
       cy.contains('Create change set', { timeout: 30000 }).click();
+
+      // Give time to redirect onto the new changeset
+      cy.url().should('not.include', 'head', { timeout: 10000 });
 
       // Find the AWS Credential
       cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential').should('be.visible').as('awsCred')

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -2,13 +2,13 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Delete Component', () => {
+  describe('component', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it('should pick up an AWS Credential add then delete it from the diagram', () => {
+    it('delete', () => {
       cy.visit('/')
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -2,9 +2,10 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Delete Components', () => {
+  describe('Delete Component', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
     it('should pick up an AWS Credential add then delete it from the diagram', () => {

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -10,12 +10,16 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
     it('should pick up an AWS Credential add then delete it from the diagram', () => {
       cy.visit('/')
 
-      cy.contains('Create change set', { timeout: 30000 })
-      .should('be.visible')
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
+      
+      cy.get('#vorm-input-3').clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
 
-      cy.get('#vorm-input-3', { timeout: 30000 }).clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
 
       cy.contains('Create change set', { timeout: 30000 }).click();
+
+      // Give time to redirect onto the new changeset
+      cy.url().should('not.include', 'head', { timeout: 10000 });
 
       // Find the AWS Credential
       cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible').as('awsCred')

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -9,9 +9,13 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
 
     it('should pick up an AWS Credential add then delete it from the diagram', () => {
       cy.visit('/')
+
       cy.contains('Create change set', { timeout: 30000 })
-        .should('be.visible')
-        .click();
+      .should('be.visible')
+
+      cy.get('#vorm-input-3', { timeout: 30000 }).clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+
+      cy.contains('Create change set', { timeout: 30000 }).click();
 
       // Find the AWS Credential
       cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible').as('awsCred')

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -1,54 +1,55 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Delete Components', () => {
-  beforeEach(function () {
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-  });
+Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+  describe('Delete Components', () => {
+    beforeEach(function () {
+      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+    });
 
-  it('should pick up an AWS Credential add then delete it from the diagram', () => {
-    cy.visit('/')
-    cy.contains('Create change set', { timeout: 10000 })
-      .should('be.visible')
-      .click();
+    it('should pick up an AWS Credential add then delete it from the diagram', () => {
+      cy.visit('/')
+      cy.contains('Create change set', { timeout: 30000 })
+        .should('be.visible')
+        .click();
 
-    // Find the AWS Credential
-    cy.get('[data-cy="asset_card', { timeout: 10000 }).contains('AWS Credential', { timeout: 10000 }).should('be.visible').as('awsCred')
+      // Find the AWS Credential
+      cy.get('[data-cy="asset_card', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible').as('awsCred')
 
-    // Find the canvas to get a location to drag to
-    cy.get('canvas').first().as('konvaStage');
+      // Find the canvas to get a location to drag to
+      cy.get('canvas').first().as('konvaStage');
 
-    // Drag to the canvas
-    cy.dragTo('@awsCred', '@konvaStage');
+      // Drag to the canvas
+      cy.dragTo('@awsCred', '@konvaStage');
 
-    // Check to make sure a component has been added to the outliner
-    cy.get('[class="component-outline-node"]', { timeout: 10000 }).
-      contains('AWS Credential', { timeout: 10000 })
-      .should('be.visible')
-      .rightclick();
+      // Check to make sure a component has been added to the outliner
+      cy.get('[class="component-outline-node"]', { timeout: 30000 }).
+        contains('AWS Credential', { timeout: 30000 })
+        .should('be.visible')
+        .rightclick();
 
-    // Click the second dropdown menu item
-    cy.get('#dropdown-menu-item-2').click();
+      // Click the second dropdown menu item
+      cy.get('#dropdown-menu-item-2').click();
 
-    // Click the destroy button
-    cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
-      .click();
+      // Click the destroy button
+      cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
+        .click();
 
-    //check to make sure a component has been added to the outliner
-    cy.get('[class="component-outline-node"]', { timeout: 10000 }).contains('AWS Credential', { timeout: 10000 }).should('be.visible');
+      //check to make sure a component has been added to the outliner
+      cy.get('[class="component-outline-node"]', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible');
 
-    // Click the button to destroy changeset
-    cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
-      .eq(1) // Selects the second button (index starts from 0 for create changeset button)
-      .click();
+      // Click the button to destroy changeset
+      cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
+        .eq(1) // Selects the second button (index starts from 0 for create changeset button)
+        .click();
 
-    // Wait for the delete panel to appear
-    cy.wait(1000);
+      // Wait for the delete panel to appear
+      cy.wait(1000);
 
-    // Then click the agree button in the UI
-    cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
-      .click();
+      // Then click the agree button in the UI
+      cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
+        .click();
 
+    })
   })
-})
-
+});

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -2,13 +2,13 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Value Propagation', () => {
+  describe('component', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
-    it('change value on component A and check it propogates to component B', () => {
+    it('value_propagation', () => {
 
       console.log(import.meta.env.VITE_UUID);
       cy.log(import.meta.env.VITE_UUID);

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -12,9 +12,16 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       // Go to the Synthetic Workspace
       cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')
 
-      // Check UI has prompted for Create Change Set, this sometimes doesn't happen
-      // I have no idea why but it breaks the test [johnrwatson]
-      cy.contains('Create change set', { timeout: 30000 }).should('be.visible');
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
+      
+      cy.get('#vorm-input-3').clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+
+      cy.contains('Create change set', { timeout: 30000 }).click();
+
+      // Give time to redirect onto the new changeset
+      cy.url().should('not.include', 'head', { timeout: 10000 });
 
       cy.url().then(currentUrl => {
         // Construct a new URL with desired query parameters for selecting 

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -2,12 +2,16 @@
 ///<reference path="../global.d.ts"/>
 
 Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
-  describe('Value Propogation', () => {
+  describe('Value Propagation', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
 
     it('change value on component A and check it propogates to component B', () => {
+
+      console.log(import.meta.env.VITE_UUID);
+      cy.log(import.meta.env.VITE_UUID);
 
       // Go to the Synthetic Workspace
       cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -1,74 +1,76 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Value Propogation', () => {
-  beforeEach(function () {
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-  });
-
-  it('change value on component A and check it propogates to component B', () => {
-
-    // Go to the Synthetic Workspace
-    cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')
-
-    // Check UI has prompted for Create Change Set, this sometimes doesn't happen
-    // I have no idea why but it breaks the test [johnrwatson]
-    cy.contains('Create change set', { timeout: 10000 }).should('be.visible');
-
-    cy.url().then(currentUrl => {
-      // Construct a new URL with desired query parameters for selecting 
-      // the attribute panel for a known component
-      let newUrl = new URL(currentUrl);
-      newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_A);
-      newUrl.searchParams.set('t', 'attributes');
-    
-      // Visit the new URL
-      cy.visit(newUrl.href);
+Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+  describe('Value Propogation', () => {
+    beforeEach(function () {
+      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
     });
 
-    // Give the page a few seconds to load
-    cy.wait(2000);
+    it('change value on component A and check it propogates to component B', () => {
 
-    // Generate a random number between 1 and 100 to insert into the 
-    // attribute value for Integer
-    const randomNumber = Math.floor(Math.random() * 100) + 1;
+      // Go to the Synthetic Workspace
+      cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')
 
-    // Find the attribute for the Integer Input
-    cy.get('.attributes-panel-item__input-wrap input[type="number"]')
-    .clear()
-    .type(randomNumber.toString() + '{enter}') // type the new value
+      // Check UI has prompted for Create Change Set, this sometimes doesn't happen
+      // I have no idea why but it breaks the test [johnrwatson]
+      cy.contains('Create change set', { timeout: 30000 }).should('be.visible');
 
-    // This will have auto-directed us onto a changeset, give it a few seconds
-    // to load up
-    cy.wait(3000)
+      cy.url().then(currentUrl => {
+        // Construct a new URL with desired query parameters for selecting 
+        // the attribute panel for a known component
+        let newUrl = new URL(currentUrl);
+        newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_A);
+        newUrl.searchParams.set('t', 'attributes');
+      
+        // Visit the new URL
+        cy.visit(newUrl.href);
+      });
 
-    cy.url().then(currentUrl => {
-      // Construct a new URL with desired query parameters for selecting 
-      // the attribute panel for a known connected component
-      let newUrl = new URL(currentUrl);
-      newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_B);
-      newUrl.searchParams.set('t', 'attributes');
-      cy.visit(newUrl.href);
-    });
+      // Give the page a few seconds to load
+      cy.wait(2000);
 
-    // Wait for the values to propagate
-    cy.wait(10000);
+      // Generate a random number between 1 and 100 to insert into the 
+      // attribute value for Integer
+      const randomNumber = Math.floor(Math.random() * 100) + 1;
 
-    // Validate that the value has propogated through the system
-    cy.get('.attributes-panel-item__input-wrap input[type="number"]')
-    .should('have.value', randomNumber.toString());
+      // Find the attribute for the Integer Input
+      cy.get('.attributes-panel-item__input-wrap input[type="number"]')
+      .clear()
+      .type(randomNumber.toString() + '{enter}') // type the new value
 
-    // Click the button to destroy changeset
-    cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
-    .eq(1) // Selects the second button (index starts from 0 for create changeset button)
-    .click();
+      // This will have auto-directed us onto a changeset, give it a few seconds
+      // to load up
+      cy.wait(3000)
 
-    // Wait for the delete panel to appear
-    cy.wait(1000);
+      cy.url().then(currentUrl => {
+        // Construct a new URL with desired query parameters for selecting 
+        // the attribute panel for a known connected component
+        let newUrl = new URL(currentUrl);
+        newUrl.searchParams.set('s', import.meta.env.VITE_SI_PROPAGATION_COMPONENT_B);
+        newUrl.searchParams.set('t', 'attributes');
+        cy.visit(newUrl.href);
+      });
 
-    // Then click the agree button in the UI
-    cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
-    .click();
+      // Wait for the values to propagate
+      cy.wait(30000);
 
+      // Validate that the value has propogated through the system
+      cy.get('.attributes-panel-item__input-wrap input[type="number"]')
+      .should('have.value', randomNumber.toString(), { timeout: 30000 });
+
+      // Click the button to destroy changeset
+      cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
+      .eq(1) // Selects the second button (index starts from 0 for create changeset button)
+      .click();
+
+      // Wait for the delete panel to appear
+      cy.wait(1000);
+
+      // Then click the agree button in the UI
+      cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
+      .click();
+
+    })
   })
-})
+});

--- a/app/web/cypress/e2e/module-index/check-modules.cy.ts
+++ b/app/web/cypress/e2e/module-index/check-modules.cy.ts
@@ -1,7 +1,7 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Module Index Validate mdoules', () => {
+describe('Module Index Validation', () => {
     it('Should have at least 40 modules', () => {
       cy.request('https://module-index.systeminit.com/builtins').then((response) => {
         // Ensure that the response status is 200

--- a/app/web/cypress/e2e/module-index/check-modules.cy.ts
+++ b/app/web/cypress/e2e/module-index/check-modules.cy.ts
@@ -1,8 +1,8 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Module Index Validation', () => {
-    it('Should have at least 40 modules', () => {
+describe('module_index', () => {
+    it('more_than_40_modules', () => {
       cy.request('https://module-index.systeminit.com/builtins').then((response) => {
         // Ensure that the response status is 200
         expect(response.status).to.eq(200);

--- a/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
+++ b/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
@@ -4,6 +4,7 @@
 describe('Validates Get Summary', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
   
     it('Checks get_summary loads with a 200', () => {

--- a/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
+++ b/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
@@ -1,13 +1,13 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe('Validates Get Summary', () => {
+describe('web', () => {
     beforeEach(function () {
       cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
     });
   
-    it('Checks get_summary loads with a 200', () => {
+    it('get_summary', () => {
   
       // Go to the Synthetic Workspace
       cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')

--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -4,6 +4,7 @@
 describe("Check Workspace Dashboard", () => {
   beforeEach(() => {
     cy.visit("/");
+    cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
   });
 
   it("lets the user go to their dashboard and click into a workspace", () => {

--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -1,13 +1,13 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-describe("Check Workspace Dashboard", () => {
+describe("workspace", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
   });
 
-  it("lets the user go to their dashboard and click into a workspace", () => {
+  it("dashboard_redirect", () => {
     cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
 
     // Go to the Synthetic User's Dashboard

--- a/app/web/cypress/global.d.ts
+++ b/app/web/cypress/global.d.ts
@@ -19,6 +19,11 @@ declare namespace Cypress {
      */
     loginToAuth0(username: string, password: string): Chainable<any>;
 
+    /**
+     * Sends Posthog Event for User Identification/Test Identification in Posthog
+    */
+    sendPosthogEvent(event: string, eventKey: string, eventData: string): Chainable<any>;
+
     dragTo(sourceElement: string, targetElement: string): void;
   }
 }

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -30,6 +30,9 @@
 // Import commands for auth0 auth providers
 import "./auth-provider-commands/auth0";
 
+// Import commands for posthog
+import "./posthog-commands/posthog";
+
 Cypress.Commands.add("getBySel", (selector, ...args) => {
   return cy.get(`[data-test=${selector}]`, ...args)
 })

--- a/app/web/cypress/support/posthog-commands/posthog.ts
+++ b/app/web/cypress/support/posthog-commands/posthog.ts
@@ -1,0 +1,19 @@
+// @ts-check
+///<reference path="../../global.d.ts" />
+
+// Note: this function leaves you on a blank page, so you must call cy.visit()
+// afterwards, before continuing with your test.
+Cypress.Commands.add("sendPosthogEvent", (event: string, eventKey: string, eventData: string) => {
+    const log = Cypress.log({
+      displayName: "SENDING POSTHOG EVENT",
+      message: [`Event: ${event} / ${eventKey} : ${eventData}`],
+      // @ts-ignore
+      autoEnd: false,
+    });
+  
+    cy.window().then((win) => {
+        ;(win as any).posthog?.capture(event, { eventKey: eventData })
+    })
+
+    log.end();
+  });


### PR DESCRIPTION
Adds the possibility of driving cypress for test magnitude using `VITE_SI_CYPRESS_MULTIPLIER` to multiply the amount of times the tests are executed on each run to simulate user load. Additionally modified the CI build to be a matrix (of 1) so we can easily multiply on that vector too to give larger scale if needed. i.e.

CI Executor Multiples x VITE_SI_CYPRESS_MULTIPLIER x Test Number = Load

I also added a Posthog command to push a custom UUID into Posthog for each test to allow us to easily look at the user session for each event. This should be super helpful when we get more complicated tests or fragile tests to figure out what is wrong. 