### PR TITLE
ENG-2403 TS was out of alignment with the rust typedef, now matching

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -797,13 +797,9 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             const tempId = `temp-edge-${+new Date()}`;
 
             return new ApiRequest<{
-              connection: {
-                id: string;
-                classification: "configuration";
-                destination: { nodeId: string; socketId: string };
-                source: { nodeId: string; socketId: string };
-              };
-              forceChangesetPk?: string;
+              id: string;
+              creatd_by: string | null;
+              deleted_by: string | null;
             }>({
               method: "post",
               url: "diagram/create_connection",
@@ -819,7 +815,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 if (this.edgesById[tempId]) {
                   const edge = this.edgesById[tempId];
                   if (edge) {
-                    this.edgesById[response.connection.id] = edge;
+                    this.edgesById[response.id] = edge;
                     delete this.edgesById[tempId];
                   }
                 }


### PR DESCRIPTION
Rust is: `{id, created_by:None, deleted_by: None}`

TS was:
```
connection: {
                id: string;
                classification: "configuration";
                destination: { nodeId: string; socketId: string };
                source: { nodeId: string; socketId: string };
              };
              forceChangesetPk?: string;
```