### PR TITLE
feat(sdf-server, dal): Adding an edge for default schema variants at pkg import time

### DIFF
--- a/lib/dal/src/action/batch.rs
+++ b/lib/dal/src/action/batch.rs
@@ -168,7 +168,7 @@ impl ActionBatch {
         workspace_snapshot
             .add_edge(
                 category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/action/batch.rs
+++ b/lib/dal/src/action/batch.rs
@@ -168,7 +168,7 @@ impl ActionBatch {
         workspace_snapshot
             .add_edge(
                 category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -203,7 +203,7 @@ impl ActionPrototype {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 func_id,
             )
             .await?;

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -203,7 +203,7 @@ impl ActionPrototype {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 func_id,
             )
             .await?;

--- a/lib/dal/src/action/runner.rs
+++ b/lib/dal/src/action/runner.rs
@@ -247,7 +247,7 @@ impl ActionRunner {
         workspace_snapshot
             .add_edge(
                 action_batch_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/action/runner.rs
+++ b/lib/dal/src/action/runner.rs
@@ -247,7 +247,7 @@ impl ActionRunner {
         workspace_snapshot
             .add_edge(
                 action_batch_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -124,7 +124,7 @@ impl AttributePrototype {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 func_id,
             )
             .await?;
@@ -230,7 +230,7 @@ impl AttributePrototype {
             .edges_directed(attribute_prototype_id, Direction::Outgoing)
             .await?
             .iter()
-            .find(|(edge_weight, _, _)| edge_weight.kind() == &EdgeWeightKind::Use)
+            .find(|(edge_weight, _, _)| edge_weight.kind() == &EdgeWeightKind::use_not_as_default())
             .map(|(_, _, target_idx)| *target_idx)
             .ok_or(AttributePrototypeError::MissingFunction(
                 attribute_prototype_id,
@@ -249,7 +249,7 @@ impl AttributePrototype {
         workspace_snapshot
             .add_edge(
                 attribute_prototype_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 func_id,
             )
             .await?;

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -124,7 +124,7 @@ impl AttributePrototype {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 func_id,
             )
             .await?;
@@ -230,7 +230,7 @@ impl AttributePrototype {
             .edges_directed(attribute_prototype_id, Direction::Outgoing)
             .await?
             .iter()
-            .find(|(edge_weight, _, _)| edge_weight.kind() == &EdgeWeightKind::use_not_as_default())
+            .find(|(edge_weight, _, _)| edge_weight.kind() == &EdgeWeightKind::new_use())
             .map(|(_, _, target_idx)| *target_idx)
             .ok_or(AttributePrototypeError::MissingFunction(
                 attribute_prototype_id,
@@ -249,7 +249,7 @@ impl AttributePrototype {
         workspace_snapshot
             .add_edge(
                 attribute_prototype_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 func_id,
             )
             .await?;

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -187,7 +187,7 @@ impl AttributePrototypeArgument {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 arg_id,
             )
             .await?;
@@ -249,7 +249,7 @@ impl AttributePrototypeArgument {
             workspace_snapshot
                 .add_edge(
                     prototype_arg.id(),
-                    EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                    EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                     func_arg_id,
                 )
                 .await?;

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -187,7 +187,7 @@ impl AttributePrototypeArgument {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 arg_id,
             )
             .await?;
@@ -249,7 +249,7 @@ impl AttributePrototypeArgument {
             workspace_snapshot
                 .add_edge(
                     prototype_arg.id(),
-                    EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                    EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                     func_arg_id,
                 )
                 .await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -292,7 +292,7 @@ impl Component {
         workspace_snapshot
             .add_edge(
                 component_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;
@@ -301,7 +301,7 @@ impl Component {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 schema_variant_id,
             )
             .await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -292,7 +292,7 @@ impl Component {
         workspace_snapshot
             .add_edge(
                 component_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;
@@ -301,7 +301,7 @@ impl Component {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 schema_variant_id,
             )
             .await?;

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -196,7 +196,7 @@ impl Func {
         workspace_snapshot
             .add_edge(
                 func_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;
@@ -234,7 +234,7 @@ impl Func {
         let func_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
                 func_category_id,
-                EdgeWeightKindDiscriminants::Use,
+                EdgeWeightKind::use_not_as_default().into(),
             )
             .await?;
         let name = name.as_ref();
@@ -384,13 +384,18 @@ impl Func {
         let arg_node_idx = workspace_snapshot.get_node_index_by_id(id).await?;
 
         let users = workspace_snapshot
-            .incoming_sources_for_edge_weight_kind(id, EdgeWeightKind::Use.into())
+            .incoming_sources_for_edge_weight_kind(id, EdgeWeightKind::use_not_as_default().into())
             .await?;
 
         let change_set = ctx.change_set_pointer()?;
         for user in users {
             workspace_snapshot
-                .remove_edge(change_set, user, arg_node_idx, EdgeWeightKind::Use.into())
+                .remove_edge(
+                    change_set,
+                    user,
+                    arg_node_idx,
+                    EdgeWeightKind::use_not_as_default().into(),
+                )
                 .await?;
         }
 

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -196,7 +196,7 @@ impl Func {
         workspace_snapshot
             .add_edge(
                 func_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;
@@ -234,7 +234,7 @@ impl Func {
         let func_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
                 func_category_id,
-                EdgeWeightKind::use_not_as_default().into(),
+                EdgeWeightKind::new_use().into(),
             )
             .await?;
         let name = name.as_ref();
@@ -384,7 +384,7 @@ impl Func {
         let arg_node_idx = workspace_snapshot.get_node_index_by_id(id).await?;
 
         let users = workspace_snapshot
-            .incoming_sources_for_edge_weight_kind(id, EdgeWeightKind::use_not_as_default().into())
+            .incoming_sources_for_edge_weight_kind(id, EdgeWeightKind::new_use().into())
             .await?;
 
         let change_set = ctx.change_set_pointer()?;
@@ -394,7 +394,7 @@ impl Func {
                     change_set,
                     user,
                     arg_node_idx,
-                    EdgeWeightKind::use_not_as_default().into(),
+                    EdgeWeightKind::new_use().into(),
                 )
                 .await?;
         }

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -193,7 +193,7 @@ impl FuncArgument {
         workspace_snapshot
             .add_edge(
                 func_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -193,7 +193,7 @@ impl FuncArgument {
         workspace_snapshot
             .add_edge(
                 func_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -555,7 +555,7 @@ impl Prop {
                     .add_ordered_edge(
                         change_set,
                         ordered_prop_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                         id,
                     )
                     .await?;
@@ -564,7 +564,7 @@ impl Prop {
                 workspace_snapshot
                     .add_edge(
                         prop_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                         id,
                     )
                     .await?;
@@ -573,7 +573,7 @@ impl Prop {
                 workspace_snapshot
                     .add_edge(
                         schema_variant_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                         id,
                     )
                     .await?;
@@ -610,7 +610,10 @@ impl Prop {
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
         for maybe_elem_node_idx in workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind(self.id, EdgeWeightKindDiscriminants::Use)
+            .outgoing_targets_for_edge_weight_kind(
+                self.id,
+                EdgeWeightKind::use_not_as_default().into(),
+            )
             .await?
         {
             if let NodeWeight::Prop(prop_inner) = workspace_snapshot

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -555,7 +555,7 @@ impl Prop {
                     .add_ordered_edge(
                         change_set,
                         ordered_prop_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                         id,
                     )
                     .await?;
@@ -564,7 +564,7 @@ impl Prop {
                 workspace_snapshot
                     .add_edge(
                         prop_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                         id,
                     )
                     .await?;
@@ -573,7 +573,7 @@ impl Prop {
                 workspace_snapshot
                     .add_edge(
                         schema_variant_id,
-                        EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                        EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                         id,
                     )
                     .await?;
@@ -610,10 +610,7 @@ impl Prop {
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
         for maybe_elem_node_idx in workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind(
-                self.id,
-                EdgeWeightKind::use_not_as_default().into(),
-            )
+            .outgoing_targets_for_edge_weight_kind(self.id, EdgeWeightKind::new_use().into())
             .await?
         {
             if let NodeWeight::Prop(prop_inner) = workspace_snapshot

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -180,7 +180,7 @@ impl SchemaVariant {
         workspace_snapshot
             .add_edge(
                 schema_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;
@@ -281,7 +281,7 @@ impl SchemaVariant {
             let schema_variant_node_indices = workspace_snapshot
                 .outgoing_targets_for_edge_weight_kind(
                     schema_id,
-                    EdgeWeightKind::use_as_default().into(),
+                    EdgeWeightKind::new_use_default().into(),
                 )
                 .await?;
 
@@ -322,7 +322,7 @@ impl SchemaVariant {
         let node_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind_by_index(
                 parent_index,
-                EdgeWeightKind::use_not_as_default().into(),
+                EdgeWeightKind::new_use().into(),
             )
             .await?;
 
@@ -523,10 +523,7 @@ impl SchemaVariant {
         ctx.workspace_snapshot()?
             .add_edge(
                 schema_variant_id,
-                EdgeWeight::new(
-                    ctx.change_set_pointer()?,
-                    EdgeWeightKind::use_not_as_default(),
-                )?,
+                EdgeWeight::new(ctx.change_set_pointer()?, EdgeWeightKind::new_use())?,
                 func_id,
             )
             .await?;
@@ -934,7 +931,7 @@ impl SchemaVariant {
 
             let mut schema_id: Option<SchemaId> = None;
             for (edge_weight, source_index, _) in maybe_schema_indices {
-                if *edge_weight.kind() == EdgeWeightKind::use_as_default() {
+                if *edge_weight.kind() == EdgeWeightKind::new_use_default() {
                     if let NodeWeight::Content(content) =
                         workspace_snapshot.get_node_weight(source_index).await?
                     {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -270,7 +270,7 @@ impl SchemaVariant {
         )
     }
 
-    /// Lists all [`SchemaVariants`](SchemaVariant) by ID in the workspace.
+    /// Lists all default [`SchemaVariants`](SchemaVariant) by ID in the workspace.
     pub async fn list_ids(ctx: &DalContext) -> SchemaVariantResult<Vec<SchemaVariantId>> {
         let schema_ids = Schema::list_ids(ctx).await?;
 
@@ -279,7 +279,10 @@ impl SchemaVariant {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         for schema_id in schema_ids {
             let schema_variant_node_indices = workspace_snapshot
-                .outgoing_targets_for_edge_weight_kind(schema_id, EdgeWeightKindDiscriminants::Use)
+                .outgoing_targets_for_edge_weight_kind(
+                    schema_id,
+                    EdgeWeightKindDiscriminants::Default,
+                )
                 .await?;
 
             for schema_variant_node_index in schema_variant_node_indices {
@@ -298,33 +301,13 @@ impl SchemaVariant {
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaVariantResult<Self> {
-        // The first pass here is that we will just return the first schema variant found for a schema
-        // We will need to add a default edge at some point in the future - that means when we import
-        // a schema variant (if it doesn't already exist) then it gets an edge for default
-        // If we are creating a new version of a schema variant then we will be able to mark it as default
-        let node_weight = {
-            let workspace_snapshot = ctx.workspace_snapshot()?;
+        let schema = Schema::get_by_id(ctx, schema_id).await?;
+        let default_schema_variant_id = schema
+            .get_default_schema_variant(ctx)
+            .await?
+            .ok_or(SchemaVariantError::DefaultSchemaVariantNotFound(schema_id))?;
 
-            let parent_index = workspace_snapshot.get_node_index_by_id(schema_id).await?;
-
-            let node_indices = workspace_snapshot
-                .outgoing_targets_for_edge_weight_kind_by_index(
-                    parent_index,
-                    EdgeWeightKindDiscriminants::Use,
-                )
-                .await?;
-
-            let node_index = node_indices
-                .first()
-                .ok_or(SchemaVariantError::DefaultSchemaVariantNotFound(schema_id))?;
-
-            workspace_snapshot
-                .get_node_weight(*node_index)
-                .await?
-                .get_content_node_weight_of_kind(ContentAddressDiscriminants::SchemaVariant)?
-        };
-
-        Self::get_by_id(ctx, node_weight.id().into()).await
+        Self::get_by_id(ctx, default_schema_variant_id).await
     }
 
     pub async fn list_for_schema(
@@ -373,6 +356,10 @@ impl SchemaVariant {
                 ))?,
             }
         }
+
+        // Now add the default schema variant to the list as this is a different edge kind
+        let default_schema_variant = Self::get_default_for_schema(ctx, schema_id).await?;
+        schema_variants.push(default_schema_variant);
 
         Ok(schema_variants)
     }
@@ -937,12 +924,19 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<Schema> {
         let schema_id = {
             let workspace_snapshot = ctx.workspace_snapshot()?;
-            let maybe_schema_indices = workspace_snapshot
+            let mut maybe_schema_indices = workspace_snapshot
+                .incoming_sources_for_edge_weight_kind(
+                    schema_variant_id,
+                    EdgeWeightKindDiscriminants::Default,
+                )
+                .await?;
+            let maybe_no_default_schema_indicies = workspace_snapshot
                 .incoming_sources_for_edge_weight_kind(
                     schema_variant_id,
                     EdgeWeightKindDiscriminants::Use,
                 )
                 .await?;
+            maybe_schema_indices.extend(maybe_no_default_schema_indicies);
 
             let mut schema_id: Option<SchemaId> = None;
             for index in maybe_schema_indices {

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -178,7 +178,7 @@ impl Secret {
         workspace_snapshot
             .add_edge(
                 secret_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -178,7 +178,7 @@ impl Secret {
         workspace_snapshot
             .add_edge(
                 secret_category_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -192,27 +192,27 @@ impl WorkspaceSnapshot {
         // Connect them to root.
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
             action_batch_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
             component_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
             func_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
             schema_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::Use)?,
+            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
             secret_node_index,
         )?;
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -192,27 +192,27 @@ impl WorkspaceSnapshot {
         // Connect them to root.
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             action_batch_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             component_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             func_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             schema_node_index,
         )?;
         graph.add_edge(
             graph.root(),
-            EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())?,
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             secret_node_index,
         )?;
 

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -18,7 +18,7 @@ pub enum EdgeWeightError {
 pub type EdgeWeightResult<T> = Result<T, EdgeWeightError>;
 
 #[remain::sorted]
-#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, EnumDiscriminants)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, EnumDiscriminants)]
 #[strum_discriminants(derive(Serialize, Deserialize))]
 pub enum EdgeWeightKind {
     Action,
@@ -31,8 +31,6 @@ pub enum EdgeWeightKind {
     /// array/map, or a field of an object. The optional [`String`] represents the key of the entry
     /// in a map.
     Contain(Option<String>),
-    /// Used to denote when something is a default. For example a default schema variant for a schema
-    Default,
     /// Used to indicate parentage within frames. It does not dictate data flow. That is provided via
     /// [`ComponentType`](crate::ComponentType).
     ///
@@ -69,8 +67,19 @@ pub enum EdgeWeightKind {
     /// Workspaces "use" functions, modules, schemas. Schemas "use" schema variants.
     /// Schema variants "use" props. Props "use" functions, and other props. Modules
     /// "use" functions, schemas, and eventually(?) components.
-    #[default]
-    Use,
+    Use {
+        is_default: bool,
+    },
+}
+
+impl EdgeWeightKind {
+    pub fn use_as_default() -> Self {
+        EdgeWeightKind::Use { is_default: true }
+    }
+
+    pub fn use_not_as_default() -> Self {
+        EdgeWeightKind::Use { is_default: false }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -73,11 +73,15 @@ pub enum EdgeWeightKind {
 }
 
 impl EdgeWeightKind {
-    pub fn use_as_default() -> Self {
+    /// Creates a new Use edge weight kind indicating that this is also the
+    /// "default" use edge
+    pub fn new_use_default() -> Self {
         EdgeWeightKind::Use { is_default: true }
     }
 
-    pub fn use_not_as_default() -> Self {
+    /// Creates a non-default use EdgeWeightKind. This is what you normally want
+    /// unless you know there should be a default/non-default difference
+    pub fn new_use() -> Self {
         EdgeWeightKind::Use { is_default: false }
     }
 }

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -31,6 +31,8 @@ pub enum EdgeWeightKind {
     /// array/map, or a field of an object. The optional [`String`] represents the key of the entry
     /// in a map.
     Contain(Option<String>),
+    /// Used to denote when something is a default. For example a default schema variant for a schema
+    Default,
     /// Used to indicate parentage within frames. It does not dictate data flow. That is provided via
     /// [`ComponentType`](crate::ComponentType).
     ///

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -939,6 +939,7 @@ impl WorkspaceSnapshotGraph {
                     EdgeWeightKindDiscriminants::Proxy => "gray",
                     EdgeWeightKindDiscriminants::Root => "black",
                     EdgeWeightKindDiscriminants::Use => "black",
+                    EdgeWeightKindDiscriminants::Default => "brown",
                 };
 
                 match edgeref.weight().kind() {
@@ -1036,7 +1037,7 @@ impl WorkspaceSnapshotGraph {
                 )
             },
         );
-        let filename_no_extension = format!("{}-{}", Ulid::new().to_string(), suffix);
+        let filename_no_extension = format!("{}-{}", Ulid::new().to_string(), suffix)
 
         let home_str = std::env::var("HOME").unwrap();
         let home = std::path::Path::new(&home_str);
@@ -1984,6 +1985,7 @@ impl WorkspaceSnapshotGraph {
                     | EdgeWeightKind::Proxy
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
+                    | EdgeWeightKind::Default
                     | EdgeWeightKind::Use => {}
                 }
             }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -939,7 +939,6 @@ impl WorkspaceSnapshotGraph {
                     EdgeWeightKindDiscriminants::Proxy => "gray",
                     EdgeWeightKindDiscriminants::Root => "black",
                     EdgeWeightKindDiscriminants::Use => "black",
-                    EdgeWeightKindDiscriminants::Default => "brown",
                 };
 
                 match edgeref.weight().kind() {
@@ -1985,8 +1984,7 @@ impl WorkspaceSnapshotGraph {
                     | EdgeWeightKind::Proxy
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
-                    | EdgeWeightKind::Default
-                    | EdgeWeightKind::Use => {}
+                    | EdgeWeightKind::Use { .. } => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1036,7 +1036,7 @@ impl WorkspaceSnapshotGraph {
                 )
             },
         );
-        let filename_no_extension = format!("{}-{}", Ulid::new().to_string(), suffix)
+        let filename_no_extension = format!("{}-{}", Ulid::new().to_string(), suffix);
 
         let home_str = std::env::var("HOME").unwrap();
         let home = std::path::Path::new(&home_str);
@@ -1964,6 +1964,10 @@ impl WorkspaceSnapshotGraph {
                         hasher.update(kind.to_string().as_bytes())
                     }
 
+                    EdgeWeightKind::Use { is_default } => {
+                        hasher.update(is_default.to_string().as_bytes())
+                    }
+
                     // This is the key representing an element in a container type corresponding
                     // to an AttributePrototype
                     EdgeWeightKind::Prototype(Some(key)) => hasher.update(key.as_bytes()),
@@ -1983,8 +1987,7 @@ impl WorkspaceSnapshotGraph {
                     | EdgeWeightKind::Prototype(None)
                     | EdgeWeightKind::Proxy
                     | EdgeWeightKind::Root
-                    | EdgeWeightKind::SocketValue
-                    | EdgeWeightKind::Use { .. } => {}
+                    | EdgeWeightKind::SocketValue => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -131,7 +131,7 @@ mod test {
             graph
                 .add_edge(
                     source,
-                    EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                    EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                         .expect("create edge weight"),
                     target,
                 )
@@ -232,7 +232,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -240,7 +240,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -250,7 +250,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -260,7 +260,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -298,7 +298,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -308,7 +308,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -318,7 +318,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -379,7 +379,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_component_node_index,
             )
@@ -387,7 +387,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_node_index,
             )
@@ -397,7 +397,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_variant_node_index,
             )
@@ -407,7 +407,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -423,7 +423,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(component_id)
@@ -480,7 +480,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -488,7 +488,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -498,7 +498,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -508,7 +508,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -519,7 +519,7 @@ mod test {
         // Ensure that the root node merkle tree hash looks as we expect before the update.
         let pre_update_root_node_merkle_tree_hash: ContentHash =
             serde_json::from_value(serde_json::json![
-                "66e2b07b8a9a5f94a0ea18618a57b3264c850ea6cfeb81f5c9a42c4397f2f49d"
+                "e24d50279e223b763e56317f692713b1b1f172258ec2df66e2b41db49982b810"
             ])
             .expect("could not deserialize");
         assert_eq!(
@@ -537,7 +537,7 @@ mod test {
 
         let post_update_root_node_merkle_tree_hash: ContentHash =
             serde_json::from_value(serde_json::json![
-                "0b9b79be9c1b4107bd32dc9fb7accde544dc10171e37847e53c4d16a9efd2da1"
+                "94f16e91eca11765f507747aacf49e2e0bacbb63ec5a11ea0cbea7d372f1b2cd"
             ])
             .expect("could not deserialize");
         assert_eq!(
@@ -622,7 +622,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -632,7 +632,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -660,7 +660,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -670,7 +670,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -729,7 +729,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -739,7 +739,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -768,7 +768,7 @@ mod test {
         let _new_onto_root_component_edge_index = base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -778,7 +778,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -810,7 +810,7 @@ mod test {
             }] => {
                 assert_eq!(new_graph.root_index, *source);
                 assert_eq!(new_onto_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::new_use(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -839,7 +839,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -869,7 +869,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_component_index,
             )
@@ -908,7 +908,7 @@ mod test {
             }] => {
                 assert_eq!(base_graph.root_index, *source);
                 assert_eq!(new_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::new_use(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -951,7 +951,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -961,7 +961,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -990,7 +990,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -1000,7 +1000,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1027,7 +1027,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -1037,7 +1037,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1069,7 +1069,7 @@ mod test {
             }] => {
                 assert_eq!(new_graph.root_index, *source);
                 assert_eq!(new_onto_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::new_use(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -1112,7 +1112,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1122,7 +1122,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1144,7 +1144,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -1154,7 +1154,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1253,7 +1253,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1263,7 +1263,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1285,7 +1285,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -1295,7 +1295,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1381,7 +1381,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_index,
             )
@@ -1406,7 +1406,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(docker_image_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_variant_index,
             )
@@ -1429,7 +1429,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 nginx_docker_image_component_index,
             )
@@ -1439,7 +1439,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_docker_image_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1464,7 +1464,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 alpine_component_index,
             )
@@ -1474,7 +1474,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(alpine_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1499,7 +1499,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_index,
             )
@@ -1524,7 +1524,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(butane_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_variant_index,
             )
@@ -1547,7 +1547,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 nginx_butane_node_index,
             )
@@ -1557,7 +1557,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_butane_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(butane_schema_variant_id)
@@ -1701,7 +1701,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1711,7 +1711,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1733,7 +1733,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -1758,7 +1758,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -1768,7 +1768,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -1797,7 +1797,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -1822,7 +1822,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -1847,7 +1847,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -1909,7 +1909,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1919,7 +1919,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1941,7 +1941,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -1966,7 +1966,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -1976,7 +1976,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -2005,7 +2005,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -2030,7 +2030,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -2055,7 +2055,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -2080,7 +2080,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )
@@ -2176,7 +2176,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2186,7 +2186,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2213,7 +2213,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
@@ -2334,7 +2334,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2344,7 +2344,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2369,7 +2369,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
@@ -2457,7 +2457,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2467,7 +2467,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2489,7 +2489,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -2514,7 +2514,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_index,
             )
@@ -2524,7 +2524,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -2553,7 +2553,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -2578,7 +2578,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -2603,7 +2603,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -2628,7 +2628,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )
@@ -2739,7 +2739,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2749,7 +2749,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2776,7 +2776,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -2803,7 +2803,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -2830,7 +2830,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -2857,7 +2857,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -2884,7 +2884,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -2918,7 +2918,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_5_index,
             )
@@ -2976,7 +2976,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2986,7 +2986,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3013,7 +3013,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3040,7 +3040,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3067,7 +3067,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3094,7 +3094,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3121,7 +3121,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3148,9 +3148,8 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight =
-            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
-                .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
+            .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3271,7 +3270,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -3281,7 +3280,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3308,7 +3307,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3335,7 +3334,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3362,7 +3361,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3389,7 +3388,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3416,7 +3415,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3453,9 +3452,8 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight =
-            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
-                .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
+            .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3579,7 +3577,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -3589,7 +3587,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3616,7 +3614,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3643,7 +3641,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3670,7 +3668,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3697,7 +3695,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3724,7 +3722,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3767,9 +3765,8 @@ mod test {
             )
             .expect("Unable to add ordered prop 5");
 
-        let new_edge_weight =
-            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
-                .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
+            .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3865,7 +3862,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -3890,7 +3887,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -3917,7 +3914,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -3944,7 +3941,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 si_prop_node_index,
             )
@@ -3971,7 +3968,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 name_prop_node_index,
             )
@@ -3994,7 +3991,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4004,7 +4001,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4031,7 +4028,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -4166,7 +4163,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -4191,7 +4188,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -4218,7 +4215,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -4245,7 +4242,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 si_prop_node_index,
             )
@@ -4272,7 +4269,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 name_prop_node_index,
             )
@@ -4299,7 +4296,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 description_prop_node_index,
             )
@@ -4322,7 +4319,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4332,7 +4329,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4359,7 +4356,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -4536,7 +4533,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -4561,7 +4558,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -4588,7 +4585,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -4615,7 +4612,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 domain_prop_node_index,
             )
@@ -4642,7 +4639,7 @@ mod test {
                 graph
                     .get_node_index_by_id(domain_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ports_prop_node_index,
             )
@@ -4669,7 +4666,7 @@ mod test {
                 graph
                     .get_node_index_by_id(ports_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 port_prop_node_index,
             )
@@ -4692,7 +4689,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4702,7 +4699,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4729,7 +4726,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -5113,7 +5110,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -5138,7 +5135,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -5165,7 +5162,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -5192,7 +5189,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 domain_prop_node_index,
             )
@@ -5219,7 +5216,7 @@ mod test {
                 graph
                     .get_node_index_by_id(domain_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 environment_prop_node_index,
             )
@@ -5246,7 +5243,7 @@ mod test {
                 graph
                     .get_node_index_by_id(environment_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 env_var_prop_node_index,
             )
@@ -5269,7 +5266,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -5279,7 +5276,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -5302,7 +5299,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -131,7 +131,8 @@ mod test {
             graph
                 .add_edge(
                     source,
-                    EdgeWeight::new(change_set, EdgeWeightKind::Use).expect("create edge weight"),
+                    EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
+                        .expect("create edge weight"),
                     target,
                 )
                 .expect("add edge");
@@ -231,7 +232,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -239,7 +240,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -249,7 +250,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -259,7 +260,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -297,7 +298,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -307,7 +308,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -317,7 +318,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -378,7 +379,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 initial_component_node_index,
             )
@@ -386,7 +387,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_node_index,
             )
@@ -396,7 +397,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_variant_node_index,
             )
@@ -406,7 +407,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -422,7 +423,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(component_id)
@@ -479,7 +480,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -487,7 +488,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -497,7 +498,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -507,7 +508,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -621,7 +622,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -631,7 +632,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -659,7 +660,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -669,7 +670,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -728,7 +729,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -738,7 +739,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -767,7 +768,7 @@ mod test {
         let _new_onto_root_component_edge_index = base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -777,7 +778,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -809,7 +810,7 @@ mod test {
             }] => {
                 assert_eq!(new_graph.root_index, *source);
                 assert_eq!(new_onto_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::Use, edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -838,7 +839,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -868,7 +869,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 new_component_index,
             )
@@ -907,7 +908,7 @@ mod test {
             }] => {
                 assert_eq!(base_graph.root_index, *source);
                 assert_eq!(new_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::Use, edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -950,7 +951,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -960,7 +961,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -989,7 +990,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -999,7 +1000,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1026,7 +1027,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -1036,7 +1037,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1068,7 +1069,7 @@ mod test {
             }] => {
                 assert_eq!(new_graph.root_index, *source);
                 assert_eq!(new_onto_component_index, *destination);
-                assert_eq!(&EdgeWeightKind::Use, edge_weight.kind());
+                assert_eq!(&EdgeWeightKind::use_not_as_default(), edge_weight.kind());
             }
             other => panic!("Unexpected updates: {:?}", other),
         }
@@ -1111,7 +1112,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1121,7 +1122,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1143,7 +1144,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -1153,7 +1154,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1252,7 +1253,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1262,7 +1263,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1284,7 +1285,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -1294,7 +1295,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -1380,7 +1381,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_index,
             )
@@ -1405,7 +1406,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(docker_image_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_variant_index,
             )
@@ -1428,7 +1429,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 nginx_docker_image_component_index,
             )
@@ -1438,7 +1439,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_docker_image_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1463,7 +1464,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 alpine_component_index,
             )
@@ -1473,7 +1474,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(alpine_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1498,7 +1499,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_index,
             )
@@ -1523,7 +1524,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(butane_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_variant_index,
             )
@@ -1546,7 +1547,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 nginx_butane_node_index,
             )
@@ -1556,7 +1557,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_butane_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(base_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(butane_schema_variant_id)
@@ -1700,7 +1701,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1710,7 +1711,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1732,7 +1733,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -1757,7 +1758,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -1767,7 +1768,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -1796,7 +1797,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -1821,7 +1822,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -1846,7 +1847,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -1908,7 +1909,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1918,7 +1919,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1940,7 +1941,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -1965,7 +1966,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -1975,7 +1976,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -2004,7 +2005,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -2029,7 +2030,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -2054,7 +2055,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -2079,7 +2080,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )
@@ -2175,7 +2176,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2185,7 +2186,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2212,7 +2213,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
@@ -2333,7 +2334,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2343,7 +2344,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2368,7 +2369,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
@@ -2456,7 +2457,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2466,7 +2467,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2488,7 +2489,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -2513,7 +2514,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_index,
             )
@@ -2523,7 +2524,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -2552,7 +2553,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -2577,7 +2578,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -2602,7 +2603,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -2627,7 +2628,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )
@@ -2738,7 +2739,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2748,7 +2749,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -2775,7 +2776,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -2802,7 +2803,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -2829,7 +2830,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -2856,7 +2857,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -2883,7 +2884,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -2917,7 +2918,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(new_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_5_index,
             )
@@ -2975,7 +2976,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -2985,7 +2986,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3012,7 +3013,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3039,7 +3040,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3066,7 +3067,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3093,7 +3094,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3120,7 +3121,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3147,8 +3148,9 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight =
+            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3269,7 +3271,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -3279,7 +3281,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3306,7 +3308,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3333,7 +3335,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3360,7 +3362,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3387,7 +3389,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3414,7 +3416,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3451,8 +3453,9 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight =
+            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3576,7 +3579,7 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -3586,7 +3589,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -3613,7 +3616,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
@@ -3640,7 +3643,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
@@ -3667,7 +3670,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
@@ -3694,7 +3697,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
@@ -3721,7 +3724,7 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
@@ -3764,8 +3767,9 @@ mod test {
             )
             .expect("Unable to add ordered prop 5");
 
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::Use)
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight =
+            EdgeWeight::new(initial_change_set, EdgeWeightKind::use_not_as_default())
+                .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
                 initial_change_set,
@@ -3861,7 +3865,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -3886,7 +3890,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -3913,7 +3917,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -3940,7 +3944,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 si_prop_node_index,
             )
@@ -3967,7 +3971,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 name_prop_node_index,
             )
@@ -3990,7 +3994,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4000,7 +4004,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4027,7 +4031,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -4162,7 +4166,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -4187,7 +4191,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -4214,7 +4218,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -4241,7 +4245,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 si_prop_node_index,
             )
@@ -4268,7 +4272,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 name_prop_node_index,
             )
@@ -4295,7 +4299,7 @@ mod test {
                 graph
                     .get_node_index_by_id(si_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 description_prop_node_index,
             )
@@ -4318,7 +4322,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4328,7 +4332,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4355,7 +4359,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -4532,7 +4536,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -4557,7 +4561,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -4584,7 +4588,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -4611,7 +4615,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 domain_prop_node_index,
             )
@@ -4638,7 +4642,7 @@ mod test {
                 graph
                     .get_node_index_by_id(domain_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 ports_prop_node_index,
             )
@@ -4665,7 +4669,7 @@ mod test {
                 graph
                     .get_node_index_by_id(ports_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 port_prop_node_index,
             )
@@ -4688,7 +4692,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -4698,7 +4702,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -4725,7 +4729,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )
@@ -5109,7 +5113,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_node_index,
             )
@@ -5134,7 +5138,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_node_index,
             )
@@ -5161,7 +5165,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_node_index,
             )
@@ -5188,7 +5192,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 domain_prop_node_index,
             )
@@ -5215,7 +5219,7 @@ mod test {
                 graph
                     .get_node_index_by_id(domain_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 environment_prop_node_index,
             )
@@ -5242,7 +5246,7 @@ mod test {
                 graph
                     .get_node_index_by_id(environment_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 env_var_prop_node_index,
             )
@@ -5265,7 +5269,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 component_node_index,
             )
@@ -5275,7 +5279,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -5298,7 +5302,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(change_set, EdgeWeightKind::use_not_as_default())
                     .expect("Unable to create EdgeWeight"),
                 root_av_node_index,
             )

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -27,7 +27,7 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::new_use())
                     .expect("could not create edge weight"),
                 schema_category_node_index,
             )
@@ -38,7 +38,7 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::use_not_as_default())
+                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::new_use())
                     .expect("could not create edge weight"),
                 func_category_node_index,
             )
@@ -66,7 +66,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             func_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             func_node_index,
         )
@@ -86,7 +86,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             schema_node_index,
         )
@@ -106,7 +106,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             schema_variant_node_index,
         )
@@ -118,7 +118,7 @@ mod test {
             .expect("could not get node index by id");
         onto.add_edge(
             schema_variant_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             func_node_index,
         )

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -27,7 +27,7 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("could not create edge weight"),
                 schema_category_node_index,
             )
@@ -38,7 +38,7 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::Use)
+                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::use_not_as_default())
                     .expect("could not create edge weight"),
                 func_category_node_index,
             )
@@ -66,7 +66,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             func_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::Use)
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
                 .expect("could not create edge weight"),
             func_node_index,
         )
@@ -86,7 +86,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::Use)
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
                 .expect("could not create edge weight"),
             schema_node_index,
         )
@@ -106,7 +106,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::Use)
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
                 .expect("could not create edge weight"),
             schema_variant_node_index,
         )
@@ -118,7 +118,7 @@ mod test {
             .expect("could not get node index by id");
         onto.add_edge(
             schema_variant_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::Use)
+            EdgeWeight::new(onto_change_set, EdgeWeightKind::use_not_as_default())
                 .expect("could not create edge weight"),
             func_node_index,
         )

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -397,9 +397,9 @@ async fn install_builtins(
     let dal = &ctx;
     let client = &module_index_client.clone();
     let modules: Vec<ModuleDetailsResponse> = module_list.modules;
-    //        .into_iter()
-    //        .filter(|m| m.name == "si-docker-image-builtin")
-    //        .collect();
+    // .into_iter()
+    // .filter(|m| m.name == "si-docker-image-builtin-20240130")
+    // .collect();
     let total = modules.len();
 
     let mut join_set = JoinSet::new();


### PR DESCRIPTION
Schema / Schema Variant Edges now exist as follows:

DEFAULT: Schema -> Uses -> Schema Variant

In order to make a schema variant the default for a schema, we need to update the
correct edge from Use to Default:

UPDATE: Schema -> Default -> Schema Variant

Therefore, when we are setting a default schema variant we need to find any existing
Default edges and convert them back to uses AND we need to find the existing Use edge
between our nodes and change that to be a Default