### PR TITLE
Restore force change set and do not assume HEAD is nil (ENG-2400)

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -13,7 +13,6 @@ export enum ChangeSetStatus {
 export type ChangeSetId = string;
 export interface ChangeSet {
   id: ChangeSetId;
-  pk: ChangeSetId;
   name: string;
   status: ChangeSetStatus;
   appliedByUserId?: UserId;

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -329,7 +329,6 @@ import {
   Inline,
 } from "@si/vue-lib/design-system";
 import { storeToRefs } from "pinia";
-import { nilId } from "@/utils/nilId";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useActionsStore } from "@/store/actions.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
@@ -417,7 +416,7 @@ function onSelectChangeSet(newVal: string) {
   }
 
   if (newVal && route.name) {
-    if (newVal === nilId()) newVal = "head";
+    if (newVal === changeSetsStore.headChangeSetId) newVal = "head";
 
     // keep everything in the current route except the change set id
     // note - we use push here, so there is a new browser history entry
@@ -442,7 +441,7 @@ async function onCreateChangeSet() {
 
   if (createReq.result.success) {
     // reusing above to navigate to new change set... will probably clean this all up later
-    onSelectChangeSet(createReq.result.data.changeSet.pk);
+    onSelectChangeSet(createReq.result.data.changeSet.id);
     createModalRef.value?.close();
   }
 }

--- a/app/web/src/pages/WorkspaceSinglePage.vue
+++ b/app/web/src/pages/WorkspaceSinglePage.vue
@@ -86,7 +86,6 @@ import { useWorkspacesStore } from "@/store/workspaces.store";
 import AppLayout from "@/components/layout/AppLayout.vue";
 import Navbar from "@/components/layout/navbar/Navbar.vue";
 import StatusBar from "@/components/StatusBar/StatusBar.vue";
-import { nilId } from "@/utils/nilId";
 
 const props = defineProps({
   changeSetId: { type: String as PropType<string | "auto"> },
@@ -118,12 +117,14 @@ function handleUrlChange() {
 
   const changeSetId = route.params.changeSetId as string | undefined;
   if ([undefined, "null", "undefined", "auto"].includes(changeSetId ?? "")) {
-    const pk = changeSetsStore.getAutoSelectedChangeSetId();
+    const id = changeSetsStore.getAutoSelectedChangeSetId();
+
     router.replace({
       name: route.name, // eslint-disable-line @typescript-eslint/no-non-null-assertion
       params: {
         ...route.params,
-        changeSetId: pk === false || pk === nilId() ? "head" : pk,
+        changeSetId:
+          id === false || id === changeSetsStore.headChangeSetId ? "head" : id,
       },
       query: { ...route.query },
     });

--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -4,7 +4,6 @@ import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 import { trackEvent } from "@/utils/tracking";
 import { Resource } from "@/api/sdf/dal/resource";
 import { useWorkspacesStore } from "@/store/workspaces.store";
-import { nilId } from "@/utils/nilId";
 import { useChangeSetsStore } from "./change_sets.store";
 import { ComponentId } from "./components.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
@@ -204,7 +203,8 @@ export const useActionsStore = () => {
         },
         actions: {
           async FETCH_QUEUED_ACTIONS() {
-            if (changeSetId === nilId()) return ApiRequest.noop;
+            if (changeSetId === changeSetsStore.headChangeSetId)
+              return ApiRequest.noop;
             return new ApiRequest<{
               actions: Record<ActionId, ProposedAction>;
             }>({
@@ -258,15 +258,8 @@ export const useActionsStore = () => {
             });
           },
           async LOAD_ACTION_BATCHES() {
-            const head = changeSetsStore.allChangeSets.find(
-              (cs) => cs.baseChangeSetId === nilId(),
-            );
-            if (!head) throw new Error("no head");
             return new ApiRequest<Array<ActionBatch>>({
               url: "/action/history",
-              params: {
-                visibility_change_set_pk: head.id,
-              },
               onSuccess: (response) => {
                 this.actionBatches = response;
                 this.runningActionBatch = response.find(

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -262,7 +262,8 @@ export const useAssetStore = () => {
         async CREATE_ASSET(asset: Asset) {
           if (changeSetsStore.creatingChangeSet)
             throw new Error("race, wait until the change set is created");
-          if (changeSetId === nilId()) changeSetsStore.creatingChangeSet = true;
+          if (changeSetId === changeSetsStore.headChangeSetId)
+            changeSetsStore.creatingChangeSet = true;
           return new ApiRequest<
             { id: AssetId; success: boolean },
             AssetCreateRequest

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -2,17 +2,21 @@ import { defineStore } from "pinia";
 import * as _ from "lodash-es";
 import { watch } from "vue";
 import { ApiRequest, addStoreHooks } from "@si/vue-lib/pinia";
-import { ChangeSet, ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import {
+  ChangeSet,
+  ChangeSetId,
+  ChangeSetStatus,
+} from "@/api/sdf/dal/change_set";
 import router from "@/router";
 import { UserId } from "@/store/auth.store";
-import { nilId } from "@/utils/nilId";
 import { useWorkspacesStore } from "./workspaces.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import { useRouterStore } from "./router.store";
 
-export type ChangeSetId = string;
-
-const HEAD_ID = nilId();
+export interface OpenChangeSetsView {
+  headChangeSetId: ChangeSetId;
+  changeSets: ChangeSet[];
+}
 
 export function useChangeSetsStore() {
   const workspacesStore = useWorkspacesStore();
@@ -21,6 +25,7 @@ export function useChangeSetsStore() {
   return addStoreHooks(
     defineStore(`w${workspacePk || "NONE"}/change-sets`, {
       state: () => ({
+        headChangeSetId: null as ChangeSetId | null,
         changeSetsById: {} as Record<ChangeSetId, ChangeSet>,
         changeSetsWrittenAtById: {} as Record<ChangeSetId, Date>,
         creatingChangeSet: false as boolean,
@@ -39,16 +44,22 @@ export function useChangeSetsStore() {
             ].includes(cs.status),
           );
         },
-        urlSelectedChangeSetId: () => {
+        urlSelectedChangeSetId(): ChangeSetId | undefined {
           const route = useRouterStore().currentRoute;
           const id = route?.params?.changeSetId as ChangeSetId | undefined;
-          return id === "head" ? HEAD_ID : id;
+          if (id === "head" && this.headChangeSetId) {
+            return this.headChangeSetId;
+          }
+          return id;
         },
         selectedChangeSet(): ChangeSet | null {
           return this.changeSetsById[this.urlSelectedChangeSetId || ""] || null;
         },
         headSelected(): boolean {
-          return this.urlSelectedChangeSetId === HEAD_ID;
+          if (this.headChangeSetId) {
+            return this.urlSelectedChangeSetId === this.headChangeSetId;
+          }
+          return false;
         },
 
         selectedChangeSetLastWrittenAt(): Date | null {
@@ -84,16 +95,11 @@ export function useChangeSetsStore() {
         },
 
         async FETCH_CHANGE_SETS() {
-          return new ApiRequest<ChangeSet[]>({
-            // TODO: probably want to fetch all change sets, not just open (or could have a filter)
-            // this endpoint currently returns dropdown-y data, should just return the change set data itself
+          return new ApiRequest<OpenChangeSetsView>({
             url: "change_set/list_open_change_sets",
             onSuccess: (response) => {
-              const changeSets = _.map(response, (rawChangeSet) => ({
-                ...rawChangeSet,
-                id: rawChangeSet.pk,
-              }));
-              this.changeSetsById = _.keyBy(changeSets, "id");
+              this.headChangeSetId = response.headChangeSetId;
+              this.changeSetsById = _.keyBy(response.changeSets, "id");
             },
           });
         },
@@ -105,7 +111,7 @@ export function useChangeSetsStore() {
               changeSetName: name,
             },
             onSuccess: (response) => {
-              this.changeSetsById[response.changeSet.pk] = response.changeSet;
+              this.changeSetsById[response.changeSet.id] = response.changeSet;
             },
           });
         },
@@ -115,7 +121,7 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/abandon_change_set",
             params: {
-              changeSetPk: this.selectedChangeSet.pk,
+              changeSetPk: this.selectedChangeSet.id,
             },
             onSuccess: (response) => {
               // this.changeSetsById[response.changeSet.pk] = response.changeSet;
@@ -128,10 +134,10 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/apply_change_set",
             params: {
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
             onSuccess: (response) => {
-              this.changeSetsById[response.changeSet.pk] = response.changeSet;
+              this.changeSetsById[response.changeSet.id] = response.changeSet;
               // could switch to head here, or could let the caller decide...
             },
           });
@@ -143,7 +149,7 @@ export function useChangeSetsStore() {
             url: "change_set/merge_vote",
             params: {
               vote,
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -153,7 +159,7 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/begin_approval_process",
             params: {
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -163,7 +169,7 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/cancel_approval_process",
             params: {
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -176,7 +182,7 @@ export function useChangeSetsStore() {
             url: "change_set/abandon_vote",
             params: {
               vote,
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -186,7 +192,7 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/begin_abandon_approval_process",
             params: {
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -196,7 +202,7 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/cancel_abandon_approval_process",
             params: {
-              visibility_change_set_pk: this.selectedChangeSet.pk,
+              visibility_change_set_pk: this.selectedChangeSet.id,
             },
           });
         },
@@ -221,12 +227,10 @@ export function useChangeSetsStore() {
           if (this.openChangeSets?.length <= 2) {
             // will select the single open change set or head if thats all that exists
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            return _.last(this.openChangeSets)!.pk;
+            return _.last(this.openChangeSets)!.id;
           }
 
-          // can add more logic to auto select eventually...
-
-          return false;
+          return this.headChangeSetId ?? false;
         },
         getGeneratedChangesetName() {
           let latestNum = 0;
@@ -249,7 +253,7 @@ export function useChangeSetsStore() {
             if (this.selectedChangeSet && workspacePk) {
               sessionStorage.setItem(
                 `SI:LAST_CHANGE_SET/${workspacePk}`,
-                this.selectedChangeSet.pk,
+                this.selectedChangeSet.id,
               );
             }
           },
@@ -272,7 +276,9 @@ export function useChangeSetsStore() {
             eventType: "ChangeSetAbandoned",
             callback: async (data) => {
               if (data.changeSetPk === this.selectedChangeSetId) {
-                await this.setActiveChangeset(HEAD_ID);
+                if (this.headChangeSetId) {
+                  await this.setActiveChangeset(this.headChangeSetId);
+                }
               }
               await this.FETCH_CHANGE_SETS();
             },
@@ -288,7 +294,7 @@ export function useChangeSetsStore() {
               const changeSet = this.changeSetsById[changeSetPk];
               if (changeSet) {
                 changeSet.status = ChangeSetStatus.Abandoned;
-                if (this.selectedChangeSet?.pk === changeSetPk) {
+                if (this.selectedChangeSet?.id === changeSetPk) {
                   this.postAbandonActor = userPk;
                 }
                 this.changeSetsById[changeSetPk] = changeSet;
@@ -308,7 +314,7 @@ export function useChangeSetsStore() {
               const changeSet = this.changeSetsById[changeSetPk];
               if (changeSet) {
                 changeSet.status = ChangeSetStatus.Applied;
-                if (this.selectedChangeSet?.pk === changeSetPk) {
+                if (this.selectedChangeSet?.id === changeSetPk) {
                   this.postApplyActor = userPk;
                 }
                 this.changeSetsById[changeSetPk] = changeSet;
@@ -318,7 +324,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetBeginApprovalProcess",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals = {};
               }
               const changeSet = this.changeSetsById[data.changeSetPk];
@@ -332,7 +338,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetCancelApprovalProcess",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals = {};
               }
               const changeSet = this.changeSetsById[data.changeSetPk];
@@ -345,7 +351,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetBeginAbandonProcess",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals = {};
               }
               const changeSet = this.changeSetsById[data.changeSetPk];
@@ -359,7 +365,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetCancelAbandonProcess",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals = {};
               }
               const changeSet = this.changeSetsById[data.changeSetPk];
@@ -371,7 +377,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetMergeVote",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals[data.userPk] = data.vote;
               }
             },
@@ -379,7 +385,7 @@ export function useChangeSetsStore() {
           {
             eventType: "ChangeSetAbandonVote",
             callback: (data) => {
-              if (this.selectedChangeSet?.pk === data.changeSetPk) {
+              if (this.selectedChangeSet?.id === data.changeSetPk) {
                 this.changeSetApprovals[data.userPk] = data.vote;
               }
             },

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -9,7 +9,6 @@ import {
   PropertyEditorValue,
   PropertyEditorValues,
 } from "@/api/sdf/dal/property_editor";
-import { nilId } from "@/utils/nilId";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import { ComponentId, useComponentsStore } from "./components.store";
@@ -275,7 +274,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest<{ success: true }>({
@@ -296,7 +295,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             const isInsert = "insert" in updatePayload;
@@ -336,7 +335,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           async SET_COMPONENT_TYPE(payload: SetTypeArgs) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             const statusStore = useStatusStore();
@@ -361,7 +360,7 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
             return new ApiRequest<{ success: true }>({
               method: "post",

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -21,14 +21,17 @@ import {
   DiagramSchema,
   DiagramSchemaVariant,
 } from "@/api/sdf/dal/diagram";
-import { ChangeStatus, ComponentStats } from "@/api/sdf/dal/change_set";
+import {
+  ChangeStatus,
+  ComponentStats,
+  ChangeSetId,
+} from "@/api/sdf/dal/change_set";
+import router from "@/router";
 import { ComponentDiff } from "@/api/sdf/dal/component";
 import { Resource } from "@/api/sdf/dal/resource";
 import { CodeView } from "@/api/sdf/dal/code_view";
 import { ActorView } from "@/api/sdf/dal/history_actor";
-import { nilId } from "@/utils/nilId";
-import router from "@/router";
-import { ChangeSetId, useChangeSetsStore } from "./change_sets.store";
+import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import {
   QualificationStatus,
@@ -740,7 +743,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             const tempInsertId = _.uniqueId("temp-insert-component");
@@ -791,7 +794,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             const tempId = `temp-edge-${+new Date()}`;
@@ -851,7 +854,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest<{ node: DiagramNode }>({
@@ -876,7 +879,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async DETACH_COMPONENT(componentId: ComponentId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest<{ node: DiagramNode }>({
@@ -966,7 +969,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async DELETE_EDGE(edgeId: EdgeId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1018,7 +1021,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async RESTORE_EDGE(edgeId: EdgeId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1055,7 +1058,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async DELETE_COMPONENT(componentId: ComponentId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1100,7 +1103,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async RESTORE_COMPONENT(componentId: ComponentId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1125,7 +1128,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             this.pastingId = null;
@@ -1162,7 +1165,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async DELETE_COMPONENTS(componentIds: ComponentId[]) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1210,7 +1213,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           async RESTORE_COMPONENTS(componentIds: ComponentId[]) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             return new ApiRequest({
@@ -1336,7 +1339,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               params: {
                 componentId,
                 workspaceId: visibilityParams.workspaceId,
-                visibility_change_set_pk: nilId(),
+                visibility_change_set_pk: changeSetsStore.headChangeSetId,
               },
               onSuccess: (response) => {
                 // do nothing
@@ -1350,7 +1353,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               url: "component/refresh",
               params: {
                 workspaceId: visibilityParams.workspaceId,
-                visibility_change_set_pk: nilId(),
+                visibility_change_set_pk: changeSetsStore.headChangeSetId,
               },
               onSuccess: (response) => {
                 // do nothing

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -88,8 +88,12 @@ export const useFuncStore = () => {
   const componentsStore = useComponentsStore();
   const changeSetStore = useChangeSetsStore();
   const selectedChangeSetId = changeSetStore.selectedChangeSet?.id;
+
+  // TODO(nick): we need to allow for empty visibility here. Temporarily send down "nil" to mean that we want the
+  // query to find the default change set.
   const visibility: Visibility = {
-    visibility_change_set_pk: selectedChangeSetId ?? nilId(),
+    visibility_change_set_pk:
+      selectedChangeSetId ?? changeSetStore.headChangeSetId ?? nilId(),
   };
 
   const workspacesStore = useWorkspacesStore();

--- a/app/web/src/store/module.store.ts
+++ b/app/web/src/store/module.store.ts
@@ -314,7 +314,7 @@ export const useModuleStore = () => {
           async INSTALL_REMOTE_MODULE(moduleId: ModuleId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             this.installingModuleId = null;

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -3,8 +3,8 @@
 
 import { ActorView } from "@/api/sdf/dal/history_actor";
 import { FuncId } from "@/store/func/funcs.store";
-import { ChangeSetId } from "@/store/change_sets.store";
 import { DetachedAttributePrototype } from "@/store/asset.store";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { ComponentId } from "../components.store";
 import { WorkspacePk } from "../workspaces.store";
 import { ActionId, ActionStatus } from "../actions.store";

--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -7,7 +7,6 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { encryptMessage } from "@/utils/messageEncryption";
 import { PropertyEditorPropWidgetKind } from "@/api/sdf/dal/property_editor";
-import { nilId } from "@/utils/nilId";
 import { ActorAndTimestamp } from "./components.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 
@@ -213,7 +212,7 @@ export function useSecretsStore() {
           async UPDATE_SECRET(secret: Secret, value?: Record<string, string>) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             if (_.isEmpty(secret.name)) {
@@ -333,7 +332,7 @@ export function useSecretsStore() {
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             if (_.isEmpty(name)) {
@@ -429,7 +428,7 @@ export function useSecretsStore() {
           async DELETE_SECRET(id: SecretId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
-            if (changeSetId === nilId())
+            if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
             const secret = this.secretsById[id];

--- a/app/web/src/store/status.store.ts
+++ b/app/web/src/store/status.store.ts
@@ -3,7 +3,8 @@ import * as _ from "lodash-es";
 import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 import { ActorView } from "@/api/sdf/dal/history_actor";
 import { useWorkspacesStore } from "@/store/workspaces.store";
-import { ChangeSetId, useChangeSetsStore } from "./change_sets.store";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 
 import { ComponentId, SocketId, useComponentsStore } from "./components.store";

--- a/app/web/src/store/viz.store.ts
+++ b/app/web/src/store/viz.store.ts
@@ -45,8 +45,12 @@ export const useVizStore = () => {
   const selectedChangeSetId = changeSetStore.selectedChangeSetId;
   const workspacesStore = useWorkspacesStore();
   const workspaceId = workspacesStore.selectedWorkspacePk;
+
+  // TODO(nick): we need to allow for empty visibility here. Temporarily send down "nil" to mean that we want the
+  // query to find the default change set.
   const visibility: Visibility = {
-    visibility_change_set_pk: selectedChangeSetId ?? nilId(),
+    visibility_change_set_pk:
+      selectedChangeSetId ?? changeSetStore.headChangeSetId ?? nilId(),
   };
 
   return addStoreHooks(

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -39,6 +39,8 @@ export type WorkspaceImportSummary = {
 const LOCAL_STORAGE_LAST_WORKSPACE_PK = "si-last-workspace-pk";
 
 export const useWorkspacesStore = () => {
+  // TODO(nick): this is fine for now since workspaces are handled outside of the snapshots, but we will need to change
+  // this once the old change set concept is gone.
   const visibility: Visibility = {
     visibility_change_set_pk: nilId(),
   };

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -159,7 +159,7 @@ pub async fn create_change_set_and_update_ctx(
         )
         .await
         .expect("could not update pointer");
-    ctx.update_visibility_v2(&change_set)
+    ctx.update_visibility_and_snapshot_to_visibility(change_set.id)
         .await
         .expect("could not update visibility and snapshot");
 }

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -11,7 +11,7 @@ use buck2_resources::Buck2Resources;
 use content_store::PgStoreTools;
 use dal::{
     job::processor::{JobQueueProcessor, NatsProcessor},
-    DalContext, JwtPublicSigningKey, ModelResult, ServicesContext, Tenancy, Workspace,
+    DalContext, JwtPublicSigningKey, ModelResult, ServicesContext, Workspace,
 };
 use derive_builder::Builder;
 use jwt_simple::prelude::RS256KeyPair;
@@ -798,10 +798,7 @@ async fn migrate_local_builtins(
     let dal_context = services_context.into_builder(true);
     let mut ctx = dal_context.build_default().await?;
 
-    let workspace = Workspace::builtin(&mut ctx).await?;
-    ctx.update_tenancy(Tenancy::new(*workspace.pk()));
-    ctx.update_to_head();
-    ctx.update_snapshot_to_visibility().await?;
+    Workspace::setup_builtin(&mut ctx).await?;
 
     info!("migrating intrinsic functions");
     func::migrate_intrinsics(&ctx).await?;

--- a/lib/dal/src/change_set_pointer/view.rs
+++ b/lib/dal/src/change_set_pointer/view.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::change_set_pointer::{
+    ChangeSetPointer, ChangeSetPointerError, ChangeSetPointerId, ChangeSetPointerResult,
+};
+use crate::{ChangeSetStatus, DalContext, UserPk};
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenChangeSetsView {
+    pub head_change_set_id: ChangeSetPointerId,
+    pub change_sets: Vec<ChangeSetView>,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSetView {
+    pub id: ChangeSetPointerId,
+    pub name: String,
+    pub status: ChangeSetStatus,
+    pub merge_requested_at: Option<DateTime<Utc>>,
+    pub base_change_set_id: Option<ChangeSetPointerId>,
+    pub merge_requested_by_user_id: Option<UserPk>,
+    pub abandon_requested_at: Option<DateTime<Utc>>,
+    pub abandon_requested_by_user_id: Option<UserPk>,
+}
+
+impl OpenChangeSetsView {
+    pub async fn assemble(ctx: &DalContext) -> ChangeSetPointerResult<Self> {
+        // List all open change sets and assemble them into individual views.
+        let open_change_sets = ChangeSetPointer::list_open(ctx).await?;
+        let mut views = Vec::with_capacity(open_change_sets.len());
+        for change_set in open_change_sets {
+            views.push(ChangeSetView {
+                id: change_set.id,
+                name: change_set.name,
+                status: change_set.status,
+                base_change_set_id: change_set.base_change_set_id,
+                merge_requested_at: None,           // cs.merge_requested_at,
+                merge_requested_by_user_id: None,   // cs.merge_requested_by_user_id,
+                abandon_requested_at: None,         // cs.abandon_requested_at,
+                abandon_requested_by_user_id: None, // cs.abandon_requested_by_user_id,
+            });
+        }
+
+        // Ensure that we find exactly one change set view that matches the open change sets found.
+        let head_change_set_id = ctx.get_workspace_default_change_set_id().await?;
+        let maybe_head_change_set_id: Vec<ChangeSetPointerId> = views
+            .iter()
+            .filter_map(|v| {
+                if v.id == head_change_set_id {
+                    Some(v.id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if maybe_head_change_set_id.len() != 1 {
+            return Err(
+                ChangeSetPointerError::UnexpectedNumberOfOpenChangeSetsMatchingDefaultChangeSet(
+                    maybe_head_change_set_id,
+                ),
+            );
+        }
+
+        Ok(Self {
+            head_change_set_id,
+            change_sets: views,
+        })
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -20,6 +20,7 @@ pub mod builtins;
 pub mod change_set;
 pub mod change_set_pointer;
 pub mod change_status;
+pub mod code_view;
 pub mod component;
 pub mod context;
 pub mod diagram;
@@ -34,10 +35,13 @@ pub mod label_list;
 pub mod pkg;
 pub mod prop;
 pub mod property_editor;
+pub mod qualification;
 pub mod schema;
+pub mod secret;
 pub mod serde_impls;
 pub mod socket;
 pub mod standard_accessors;
+pub mod standard_id;
 pub mod standard_model;
 pub mod standard_pk;
 pub mod tenancy;
@@ -52,16 +56,12 @@ pub mod ws_event;
 // TODO(nick,jacob): this should self-destruct once the new engine is in place.
 // pub mod node;
 // pub mod socket;
-
-pub mod code_view;
 // pub mod edge;
 // pub mod index_map;
 // pub mod prop_tree;
 // pub mod prototype_context;
 // pub mod prototype_list_for_func;
-pub mod qualification;
 // pub mod reconciliation_prototype;
-pub mod secret;
 // pub mod status;
 //pub mod tasks;
 

--- a/lib/dal/src/standard_id.rs
+++ b/lib/dal/src/standard_id.rs
@@ -1,0 +1,112 @@
+#[macro_export]
+macro_rules! id {
+    (
+        $(#[$($attrss:tt)*])*
+        $name:ident
+    ) => {
+        $(#[$($attrss)*])*
+        #[derive(
+            Eq,
+            PartialEq,
+            PartialOrd,
+            Ord,
+            Copy,
+            Clone,
+            Hash,
+            derive_more::From,
+            derive_more::Into,
+            derive_more::Display,
+            serde::Serialize,
+            serde::Deserialize,
+        )]
+        pub struct $name(ulid::Ulid);
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name)).field(&self.0.to_string()).finish()
+            }
+        }
+
+        impl $name {
+            /// Generates a new key which is virtually guaranteed to be unique.
+            pub fn generate() -> Self {
+                Self(ulid::Ulid::new())
+            }
+
+            /// Converts type into inner [`Ulid`](::ulid::Ulid).
+            pub fn into_inner(self) -> ::ulid::Ulid {
+                self.0
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(id: $name) -> Self {
+                ulid::Ulid::from(id.0).into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for ulid::Ulid {
+            fn from(id: &'a $name) -> Self {
+                id.0
+            }
+        }
+
+        impl<'a> From<&'a $name> for $name {
+            fn from(id: &'a $name) -> Self {
+                *id
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = ulid::DecodeError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(ulid::Ulid::from_string(s)?))
+            }
+        }
+
+        impl<'a> postgres_types::FromSql<'a> for $name {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                raw: &'a [u8],
+            ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+                let id: String = postgres_types::FromSql::from_sql(ty, raw)?;
+                Ok(Self(ulid::Ulid::from_string(&id)?))
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+        }
+
+        impl postgres_types::ToSql for $name {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            where
+                Self: Sized,
+            {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool
+            where
+                Self: Sized,
+            {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+        }
+    };
+}

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -1,0 +1,120 @@
+use dal::change_set_pointer::view::OpenChangeSetsView;
+use dal::change_set_pointer::ChangeSetPointer;
+use dal::DalContext;
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+use std::collections::HashSet;
+
+#[test]
+async fn open_change_sets(ctx: &mut DalContext) {
+    let view = OpenChangeSetsView::assemble(ctx)
+        .await
+        .expect("could not assemble view");
+
+    // Check that the expected number of open change sets exist.
+    assert_eq!(
+        2,                      // expected
+        view.change_sets.len()  // actual
+    );
+
+    // Check that we collected "head" properly.
+    let head_change_set_id = ctx
+        .get_workspace_default_change_set_id()
+        .await
+        .expect("could not get the default change set id for the workspace");
+    assert_eq!(
+        head_change_set_id,      // expected
+        view.head_change_set_id  // actual
+    );
+
+    // Ensure that the current change set is not "head".
+    let current_change_set_id = ctx.change_set_id();
+    assert_ne!(current_change_set_id, head_change_set_id);
+
+    // Ensure that the views contain the change sets that we expect.
+    let change_set_ids = HashSet::from_iter(view.change_sets.iter().map(|c| c.id));
+    assert_eq!(
+        HashSet::from([current_change_set_id, head_change_set_id]), // expected
+        change_set_ids,                                             // actual
+    );
+
+    // Apply the change set and perform a blocking commit.
+    let mut change_set = ChangeSetPointer::find(ctx, ctx.change_set_id())
+        .await
+        .expect("could not perform find change set")
+        .expect("no change set found");
+    change_set
+        .apply_to_base_change_set(ctx)
+        .await
+        .expect("could not apply to base change set");
+    let conflicts = ctx
+        .blocking_commit()
+        .await
+        .expect("could not perform commit");
+    assert!(conflicts.is_none());
+
+    // Assemble the view again and ensure only "head" exists.
+    let mut view = OpenChangeSetsView::assemble(ctx)
+        .await
+        .expect("could not assemble view");
+
+    // Check that the expected number of open change sets exist. There should only be one.
+    let head_change_set_view = view.change_sets.pop().expect("change sets are empty");
+    assert!(view.change_sets.is_empty());
+    assert_eq!(
+        view.head_change_set_id, // expected
+        head_change_set_view.id  // actual
+    );
+    assert_eq!(
+        head_change_set_id,      // expected
+        head_change_set_view.id  // actual
+    );
+
+    // Create a new change set and perform a commit without rebasing.
+    let new_change_set = ChangeSetPointer::fork_head(ctx, "new change set")
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility_and_snapshot_to_visibility(new_change_set.id)
+        .await
+        .expect("could not update visibility");
+    ctx.commit_no_rebase()
+        .await
+        .expect("could not perform commit");
+
+    // List views again.
+    let view = OpenChangeSetsView::assemble(ctx)
+        .await
+        .expect("could not assemble view");
+
+    // Check that the expected number of open change sets exist... again.
+    assert_eq!(
+        2,                      // expected
+        view.change_sets.len()  // actual
+    );
+
+    // Check that we collected "head" properly... again.
+    let head_change_set_id_again = ctx
+        .get_workspace_default_change_set_id()
+        .await
+        .expect("could not get the default change set id for the workspace");
+    assert_eq!(
+        head_change_set_id,       // expected
+        head_change_set_id_again  // actual
+    );
+    assert_eq!(
+        head_change_set_id,      // expected
+        view.head_change_set_id  // actual
+    );
+
+    // Ensure that the current change set is not "head"... again.
+    let current_change_set_id_again = ctx.change_set_id();
+    assert_ne!(head_change_set_id, current_change_set_id_again);
+    assert_ne!(current_change_set_id, current_change_set_id_again);
+
+    // Ensure that the views contain the change sets that we expect... again.
+    let change_set_ids_again = HashSet::from_iter(view.change_sets.iter().map(|c| c.id));
+    assert_eq!(
+        HashSet::from([current_change_set_id_again, head_change_set_id_again]), // expected
+        change_set_ids_again,                                                   // actual
+    );
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,5 +1,6 @@
 mod before_funcs;
 mod builtins;
+mod change_set;
 mod component;
 mod connection;
 mod frame;

--- a/lib/rebaser-server/src/server/core_loop.rs
+++ b/lib/rebaser-server/src/server/core_loop.rs
@@ -175,7 +175,7 @@ async fn perform_rebase_and_reply_infallible(
             return;
         }
     };
-    ctx.update_visibility(Visibility::new_head(false));
+    ctx.update_visibility_deprecated(Visibility::new_head(false));
     ctx.update_tenancy(Tenancy::new(WorkspacePk::NONE));
 
     let reply_subject = reply_subject.to_subject();

--- a/lib/sdf-server/src/server/service/action/history.rs
+++ b/lib/sdf-server/src/server/service/action/history.rs
@@ -1,18 +1,10 @@
-use axum::{extract::Query, Json};
+use axum::Json;
 use dal::action::runner::ActionHistoryView;
-use dal::Visibility;
 use dal::{ActionBatch, ActionBatchId, ActionCompletionStatus};
 use serde::{Deserialize, Serialize};
 
 use super::ActionResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ListActionHistoryRequest {
-    #[serde(flatten)]
-    pub visibility: Visibility,
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -31,9 +23,8 @@ pub type ListActionHistoryResponse = Vec<BatchHistoryView>;
 pub async fn history(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    Query(request): Query<ListActionHistoryRequest>,
 ) -> ActionResult<Json<ListActionHistoryResponse>> {
-    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let ctx = builder.build_head(request_ctx).await?;
 
     let mut batch_views = Vec::new();
     for batch in ActionBatch::list(&ctx).await? {

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -44,6 +44,8 @@ pub enum ChangeSetError {
     ActionRunner(#[from] ActionRunnerError),
     // #[error("action {0} not found")]
     // ActionNotFound(ActionId),
+    #[error("base change set not found for change set: {0}")]
+    BaseChangeSetNotFound(ChangeSetPointerId),
     #[error(transparent)]
     ChangeSet(#[from] DalChangeSetError),
     #[error("change set not found")]

--- a/lib/sdf-server/src/server/service/change_set/create_change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set/create_change_set.rs
@@ -31,6 +31,8 @@ pub async fn create_change_set(
 
     let change_set_name = &request.change_set_name;
 
+    // TODO(nick): this should not always fork "head". It should fork from the base change set id or
+    // "head".
     let change_set_pointer = ChangeSetPointer::fork_head(&ctx, change_set_name).await?;
 
     track(

--- a/lib/sdf-server/src/server/service/change_set/list_open_change_sets.rs
+++ b/lib/sdf-server/src/server/service/change_set/list_open_change_sets.rs
@@ -1,44 +1,10 @@
 use axum::Json;
-use chrono::{DateTime, Utc};
-//use dal::action::ActionId;
-use dal::change_set_pointer::{ChangeSetPointer, ChangeSetPointerId};
-use dal::ActionKind;
-use dal::{ActionPrototypeId, ChangeSetStatus, ComponentId, UserPk};
-use serde::{Deserialize, Serialize};
-use ulid::Ulid;
+use dal::change_set_pointer::view::OpenChangeSetsView;
 
 use super::ChangeSetResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct ActionView {
-    // FIXME(nick,zack,jacob): drop ActionId since it does not exist yet for the graph switchover.
-    pub id: Ulid,
-    pub action_prototype_id: ActionPrototypeId,
-    pub kind: ActionKind,
-    pub name: String,
-    pub component_id: ComponentId,
-    pub actor: Option<String>,
-    pub parents: Vec<()>,
-}
-
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct ChangeSetView {
-    // TODO: pk and id are now identical and one of them should be removed
-    pub id: ChangeSetPointerId,
-    pub pk: ChangeSetPointerId,
-    pub name: String,
-    pub status: ChangeSetStatus,
-    pub merge_requested_at: Option<DateTime<Utc>>,
-    pub base_change_set_id: ChangeSetPointerId,
-    pub merge_requested_by_user_id: Option<UserPk>,
-    pub abandon_requested_at: Option<DateTime<Utc>>,
-    pub abandon_requested_by_user_id: Option<UserPk>,
-}
-
-pub type ListOpenChangeSetsResponse = Vec<ChangeSetView>;
+pub type ListOpenChangeSetsResponse = OpenChangeSetsView;
 
 pub async fn list_open_change_sets(
     HandlerContext(builder): HandlerContext,
@@ -46,22 +12,7 @@ pub async fn list_open_change_sets(
 ) -> ChangeSetResult<Json<ListOpenChangeSetsResponse>> {
     let ctx = builder.build_head(access_builder).await?;
 
-    let list = ChangeSetPointer::list_open(&ctx).await?;
-    let mut view = Vec::with_capacity(list.len());
-    for cs in list {
-        view.push(ChangeSetView {
-            // TODO: remove change sets entirely!
-            id: cs.id,
-            pk: cs.id,
-            name: cs.name,
-            status: cs.status,
-            base_change_set_id: cs.base_change_set_id.unwrap_or_default(),
-            merge_requested_at: None,           // cs.merge_requested_at,
-            merge_requested_by_user_id: None,   // cs.merge_requested_by_user_id,
-            abandon_requested_at: None,         // cs.abandon_requested_at,
-            abandon_requested_by_user_id: None, // cs.abandon_requested_by_user_id,
-        });
-    }
+    let view = OpenChangeSetsView::assemble(&ctx).await?;
 
     Ok(Json(view))
 }


### PR DESCRIPTION
## Description

This commit restores "force change set" functionality into the system, but it required removing and replacing assumptions about what "HEAD visibility" means... all over the system.

In the old engine, you could assume the HEAD visibility because it was a `nilId` for every tenant, workspace, etc. In the new engine, workspaces should have different default change set ids (essentially "HEAD"). Therefore, we cannot assume HEAD will be the `nilId` and we need to derive it from the workspace. This commit follows the aforementioned design goal by adjusting how builtin workspace creation works and how we derive HEAD everywhere in all critical paths of the codebase.

There's more work to be done, like completely switching over to the new `ChangeSetPointer` (to be renamed `ChangeSet`) domain and refactoring remaining visibility mutation locations, but this first pass should set us up for the future.

<img src="https://media2.giphy.com/media/0QpOJRpBQqX27MzPCQ/giphy.gif"/>

## Disclaimer

As mentioned above, there are many more locations to clean up. Moreover, we may want to investigate making `headChangeSetId` become non-nullable in the frontend. Perhaps, we get it from the workspace.

There's all the question of naming: head, base, default... lot of names for kinds of `ChangeSets`. Fortunately, the ubiquitous language is solid. We just need to be careful here to not conflate names. This will come as we refactor and polish the domains.

## Backend Changes

- Create a new `ChangeSetPointer` using a generated `Ulid` rather than `NONE` for the builtin workspace's default change set id
- Set up the builtin workspace internally rather than returning it
- Ensure `force_new` uses the default change set id for the workspace to determine HEAD
- Rename `update_visibility` functions to reflect real world use
- Add new `standard_id` module with an `id!` macro
- Use the new `id!` macro to remove `NONE` from `ChangeSetPointerId`
- Drop pk from `ChangeSetPointer`
- Move updating change set status to `Applied` inside `apply_to_base_change_set`
- Consolidate open change set views in backend to one location
- Add head change set id to open change set views return type
- Remove `NONE` assumptions from `DalContext` for `ChangeSetPointerId` (use default change set id instead)
- Add integration test for open change sets view

## Frontend Changes

- Derive the head change set from the backend route
- Use `headChangeSetId` returned from the `list_open_change_sets` route
- Replace `nilId` usages and HEAD assumptions with the `headChangeSetId`
- Drop pk from `ChangeSet` and update usages to use the id
- Remove duplicate `ChangeSetId` definitions
