### PR TITLE
fix(dal,web,sdf): remove the `override_schema` flag

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -95,16 +95,11 @@ export interface VariantDef extends ListedVariantDef {
 export type Asset = VariantDef;
 export type AssetListEntry = ListedVariantDef;
 export type AssetSaveRequest = Visibility & {
-  overrideBuiltinSchemaFeatureFlag: boolean;
   multiVariantEditingFlag: boolean;
 } & Omit<Asset, "createdAt" | "updatedAt" | "variantExists" | "hasComponents">;
 export type AssetCreateRequest = Omit<
   AssetSaveRequest,
-  | "id"
-  | "definition"
-  | "variantExists"
-  | "overrideBuiltinSchemaFeatureFlag"
-  | "multiVariantEditingFlag"
+  "id" | "definition" | "variantExists" | "multiVariantEditingFlag"
 >;
 export type AssetCloneRequest = Visibility & { id: AssetId };
 
@@ -353,8 +348,6 @@ export const useAssetStore = () => {
               };
             },
             params: {
-              overrideBuiltinSchemaFeatureFlag:
-                featureFlagsStore.OVERRIDE_SCHEMA,
               multiVariantEditingFlag: featureFlagsStore.MULTI_VARIANT_EDITING,
               ...visibility,
               ..._.omit(asset, [
@@ -418,8 +411,6 @@ export const useAssetStore = () => {
             url: "/variant_def/exec_variant_def",
             keyRequestStatusBy: assetId,
             params: {
-              overrideBuiltinSchemaFeatureFlag:
-                featureFlagsStore.OVERRIDE_SCHEMA,
               multiVariantEditingFlag: featureFlagsStore.MULTI_VARIANT_EDITING,
               ...visibility,
               ..._.omit(asset, [

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -13,7 +13,6 @@ const FLAG_MAPPING = {
   JOI_VALIDATIONS: "joi_validations",
   MODULES_TAB: "modules_tab",
   MULTI_VARIANT_EDITING: "multiVariantEditing",
-  OVERRIDE_SCHEMA: "override_schema",
   RESIZABLE_PANEL_UPGRADE: "resizable-panel-upgrade",
   SECRETS: "secrets",
   WORKSPACE_BACKUPS: "workspaceBackups",

--- a/app/web/src/store/module.store.ts
+++ b/app/web/src/store/module.store.ts
@@ -4,7 +4,6 @@ import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 import { DiagramInputSocket, DiagramOutputSocket } from "@/api/sdf/dal/diagram";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import { nilId } from "@/utils/nilId";
-import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRouterStore } from "./router.store";
@@ -112,7 +111,6 @@ export const useModuleStore = () => {
   const workspacesStore = useWorkspacesStore();
   const workspaceId = workspacesStore.selectedWorkspacePk;
 
-  const featureFlagsStore = useFeatureFlagsStore();
   return addStoreHooks(
     defineStore(
       `ws${workspaceId || "NONE"}/cs${changeSetId || "NONE"}/modules`,
@@ -329,8 +327,6 @@ export const useModuleStore = () => {
               params: {
                 id: moduleId,
                 ...visibility,
-                overrideBuiltinSchemaFeatureFlag:
-                  featureFlagsStore.OVERRIDE_SCHEMA,
               },
               onSuccess: (data) => {
                 this.installingModuleId = data.id;

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -7,7 +7,6 @@ import { useRealtimeStore } from "@/store/realtime/realtime.store";
 import { ModuleId } from "@/store/module.store";
 import { nilId } from "@/utils/nilId";
 import { Visibility } from "@/api/sdf/dal/visibility";
-import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { useAuthStore, UserId } from "./auth.store";
 import { useRouterStore } from "./router.store";
 import { AuthApiRequest } from ".";
@@ -44,7 +43,6 @@ export const useWorkspacesStore = () => {
     visibility_change_set_pk: nilId(),
   };
 
-  const featureFlagsStore = useFeatureFlagsStore();
   return addStoreHooks(
     defineStore("workspaces", {
       state: () => ({
@@ -130,8 +128,6 @@ export const useWorkspacesStore = () => {
             params: {
               id: moduleId,
               ...visibility,
-              overrideBuiltinSchemaFeatureFlag:
-                featureFlagsStore.OVERRIDE_SCHEMA,
             },
             onSuccess: (data) => {
               this.workspaceImportSummary = null;

--- a/lib/dal/examples/dal-pkg-import/main.rs
+++ b/lib/dal/examples/dal-pkg-import/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
         "--- Importing pkg: {tar_file} into change set \"{change_set_name}\" in workspace \"{}\"",
         workspace.name()
     );
-    import_pkg_from_pkg(&ctx, &pkg, None, true).await?;
+    import_pkg_from_pkg(&ctx, &pkg, None).await?;
 
     println!("--- Committing database transaction");
     ctx.commit().await?;

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -63,7 +63,7 @@ pub async fn migrate_intrinsics(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .is_none()
     {
-        import_pkg_from_pkg(ctx, &intrinsics_pkg, None, true).await?;
+        import_pkg_from_pkg(ctx, &intrinsics_pkg, None).await?;
         ctx.blocking_commit().await?;
     }
 

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -120,7 +120,6 @@ async fn migrate_pkg(
                 schemas: Some(schemas),
                 ..Default::default()
             }),
-            true,
         )
         .await?;
     }

--- a/lib/dal/src/builtins/schema/test_exclusive_schema_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_schema_fallout.rs
@@ -203,7 +203,6 @@ pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> Builtins
             schemas: Some(vec!["fallout".into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 

--- a/lib/dal/src/builtins/schema/test_exclusive_schema_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_schema_starfield.rs
@@ -312,7 +312,6 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
             schemas: Some(vec!["starfield".into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 

--- a/lib/dal/tests/integration_test/internal/pkg.rs
+++ b/lib/dal/tests/integration_test/internal/pkg.rs
@@ -319,7 +319,6 @@ async fn make_stellarfield(ctx: &DalContext) -> BuiltinsResult<()> {
             schemas: Some(vec!["stellarfield".into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 
@@ -346,7 +345,7 @@ async fn test_workspace_pkg_export(DalContextHeadRef(ctx): DalContextHeadRef<'_>
     let pkg = SiPkg::load_from_bytes(package_bytes).expect("able to load from bytes");
     let _spec = pkg.to_spec().await.expect("can convert to spec");
 
-    import_pkg_from_pkg(ctx, &pkg, None, true)
+    import_pkg_from_pkg(ctx, &pkg, None)
         .await
         .expect("able to import workspace");
 }
@@ -391,7 +390,7 @@ async fn test_module_pkg_export(DalContextHeadRef(ctx): DalContextHeadRef<'_>) {
         .expect("can create change set");
 
     let new_ctx = ctx.clone_with_new_visibility(ctx.visibility().to_change_set(new_change_set.pk));
-    import_pkg_from_pkg(&new_ctx, &pkg, None, true)
+    import_pkg_from_pkg(&new_ctx, &pkg, None)
         .await
         .expect("able to import pkg");
 
@@ -669,12 +668,12 @@ async fn test_install_pkg(ctx: &DalContext) {
 
     let pkg_b = SiPkg::load_from_spec(spec_b).expect("able to load pkg from spec");
 
-    import_pkg_from_pkg(ctx, &pkg_a, None, true)
+    import_pkg_from_pkg(ctx, &pkg_a, None)
         .await
         .expect("able to install pkg");
 
     // We should refuse to install the same package twice
-    let second_import_result = import_pkg_from_pkg(ctx, &pkg_a, None, true).await;
+    let second_import_result = import_pkg_from_pkg(ctx, &pkg_a, None).await;
     assert!(matches!(
         second_import_result,
         Err(PkgError::PackageAlreadyInstalled(_))
@@ -755,7 +754,7 @@ async fn test_install_pkg(ctx: &DalContext) {
         }
     }
 
-    import_pkg_from_pkg(ctx, &pkg_b, None, true)
+    import_pkg_from_pkg(ctx, &pkg_b, None)
         .await
         .expect("install pkg b");
 

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -437,7 +437,6 @@ async fn install_builtins(
                         no_record: false,
                         is_builtin: true,
                     }),
-                    true,
                 )
                 .await
                 {

--- a/lib/sdf-server/src/server/service/pkg/install_pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg/install_pkg.rs
@@ -22,7 +22,6 @@ use ulid::Ulid;
 #[serde(rename_all = "camelCase")]
 pub struct InstallPkgRequest {
     pub id: Ulid,
-    pub override_builtin_schema_feature_flag: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -101,13 +100,7 @@ async fn install_pkg_inner(
 
     let pkg = SiPkg::load_from_bytes(pkg_data)?;
     let metadata = pkg.metadata()?;
-    let (_, svs, _import_skips) = import_pkg_from_pkg(
-        ctx,
-        &pkg,
-        None, // TODO: add is_builtin option
-        request.override_builtin_schema_feature_flag,
-    )
-    .await?;
+    let (_, svs, _import_skips) = import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     track(
         &posthog_client,

--- a/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/exec_variant_def.rs
@@ -347,7 +347,6 @@ pub async fn exec_variant_def_inner(
             no_record: true,
             is_builtin: false,
         }),
-        request.override_builtin_schema_feature_flag,
     )
     .await?;
 

--- a/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
+++ b/lib/sdf-server/src/server/service/variant_definition/save_variant_def.rs
@@ -19,7 +19,6 @@ pub struct SaveVariantDefRequest {
     pub code: String,
     pub description: Option<String>,
     pub component_type: ComponentType,
-    pub override_builtin_schema_feature_flag: bool,
     pub multi_variant_editing_flag: bool,
     #[serde(flatten)]
     pub visibility: Visibility,

--- a/lib/sdf-server/tests/service_tests/scenario.rs
+++ b/lib/sdf-server/tests/service_tests/scenario.rs
@@ -426,7 +426,6 @@ impl ScenarioHarness {
             component_type: ComponentType::Component,
             description: None,
             visibility: *visibility,
-            override_builtin_schema_feature_flag: true,
             multi_variant_editing_flag: false,
         };
 
@@ -455,7 +454,6 @@ impl ScenarioHarness {
             component_type: ComponentType::Component,
             description: None,
             visibility: *visibility,
-            override_builtin_schema_feature_flag: true,
             multi_variant_editing_flag: true,
         };
         let response: SaveVariantDefResponse = self


### PR DESCRIPTION
This behavior will be replaced by the ability to migrate a component to the latest schema variant.