### PR TITLE
Add color to rebaser telemetry and close tracker (ENG-2381)

### DIFF
--- a/bin/rebaser/src/args.rs
+++ b/bin/rebaser/src/args.rs
@@ -17,6 +17,41 @@ pub(crate) struct Args {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long = "no-color",
+        default_value = "false",
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: bool,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long = "force-color",
+        default_value = "false",
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: bool,
+
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -29,6 +29,13 @@ async fn async_main() -> Result<()> {
 
     let (mut telemetry, telemetry_shutdown) = {
         let config = TelemetryConfig::builder()
+            .force_color(args.force_color.then_some(true))
+            .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
             .service_name("rebaser")
             .service_namespace("si")
             .log_env_var_prefix("SI")
@@ -47,6 +54,8 @@ async fn async_main() -> Result<()> {
     debug!(arguments =?args, "parsed cli arguments");
 
     let config = Config::try_from(args)?;
+
+    task_tracker.close();
 
     Server::from_config(config).await?.run().await?;
 


### PR DESCRIPTION
## Description

Mimic sdf and pinga behavior by adding color to rebaser telemetry config and closing the tracker. We also add args the mimic the pinga args of the same name.

<img src="https://media4.giphy.com/media/lYgsRPkt16EL5U2fvR/giphy-downsized-medium.gif"/>