### PR TITLE
feat: enhanced NATS core/Jetstream support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,8 +1152,6 @@ dependencies = [
  "si-service",
  "si-std",
  "telemetry-application",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5603,6 +5601,7 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "telemetry",
+ "telemetry-application",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5597,6 +5597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "si-service"
+version = "0.1.0"
+dependencies = [
+ "telemetry",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "si-settings"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
@@ -1149,9 +1149,10 @@ dependencies = [
  "clap 4.5.2",
  "color-eyre",
  "council-server",
- "si-service",
  "si-std",
  "telemetry-application",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2504,6 +2505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3332,22 @@ dependencies = [
  "telemetry-nats",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "naxum"
+version = "0.1.0"
+dependencies = [
+ "async-nats",
+ "async-trait",
+ "bytes 1.5.0",
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6706,6 +6733,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "hdrhistogram",
  "indexmap 1.9.3",
  "pin-project 1.1.5",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "clap 4.5.2",
  "color-eyre",
  "council-server",
+ "si-service",
  "si-std",
  "telemetry-application",
  "tokio",
@@ -5600,6 +5601,7 @@ dependencies = [
 name = "si-service"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
  "telemetry",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "lib/nats-multiplexer-client",
     "lib/nats-multiplexer-core",
     "lib/nats-subscriber",
+    "lib/naxum",
     "lib/object-tree",
     "lib/pinga-server",
     "lib/rebaser-client",
@@ -193,7 +194,7 @@ tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alon
 tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
 toml = { version = "0.8.8" }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4", features = [
     "compression-br",
     "compression-deflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "lib/si-layer-cache",
     "lib/si-pkg",
     "lib/si-posthog-rs",
+    "lib/si-service",
     "lib/si-settings",
     "lib/si-std",
     "lib/si-test-macros",

--- a/lib/naxum/BUCK
+++ b/lib/naxum/BUCK
@@ -1,0 +1,17 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "naxum",
+    deps = [
+        "//third-party/rust:async-nats",
+        "//third-party/rust:async-trait",
+        "//third-party/rust:bytes",
+        "//third-party/rust:futures",
+        "//third-party/rust:pin-project-lite",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tracing",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+)

--- a/lib/naxum/Cargo.toml
+++ b/lib/naxum/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "naxum"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70.0"
+authors = ["Fletcher Nichol <fnichol@nichol.ca>"]
+publish = false
+
+[dependencies]
+async-nats = { workspace = true }
+async-trait = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true } # NOTE: if extracted this can be `futures-util`
+pin-project-lite = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tower = { workspace = true }
+tracing = { workspace = true } # NOTE: left with vanilla tracing for potential future extraction
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }

--- a/lib/naxum/examples/nats-core-subscriber/BUCK
+++ b/lib/naxum/examples/nats-core-subscriber/BUCK
@@ -1,0 +1,20 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "nats-core-subscriber",
+    srcs = ["main.rs"],
+    crate_root = "main.rs",
+    deps = [
+        "//lib/naxum:naxum",
+        "//third-party/rust:async-nats",
+        "//third-party/rust:futures",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+    ],
+)

--- a/lib/naxum/examples/nats-core-subscriber/main.rs
+++ b/lib/naxum/examples/nats-core-subscriber/main.rs
@@ -1,0 +1,126 @@
+use std::{convert::Infallible, env, error, str, time::Duration};
+
+use futures::StreamExt;
+use naxum::{
+    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, ServiceExt,
+};
+use tokio::{
+    signal::unix::{self, SignalKind},
+    time,
+};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tower::ServiceBuilder;
+use tracing::{error, info};
+use tracing_subscriber::{
+    fmt::{self, format::FmtSpan},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+    EnvFilter, Registry,
+};
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_core_subscribe=trace,naxum=trace,info";
+
+#[derive(Clone, Debug)]
+struct AppState {}
+
+async fn default(
+    State(_state): State<AppState>,
+    msg: async_nats::Message,
+) -> naxum::response::Result<()> {
+    info!(subject = msg.subject.as_str(), "processing message");
+
+    time::sleep(Duration::from_millis(10)).await;
+    let payload = str::from_utf8(&msg.payload).expect("TODO");
+    info!(payload, "finished message");
+
+    Ok(())
+}
+
+async fn handle_error(err: BoxError) {
+    if err.is::<tower::timeout::error::Elapsed>() {
+        error!(error = ?err, "message took too long to process");
+    } else {
+        error!(error = ?err, "unknown error");
+    }
+}
+
+#[allow(clippy::disallowed_methods)] // env vars are supporting alternatives in an example
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .pretty(),
+        )
+        .try_init()?;
+
+    let url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_owned());
+    let subject = env::var("NATS_SUBJECT").unwrap_or_else(|_| "naxum.test.core.>".to_owned());
+
+    // Create a NATS client, JetStream context, a consumer, and finally an async `Stream` of
+    // messages
+    let client = async_nats::connect(url).await?;
+    let messages = client
+        .subscribe(subject.clone())
+        .await?
+        // Core NATS subscriptions are a stream of `Option<Message>` so we convert this into a
+        // stream of `Option<Result<Message, Infallible>>`
+        .map(Ok::<_, Infallible>);
+
+    // Setup a Tower `Service` stack with some middleware
+    let app = ServiceBuilder::new()
+        .concurrency_limit(500)
+        .layer(TraceLayer::new())
+        .timeout(Duration::from_millis(100))
+        .service(default.with_state(AppState {}))
+        .handle_error(handle_error);
+
+    // Use a Tokio `TaskTracker` and `CancellationToken` to support signal handling and graceful
+    // shutdown
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    let naxum_token = token.clone();
+    tracker.spawn(async move {
+        info!(
+            subject = subject.as_str(),
+            "ready to receive messages on a core nats subscription",
+        );
+        naxum::serve(messages, app.into_make_service())
+            .with_graceful_shutdown(naxum::wait_on_cancelled(naxum_token))
+            .await
+    });
+
+    // Create streams of `SIGINT` (i.e. `Ctrl+c`) and `SIGTERM` signals
+    let mut sig_int = unix::signal(SignalKind::interrupt())?;
+    let mut sig_term = unix::signal(SignalKind::terminate())?;
+
+    // Wait until one of the signal streams gets a signal, after which we will close the task
+    // tracker and cancel the token, signaling all holders of the token
+    tokio::select! {
+        _ = sig_int.recv() => {
+            info!("received SIGINT, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = sig_term.recv() => {
+            info!("received SIGTERM, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+    }
+
+    // Wait for all tasks to finish
+    tracker.wait().await;
+
+    info!("graceful shutdown complete");
+    Ok(())
+}

--- a/lib/naxum/examples/nats-js-consumer/BUCK
+++ b/lib/naxum/examples/nats-js-consumer/BUCK
@@ -1,0 +1,20 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "nats-js-consumer",
+    srcs = ["main.rs"],
+    crate_root = "main.rs",
+    deps = [
+        "//lib/naxum:naxum",
+        "//third-party/rust:async-nats",
+        "//third-party/rust:futures",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+    ],
+)

--- a/lib/naxum/examples/nats-js-consumer/main.rs
+++ b/lib/naxum/examples/nats-js-consumer/main.rs
@@ -1,0 +1,137 @@
+use std::{env, error, str, time::Duration};
+
+use async_nats::jetstream;
+use naxum::{
+    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, ServiceExt,
+};
+use tokio::{
+    signal::unix::{self, SignalKind},
+    time,
+};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tower::ServiceBuilder;
+use tracing::{error, info};
+use tracing_subscriber::{
+    fmt::{self, format::FmtSpan},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+    EnvFilter, Registry,
+};
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_js_consumer=trace,naxum=trace,info";
+
+#[derive(Clone, Debug)]
+struct AppState {}
+
+async fn default(
+    State(_state): State<AppState>,
+    msg: jetstream::Message,
+) -> naxum::response::Result<()> {
+    info!(subject = msg.subject.as_str(), "processing message");
+
+    time::sleep(Duration::from_millis(10)).await;
+    let payload = str::from_utf8(&msg.payload).expect("TODO");
+
+    msg.ack().await.expect("TODO");
+
+    info!(payload, "finished message");
+
+    Ok(())
+}
+
+async fn handle_error(err: BoxError) {
+    if err.is::<tower::timeout::error::Elapsed>() {
+        error!(error = ?err, "message took too long to process");
+    } else {
+        error!(error = ?err, "unknown error");
+    }
+}
+
+#[allow(clippy::disallowed_methods)] // env vars are supporting alternatives in an example
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .pretty(),
+        )
+        .try_init()?;
+
+    let url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_owned());
+    let subject = env::var("NATS_SUBJECT").unwrap_or_else(|_| "naxum.test.js.>".to_owned());
+    let stream_name = env::var("NATS_STREAM").unwrap_or_else(|_| "NAXUM_TEST".to_owned());
+
+    // Create a NATS client, JetStream context, a consumer, and finally an async `Stream` of
+    // messages
+    let client = async_nats::connect(url).await?;
+    let context = jetstream::new(client);
+    let stream = context
+        .get_or_create_stream(jetstream::stream::Config {
+            name: stream_name.clone(),
+            subjects: vec![subject.clone()],
+            ..Default::default()
+        })
+        .await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config::default())
+        .await?;
+    let messages = consumer.messages().await?;
+
+    // Setup a Tower `Service` stack with some middleware
+    let app = ServiceBuilder::new()
+        .concurrency_limit(500)
+        .layer(TraceLayer::new())
+        .timeout(Duration::from_millis(100))
+        .service(default.with_state(AppState {}))
+        .handle_error(handle_error);
+
+    // Use a Tokio `TaskTracker` and `CancellationToken` to support signal handling and graceful
+    // shutdown
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    let naxum_token = token.clone();
+    tracker.spawn(async move {
+        info!(
+            stream = stream_name.as_str(),
+            subject = subject.as_str(),
+            "ready to receive messages with a nats jetstream consumer",
+        );
+        naxum::serve(messages, app.into_make_service())
+            .with_graceful_shutdown(naxum::wait_on_cancelled(naxum_token))
+            .await
+    });
+
+    // Create streams of `SIGINT` (i.e. `Ctrl+c`) and `SIGTERM` signals
+    let mut sig_int = unix::signal(SignalKind::interrupt())?;
+    let mut sig_term = unix::signal(SignalKind::terminate())?;
+
+    // Wait until one of the signal streams gets a signal, after which we will close the task
+    // tracker and cancel the token, signaling all holders of the token
+    tokio::select! {
+        _ = sig_int.recv() => {
+            info!("received SIGINT, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = sig_term.recv() => {
+            info!("received SIGTERM, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+    }
+
+    // Wait for all tasks to finish
+    tracker.wait().await;
+
+    info!("graceful shutdown complete");
+    Ok(())
+}

--- a/lib/naxum/src/cancellation.rs
+++ b/lib/naxum/src/cancellation.rs
@@ -1,0 +1,5 @@
+use tokio_util::sync::CancellationToken;
+
+pub async fn wait_on_cancelled(token: CancellationToken) {
+    token.cancelled().await
+}

--- a/lib/naxum/src/error.rs
+++ b/lib/naxum/src/error.rs
@@ -1,0 +1,34 @@
+use crate::BoxError;
+use std::{error, fmt};
+
+/// Errors that can happen when using naxum.
+#[derive(Debug)]
+pub struct Error {
+    inner: BoxError,
+}
+
+impl Error {
+    /// Create a new `Error` from a boxable error.
+    pub fn new(error: impl Into<BoxError>) -> Self {
+        Self {
+            inner: error.into(),
+        }
+    }
+
+    /// Convert an `Error` back into the underlying boxed trait object.
+    pub fn into_inner(self) -> BoxError {
+        self.inner
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        Some(&*self.inner)
+    }
+}

--- a/lib/naxum/src/error_handling.rs
+++ b/lib/naxum/src/error_handling.rs
@@ -1,0 +1,250 @@
+use std::{
+    convert::Infallible,
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use tower::{Layer, Service, ServiceExt};
+
+use crate::{
+    extract::FromMessageHead,
+    response::{IntoResponse, Response},
+    MessageHead,
+};
+
+pub struct HandleErrorLayer<F, T> {
+    f: F,
+    _extractor: PhantomData<fn() -> T>,
+}
+
+impl<F, T> HandleErrorLayer<F, T> {
+    pub fn new(f: F) -> Self {
+        Self {
+            f,
+            _extractor: PhantomData,
+        }
+    }
+}
+
+impl<F, T> Clone for HandleErrorLayer<F, T>
+where
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: self.f.clone(),
+            _extractor: PhantomData,
+        }
+    }
+}
+
+impl<F, T> fmt::Debug for HandleErrorLayer<F, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandleErrorLayer")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+impl<S, F, T> Layer<S> for HandleErrorLayer<F, T>
+where
+    F: Clone,
+{
+    type Service = HandleError<S, F, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HandleError::new(inner, self.f.clone())
+    }
+}
+
+pub struct HandleError<S, F, T> {
+    inner: S,
+    f: F,
+    _extractor: PhantomData<fn() -> T>,
+}
+
+impl<S, F, T> HandleError<S, F, T> {
+    pub fn new(inner: S, f: F) -> Self {
+        Self {
+            inner,
+            f,
+            _extractor: PhantomData,
+        }
+    }
+}
+
+impl<S, F, T> Clone for HandleError<S, F, T>
+where
+    S: Clone,
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            f: self.f.clone(),
+            _extractor: PhantomData,
+        }
+    }
+}
+
+impl<S, F, E> fmt::Debug for HandleError<S, F, E>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandleError")
+            .field("inner", &self.inner)
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+impl<S, R, F, Fut, Res> Service<R> for HandleError<S, F, ()>
+where
+    S: Service<R> + Clone + Send + 'static,
+    S::Response: Send,
+    S::Error: Send,
+    S::Future: Send,
+    F: FnOnce(S::Error) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = Res> + Send,
+    Res: IntoResponse,
+    R: MessageHead + Send + 'static,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = future::HandleErrorFuture;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let f = self.f.clone();
+
+        let clone = self.inner.clone();
+        let inner = std::mem::replace(&mut self.inner, clone);
+
+        let future = Box::pin(async move {
+            // TODO(fnichol): at the moment the response type `Res` is generic, however we know
+            // that by the end we want our response type to be unit (i.e. `()`). Should we shut
+            // down the extra generics or allow the final response types to be dropped here?
+            // Unclear...
+            #[allow(clippy::unit_arg)]
+            match inner.oneshot(req).await {
+                Ok(_res) => Ok(()),
+                Err(err) => Ok(f(err).await.into_response()),
+            }
+        });
+
+        future::HandleErrorFuture { future }
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! impl_service {
+    ( $($ty:ident),* $(,)? ) => {
+        impl<S, R, F, Res, Fut, $($ty,)*> Service<R>
+            for HandleError<S, F, ($($ty,)*)>
+        where
+            S: Service<R> + Clone + Send + 'static,
+            S::Response: IntoResponse + Send,
+            S::Error: Send,
+            S::Future: Send,
+            F: FnOnce($($ty),*, S::Error) -> Fut + Clone + Send + 'static,
+            Fut: Future<Output = Res> + Send,
+            Res: IntoResponse,
+            $( $ty: FromMessageHead<()> + Send,)*
+            R: MessageHead + Send + 'static,
+        {
+            type Response = Response;
+            type Error = Infallible;
+
+            type Future = future::HandleErrorFuture;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            #[allow(non_snake_case)]
+            fn call(&mut self, req: R) -> Self::Future {
+                let f = self.f.clone();
+
+                let clone = self.inner.clone();
+                let inner = std::mem::replace(&mut self.inner, clone);
+
+                let future = Box::pin(async move {
+                    let (mut parts, body) = req.into_parts();
+
+                    $(
+                        let $ty = match $ty::from_message_head(&mut parts, &()).await {
+                            Ok(value) => value,
+                            Err(rejection) => return Ok(rejection.into_response()),
+                        };
+                    )*
+
+                    let req = match R::from_parts(parts, body) {
+                        Ok(value) => value,
+                        Err(rejection) => return Ok(rejection.into_response()),
+                    };
+
+                    match inner.oneshot(req).await {
+                        Ok(res) => Ok(res.into_response()),
+                        Err(err) => Ok(f($($ty),*, err).await.into_response()),
+                    }
+                });
+
+                future::HandleErrorFuture { future }
+            }
+        }
+    }
+}
+
+impl_service!(T1);
+impl_service!(T1, T2);
+impl_service!(T1, T2, T3);
+impl_service!(T1, T2, T3, T4);
+impl_service!(T1, T2, T3, T4, T5);
+impl_service!(T1, T2, T3, T4, T5, T6);
+impl_service!(T1, T2, T3, T4, T5, T6, T7);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+
+pub mod future {
+    use std::{
+        convert::Infallible,
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use pin_project_lite::pin_project;
+
+    use crate::response::Response;
+
+    pin_project! {
+        pub struct HandleErrorFuture {
+            #[pin]
+            pub(super) future: Pin<Box<dyn Future<Output = Result<Response, Infallible>>
+                + Send
+                + 'static
+            >>,
+        }
+    }
+
+    impl Future for HandleErrorFuture {
+        type Output = Result<Response, Infallible>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.project().future.poll(cx)
+        }
+    }
+}

