### PR TITLE
fix: add healthcheck to postgres + only report healthy when database are available

### DIFF
--- a/component/postgres/multiple-database-support.sh
+++ b/component/postgres/multiple-database-support.sh
@@ -36,6 +36,11 @@ create_db() {
 	EOF
 }
 
+# This adds a "ready-file" so that the postgres container only reports ready
+# after all the databases have been created. This prevents SDF or any other
+# consuming service starting before postgres is ready
+echo "ready" >/tmp/ready
+
 die() {
   printf -- "\nxxx %s\n\n" "$1" >&2
   exit 1

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -12,6 +12,11 @@ services:
       - "POSTGRES_MULTIPLE_DBS=si_content_store,si_layer_db,si_auth,si_module_index,si_key_value_pairs"
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /tmp/ready ]"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   postgres-test:
     image: systeminit/postgres:stable
@@ -28,6 +33,11 @@ services:
       - "full_page_writes=off"
     ports:
       - "6432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /tmp/ready ]"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   nats:
     image: systeminit/nats:stable
@@ -37,6 +47,11 @@ services:
     ports:
       - "4222:4222"
       - "8222:8222"
+    # We can't have the docker-compose finish before postgres is ready, this is 
+    # a workaround to allow the rest of the tilt file continue to create sdf etc
+    # so that the start doesn't fail as the databases don't exist
+    depends_on:
+      - postgres
 
   jaeger:
     image: systeminit/jaeger:stable


### PR DESCRIPTION
This prevents downstream services to postgres starting before the databases in postgres are available

Validated locally. Needs the clients to pull the newest image for postgres to consume the change.