### PR TITLE
feat(layer-cache): get_many returns to the PgLayer

### DIFF
--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -1,3 +1,5 @@
+use rand::thread_rng;
+use rand::seq::SliceRandom;
 use std::sync::Arc;
 
 use si_layer_cache::layer_cache::LayerCache;
@@ -111,5 +113,38 @@ async fn get_bulk_inserts_to_memory() {
     for value in values {
         let key = value.to_string();
         assert_eq!(key, get_values[&key]);
+    }
+}
+
+#[tokio::test]
+async fn get_bulk_from_db() {
+    let layer_cache = make_layer_cache("get_bulk").await;
+
+    let mut values = [
+        "skid row",
+        "kid scrow",
+        "march for macragge",
+        "magnus did nothing wrong",
+        "steppa pig",
+    ];
+
+    let mut rng = thread_rng();
+
+    for _i in 0..5 {
+        values.shuffle(&mut rng);
+        for value in values {
+            let _ = layer_cache.pg().insert(value, "cas", value.as_ref()).await;
+        }
+
+        let get_values = layer_cache
+            .pg()
+            .get_many(values.as_ref())
+            .await
+            .expect("should get bulk")
+            .expect("should have results");
+
+        for value in values {
+            assert_eq!(value.as_bytes(), get_values[value]);
+        }
     }
 }


### PR DESCRIPTION
Now that the values in pg are strings this is much more straightforward to implement.

<img src="https://media1.giphy.com/media/C9pYsj3Lk0ET0Y9JUu/giphy-downsized-medium.gif"/>