--- a/lib/naxum/src/extract.rs
+++ b/lib/naxum/src/extract.rs
@@ -1,0 +1,119 @@
+use std::convert::Infallible;
+
+use async_trait::async_trait;
+
+use crate::{message::Head, response::IntoResponse, MessageHead};
+
+mod message_parts;
+pub mod rejection;
+mod state;
+mod tuple;
+
+pub use self::state::State;
+
+mod private {
+    #[derive(Debug, Clone, Copy)]
+    pub enum ViaHead {}
+
+    #[derive(Debug, Clone, Copy)]
+    pub enum ViaMessage {}
+}
+
+#[async_trait]
+pub trait FromMessageHead<S>: Sized {
+    type Rejection: IntoResponse;
+
+    async fn from_message_head(head: &mut Head, state: &S) -> Result<Self, Self::Rejection>;
+}
+
+#[async_trait]
+pub trait FromMessage<S, R, M = private::ViaMessage>: Sized
+where
+    R: MessageHead,
+{
+    type Rejection: IntoResponse;
+
+    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection>;
+}
+
+#[async_trait]
+impl<S, R, T> FromMessage<S, R, private::ViaHead> for T
+where
+    S: Send + Sync,
+    R: MessageHead + Send + 'static,
+    T: FromMessageHead<S>,
+{
+    type Rejection = <Self as FromMessageHead<S>>::Rejection;
+
+    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+        let (mut head, _payload) = req.into_parts();
+        Self::from_message_head(&mut head, state).await
+    }
+}
+
+#[async_trait]
+impl<S, T> FromMessageHead<S> for Option<T>
+where
+    S: Send + Sync,
+    T: FromMessageHead<S>,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, state: &S) -> Result<Self, Self::Rejection> {
+        Ok(T::from_message_head(head, state).await.ok())
+    }
+}
+
+#[async_trait]
+impl<S, R, T> FromMessage<S, R> for Option<T>
+where
+    S: Send + Sync,
+    R: MessageHead + Send + 'static,
+    T: FromMessage<S, R>,
+{
+    type Rejection = Infallible;
+
+    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+        Ok(T::from_message(req, state).await.ok())
+    }
+}
+
+#[async_trait]
+impl<S, T> FromMessageHead<S> for Result<T, T::Rejection>
+where
+    T: FromMessageHead<S>,
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, state: &S) -> Result<Self, Self::Rejection> {
+        Ok(T::from_message_head(head, state).await)
+    }
+}
+
+#[async_trait]
+impl<S, R, T> FromMessage<S, R> for Result<T, T::Rejection>
+where
+    S: Send + Sync,
+    R: MessageHead + Send + 'static,
+    T: FromMessageHead<S>,
+{
+    type Rejection = Infallible;
+
+    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+        Ok(T::from_message(req, state).await)
+    }
+}
+
+pub trait FromRef<T> {
+    fn from_ref(input: &T) -> Self;
+}
+
+impl<T> FromRef<T> for T
+where
+    T: Clone,
+{
+    fn from_ref(input: &T) -> Self {
+        input.clone()
+    }
+}

--- a/lib/naxum/src/extract/message_parts.rs
+++ b/lib/naxum/src/extract/message_parts.rs
@@ -1,0 +1,134 @@
+use std::{convert::Infallible, str};
+
+use async_nats::{HeaderMap, Subject};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::{
+    extract::rejection::InvalidUtf8,
+    message::{Extensions, Head},
+    MessageHead,
+};
+
+use super::{rejection::StringRejection, FromMessage, FromMessageHead};
+
+#[async_trait]
+impl<S, R> FromMessage<S, R> for R
+where
+    S: Send + Sync,
+    R: MessageHead + Send,
+{
+    type Rejection = Infallible;
+
+    async fn from_message(req: R, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(req)
+    }
+}
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Subject {
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(head.subject.clone())
+    }
+}
+
+pub struct Reply(pub Option<Subject>);
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Reply {
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(head.reply.clone()))
+    }
+}
+
+pub struct Headers(pub Option<HeaderMap>);
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Headers {
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(head.headers.clone()))
+    }
+}
+
+pub struct StatusCode(pub Option<async_nats::StatusCode>);
+
+#[async_trait]
+impl<S> FromMessageHead<S> for StatusCode {
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(head.status))
+    }
+}
+
+pub struct Length(pub usize);
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Length {
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(head.length))
+    }
+}
+
+#[async_trait]
+impl<S, R> FromMessage<S, R> for Bytes
+where
+    S: Send + Sync,
+    R: MessageHead + Send + 'static,
+{
+    type Rejection = Infallible;
+
+    async fn from_message(req: R, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(req.into_parts().1)
+    }
+}
+
+#[async_trait]
+impl<S, R> FromMessage<S, R> for String
+where
+    S: Send + Sync,
+    R: MessageHead + Send + 'static,
+{
+    type Rejection = StringRejection;
+
+    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = Bytes::from_message(req, state).await.unwrap();
+        let string = str::from_utf8(&bytes)
+            .map_err(InvalidUtf8::from_err)?
+            .to_owned();
+
+        Ok(string)
+    }
+}
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Head
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(head.clone())
+    }
+}
+
+#[async_trait]
+impl<S> FromMessageHead<S> for Extensions
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(head.extensions.clone())
+    }
+}

