### PR TITLE
fix(si-layer-cache): write generates the keys from the hash of the value

### DIFF
--- a/lib/si-events-rs/src/actor.rs
+++ b/lib/si-events-rs/src/actor.rs
@@ -35,3 +35,9 @@ impl FromStr for UserPk {
         Ok(Self(Ulid::from_str(s)?))
     }
 }
+
+impl From<ulid::Ulid> for UserPk {
+    fn from(value: ulid::Ulid) -> Self {
+        Self(value)
+    }
+}

--- a/lib/si-events-rs/src/tenancy.rs
+++ b/lib/si-events-rs/src/tenancy.rs
@@ -30,6 +30,12 @@ impl FromStr for WorkspacePk {
     }
 }
 
+impl From<ulid::Ulid> for WorkspacePk {
+    fn from(value: ulid::Ulid) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ChangeSetPk(Ulid);
 
@@ -49,6 +55,12 @@ impl Default for ChangeSetPk {
     }
 }
 
+impl From<ulid::Ulid> for ChangeSetPk {
+    fn from(value: ulid::Ulid) -> Self {
+        Self(value)
+    }
+}
+
 impl FromStr for ChangeSetPk {
     type Err = ulid::DecodeError;
 
@@ -57,7 +69,7 @@ impl FromStr for ChangeSetPk {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Tenancy {
     pub change_set_pk: ChangeSetPk,
     pub workspace_pk: WorkspacePk,


### PR DESCRIPTION
Generating the key before sending the data to the `write` method means serializing twice, since we'll need to get the postcard bytes to serialize the data (and then serialize the data in the write method). Write should handle this. For non content-address keys we will need a different interface.

Also adds some extensions to some types in `si-events` to ease conversion from dal types.