### PR TITLE
hotfix(dal): disable attribute override query temporarily

### DIFF
--- a/lib/dal/src/property_editor/values_summary.rs
+++ b/lib/dal/src/property_editor/values_summary.rs
@@ -109,7 +109,8 @@ impl PropertyEditorValuesSummary {
         let attribute_value_controlling_func_info =
             AttributeValue::get_controlling_func_id(ctx, component_id).await?;
 
-        let overrides = AttributeValue::list_attributes_with_overridden(ctx, component_id).await?;
+        //let overrides = AttributeValue::list_attributes_with_overridden(ctx, component_id).await?;
+        let overrides: HashMap<AttributeValueId, bool> = HashMap::new();
 
         for work in work_queue {
             let work_attribute_value_id = *work.attribute_value.id();


### PR DESCRIPTION
This query is hanging and blocking work, disabling it while I work on an alternative approach