--- a/lib/naxum/src/extract/rejection.rs
+++ b/lib/naxum/src/extract/rejection.rs
@@ -1,0 +1,67 @@
+use std::{error, fmt};
+
+use crate::{
+    response::{IntoResponse, Response},
+    BoxError, Error,
+};
+
+#[derive(Debug)]
+pub struct InvalidUtf8(Error);
+
+impl InvalidUtf8 {
+    pub(crate) fn from_err<E>(err: E) -> Self
+    where
+        E: Into<BoxError>,
+    {
+        Self(Error::new(err))
+    }
+}
+
+impl IntoResponse for InvalidUtf8 {
+    fn into_response(self) -> Response {
+        // TODO: log rejection
+    }
+}
+
+impl fmt::Display for InvalidUtf8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "message payload didn't contain valid UTF-8")
+    }
+}
+
+impl error::Error for InvalidUtf8 {}
+
+#[derive(Debug)]
+pub enum StringRejection {
+    InvalidUtf8(InvalidUtf8),
+}
+
+impl IntoResponse for StringRejection {
+    fn into_response(self) -> crate::response::Response {
+        match self {
+            StringRejection::InvalidUtf8(inner) => inner.into_response(),
+        }
+    }
+}
+
+impl From<InvalidUtf8> for StringRejection {
+    fn from(value: InvalidUtf8) -> Self {
+        Self::InvalidUtf8(value)
+    }
+}
+
+impl fmt::Display for StringRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidUtf8(inner) => write!(f, "{inner}"),
+        }
+    }
+}
+
+impl error::Error for StringRejection {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::InvalidUtf8(inner) => inner.source(),
+        }
+    }
+}

--- a/lib/naxum/src/extract/state.rs
+++ b/lib/naxum/src/extract/state.rs
@@ -1,0 +1,41 @@
+use std::{convert::Infallible, ops};
+
+use async_trait::async_trait;
+
+use crate::message::Head;
+
+use super::{FromMessageHead, FromRef};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct State<S>(pub S);
+
+#[async_trait]
+impl<OuterState, InnerState> FromMessageHead<OuterState> for State<InnerState>
+where
+    InnerState: FromRef<OuterState>,
+    OuterState: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(
+        _head: &mut Head,
+        state: &OuterState,
+    ) -> Result<Self, Self::Rejection> {
+        let inner_state = InnerState::from_ref(state);
+        Ok(Self(inner_state))
+    }
+}
+
+impl<S> ops::Deref for State<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S> ops::DerefMut for State<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/lib/naxum/src/extract/tuple.rs
+++ b/lib/naxum/src/extract/tuple.rs
@@ -1,0 +1,83 @@
+use std::convert::Infallible;
+
+use async_trait::async_trait;
+
+use crate::{
+    message::Head,
+    response::{IntoResponse, Response},
+    MessageHead,
+};
+
+use super::{FromMessage, FromMessageHead};
+
+#[async_trait]
+impl<S> FromMessageHead<S> for ()
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_message_head(_head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(())
+    }
+}
+
+macro_rules! impl_from_message {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[async_trait]
+        #[allow(non_snake_case, unused_mut, unused_variables)]
+        impl<S, $($ty,)* $last> FromMessageHead<S> for ($($ty,)* $last,)
+        where
+            $( $ty: FromMessageHead<S> + Send, )*
+            $last: FromMessageHead<S> + Send,
+            S: Send + Sync,
+        {
+            type Rejection = Response;
+
+            async fn from_message_head(head: &mut Head, state: &S) -> Result<Self, Self::Rejection> {
+                $(
+                    let $ty = $ty::from_message_head(head, state)
+                        .await
+                        .map_err(|err| err.into_response())?;
+                )*
+                let $last = $last::from_message_head(head, state)
+                    .await
+                    .map_err(|err| err.into_response())?;
+
+                Ok(($($ty,)* $last,))
+            }
+        }
+
+        // This impl must not be generic over M, otherwise it would conflict with the blanket
+        // implementation of `FromMessage<S, Mut>` for `T: FromMessageHead<S>`.
+        #[async_trait]
+        #[allow(non_snake_case, unused_mut, unused_variables)]
+        impl<S, R, $($ty,)* $last> FromMessage<S, R> for ($($ty,)* $last,)
+        where
+            $( $ty: FromMessageHead<S> + Send, )*
+            $last: FromMessage<S, R> + Send,
+            S: Send + Sync,
+            R: MessageHead + Send + 'static,
+        {
+            type Rejection = Response;
+
+            async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+                let (mut head, body) = req.into_parts();
+
+                $(
+                    let $ty = $ty::from_message_head(&mut head, state).await.map_err(|err| err.into_response())?;
+                )*
+
+                let req = R::from_parts(head, body).map_err(|err| err.into_response())?;
+
+                let $last = $last::from_message(req, state).await.map_err(|err| err.into_response())?;
+
+                Ok(($($ty,)* $last,))
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_from_message);

--- a/lib/naxum/src/handler.rs
+++ b/lib/naxum/src/handler.rs
@@ -1,0 +1,220 @@
+use core::fmt;
+use std::{
+    convert::Infallible,
+    future::{ready, Future, Ready},
+    marker::PhantomData,
+    pin::Pin,
+};
+
+use tower::{Layer, Service, ServiceExt};
+
+use crate::{
+    extract::{FromMessage, FromMessageHead},
+    make_service::IntoMakeService,
+    response::{IntoResponse, Response},
+    MessageHead,
+};
+
+pub mod future;
+mod service;
+
+pub use self::service::HandlerService;
+
+pub trait Handler<T, S, R>: Clone + Send + Sized + 'static
+where
+    R: MessageHead,
+{
+    type Future: Future<Output = Response> + Send + 'static;
+
+    fn call(self, req: R, state: S) -> Self::Future;
+
+    fn layer<L>(self, layer: L) -> Layered<L, Self, T, S, R>
+    where
+        L: Layer<HandlerService<Self, T, S, R>> + Clone,
+        L::Service: Service<R>,
+    {
+        Layered {
+            layer,
+            handler: self,
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+
+    fn with_state(self, state: S) -> HandlerService<Self, T, S, R> {
+        HandlerService::new(self, state)
+    }
+}
+
+impl<F, Fut, Res, S, R> Handler<((),), S, R> for F
+where
+    F: FnOnce() -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = Res> + Send,
+    Res: IntoResponse,
+    R: MessageHead,
+{
+    type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+    fn call(self, _req: R, _state: S) -> Self::Future {
+        Box::pin(async move { self().await.into_response() })
+    }
+}
+
+macro_rules! impl_handler {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[allow(non_snake_case, unused_mut)]
+        impl<F, Fut, S, R, Res, M, $($ty,)* $last> Handler<(M, $($ty,)* $last,), S, R> for F
+        where
+            F: FnOnce($($ty,)* $last,) -> Fut + Clone + Send + 'static,
+            Fut: Future<Output = Res> + Send,
+            S: Send + Sync + 'static,
+            R: MessageHead + Send + 'static,
+            Res: IntoResponse,
+            $( $ty: FromMessageHead<S> + Send, )*
+            $last: FromMessage<S, R, M> + Send,
+        {
+            type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+            fn call(self, req: R, state: S) -> Self::Future {
+                Box::pin(async move {
+                    let (mut parts, body) = req.into_parts();
+                    let state = &state;
+
+                    $(
+                        let $ty = match $ty::from_message_head(&mut parts, state).await {
+                            Ok(value) => value,
+                            Err(rejection) => return rejection.into_response(),
+                        };
+                    )*
+
+                    let req = match R::from_parts(parts, body) {
+                        Ok(value) => value,
+                        Err(rejection) => return rejection.into_response(),
+                    };
+
+                    let $last = match $last::from_message(req, state).await {
+                        Ok(value) => value,
+                        Err(rejection) => return rejection.into_response(),
+                    };
+
+                    let res = self($($ty,)* $last,).await;
+
+                    res.into_response()
+                })
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_handler);
+
+mod private {
+    // Marker type for `impl<T: IntoResponse> Handler for T`
+    #[allow(missing_debug_implementations)]
+    pub enum IntoResponseHandler {}
+}
+
+impl<T, S, R> Handler<private::IntoResponseHandler, S, R> for T
+where
+    T: IntoResponse + Clone + Send + 'static,
+    R: MessageHead,
+{
+    type Future = Ready<Response>;
+
+    fn call(self, _req: R, _state: S) -> Self::Future {
+        #[allow(clippy::unit_arg)]
+        ready(self.into_response())
+    }
+}
+
+pub struct Layered<L, H, T, S, R> {
+    layer: L,
+    handler: H,
+    _marker: PhantomData<fn() -> (T, S)>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<L, H, T, S, R> fmt::Debug for Layered<L, H, T, S, R>
+where
+    L: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Layered")
+            .field("layer", &self.layer)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L, H, T, S, R> Clone for Layered<L, H, T, S, R>
+where
+    L: Clone,
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            layer: self.layer.clone(),
+            handler: self.handler.clone(),
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+impl<L, H, T, S, R> Handler<T, S, R> for Layered<L, H, T, S, R>
+where
+    L: Layer<HandlerService<H, T, S, R>> + Clone + Send + 'static,
+    H: Handler<T, S, R>,
+    L::Service: Service<R, Error = Infallible> + Clone + Send + 'static,
+    <L::Service as Service<R>>::Response: IntoResponse,
+    <L::Service as Service<R>>::Future: Send,
+    T: 'static,
+    S: 'static,
+    R: MessageHead + Send + 'static,
+{
+    type Future = future::LayeredFuture<L::Service, R>;
+
+    fn call(self, req: R, state: S) -> Self::Future {
+        use futures::future::{FutureExt, Map};
+
+        let svc = self.handler.with_state(state);
+        let svc = self.layer.layer(svc);
+
+        #[allow(clippy::type_complexity)]
+        let future: Map<
+            _,
+            fn(
+                Result<<L::Service as Service<R>>::Response, <L::Service as Service<R>>::Error>,
+            ) -> _,
+        > = svc.oneshot(req).map(|result| match result {
+            Ok(res) => res.into_response(),
+            Err(err) => match err {},
+        });
+
+        future::LayeredFuture::new(future)
+    }
+}
+
+pub trait HandlerWithoutStateExt<T, R>: Handler<T, (), R>
+where
+    R: MessageHead,
+{
+    fn into_service(self) -> HandlerService<Self, T, (), R>;
+
+    fn into_make_service(self) -> IntoMakeService<HandlerService<Self, T, (), R>>;
+}
+
+impl<H, T, R> HandlerWithoutStateExt<T, R> for H
+where
+    H: Handler<T, (), R>,
+    R: MessageHead,
+{
+    fn into_service(self) -> HandlerService<Self, T, (), R> {
+        self.with_state(())
+    }
+
+    fn into_make_service(self) -> IntoMakeService<HandlerService<Self, T, (), R>> {
+        self.into_service().into_make_service()
+    }
+}

--- a/lib/naxum/src/handler/future.rs
+++ b/lib/naxum/src/handler/future.rs
@@ -1,0 +1,87 @@
+//! Handler future types.
+
+#![allow(clippy::type_complexity)] // For `Map<F, fn....>` type
+
+use std::{
+    convert::Infallible,
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::future::Map;
+use pin_project_lite::pin_project;
+use tower::{util::Oneshot, Service};
+
+use crate::{response::Response, MessageHead};
+
+pin_project! {
+    pub struct IntoServiceFuture<F> {
+        #[pin]
+        future: Map<
+            F,
+            fn(Response) -> Result<Response, Infallible>,
+        >,
+    }
+}
+
+impl<F> IntoServiceFuture<F> {
+    pub(crate) fn new(future: Map<F, fn(Response) -> Result<Response, Infallible>>) -> Self {
+        Self { future }
+    }
+}
+
+impl<F> fmt::Debug for IntoServiceFuture<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoServiceFuture").finish_non_exhaustive()
+    }
+}
+
+impl<F> Future for IntoServiceFuture<F>
+where
+    Map<F, fn(Response) -> Result<Response, Infallible>>: Future,
+{
+    type Output = <Map<F, fn(Response) -> Result<Response, Infallible>> as Future>::Output;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}
+
+pin_project! {
+    pub struct LayeredFuture<S, R>
+    where
+        S: Service<R>,
+        R: MessageHead,
+    {
+        #[pin]
+        inner: Map<Oneshot<S, R>, fn(Result<S::Response, S::Error>) -> Response>,
+    }
+}
+
+impl<S, R> LayeredFuture<S, R>
+where
+    S: Service<R>,
+    R: MessageHead,
+{
+    pub(super) fn new(
+        inner: Map<Oneshot<S, R>, fn(Result<S::Response, S::Error>) -> Response>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, R> Future for LayeredFuture<S, R>
+where
+    S: Service<R>,
+    R: MessageHead,
+{
+    type Output = Response;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}

--- a/lib/naxum/src/handler/service.rs
+++ b/lib/naxum/src/handler/service.rs
@@ -1,0 +1,86 @@
+use std::{
+    convert::Infallible,
+    fmt,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use futures::FutureExt;
+use tower::Service;
+
+use crate::{make_service::IntoMakeService, response::Response, MessageHead};
+
+use super::Handler;
+
+pub struct HandlerService<H, T, S, R> {
+    handler: H,
+    state: S,
+    _marker: PhantomData<fn() -> T>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<H, T, S, R> HandlerService<H, T, S, R> {
+    pub(super) fn new(handler: H, state: S) -> Self {
+        Self {
+            handler,
+            state,
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+
+    pub fn into_make_service(self) -> IntoMakeService<HandlerService<H, T, S, R>> {
+        IntoMakeService::new(self)
+    }
+
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+}
+
+impl<H, T, S, R> fmt::Debug for HandlerService<H, T, S, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandlerService").finish_non_exhaustive()
+    }
+}
+
+impl<H, T, S, R> Clone for HandlerService<H, T, S, R>
+where
+    H: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+impl<H, T, S, R> Service<R> for HandlerService<H, T, S, R>
+where
+    H: Handler<T, S, R> + Clone + Send + 'static,
+    S: Clone + Send + Sync,
+    R: MessageHead,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = super::future::IntoServiceFuture<H::Future>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `IntoService` can only be constructed from async functions which are always ready, or
+        // from `Layered` which buffers in `<Layered as Handler>::call` and is therefore
+        // also always ready.
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let handler = self.handler.clone();
+        let future = Handler::call(handler, req, self.state.clone());
+        let future = future.map(Ok as _);
+
+        super::future::IntoServiceFuture::new(future)
+    }
+}

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -8,6 +8,7 @@ pub mod extract;
 pub mod handler;
 mod make_service;
 mod message;
+pub mod middleware;
 pub mod response;
 pub mod serve;
 mod service_ext;

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -1,0 +1,23 @@
+#[macro_use]
+pub(crate) mod macros;
+
+mod cancellation;
+mod error;
+pub mod error_handling;
+pub mod extract;
+pub mod handler;
+mod make_service;
+mod message;
+pub mod response;
+pub mod serve;
+mod service_ext;
+
+pub use self::cancellation::wait_on_cancelled;
+pub use self::error::Error;
+pub use self::message::MessageHead;
+pub use self::serve::serve;
+pub use self::service_ext::ServiceExt;
+pub use async_trait::async_trait;
+
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -15,7 +15,8 @@ mod service_ext;
 
 pub use self::cancellation::wait_on_cancelled;
 pub use self::error::Error;
-pub use self::message::MessageHead;
+pub use self::make_service::IntoMakeService;
+pub use self::message::{Head, MessageHead};
 pub use self::serve::serve;
 pub use self::service_ext::ServiceExt;
 pub use async_trait::async_trait;

--- a/lib/naxum/src/macros.rs
+++ b/lib/naxum/src/macros.rs
@@ -1,0 +1,21 @@
+#[rustfmt::skip]
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!([], T1);
+        $name!([T1], T2);
+        $name!([T1, T2], T3);
+        $name!([T1, T2, T3], T4);
+        $name!([T1, T2, T3, T4], T5);
+        $name!([T1, T2, T3, T4, T5], T6);
+        $name!([T1, T2, T3, T4, T5, T6], T7);
+        $name!([T1, T2, T3, T4, T5, T6, T7], T8);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13], T14);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14], T15);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15], T16);
+    };
+}

