### PR TITLE
chore: refresh NATS support

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -41,7 +41,6 @@ services:
     command:
       - "--config"
       - "nats-server.conf"
-      - "-DVV"
 
   jaeger:
     image: systeminit/jaeger:stable

--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -9,7 +9,7 @@ docker_image(
         "nats-server.conf": "component/nats",
     },
     build_args = {
-        "BASE_VERSION": "2.10.10",
+        "BASE_VERSION": "2.10.11",
     },
     run_docker_args = [
         "--publish",

--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -18,6 +18,5 @@ docker_image(
     run_container_args = [
         "--config",
         "nats-server.conf",
-        "-DVV",
     ],
 )

--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -14,6 +14,8 @@ docker_image(
     run_docker_args = [
         "--publish",
         "4222:4222",
+        "--publish",
+        "8222:8222",
     ],
     run_container_args = [
         "--config",

--- a/component/nats/nats-server.conf
+++ b/component/nats/nats-server.conf
@@ -12,5 +12,8 @@ max_payload: 8MB
 # Default: 64MB
 max_pending: 128MB
 
+# http port for server monitoring
+http_port: 8222
+
 # JetStream configuration
 jetstream {}

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -34,7 +34,6 @@ services:
     command:
       - "--config"
       - "nats-server.conf"
-      - "-DVV"
     ports:
       - "4222:4222"
 

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -36,6 +36,7 @@ services:
       - "nats-server.conf"
     ports:
       - "4222:4222"
+      - "8222:8222"
 
   jaeger:
     image: systeminit/jaeger:stable

--- a/flake.nix
+++ b/flake.nix
@@ -324,6 +324,8 @@
               buildkite-test-collector-rust
               docker-compose
               jq
+              nats-top
+              natscli
               # pgcli
               reindeer
               shellcheck


### PR DESCRIPTION
This change adds 2 new tools to our development environment (a NATS CLI `nats` and a top-like program `nats-top`), drops some of the default overly-verbose logging, and bumps the version of the NATS server.

<img src="https://media1.giphy.com/media/9PtfS5tTC8ejlYfCLU/giphy.gif"/>