### PR TITLE
Disable PG full page writes in test DB instances

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -33,6 +33,8 @@ services:
     command:
       - "-c"
       - "fsync=off"
+      - "-c"
+      - "full_page_writes=off"
 
   nats:
     image: systeminit/nats:stable

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -24,6 +24,8 @@ services:
     command:
       - "-c"
       - "fsync=off"
+      - "-c"
+      - "full_page_writes=off"
     ports:
       - "6432:5432"
 


### PR DESCRIPTION
The PG [docs for the fsync option][1] mention that you should consider turning off `full_page_writes` if you're disabling `fsync`. This doesn't make anywhere near as much of a difference as disabling `fsync` does, but should help some in more I/O bound environments when running tests.

[1]: https://www.postgresql.org/docs/16/runtime-config-wal.html#GUC-FSYNC