### PR TITLE
Add node modules troubleshooting and centralize troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For more information on how to use and develop the System Initiative software, t
 To start, we recommend reading the [Open Source](#open-source) and [Contributing](#contributing) sources below.
 They provide information on licensing, contributor rights, and more.
 
-Afterwards, navigate to the [contributing guide](CONTRIBUTING.md) to get started.
+After that, navigate to the [contributing guide](CONTRIBUTING.md) to get started.
 
 ## Open Source
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,43 +4,26 @@ The diagram (created with [asciiflow](https://asciiflow.com)) below illustrates 
 There are other components and paradigms that aren't displayed, but this diagram is purely meant to show the overall flow from "mouse-click" onwards.
 
 ```
-                   ┌───────┐   ┌─────────┐
-                   │ pinga ├───│ council │
-                   └───┬───┘   └─────────┘
+        ┌───────┐             ┌─────────┐
+        │ pinga ├──────┬──────│ rebaser │
+        └───────┘      │      └─────────┘
                        │
                        │
+┌─────┐   ┌─────┐   ┌──┴──┐
+│ web ├───┤ sdf ├───┤ dal │
+└─────┘   └─────┘   └──┬──┘
                        │
-┌─────┐   ┌─────┐   ┌──┴──┐   ┌──────────┐
-│ web ├───┤ sdf ├───┤ dal ├───┤ postgres │
-└─────┘   └─────┘   └──┬──┘   └──────────┘
                        │
-      ┌────────────────┘
-      │
-┌─────┴────┐   ┌──────────────────┐   ┌─────────┐      ┌───────────────────┐
-│ veritech ├───┤ deadpool-cyclone ├───┤ cyclone ├ ─ ─> │ execution runtime │
-│          │   │                  │   │         │      │ (e.g. lang-js)    │
-└──────────┘   └──────────────────┘   └─────────┘      └───────────────────┘
+                 ┌─────┴────┐
+                 │ veritech │
+                 └──────────┘
 ```
 
-## Internal Definitions
+## Definitions
 
 - **[web](../app/web/):** the primary frontend web application for SI
 - **[sdf](../bin/sdf/):** the backend webserver for communicating with `web`
 - **[dal](../lib/dal/):** the library used by `sdf` routes to "make stuff happen" (the keystone of SI)
-- **[pinga](../bin/pinga/):** the job queueing service used by the `dal` to execute non-trivial jobs via `nats`
-- **[council](../bin/council/):** the DependentValuesUpdate job's synchronization service, used by `dal` via `nats` to avoid race conditions when updating attribute values
+- **[pinga](../bin/pinga/):** the job queueing service used to execute non-trivial jobs
+- **[rebaser](../bin/rebaser/):** where all workspace-level changes are persisted and conflicts are detected based on proposed changes
 - **[veritech](../bin/veritech/):** a backend webserver for dispatching functions in secure runtime environments
-- **[deadpool-cyclone](../lib/deadpool-cyclone/):** a library used for managing a pool of `cyclone` instances of varying "types" (i.e. HTTP, UDS)
-- **[cyclone](../bin/cyclone/):** the manager for a secure execution runtime environment (e.g. `lang-js`)
-- **[lang-js](../bin/lang-js/):** a secure-ish (don't trust it) execution runtime environment for JS functions
-
-## External Definitions
-
-- **[postgres](https://postgresql.org):** the database for storing SI data
-- **[nats](https://nats.io):** the messaging system used everywhere in SI, by `pinga`, `council`, `dal` and `sdf` (for multicast websocket events)
-
-## Additional Notes
-
-It's worth noting that our database has many stored procedures (i.e. database functions) that perform non-trivial logic.
-While the [dal](../lib/dal) is the primary "data access layer" for the rest of the SI stack, it does not perform _all_ the heavy lifting.
-

--- a/docs/DEVELOPMENT_ENVIRONMENT.md
+++ b/docs/DEVELOPMENT_ENVIRONMENT.md
@@ -142,22 +142,6 @@ There are two primary options to do so:
 2. Otherwise, you can execute `nix develop` to enter the environment, `nix develop --command <command>` to
    execute a command, or use the environment in whatever way your prefer.
 
-## Troubleshooting Potential Service Conflicts
-
-SI uses external services in conjunction with its native components.
-These external services are deployed via [`docker compose`](https://docs.docker.com/compose/) and are configured to stick to their default settings as
-closely as possible, including port settings.
-Thus, it is worth checking if you are running these services to avoid conflicts when running SI.
-Potentially conflicting services include, but are not limited to, the following:
-
-* PostgreSQL DB
-* OpenTelemetry
-* NATS
-* Watchtower
-
-In the case of a port conflict, a good strategy is to temporarily disable the host service until SI is no longer being
-run.
-
 ## How Will I Know That Each Component Is Ready?
 
 For backend services like `veritech` and `sdf`, there will usually be an `INFO`-level log indicating that the

--- a/docs/EDITORS_AND_IDES.md
+++ b/docs/EDITORS_AND_IDES.md
@@ -2,17 +2,6 @@
 
 This document contains information related to using editors and IDEs when developing the System Initiative software.
 
-## Seeing Errors Related to Procedural Macros
-
-In your editor, you may find that you'll see errors like `"YourEnum does not implement Display"` if you are using
-[`Display` from the `strum` crate](https://docs.rs/strum/latest/strum/derive.Display.html).
-This is because your editor may not have proc (procedural) macros enabled.
-
-As of 15 September 2022, this feature is not enabled in [IntelliJ Rust](https://www.jetbrains.com/rust/) by default and
-can cause the [aforementioned issue](https://github.com/intellij-rust/intellij-rust/issues/8847) to occur (which
-affects all [JetBrains](https://www.jetbrains.com/) IDEs, such as [CLion](https://www.jetbrains.com/clion/)).
-Thus, you will have to use the experimental proc macros feature or wait for stable proc macros support.
-
 ## Direnv
 
 For notes on using plugins with `direnv`, see [`DEVELOPMENT_ENVIRONMENT`](./DEVELOPMENT_ENVIRONMENT.md).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,45 @@
+# Troubleshooting
+
+This document contains common troubleshooting scenarios when working on the System Initiative software.
+
+## Build Errors Related to Running Services Reliant on `node_modules`
+
+Since we switched to `buck2` for our build infrastructure in mid-2023, you may experience issues when running services reliant on `node_modules` within older cloned instances of the repostiory.
+To solve these build errors, run the following in the root of your repository:
+
+> *Warning: this command deletes files.*
+> Ensure your current working directory is the root of the repository and understand what the command does before executing.
+> Please reach out to us [on Discord](https://discord.com/invite/system-init) if you have any questions.
+
+```bash
+find app bin lib third-party/node -type d -name node_modules -exec rm -rf {} \;; rm -rf node_modules
+```
+
+## NATS Jetstream Not Enabled
+
+If you see an error related to [NATS Jetstream](https://docs.nats.io/nats-concepts/jetstream) not being enabled when running the stack or tests, your local [`systeminit/nats`](https://hub.docker.com/repository/docker/systeminit/nats/) image is likely out of date.
+To get the most up-to-date images (including the aforementioned image), run the following command:
+
+```bash
+buck2 run //dev:pull
+```
+
+## Potential Service Conflicts
+
+SI uses external services in conjunction with its native components.
+These external services are deployed via [`docker compose`](https://docs.docker.com/compose/) and are configured to stick to their default settings as closely as possible, including port settings.
+Thus, it is worth checking if you are running these services to avoid conflicts when running SI.
+Potentially conflicting services include, but are not limited to, the following:
+
+* PostgreSQL DB
+* OpenTelemetry
+* NATS
+* Watchtower
+
+In the case of a port conflict, a good strategy is to temporarily disable the host service until SI is no longer being run.
+
+## Seeing Errors Related to Procedural Macros
+
+In your editor, you may find that you'll see errors like `"YourEnum does not implement Display"` if you are using [`Display` from the `strum` crate](https://docs.rs/strum/latest/strum/derive.Display.html).
+This is because your editor may not have proc (procedural) macros enabled.
+Check out your editor or relevant plugin docs for more information.


### PR DESCRIPTION
## Description

This PR adds a node modules troubleshooting section to the `docs/` directory within a new troubleshooting doc. The new troubleshooting doc centralizes other troubleshooting-related tasks from other docs.

<img src="https://media0.giphy.com/media/etKfsurOOmwS9zLGHa/giphy.gif"/>

## Additional Changes

- Add a new troubleshooting section related to NATS Jetstream not being enabled
- Refactor architecture diagram to include the rebaser and modernize descriptions
- Drop unnecessary parts of the architecture diagram (e.g. external services and naive depictions of the function execution flow)
- Remove irrelevant or outdated docs sections
- Fix a grammatical issue in the root README