### PR TITLE
fix: need both uids to match

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -44,7 +44,7 @@ JAILER_NS="jailer-$SB_ID"
 
 # Create a user and group to run the execution via for one micro-vm
 function user_prep() {
-  useradd -M -u 100$SB_ID $JAILER_NS
+  useradd -M -u 30$SB_ID $JAILER_NS
   usermod -L $JAILER_NS
 
   # This group was created earlier on the machine provisioning
@@ -53,7 +53,7 @@ function user_prep() {
   usermod -a -G kvm $JAILER_NS
 }
 
-if ! id $JAILER_NS >/dev/null 2>&1; then
+if ! id 30$SB_ID >/dev/null 2>&1; then
   retry user_prep
 fi
 

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -842,7 +842,7 @@ impl LocalFirecrackerRuntime {
             .arg("--exec-file")
             .arg("/usr/bin/firecracker")
             .arg("--uid")
-            .arg(format!("10000{}", vm_id))
+            .arg(format!("30{}", vm_id))
             .arg("--gid")
             .arg("10000")
             .arg("--netns")


### PR DESCRIPTION
UID was still too big and the jailer was not selecting the correct UID, so runs were failing.