### PR TITLE
Ack messages when done rebasing in the new engine

### DIFF
--- a/lib/rebaser-server/src/server/core_loop.rs
+++ b/lib/rebaser-server/src/server/core_loop.rs
@@ -148,11 +148,13 @@ async fn core_loop_infallible(
             continue;
         };
 
-        tokio::spawn(perform_rebase_and_reply_infallible(
-            ctx_builder.clone(),
-            request_message,
-            reply_subject,
-        ));
+        let ctx_builder = ctx_builder.clone();
+        tokio::spawn(async move {
+            perform_rebase_and_reply_infallible(ctx_builder, request_message, reply_subject).await;
+            if let Err(err) = message.ack_with(AckKind::Ack).await {
+                error!(?message, ?err, "failing acking message");
+            }
+        });
     }
 }
 


### PR DESCRIPTION
We ack with progress when pulling a message off of the stream in the rebaser. However, we do not finishing acking the message once done. This probably needs a further look for the long term, but this will stop the bleeding in the interim.

Congrats to @vbustamante for finding this bug on the first day of working in the new engine :tada: