### PR TITLE
chore(dal): Ensure that all different get_code Language types are covered

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -816,6 +816,7 @@ async fn migrate_local_builtins(
     schemas::migrate_test_exclusive_schema_fallout(&ctx).await?;
     schemas::migrate_test_exclusive_schema_bethesda_secret(&ctx).await?;
     schemas::migrate_test_exclusive_schema_swifty(&ctx).await?;
+    schemas::migrate_test_exclusive_schema_katy_perry(&ctx).await?;
 
     ctx.blocking_commit().await?;
 

--- a/lib/dal-test/src/schemas/mod.rs
+++ b/lib/dal-test/src/schemas/mod.rs
@@ -1,10 +1,12 @@
 mod schema_helpers;
 mod test_exclusive_schema_bethesda_secret;
 mod test_exclusive_schema_fallout;
+mod test_exclusive_schema_katy_perry;
 mod test_exclusive_schema_starfield;
 mod test_exclusive_schema_swifty;
 
 pub use test_exclusive_schema_bethesda_secret::migrate_test_exclusive_schema_bethesda_secret;
 pub use test_exclusive_schema_fallout::migrate_test_exclusive_schema_fallout;
+pub use test_exclusive_schema_katy_perry::migrate_test_exclusive_schema_katy_perry;
 pub use test_exclusive_schema_starfield::migrate_test_exclusive_schema_starfield;
 pub use test_exclusive_schema_swifty::migrate_test_exclusive_schema_swifty;

--- a/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
@@ -1,0 +1,128 @@
+use crate::schemas::schema_helpers::{
+    build_asset_func, build_codegen_func, build_resource_payload_to_value_func,
+    create_identity_func,
+};
+use dal::pkg::import_pkg_from_pkg;
+use dal::{pkg, prop::PropPath, ComponentType};
+use dal::{BuiltinsResult, DalContext, PropKind};
+use si_pkg::{
+    AttrFuncInputSpec, AttrFuncInputSpecKind, LeafInputLocation, LeafKind, PkgSpec, PropSpec,
+    SchemaSpec, SchemaVariantSpec, SchemaVariantSpecData, SiPkg,
+};
+use si_pkg::{LeafFunctionSpec, SchemaSpecData};
+
+pub async fn migrate_test_exclusive_schema_katy_perry(ctx: &DalContext) -> BuiltinsResult<()> {
+    let mut kp_builder = PkgSpec::builder();
+
+    kp_builder
+        .name("katy perry")
+        .version("2024-03-12")
+        .created_by("System Initiative");
+
+    let identity_func_spec = create_identity_func();
+
+    // Create Scaffold Func
+    let fn_name = "test:scaffoldSwiftyKatyPerry";
+    let kp_authoring_schema_func = build_asset_func(fn_name).await?;
+
+    // Author Resource Payload Func
+    let resource_payload_to_value_func = build_resource_payload_to_value_func().await?;
+
+    // Build YAML CodeGen Func
+    let yaml_codegen_fn_name = "test:generateYamlCode";
+    let yaml_codegen_func_code = "async function main(input: Input): Promise < Output > {
+                return {
+                    format: \"yaml\",
+                    code: Object.keys(input.domain).length > 0 ? YAML.stringify(input.domain) : \"\"
+                };
+            }";
+    let yaml_code_gen_func =
+        build_codegen_func(yaml_codegen_func_code, yaml_codegen_fn_name).await?;
+
+    // Build string CodeGen Func
+    let string_codegen_fn_name = "test:generateStringCode";
+    let string_codegen_func_code = "async function main(input: Input): Promise < Output > {
+                return {
+                    format: \"string\",
+                    code: \"poop canoe\"
+                };
+            }";
+    let string_code_gen_func =
+        build_codegen_func(string_codegen_func_code, string_codegen_fn_name).await?;
+
+    let kp_schema = SchemaSpec::builder()
+        .name("katy perry")
+        .data(
+            SchemaSpecData::builder()
+                .name("katy perry")
+                .category("test exclusive")
+                .category_name("katy perry")
+                .build()
+                .expect("schema spec data build"),
+        )
+        .variant(
+            SchemaVariantSpec::builder()
+                .name("v0")
+                .unique_id("katy_perry_sv")
+                .data(
+                    SchemaVariantSpecData::builder()
+                        .name("v0")
+                        .color("#ffffff")
+                        .func_unique_id(&kp_authoring_schema_func.unique_id)
+                        .component_type(ComponentType::Component)
+                        .build()
+                        .expect("build variant spec data"),
+                )
+                .domain_prop(
+                    PropSpec::builder()
+                        .name("name")
+                        .kind(PropKind::String)
+                        .func_unique_id(&identity_func_spec.unique_id)
+                        .input(
+                            AttrFuncInputSpec::builder()
+                                .kind(AttrFuncInputSpecKind::Prop)
+                                .name("identity")
+                                .prop_path(PropPath::new(["root", "si", "name"]))
+                                .build()?,
+                        )
+                        .build()?,
+                )
+                .leaf_function(
+                    LeafFunctionSpec::builder()
+                        .func_unique_id(yaml_codegen_fn_name)
+                        .leaf_kind(LeafKind::CodeGeneration)
+                        .inputs(vec![LeafInputLocation::Domain])
+                        .build()?,
+                )
+                .leaf_function(
+                    LeafFunctionSpec::builder()
+                        .func_unique_id(string_codegen_fn_name)
+                        .leaf_kind(LeafKind::CodeGeneration)
+                        .inputs(vec![LeafInputLocation::Domain])
+                        .build()?,
+                )
+                .build()?,
+        )
+        .build()?;
+
+    let swifty_spec = kp_builder
+        .func(identity_func_spec)
+        .func(resource_payload_to_value_func)
+        .func(yaml_code_gen_func)
+        .func(string_code_gen_func)
+        .schema(kp_schema)
+        .build()?;
+
+    let swifty_pkg = SiPkg::load_from_spec(swifty_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &swifty_pkg,
+        Some(pkg::ImportOptions {
+            schemas: Some(vec!["katy perry".into()]),
+            ..Default::default()
+        }),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/lib/dal/tests/integration_test/component/get_code.rs
+++ b/lib/dal/tests/integration_test/component/get_code.rs
@@ -1,0 +1,95 @@
+use dal::code_view::CodeLanguage;
+use dal::{Component, DalContext};
+use dal_test::test;
+use dal_test::test_harness::create_component_for_schema_name;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn get_code_json_lang(ctx: &mut DalContext) {
+    let component = create_component_for_schema_name(ctx, "swifty", "shake it off").await;
+
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    ctx.update_snapshot_to_visibility()
+        .await
+        .expect("unable to update snapshot to visiblity");
+
+    let (codegen_view, has_code) = Component::list_code_generated(ctx, component.id())
+        .await
+        .expect("unable to get codegen views");
+
+    assert_eq!(codegen_view.len(), 1);
+    assert!(has_code, "true");
+
+    // This is safe as we would have failed the above test otherwise
+    let codegen = codegen_view.clone().pop().unwrap();
+
+    assert_eq!(codegen.language, CodeLanguage::Json,);
+    assert_eq!(codegen.func, Some("test:generateCode".to_string()));
+    assert_eq!(codegen.message, None);
+    assert_eq!(
+        codegen.code,
+        Some("{\n  \"name\": \"shake it off\"\n}".to_string())
+    );
+}
+
+#[test]
+async fn get_code_yaml_and_string(ctx: &mut DalContext) {
+    let component =
+        create_component_for_schema_name(ctx, "katy perry", "all codegen and no actions").await;
+
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    ctx.update_snapshot_to_visibility()
+        .await
+        .expect("unable to update snapshot to visiblity");
+
+    let (codegen_view, has_code) = Component::list_code_generated(ctx, component.id())
+        .await
+        .expect("unable to get codegen views");
+
+    assert_eq!(codegen_view.len(), 2);
+    assert!(has_code, "true");
+
+    let string_codegen = codegen_view
+        .iter()
+        .find(|&f| f.func == Some("test:generateStringCode".to_string()))
+        .expect("Unable to find string codegen func");
+
+    assert_eq!(string_codegen.language, CodeLanguage::String);
+    assert_eq!(string_codegen.message, None);
+    assert_eq!(string_codegen.code, Some("poop canoe".to_string()));
+
+    let yaml_codegen = codegen_view
+        .iter()
+        .find(|&f| f.func == Some("test:generateYamlCode".to_string()))
+        .expect("Unable to find yaml codegen func");
+
+    assert_eq!(yaml_codegen.language, CodeLanguage::Yaml);
+    assert_eq!(yaml_codegen.message, None);
+    assert_eq!(
+        yaml_codegen.code,
+        Some("name: all codegen and no actions\n".to_string())
+    );
+}
+
+#[test]
+async fn get_code_no_codegen_funcs(ctx: &mut DalContext) {
+    let starfield_component =
+        create_component_for_schema_name(ctx, "starfield", "no codegen funcs here").await;
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    ctx.update_snapshot_to_visibility()
+        .await
+        .expect("unable to update snapshot to visiblity");
+
+    let (codegen_view, has_code) = Component::list_code_generated(ctx, starfield_component.id())
+        .await
+        .expect("unable to get codegen views");
+
+    assert!(codegen_view.is_empty());
+    assert_eq!(has_code, false);
+}

--- a/lib/dal/tests/integration_test/component/set_type.rs
+++ b/lib/dal/tests/integration_test/component/set_type.rs
@@ -1,0 +1,23 @@
+use dal::{ComponentType, DalContext};
+use dal_test::test;
+use dal_test::test_harness::create_component_for_schema_name;
+
+#[test]
+async fn set_type(ctx: &mut DalContext) {
+    let component = create_component_for_schema_name(ctx, "starfield", "black star").await;
+
+    pretty_assertions_sorted::assert_eq!(
+        component.get_type(ctx).await.expect("could not get type"),
+        ComponentType::Component
+    );
+
+    component
+        .set_type(ctx, ComponentType::ConfigurationFrameUp)
+        .await
+        .expect("could not set type");
+
+    pretty_assertions_sorted::assert_eq!(
+        component.get_type(ctx).await.expect("could not get type"),
+        ComponentType::ConfigurationFrameUp
+    );
+}


### PR DESCRIPTION
This introduces a new test schema - Katy Perry - it's all codegen funcs and no actions :D
