### PR TITLE
Wendy/eng 2355 hide the add array item button when array is set from an

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -116,6 +116,7 @@ export interface PropertyEditorValue {
   overridden: boolean;
   controllingFuncId: string;
   controllingAttributeValueId: string;
+  ancestorManual: boolean;
   // TODO(Wendy) - we also need the default funcId and funcName for this prop to tell the user the default func that was overriden
 }
 

--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -350,4 +350,10 @@ provide(AttributesPanelContextInjectionKey, {
     z-index: 3;
   }
 }
+
+.picker_editor input {
+  body.dark & {
+    color: white;
+  }
+}
 </style>

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -1013,7 +1013,7 @@ const setSource = (source: SourceKind) => {
   if (source === "manually") {
     const value = props.attributeDef.value?.value ?? null;
 
-    console.log(value);
+    // console.log(value);
 
     attributesStore.UPDATE_PROPERTY_VALUE({
       update: {

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -11,12 +11,13 @@
       '--collapsed': canHaveChildren && !isOpen,
     }"
   >
-    <!-- SECTION HEADER -->
+    <!-- SECTION -->
     <div
       v-if="canHaveChildren"
       @mouseover.stop="onSectionHoverStart"
       @mouseleave="onSectionHoverEnd"
     >
+      <!-- HEADER -->
       <div
         class="attributes-panel-item__section-header-wrap"
         :style="{
@@ -35,7 +36,7 @@
         </div>
 
         <div
-          class="attributes-panel-item__section-header group/header"
+          class="attributes-panel-item__section-header"
           :style="{ marginLeft: indentPx }"
           @click="toggleOpen(true)"
         >
@@ -50,18 +51,24 @@
             :name="icon"
             size="none"
           />
-          <div class="attributes-panel-item__section-header-label mr-xs">
-            <template v-if="isChildOfArray">
-              {{ propName }}[{{ attributeDef.arrayIndex }}]
-            </template>
-            <template v-else-if="isChildOfMap">
-              <span>{{ attributeDef.mapKey }}</span>
-            </template>
-            <template v-else>
-              <span>{{ fullPropDef.name }}</span>
-            </template>
+          <div class="attributes-panel-item__section-header-label">
+            <div
+              ref="headerMainLabelRef"
+              v-tooltip="headerMainLabelTooltip"
+              class="attributes-panel-item__section-header-label-main leading-loose"
+            >
+              <template v-if="isChildOfArray">
+                {{ propName }}[{{ attributeDef.arrayIndex }}]
+              </template>
+              <template v-else-if="isChildOfMap">
+                {{ attributeDef.mapKey }}
+              </template>
+              <template v-else>
+                {{ fullPropDef.name }}
+              </template>
+            </div>
 
-            <span
+            <div
               v-if="isMap || isArray"
               class="attributes-panel-item__section-header-child-count"
             >
@@ -74,20 +81,8 @@
               <template v-else
                 >({{ attributeDef.children.length }} items)</template
               >
-            </span>
+            </div>
           </div>
-          <!-- <div
-            :class="
-              clsx(
-                'border dark:group-hover/header:hover:text-action-500 group-hover/header:hover:text-action-300 rounded p-[1px] m-[2px] w-5 h-5 cursor-pointer',
-                sourceOverridden
-                  ? ' text-warning-500 dark:text-warning-300 border-warning-500 dark:border-warning-300 dark:group-hover/header:hover:border-action-500 group-hover/header:hover:border-action-300 dark:group-hover/header:text-shade-100 dark:group-hover/header:border-shade-100 group-hover/header:text-shade-0 group-hover/header:border-shade-0'
-                  : 'border-transparent',
-              )
-            "
-          >
-            <Icon v-tooltip="sourceTooltip" :name="sourceIcon" size="none" />
-          </div> -->
           <SourceIconWithTooltip
             v-if="
               featureFlagsStore.INDICATORS_MANUAL_FUNCTION_SOCKET &&
@@ -98,24 +93,49 @@
             :tooltipText="sourceTooltip"
             header
           />
-          <div class="attributes-panel-item__action-icons">
-            <!-- <Icon
-              :name="isOpen ? 'collapse-row' : 'expand-row'"
-              @click.stop="toggleOpen"
-            /> -->
-            <!-- <Icon v-if="isChildOfArray || isChildOfMap" name="trash" />
-            <Icon v-if="isChildOfArray" name="arrow--up" />
-            <Icon v-if="isChildOfArray" name="arrow--down" /> -->
-          </div>
+          <!-- DROPDOWN MENU FOR SELECT SOURCE -->
+          <!-- TODO(Wendy) - currently we hide this menu if the prop is set manually since you can't select another option yet -->
+          <template
+            v-if="
+              propSource !== 'manually' &&
+              featureFlagsStore.INDICATORS_MANUAL_FUNCTION_SOCKET
+            "
+          >
+            <div
+              class="attributes-panel-item__section-header-source-select"
+              @click="sourceSelectMenuRef?.open($event)"
+            >
+              <div>set:</div>
+              <div
+                class="flex flex-row items-center border pl-2xs pr-[2px] h-4 text-xs"
+              >
+                <div class="flex-none whitespace-nowrap">{{ propSource }}</div>
+                <Icon name="chevron--down" size="sm" />
+              </div>
+            </div>
+            <DropdownMenu ref="sourceSelectMenuRef">
+              <!-- TODO(Wendy) - Currently you can't switch to anything but manually -->
+              <template v-for="source in sourceKinds" :key="source">
+                <DropdownMenuItem
+                  v-if="source === 'manually' || propSource === source"
+                  :label="source"
+                  :checked="propSource === source"
+                  @click="setSource(source)"
+                />
+              </template>
+            </DropdownMenu>
+          </template>
         </div>
       </div>
 
+      <!-- LEFT BORDER LINE -->
       <div
         v-show="isOpen"
         class="attributes-panel-item__left-border"
         :style="{ marginLeft: indentPx, zIndex: headerZIndex }"
       />
 
+      <!-- CHILDREN -->
       <div v-show="isOpen" class="attributes-panel-item__children">
         <template v-if="attributeDef.children.length">
           <!-- <div class="w-[50%] h-[1px] bg-shade-0 ml-auto"></div> -->
@@ -126,49 +146,59 @@
             :level="level + 1"
           />
         </template>
-
-        <div
-          v-if="isArray || isMap"
-          class="attributes-panel-item__add-child-row"
-          :style="{ marginLeft: indentPx }"
+        <!-- <div
+          v-else
+          :style="{
+            marginLeft: `${HEADER_HEIGHT + INDENT_SIZE * (props.level + 1)}px`,
+          }"
         >
-          <Icon
-            class="attributes-panel-item__nested-arrow-icon"
-            name="nested-arrow-right"
-            size="none"
-          />
+          This prop does not currently have any children.
+        </div> -->
 
-          <input
-            v-if="isMap"
-            v-model="newMapChildKey"
-            type="text"
-            placeholder="key"
-            :class="
-              clsx(
-                'attributes-panel-item__new-child-key-input',
-                isMapKeyError &&
-                  'attributes-panel-item__new-child-key-input__error',
-              )
-            "
-            @blur="clearKeyError"
-            @keyup.enter="addChildHandler"
-          />
-
-          <button
-            class="attributes-panel-item__new-child-button"
-            @click="addChildHandler"
+        <template v-if="(isArray || isMap) && propManual">
+          <div
+            class="attributes-panel-item__add-child-row"
+            :style="{ marginLeft: indentPx }"
           >
-            <Icon name="plus" size="none" />
-            {{ isArray ? "Add array item" : "Add map item" }}
-          </button>
-        </div>
-        <div
-          v-if="isMap && isMapKeyError"
-          :style="{ marginLeft: indentPx }"
-          class="attributes-panel-item__map-key-error"
-        >
-          You must enter a valid key.
-        </div>
+            <Icon
+              class="attributes-panel-item__nested-arrow-icon"
+              name="nested-arrow-right"
+              size="none"
+            />
+
+            <input
+              v-if="isMap"
+              v-model="newMapChildKey"
+              type="text"
+              placeholder="key"
+              :class="
+                clsx(
+                  'attributes-panel-item__new-child-key-input',
+                  isMapKeyError &&
+                    'attributes-panel-item__new-child-key-input__error',
+                )
+              "
+              @blur="clearKeyError"
+              @keyup.enter="addChildHandler"
+            />
+
+            <button
+              class="attributes-panel-item__new-child-button"
+              @click="addChildHandler"
+            >
+              <Icon name="plus" size="none" />
+              {{ isArray ? "Add array item" : "Add map item" }}
+            </button>
+          </div>
+
+          <div
+            v-if="isMap && isMapKeyError"
+            :style="{ marginLeft: indentPx }"
+            class="attributes-panel-item__map-key-error"
+          >
+            You must enter a valid key.
+          </div>
+        </template>
       </div>
     </div>
 
@@ -212,13 +242,6 @@
           name="question-circle"
           class="attributes-panel-item__help-icon"
         /> -->
-
-        <div class="attributes-panel-item__action-icons">
-          <!-- <Icon v-if="isChildOfArray || isChildOfMap" name="trash" size="sm" />
-          <Icon v-if="isChildOfArray" name="arrow--up" size="sm" />
-          <Icon v-if="isChildOfArray" name="arrow--down" size="sm" />
-          <Icon v-if="isChildOfMap" name="edit" size="sm" /> -->
-        </div>
 
         <div class="attributes-panel-item__static-icons">
           <button
@@ -551,6 +574,8 @@ import * as _ from "lodash-es";
 import { computed, PropType, ref, watch } from "vue";
 import clsx from "clsx";
 import {
+  DropdownMenu,
+  DropdownMenuItem,
   Icon,
   IconNames,
   Modal,
@@ -572,6 +597,9 @@ import SecretsModal from "../SecretsModal.vue";
 import SourceIconWithTooltip from "./SourceIconWithTooltip.vue";
 import CodeViewer from "../CodeViewer.vue";
 
+const sourceKinds = ["manually", "via socket", "via attribute func"] as const;
+export type SourceKind = (typeof sourceKinds)[number];
+
 const props = defineProps({
   parentPath: { type: String },
   attributeDef: { type: Object as PropType<AttributeTreeItem>, required: true },
@@ -584,7 +612,20 @@ const props = defineProps({
 
 const featureFlagsStore = useFeatureFlagsStore();
 
-const isOpen = ref(true);
+const headerMainLabelRef = ref();
+const headerMainLabelTooltip = computed(() => {
+  if (!headerMainLabelRef.value) return;
+
+  if (
+    headerMainLabelRef.value.clientWidth < headerMainLabelRef.value.scrollWidth
+  ) {
+    return {
+      content: headerMainLabelRef.value.textContent,
+    };
+  } else return {};
+});
+
+const isOpen = ref(true); // ref(props.attributeDef.children.length > 0);
 const showValidationDetails = ref(false);
 
 const rootCtx = useAttributesPanelContext();
@@ -694,6 +735,19 @@ const propSetByFunc = computed(
     !propHasSocket.value &&
     !propPopulatedBySocket.value,
 );
+const propManual = computed(
+  () =>
+    !(
+      propPopulatedBySocket.value ||
+      propHasSocket.value ||
+      propSetByFunc.value
+    ),
+);
+const propSource = computed<SourceKind>(() => {
+  if (propHasSocket.value || propPopulatedBySocket.value) return "via socket";
+  else if (propSetByFunc.value) return "via attribute func";
+  else return "manually";
+});
 
 const sourceIcon = computed(() => {
   if (propPopulatedBySocket.value) return "circle-full";
@@ -930,6 +984,18 @@ const confirmEdit = () => {
 };
 
 const editOverride = ref(false);
+
+const sourceSelectMenuRef = ref<InstanceType<typeof DropdownMenu>>();
+
+const setSource = (source: SourceKind) => {
+  if (source === "manually") {
+    // TODO(Wendy) - Here's where we can put logic for disconnecting this prop from its socket or function so it can be set manually
+  } else if (source === "via socket") {
+    // TODO(Wendy) - Here's where we can put logic for selecting a socket to connect to this prop
+  } else {
+    // TODO(Wendy) - Here's where we can put logic for selecting an attribute function to populate this prop
+  }
+};
 </script>
 
 <style lang="less">
@@ -969,16 +1035,28 @@ const editOverride = ref(false);
   background: var(--header-bg-color);
   color: var(--header-text-color);
   display: flex;
+  flex-direction: row;
+  gap: 4px;
   align-items: center;
   border-bottom: 1px solid var(--panel-bg-color);
   user-select: none;
+  padding-right: 4px;
+}
+
+.attributes-panel-item__section-header-label-main {
+  flex-basis: 0px;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .attributes-panel-item__section-header-child-count {
   font-style: italic;
-  margin-left: 12px;
+  margin-right: 4px;
   font-size: 12px;
   opacity: 0.5;
+  flex: none;
 }
 
 .attributes-panel-item__section-toggle {
@@ -1010,6 +1088,15 @@ const editOverride = ref(false);
   }
 }
 
+.attributes-panel-item__section-header-label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  white-space: nowrap;
+  gap: 4px;
+  min-width: 0;
+}
+
 .attributes-panel-item__nested-arrow-icon {
   width: 14px;
   height: 14px;
@@ -1017,7 +1104,6 @@ const editOverride = ref(false);
 .attributes-panel-item__type-icon {
   height: 100%;
   padding: 2px;
-  margin-right: @spacing-px[xs];
   position: relative;
 }
 
@@ -1161,8 +1247,8 @@ const editOverride = ref(false);
 .attributes-panel-item__action-icons {
   gap: 4px;
   padding: 4px;
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: 4px;
+  margin-right: 4px;
 
   .attributes-panel-item__item-inner & {
     position: absolute;
@@ -1175,10 +1261,26 @@ const editOverride = ref(false);
 
   .attributes-panel-item__section-header & {
     display: none;
-    margin-left: 30px;
   }
   .attributes-panel-item__section-header:hover & {
     display: flex;
+  }
+}
+
+.attributes-panel-item__section-header-source-select {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  cursor: pointer;
+}
+
+.attributes-panel-item__section-header-source-select > div {
+  .attributes-panel-item__section-header:hover & {
+    body.dark & {
+      border-color: black;
+    }
   }
 }
 

--- a/app/web/src/components/layout/navbar/NavbarButton.vue
+++ b/app/web/src/components/layout/navbar/NavbarButton.vue
@@ -3,7 +3,7 @@
     :is="linkTo ? RouterLink : 'button'"
     v-tooltip="{
       content: tooltipText,
-      delay: { show: 10, hide: 100 },
+      delay: { show: 0, hide: 100 },
       instantMove: true,
     }"
     :to="linkTo"

--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -24,6 +24,9 @@ app.use(createHead());
 app.use(router);
 app.use(store);
 
+// set the default tooltip delay to show and hide faster
+FloatingVue.options.themes.tooltip.delay = { show: 10, hide: 100 };
+
 // we attach to the #app-layout div (in AppLayout.vue) to stay within an overflow hidden div and not mess with page scrollbars
 app.use(FloatingVue, {
   container: "#app-layout",
@@ -32,10 +35,13 @@ app.use(FloatingVue, {
       $extend: "tooltip",
       html: true,
     },
-    "user-info": {
+    "instant-show": {
       $extend: "tooltip",
-      delay: { show: 10, hide: 100 },
       instantMove: true,
+      delay: { show: 0, hide: 100 },
+    },
+    "user-info": {
+      $extend: "instant-show",
       html: true,
     },
     "w-380": {

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -122,6 +122,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
             function getAttributeValueWithChildren(
               valueId: string,
               parentValueId: string,
+              ancestorManual = true,
               indexInParentArray?: number,
             ): AttributeTreeItem | undefined {
               /* eslint-disable @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-explicit-any */
@@ -135,6 +136,12 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
               if (!propDef) return;
 
               // console.log("HERE", value);
+
+              value.ancestorManual = ancestorManual;
+              const isAncestorManual =
+                ancestorManual &&
+                value.isControlledByIntrinsicFunc &&
+                !(value.canBeSetBySocket || value.isFromExternalSource);
 
               return {
                 propDef,
@@ -155,6 +162,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
                     getAttributeValueWithChildren(
                       cvId,
                       valueId,
+                      isAncestorManual,
                       propDef.kind === "array" ? index : undefined,
                     ),
                   ),

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -45,6 +45,7 @@ export function useFeatureFlagsStore() {
         // You can override feature flags while working on a feature by setting them to true here
 
         // this.MULTI_VARIANT_EDITING = true;
+        this.INDICATORS_MANUAL_FUNCTION_SOCKET = true;
 
         // Make sure to remove the override before committing your code!
       },

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -45,7 +45,6 @@ export function useFeatureFlagsStore() {
         // You can override feature flags while working on a feature by setting them to true here
 
         // this.MULTI_VARIANT_EDITING = true;
-        this.INDICATORS_MANUAL_FUNCTION_SOCKET = true;
 
         // Make sure to remove the override before committing your code!
       },


### PR DESCRIPTION
- Add Map/Array Item button only shows when the parent Map/Array is set to be edited manually
- Dropdown menu on any parent prop which has children (maps, arrays, objects) that is set via a socket or attribute function
- The dropdown menu currently only allows you to switch to manually editing that prop and its children, but will have the option to connect a socket or attribute function in the future
- Props which have children and have a parent that is not set manually do not show this dropdown since their parent must be set to manual before they can be set to manual
- Ability to view textbox and codeviewer prop data if the prop is not editable