--- a/lib/naxum/src/make_service.rs
+++ b/lib/naxum/src/make_service.rs
@@ -1,0 +1,71 @@
+use std::{
+    convert::Infallible,
+    fmt,
+    future::{ready, Future, Ready},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+use tower::Service;
+
+#[derive(Clone, Debug)]
+pub struct IntoMakeService<S> {
+    svc: S,
+}
+
+impl<S> IntoMakeService<S> {
+    pub(crate) fn new(svc: S) -> Self {
+        Self { svc }
+    }
+}
+
+impl<S, T> Service<T> for IntoMakeService<S>
+where
+    S: Clone,
+{
+    type Response = S;
+    type Error = Infallible;
+    type Future = IntoMakeServiceFuture<S>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _target: T) -> Self::Future {
+        IntoMakeServiceFuture::new(ready(Ok(self.svc.clone())))
+    }
+}
+
+pin_project! {
+    pub struct IntoMakeServiceFuture<S> {
+        #[pin]
+        future: Ready<Result<S, Infallible>>,
+    }
+}
+
+impl<S> IntoMakeServiceFuture<S> {
+    pub(crate) fn new(future: Ready<Result<S, Infallible>>) -> Self {
+        Self { future }
+    }
+}
+
+impl<S> fmt::Debug for IntoMakeServiceFuture<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoMakeServiceFuture")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S> Future for IntoMakeServiceFuture<S>
+where
+    Ready<Result<S, Infallible>>: Future,
+{
+    type Output = <Ready<Result<S, Infallible>> as Future>::Output;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}

