### PR TITLE
fix/politely wait after attribute change

### DIFF
--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -5,9 +5,19 @@ import vitePreprocessor from 'cypress-vite'
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      on('file:preprocessor', vitePreprocessor(path.resolve('./vite.config.ts'),
-      ))
+      on('file:preprocessor', 
+        vitePreprocessor(
+          path.resolve('./vite.config.ts'),
+        )
+      ),
+      on('task', {
+        log(message) {
+          console.log(message)
+          return null
+        }
+      })
     },
+    
     // Hotfix, needs amended
     baseUrl: 'https://app.systeminit.com',
     chromeWebSecurity: false,

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -45,14 +45,15 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       // attribute value for Integer
       const randomNumber = Math.floor(Math.random() * 100) + 1;
 
+      cy.intercept('POST', '/api/component/update_property_editor_value').as('updatePropertyEditorValue');
+
       // Find the attribute for the Integer Input
       cy.get('.attributes-panel-item__input-wrap input[type="number"]')
       .clear()
       .type(randomNumber.toString() + '{enter}') // type the new value
 
-      // This will have auto-directed us onto a changeset, give it a few seconds
-      // to load up
-      cy.wait(3000)
+      // Intercept the API call and alias it
+      cy.wait('@updatePropertyEditorValue', { timeout: 60000 }).its('response.statusCode').should('eq', 200);
 
       cy.url().then(currentUrl => {
         // Construct a new URL with desired query parameters for selecting 
@@ -64,10 +65,10 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       });
 
       // Wait for the values to propagate
-      cy.wait(30000);
+      cy.wait(60000);
 
       // Validate that the value has propogated through the system
-      cy.get('.attributes-panel-item__input-wrap input[type="number"]')
+      cy.get('.attributes-panel-item__input-wrap input[type="number"]', { timeout: 30000 })
       .should('have.value', randomNumber.toString(), { timeout: 30000 });
 
       // Click the button to destroy changeset


### PR DESCRIPTION
Amend the cypress synthetic to wait until the call to /api/component/update_property_editor_value finishes before navigating away to check the value on the child component.

In the synthetic UI validation workspace something is definitely awry as the attribute updates are taking ~ 30s to finish In another workspace with zero other content/change sets in it, the update_property_editor_value calls take ~5s. We will investigate this further.

NB: What's pretty gnarly about this is that if the user navigates away after making the attribute change (such as refreshing the page) the attribute change is lost in the ether. 

This modifies the synthetic test to politely wait for this API call to finish before navigating away which should put us back to green, but we should definitely investigate what's up in the Synthetic workspace.

</hr>

This also adds a log out in the cypress log for the uuid of the run, so we can more easily identify the runs in posthog.