### PR TITLE
fix: change log formatting to text to make grafana logs readable

### DIFF
--- a/component/init/configs/vector.yaml
+++ b/component/init/configs/vector.yaml
@@ -12,7 +12,7 @@ sinks:
     inputs: ["$SI_SERVICE-journal"]
     compression: "gzip"
     encoding:
-      codec: "json"
+      codec: "text"
     region: "us-east-1"
     group_name: "/ec2/$SI_HOSTENV-$SI_SERVICE"
     stream_name: "{{ host }}"


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/xUOxfbAOLZmR356YgM/giphy.gif"/>

We're shipping logs to cloudwatch in a pretty much unreadable way. We include a ton of metadata, but none of it is mapped in way that makes it useful. This change will cause us to just ship the regular log line instead.