### PR TITLE
chore(*): make all graph accesses async, remove need for lock management

### DIFF
--- a/lib/dal/src/action/runner.rs
+++ b/lib/dal/src/action/runner.rs
@@ -248,14 +248,16 @@ impl ActionRunner {
         let node_weight =
             NodeWeight::new_content(change_set, id, ContentAddress::ActionRunner(hash))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
+        let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        workspace_snapshot.add_node(node_weight.to_owned())?;
-        workspace_snapshot.add_edge(
-            action_batch_id,
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
-            id,
-        )?;
+        workspace_snapshot.add_node(node_weight.to_owned()).await?;
+        workspace_snapshot
+            .add_edge(
+                action_batch_id,
+                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                id,
+            )
+            .await?;
 
         Ok(ActionRunner::assemble(id.into(), content))
     }
@@ -351,8 +353,9 @@ impl ActionRunner {
             .await
             .add(&ActionRunnerContent::V1(content.clone()))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-        workspace_snapshot.update_content(ctx.change_set_pointer()?, self.id.into(), hash)?;
+        ctx.workspace_snapshot()?
+            .update_content(ctx.change_set_pointer()?, self.id.into(), hash)
+            .await?;
         Ok(())
     }
 
@@ -370,8 +373,9 @@ impl ActionRunner {
             .await
             .add(&ActionRunnerContent::V1(content.clone()))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-        workspace_snapshot.update_content(ctx.change_set_pointer()?, self.id.into(), hash)?;
+        ctx.workspace_snapshot()?
+            .update_content(ctx.change_set_pointer()?, self.id.into(), hash)
+            .await?;
         Ok(())
     }
 
@@ -389,8 +393,9 @@ impl ActionRunner {
             .await
             .add(&ActionRunnerContent::V1(content.clone()))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-        workspace_snapshot.update_content(ctx.change_set_pointer()?, self.id.into(), hash)?;
+        ctx.workspace_snapshot()?
+            .update_content(ctx.change_set_pointer()?, self.id.into(), hash)
+            .await?;
         Ok(())
     }
 
@@ -404,8 +409,9 @@ impl ActionRunner {
             .await
             .add(&ActionRunnerContent::V1(content.clone()))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-        workspace_snapshot.update_content(ctx.change_set_pointer()?, self.id.into(), hash)?;
+        ctx.workspace_snapshot()?
+            .update_content(ctx.change_set_pointer()?, self.id.into(), hash)
+            .await?;
         Ok(())
     }
 
@@ -419,8 +425,9 @@ impl ActionRunner {
             .await
             .add(&ActionRunnerContent::V1(content.clone()))?;
 
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-        workspace_snapshot.update_content(ctx.change_set_pointer()?, self.id.into(), hash)?;
+        ctx.workspace_snapshot()?
+            .update_content(ctx.change_set_pointer()?, self.id.into(), hash)
+            .await?;
         Ok(())
     }
 
