### PR TITLE
Fix/userid

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -44,7 +44,7 @@ JAILER_NS="jailer-$SB_ID"
 
 # Create a user and group to run the execution via for one micro-vm
 function user_prep() {
-  useradd -M -u 10000$SB_ID $JAILER_NS
+  useradd -M -u 100$SB_ID $JAILER_NS
   usermod -L $JAILER_NS
 
   # This group was created earlier on the machine provisioning
@@ -53,7 +53,7 @@ function user_prep() {
   usermod -a -G kvm $JAILER_NS
 }
 
-if ! id 10000$SB_ID >/dev/null 2>&1; then
+if ! id $JAILER_NS >/dev/null 2>&1; then
   retry user_prep
 fi
 


### PR DESCRIPTION
We switched to Amazon Linux 2023 as our base ami. In some cases, the MAX_UID for the base of that AMI is set to a number lower than the UID we set for the firecracker users. This is reported as a warning, but propagated as an error. This can cause jail preparation to fail. This reduces our UIDs to being under that limit. I tested this locally and an AML 2023 vm.