--- a/lib/naxum/src/message.rs
+++ b/lib/naxum/src/message.rs
@@ -1,0 +1,218 @@
+use std::{error, fmt};
+
+use async_nats::{HeaderMap, StatusCode, Subject};
+use bytes::Bytes;
+
+mod extensions;
+
+pub use extensions::Extensions;
+
+use crate::response::{IntoResponse, Response};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FromPartsError(&'static str);
+
+impl fmt::Display for FromPartsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to build message from parts: {}", self.0)
+    }
+}
+
+impl error::Error for FromPartsError {}
+
+impl IntoResponse for FromPartsError {
+    fn into_response(self) -> Response {}
+}
+
+pub trait MessageHead {
+    /// Subject to which message is published to.
+    fn subject(&self) -> &Subject;
+
+    /// Optional reply subject to which response can be published by a subscriber or consumer.
+    fn reply(&self) -> Option<&Subject>;
+
+    /// Optional headers.
+    fn headers(&self) -> Option<&HeaderMap>;
+
+    /// Optional Status of the message. Used mostly for internal handling.
+    fn status(&self) -> Option<StatusCode>;
+
+    /// Length of message in bytes.
+    fn length(&self) -> usize;
+
+    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError>
+    where
+        Self: Sized;
+
+    fn into_parts(self) -> (Head, Bytes);
+}
+
+impl MessageHead for async_nats::Message {
+    fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    fn reply(&self) -> Option<&Subject> {
+        self.reply.as_ref()
+    }
+
+    fn headers(&self) -> Option<&HeaderMap> {
+        self.headers.as_ref()
+    }
+
+    fn status(&self) -> Option<StatusCode> {
+        self.status
+    }
+
+    fn length(&self) -> usize {
+        self.length
+    }
+
+    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError> {
+        let Head {
+            subject,
+            reply,
+            headers,
+            status,
+            description,
+            length,
+            extensions: _,
+        } = head;
+        Ok(Self {
+            subject,
+            reply,
+            payload,
+            headers,
+            status,
+            description,
+            length,
+        })
+    }
+
+    fn into_parts(self) -> (Head, Bytes) {
+        let Self {
+            subject,
+            reply,
+            payload,
+            headers,
+            status,
+            description,
+            length,
+        } = self;
+
+        (
+            Head {
+                subject,
+                reply,
+                headers,
+                status,
+                description,
+                length,
+                extensions: Extensions::new(),
+            },
+            payload,
+        )
+    }
+}
+
+impl MessageHead for async_nats::jetstream::Message {
+    fn subject(&self) -> &Subject {
+        &self.message.subject
+    }
+
+    fn reply(&self) -> Option<&Subject> {
+        self.message.reply.as_ref()
+    }
+
+    fn headers(&self) -> Option<&HeaderMap> {
+        self.message.headers.as_ref()
+    }
+
+    fn status(&self) -> Option<StatusCode> {
+        self.message.status
+    }
+
+    fn length(&self) -> usize {
+        self.message.length
+    }
+
+    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError> {
+        let Head {
+            subject,
+            reply,
+            headers,
+            status,
+            description,
+            length,
+            mut extensions,
+        } = head;
+        let message = async_nats::Message {
+            subject,
+            reply,
+            payload,
+            headers,
+            status,
+            description,
+            length,
+        };
+        let context = extensions
+            .remove::<async_nats::jetstream::Context>()
+            .ok_or(FromPartsError(
+                "jetstream context not found in message head extensions",
+            ))?;
+        Ok(Self { message, context })
+    }
+
+    fn into_parts(self) -> (Head, Bytes) {
+        let Self { message, context } = self;
+        let async_nats::Message {
+            subject,
+            reply,
+            payload,
+            headers,
+            status,
+            description,
+            length,
+        } = message;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(context);
+
+        (
+            Head {
+                subject,
+                reply,
+                headers,
+                status,
+                description,
+                length,
+                extensions,
+            },
+            payload,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Head {
+    /// Subject to which message is published to.
+    pub subject: Subject,
+
+    /// Optional reply subject to which response can be published by a subscriber or consumer.
+    pub reply: Option<Subject>,
+
+    /// Optional headers.
+    pub headers: Option<HeaderMap>,
+
+    /// Optional Status of the message. Used mostly for internal handling.
+    pub status: Option<StatusCode>,
+
+    /// Optional status description.
+    pub description: Option<String>,
+
+    /// Length of message in bytes.
+    pub length: usize,
+
+    /// The message's extensions
+    pub extensions: Extensions,
+}

--- a/lib/naxum/src/message/extensions.rs
+++ b/lib/naxum/src/message/extensions.rs
@@ -1,0 +1,334 @@
+// Vendored from the `http` create, released under the Apache v2 and MIT licenses
+//
+// Source:
+// https://github.com/hyperium/http/blob/63102bcd29fcd4a094cac6a4afb0af370ef1fcbe/src/extensions.rs
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::{BuildHasherDefault, Hasher};
+
+type AnyMap = HashMap<TypeId, Box<dyn AnyClone + Send + Sync>, BuildHasherDefault<IdHasher>>;
+
+// With TypeIds as keys, there's no need to hash them. They are already hashes
+// themselves, coming from the compiler. The IdHasher just holds the u64 of
+// the TypeId, and then returns it, instead of doing any bit fiddling.
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+/// A type map of protocol extensions.
+///
+/// `Extensions` can be used by `Request` and `Response` to store
+/// extra data derived from the underlying protocol.
+#[derive(Clone, Default)]
+pub struct Extensions {
+    // If extensions are never used, no need to carry around an empty HashMap.
+    // That's 3 words. Instead, this is only 1 word.
+    map: Option<Box<AnyMap>>,
+}
+
+impl Extensions {
+    /// Create an empty `Extensions`.
+    #[inline]
+    pub fn new() -> Extensions {
+        Extensions { map: None }
+    }
+
+    /// Insert a type into this `Extensions`.
+    ///
+    /// If a extension of this type already existed, it will
+    /// be returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// assert!(ext.insert(5i32).is_none());
+    /// assert!(ext.insert(4u8).is_none());
+    /// assert_eq!(ext.insert(9i32), Some(5i32));
+    /// ```
+    pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
+        self.map
+            .get_or_insert_with(Box::default)
+            .insert(TypeId::of::<T>(), Box::new(val))
+            .and_then(|boxed| boxed.into_any().downcast().ok().map(|boxed| *boxed))
+    }
+
+    /// Get a reference to a type previously inserted on this `Extensions`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// assert!(ext.get::<i32>().is_none());
+    /// ext.insert(5i32);
+    ///
+    /// assert_eq!(ext.get::<i32>(), Some(&5i32));
+    /// ```
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.map
+            .as_ref()
+            .and_then(|map| map.get(&TypeId::of::<T>()))
+            .and_then(|boxed| (**boxed).as_any().downcast_ref())
+    }
+
+    /// Get a mutable reference to a type previously inserted on this `Extensions`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// ext.insert(String::from("Hello"));
+    /// ext.get_mut::<String>().unwrap().push_str(" World");
+    ///
+    /// assert_eq!(ext.get::<String>().unwrap(), "Hello World");
+    /// ```
+    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.get_mut(&TypeId::of::<T>()))
+            .and_then(|boxed| (**boxed).as_any_mut().downcast_mut())
+    }
+
+    /// Get a mutable reference to a type, inserting `value` if not already present on this
+    /// `Extensions`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// *ext.get_or_insert(1i32) += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
+    /// ```
+    pub fn get_or_insert<T: Clone + Send + Sync + 'static>(&mut self, value: T) -> &mut T {
+        self.get_or_insert_with(|| value)
+    }
+
+    /// Get a mutable reference to a type, inserting the value created by `f` if not already present
+    /// on this `Extensions`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// *ext.get_or_insert_with(|| 1i32) += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
+    /// ```
+    pub fn get_or_insert_with<T: Clone + Send + Sync + 'static, F: FnOnce() -> T>(
+        &mut self,
+        f: F,
+    ) -> &mut T {
+        let out = self
+            .map
+            .get_or_insert_with(Box::default)
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(f()));
+        (**out).as_any_mut().downcast_mut().unwrap()
+    }
+
+    /// Get a mutable reference to a type, inserting the type's default value if not already present
+    /// on this `Extensions`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// *ext.get_or_insert_default::<i32>() += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 2);
+    /// ```
+    pub fn get_or_insert_default<T: Default + Clone + Send + Sync + 'static>(&mut self) -> &mut T {
+        self.get_or_insert_with(T::default)
+    }
+
+    /// Remove a type from this `Extensions`.
+    ///
+    /// If a extension of this type existed, it will be returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// ext.insert(5i32);
+    /// assert_eq!(ext.remove::<i32>(), Some(5i32));
+    /// assert!(ext.get::<i32>().is_none());
+    /// ```
+    pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.remove(&TypeId::of::<T>()))
+            .and_then(|boxed| boxed.into_any().downcast().ok().map(|boxed| *boxed))
+    }
+
+    /// Clear the `Extensions` of all inserted extensions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// ext.insert(5i32);
+    /// ext.clear();
+    ///
+    /// assert!(ext.get::<i32>().is_none());
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        if let Some(ref mut map) = self.map {
+            map.clear();
+        }
+    }
+
+    /// Check whether the extension set is empty or not.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// assert!(ext.is_empty());
+    /// ext.insert(5i32);
+    /// assert!(!ext.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.map.as_ref().map_or(true, |map| map.is_empty())
+    }
+
+    /// Get the numer of extensions available.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext = Extensions::new();
+    /// assert_eq!(ext.len(), 0);
+    /// ext.insert(5i32);
+    /// assert_eq!(ext.len(), 1);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.map.as_ref().map_or(0, |map| map.len())
+    }
+
+    /// Extends `self` with another `Extensions`.
+    ///
+    /// If an instance of a specific type exists in both, the one in `self` is overwritten with the
+    /// one from `other`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use http::Extensions;
+    /// let mut ext_a = Extensions::new();
+    /// ext_a.insert(8u8);
+    /// ext_a.insert(16u16);
+    ///
+    /// let mut ext_b = Extensions::new();
+    /// ext_b.insert(4u8);
+    /// ext_b.insert("hello");
+    ///
+    /// ext_a.extend(ext_b);
+    /// assert_eq!(ext_a.len(), 3);
+    /// assert_eq!(ext_a.get::<u8>(), Some(&4u8));
+    /// assert_eq!(ext_a.get::<u16>(), Some(&16u16));
+    /// assert_eq!(ext_a.get::<&'static str>().copied(), Some("hello"));
+    /// ```
+    pub fn extend(&mut self, other: Self) {
+        if let Some(other) = other.map {
+            if let Some(map) = &mut self.map {
+                map.extend(*other);
+            } else {
+                self.map = Some(other);
+            }
+        }
+    }
+}
+
+impl fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Extensions").finish()
+    }
+}
+
+trait AnyClone: Any {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+impl<T: Clone + Send + Sync + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl Clone for Box<dyn AnyClone + Send + Sync> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
+
+#[test]
+fn test_extensions() {
+    #[derive(Clone, Debug, PartialEq)]
+    struct MyType(i32);
+
+    let mut extensions = Extensions::new();
+
+    extensions.insert(5i32);
+    extensions.insert(MyType(10));
+
+    assert_eq!(extensions.get(), Some(&5i32));
+    assert_eq!(extensions.get_mut(), Some(&mut 5i32));
+
+    let ext2 = extensions.clone();
+
+    assert_eq!(extensions.remove::<i32>(), Some(5i32));
+    assert!(extensions.get::<i32>().is_none());
+
+    // clone still has it
+    assert_eq!(ext2.get(), Some(&5i32));
+    assert_eq!(ext2.get(), Some(&MyType(10)));
+
+    assert_eq!(extensions.get::<bool>(), None);
+    assert_eq!(extensions.get(), Some(&MyType(10)));
+}

--- a/lib/naxum/src/middleware.rs
+++ b/lib/naxum/src/middleware.rs
@@ -1,0 +1,10 @@
+pub mod trace;
+
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub enum LatencyUnit {
+    Seconds,
+    Millis,
+    Micros,
+    Nanos,
+}

--- a/lib/naxum/src/middleware.rs
+++ b/lib/naxum/src/middleware.rs
@@ -1,3 +1,4 @@
+pub mod delay;
 pub mod trace;
 
 #[non_exhaustive]

--- a/lib/naxum/src/middleware/delay/future.rs
+++ b/lib/naxum/src/middleware/delay/future.rs
@@ -1,0 +1,37 @@
+use std::{
+    convert::Infallible,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+use tokio::time::Sleep;
+
+pin_project! {
+    pub struct ResponseFuture<T> {
+        #[pin]
+        pub(crate) response: T,
+        #[pin]
+        pub(crate) sleep: Sleep,
+    }
+}
+
+impl<F, T> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<T, Infallible>>,
+{
+    type Output = Result<T, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // First, try polling the wait/sleep
+        if this.sleep.poll(cx).is_pending() {
+            return Poll::Pending;
+        }
+
+        // Now poll the response future
+        this.response.poll(cx)
+    }
+}

--- a/lib/naxum/src/middleware/delay/layer.rs
+++ b/lib/naxum/src/middleware/delay/layer.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use tower::Layer;
+
+use super::service::Delay;
+
+pub struct DelayLayer {
+    pub(crate) wait: Duration,
+}
+
+impl DelayLayer {
+    pub fn new(wait: Duration) -> Self {
+        Self { wait }
+    }
+}
+
+impl<S> Layer<S> for DelayLayer {
+    type Service = Delay<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Delay {
+            inner,
+            wait: self.wait,
+        }
+    }
+}

--- a/lib/naxum/src/middleware/delay/mod.rs
+++ b/lib/naxum/src/middleware/delay/mod.rs
@@ -1,0 +1,5 @@
+mod future;
+mod layer;
+mod service;
+
+pub use self::{layer::DelayLayer, service::Delay};

--- a/lib/naxum/src/middleware/delay/service.rs
+++ b/lib/naxum/src/middleware/delay/service.rs
@@ -1,0 +1,44 @@
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use tokio::time;
+use tower::Service;
+
+use super::future::ResponseFuture;
+
+pub struct Delay<S> {
+    pub(crate) inner: S,
+    pub(crate) wait: Duration,
+}
+
+impl<S> Delay<S> {
+    pub fn new(inner: S, wait: Duration) -> Self {
+        Self { inner, wait }
+    }
+}
+
+impl<S, Request> Service<Request> for Delay<S>
+where
+    S: Service<Request, Error = Infallible>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let response = self.inner.call(request);
+        let sleep = time::sleep(self.wait);
+
+        ResponseFuture { response, sleep }
+    }
+}