@@ -467,14 +474,15 @@ impl ActionRunner {
         ctx: &DalContext,
         batch_id: ActionBatchId,
     ) -> ActionRunnerResult<Vec<Self>> {
-        let workspace_snapshot = ctx.workspace_snapshot()?.read().await;
+        let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let nodes = workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind(batch_id, EdgeWeightKindDiscriminants::Use)?;
+            .outgoing_targets_for_edge_weight_kind(batch_id, EdgeWeightKindDiscriminants::Use)
+            .await?;
         let mut node_weights = Vec::with_capacity(nodes.len());
         let mut content_hashes = Vec::with_capacity(nodes.len());
         for node in nodes {
-            let weight = workspace_snapshot.get_node_weight(node)?;
+            let weight = workspace_snapshot.get_node_weight(node).await?;
             content_hashes.push(weight.content_hash());
             node_weights.push(weight);
         }

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -66,10 +66,7 @@ impl StaticArgumentValue {
         let node_weight =
             NodeWeight::new_content(change_set, id, ContentAddress::StaticArgumentValue(hash))?;
 
-        {
-            let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-            workspace_snapshot.add_node(node_weight)?;
-        }
+        ctx.workspace_snapshot()?.add_node(node_weight).await?;
 
         Ok(StaticArgumentValue::assemble(id.into(), content))
     }
@@ -78,11 +75,11 @@ impl StaticArgumentValue {
         ctx: &DalContext,
         id: StaticArgumentValueId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        let workspace_snapshot = ctx.workspace_snapshot()?.read().await;
+        let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let ulid: ulid::Ulid = id.into();
-        let node_index = workspace_snapshot.get_node_index_by_id(ulid)?;
-        let node_weight = workspace_snapshot.get_node_weight(node_index)?;
+        let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
+        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash = node_weight.content_hash();
 
         let content: StaticArgumentValueContent = ctx

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -57,18 +57,20 @@ impl DependentValueGraph {
             // Gather the Attribute Prototype Arguments that take the thing the
             // current value is for (prop, or socket) as an input
             let relevant_apas = {
-                let workspace_snapshot = ctx.workspace_snapshot()?.read().await;
+                let workspace_snapshot = ctx.workspace_snapshot()?;
 
                 let attribute_prototype_argument_idxs = workspace_snapshot
                     .incoming_sources_for_edge_weight_kind(
                         data_source_id,
                         EdgeWeightKindDiscriminants::PrototypeArgumentValue,
-                    )?;
+                    )
+                    .await?;
 
                 let mut relevant_apas = vec![];
                 for apa_idx in attribute_prototype_argument_idxs {
                     let apa = workspace_snapshot
-                        .get_node_weight(apa_idx)?
+                        .get_node_weight(apa_idx)
+                        .await?
                         .get_attribute_prototype_argument_node_weight()?;
 
                     match apa.targets() {

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -67,14 +67,15 @@ impl Frame {
         parent_id: ComponentId,
         child_id: ComponentId,
     ) -> FrameResult<()> {
-        let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
         let change_set = ctx.change_set_pointer()?;
 
-        workspace_snapshot.add_edge(
-            parent_id,
-            EdgeWeight::new(change_set, EdgeWeightKind::FrameContains)?,
-            child_id,
-        )?;
+        ctx.workspace_snapshot()?
+            .add_edge(
+                parent_id,
+                EdgeWeight::new(change_set, EdgeWeightKind::FrameContains)?,
+                child_id,
+            )
+            .await?;
 
         Ok(())
     }

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -39,12 +39,13 @@ impl Component {
             .copied()
             .ok_or(ComponentError::MissingQualificationsValue(component_id))?;
 
-        let qualification_attribute_value_ids = {
-            let workspace_snapshot = ctx.workspace_snapshot()?.read().await;
-            match workspace_snapshot.ordered_children_for_node(qualification_map_value_id)? {
-                Some(value_ids) => value_ids,
-                None => return Ok(vec![]), // should probably be an error
-            }
+        let qualification_attribute_value_ids = match ctx
+            .workspace_snapshot()?
+            .ordered_children_for_node(qualification_map_value_id)
+            .await?
+        {
+            Some(value_ids) => value_ids,
+            None => return Ok(vec![]), // should probably be an error
         };
 
         for qualification_attribute_value_id in qualification_attribute_value_ids {

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -36,20 +36,22 @@ impl PropertyEditorSchema {
         let root_property_editor_prop_id = root_property_editor_prop.id;
         props.insert(root_property_editor_prop_id, root_property_editor_prop);
 
+        let workspace_snapshot = ctx.workspace_snapshot()?;
         let mut work_queue = VecDeque::from([(root_prop_id, root_property_editor_prop_id)]);
         while let Some((prop_id, property_editor_prop_id)) = work_queue.pop_front() {
             // Collect all child props.
             let mut cache = Vec::new();
             {
-                let workspace_snapshot = ctx.workspace_snapshot()?.read().await;
                 for child_prop_node_index in workspace_snapshot
                     .outgoing_targets_for_edge_weight_kind(
                         prop_id,
                         EdgeWeightKindDiscriminants::Use,
-                    )?
+                    )
+                    .await?
                 {
-                    if let NodeWeight::Prop(child_prop_weight) =
-                        workspace_snapshot.get_node_weight(child_prop_node_index)?
+                    if let NodeWeight::Prop(child_prop_weight) = workspace_snapshot
+                        .get_node_weight(child_prop_node_index)
+                        .await?
                     {
                         let child_prop_id: PropId = child_prop_weight.id().into();
 

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -244,14 +244,13 @@ impl SchemaVariant {
 
         let attribute_prototype_id = AttributePrototype::new(ctx, func_id).await?.id();
 
-        {
-            let mut workspace_snapshot = ctx.workspace_snapshot()?.write().await;
-            workspace_snapshot.add_edge(
+        ctx.workspace_snapshot()?
+            .add_edge(
                 item_prop_id,
                 EdgeWeight::new(ctx.change_set_pointer()?, EdgeWeightKind::Prototype(key))?,
                 attribute_prototype_id,
-            )?;
-        }
+            )
+            .await?;
 
         for input in inputs {
             let input_prop_id = SchemaVariant::find_root_child_prop_id(

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -96,7 +96,7 @@ impl Workspace {
         let mut change_set = ChangeSetPointer::new_head(ctx).await?;
         let workspace_snapshot = WorkspaceSnapshot::initial(ctx, &change_set).await?;
         change_set
-            .update_pointer(ctx, workspace_snapshot.id())
+            .update_pointer(ctx, workspace_snapshot.id().await)
             .await?;
         let change_set_id = change_set.id;
 
@@ -183,7 +183,7 @@ impl Workspace {
         let workspace_snapshot =
             WorkspaceSnapshot::find_for_change_set(ctx, builtin.default_change_set_id).await?;
         change_set
-            .update_pointer(ctx, workspace_snapshot.id())
+            .update_pointer(ctx, workspace_snapshot.id().await)
             .await?;
         let change_set_id = change_set.id;
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -30,11 +30,12 @@ pub mod node_weight;
 pub mod update;
 pub mod vector_clock;
 
+use std::sync::Arc;
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
 use chrono::{DateTime, Utc};
 use content_store::{ContentHash, Store, StoreError};
 use petgraph::prelude::*;
-use petgraph::stable_graph::Edges;
-use serde::{Deserialize, Serialize};
 use si_data_pg::{PgError, PgRow};
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -104,12 +105,11 @@ pub type WorkspaceSnapshotResult<T> = Result<T, WorkspaceSnapshotError>;
 
 pk!(WorkspaceSnapshotId);
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct WorkspaceSnapshot {
-    id: WorkspaceSnapshotId,
-    created_at: DateTime<Utc>,
-    #[serde(skip_serializing)]
-    working_copy: WorkspaceSnapshotGraph,
+    id: Arc<RwLock<WorkspaceSnapshotId>>,
+    created_at: Arc<RwLock<DateTime<Utc>>>,
+    working_copy: Arc<RwLock<WorkspaceSnapshotGraph>>,
 }
 
 impl TryFrom<PgRow> for WorkspaceSnapshot {
@@ -120,11 +120,11 @@ impl TryFrom<PgRow> for WorkspaceSnapshot {
         let snapshot: Vec<u8> = row.try_get("snapshot")?;
         info!("snapshot copy into vec: {:?}", start.elapsed());
         let start = Instant::now();
-        let working_copy = postcard::from_bytes(&snapshot)?;
+        let working_copy = Arc::new(RwLock::new(postcard::from_bytes(&snapshot)?));
         info!("snapshot deserialize: {:?}", start.elapsed());
         Ok(Self {
-            id: row.try_get("id")?,
-            created_at: row.try_get("created_at")?,
+            id: Arc::new(RwLock::new(row.try_get("id")?)),
+            created_at: Arc::new(RwLock::new(row.try_get("created_at")?)),
             working_copy,
         })
     }
@@ -144,6 +144,7 @@ pub(crate) fn serde_value_to_string_type(value: &serde_json::Value) -> String {
 }
 
 impl WorkspaceSnapshot {
+    #[instrument(level = "debug", skip_all)]
     pub async fn initial(
         ctx: &DalContext,
         change_set: &ChangeSetPointer,
@@ -188,33 +189,37 @@ impl WorkspaceSnapshot {
 
         // We do not care about any field other than "working_copy" because "write" will populate
         // them using the assigned working copy.
-        let mut initial = Self {
-            id: WorkspaceSnapshotId::NONE,
-            created_at: Utc::now(),
-            working_copy: graph,
+        let initial = Self {
+            id: Arc::new(RwLock::new(WorkspaceSnapshotId::NONE)),
+            created_at: Arc::new(RwLock::new(Utc::now())),
+            working_copy: Arc::new(RwLock::new(graph)),
         };
+
         initial.write(ctx, change_set.vector_clock_id()).await?;
 
         Ok(initial)
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub async fn write(
-        &mut self,
+        &self,
         ctx: &DalContext,
         vector_clock_id: VectorClockId,
     ) -> WorkspaceSnapshotResult<WorkspaceSnapshotId> {
         // Pull out the working copy and clean it up.
-        let working_copy = self.working_copy_mut();
-        working_copy.cleanup();
+        {
+            let mut working_copy = self.working_copy_mut().await;
+            working_copy.cleanup();
 
-        // Mark everything left as seen.
-        working_copy.mark_graph_seen(vector_clock_id)?;
+            // Mark everything left as seen.
+            working_copy.mark_graph_seen(vector_clock_id)?;
+        }
 
         // Write out to the content store.
         ctx.content_store().lock().await.write().await?;
 
         // Stamp the new workspace snapshot.
-        let serialized_snapshot = postcard::to_stdvec(&working_copy)?;
+        let serialized_snapshot = postcard::to_stdvec(&*self.working_copy().await)?;
         let row = ctx
             .txns()
             .await?
@@ -224,88 +229,112 @@ impl WorkspaceSnapshot {
                 &[&serialized_snapshot],
             )
             .await?;
-        let object = Self::try_from(row)?;
 
-        // Reset relevant fields on self.
-        self.id = object.id;
-        self.created_at = object.created_at;
+        let updated_snapshot = Self::try_from(row)?;
 
-        Ok(self.id)
+        let new_id = updated_snapshot.id().await;
+        *self.id.write().await = new_id;
+        *self.created_at.write().await = *updated_snapshot.created_at.read().await;
+
+        Ok(new_id)
     }
 
-    pub fn id(&self) -> WorkspaceSnapshotId {
-        self.id
+    pub async fn id(&self) -> WorkspaceSnapshotId {
+        *self.id.read().await
     }
 
-    pub fn root(&self) -> WorkspaceSnapshotResult<NodeIndex> {
-        Ok(self.working_copy.root())
+    pub async fn root(&self) -> WorkspaceSnapshotResult<NodeIndex> {
+        Ok(self.working_copy.read().await.root())
     }
 
-    fn working_copy_mut(&mut self) -> &mut WorkspaceSnapshotGraph {
-        &mut self.working_copy
+    #[instrument(level = "debug", skip_all)]
+    async fn working_copy(&self) -> RwLockReadGuard<'_, WorkspaceSnapshotGraph> {
+        self.working_copy.read().await
     }
 
-    pub fn add_node(&mut self, node: NodeWeight) -> WorkspaceSnapshotResult<NodeIndex> {
-        let new_node_index = self.working_copy.add_node(node)?;
+    #[instrument(level = "debug", skip_all)]
+    async fn working_copy_mut(&self) -> RwLockWriteGuard<'_, WorkspaceSnapshotGraph> {
+        self.working_copy.write().await
+    }
+
+    pub async fn add_node(&self, node: NodeWeight) -> WorkspaceSnapshotResult<NodeIndex> {
+        let new_node_index = self.working_copy_mut().await.add_node(node)?;
         Ok(new_node_index)
     }
 
-    pub fn add_ordered_node(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn add_ordered_node(
+        &self,
         change_set: &ChangeSetPointer,
         node: NodeWeight,
     ) -> WorkspaceSnapshotResult<NodeIndex> {
-        let new_node_index = self.working_copy.add_ordered_node(change_set, node)?;
+        let new_node_index = self
+            .working_copy_mut()
+            .await
+            .add_ordered_node(change_set, node)?;
         Ok(new_node_index)
     }
 
-    pub fn update_content(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn update_content(
+        &self,
         change_set: &ChangeSetPointer,
         id: Ulid,
         new_content_hash: ContentHash,
     ) -> WorkspaceSnapshotResult<()> {
         Ok(self
-            .working_copy
+            .working_copy_mut()
+            .await
             .update_content(change_set, id, new_content_hash)?)
     }
 
-    pub fn add_edge(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn add_edge(
+        &self,
         from_node_id: impl Into<Ulid>,
         edge_weight: EdgeWeight,
         to_node_id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<EdgeIndex> {
-        let from_node_index = self.working_copy.get_node_index_by_id(from_node_id)?;
-        let to_node_index = self.working_copy.get_node_index_by_id(to_node_id)?;
+        let from_node_index = self
+            .working_copy()
+            .await
+            .get_node_index_by_id(from_node_id)?;
+        let to_node_index = self.working_copy().await.get_node_index_by_id(to_node_id)?;
         Ok(self
-            .working_copy
+            .working_copy_mut()
+            .await
             .add_edge(from_node_index, edge_weight, to_node_index)?)
     }
 
     // NOTE(nick): this should only be used by the rebaser and in specific scenarios where the
     // indices are definitely correct.
-    pub fn add_edge_unchecked(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn add_edge_unchecked(
+        &self,
         from_node_index: NodeIndex,
         edge_weight: EdgeWeight,
         to_node_index: NodeIndex,
     ) -> WorkspaceSnapshotResult<EdgeIndex> {
         Ok(self
-            .working_copy
+            .working_copy_mut()
+            .await
             .add_edge(from_node_index, edge_weight, to_node_index)?)
     }
 
-    pub fn add_ordered_edge(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn add_ordered_edge(
+        &self,
         change_set: &ChangeSetPointer,
         from_node_id: impl Into<Ulid>,
         edge_weight: EdgeWeight,
         to_node_id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<EdgeIndex> {
-        let from_node_index = self.working_copy.get_node_index_by_id(from_node_id)?;
-        let to_node_index = self.working_copy.get_node_index_by_id(to_node_id)?;
-        let (edge_index, _) = self.working_copy.add_ordered_edge(
+        let from_node_index = self
+            .working_copy()
+            .await
+            .get_node_index_by_id(from_node_id)?;
+        let to_node_index = self.working_copy().await.get_node_index_by_id(to_node_id)?;
+        let (edge_index, _) = self.working_copy_mut().await.add_ordered_edge(
             change_set,
             from_node_index,
             edge_weight,
@@ -314,98 +343,138 @@ impl WorkspaceSnapshot {
         Ok(edge_index)
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub async fn detect_conflicts_and_updates(
         &self,
         to_rebase_vector_clock_id: VectorClockId,
-        onto_workspace_snapshot: &mut WorkspaceSnapshot,
+        onto_workspace_snapshot: &WorkspaceSnapshot,
         onto_vector_clock_id: VectorClockId,
     ) -> WorkspaceSnapshotResult<(Vec<Conflict>, Vec<Update>)> {
-        Ok(self.working_copy.detect_conflicts_and_updates(
+        Ok(self.working_copy().await.detect_conflicts_and_updates(
             to_rebase_vector_clock_id,
-            &onto_workspace_snapshot.working_copy,
+            &*onto_workspace_snapshot.working_copy().await,
             onto_vector_clock_id,
         )?)
     }
 
     // NOTE(nick): this should only be used by the rebaser.
-    pub fn edge_endpoints(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn edge_endpoints(
+        &self,
         edge_index: EdgeIndex,
     ) -> WorkspaceSnapshotResult<(NodeIndex, NodeIndex)> {
-        Ok(self.working_copy.edge_endpoints(edge_index)?)
+        Ok(self.working_copy_mut().await.edge_endpoints(edge_index)?)
     }
 
-    pub fn import_subgraph(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn import_subgraph(
+        &self,
         other: &mut Self,
         root_index: NodeIndex,
     ) -> WorkspaceSnapshotResult<()> {
         Ok(self
-            .working_copy
-            .import_subgraph(&other.working_copy, root_index)?)
+            .working_copy_mut()
+            .await
+            .import_subgraph(&*other.working_copy().await, root_index)?)
     }
 
     /// Calls [`WorkspaceSnapshotGraph::replace_references()`]
-    pub fn replace_references(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn replace_references(
+        &self,
         original_node_index: NodeIndex,
     ) -> WorkspaceSnapshotResult<()> {
-        Ok(self.working_copy.replace_references(original_node_index)?)
+        Ok(self
+            .working_copy_mut()
+            .await
+            .replace_references(original_node_index)?)
     }
 
-    pub fn get_node_weight_by_id(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn get_node_weight_by_id(
         &self,
         id: impl Into<Ulid>,
-    ) -> WorkspaceSnapshotResult<&NodeWeight> {
-        let node_idx = self.get_node_index_by_id(id)?;
-        Ok(self.working_copy.get_node_weight(node_idx)?)
+    ) -> WorkspaceSnapshotResult<NodeWeight> {
+        let node_idx = self.get_node_index_by_id(id).await?;
+        Ok(self
+            .working_copy()
+            .await
+            .get_node_weight(node_idx)?
+            .to_owned())
     }
 
-    pub fn get_node_weight(&self, node_index: NodeIndex) -> WorkspaceSnapshotResult<&NodeWeight> {
-        Ok(self.working_copy.get_node_weight(node_index)?)
+    #[instrument(level = "debug", skip_all)]
+    pub async fn get_node_weight(
+        &self,
+        node_index: NodeIndex,
+    ) -> WorkspaceSnapshotResult<NodeWeight> {
+        Ok(self
+            .working_copy()
+            .await
+            .get_node_weight(node_index)?
+            .to_owned())
     }
 
-    pub fn find_equivalent_node(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn find_equivalent_node(
         &self,
         id: Ulid,
         lineage_id: Ulid,
     ) -> WorkspaceSnapshotResult<Option<NodeIndex>> {
-        Ok(self.working_copy.find_equivalent_node(id, lineage_id)?)
+        Ok(self
+            .working_copy()
+            .await
+            .find_equivalent_node(id, lineage_id)?)
     }
 
-    pub fn cleanup(&mut self) -> WorkspaceSnapshotResult<()> {
-        self.working_copy.cleanup();
+    #[instrument(level = "debug", skip_all)]
+    pub async fn cleanup(&self) -> WorkspaceSnapshotResult<()> {
+        self.working_copy_mut().await.cleanup();
         Ok(())
     }
 
-    pub fn nodes(&self) -> WorkspaceSnapshotResult<impl Iterator<Item = (&NodeWeight, NodeIndex)>> {
-        Ok(self.working_copy.nodes())
+    #[instrument(level = "debug", skip_all)]
+    pub async fn nodes(&self) -> WorkspaceSnapshotResult<Vec<(NodeWeight, NodeIndex)>> {
+        Ok(self
+            .working_copy()
+            .await
+            .nodes()
+            .map(|(weight, index)| (weight.to_owned(), index))
+            .collect())
     }
 
-    pub fn edges(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn edges(&self) -> WorkspaceSnapshotResult<Vec<(EdgeWeight, NodeIndex, NodeIndex)>> {
+        Ok(self
+            .working_copy()
+            .await
+            .edges()
+            .map(|(weight, from, to)| (weight.to_owned(), from, to))
+            .collect())
+    }
+
+    pub async fn dot(&self) {
+        self.working_copy().await.dot();
+    }
+
+    pub async fn tiny_dot_to_file(&self, suffix: Option<&str>) {
+        self.working_copy().await.tiny_dot_to_file(suffix);
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub async fn get_node_index_by_id(
         &self,
-    ) -> WorkspaceSnapshotResult<impl Iterator<Item = (&EdgeWeight, NodeIndex, NodeIndex)>> {
-        Ok(self.working_copy.edges())
+        id: impl Into<Ulid>,
+    ) -> WorkspaceSnapshotResult<NodeIndex> {
+        Ok(self.working_copy().await.get_node_index_by_id(id)?)
     }
 
-    pub fn dot(&self) {
-        self.working_copy.dot();
-    }
-
-    pub fn tiny_dot_to_file(&self, suffix: Option<&str>) {
-        self.working_copy.tiny_dot_to_file(suffix);
-    }
-
-    #[inline(always)]
-    pub fn get_node_index_by_id(&self, id: impl Into<Ulid>) -> WorkspaceSnapshotResult<NodeIndex> {
-        Ok(self.working_copy.get_node_index_by_id(id)?)
-    }
-
-    pub fn get_latest_node_index(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn get_latest_node_index(
         &self,
         node_index: NodeIndex,
     ) -> WorkspaceSnapshotResult<NodeIndex> {
-        Ok(self.working_copy.get_latest_node_idx(node_index)?)
+        Ok(self.working_copy().await.get_latest_node_idx(node_index)?)
     }
 
     #[instrument(skip_all)]
@@ -440,74 +509,103 @@ impl WorkspaceSnapshot {
         Self::try_from(row)
     }
 
-    pub fn get_category_node(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn get_category_node(
         &self,
         source: Option<Ulid>,
         kind: CategoryNodeKind,
     ) -> WorkspaceSnapshotResult<Ulid> {
-        let (category_node_id, _) = self.working_copy.get_category_node(source, kind)?;
+        let (category_node_id, _) = self.working_copy().await.get_category_node(source, kind)?;
         Ok(category_node_id)
     }
 
-    pub fn edges_directed(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn edges_directed(
         &self,
         id: impl Into<Ulid>,
         direction: Direction,
-    ) -> WorkspaceSnapshotResult<Edges<'_, EdgeWeight, Directed, u32>> {
-        let node_index = self.working_copy.get_node_index_by_id(id)?;
-        Ok(self.working_copy.edges_directed(node_index, direction))
+    ) -> WorkspaceSnapshotResult<Vec<(EdgeWeight, NodeIndex, NodeIndex)>> {
+        let node_index = self.working_copy().await.get_node_index_by_id(id)?;
+        Ok(self
+            .working_copy()
+            .await
+            .edges_directed(node_index, direction)
+            .map(|edge_ref| {
+                (
+                    edge_ref.weight().to_owned(),
+                    edge_ref.source(),
+                    edge_ref.target(),
+                )
+            })
+            .collect())
     }
 
-    pub fn edges_directed_for_edge_weight_kind(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn edges_directed_for_edge_weight_kind(
         &self,
         id: impl Into<Ulid>,
         direction: Direction,
         edge_kind: EdgeWeightKindDiscriminants,
-    ) -> WorkspaceSnapshotResult<Vec<petgraph::stable_graph::EdgeReference<'_, EdgeWeight>>> {
-        let node_index = self.working_copy.get_node_index_by_id(id)?;
+    ) -> WorkspaceSnapshotResult<Vec<(EdgeWeight, NodeIndex, NodeIndex)>> {
+        let node_index = self.working_copy().await.get_node_index_by_id(id)?;
 
         Ok(self
-            .working_copy
+            .working_copy()
+            .await
             .edges_directed_for_edge_weight_kind(node_index, direction, edge_kind))
     }
 
-    pub fn edges_directed_by_index(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn edges_directed_by_index(
         &self,
         node_index: NodeIndex,
         direction: Direction,
-    ) -> WorkspaceSnapshotResult<Edges<'_, EdgeWeight, Directed, u32>> {
-        Ok(self.working_copy.edges_directed(node_index, direction))
+    ) -> WorkspaceSnapshotResult<Vec<(EdgeWeight, NodeIndex, NodeIndex)>> {
+        Ok(self
+            .working_copy()
+            .await
+            .edges_directed(node_index, direction)
+            .map(|edge_ref| {
+                (
+                    edge_ref.weight().to_owned(),
+                    edge_ref.source(),
+                    edge_ref.target(),
+                )
+            })
+            .collect())
     }
 
-    pub fn remove_all_edges(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn remove_all_edges(
+        &self,
         change_set: &ChangeSetPointer,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<()> {
         let id = id.into();
-        let mut edges = Vec::new();
-        for edge in self.edges_directed(id, Direction::Incoming)? {
-            edges.push((edge.source(), edge.target(), edge.weight().kind().clone()));
+        for (edge_weight, source, target) in self.edges_directed(id, Direction::Outgoing).await? {
+            self.remove_edge(change_set, source, target, edge_weight.kind().into())
+                .await?;
         }
-        for edge in self.edges_directed(id, Direction::Outgoing)? {
-            edges.push((edge.source(), edge.target(), edge.weight().kind().clone()));
-        }
-        for (source, target, kind) in edges {
-            self.remove_edge(change_set, source, target, kind.into())?;
+        for (edge_weight, source, target) in self.edges_directed(id, Direction::Incoming).await? {
+            self.remove_edge(change_set, source, target, edge_weight.kind().into())
+                .await?;
         }
         Ok(())
     }
 
-    pub fn incoming_sources_for_edge_weight_kind(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn incoming_sources_for_edge_weight_kind(
         &self,
         id: impl Into<Ulid>,
         edge_weight_kind_discrim: EdgeWeightKindDiscriminants,
     ) -> WorkspaceSnapshotResult<Vec<NodeIndex>> {
         Ok(self
-            .edges_directed(id.into(), Direction::Incoming)?
-            .filter_map(|edge_ref| {
-                if edge_weight_kind_discrim == edge_ref.weight().kind().into() {
-                    Some(edge_ref.source())
+            .edges_directed(id.into(), Direction::Incoming)
+            .await?
+            .into_iter()
+            .filter_map(|(edge_weight, source_idx, _)| {
+                if edge_weight_kind_discrim == edge_weight.kind().into() {
+                    Some(source_idx)
                 } else {
                     None
                 }
@@ -515,17 +613,20 @@ impl WorkspaceSnapshot {
             .collect())
     }
 
-    pub fn outgoing_targets_for_edge_weight_kind(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn outgoing_targets_for_edge_weight_kind(
         &self,
         id: impl Into<Ulid>,
         edge_weight_kind_discrim: EdgeWeightKindDiscriminants,
     ) -> WorkspaceSnapshotResult<Vec<NodeIndex>> {
         let id = id.into();
         Ok(self
-            .edges_directed(id, Direction::Outgoing)?
-            .filter_map(|edge_ref| {
-                if edge_weight_kind_discrim == edge_ref.weight().kind().into() {
-                    Some(edge_ref.target())
+            .edges_directed(id, Direction::Outgoing)
+            .await?
+            .into_iter()
+            .filter_map(|(edge_weight, _, target_idx)| {
+                if edge_weight_kind_discrim == edge_weight.kind().into() {
+                    Some(target_idx)
                 } else {
                     None
                 }
@@ -533,16 +634,19 @@ impl WorkspaceSnapshot {
             .collect())
     }
 
-    pub fn outgoing_targets_for_edge_weight_kind_by_index(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn outgoing_targets_for_edge_weight_kind_by_index(
         &self,
         node_index: NodeIndex,
         edge_weight_kind_discrim: EdgeWeightKindDiscriminants,
     ) -> WorkspaceSnapshotResult<Vec<NodeIndex>> {
         Ok(self
-            .edges_directed_by_index(node_index, Direction::Outgoing)?
-            .filter_map(|edge_ref| {
-                if edge_weight_kind_discrim == edge_ref.weight().kind().into() {
-                    Some(edge_ref.target())
+            .edges_directed_by_index(node_index, Direction::Outgoing)
+            .await?
+            .into_iter()
+            .filter_map(|(edge_weight, _, target_idx)| {
+                if edge_weight_kind_discrim == edge_weight.kind().into() {
+                    Some(target_idx)
                 } else {
                     None
                 }
@@ -550,81 +654,93 @@ impl WorkspaceSnapshot {
             .collect())
     }
 
-    pub fn all_outgoing_targets(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn all_outgoing_targets(
         &self,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<Vec<NodeWeight>> {
         let mut result = vec![];
         let target_idxs: Vec<NodeIndex> = self
-            .edges_directed(id, Direction::Outgoing)?
-            .map(|edge_ref| edge_ref.target())
+            .edges_directed(id, Direction::Outgoing)
+            .await?
+            .into_iter()
+            .map(|(_, _, target_idx)| target_idx)
             .collect();
 
         for target_idx in target_idxs {
-            let node_weight = self.get_node_weight(target_idx)?;
+            let node_weight = self.get_node_weight(target_idx).await?;
             result.push(node_weight.to_owned());
         }
 
         Ok(result)
     }
 
-    pub fn all_incoming_sources(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn all_incoming_sources(
         &self,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<Vec<NodeWeight>> {
         let mut result = vec![];
         let source_idxs: Vec<NodeIndex> = self
-            .edges_directed(id, Direction::Incoming)?
-            .map(|edge_ref| edge_ref.source())
+            .edges_directed(id, Direction::Incoming)
+            .await?
+            .into_iter()
+            .map(|(_, source_idx, _)| source_idx)
             .collect();
 
         for source_idx in source_idxs {
-            let node_weight = self.get_node_weight(source_idx)?;
+            let node_weight = self.get_node_weight(source_idx).await?;
             result.push(node_weight.to_owned());
         }
 
         Ok(result)
     }
 
-    pub fn remove_incoming_edges_of_kind(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn remove_incoming_edges_of_kind(
+        &self,
         change_set: &ChangeSetPointer,
         target_id: impl Into<Ulid>,
         kind: EdgeWeightKindDiscriminants,
     ) -> WorkspaceSnapshotResult<()> {
         let target_id = target_id.into();
 
-        let sources = self.incoming_sources_for_edge_weight_kind(target_id, kind)?;
+        let sources = self
+            .incoming_sources_for_edge_weight_kind(target_id, kind)
+            .await?;
         for source_node_idx in sources {
-            let target_node_idx = self.get_node_index_by_id(target_id)?;
-            self.remove_edge(change_set, source_node_idx, target_node_idx, kind)?;
+            let target_node_idx = self.get_node_index_by_id(target_id).await?;
+            self.remove_edge(change_set, source_node_idx, target_node_idx, kind)
+                .await?;
         }
 
         Ok(())
     }
 
-    pub fn remove_node_by_id(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn remove_node_by_id(
+        &self,
         change_set: &ChangeSetPointer,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<()> {
         let id: Ulid = id.into();
-        let node_idx = self.get_node_index_by_id(id)?;
-        self.remove_all_edges(change_set, id)?;
-        self.working_copy.remove_node(node_idx);
-        self.working_copy.remove_node_id(id);
+        let node_idx = self.get_node_index_by_id(id).await?;
+        self.remove_all_edges(change_set, id).await?;
+        self.working_copy_mut().await.remove_node(node_idx);
+        self.working_copy_mut().await.remove_node_id(id);
 
         Ok(())
     }
 
-    pub fn remove_edge(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn remove_edge(
+        &self,
         change_set: &ChangeSetPointer,
         source_node_index: NodeIndex,
         target_node_index: NodeIndex,
         edge_kind: EdgeWeightKindDiscriminants,
     ) -> WorkspaceSnapshotResult<()> {
-        Ok(self.working_copy.remove_edge(
+        Ok(self.working_copy_mut().await.remove_edge(
             change_set,
             source_node_index,
             target_node_index,
@@ -634,25 +750,30 @@ impl WorkspaceSnapshot {
 
     /// Perform [`Updates`](Update) using [`self`](WorkspaceSnapshot) as the "to rebase" graph and
     /// another [`snapshot`](WorkspaceSnapshot) as the "onto" graph.
-    pub fn perform_updates(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn perform_updates(
+        &self,
         to_rebase_change_set: &ChangeSetPointer,
-        onto: &mut WorkspaceSnapshot,
+        onto: &WorkspaceSnapshot,
         updates: &[Update],
     ) -> WorkspaceSnapshotResult<()> {
-        Ok(self
-            .working_copy
-            .perform_updates(to_rebase_change_set, &onto.working_copy, updates)?)
+        Ok(self.working_copy_mut().await.perform_updates(
+            to_rebase_change_set,
+            &*onto.working_copy().await,
+            updates,
+        )?)
     }
 
     /// Mark whether a prop can be used as an input to a function. Props below
     /// Maps and Arrays are not valid inputs. Must only be used when
     /// "finalizing" a schema variant!
-    pub fn mark_prop_as_able_to_be_used_as_prototype_arg(
-        &mut self,
+    #[instrument(level = "debug", skip_all)]
+    pub async fn mark_prop_as_able_to_be_used_as_prototype_arg(
+        &self,
         node_index: NodeIndex,
     ) -> WorkspaceSnapshotResult<()> {
-        self.working_copy
+        self.working_copy_mut()
+            .await
             .update_node_weight(node_index, |node_weight| match node_weight {
                 NodeWeight::Prop(prop_inner) => {
                     prop_inner.set_can_be_used_as_prototype_arg(true);
@@ -664,24 +785,26 @@ impl WorkspaceSnapshot {
         Ok(())
     }
 
-    pub fn ordering_node_for_container(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn ordering_node_for_container(
         &self,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<Option<OrderingNodeWeight>> {
-        let idx = self.get_node_index_by_id(id)?;
-        Ok(self.working_copy.ordering_node_for_container(idx)?)
+        let idx = self.get_node_index_by_id(id).await?;
+        Ok(self.working_copy().await.ordering_node_for_container(idx)?)
     }
 
-    pub fn ordered_children_for_node(
+    #[instrument(level = "debug", skip_all)]
+    pub async fn ordered_children_for_node(
         &self,
         id: impl Into<Ulid>,
     ) -> WorkspaceSnapshotResult<Option<Vec<Ulid>>> {
-        let idx = self.get_node_index_by_id(id.into())?;
+        let idx = self.get_node_index_by_id(id.into()).await?;
         let mut result = vec![];
         Ok(
-            if let Some(idxs) = self.working_copy.ordered_children_for_node(idx)? {
+            if let Some(idxs) = self.working_copy().await.ordered_children_for_node(idx)? {
                 for idx in idxs {
-                    let id = self.get_node_weight(idx)?.id();
+                    let id = self.get_node_weight(idx).await?.id();
                     result.push(id);
                 }
                 Some(result)

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use content_store::{ContentHash, Store, StoreError};
-use petgraph::stable_graph::{EdgeReference, Edges};
+use petgraph::stable_graph::Edges;
 use petgraph::{algo, prelude::*, visit::DfsEvent};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -255,10 +255,20 @@ impl WorkspaceSnapshotGraph {
         node_index: NodeIndex,
         direction: Direction,
         edge_kind: EdgeWeightKindDiscriminants,
-    ) -> Vec<EdgeReference<'_, EdgeWeight>> {
+    ) -> Vec<(EdgeWeight, NodeIndex, NodeIndex)> {
         self.graph
             .edges_directed(node_index, direction)
-            .filter(|edge_ref| edge_kind == edge_ref.weight().kind().into())
+            .filter_map(|edge_ref| {
+                if edge_kind == edge_ref.weight().kind().into() {
+                    Some((
+                        edge_ref.weight().to_owned(),
+                        edge_ref.source(),
+                        edge_ref.target(),
+                    ))
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -233,13 +233,7 @@ async fn delete_func_node(ctx: &mut DalContext) {
         .await
         .expect("unable to update snapshot to visiblity");
 
-    let snapshot_id_before_deletion = {
-        ctx.workspace_snapshot()
-            .expect("get snap")
-            .read()
-            .await
-            .id()
-    };
+    let snapshot_id_before_deletion = ctx.workspace_snapshot().expect("get snap").id().await;
 
     Func::get_by_id(ctx, func.id)
         .await
@@ -258,13 +252,7 @@ async fn delete_func_node(ctx: &mut DalContext) {
         .await
         .expect("unable to update snapshot to visiblity");
 
-    let snapshot_id_after_deletion = {
-        ctx.workspace_snapshot()
-            .expect("get snap")
-            .read()
-            .await
-            .id()
-    };
+    let snapshot_id_after_deletion = ctx.workspace_snapshot().expect("get snap").id().await;
 
     // A sanity check
     assert_ne!(snapshot_id_before_deletion, snapshot_id_after_deletion);


### PR DESCRIPTION
This moves the lock on the snapshot graph inside the WorkspaceSnapshot, so the caller never has to manage the lock. Instead, the lock is controlled by the methods defined in the WorkspaceSnapshot implementation. A consequence of this is that all methods on WorkspaceSnapshot must be async, since the RwLock methods are async. But we want this to happen anyway, since shrinking the snapshot means all accesses will have to go through async boundaries to fetch node weights from the caches.