### PR TITLE
feat(dal): remove direct node/edge weight accesses

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -3165,8 +3165,8 @@ mod test {
             destination_node_index_for_ordinal_edge,
         ) = maybe_ordinal_edge_information.expect("ordinal edge information not found");
         let ordinal_edge_weight = initial_graph
-            .graph
-            .edge_weight(ordinal_edge_index)
+            .get_edge_weight_opt(ordinal_edge_index)
+            .expect("should not error when getting edge")
             .expect("could not get edge weight for index")
             .to_owned();
         let source_node_id_for_ordinal_edge = initial_graph
@@ -3469,8 +3469,8 @@ mod test {
             destination_node_index_for_ordinal_edge,
         ) = maybe_ordinal_edge_information.expect("ordinal edge information not found");
         let ordinal_edge_weight = initial_graph
-            .graph
-            .edge_weight(ordinal_edge_index)
+            .get_edge_weight_opt(ordinal_edge_index)
+            .expect("should not error when getting edge")
             .expect("could not get edge weight for index")
             .to_owned();
         let source_node_id_for_ordinal_edge = initial_graph
@@ -3782,8 +3782,8 @@ mod test {
             destination_node_index_for_ordinal_edge,
         ) = maybe_ordinal_edge_information.expect("ordinal edge information not found");
         let ordinal_edge_weight = initial_graph
-            .graph
-            .edge_weight(ordinal_edge_index)
+            .get_edge_weight_opt(ordinal_edge_index)
+            .expect("should not error when getting edge")
             .expect("could not get edge weight for index")
             .to_owned();
         let source_node_id_for_ordinal_edge = initial_graph


### PR DESCRIPTION
In order to support the small graph and access to node and edge weights
through the caching layer, we cannot use the petgraph `node_weight` or
`edge_weight` methods directly in most cases. Instead we need to access
the weights through a method that will look them up in the caching layer
(or fetch it from the content store). This removes all direct calls to
the petgraph `node_weight` and `edge_weight` methods, replacing them
with calls to `get_node_weight` and `get_node_weight_opt`. These methods
are sync right now but will become async. Some other accesses remain
(calls to `edges_directed`, `node_weights()` and calls to
`node_weight_mut`, etc.) that also have to be made indirect.