--- a/lib/naxum/src/middleware/trace/future.rs
+++ b/lib/naxum/src/middleware/trace/future.rs
@@ -1,0 +1,59 @@
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use pin_project_lite::pin_project;
+use tracing::Span;
+
+use crate::response::Response;
+
+use super::on_response::OnResponse;
+
+pin_project! {
+    pub struct ResponseFuture<F, OnResponse> {
+        #[pin]
+        pub(crate) inner: F,
+        pub(crate) span: Span,
+        pub(crate) on_response: Option<OnResponse>,
+        pub(crate) start: Instant,
+    }
+}
+
+impl<Fut, E, OnResponseT> Future for ResponseFuture<Fut, OnResponseT>
+where
+    Fut: Future<Output = Result<Response, E>>,
+    E: fmt::Display + 'static,
+    OnResponseT: OnResponse,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.span.enter();
+        let result = futures::ready!(this.inner.poll(cx));
+        let latency = this.start.elapsed();
+
+        match result {
+            Ok(res) => {
+                this.on_response
+                    .take()
+                    .unwrap()
+                    .on_response(&res, latency, this.span);
+
+                // TODO(fnichol): we need to propagate the span, which seems to infer that we need
+                // some kind of response struct, even if it's used to extend to the lifetime of the
+                // processing
+
+                Poll::Ready(Ok(res))
+            }
+            Err(err) => {
+                // TODO(fnichol): is logging appropriate here?
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+}

--- a/lib/naxum/src/middleware/trace/layer.rs
+++ b/lib/naxum/src/middleware/trace/layer.rs
@@ -1,0 +1,96 @@
+use tower::Layer;
+
+use super::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, Trace};
+
+pub struct TraceLayer<
+    MakeSpan = DefaultMakeSpan,
+    OnRequest = DefaultOnRequest,
+    OnResponse = DefaultOnResponse,
+> {
+    pub(crate) make_span: MakeSpan,
+    pub(crate) on_request: OnRequest,
+    pub(crate) on_response: OnResponse,
+}
+
+impl Default for TraceLayer {
+    fn default() -> Self {
+        Self {
+            make_span: DefaultMakeSpan::new(),
+            on_request: DefaultOnRequest::default(),
+            on_response: DefaultOnResponse::default(),
+        }
+    }
+}
+impl TraceLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<MakeSpan, OnRequest, OnResponse> TraceLayer<MakeSpan, OnRequest, OnResponse> {
+    pub fn on_request<NewOnRequest>(
+        self,
+        new_on_request: NewOnRequest,
+    ) -> TraceLayer<MakeSpan, NewOnRequest, OnResponse> {
+        let Self {
+            make_span,
+            on_request: _,
+            on_response,
+        } = self;
+        TraceLayer {
+            make_span,
+            on_request: new_on_request,
+            on_response,
+        }
+    }
+
+    pub fn on_response<NewOnResponse>(
+        self,
+        new_on_response: NewOnResponse,
+    ) -> TraceLayer<MakeSpan, OnRequest, NewOnResponse> {
+        let Self {
+            make_span,
+            on_request,
+            on_response: _,
+        } = self;
+        TraceLayer {
+            make_span,
+            on_request,
+            on_response: new_on_response,
+        }
+    }
+
+    pub fn make_span_with<NewMakeSpan>(
+        self,
+        new_make_span: NewMakeSpan,
+    ) -> TraceLayer<NewMakeSpan, OnRequest, OnResponse> {
+        let Self {
+            make_span: _,
+            on_request,
+            on_response,
+        } = self;
+        TraceLayer {
+            make_span: new_make_span,
+            on_request,
+            on_response,
+        }
+    }
+}
+
+impl<S, MakeSpan, OnRequest, OnResponse> Layer<S> for TraceLayer<MakeSpan, OnRequest, OnResponse>
+where
+    MakeSpan: Clone,
+    OnRequest: Clone,
+    OnResponse: Clone,
+{
+    type Service = Trace<S, MakeSpan, OnRequest, OnResponse>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Trace {
+            inner,
+            make_span: self.make_span.clone(),
+            on_request: self.on_request.clone(),
+            on_response: self.on_response.clone(),
+        }
+    }
+}

--- a/lib/naxum/src/middleware/trace/make_span.rs
+++ b/lib/naxum/src/middleware/trace/make_span.rs
@@ -1,0 +1,98 @@
+use tracing::{Level, Span};
+
+use crate::MessageHead;
+
+use super::DEFAULT_MESSAGE_LEVEL;
+
+pub trait MakeSpan<R> {
+    fn make_span(&mut self, req: &R) -> Span;
+}
+
+impl<R> MakeSpan<R> for Span {
+    fn make_span(&mut self, _req: &R) -> Span {
+        self.clone()
+    }
+}
+
+impl<F, R> MakeSpan<R> for F
+where
+    F: FnMut(&R) -> Span,
+{
+    fn make_span(&mut self, req: &R) -> Span {
+        self(req)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultMakeSpan {
+    level: Level,
+    include_headers: bool,
+}
+
+impl DefaultMakeSpan {
+    pub fn new() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+            include_headers: false,
+        }
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn include_headers(mut self, include_headers: bool) -> Self {
+        self.include_headers = include_headers;
+        self
+    }
+}
+
+impl Default for DefaultMakeSpan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R> MakeSpan<R> for DefaultMakeSpan
+where
+    R: MessageHead,
+{
+    fn make_span(&mut self, req: &R) -> Span {
+        // This ugly macro is needed, unfortunately, because `tracing::span!`
+        // required the level argument to be static. Meaning we can't just pass
+        // `self.level`.
+        macro_rules! make_span {
+            ($level:expr) => {
+                if self.include_headers {
+                    tracing::span!(
+                        $level,
+                        "receive message",
+                        subject = req.subject().as_str(),
+                        reply = ?req.reply(),
+                        status = ?req.status(),
+                        length = req.length(),
+                        headers = ?req.headers(),
+                    )
+                } else {
+                    tracing::span!(
+                        $level,
+                        "receive message",
+                        subject = req.subject().as_str(),
+                        reply = ?req.reply(),
+                        status = ?req.status(),
+                        length = req.length(),
+                    )
+                }
+            }
+        }
+
+        match self.level {
+            Level::ERROR => make_span!(Level::ERROR),
+            Level::WARN => make_span!(Level::WARN),
+            Level::INFO => make_span!(Level::INFO),
+            Level::DEBUG => make_span!(Level::DEBUG),
+            Level::TRACE => make_span!(Level::TRACE),
+        }
+    }
+}

--- a/lib/naxum/src/middleware/trace/make_span.rs
+++ b/lib/naxum/src/middleware/trace/make_span.rs
@@ -59,6 +59,9 @@ where
     R: MessageHead,
 {
     fn make_span(&mut self, req: &R) -> Span {
+        let reply = req.reply().map(|r| r.as_str()).unwrap_or_default();
+        let status = req.status().map(|s| s.as_u16()).unwrap_or_default();
+
         // This ugly macro is needed, unfortunately, because `tracing::span!`
         // required the level argument to be static. Meaning we can't just pass
         // `self.level`.
@@ -69,8 +72,8 @@ where
                         $level,
                         "receive message",
                         subject = req.subject().as_str(),
-                        reply = ?req.reply(),
-                        status = ?req.status(),
+                        reply = reply,
+                        status = status,
                         length = req.length(),
                         headers = ?req.headers(),
                     )
@@ -79,8 +82,8 @@ where
                         $level,
                         "receive message",
                         subject = req.subject().as_str(),
-                        reply = ?req.reply(),
-                        status = ?req.status(),
+                        reply = reply,
+                        status = status,
                         length = req.length(),
                     )
                 }

--- a/lib/naxum/src/middleware/trace/mod.rs
+++ b/lib/naxum/src/middleware/trace/mod.rs
@@ -1,0 +1,82 @@
+macro_rules! event_dynamic_lvl {
+    ( $(target: $target:expr,)? $(parent: $parent:expr,)? $lvl:expr, $($tt:tt)* ) => {
+        match $lvl {
+            tracing::Level::ERROR => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::ERROR,
+                    $($tt)*
+                );
+            }
+            tracing::Level::WARN => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::WARN,
+                    $($tt)*
+                );
+            }
+            tracing::Level::INFO => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::INFO,
+                    $($tt)*
+                );
+            }
+            tracing::Level::DEBUG => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::DEBUG,
+                    $($tt)*
+                );
+            }
+            tracing::Level::TRACE => {
+                tracing::event!(
+                    $(target: $target,)?
+                    $(parent: $parent,)?
+                    tracing::Level::TRACE,
+                    $($tt)*
+                );
+            }
+        }
+    };
+}
+
+mod future;
+mod layer;
+mod make_span;
+mod on_request;
+mod on_response;
+mod service;
+
+use std::{fmt, time::Duration};
+
+use tracing::Level;
+
+pub use self::{
+    layer::TraceLayer, make_span::DefaultMakeSpan, on_request::DefaultOnRequest,
+    on_response::DefaultOnResponse, service::Trace,
+};
+
+use super::LatencyUnit;
+
+const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
+
+struct Latency {
+    unit: LatencyUnit,
+    duration: Duration,
+}
+
+impl fmt::Display for Latency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unit {
+            LatencyUnit::Seconds => write!(f, "{} s", self.duration.as_secs_f64()),
+            LatencyUnit::Millis => write!(f, "{} ms", self.duration.as_millis()),
+            LatencyUnit::Micros => write!(f, "{} μs", self.duration.as_micros()),
+            LatencyUnit::Nanos => write!(f, "{} ns", self.duration.as_nanos()),
+        }
+    }
+}

--- a/lib/naxum/src/middleware/trace/on_request.rs
+++ b/lib/naxum/src/middleware/trace/on_request.rs
@@ -1,0 +1,50 @@
+use tracing::{Level, Span};
+
+use super::DEFAULT_MESSAGE_LEVEL;
+
+pub trait OnRequest<R> {
+    fn on_request(&mut self, req: &R, span: &Span);
+}
+
+impl<R> OnRequest<R> for () {
+    fn on_request(&mut self, _req: &R, _span: &Span) {}
+}
+
+impl<R, F> OnRequest<R> for F
+where
+    F: FnMut(&R, &Span),
+{
+    fn on_request(&mut self, req: &R, span: &Span) {
+        self(req, span)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnRequest {
+    level: Level,
+}
+
+impl Default for DefaultOnRequest {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+        }
+    }
+}
+
+impl DefaultOnRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+}
+
+impl<R> OnRequest<R> for DefaultOnRequest {
+    fn on_request(&mut self, _req: &R, _span: &Span) {
+        event_dynamic_lvl!(self.level, "started processing message");
+    }
+}

--- a/lib/naxum/src/middleware/trace/on_response.rs
+++ b/lib/naxum/src/middleware/trace/on_response.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use tracing::{Level, Span};
+
+use crate::{
+    middleware::{trace::Latency, LatencyUnit},
+    response::Response,
+};
+
+use super::DEFAULT_MESSAGE_LEVEL;
+
+pub trait OnResponse {
+    fn on_response(self, response: &Response, latency: Duration, span: &Span);
+}
+
+impl OnResponse for () {
+    #[inline]
+    fn on_response(self, _response: &Response, _latency: Duration, _span: &Span) {}
+}
+
+impl<F> OnResponse for F
+where
+    F: FnOnce(&Response, Duration, &Span),
+{
+    fn on_response(self, response: &Response, latency: Duration, span: &Span) {
+        self(response, latency, span)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultOnResponse {
+    level: Level,
+    latency_unit: LatencyUnit,
+}
+
+impl Default for DefaultOnResponse {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_MESSAGE_LEVEL,
+            latency_unit: LatencyUnit::Millis,
+        }
+    }
+}
+
+impl DefaultOnResponse {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn latency_unit(mut self, latency_unit: LatencyUnit) -> Self {
+        self.latency_unit = latency_unit;
+        self
+    }
+}
+
+impl OnResponse for DefaultOnResponse {
+    fn on_response(self, _response: &Response, latency: Duration, _span: &Span) {
+        let latency = Latency {
+            unit: self.latency_unit,
+            duration: latency,
+        };
+
+        event_dynamic_lvl!(
+            self.level,
+            %latency,
+            "finished processing mesasge"
+        );
+    }
+}

