### PR TITLE
fix: vector needs to mount the journal in order to ship systemd logs

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - 8686:8686
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /var/log/journal:/var/log/journal
       - config:/etc/vector/
     depends_on:
       init:

--- a/component/init/configs/vector.yaml
+++ b/component/init/configs/vector.yaml
@@ -4,6 +4,7 @@ sources:
   $SI_SERVICE-journal:
     type: "journald"
     include_units: ["$SI_SERVICE"]
+    journal_directory: "/var/log/journal"
 
 sinks:
   cloudwatch:


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/3oEduIBjrydlnXYrAI/giphy.gif"/>

Vector needs to mount the journal on the host so it can ship systemd logs.