### PR TITLE
Remove override flag and centralized property editor values accessors

### DIFF
--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -55,8 +55,7 @@ pub async fn migrate_intrinsics(ctx: &DalContext) -> BuiltinsResult<()> {
         .await?
         .is_none()
     {
-        // TODO(nick): decide what to do with override builtin schema feature flag.
-        import_pkg_from_pkg(ctx, &intrinsics_pkg, None, true).await?;
+        import_pkg_from_pkg(ctx, &intrinsics_pkg, None).await?;
         ctx.blocking_commit().await?;
     }
 

--- a/lib/dal/src/builtins/schema.rs
+++ b/lib/dal/src/builtins/schema.rs
@@ -156,7 +156,6 @@ pub async fn migrate_pkg(
 
     let root_hash = pkg.hash()?.to_string();
     if InstalledPkg::find_by_hash(ctx, &root_hash).await?.is_none() {
-        // TODO(nick): decide what to do with override builtin schema feature flag.
         import_pkg_from_pkg(
             ctx,
             &pkg,
@@ -164,7 +163,6 @@ pub async fn migrate_pkg(
                 schemas: Some(schemas),
                 ..Default::default()
             }),
-            true,
         )
         .await?;
     }

--- a/lib/dal/src/builtins/schema/test_exclusive_schema_bethesda_secret.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_schema_bethesda_secret.rs
@@ -115,7 +115,6 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    // TODO(nick): decide what to do with override schema builtin featuee flag.
     import_pkg_from_pkg(
         ctx,
         &pkg,
@@ -123,7 +122,6 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
             schemas: Some(vec![name.into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 

--- a/lib/dal/src/builtins/schema/test_exclusive_schema_fallout.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_schema_fallout.rs
@@ -196,7 +196,6 @@ pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> Builtins
         .build()?;
 
     let fallout_pkg = SiPkg::load_from_spec(fallout_spec)?;
-    // TODO(nick): decide what to do with override schema builtin featuee flag.
     import_pkg_from_pkg(
         ctx,
         &fallout_pkg,
@@ -204,7 +203,6 @@ pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> Builtins
             schemas: Some(vec!["fallout".into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 

--- a/lib/dal/src/builtins/schema/test_exclusive_schema_starfield.rs
+++ b/lib/dal/src/builtins/schema/test_exclusive_schema_starfield.rs
@@ -409,7 +409,6 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
         .build()?;
 
     let starfield_pkg = SiPkg::load_from_spec(starfield_spec)?;
-    // TODO(nick): decide what to do with override schema builtin featuee flag.
     import_pkg_from_pkg(
         ctx,
         &starfield_pkg,
@@ -417,7 +416,6 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
             schemas: Some(vec!["starfield".into()]),
             ..Default::default()
         }),
-        true,
     )
     .await?;
 

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1359,7 +1359,6 @@ pub async fn import_pkg_from_pkg(
     ctx: &DalContext,
     pkg: &SiPkg,
     options: Option<ImportOptions>,
-    _override_builtin_schema_feature_flag: bool,
 ) -> PkgResult<(
     Option<InstalledPkgId>,
     Vec<SchemaVariantId>,
@@ -1495,7 +1494,7 @@ pub async fn import_pkg(ctx: &DalContext, pkg_file_path: impl AsRef<Path>) -> Pk
     println!("Importing package from {:?}", pkg_file_path.as_ref());
     let pkg = SiPkg::load_from_file(&pkg_file_path).await?;
 
-    import_pkg_from_pkg(ctx, &pkg, None, true).await?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(pkg)
 }

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -136,6 +136,70 @@ impl PropertyEditorValues {
             values,
         })
     }
+
+    /// Finds the [`AttributeValueId`](AttributeValue) for a given [`PropId`](Prop).
+    ///
+    /// This is useful for non-maps and non-array [`Props`](Prop).
+    pub fn find_by_prop_id(&self, prop_id: PropId) -> Option<AttributeValueId> {
+        self.values
+            .iter()
+            .find(|(_, property_editor_value)| property_editor_value.prop_id() == prop_id)
+            .map(|(_, found_property_editor_value)| {
+                found_property_editor_value.attribute_value_id()
+            })
+    }
+
+    /// Finds the [`AttributeValueId`](AttributeValue) and the [`Value`] corresponding to it for a
+    /// given [`PropId`](Prop).
+    ///
+    /// This is useful for non-maps and non-array [`Props`](Prop).
+    pub fn find_with_value_by_prop_id(&self, prop_id: PropId) -> Option<(Value, AttributeValueId)> {
+        self.values
+            .iter()
+            .find(|(_, property_editor_value)| property_editor_value.prop_id() == prop_id)
+            .map(|(_, found_property_editor_value)| {
+                (
+                    found_property_editor_value.value.to_owned(),
+                    found_property_editor_value.attribute_value_id(),
+                )
+            })
+    }
+
+    /// Lists the [`AttributeValueIds`](AttributeValue) for a given [`PropId`](Prop).
+    ///
+    /// This is useful for map and array [`Props`](Prop).
+    pub fn list_by_prop_id(&self, prop_id: PropId) -> Vec<AttributeValueId> {
+        self.values
+            .iter()
+            .filter_map(|(_, property_editor_value)| {
+                if property_editor_value.prop_id() == prop_id {
+                    Some(property_editor_value.attribute_value_id())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Lists the [`AttributeValueIds`](AttributeValue) and the [`Values`] corresponding to them for
+    /// a given [`PropId`](Prop).
+    ///
+    /// This is useful for map and array [`Props`](Prop).
+    pub fn list_with_values_by_prop_id(&self, prop_id: PropId) -> Vec<(Value, AttributeValueId)> {
+        self.values
+            .iter()
+            .filter_map(|(_, property_editor_value)| {
+                if property_editor_value.prop_id() == prop_id {
+                    Some((
+                        property_editor_value.value(),
+                        property_editor_value.attribute_value_id(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/lib/dal/tests/integration_test/internal/new_engine/before_funcs.rs
+++ b/lib/dal/tests/integration_test/internal/new_engine/before_funcs.rs
@@ -95,10 +95,7 @@ async fn secret_definition_works_with_dummy_qualification(
             .await
             .expect("unable to list prop values");
         let reference_to_secret_attribute_value_id = property_values
-            .values
-            .iter()
-            .find(|(_, v)| v.prop_id() == reference_to_secret_prop.id)
-            .map(|(_, pvalue)| pvalue.attribute_value_id())
+            .find_by_prop_id(reference_to_secret_prop.id)
             .expect("unable to find attribute value");
 
         let fail_value =
@@ -180,11 +177,8 @@ async fn secret_definition_works_with_dummy_qualification(
             .await
             .expect("unable to list prop values");
         let reference_to_secret_attribute_value_id = property_values
-            .values
-            .iter()
-            .find(|(_, v)| v.prop_id() == reference_to_secret_prop.id)
-            .map(|(_, pvalue)| pvalue.attribute_value_id())
-            .expect("unable to find attribute value");
+            .find_by_prop_id(reference_to_secret_prop.id)
+            .expect("could not find attribute value");
 
         let success_value =
             serde_json::json!(secret_that_will_pass_the_qualification.id().to_string());

--- a/lib/dal/tests/integration_test/internal/new_engine/component.rs
+++ b/lib/dal/tests/integration_test/internal/new_engine/component.rs
@@ -60,10 +60,7 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
 
     // Update image
     let image_av_id = property_values
-        .values
-        .iter()
-        .find(|(_, v)| v.prop_id() == image_prop_id)
-        .map(|(_, pvalue)| pvalue.attribute_value_id())
+        .find_by_prop_id(image_prop_id)
         .expect("can't find default attribute value for ExposedPorts");
 
     let image_value = serde_json::json!("fiona/apple");
@@ -72,10 +69,7 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .expect("able to update image prop with 'fiona/apple'");
 
     let exposed_port_attribute_value_id = property_values
-        .values
-        .iter()
-        .find(|(_, v)| v.prop_id() == exposed_ports_prop_id)
-        .map(|(_, pvalue)| pvalue.attribute_value_id())
+        .find_by_prop_id(exposed_ports_prop_id)
         .expect("can't find default attribute value for ExposedPorts");
 
     // Insert it unset first (to mimick frontend)
@@ -90,26 +84,14 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .expect("able to list prop values");
 
     let (fetched_image_value, image_av_id_again) = property_values
-        .values
-        .iter()
-        .find(|(_, v)| v.prop_id() == image_prop_id)
-        .map(|(_, v)| (v.value(), v.attribute_value_id()))
+        .find_with_value_by_prop_id(image_prop_id)
         .expect("able to get image av id from pvalues");
 
     assert_eq!(image_av_id, image_av_id_again);
     assert_eq!(image_value, fetched_image_value);
 
-    let mut inserted_attribute_values: Vec<AttributeValueId> = property_values
-        .values
-        .iter()
-        .filter_map(|(_, v)| {
-            if v.prop_id() == exposed_ports_elem_prop_id {
-                Some(v.attribute_value_id())
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut inserted_attribute_values: Vec<AttributeValueId> =
+        property_values.list_by_prop_id(exposed_ports_elem_prop_id);
 
     assert_eq!(1, inserted_attribute_values.len());
     let pvalues_inserted_attribute_value_id =
@@ -135,26 +117,14 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .expect("able to list prop values");
 
     let (fetched_image_value, image_av_id_again) = property_values
-        .values
-        .iter()
-        .find(|(_, v)| v.prop_id() == image_prop_id)
-        .map(|(_, v)| (v.value(), v.attribute_value_id()))
+        .find_with_value_by_prop_id(image_prop_id)
         .expect("able to get image av id from pvalues");
 
     assert_eq!(image_av_id, image_av_id_again);
     assert_eq!(image_value, fetched_image_value);
 
-    let mut inserted_attribute_values: Vec<(serde_json::Value, AttributeValueId)> = property_values
-        .values
-        .iter()
-        .filter_map(|(_, v)| {
-            if v.prop_id() == exposed_ports_elem_prop_id {
-                Some((v.value(), v.attribute_value_id()))
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut inserted_attribute_values =
+        property_values.list_with_values_by_prop_id(exposed_ports_elem_prop_id);
     assert_eq!(1, inserted_attribute_values.len());
     let (inserted_value, pvalues_inserted_attribute_value_id) =
         inserted_attribute_values.pop().expect("get our av id");
@@ -173,17 +143,8 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .await
         .expect("able to list prop values");
 
-    let mut inserted_attribute_values: Vec<(serde_json::Value, AttributeValueId)> = property_values
-        .values
-        .iter()
-        .filter_map(|(_, v)| {
-            if v.prop_id() == exposed_ports_elem_prop_id {
-                Some((v.value(), v.attribute_value_id()))
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut inserted_attribute_values =
+        property_values.list_with_values_by_prop_id(exposed_ports_elem_prop_id);
     assert_eq!(1, inserted_attribute_values.len());
     let (inserted_value, pvalues_inserted_attribute_value_id) =
         inserted_attribute_values.pop().expect("get our av id");
@@ -202,17 +163,8 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .await
         .expect("able to list prop values");
 
-    let mut inserted_attribute_values: Vec<(serde_json::Value, AttributeValueId)> = property_values
-        .values
-        .iter()
-        .filter_map(|(_, v)| {
-            if v.prop_id() == exposed_ports_elem_prop_id {
-                Some((v.value(), v.attribute_value_id()))
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut inserted_attribute_values =
+        property_values.list_with_values_by_prop_id(exposed_ports_elem_prop_id);
     assert_eq!(1, inserted_attribute_values.len());
     let (inserted_value, pvalues_inserted_attribute_value_id) =
         inserted_attribute_values.pop().expect("get our av id");

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -419,7 +419,6 @@ async fn install_builtins(
         let (pkg_name, res) = res?;
         match res {
             Ok(pkg) => {
-                // TODO(nick): decide what to do with the override schema builtin flag in the new engine.
                 if let Err(err) = dal::pkg::import_pkg_from_pkg(
                     &ctx,
                     &pkg,
@@ -429,7 +428,6 @@ async fn install_builtins(
                         no_record: false,
                         is_builtin: true,
                     }),
-                    true,
                 )
                 .await
                 {


### PR DESCRIPTION
## Description

This commit removes the override schema builtin feature flag. It also centralizes accessor patterns for property editor values.

## GIF

<img src="https://media3.giphy.com/media/dTVkuaA36F89TVzxqZ/giphy.gif"/>

