### PR TITLE
fix: incorrect env var in otelcol config

### DIFF
--- a/component/init/configs/config.yaml
+++ b/component/init/configs/config.yaml
@@ -13,7 +13,7 @@ exporters:
   otlp:
     endpoint: "api.honeycomb.io:443"
     headers:
-      "x-honeycomb-team": "$HONEYCOMB_API_KEY"
+      "x-honeycomb-team": "$SI_HONEYCOMB_API_KEY"
 
 extensions:
   zpages:


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif"/>

Incorrect env var for the honeycomb api key means we weren't exporting traces. Whoops.