--- a/lib/naxum/src/middleware/trace/service.rs
+++ b/lib/naxum/src/middleware/trace/service.rs
@@ -1,0 +1,136 @@
+use std::{
+    fmt,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use tower::Service;
+
+use crate::{response::Response, MessageHead};
+
+use super::{
+    future::ResponseFuture, make_span::MakeSpan, on_request::OnRequest, on_response::OnResponse,
+    DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Trace<
+    S,
+    MakeSpan = DefaultMakeSpan,
+    OnRequest = DefaultOnRequest,
+    OnResponse = DefaultOnResponse,
+> {
+    pub(crate) inner: S,
+    pub(crate) make_span: MakeSpan,
+    pub(crate) on_request: OnRequest,
+    pub(crate) on_response: OnResponse,
+}
+
+impl<S> Trace<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            make_span: DefaultMakeSpan::new(),
+            on_request: DefaultOnRequest::default(),
+            on_response: DefaultOnResponse::default(),
+        }
+    }
+
+    pub fn layer() -> TraceLayer {
+        TraceLayer::new()
+    }
+}
+
+impl<S, MakeSpan, OnRequest, OnResponse> Trace<S, MakeSpan, OnRequest, OnResponse> {
+    pub fn on_request<NewOnRequest>(
+        self,
+        new_on_request: NewOnRequest,
+    ) -> Trace<S, MakeSpan, NewOnRequest, OnResponse> {
+        let Self {
+            inner,
+            make_span,
+            on_request: _,
+            on_response,
+        } = self;
+        Trace {
+            inner,
+            make_span,
+            on_request: new_on_request,
+            on_response,
+        }
+    }
+
+    pub fn on_response<NewOnResponse>(
+        self,
+        new_on_response: NewOnResponse,
+    ) -> Trace<S, MakeSpan, OnRequest, NewOnResponse> {
+        let Self {
+            inner,
+            make_span,
+            on_request,
+            on_response: _,
+        } = self;
+        Trace {
+            inner,
+            make_span,
+            on_request,
+            on_response: new_on_response,
+        }
+    }
+
+    pub fn make_span_with<NewMakeSpan>(
+        self,
+        new_make_span: NewMakeSpan,
+    ) -> Trace<S, NewMakeSpan, OnRequest, OnResponse> {
+        let Self {
+            inner,
+            make_span: _,
+            on_request,
+            on_response,
+        } = self;
+        Trace {
+            inner,
+            make_span: new_make_span,
+            on_request,
+            on_response,
+        }
+    }
+}
+
+impl<S, R, NewMakeSpanT, OnRequestT, OnResponseT> Service<R>
+    for Trace<S, NewMakeSpanT, OnRequestT, OnResponseT>
+where
+    S: Service<R, Response = Response>,
+    S::Error: fmt::Display + 'static,
+    NewMakeSpanT: MakeSpan<R>,
+    OnRequestT: OnRequest<R>,
+    OnResponseT: OnResponse + Clone,
+    R: MessageHead,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, OnResponseT>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let start = Instant::now();
+
+        let span = self.make_span.make_span(&req);
+
+        let future = {
+            let _guard = span.enter();
+            self.on_request.on_request(&req, &span);
+            self.inner.call(req)
+        };
+
+        ResponseFuture {
+            inner: future,
+            span,
+            on_response: Some(self.on_response.clone()),
+            start,
+        }
+    }
+}

