### PR TITLE
feat(layer-cache): add get_bulk method to layer-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,6 +5587,7 @@ dependencies = [
  "lazy_static",
  "moka",
  "postcard",
+ "rand 0.8.5",
  "refinery",
  "remain",
  "serde",

--- a/lib/si-layer-cache/BUCK
+++ b/lib/si-layer-cache/BUCK
@@ -47,6 +47,7 @@ rust_test(
         "//third-party/rust:futures",
         "//third-party/rust:moka",
         "//third-party/rust:postcard",
+        "//third-party/rust:rand",
         "//third-party/rust:serde_json",
         "//third-party/rust:sled",
         "//third-party/rust:tempfile",

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -32,6 +32,7 @@ buck2-resources = { path = "../../lib/buck2-resources" }
 criterion = { workspace = true }
 moka = { workspace = true }
 postcard = { workspace = true }
+rand = { workspace = true }
 sled = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/lib/si-layer-cache/src/db/cas.rs
+++ b/lib/si-layer-cache/src/db/cas.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -61,5 +62,9 @@ where
 
     pub async fn read(&self, key: &CasPk) -> LayerDbResult<Option<Arc<V>>> {
         self.cache.get(key).await
+    }
+
+    pub async fn read_many(&self, keys: &[CasPk]) -> LayerDbResult<HashMap<CasPk, Arc<V>>> {
+        self.cache.get_bulk(keys).await
     }
 }

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -73,35 +73,10 @@ where
 
     pub async fn get_bulk(&self, keys: &[K]) -> LayerDbResult<HashMap<K, V>> {
         let mut found_keys = HashMap::new();
-        let mut not_found: Vec<K> = vec![];
 
         for key in keys {
-            if let Some(found) = match self.memory_cache.get(key).await {
-                Some(memory_value) => Some(memory_value),
-                None => match self.disk_cache.get(key)? {
-                    Some(value) => {
-                        let deserialized: V = postcard::from_bytes(&value)?;
-
-                        self.memory_cache.insert(*key, deserialized.clone()).await;
-                        Some(deserialized)
-                    }
-                    None => {
-                        not_found.push(*key);
-                        None
-                    }
-                },
-            } {
-                found_keys.insert(*key, found);
-            }
-        }
-
-        if !not_found.is_empty() {
-            if let Some(pg_found) = self.pg.get_many(&not_found).await? {
-                for (k, v) in pg_found {
-                    let deserialized: V = postcard::from_bytes(&v)?;
-                    self.memory_cache.insert(k, deserialized.clone()).await;
-                    found_keys.insert(k, deserialized);
-                }
+            if let Some(v) = self.get(key).await? {
+                found_keys.insert(*key, v);
             }
         }
 

--- a/lib/si-layer-cache/src/pg.rs
+++ b/lib/si-layer-cache/src/pg.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::{marker::PhantomData, sync::Arc};
 
 use si_data_pg::{PgPool, PgPoolConfig};
@@ -30,7 +29,6 @@ where
     pool: Arc<PgPool>,
     pub table_name: String,
     get_value_query: String,
-    get_value_many_query: String,
     insert_value_query: String,
     contains_key_query: String,
     search_query: String,
@@ -39,14 +37,13 @@ where
 
 impl<K> PgLayer<K>
 where
-    K: AsRef<[u8]> + Copy + Send + Sync + std::hash::Hash + std::cmp::Eq,
+    K: AsRef<[u8]> + Copy + Send + Sync,
 {
     pub fn new(pg_pool: PgPool, table_name: impl Into<String>) -> Self {
         let table_name = table_name.into();
         Self {
             pool: Arc::new(pg_pool),
             get_value_query: format!("SELECT value FROM {table_name} WHERE key = $1 LIMIT 1"),
-            get_value_many_query: format!("SELECT value FROM {table_name} WHERE key = any($1)"),
             insert_value_query: format!("INSERT INTO {table_name} (key, sort_key, value) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING"),
             contains_key_query: format!("SELECT key FROM {table_name} WHERE key = $1 LIMIT 1"),
             search_query: format!("SELECT value FROM {table_name} WHERE sort_key LIKE $1"),
@@ -70,27 +67,6 @@ where
             Some(row) => Ok(Some(row.get("value"))),
             None => Ok(None),
         }
-    }
-
-    pub async fn get_many(&self, keys: &[K]) -> LayerDbResult<Option<HashMap<K, Vec<u8>>>> {
-        let mut result = HashMap::new();
-        let client = self.pool.get().await?;
-
-        let key_refs: Vec<_> = keys.iter().map(|k| k.as_ref()).collect();
-
-        let maybe_rows = client
-            .query(&self.get_value_many_query, &[&key_refs])
-            .await?;
-
-        if maybe_rows.is_empty() {
-            return Ok(None);
-        }
-
-        for (key, row) in keys.iter().zip(maybe_rows.into_iter()) {
-            result.insert(*key, row.get("value"));
-        }
-
-        Ok(Some(result))
     }
 
     pub async fn search(&self, sort_key_like: impl AsRef<str>) -> LayerDbResult<Vec<Vec<u8>>> {

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -84,3 +84,51 @@ async fn get_inserts_to_memory() {
 
     assert!(layer_cache.memory_cache().contains(&skid_row));
 }
+
+#[tokio::test]
+async fn get_bulk_inserts_to_memory() {
+    let layer_cache = make_layer_cache("get_bulk_inserts_to_memory").await;
+
+    let values = ["skid row", "kid scrow", "march for macragge"];
+
+    for value in &values {
+        layer_cache.insert(value, value.to_string()).await
+    }
+
+    let get_values = layer_cache
+        .get_bulk(&values)
+        .await
+        .expect("should get bulk");
+
+    for value in values {
+        assert_eq!(value, get_values[value]);
+    }
+}
+
+#[tokio::test]
+async fn get_bulk_from_db() {
+    let layer_cache = make_layer_cache("get_bulk").await;
+
+    let values = [
+        "skid row",
+        "kid scrow",
+        "march for macragge",
+        "magnus did nothing wrong",
+        "steppa pig",
+    ];
+
+    for value in values {
+        let _ = layer_cache.pg().insert(value, "cas", value.as_ref()).await;
+    }
+
+    let get_values = layer_cache
+        .pg()
+        .get_many(values.as_ref())
+        .await
+        .expect("should get bulk")
+        .expect("should have results");
+
+    for value in values {
+        assert_eq!(value.as_bytes(), get_values[value]);
+    }
+}

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -1,3 +1,5 @@
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use si_layer_cache::layer_cache::LayerCache;
 
 async fn make_layer_cache(db_name: &str) -> LayerCache<&'static str, String> {
@@ -109,7 +111,7 @@ async fn get_bulk_inserts_to_memory() {
 async fn get_bulk_from_db() {
     let layer_cache = make_layer_cache("get_bulk").await;
 
-    let values = [
+    let mut values = [
         "skid row",
         "kid scrow",
         "march for macragge",
@@ -117,18 +119,23 @@ async fn get_bulk_from_db() {
         "steppa pig",
     ];
 
-    for value in values {
-        let _ = layer_cache.pg().insert(value, "cas", value.as_ref()).await;
-    }
+    let mut rng = thread_rng();
 
-    let get_values = layer_cache
-        .pg()
-        .get_many(values.as_ref())
-        .await
-        .expect("should get bulk")
-        .expect("should have results");
+    for _i in 0..5 {
+        values.shuffle(&mut rng);
+        for value in values {
+            let _ = layer_cache.pg().insert(value, "cas", value.as_ref()).await;
+        }
 
-    for value in values {
-        assert_eq!(value.as_bytes(), get_values[value]);
+        let get_values = layer_cache
+            .pg()
+            .get_many(values.as_ref())
+            .await
+            .expect("should get bulk")
+            .expect("should have results");
+
+        for value in values {
+            assert_eq!(value.as_bytes(), get_values[value]);
+        }
     }
 }

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-use rand::thread_rng;
 use si_layer_cache::layer_cache::LayerCache;
 
 async fn make_layer_cache(db_name: &str) -> LayerCache<&'static str, String> {
@@ -104,38 +102,5 @@ async fn get_bulk_inserts_to_memory() {
 
     for value in values {
         assert_eq!(value, get_values[value]);
-    }
-}
-
-#[tokio::test]
-async fn get_bulk_from_db() {
-    let layer_cache = make_layer_cache("get_bulk").await;
-
-    let mut values = [
-        "skid row",
-        "kid scrow",
-        "march for macragge",
-        "magnus did nothing wrong",
-        "steppa pig",
-    ];
-
-    let mut rng = thread_rng();
-
-    for _i in 0..5 {
-        values.shuffle(&mut rng);
-        for value in values {
-            let _ = layer_cache.pg().insert(value, "cas", value.as_ref()).await;
-        }
-
-        let get_values = layer_cache
-            .pg()
-            .get_many(values.as_ref())
-            .await
-            .expect("should get bulk")
-            .expect("should have results");
-
-        for value in values {
-            assert_eq!(value.as_bytes(), get_values[value]);
-        }
     }
 }


### PR DESCRIPTION
This can be used to get many values from the cache at once. Values that fall through to database queries will be batched into a single query.<img src="https://media3.giphy.com/media/G4AdhRHsJK1ZbSCRRB/giphy.gif"/>