### PR TITLE
Fix content pair creation races by only writing out

### DIFF
--- a/lib/content-store/src/store/pg.rs
+++ b/lib/content-store/src/store/pg.rs
@@ -130,7 +130,7 @@ impl Store for PgStore {
     async fn write(&mut self) -> StoreResult<()> {
         for (key, item) in self.inner.iter_mut() {
             if !item.written {
-                ContentPair::find_or_create(&self.pg_pool, key.to_owned(), &item.value).await?;
+                ContentPair::new(&self.pg_pool, key.to_owned(), &item.value).await?;
                 item.written = true;
             }
         }

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -155,7 +155,6 @@ impl WorkspaceSnapshot {
             graph.add_category_node(change_set, CategoryNodeKind::Component)?;
         let func_node_index = graph.add_category_node(change_set, CategoryNodeKind::Func)?;
         let schema_node_index = graph.add_category_node(change_set, CategoryNodeKind::Schema)?;
-
         let secret_node_index = graph.add_category_node(change_set, CategoryNodeKind::Secret)?;
 
         // Connect them to root.


### PR DESCRIPTION
## Description

Fix content pair creation races by only writing out and not returning anything. We do not use long-running transactions with the content store, and since there may be many users of the content store, we should not be picky when writing out. Simply write out, do nothing if the pair already exists, and move on.

## GIF

<img src="https://media0.giphy.com/media/6Z3D5t31ZdoNW/giphy.gif"/>