--- a/lib/naxum/src/response.rs
+++ b/lib/naxum/src/response.rs
@@ -1,0 +1,32 @@
+mod into_response;
+
+pub use self::into_response::IntoResponse;
+
+pub type Response = ();
+
+pub type Result<T, E = ErrorResponse> = std::result::Result<T, E>;
+
+impl<T> IntoResponse for Result<T>
+where
+    T: IntoResponse,
+{
+    fn into_response(self) -> Response {
+        match self {
+            Ok(ok) => ok.into_response(),
+            Err(err) => err.0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ErrorResponse(Response);
+
+impl<T> From<T> for ErrorResponse
+where
+    T: IntoResponse,
+{
+    fn from(value: T) -> Self {
+        #[allow(clippy::unit_arg)]
+        Self(value.into_response())
+    }
+}

--- a/lib/naxum/src/response/into_response.rs
+++ b/lib/naxum/src/response/into_response.rs
@@ -1,0 +1,116 @@
+use core::fmt;
+use std::{borrow::Cow, convert::Infallible};
+
+use async_nats::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use bytes::{buf::Chain, Buf, Bytes, BytesMut};
+
+use super::Response;
+
+pub trait IntoResponse {
+    fn into_response(self) -> Response;
+}
+
+impl IntoResponse for () {
+    fn into_response(self) -> Response {
+        self
+    }
+}
+
+impl IntoResponse for Infallible {
+    fn into_response(self) -> Response {
+        match self {}
+    }
+}
+
+impl<T, E> IntoResponse for Result<T, E>
+where
+    T: IntoResponse,
+    E: IntoResponse,
+{
+    fn into_response(self) -> Response {
+        match self {
+            Ok(value) => value.into_response(),
+            Err(err) => err.into_response(),
+        }
+    }
+}
+
+impl IntoResponse for &'static str {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for String {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Box<str> {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Cow<'static, str> {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Bytes {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for BytesMut {
+    fn into_response(self) -> Response {}
+}
+
+impl<T, U> IntoResponse for Chain<T, U>
+where
+    T: Buf + Unpin + Send + 'static,
+    U: Buf + Unpin + Send + 'static,
+{
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for &'static [u8] {
+    fn into_response(self) -> Response {}
+}
+
+impl<const N: usize> IntoResponse for [u8; N] {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Vec<u8> {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Box<[u8]> {
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for Cow<'static, [u8]> {
+    fn into_response(self) -> Response {}
+}
+
+impl<R> IntoResponse for (StatusCode, R)
+where
+    R: IntoResponse,
+{
+    fn into_response(self) -> Response {}
+}
+
+impl IntoResponse for HeaderMap {
+    fn into_response(self) -> Response {}
+}
+
+impl<K, V, const N: usize> IntoResponse for [(K, V); N]
+where
+    K: TryInto<HeaderName>,
+    K::Error: fmt::Display,
+    V: TryInto<HeaderValue>,
+    V::Error: fmt::Display,
+{
+    fn into_response(self) -> Response {}
+}
+
+impl<R> IntoResponse for (R,)
+where
+    R: IntoResponse,
+{
+    fn into_response(self) -> Response {}
+}

--- a/lib/naxum/src/serve.rs
+++ b/lib/naxum/src/serve.rs
@@ -1,0 +1,231 @@
+use std::{
+    convert::Infallible,
+    error, fmt,
+    future::{poll_fn, Future, IntoFuture},
+    io,
+    marker::PhantomData,
+    ops,
+};
+
+use futures::{Stream, TryStreamExt};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tower::{Service, ServiceExt};
+use tracing::{trace, warn};
+
+use crate::{message::MessageHead, response::Response};
+
+pub fn serve<M, S, T, E, R>(stream: T, make_service: M) -> Serve<M, S, T, E, R>
+where
+    M: for<'a> Service<IncomingMessage<'a, R>, Error = Infallible, Response = S>,
+    S: Service<R, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    T: Stream<Item = Result<R, E>>,
+    E: error::Error,
+    R: MessageHead,
+{
+    Serve {
+        stream,
+        make_service,
+        _service_marker: PhantomData,
+        _stream_error_marker: PhantomData,
+        _request_marker: PhantomData,
+    }
+}
+
+#[must_use = "futures must be awaited or polled"]
+pub struct Serve<M, S, T, E, R> {
+    stream: T,
+    make_service: M,
+    _service_marker: PhantomData<S>,
+    _stream_error_marker: PhantomData<E>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<M, S, T, E, R> fmt::Debug for Serve<M, S, T, E, R>
+where
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Serve")
+            .field("make_service", &self.make_service)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M, S, T, E, R> Serve<M, S, T, E, R> {
+    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<M, S, T, E, R, F>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        WithGracefulShutdown {
+            stream: self.stream,
+            make_service: self.make_service,
+            signal,
+            _service_marker: PhantomData,
+            _stream_error_marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+/// Serve future with supporting a  graceful shutdown.
+#[must_use = "futures must be awaited or polled"]
+pub struct WithGracefulShutdown<M, S, T, E, R, F> {
+    stream: T,
+    make_service: M,
+    signal: F,
+    _service_marker: PhantomData<S>,
+    _stream_error_marker: PhantomData<E>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<M, S, T, E, R, F> fmt::Debug for WithGracefulShutdown<M, S, T, E, R, F>
+where
+    M: fmt::Debug,
+    S: fmt::Debug,
+    F: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WithGracefulShutdown")
+            .field("make_service", &self.make_service)
+            .field("signal", &self.signal)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M, S, T, E, R, F> IntoFuture for WithGracefulShutdown<M, S, T, E, R, F>
+where
+    M: for<'a> Service<IncomingMessage<'a, R>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingMessage<'a, R>>>::Future: Send,
+    S: Service<R, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    T: Stream<Item = Result<R, E>> + Unpin + Send + 'static,
+    E: error::Error,
+    R: MessageHead + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    type Output = io::Result<()>;
+    type IntoFuture = private::ServeFuture;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self {
+            mut stream,
+            mut make_service,
+            signal,
+            ..
+        } = self;
+
+        let tracker = TaskTracker::new();
+        let graceful_token = CancellationToken::new();
+
+        let token = graceful_token.clone();
+        tracker.spawn(async move {
+            signal.await;
+            trace!("received graceful shutdown signal, telling tasks to shutdown");
+            token.cancel();
+        });
+
+        private::ServeFuture(Box::pin(async move {
+            loop {
+                let msg = tokio::select! {
+                    msg = next_message(&mut stream) => {
+                        match msg {
+                            Some(msg) => msg,
+                            None => continue,
+                        }
+                    }
+                    _ = graceful_token.cancelled() => {
+                        trace!("signal received, not accepting new messages");
+                        tracker.close();
+                        break;
+                    }
+                };
+
+                trace!(subject = msg.subject().as_str(), "message received");
+
+                poll_fn(|cx| make_service.poll_ready(cx))
+                    .await
+                    .unwrap_or_else(|err| match err {});
+
+                let tower_svc = make_service
+                    .call(IncomingMessage { msg: &msg })
+                    .await
+                    .unwrap_or_else(|err| match err {});
+
+                let graceful_token = graceful_token.clone();
+                tracker.spawn(async move {
+                    tokio::select! {
+                        _result = tower_svc.oneshot(msg) => {
+                            // huh
+                        }
+                        _ = graceful_token.cancelled() => {
+                            trace!("signal received in task, starting graceful shutdown");
+                        }
+                    }
+                });
+            }
+
+            tracker.wait().await;
+
+            Ok(())
+        }))
+    }
+}
+
+async fn next_message<T, E, R>(stream: &mut T) -> Option<R>
+where
+    T: Stream<Item = Result<R, E>> + Unpin + Send + 'static,
+    E: error::Error,
+    R: MessageHead + Send + 'static,
+{
+    match stream.try_next().await {
+        Ok(maybe) => maybe,
+        Err(err) => {
+            // TODO(fnichol): this level might need to be `trace!()`, just unclear at the moment
+            warn!(error = ?err, "failed to resolve next message in stream");
+            None
+        }
+    }
+}
+
+mod private {
+    use std::{
+        fmt,
+        future::Future,
+        io,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    pub struct ServeFuture(pub(super) futures::future::BoxFuture<'static, io::Result<()>>);
+
+    impl Future for ServeFuture {
+        type Output = io::Result<()>;
+
+        #[inline]
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.0.as_mut().poll(cx)
+        }
+    }
+
+    impl fmt::Debug for ServeFuture {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("ServeFuture").finish_non_exhaustive()
+        }
+    }
+}
+
+pub struct IncomingMessage<'a, R> {
+    msg: &'a R,
+}
+
+impl<R> ops::Deref for IncomingMessage<'_, R>
+where
+    R: MessageHead,
+{
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        self.msg
+    }
+}

--- a/lib/naxum/src/service_ext.rs
+++ b/lib/naxum/src/service_ext.rs
@@ -1,0 +1,20 @@
+use tower::Service;
+
+use crate::{error_handling::HandleError, make_service::IntoMakeService};
+
+pub trait ServiceExt<R>: Service<R> + Sized {
+    fn into_make_service(self) -> IntoMakeService<Self>;
+
+    fn handle_error<F, T>(self, f: F) -> HandleError<Self, F, T> {
+        HandleError::new(self, f)
+    }
+}
+
+impl<S, R> ServiceExt<R> for S
+where
+    S: Service<R> + Sized,
+{
+    fn into_make_service(self) -> IntoMakeService<Self> {
+        IntoMakeService::new(self)
+    }
+}

--- a/lib/si-service/BUCK
+++ b/lib/si-service/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "si-service",
     deps = [
+        "//lib/telemetry-application-rs:telemetry-application",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:color-eyre",
         "//third-party/rust:thiserror",

--- a/lib/si-service/BUCK
+++ b/lib/si-service/BUCK
@@ -1,0 +1,12 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "si-service",
+    deps = [
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+)

--- a/lib/si-service/BUCK
+++ b/lib/si-service/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "si-service",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:color-eyre",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-util",

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 color-eyre = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-application = { path = "../../lib/telemetry-application-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "si-service"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.64"
+publish = false
+
+[dependencies]
+telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+color-eyre = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/lib/si-service/src/lib.rs
+++ b/lib/si-service/src/lib.rs
@@ -1,0 +1,19 @@
+//! System Initiative common service/server support.
+
+#![warn(
+    clippy::unwrap_in_result,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::missing_panics_doc,
+    clippy::panic_in_result_fn,
+    missing_docs
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::module_inception,
+    clippy::module_name_repetitions
+)]
+
+pub mod shutdown;

--- a/lib/si-service/src/lib.rs
+++ b/lib/si-service/src/lib.rs
@@ -20,3 +20,14 @@ pub mod rt;
 pub mod shutdown;
 
 pub use color_eyre::{self, eyre::Error, Result};
+pub use telemetry_application;
+pub use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+/// A "prelude" for crates implementing services/server binaries.
+pub mod prelude {
+    pub use std::future::IntoFuture as _;
+
+    pub use color_eyre::Result;
+    pub use telemetry_application::prelude::*;
+    pub use tokio_util::{sync::CancellationToken, task::TaskTracker};
+}

--- a/lib/si-service/src/lib.rs
+++ b/lib/si-service/src/lib.rs
@@ -16,4 +16,7 @@
     clippy::module_name_repetitions
 )]
 
+pub mod rt;
 pub mod shutdown;
+
+pub use color_eyre::{self, eyre::Error, Result};

--- a/lib/si-service/src/rt.rs
+++ b/lib/si-service/src/rt.rs
@@ -1,0 +1,36 @@
+//! Common Tokio runtime related behavior.
+
+use std::future::Future;
+
+use color_eyre::{eyre::eyre, Result};
+
+const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
+
+/// Create a Tokio runtime and block on a primary async function, i.e. an "async_main()".
+///
+/// # Notes
+///
+/// This funciton  creates a Tokio runtime on a spawned thread. It is intended to be run as the
+/// entry point for a `main()` program as an alternative to the `#[tokio::main]` attribute macro.
+pub fn block_on<S, Fut>(thread_name: S, future: Fut) -> Result<()>
+where
+    S: Into<String>,
+    Fut: Future<Output = Result<()>> + Send + 'static,
+{
+    let thread_name = thread_name.into();
+
+    let thread_builder = ::std::thread::Builder::new().stack_size(RT_DEFAULT_THREAD_STACK_SIZE);
+    let thread_handler = thread_builder.spawn(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_stack_size(RT_DEFAULT_THREAD_STACK_SIZE)
+            .thread_name(thread_name)
+            .enable_all()
+            .build()?
+            .block_on(future)
+    })?;
+
+    match thread_handler.join() {
+        Ok(result) => result,
+        Err(_) => Err(eyre!("couldn't join on the associated thread")),
+    }
+}

--- a/lib/si-service/src/shutdown.rs
+++ b/lib/si-service/src/shutdown.rs
@@ -1,0 +1,95 @@
+//! Graceful service/server shutdown using cancellation tokens, task trackers, driven by Unix
+//! signal handling.
+
+use std::{error, future::Future, io, time::Duration};
+
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{
+    signal::unix::{self, SignalKind},
+    time::timeout,
+};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+/// An error that can be returned when gracefully shutting down.
+///
+/// See [`graceful`] for more details.
+#[derive(Debug, Error)]
+pub enum ShutdownError {
+    /// When a signal handler fails to be correcly setup
+    #[error("failed to setup signal handler: {0}")]
+    Signal(#[source] io::Error),
+    /// When there is a telemetry-related error
+    #[error("telemetry shutdown error: {0}")]
+    Telemetry(#[source] Box<dyn error::Error + Send + Sync + 'static>),
+    /// When the timeout to wait for graceful shutdown has been exceeded
+    #[error("graceful shutdown timeout elapsed: {0:?}")]
+    TimeoutElapsed(Duration),
+}
+
+impl ShutdownError {
+    fn telemetry<E>(err: E) -> Self
+    where
+        E: error::Error + Send + Sync + 'static,
+    {
+        Self::Telemetry(Box::new(err))
+    }
+}
+
+/// Gracfully shutdown a service that may be running multiple tasks and in-flight work.
+///
+/// # Platform-specific behavior
+///
+/// This function sets up a signal handler for both `SIGINT` (i.e. `Ctrl+c`) and `SIGTERM` so usage
+/// of this function with other code intercepting these signals is *highly* discouraged.
+pub async fn graceful<Fut, E>(
+    tracker: TaskTracker,
+    token: CancellationToken,
+    telemetry_guard: Option<Fut>,
+    shutdown_timeout: Option<Duration>,
+) -> Result<(), ShutdownError>
+where
+    Fut: Future<Output = Result<(), E>>,
+    E: error::Error + Send + Sync + 'static,
+{
+    let mut sig_int = unix::signal(SignalKind::interrupt()).map_err(ShutdownError::Signal)?;
+    let mut sig_term = unix::signal(SignalKind::terminate()).map_err(ShutdownError::Signal)?;
+
+    tokio::select! {
+        _ = sig_int.recv() => {
+            info!("received SIGINT, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = sig_term.recv() => {
+            info!("received SIGTERM, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+    }
+
+    // Wait for all tasks to finish
+    match shutdown_timeout {
+        Some(duration) => {
+            if let Err(_elapsed) = timeout(duration, tracker.wait()).await {
+                warn!("graceful shutdown timeout exceeded; completing shutdown anyway");
+                if let Some(telemetry_guard) = telemetry_guard {
+                    // Wait for telemetry to shutdown
+                    telemetry_guard.await.map_err(ShutdownError::telemetry)?;
+                }
+                return Err(ShutdownError::TimeoutElapsed(duration));
+            }
+        }
+        None => {
+            tracker.wait().await;
+        }
+    }
+
+    if let Some(telemetry_guard) = telemetry_guard {
+        // Wait for telemetry to shutdown
+        telemetry_guard.await.map_err(ShutdownError::telemetry)?;
+    }
+
+    info!("graceful shutdown complete.");
+    Ok(())
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -5556,6 +5556,27 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "hdrhistogram-7.5.4.crate",
+    sha256 = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d",
+    strip_prefix = "hdrhistogram-7.5.4",
+    urls = ["https://crates.io/api/v1/crates/hdrhistogram/7.5.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hdrhistogram-7.5.4",
+    srcs = [":hdrhistogram-7.5.4.crate"],
+    crate = "hdrhistogram",
+    crate_root = "hdrhistogram-7.5.4.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":byteorder-1.5.0",
+        ":num-traits-0.2.18",
+    ],
+)
+
+http_archive(
     name = "heapless-0.7.17.crate",
     sha256 = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f",
     strip_prefix = "heapless-0.7.17",
@@ -15822,18 +15843,27 @@ cargo.rust_library(
         "buffer",
         "default",
         "discover",
+        "filter",
+        "full",
         "futures-core",
         "futures-util",
+        "hdrhistogram",
+        "hedge",
         "indexmap",
         "limit",
         "load",
+        "load-shed",
         "log",
         "make",
         "pin-project",
         "pin-project-lite",
         "rand",
         "ready-cache",
+        "reconnect",
+        "retry",
         "slab",
+        "spawn-ready",
+        "steer",
         "timeout",
         "tokio",
         "tokio-util",
@@ -15844,6 +15874,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
+        ":hdrhistogram-7.5.4",
         ":indexmap-1.9.3",
         ":pin-project-1.1.5",
         ":pin-project-lite-0.2.13",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
@@ -2175,6 +2175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
 ]
 
 [[package]]
@@ -5900,6 +5910,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "hdrhistogram",
  "indexmap 1.9.3",
  "pin-project 1.1.5",
  "pin-project-lite",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -154,7 +154,7 @@ tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alon
 tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
 toml = { version = "0.8.8" }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4", features = [
     "compression-br",
     "compression-deflate",


### PR DESCRIPTION
This is work extracted from re-working Council (now essentially defunct). Highlights include:

- A new extracted `si-service` crate that helps set up and build Rust binaries (i.e. crates under `bin/`)
- Better telemetry shutdown semantics
- A small update to `si-data-nats` giving access to the underlying Jetstream APIs (temporary measure)
- A new crate `naxum` which is an approach to writing incoming NATS-based messaging applications, directly modeled from the [axum](https://crates.io/crates/axum) crate (which supports writing HTTP applications). As with axum, naxum is based on the [Tower](https://crates.io/crates/tower) middleware framework allowing us to use and reuse common middlewares such as timeout, load shedding, rate limiting, tracing, etc., etc. Note that while naxum is currently very under-documented, as it's as close to a 1:1 port of axum, axum's docs will suffice for the moment.
- A generic Delay middleware to help when developing applications which introduces artificial delay before servicing a request.