### PR TITLE
feat(*): move workspace snapshots into layerdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,6 +4445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "si-data-nats",
+ "si-events",
  "telemetry",
  "thiserror",
  "ulid",
@@ -4456,6 +4457,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "si-events",
  "ulid",
 ]
 

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -154,7 +154,7 @@ pub async fn create_change_set_and_update_ctx(
         .update_pointer(
             ctx,
             base_change_set
-                .workspace_snapshot_id
+                .workspace_snapshot_address
                 .expect("no workspace snapshot set on base change set"),
         )
         .await

--- a/lib/dal/src/migrations/U3001__change_set_pointers.sql
+++ b/lib/dal/src/migrations/U3001__change_set_pointers.sql
@@ -1,12 +1,12 @@
 CREATE TABLE change_set_pointers
 (
-    id                    ident primary key        NOT NULL DEFAULT ident_create_v1(),
-    created_at            timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
-    updated_at            timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
-    name                  text                     NOT NULL,
-    base_change_set_id    ident,
-    status                text                     NOT NULL,
+    id                         ident primary key        NOT NULL DEFAULT ident_create_v1(),
+    created_at                 timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at                 timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    name                       text                     NOT NULL,
+    base_change_set_id         ident,
+    status                     text                     NOT NULL,
 
-    workspace_id          ident REFERENCES workspaces (pk) DEFERRABLE,
-    workspace_snapshot_id ident REFERENCES workspace_snapshots (id)
+    workspace_id               ident                    REFERENCES workspaces (pk) DEFERRABLE,
+    workspace_snapshot_address text
 );

--- a/lib/dal/src/queries/workspace_snapshot/find_for_change_set.sql
+++ b/lib/dal/src/queries/workspace_snapshot/find_for_change_set.sql
@@ -1,4 +1,0 @@
-SELECT * FROM workspace_snapshots
-JOIN change_set_pointers
-    ON change_set_pointers.id = $1
-           AND change_set_pointers.workspace_snapshot_id = workspace_snapshots.id

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -110,6 +110,10 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
     .await
     .expect("able to make a func");
 
+    Func::get_by_id(ctx, func.id)
+        .await
+        .expect("able to get func by id before commit");
+
     ctx.commit().await.expect("unable to commit");
 
     ctx.update_snapshot_to_visibility()
@@ -118,7 +122,7 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
 
     Func::get_by_id(ctx, func.id)
         .await
-        .expect("able to get func by id");
+        .expect("able to get func by id after rebase");
 
     let new_code_base64 = general_purpose::STANDARD_NO_PAD.encode("this is new code");
 

--- a/lib/rebaser-client/BUCK
+++ b/lib/rebaser-client/BUCK
@@ -5,6 +5,7 @@ rust_library(
     deps = [
         "//lib/rebaser-core:rebaser-core",
         "//lib/si-data-nats:si-data-nats",
+        "//lib/si-events-rs:si-events",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:futures",
         "//third-party/rust:remain",

--- a/lib/rebaser-client/Cargo.toml
+++ b/lib/rebaser-client/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 rebaser-core = { path = "../../lib/rebaser-core" }
 si-data-nats = { path = "../../lib/si-data-nats" }
+si-events = { path = "../../lib/si-events-rs" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
 futures = { workspace = true }

--- a/lib/rebaser-client/src/lib.rs
+++ b/lib/rebaser-client/src/lib.rs
@@ -32,6 +32,7 @@ use rebaser_core::{RebaserMessagingConfig, RequestRebaseMessage, SubjectGenerato
 use si_data_nats::jetstream::{Context, JetstreamError};
 use si_data_nats::subject::ToSubject;
 use si_data_nats::NatsClient;
+use si_events::WorkspaceSnapshotAddress;
 use telemetry::prelude::error;
 use thiserror::Error;
 use ulid::Ulid;
@@ -85,7 +86,7 @@ impl Client {
     pub async fn request_rebase(
         &self,
         to_rebase_change_set_id: Ulid,
-        onto_workspace_snapshot_id: Ulid,
+        onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
     ) -> ClientResult<ReplyRebaseMessage> {
         let subject = SubjectGenerator::request(
@@ -96,7 +97,7 @@ impl Client {
 
         let serialized_messaged = serde_json::to_vec(&RequestRebaseMessage {
             to_rebase_change_set_id,
-            onto_workspace_snapshot_id,
+            onto_workspace_snapshot_address,
             onto_vector_clock_id,
         })?;
 

--- a/lib/rebaser-core/BUCK
+++ b/lib/rebaser-core/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "rebaser-core",
     deps = [
+        "//lib/si-events-rs:si-events",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",
         "//third-party/rust:ulid",

--- a/lib/rebaser-core/Cargo.toml
+++ b/lib/rebaser-core/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 serde = { workspace = true }
 serde_json = { workspace = true }
 ulid = { workspace = true }
+si-events = { path = "../../lib/si-events-rs" }

--- a/lib/rebaser-core/src/lib.rs
+++ b/lib/rebaser-core/src/lib.rs
@@ -31,6 +31,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
+use si_events::WorkspaceSnapshotAddress;
 use ulid::Ulid;
 
 mod messaging_config;
@@ -46,7 +47,7 @@ pub struct RequestRebaseMessage {
     pub to_rebase_change_set_id: Ulid,
     /// Corresponds to the workspace snapshot that will be the "onto" workspace snapshot when
     /// rebasing the "to rebase" workspace snapshot.
-    pub onto_workspace_snapshot_id: Ulid,
+    pub onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
     /// Derived from the ephemeral or persisted change set that's either the base change set, the
     /// last change set before edits were made, or the change set that you are trying to rebase
     /// onto base.

--- a/lib/rebaser-server/src/server/rebase.rs
+++ b/lib/rebaser-server/src/server/rebase.rs
@@ -44,17 +44,18 @@ pub(crate) async fn perform_rebase(
             .ok_or(RebaseError::MissingChangeSetPointer(
                 message.to_rebase_change_set_id.into(),
             ))?;
-    let to_rebase_workspace_snapshot_id = to_rebase_change_set.workspace_snapshot_id.ok_or(
-        RebaseError::MissingWorkspaceSnapshotForChangeSet(to_rebase_change_set.id),
-    )?;
+    let to_rebase_workspace_snapshot_address =
+        to_rebase_change_set.workspace_snapshot_address.ok_or(
+            RebaseError::MissingWorkspaceSnapshotForChangeSet(to_rebase_change_set.id),
+        )?;
     info!("before snapshot fetch and parse: {:?}", start.elapsed());
     let to_rebase_workspace_snapshot =
-        WorkspaceSnapshot::find(ctx, to_rebase_workspace_snapshot_id).await?;
+        WorkspaceSnapshot::find(ctx, to_rebase_workspace_snapshot_address).await?;
     let onto_workspace_snapshot: WorkspaceSnapshot =
-        WorkspaceSnapshot::find(ctx, message.onto_workspace_snapshot_id.into()).await?;
+        WorkspaceSnapshot::find(ctx, message.onto_workspace_snapshot_address).await?;
     info!(
         "to_rebase_id: {}, onto_id: {}",
-        to_rebase_workspace_snapshot_id,
+        to_rebase_workspace_snapshot_address,
         onto_workspace_snapshot.id().await
     );
     info!("after snapshot fetch and parse: {:?}", start.elapsed());

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -3,8 +3,10 @@ mod cas;
 pub mod content_hash;
 mod tenancy;
 mod web_event;
+pub mod workspace_snapshot_address;
 
 pub use crate::{
     actor::Actor, actor::UserPk, cas::CasValue, content_hash::ContentHash, tenancy::ChangeSetId,
     tenancy::Tenancy, tenancy::WorkspacePk, web_event::WebEvent,
+    workspace_snapshot_address::WorkspaceSnapshotAddress,
 };

--- a/lib/si-events-rs/src/workspace_snapshot_address.rs
+++ b/lib/si-events-rs/src/workspace_snapshot_address.rs
@@ -1,0 +1,121 @@
+use bytes::BytesMut;
+use postgres_types::ToSql;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Serialize,
+};
+use std::{fmt, str::FromStr};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct WorkspaceSnapshotAddress(blake3::Hash);
+
+impl WorkspaceSnapshotAddress {
+    #[must_use]
+    pub fn new(input: &[u8]) -> Self {
+        Self(blake3::hash(input))
+    }
+
+    pub fn nil() -> Self {
+        Self(blake3::Hash::from_bytes([0; 32]))
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("failed to parse hash hex string")]
+pub struct WorkspaceSnapshotAddressParseError(#[from] blake3::HexError);
+
+impl FromStr for WorkspaceSnapshotAddress {
+    type Err = WorkspaceSnapshotAddressParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(blake3::Hash::from_str(s)?))
+    }
+}
+
+impl std::fmt::Display for WorkspaceSnapshotAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serialize for WorkspaceSnapshotAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+struct WorkspaceSnapshotAddressVisitor;
+
+impl<'de> Visitor<'de> for WorkspaceSnapshotAddressVisitor {
+    type Value = WorkspaceSnapshotAddress;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a blake3 hash string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        WorkspaceSnapshotAddress::from_str(v).map_err(|e| E::custom(e.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceSnapshotAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(WorkspaceSnapshotAddressVisitor)
+    }
+}
+
+impl ToSql for WorkspaceSnapshotAddress {
+    fn to_sql(
+        &self,
+        ty: &postgres_types::Type,
+        out: &mut BytesMut,
+    ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let self_string = self.to_string();
+
+        self_string.to_sql(ty, out)
+    }
+
+    fn accepts(ty: &postgres_types::Type) -> bool
+    where
+        Self: Sized,
+    {
+        String::accepts(ty)
+    }
+
+    fn to_sql_checked(
+        &self,
+        ty: &postgres_types::Type,
+        out: &mut BytesMut,
+    ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        let self_string = self.to_string();
+        self_string.to_sql_checked(ty, out)
+    }
+}
+
+impl<'a> postgres_types::FromSql<'a> for WorkspaceSnapshotAddress {
+    fn from_sql(
+        ty: &postgres_types::Type,
+        raw: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        let hash_string: String = postgres_types::FromSql::from_sql(ty, raw)?;
+        Ok(Self(blake3::Hash::from_str(&hash_string)?))
+    }
+
+    fn accepts(ty: &postgres_types::Type) -> bool {
+        ty == &postgres_types::Type::TEXT
+            || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::TEXT)
+    }
+}

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use serde::{de::DeserializeOwned, Serialize};
+use si_events::{Actor, Tenancy, WebEvent, WorkspaceSnapshotAddress};
+
+use crate::{
+    error::LayerDbResult,
+    event::{LayeredEvent, LayeredEventKind},
+    layer_cache::LayerCache,
+    persister::{PersisterClient, PersisterStatusReader},
+};
+
+pub const DBNAME: &str = "workspace_snapshots";
+pub const CACHE_NAME: &str = "workspace_snapshots";
+pub const PARTITION_KEY: &str = "workspace_snapshots";
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceSnapshotDb<V>
+where
+    V: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    pub cache: LayerCache<Arc<V>>,
+    persister_client: PersisterClient,
+}
+
+impl<V> WorkspaceSnapshotDb<V>
+where
+    V: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    pub fn new(cache: LayerCache<Arc<V>>, persister_client: PersisterClient) -> Self {
+        Self {
+            cache,
+            persister_client,
+        }
+    }
+
+    pub async fn write(
+        &self,
+        value: Arc<V>,
+        web_events: Option<Vec<WebEvent>>,
+        tenancy: Tenancy,
+        actor: Actor,
+    ) -> LayerDbResult<(WorkspaceSnapshotAddress, PersisterStatusReader)> {
+        let postcard_value = postcard::to_stdvec(&value)?;
+        let key = WorkspaceSnapshotAddress::new(&postcard_value);
+        let cache_key: Arc<str> = key.to_string().into();
+
+        self.cache.insert(cache_key.clone(), value.clone()).await;
+
+        let event = LayeredEvent::new(
+            LayeredEventKind::SnapshotWrite,
+            Arc::new(DBNAME.to_string()),
+            cache_key,
+            Arc::new(postcard_value),
+            Arc::new("workspace_snapshot".to_string()),
+            web_events,
+            tenancy,
+            actor,
+        );
+        let reader = self.persister_client.write_event(event)?;
+
+        Ok((key, reader))
+    }
+
+    pub async fn read(&self, key: &WorkspaceSnapshotAddress) -> LayerDbResult<Option<Arc<V>>> {
+        self.cache.get(key.to_string().into()).await
+    }
+}

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -58,6 +58,7 @@ impl std::str::FromStr for LayeredEventId {
 pub enum LayeredEventKind {
     CasInsertion,
     Raw,
+    SnapshotWrite,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -1,9 +1,7 @@
+use std::{collections::HashMap, fmt::Display, path::Path, sync::Arc};
+
 use serde::{de::DeserializeOwned, Serialize};
 use si_data_pg::{PgPool, PgPoolConfig};
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::path::Path;
-use std::sync::Arc;
 
 use crate::disk_cache::DiskCache;
 use crate::error::LayerDbResult;
@@ -28,7 +26,7 @@ where
     pub async fn new(name: &str, fast_disk: sled::Db, pg_pool: PgPool) -> LayerDbResult<Self> {
         let disk_cache = Arc::new(DiskCache::new(fast_disk, name.as_bytes())?);
 
-        let pg = PgLayer::new(pg_pool.clone(), "cas");
+        let pg = PgLayer::new(pg_pool.clone(), name);
 
         Ok(LayerCache {
             memory_cache: MemoryCache::new(),

--- a/lib/si-layer-cache/src/migrations/U0002__workspace_snapshots.sql
+++ b/lib/si-layer-cache/src/migrations/U0002__workspace_snapshots.sql
@@ -1,0 +1,10 @@
+CREATE TABLE workspace_snapshots
+(
+    key               text                      NOT NULL PRIMARY KEY,
+    sort_key          text                      NOT NULL,
+    created_at        timestamp with time zone  NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    value             bytea                     NOT NULL,
+    serialization_lib text                      NOT NULL DEFAULT 'postcard'
+);
+
+CREATE INDEX IF NOT EXISTS workspace_snapshots_sort_key ON workspace_snapshots (sort_key);

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -6,10 +6,12 @@ use tokio::time::Instant;
 
 use crate::integration_test::{setup_nats_client, setup_pg_db};
 
+type TestLayerDb = LayerDb<CasValue, String>;
+
 #[tokio::test]
 async fn write_to_db() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let ldb = LayerDb::new(
+    let ldb: TestLayerDb = LayerDb::new(
         tempdir,
         setup_pg_db("cas_write_to_db").await,
         setup_nats_client(Some("cas_write_to_db".to_string())).await,
@@ -70,7 +72,7 @@ async fn write_to_db() {
 #[tokio::test]
 async fn write_and_read_many() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let ldb = LayerDb::new(
+    let ldb: TestLayerDb = LayerDb::new(
         tempdir,
         setup_pg_db("cas_write_and_read_many").await,
         setup_nats_client(Some("cas_write_and_read_many".to_string())).await,
@@ -119,7 +121,7 @@ async fn write_and_read_many() {
 #[tokio::test]
 async fn cold_read_from_db() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let ldb = LayerDb::new(
+    let ldb: TestLayerDb = LayerDb::new(
         tempdir,
         setup_pg_db("cas_cold_read_from_db").await,
         setup_nats_client(Some("cas_cold_read_from_db".to_string())).await,
@@ -211,7 +213,7 @@ async fn writes_are_gossiped() {
     let db = setup_pg_db("cas_writes_are_gossiped").await;
 
     // First, we need a layerdb for slash
-    let ldb_slash = LayerDb::new(
+    let ldb_slash: TestLayerDb = LayerDb::new(
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("cas_writes_are_gossiped".to_string())).await,
@@ -221,7 +223,7 @@ async fn writes_are_gossiped() {
     ldb_slash.pg_migrate().await.expect("migrate layerdb");
 
     // Then, we need a layerdb for axl
-    let ldb_axl = LayerDb::new(
+    let ldb_axl: TestLayerDb = LayerDb::new(
         tempdir_axl,
         db,
         setup_nats_client(Some("cas_write_to_db".to_string())).await,

--- a/lib/si-layer-cache/tests/integration_test/db/mod.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/mod.rs
@@ -16,6 +16,8 @@ use ulid::Ulid;
 
 use crate::integration_test::{setup_nats_client, setup_pg_db};
 
+type TestLayerDb = LayerDb<Arc<String>, String>;
+
 #[tokio::test]
 async fn activities() {
     let tempdir_slash = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
@@ -23,7 +25,7 @@ async fn activities() {
     let db = setup_pg_db("activities").await;
 
     // First, we need a layerdb for slash
-    let ldb_slash: LayerDb<Arc<String>> = LayerDb::new(
+    let ldb_slash: LayerDb<Arc<String>, String> = LayerDb::new(
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("activities".to_string())).await,
@@ -33,7 +35,7 @@ async fn activities() {
     ldb_slash.pg_migrate().await.expect("migrate layerdb");
 
     // Then, we need a layerdb for axl
-    let ldb_axl: LayerDb<Arc<String>> = LayerDb::new(
+    let ldb_axl: TestLayerDb = LayerDb::new(
         tempdir_axl,
         db,
         setup_nats_client(Some("activities".to_string())).await,
@@ -76,7 +78,7 @@ async fn activities_subscribe_partial() {
     let db = setup_pg_db("activities_subscribe_partial").await;
 
     // First, we need a layerdb for slash
-    let ldb_slash: LayerDb<Arc<String>> = LayerDb::new(
+    let ldb_slash: TestLayerDb = LayerDb::new(
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("activities_subscribe_partial".to_string())).await,
@@ -86,7 +88,7 @@ async fn activities_subscribe_partial() {
     ldb_slash.pg_migrate().await.expect("migrate layerdb");
 
     // Then, we need a layerdb for axl
-    let ldb_axl: LayerDb<Arc<String>> = LayerDb::new(
+    let ldb_axl: TestLayerDb = LayerDb::new(
         tempdir_axl,
         db,
         setup_nats_client(Some("activities_subscribe_partial".to_string())).await,

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -8,7 +8,7 @@ async fn make_layer_cache(db_name: &str) -> LayerCache<String> {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let db = sled::open(tempdir).expect("unable to open sled database");
 
-    let layer_cache = LayerCache::new("test1", db, super::setup_pg_db(db_name).await)
+    let layer_cache = LayerCache::new("cas", db, super::setup_pg_db(db_name).await)
         .await
         .expect("cannot create layer cache");
     layer_cache.pg().migrate().await.expect("migrate");


### PR DESCRIPTION
Moves storage and fetch of the workspace snapshot into its own layer cache and database (WorkspaceSnapshotDb). This enables us to use an Arc without extra copying when performing read-only graph operations.

Some changes were required to the blocking_commit and commit internals to ensure we perform a rebase even if no transaction has been opened in the Dal Postgres transactions state.