### PR TITLE
fix(*): upgrade opentelemetry crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,13 +217,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -245,18 +245,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -428,10 +428,10 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 dependencies = [
  "serde",
 ]
@@ -620,15 +620,15 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "syn_derive",
 ]
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -864,14 +864,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -899,9 +899,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -982,7 +982,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
  "tracing",
 ]
 
@@ -1114,7 +1114,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 name = "council"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "council-server",
  "si-std",
@@ -1284,7 +1284,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
  "parking_lot 0.12.1",
@@ -1379,14 +1379,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "cyclone"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "cyclone-server",
  "telemetry-application",
@@ -1623,7 +1623,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1645,7 +1645,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2025,7 +2025,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2254,9 +2254,9 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -2273,7 +2273,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2510,6 +2510,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2743,8 +2749,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.52",
- "toml 0.8.11",
+ "syn 2.0.53",
+ "toml 0.8.12",
  "unicode-xid",
 ]
 
@@ -2819,7 +2825,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2877,6 +2883,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2972,7 +2987,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -3051,7 +3066,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3142,7 +3157,7 @@ dependencies = [
 name = "module-index"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "module-index-server",
  "si-std",
@@ -3351,7 +3366,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "libc",
 ]
@@ -3555,13 +3570,12 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.5",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3571,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3590,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3602,18 +3616,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
-dependencies = [
- "opentelemetry",
-]
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3702,11 +3713,11 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3715,12 +3726,12 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3917,7 +3928,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3936,7 +3947,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pinga"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "pinga-server",
  "si-std",
@@ -4094,10 +4105,10 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4224,16 +4235,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "version_check",
- "yansi 1.0.0",
+ "yansi 1.0.1",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes 1.5.0",
  "prost-derive",
@@ -4241,15 +4252,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4278,7 +4289,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "memchr",
  "unicase",
 ]
@@ -4400,7 +4411,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -4427,7 +4438,7 @@ dependencies = [
 name = "rebaser"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "rebaser-server",
  "telemetry-application",
@@ -4539,12 +4550,12 @@ dependencies = [
  "log",
  "regex",
  "serde",
- "siphasher 1.0.0",
+ "siphasher 1.0.1",
  "thiserror",
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.11",
+ "toml 0.8.12",
  "url",
  "walkdir",
 ]
@@ -4559,7 +4570,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4614,7 +4625,7 @@ checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4628,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
@@ -4822,11 +4833,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4967,7 +4978,7 @@ dependencies = [
 name = "sdf"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "nats-multiplexer",
  "rebaser-client",
@@ -5041,18 +5052,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "sea-orm"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe"
+checksum = "c8814e37dc25de54398ee62228323657520b7f29713b8e238649385dbe473ee0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5078,15 +5089,15 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa"
+checksum = "5e115c6b078e013aa963cc2d38c196c2c40b05f03d0ac872fe06b6e0d5265603"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.52",
+ "syn 2.0.53",
  "unicode-ident",
 ]
 
@@ -5224,7 +5235,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5266,7 +5277,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5343,7 +5354,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5355,14 +5366,14 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
  "indexmap 2.2.5",
  "itoa",
@@ -5406,7 +5417,7 @@ dependencies = [
 name = "si"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "derive_builder",
  "serde_json",
@@ -5461,7 +5472,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.8.11",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -5656,7 +5667,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5731,9 +5742,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skeptic"
@@ -5929,7 +5940,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -5956,7 +5967,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "bytes 1.5.0",
  "chrono",
@@ -6003,7 +6014,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "chrono",
  "crc",
@@ -6125,11 +6136,11 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6164,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6182,7 +6193,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6336,7 +6347,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6365,7 +6376,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6480,7 +6491,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6571,9 +6582,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6583,9 +6594,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
  "bytes 1.5.0",
@@ -6646,14 +6657,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.7",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -6678,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -6691,16 +6702,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes 1.5.0",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -6745,7 +6755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bytes 1.5.0",
  "futures-core",
  "futures-util",
@@ -6792,7 +6802,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6828,9 +6838,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -6841,7 +6851,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "web-time 0.2.4",
+ "web-time",
 ]
 
 [[package]]
@@ -6921,7 +6931,7 @@ dependencies = [
  "getrandom 0.2.12",
  "rand 0.8.5",
  "serde",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -6980,9 +6990,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -7028,9 +7038,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
@@ -7052,7 +7062,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "veritech"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "si-std",
  "telemetry-application",
@@ -7215,7 +7225,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -7249,7 +7259,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7265,16 +7275,6 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7575,9 +7575,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2861d76f58ec8fc95708b9b1e417f7b12fd72ad33c01fa6886707092dea0d3"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yrs"
@@ -7611,7 +7611,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7631,5 +7631,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,10 +125,10 @@ nkeys = "0.4.0"
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 open = "5.0.0"
-opentelemetry = { version = "0.21.0", features = ["trace"] }
-opentelemetry-otlp = "0.14.0"
-opentelemetry-semantic-conventions = "0.13.0"
-opentelemetry_sdk = { version = "0.21.1", features = ["rt-tokio"] }
+opentelemetry = { version = "0.22.0", features = ["trace"] }
+opentelemetry-otlp = "0.15.0"
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 ouroboros = "0.18.1"
 paste = "1.0.12"
 pathdiff = "0.2.1"
@@ -203,7 +203,7 @@ tower-http = { version = "0.4", features = [
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.22.0"
+tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -29,7 +29,7 @@ use opentelemetry_sdk::{
 };
 use opentelemetry_semantic_conventions::resource;
 use telemetry::{
-    opentelemetry::{global, trace::TraceError},
+    opentelemetry::{global, trace::TraceError, KeyValue},
     prelude::*,
     tracing::Subscriber,
     TelemetryCommand, TracingLevel, Verbosity,
@@ -406,9 +406,12 @@ fn telemetry_resource(config: &TelemetryConfig) -> Resource {
         ],
     )
     .merge(&Resource::new(vec![
-        resource::SERVICE_NAME.string(config.service_name.to_string()),
-        resource::SERVICE_VERSION.string(config.service_version.to_string()),
-        resource::SERVICE_NAMESPACE.string("si"),
+        KeyValue::new(resource::SERVICE_NAME, config.service_name.to_string()),
+        KeyValue::new(
+            resource::SERVICE_VERSION,
+            config.service_version.to_string(),
+        ),
+        KeyValue::new(resource::SERVICE_NAMESPACE, "si"),
     ]))
 }
 

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -407,18 +407,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anyhow-1.0.80.crate",
-    sha256 = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1",
-    strip_prefix = "anyhow-1.0.80",
-    urls = ["https://crates.io/api/v1/crates/anyhow/1.0.80/download"],
+    name = "anyhow-1.0.81.crate",
+    sha256 = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247",
+    strip_prefix = "anyhow-1.0.81",
+    urls = ["https://crates.io/api/v1/crates/anyhow/1.0.81/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anyhow-1.0.80",
-    srcs = [":anyhow-1.0.80.crate"],
+    name = "anyhow-1.0.81",
+    srcs = [":anyhow-1.0.81.crate"],
     crate = "anyhow",
-    crate_root = "anyhow-1.0.80.crate/src/lib.rs",
+    crate_root = "anyhow-1.0.81.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -485,7 +485,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":brotli-3.4.0",
+        ":brotli-3.5.0",
         ":flate2-1.0.28",
         ":futures-core-0.3.30",
         ":memchr-2.7.1",
@@ -569,7 +569,7 @@ cargo.rust_library(
         ":serde_json-1.0.114",
         ":serde_nanos-0.1.3",
         ":serde_repr-0.1.18",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tokio-1.36.0",
         ":tokio-retry-0.3.0",
@@ -581,30 +581,30 @@ cargo.rust_library(
 
 alias(
     name = "async-recursion",
-    actual = ":async-recursion-1.0.5",
+    actual = ":async-recursion-1.1.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-recursion-1.0.5.crate",
-    sha256 = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0",
-    strip_prefix = "async-recursion-1.0.5",
-    urls = ["https://crates.io/api/v1/crates/async-recursion/1.0.5/download"],
+    name = "async-recursion-1.1.0.crate",
+    sha256 = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5",
+    strip_prefix = "async-recursion-1.1.0",
+    urls = ["https://crates.io/api/v1/crates/async-recursion/1.1.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-recursion-1.0.5",
-    srcs = [":async-recursion-1.0.5.crate"],
+    name = "async-recursion-1.1.0",
+    srcs = [":async-recursion-1.1.0.crate"],
     crate = "async_recursion",
-    crate_root = "async-recursion-1.0.5.crate/src/lib.rs",
+    crate_root = "async-recursion-1.1.0.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -647,38 +647,38 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
 alias(
     name = "async-trait",
-    actual = ":async-trait-0.1.77",
+    actual = ":async-trait-0.1.78",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-trait-0.1.77.crate",
-    sha256 = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9",
-    strip_prefix = "async-trait-0.1.77",
-    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.77/download"],
+    name = "async-trait-0.1.78.crate",
+    sha256 = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85",
+    strip_prefix = "async-trait-0.1.78",
+    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.78/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-trait-0.1.77",
-    srcs = [":async-trait-0.1.77.crate"],
+    name = "async-trait-0.1.78",
+    srcs = [":async-trait-0.1.78.crate"],
     crate = "async_trait",
-    crate_root = "async-trait-0.1.77.crate/src/lib.rs",
+    crate_root = "async-trait-0.1.78.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -869,7 +869,7 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
         ":serde-1.0.197",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":url-2.5.0",
     ],
@@ -882,7 +882,7 @@ cargo.rust_library(
     crate_root = "rust-s3-61c54947c717d042/aws-region/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":thiserror-1.0.57"],
+    deps = [":thiserror-1.0.58"],
 )
 
 alias(
@@ -921,7 +921,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":axum-core-0.3.4",
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
@@ -940,7 +940,7 @@ cargo.rust_library(
         ":pin-project-lite-0.2.13",
         ":serde-1.0.197",
         ":serde_json-1.0.114",
-        ":serde_path_to_error-0.1.15",
+        ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
@@ -968,7 +968,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":bytes-1.5.0",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -998,9 +998,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -1237,18 +1237,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "bitflags-2.4.2.crate",
-    sha256 = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf",
-    strip_prefix = "bitflags-2.4.2",
-    urls = ["https://crates.io/api/v1/crates/bitflags/2.4.2/download"],
+    name = "bitflags-2.5.0.crate",
+    sha256 = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1",
+    strip_prefix = "bitflags-2.5.0",
+    urls = ["https://crates.io/api/v1/crates/bitflags/2.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bitflags-2.4.2",
-    srcs = [":bitflags-2.4.2.crate"],
+    name = "bitflags-2.5.0",
+    srcs = [":bitflags-2.5.0.crate"],
     crate = "bitflags",
-    crate_root = "bitflags-2.4.2.crate/src/lib.rs",
+    crate_root = "bitflags-2.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "serde",
@@ -1286,14 +1286,14 @@ cargo.rust_library(
 
 alias(
     name = "blake3",
-    actual = ":blake3-1.5.0",
+    actual = ":blake3-1.5.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "blake3-1.5.0.crate",
-    sha256 = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87",
-    strip_prefix = "blake3-1.5.0",
+    name = "blake3-1.5.1.crate",
+    sha256 = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52",
+    strip_prefix = "blake3-1.5.1",
     sub_targets = [
         "c/blake3.c",
         "c/blake3.h",
@@ -1314,15 +1314,15 @@ http_archive(
         "c/blake3_sse41_x86-64_windows_gnu.S",
         "c/blake3_sse41_x86-64_windows_msvc.asm",
     ],
-    urls = ["https://crates.io/api/v1/crates/blake3/1.5.0/download"],
+    urls = ["https://crates.io/api/v1/crates/blake3/1.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "blake3-1.5.0",
-    srcs = [":blake3-1.5.0.crate"],
+    name = "blake3-1.5.1",
+    srcs = [":blake3-1.5.1.crate"],
     crate = "blake3",
-    crate_root = "blake3-1.5.0.crate/src/lib.rs",
+    crate_root = "blake3-1.5.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -1331,7 +1331,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             rustc_flags = ["--cfg=blake3_neon"],
-            deps = [":blake3-1.5.0-simd_neon-aarch64"],
+            deps = [":blake3-1.5.1-simd_neon-aarch64"],
         ),
         "linux-x86_64": dict(
             rustc_flags = [
@@ -1340,11 +1340,11 @@ cargo.rust_library(
                 "--cfg=blake3_sse2_ffi",
                 "--cfg=blake3_sse41_ffi",
             ],
-            deps = [":blake3-1.5.0-simd_x86_unix"],
+            deps = [":blake3-1.5.1-simd_x86_unix"],
         ),
         "macos-arm64": dict(
             rustc_flags = ["--cfg=blake3_neon"],
-            deps = [":blake3-1.5.0-simd_neon-aarch64"],
+            deps = [":blake3-1.5.1-simd_neon-aarch64"],
         ),
         "macos-x86_64": dict(
             rustc_flags = [
@@ -1353,7 +1353,7 @@ cargo.rust_library(
                 "--cfg=blake3_sse2_ffi",
                 "--cfg=blake3_sse41_ffi",
             ],
-            deps = [":blake3-1.5.0-simd_x86_unix"],
+            deps = [":blake3-1.5.1-simd_x86_unix"],
         ),
         "windows-gnu": dict(
             rustc_flags = [
@@ -1362,7 +1362,7 @@ cargo.rust_library(
                 "--cfg=blake3_sse2_ffi",
                 "--cfg=blake3_sse41_ffi",
             ],
-            deps = [":blake3-1.5.0-simd_x86_windows_gnu"],
+            deps = [":blake3-1.5.1-simd_x86_windows_gnu"],
         ),
         "windows-msvc": dict(
             rustc_flags = [
@@ -1371,7 +1371,7 @@ cargo.rust_library(
                 "--cfg=blake3_sse2_ffi",
                 "--cfg=blake3_sse41_ffi",
             ],
-            deps = [":blake3-1.5.0-simd_x86_windows_msvc"],
+            deps = [":blake3-1.5.1-simd_x86_windows_msvc"],
         ),
     },
     visibility = [],
@@ -1384,22 +1384,22 @@ cargo.rust_library(
 )
 
 cxx_library(
-    name = "blake3-1.5.0-simd_neon-aarch64",
-    srcs = [":blake3-1.5.0.crate[c/blake3_neon.c]"],
+    name = "blake3-1.5.1-simd_neon-aarch64",
+    srcs = [":blake3-1.5.1.crate[c/blake3_neon.c]"],
     headers = [
-        ":blake3-1.5.0.crate[c/blake3.h]",
-        ":blake3-1.5.0.crate[c/blake3_impl.h]",
+        ":blake3-1.5.1.crate[c/blake3.h]",
+        ":blake3-1.5.1.crate[c/blake3_impl.h]",
     ],
     preferred_linkage = "static",
     visibility = [],
 )
 
 cxx_library(
-    name = "blake3-1.5.0-simd_neon-armv7",
-    srcs = [":blake3-1.5.0.crate[c/blake3_neon.c]"],
+    name = "blake3-1.5.1-simd_neon-armv7",
+    srcs = [":blake3-1.5.1.crate[c/blake3_neon.c]"],
     headers = [
-        ":blake3-1.5.0.crate[c/blake3.h]",
-        ":blake3-1.5.0.crate[c/blake3_impl.h]",
+        ":blake3-1.5.1.crate[c/blake3.h]",
+        ":blake3-1.5.1.crate[c/blake3_impl.h]",
     ],
     compiler_flags = [
         "-mfpu=neon-vfpv4",
@@ -1410,19 +1410,19 @@ cxx_library(
 )
 
 cxx_library(
-    name = "blake3-1.5.0-simd_x86_unix",
+    name = "blake3-1.5.1-simd_x86_unix",
     srcs = [
-        ":blake3-1.5.0.crate[c/blake3.c]",
-        ":blake3-1.5.0.crate[c/blake3_avx2_x86-64_unix.S]",
-        ":blake3-1.5.0.crate[c/blake3_avx512_x86-64_unix.S]",
-        ":blake3-1.5.0.crate[c/blake3_dispatch.c]",
-        ":blake3-1.5.0.crate[c/blake3_portable.c]",
-        ":blake3-1.5.0.crate[c/blake3_sse2_x86-64_unix.S]",
-        ":blake3-1.5.0.crate[c/blake3_sse41_x86-64_unix.S]",
+        ":blake3-1.5.1.crate[c/blake3.c]",
+        ":blake3-1.5.1.crate[c/blake3_avx2_x86-64_unix.S]",
+        ":blake3-1.5.1.crate[c/blake3_avx512_x86-64_unix.S]",
+        ":blake3-1.5.1.crate[c/blake3_dispatch.c]",
+        ":blake3-1.5.1.crate[c/blake3_portable.c]",
+        ":blake3-1.5.1.crate[c/blake3_sse2_x86-64_unix.S]",
+        ":blake3-1.5.1.crate[c/blake3_sse41_x86-64_unix.S]",
     ],
     headers = [
-        ":blake3-1.5.0.crate[c/blake3.h]",
-        ":blake3-1.5.0.crate[c/blake3_impl.h]",
+        ":blake3-1.5.1.crate[c/blake3.h]",
+        ":blake3-1.5.1.crate[c/blake3_impl.h]",
     ],
     compatible_with = [
         "prelude//os/constraints:linux",
@@ -1437,19 +1437,19 @@ cxx_library(
 )
 
 cxx_library(
-    name = "blake3-1.5.0-simd_x86_windows_gnu",
+    name = "blake3-1.5.1-simd_x86_windows_gnu",
     srcs = [
-        ":blake3-1.5.0.crate[c/blake3.c]",
-        ":blake3-1.5.0.crate[c/blake3_avx2_x86-64_windows_gnu.S]",
-        ":blake3-1.5.0.crate[c/blake3_avx512_x86-64_windows_gnu.S]",
-        ":blake3-1.5.0.crate[c/blake3_dispatch.c]",
-        ":blake3-1.5.0.crate[c/blake3_portable.c]",
-        ":blake3-1.5.0.crate[c/blake3_sse2_x86-64_windows_gnu.S]",
-        ":blake3-1.5.0.crate[c/blake3_sse41_x86-64_windows_gnu.S]",
+        ":blake3-1.5.1.crate[c/blake3.c]",
+        ":blake3-1.5.1.crate[c/blake3_avx2_x86-64_windows_gnu.S]",
+        ":blake3-1.5.1.crate[c/blake3_avx512_x86-64_windows_gnu.S]",
+        ":blake3-1.5.1.crate[c/blake3_dispatch.c]",
+        ":blake3-1.5.1.crate[c/blake3_portable.c]",
+        ":blake3-1.5.1.crate[c/blake3_sse2_x86-64_windows_gnu.S]",
+        ":blake3-1.5.1.crate[c/blake3_sse41_x86-64_windows_gnu.S]",
     ],
     headers = [
-        ":blake3-1.5.0.crate[c/blake3.h]",
-        ":blake3-1.5.0.crate[c/blake3_impl.h]",
+        ":blake3-1.5.1.crate[c/blake3.h]",
+        ":blake3-1.5.1.crate[c/blake3_impl.h]",
     ],
     compatible_with = ["prelude//os/constraints:windows"],
     compiler_flags = [
@@ -1461,19 +1461,19 @@ cxx_library(
 )
 
 cxx_library(
-    name = "blake3-1.5.0-simd_x86_windows_msvc",
+    name = "blake3-1.5.1-simd_x86_windows_msvc",
     srcs = [
-        ":blake3-1.5.0.crate[c/blake3.c]",
-        ":blake3-1.5.0.crate[c/blake3_avx2_x86-64_windows_msvc.asm]",
-        ":blake3-1.5.0.crate[c/blake3_avx512_x86-64_windows_msvc.asm]",
-        ":blake3-1.5.0.crate[c/blake3_dispatch.c]",
-        ":blake3-1.5.0.crate[c/blake3_portable.c]",
-        ":blake3-1.5.0.crate[c/blake3_sse2_x86-64_windows_msvc.asm]",
-        ":blake3-1.5.0.crate[c/blake3_sse41_x86-64_windows_msvc.asm]",
+        ":blake3-1.5.1.crate[c/blake3.c]",
+        ":blake3-1.5.1.crate[c/blake3_avx2_x86-64_windows_msvc.asm]",
+        ":blake3-1.5.1.crate[c/blake3_avx512_x86-64_windows_msvc.asm]",
+        ":blake3-1.5.1.crate[c/blake3_dispatch.c]",
+        ":blake3-1.5.1.crate[c/blake3_portable.c]",
+        ":blake3-1.5.1.crate[c/blake3_sse2_x86-64_windows_msvc.asm]",
+        ":blake3-1.5.1.crate[c/blake3_sse41_x86-64_windows_msvc.asm]",
     ],
     headers = [
-        ":blake3-1.5.0.crate[c/blake3.h]",
-        ":blake3-1.5.0.crate[c/blake3_impl.h]",
+        ":blake3-1.5.1.crate[c/blake3.h]",
+        ":blake3-1.5.1.crate[c/blake3_impl.h]",
     ],
     compatible_with = ["prelude//os/constraints:windows"],
     preferred_linkage = "static",
@@ -1555,7 +1555,7 @@ cargo.rust_library(
         ":serde_json-1.0.114",
         ":serde_repr-0.1.18",
         ":serde_urlencoded-0.7.1",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":tokio-util-0.7.10",
         ":url-2.5.0",
@@ -1580,23 +1580,23 @@ cargo.rust_library(
     deps = [
         ":serde-1.0.197",
         ":serde_repr-0.1.18",
-        ":serde_with-3.6.1",
+        ":serde_with-3.7.0",
     ],
 )
 
 http_archive(
-    name = "brotli-3.4.0.crate",
-    sha256 = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f",
-    strip_prefix = "brotli-3.4.0",
-    urls = ["https://crates.io/api/v1/crates/brotli/3.4.0/download"],
+    name = "brotli-3.5.0.crate",
+    sha256 = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391",
+    strip_prefix = "brotli-3.5.0",
+    urls = ["https://crates.io/api/v1/crates/brotli/3.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "brotli-3.4.0",
-    srcs = [":brotli-3.4.0.crate"],
+    name = "brotli-3.5.0",
+    srcs = [":brotli-3.5.0.crate"],
     crate = "brotli",
-    crate_root = "brotli-3.4.0.crate/src/lib.rs",
+    crate_root = "brotli-3.5.0.crate/src/lib.rs",
     edition = "2015",
     features = [
         "alloc-stdlib",
@@ -1943,23 +1943,23 @@ cargo.rust_library(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.2",
+    actual = ":clap-4.5.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.2.crate",
-    sha256 = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651",
-    strip_prefix = "clap-4.5.2",
-    urls = ["https://crates.io/api/v1/crates/clap/4.5.2/download"],
+    name = "clap-4.5.3.crate",
+    sha256 = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813",
+    strip_prefix = "clap-4.5.3",
+    urls = ["https://crates.io/api/v1/crates/clap/4.5.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.2",
-    srcs = [":clap-4.5.2.crate"],
+    name = "clap-4.5.3",
+    srcs = [":clap-4.5.3.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.2.crate/src/lib.rs",
+    crate_root = "clap-4.5.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1976,7 +1976,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":clap_builder-4.5.2",
-        ":clap_derive-4.5.0",
+        ":clap_derive-4.5.3",
     ],
 )
 
@@ -2015,27 +2015,27 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "clap_derive-4.5.0.crate",
-    sha256 = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47",
-    strip_prefix = "clap_derive-4.5.0",
-    urls = ["https://crates.io/api/v1/crates/clap_derive/4.5.0/download"],
+    name = "clap_derive-4.5.3.crate",
+    sha256 = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f",
+    strip_prefix = "clap_derive-4.5.3",
+    urls = ["https://crates.io/api/v1/crates/clap_derive/4.5.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_derive-4.5.0",
-    srcs = [":clap_derive-4.5.0.crate"],
+    name = "clap_derive-4.5.3",
+    srcs = [":clap_derive-4.5.3.crate"],
     crate = "clap_derive",
-    crate_root = "clap_derive-4.5.0.crate/src/lib.rs",
+    crate_root = "clap_derive-4.5.3.crate/src/lib.rs",
     edition = "2021",
     features = ["default"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":heck-0.4.1",
-        ":proc-macro2-1.0.78",
+        ":heck-0.5.0",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -2112,23 +2112,23 @@ cargo.rust_library(
 
 alias(
     name = "color-eyre",
-    actual = ":color-eyre-0.6.2",
+    actual = ":color-eyre-0.6.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "color-eyre-0.6.2.crate",
-    sha256 = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204",
-    strip_prefix = "color-eyre-0.6.2",
-    urls = ["https://crates.io/api/v1/crates/color-eyre/0.6.2/download"],
+    name = "color-eyre-0.6.3.crate",
+    sha256 = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5",
+    strip_prefix = "color-eyre-0.6.3",
+    urls = ["https://crates.io/api/v1/crates/color-eyre/0.6.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "color-eyre-0.6.2",
-    srcs = [":color-eyre-0.6.2.crate"],
+    name = "color-eyre-0.6.3",
+    srcs = [":color-eyre-0.6.3.crate"],
     crate = "color_eyre",
-    crate_root = "color-eyre-0.6.2.crate/src/lib.rs",
+    crate_root = "color-eyre-0.6.3.crate/src/lib.rs",
     edition = "2018",
     features = [
         "capture-spantrace",
@@ -2300,7 +2300,7 @@ cargo.rust_library(
     features = ["toml"],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":lazy_static-1.4.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
@@ -2477,7 +2477,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_json-1.0.114",
         ":tar-0.4.40",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":url-2.5.0",
     ],
@@ -2529,7 +2529,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_json-1.0.114",
         ":tar-0.4.40",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":url-2.5.0",
     ],
@@ -3045,7 +3045,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":bitflags-2.4.2",
+        ":bitflags-2.5.0",
         ":parking_lot-0.12.1",
     ],
 )
@@ -3325,9 +3325,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -3403,7 +3403,7 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":strsim-0.10.0",
         ":syn-1.0.109",
@@ -3432,10 +3432,10 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":strsim-0.10.0",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -3481,7 +3481,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.8",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -3501,7 +3501,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":anyhow-1.0.80",
+        ":anyhow-1.0.81",
         ":html-escape-0.2.13",
         ":nom-7.1.3",
         ":ordered-float-2.10.1",
@@ -3559,7 +3559,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":deadpool-runtime-0.1.3",
         ":num_cpus-1.16.0",
         ":tokio-1.36.0",
@@ -3693,7 +3693,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -3744,7 +3744,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.14.4",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -3824,7 +3824,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -4001,7 +4001,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_json-1.0.114",
         ":tar-0.4.40",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":url-2.5.0",
     ],
 )
@@ -4233,7 +4233,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-3.1.15",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -4387,9 +4387,9 @@ cargo.rust_library(
     deps = [
         ":num-bigint-0.4.4",
         ":num-traits-0.2.18",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -4982,23 +4982,23 @@ cargo.rust_library(
 
 alias(
     name = "futures-lite",
-    actual = ":futures-lite-2.2.0",
+    actual = ":futures-lite-2.3.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "futures-lite-2.2.0.crate",
-    sha256 = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba",
-    strip_prefix = "futures-lite-2.2.0",
-    urls = ["https://crates.io/api/v1/crates/futures-lite/2.2.0/download"],
+    name = "futures-lite-2.3.0.crate",
+    sha256 = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5",
+    strip_prefix = "futures-lite-2.3.0",
+    urls = ["https://crates.io/api/v1/crates/futures-lite/2.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-lite-2.2.0",
-    srcs = [":futures-lite-2.2.0.crate"],
+    name = "futures-lite-2.3.0",
+    srcs = [":futures-lite-2.3.0.crate"],
     crate = "futures_lite",
-    crate_root = "futures-lite-2.2.0.crate/src/lib.rs",
+    crate_root = "futures-lite-2.3.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -5036,9 +5036,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -5386,18 +5386,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "h2-0.3.24.crate",
-    sha256 = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9",
-    strip_prefix = "h2-0.3.24",
-    urls = ["https://crates.io/api/v1/crates/h2/0.3.24/download"],
+    name = "h2-0.3.25.crate",
+    sha256 = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb",
+    strip_prefix = "h2-0.3.25",
+    urls = ["https://crates.io/api/v1/crates/h2/0.3.25/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "h2-0.3.24",
-    srcs = [":h2-0.3.24.crate"],
+    name = "h2-0.3.25",
+    srcs = [":h2-0.3.25.crate"],
     crate = "h2",
-    crate_root = "h2-0.3.24.crate/src/lib.rs",
+    crate_root = "h2-0.3.25.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [
@@ -5638,6 +5638,23 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":unicode-segmentation-1.11.0"],
+)
+
+http_archive(
+    name = "heck-0.5.0.crate",
+    sha256 = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+    strip_prefix = "heck-0.5.0",
+    urls = ["https://crates.io/api/v1/crates/heck/0.5.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "heck-0.5.0",
+    srcs = [":heck-0.5.0.crate"],
+    crate = "heck",
+    crate_root = "heck-0.5.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
 )
 
 alias(
@@ -5965,7 +5982,7 @@ cargo.rust_library(
         ":futures-channel-0.3.30",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
-        ":h2-0.3.24",
+        ":h2-0.3.25",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":httparse-1.8.0",
@@ -6154,11 +6171,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.22",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":serde-1.0.197",
-        ":syn-2.0.52",
-        ":toml-0.8.10",
+        ":syn-2.0.53",
+        ":toml-0.8.12",
         ":unicode-xid-0.2.4",
     ],
 )
@@ -6350,9 +6367,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -6388,7 +6405,7 @@ cargo.rust_library(
         ":dyn-clone-1.0.17",
         ":lazy_static-1.4.0",
         ":newline-converter-0.2.2",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":unicode-segmentation-1.11.0",
         ":unicode-width-0.1.11",
     ],
@@ -6495,6 +6512,25 @@ cargo.rust_library(
     deps = [":either-1.10.0"],
 )
 
+http_archive(
+    name = "itertools-0.11.0.crate",
+    sha256 = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57",
+    strip_prefix = "itertools-0.11.0",
+    urls = ["https://crates.io/api/v1/crates/itertools/0.11.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "itertools-0.11.0",
+    srcs = [":itertools-0.11.0.crate"],
+    crate = "itertools",
+    crate_root = "itertools-0.11.0.crate/src/lib.rs",
+    edition = "2018",
+    features = ["use_alloc"],
+    visibility = [],
+    deps = [":either-1.10.0"],
+)
+
 alias(
     name = "itertools",
     actual = ":itertools-0.12.1",
@@ -6587,7 +6623,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anyhow-1.0.80",
+        ":anyhow-1.0.81",
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.34",
@@ -6602,7 +6638,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":serde-1.0.197",
         ":serde_json-1.0.114",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":zeroize-1.7.0",
     ],
 )
@@ -7373,9 +7409,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -7670,7 +7706,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-lock-2.8.0",
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":crossbeam-channel-0.5.12",
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.19",
@@ -7680,9 +7716,9 @@ cargo.rust_library(
         ":quanta-0.12.2",
         ":smallvec-1.13.1",
         ":tagptr-0.2.0",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":triomphe-0.1.11",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
     ],
 )
 
@@ -7903,7 +7939,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bitflags-2.4.2",
+        ":bitflags-2.5.0",
         ":cfg-if-1.0.0",
         ":libc-0.2.153",
     ],
@@ -8473,23 +8509,23 @@ cargo.rust_library(
 
 alias(
     name = "opentelemetry",
-    actual = ":opentelemetry-0.21.0",
+    actual = ":opentelemetry-0.22.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "opentelemetry-0.21.0.crate",
-    sha256 = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a",
-    strip_prefix = "opentelemetry-0.21.0",
-    urls = ["https://crates.io/api/v1/crates/opentelemetry/0.21.0/download"],
+    name = "opentelemetry-0.22.0.crate",
+    sha256 = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf",
+    strip_prefix = "opentelemetry-0.22.0",
+    urls = ["https://crates.io/api/v1/crates/opentelemetry/0.22.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "opentelemetry-0.21.0",
-    srcs = [":opentelemetry-0.21.0.crate"],
+    name = "opentelemetry-0.22.0",
+    srcs = [":opentelemetry-0.22.0.crate"],
     crate = "opentelemetry",
-    crate_root = "opentelemetry-0.21.0.crate/src/lib.rs",
+    crate_root = "opentelemetry-0.22.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -8501,43 +8537,42 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
-        ":indexmap-2.2.5",
         ":once_cell-1.19.0",
         ":pin-project-lite-0.2.13",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":urlencoding-2.1.3",
     ],
 )
 
 alias(
     name = "opentelemetry-otlp",
-    actual = ":opentelemetry-otlp-0.14.0",
+    actual = ":opentelemetry-otlp-0.15.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "opentelemetry-otlp-0.14.0.crate",
-    sha256 = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930",
-    strip_prefix = "opentelemetry-otlp-0.14.0",
-    urls = ["https://crates.io/api/v1/crates/opentelemetry-otlp/0.14.0/download"],
+    name = "opentelemetry-otlp-0.15.0.crate",
+    sha256 = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb",
+    strip_prefix = "opentelemetry-otlp-0.15.0",
+    urls = ["https://crates.io/api/v1/crates/opentelemetry-otlp/0.15.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "opentelemetry-otlp-0.14.0",
-    srcs = [":opentelemetry-otlp-0.14.0.crate"],
+    name = "opentelemetry-otlp-0.15.0",
+    srcs = [":opentelemetry-otlp-0.15.0.crate"],
     crate = "opentelemetry_otlp",
-    crate_root = "opentelemetry-otlp-0.14.0.crate/src/lib.rs",
+    crate_root = "opentelemetry-otlp-0.15.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "opentelemetry-otlp-0.14.0.crate",
+        "CARGO_MANIFEST_DIR": "opentelemetry-otlp-0.15.0.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Exporter for the OpenTelemetry Collector",
         "CARGO_PKG_NAME": "opentelemetry-otlp",
         "CARGO_PKG_REPOSITORY": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp",
-        "CARGO_PKG_VERSION": "0.14.0",
+        "CARGO_PKG_VERSION": "0.15.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "14",
+        "CARGO_PKG_VERSION_MINOR": "15",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -8551,33 +8586,33 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":futures-core-0.3.30",
         ":http-0.2.12",
-        ":opentelemetry-0.21.0",
-        ":opentelemetry-proto-0.4.0",
-        ":opentelemetry-semantic-conventions-0.13.0",
-        ":opentelemetry_sdk-0.21.2",
-        ":prost-0.11.9",
-        ":thiserror-1.0.57",
+        ":opentelemetry-0.22.0",
+        ":opentelemetry-proto-0.5.0",
+        ":opentelemetry-semantic-conventions-0.14.0",
+        ":opentelemetry_sdk-0.22.1",
+        ":prost-0.12.3",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
-        ":tonic-0.9.2",
+        ":tonic-0.11.0",
     ],
 )
 
 http_archive(
-    name = "opentelemetry-proto-0.4.0.crate",
-    sha256 = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1",
-    strip_prefix = "opentelemetry-proto-0.4.0",
-    urls = ["https://crates.io/api/v1/crates/opentelemetry-proto/0.4.0/download"],
+    name = "opentelemetry-proto-0.5.0.crate",
+    sha256 = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4",
+    strip_prefix = "opentelemetry-proto-0.5.0",
+    urls = ["https://crates.io/api/v1/crates/opentelemetry-proto/0.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "opentelemetry-proto-0.4.0",
-    srcs = [":opentelemetry-proto-0.4.0.crate"],
+    name = "opentelemetry-proto-0.5.0",
+    srcs = [":opentelemetry-proto-0.5.0.crate"],
     crate = "opentelemetry_proto",
-    crate_root = "opentelemetry-proto-0.4.0.crate/src/lib.rs",
+    crate_root = "opentelemetry-proto-0.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "gen-tonic",
@@ -8588,67 +8623,66 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":opentelemetry-0.21.0",
-        ":opentelemetry_sdk-0.21.2",
-        ":prost-0.11.9",
-        ":tonic-0.9.2",
+        ":opentelemetry-0.22.0",
+        ":opentelemetry_sdk-0.22.1",
+        ":prost-0.12.3",
+        ":tonic-0.11.0",
     ],
 )
 
 alias(
     name = "opentelemetry-semantic-conventions",
-    actual = ":opentelemetry-semantic-conventions-0.13.0",
+    actual = ":opentelemetry-semantic-conventions-0.14.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "opentelemetry-semantic-conventions-0.13.0.crate",
-    sha256 = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84",
-    strip_prefix = "opentelemetry-semantic-conventions-0.13.0",
-    urls = ["https://crates.io/api/v1/crates/opentelemetry-semantic-conventions/0.13.0/download"],
+    name = "opentelemetry-semantic-conventions-0.14.0.crate",
+    sha256 = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910",
+    strip_prefix = "opentelemetry-semantic-conventions-0.14.0",
+    urls = ["https://crates.io/api/v1/crates/opentelemetry-semantic-conventions/0.14.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "opentelemetry-semantic-conventions-0.13.0",
-    srcs = [":opentelemetry-semantic-conventions-0.13.0.crate"],
+    name = "opentelemetry-semantic-conventions-0.14.0",
+    srcs = [":opentelemetry-semantic-conventions-0.14.0.crate"],
     crate = "opentelemetry_semantic_conventions",
-    crate_root = "opentelemetry-semantic-conventions-0.13.0.crate/src/lib.rs",
+    crate_root = "opentelemetry-semantic-conventions-0.14.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":opentelemetry-0.21.0"],
 )
 
 alias(
     name = "opentelemetry_sdk",
-    actual = ":opentelemetry_sdk-0.21.2",
+    actual = ":opentelemetry_sdk-0.22.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "opentelemetry_sdk-0.21.2.crate",
-    sha256 = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4",
-    strip_prefix = "opentelemetry_sdk-0.21.2",
-    urls = ["https://crates.io/api/v1/crates/opentelemetry_sdk/0.21.2/download"],
+    name = "opentelemetry_sdk-0.22.1.crate",
+    sha256 = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e",
+    strip_prefix = "opentelemetry_sdk-0.22.1",
+    urls = ["https://crates.io/api/v1/crates/opentelemetry_sdk/0.22.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "opentelemetry_sdk-0.21.2",
-    srcs = [":opentelemetry_sdk-0.21.2.crate"],
+    name = "opentelemetry_sdk-0.22.1",
+    srcs = [":opentelemetry_sdk-0.22.1.crate"],
     crate = "opentelemetry_sdk",
-    crate_root = "opentelemetry_sdk-0.21.2.crate/src/lib.rs",
+    crate_root = "opentelemetry_sdk-0.22.1.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "opentelemetry_sdk-0.21.2.crate",
+        "CARGO_MANIFEST_DIR": "opentelemetry_sdk-0.22.1.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "The SDK for the OpenTelemetry metrics collection and distributed tracing framework",
         "CARGO_PKG_NAME": "opentelemetry_sdk",
         "CARGO_PKG_REPOSITORY": "https://github.com/open-telemetry/opentelemetry-rust",
-        "CARGO_PKG_VERSION": "0.21.2",
+        "CARGO_PKG_VERSION": "0.22.1",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "21",
-        "CARGO_PKG_VERSION_PATCH": "2",
+        "CARGO_PKG_VERSION_MINOR": "22",
+        "CARGO_PKG_VERSION_PATCH": "1",
     },
     features = [
         "async-trait",
@@ -8665,20 +8699,20 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":crossbeam-channel-0.5.12",
         ":futures-channel-0.3.30",
         ":futures-executor-0.3.30",
         ":futures-util-0.3.30",
         ":glob-0.3.1",
         ":once_cell-1.19.0",
-        ":opentelemetry-0.21.0",
+        ":opentelemetry-0.22.0",
         ":ordered-float-4.2.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
-        ":tokio-stream-0.1.14",
+        ":tokio-stream-0.1.15",
     ],
 )
 
@@ -8859,9 +8893,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -8885,10 +8919,10 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -9393,7 +9427,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -9416,9 +9450,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -9658,7 +9692,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_json-1.0.114",
         ":tar-0.4.40",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":url-2.5.0",
     ],
@@ -9809,9 +9843,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -10019,7 +10053,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":syn-1.0.109",
     ],
@@ -10069,45 +10103,45 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
     ],
 )
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.78",
+    actual = ":proc-macro2-1.0.79",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.78.crate",
-    sha256 = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae",
-    strip_prefix = "proc-macro2-1.0.78",
-    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.78/download"],
+    name = "proc-macro2-1.0.79.crate",
+    sha256 = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e",
+    strip_prefix = "proc-macro2-1.0.79",
+    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.79/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.78",
-    srcs = [":proc-macro2-1.0.78.crate"],
+    name = "proc-macro2-1.0.79",
+    srcs = [":proc-macro2-1.0.79.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.78.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.79.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.78-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.79-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.12"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.78-build-script-build",
-    srcs = [":proc-macro2-1.0.78.crate"],
+    name = "proc-macro2-1.0.79-build-script-build",
+    srcs = [":proc-macro2-1.0.79.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.78.crate/build.rs",
+    crate_root = "proc-macro2-1.0.79.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -10117,14 +10151,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.78-build-script-run",
+    name = "proc-macro2-1.0.79-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.78-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.79-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.78",
+    version = "1.0.79",
 )
 
 http_archive(
@@ -10148,26 +10182,26 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
-        ":yansi-1.0.0",
+        ":syn-2.0.53",
+        ":yansi-1.0.1",
     ],
 )
 
 http_archive(
-    name = "prost-0.11.9.crate",
-    sha256 = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd",
-    strip_prefix = "prost-0.11.9",
-    urls = ["https://crates.io/api/v1/crates/prost/0.11.9/download"],
+    name = "prost-0.12.3.crate",
+    sha256 = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a",
+    strip_prefix = "prost-0.12.3",
+    urls = ["https://crates.io/api/v1/crates/prost/0.12.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "prost-0.11.9",
-    srcs = [":prost-0.11.9.crate"],
+    name = "prost-0.12.3",
+    srcs = [":prost-0.12.3.crate"],
     crate = "prost",
-    crate_root = "prost-0.11.9.crate/src/lib.rs",
+    crate_root = "prost-0.12.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -10177,32 +10211,32 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.5.0",
-        ":prost-derive-0.11.9",
+        ":prost-derive-0.12.3",
     ],
 )
 
 http_archive(
-    name = "prost-derive-0.11.9.crate",
-    sha256 = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4",
-    strip_prefix = "prost-derive-0.11.9",
-    urls = ["https://crates.io/api/v1/crates/prost-derive/0.11.9/download"],
+    name = "prost-derive-0.12.3.crate",
+    sha256 = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e",
+    strip_prefix = "prost-derive-0.12.3",
+    urls = ["https://crates.io/api/v1/crates/prost-derive/0.12.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "prost-derive-0.11.9",
-    srcs = [":prost-derive-0.11.9.crate"],
+    name = "prost-derive-0.12.3",
+    srcs = [":prost-derive-0.12.3.crate"],
     crate = "prost_derive",
-    crate_root = "prost-derive-0.11.9.crate/src/lib.rs",
+    crate_root = "prost-derive-0.12.3.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.80",
-        ":itertools-0.10.5",
-        ":proc-macro2-1.0.78",
+        ":anyhow-1.0.81",
+        ":itertools-0.11.0",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-1.0.109",
+        ":syn-2.0.53",
     ],
 )
 
@@ -10314,7 +10348,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.78"],
+    deps = [":proc-macro2-1.0.79"],
 )
 
 http_archive(
@@ -10535,7 +10569,7 @@ cargo.rust_library(
     crate_root = "raw-cpuid-11.0.1.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":bitflags-2.4.2"],
+    deps = [":bitflags-2.5.0"],
 )
 
 http_archive(
@@ -10632,17 +10666,17 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":cfg-if-1.0.0",
         ":log-0.4.21",
         ":regex-1.10.3",
         ":serde-1.0.197",
-        ":siphasher-1.0.0",
-        ":thiserror-1.0.57",
+        ":siphasher-1.0.1",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
-        ":toml-0.8.10",
+        ":toml-0.8.12",
         ":url-2.5.0",
         ":walkdir-2.5.0",
     ],
@@ -10665,11 +10699,11 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":refinery-core-0.8.12",
         ":regex-1.10.3",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -10872,32 +10906,32 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.11.24",
+    actual = ":reqwest-0.11.27",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.11.24.crate",
-    sha256 = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251",
-    strip_prefix = "reqwest-0.11.24",
-    urls = ["https://crates.io/api/v1/crates/reqwest/0.11.24/download"],
+    name = "reqwest-0.11.27.crate",
+    sha256 = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62",
+    strip_prefix = "reqwest-0.11.27",
+    urls = ["https://crates.io/api/v1/crates/reqwest/0.11.27/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.11.24",
-    srcs = [":reqwest-0.11.24.crate"],
+    name = "reqwest-0.11.27",
+    srcs = [":reqwest-0.11.27.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.11.24.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "reqwest-0.11.27.crate/src/lib.rs",
+    edition = "2021",
     features = [
         "__rustls",
         "__tls",
@@ -10916,7 +10950,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -10936,7 +10970,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -10956,7 +10990,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -10977,7 +11011,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -10998,7 +11032,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -11019,7 +11053,7 @@ cargo.rust_library(
         "windows-msvc": dict(
             deps = [
                 ":encoding_rs-0.8.33",
-                ":h2-0.3.24",
+                ":h2-0.3.25",
                 ":http-body-0.4.6",
                 ":hyper-0.14.28",
                 ":hyper-rustls-0.24.2",
@@ -11896,7 +11930,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
@@ -11919,11 +11953,11 @@ cargo.rust_library(
         ":serde_derive-1.0.197",
         ":serde_json-1.0.114",
         ":sha2-0.10.8",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tokio-1.36.0",
         ":tokio-rustls-0.24.1",
-        ":tokio-stream-0.1.14",
+        ":tokio-stream-0.1.15",
         ":url-2.5.0",
     ],
 )
@@ -12023,18 +12057,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustix-0.38.31.crate",
-    sha256 = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949",
-    strip_prefix = "rustix-0.38.31",
-    urls = ["https://crates.io/api/v1/crates/rustix/0.38.31/download"],
+    name = "rustix-0.38.32.crate",
+    sha256 = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89",
+    strip_prefix = "rustix-0.38.32",
+    urls = ["https://crates.io/api/v1/crates/rustix/0.38.32/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustix-0.38.31",
-    srcs = [":rustix-0.38.31.crate"],
+    name = "rustix-0.38.32",
+    srcs = [":rustix-0.38.32.crate"],
     crate = "rustix",
-    crate_root = "rustix-0.38.31.crate/src/lib.rs",
+    crate_root = "rustix-0.38.32.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12088,16 +12122,16 @@ cargo.rust_library(
             deps = [":windows-sys-0.52.0"],
         ),
     },
-    rustc_flags = ["@$(location :rustix-0.38.31-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :rustix-0.38.32-build-script-run[rustc_flags])"],
     visibility = [],
-    deps = [":bitflags-2.4.2"],
+    deps = [":bitflags-2.5.0"],
 )
 
 cargo.rust_binary(
-    name = "rustix-0.38.31-build-script-build",
-    srcs = [":rustix-0.38.31.crate"],
+    name = "rustix-0.38.32-build-script-build",
+    srcs = [":rustix-0.38.32.crate"],
     crate = "build_script_build",
-    crate_root = "rustix-0.38.31.crate/build.rs",
+    crate_root = "rustix-0.38.32.crate/build.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12111,9 +12145,9 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rustix-0.38.31-build-script-run",
+    name = "rustix-0.38.32-build-script-run",
     package_name = "rustix",
-    buildscript_rule = ":rustix-0.38.31-build-script-build",
+    buildscript_rule = ":rustix-0.38.32-build-script-build",
     features = [
         "alloc",
         "default",
@@ -12122,7 +12156,7 @@ buildscript_run(
         "termios",
         "use-libc-auxv",
     ],
-    version = "0.38.31",
+    version = "0.38.32",
 )
 
 http_archive(
@@ -12513,31 +12547,31 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
 alias(
     name = "sea-orm",
-    actual = ":sea-orm-0.12.14",
+    actual = ":sea-orm-0.12.15",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "sea-orm-0.12.14.crate",
-    sha256 = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe",
-    strip_prefix = "sea-orm-0.12.14",
-    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.14/download"],
+    name = "sea-orm-0.12.15.crate",
+    sha256 = "c8814e37dc25de54398ee62228323657520b7f29713b8e238649385dbe473ee0",
+    strip_prefix = "sea-orm-0.12.15",
+    urls = ["https://crates.io/api/v1/crates/sea-orm/0.12.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-0.12.14",
-    srcs = [":sea-orm-0.12.14.crate"],
+    name = "sea-orm-0.12.15",
+    srcs = [":sea-orm-0.12.15.crate"],
     crate = "sea_orm",
-    crate_root = "sea-orm-0.12.14.crate/src/lib.rs",
+    crate_root = "sea-orm-0.12.15.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bigdecimal",
@@ -12566,41 +12600,41 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":bigdecimal-0.3.1",
         ":chrono-0.4.35",
         ":futures-0.3.30",
         ":log-0.4.21",
         ":ouroboros-0.17.2",
         ":rust_decimal-1.34.3",
-        ":sea-orm-macros-0.12.14",
+        ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
         ":serde-1.0.197",
         ":serde_json-1.0.114",
-        ":sqlx-0.7.3",
+        ":sqlx-0.7.4",
         ":strum-0.25.0",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tracing-0.1.40",
         ":url-2.5.0",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
     ],
 )
 
 http_archive(
-    name = "sea-orm-macros-0.12.14.crate",
-    sha256 = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa",
-    strip_prefix = "sea-orm-macros-0.12.14",
-    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.14/download"],
+    name = "sea-orm-macros-0.12.15.crate",
+    sha256 = "5e115c6b078e013aa963cc2d38c196c2c40b05f03d0ac872fe06b6e0d5265603",
+    strip_prefix = "sea-orm-macros-0.12.15",
+    urls = ["https://crates.io/api/v1/crates/sea-orm-macros/0.12.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-orm-macros-0.12.14",
-    srcs = [":sea-orm-macros-0.12.14.crate"],
+    name = "sea-orm-macros-0.12.15",
+    srcs = [":sea-orm-macros-0.12.15.crate"],
     crate = "sea_orm_macros",
-    crate_root = "sea-orm-macros-0.12.14.crate/src/lib.rs",
+    crate_root = "sea-orm-macros-0.12.15.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bae",
@@ -12615,9 +12649,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -12668,7 +12702,7 @@ cargo.rust_library(
         ":rust_decimal-1.34.3",
         ":serde_json-1.0.114",
         ":time-0.3.34",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
     ],
 )
 
@@ -12711,9 +12745,9 @@ cargo.rust_library(
         ":rust_decimal-1.34.3",
         ":sea-query-0.30.7",
         ":serde_json-1.0.114",
-        ":sqlx-0.7.3",
+        ":sqlx-0.7.4",
         ":time-0.3.34",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
     ],
 )
 
@@ -13020,9 +13054,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -13083,18 +13117,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "serde_path_to_error-0.1.15.crate",
-    sha256 = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c",
-    strip_prefix = "serde_path_to_error-0.1.15",
-    urls = ["https://crates.io/api/v1/crates/serde_path_to_error/0.1.15/download"],
+    name = "serde_path_to_error-0.1.16.crate",
+    sha256 = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6",
+    strip_prefix = "serde_path_to_error-0.1.16",
+    urls = ["https://crates.io/api/v1/crates/serde_path_to_error/0.1.16/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_path_to_error-0.1.15",
-    srcs = [":serde_path_to_error-0.1.15.crate"],
+    name = "serde_path_to_error-0.1.16",
+    srcs = [":serde_path_to_error-0.1.16.crate"],
     crate = "serde_path_to_error",
-    crate_root = "serde_path_to_error-0.1.15.crate/src/lib.rs",
+    crate_root = "serde_path_to_error-0.1.16.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -13120,9 +13154,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -13232,23 +13266,23 @@ cargo.rust_library(
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.6.1",
+    actual = ":serde_with-3.7.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.6.1.crate",
-    sha256 = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270",
-    strip_prefix = "serde_with-3.6.1",
-    urls = ["https://crates.io/api/v1/crates/serde_with/3.6.1/download"],
+    name = "serde_with-3.7.0.crate",
+    sha256 = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a",
+    strip_prefix = "serde_with-3.7.0",
+    urls = ["https://crates.io/api/v1/crates/serde_with/3.7.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.6.1",
-    srcs = [":serde_with-3.6.1.crate"],
+    name = "serde_with-3.7.0",
+    srcs = [":serde_with-3.7.0.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.6.1.crate/src/lib.rs",
+    crate_root = "serde_with-3.7.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13269,7 +13303,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_derive-1.0.197",
         ":serde_json-1.0.114",
-        ":serde_with_macros-3.6.1",
+        ":serde_with_macros-3.7.0",
     ],
 )
 
@@ -13291,55 +13325,55 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.8",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
 http_archive(
-    name = "serde_with_macros-3.6.1.crate",
-    sha256 = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d",
-    strip_prefix = "serde_with_macros-3.6.1",
-    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.6.1/download"],
+    name = "serde_with_macros-3.7.0.crate",
+    sha256 = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655",
+    strip_prefix = "serde_with_macros-3.7.0",
+    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.7.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.6.1",
-    srcs = [":serde_with_macros-3.6.1.crate"],
+    name = "serde_with_macros-3.7.0",
+    srcs = [":serde_with_macros-3.7.0.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.6.1.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.7.0.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":darling-0.20.8",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
 alias(
     name = "serde_yaml",
-    actual = ":serde_yaml-0.9.32",
+    actual = ":serde_yaml-0.9.33",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_yaml-0.9.32.crate",
-    sha256 = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f",
-    strip_prefix = "serde_yaml-0.9.32",
-    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.32/download"],
+    name = "serde_yaml-0.9.33.crate",
+    sha256 = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9",
+    strip_prefix = "serde_yaml-0.9.33",
+    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.33/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_yaml-0.9.32",
-    srcs = [":serde_yaml-0.9.32.crate"],
+    name = "serde_yaml-0.9.33",
+    srcs = [":serde_yaml-0.9.33.crate"],
     crate = "serde_yaml",
-    crate_root = "serde_yaml-0.9.32.crate/src/lib.rs",
+    crate_root = "serde_yaml-0.9.33.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -13347,7 +13381,7 @@ cargo.rust_library(
         ":itoa-1.0.10",
         ":ryu-1.0.17",
         ":serde-1.0.197",
-        ":unsafe-libyaml-0.2.10",
+        ":unsafe-libyaml-0.2.11",
     ],
 )
 
@@ -13625,18 +13659,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "siphasher-1.0.0.crate",
-    sha256 = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe",
-    strip_prefix = "siphasher-1.0.0",
-    urls = ["https://crates.io/api/v1/crates/siphasher/1.0.0/download"],
+    name = "siphasher-1.0.1.crate",
+    sha256 = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d",
+    strip_prefix = "siphasher-1.0.1",
+    urls = ["https://crates.io/api/v1/crates/siphasher/1.0.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "siphasher-1.0.0",
-    srcs = [":siphasher-1.0.0.crate"],
+    name = "siphasher-1.0.1",
+    srcs = [":siphasher-1.0.1.crate"],
     crate = "siphasher",
-    crate_root = "siphasher-1.0.0.crate/src/lib.rs",
+    crate_root = "siphasher-1.0.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -13943,18 +13977,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "sqlx-0.7.3.crate",
-    sha256 = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf",
-    strip_prefix = "sqlx-0.7.3",
-    urls = ["https://crates.io/api/v1/crates/sqlx/0.7.3/download"],
+    name = "sqlx-0.7.4.crate",
+    sha256 = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa",
+    strip_prefix = "sqlx-0.7.4",
+    urls = ["https://crates.io/api/v1/crates/sqlx/0.7.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sqlx-0.7.3",
-    srcs = [":sqlx-0.7.3.crate"],
+    name = "sqlx-0.7.4",
+    srcs = [":sqlx-0.7.4.crate"],
     crate = "sqlx",
-    crate_root = "sqlx-0.7.3.crate/src/lib.rs",
+    crate_root = "sqlx-0.7.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "_rt-tokio",
@@ -13972,24 +14006,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":sqlx-core-0.7.3",
-        ":sqlx-postgres-0.7.3",
+        ":sqlx-core-0.7.4",
+        ":sqlx-postgres-0.7.4",
     ],
 )
 
 http_archive(
-    name = "sqlx-core-0.7.3.crate",
-    sha256 = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd",
-    strip_prefix = "sqlx-core-0.7.3",
-    urls = ["https://crates.io/api/v1/crates/sqlx-core/0.7.3/download"],
+    name = "sqlx-core-0.7.4.crate",
+    sha256 = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6",
+    strip_prefix = "sqlx-core-0.7.4",
+    urls = ["https://crates.io/api/v1/crates/sqlx-core/0.7.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sqlx-core-0.7.3",
-    srcs = [":sqlx-core-0.7.3.crate"],
+    name = "sqlx-core-0.7.4",
+    srcs = [":sqlx-core-0.7.4.crate"],
     crate = "sqlx_core",
-    crate_root = "sqlx-core-0.7.3.crate/src/lib.rs",
+    crate_root = "sqlx-core-0.7.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "_rt-tokio",
@@ -14024,7 +14058,6 @@ cargo.rust_library(
         ":chrono-0.4.35",
         ":crc-3.0.1",
         ":crossbeam-queue-0.3.11",
-        ":dotenvy-0.15.7",
         ":either-1.10.0",
         ":event-listener-2.5.3",
         ":futures-channel-0.3.30",
@@ -14048,30 +14081,30 @@ cargo.rust_library(
         ":sha2-0.10.8",
         ":smallvec-1.13.1",
         ":sqlformat-0.2.3",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tokio-1.36.0",
-        ":tokio-stream-0.1.14",
+        ":tokio-stream-0.1.15",
         ":tracing-0.1.40",
         ":url-2.5.0",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
         ":webpki-roots-0.25.4",
     ],
 )
 
 http_archive(
-    name = "sqlx-postgres-0.7.3.crate",
-    sha256 = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24",
-    strip_prefix = "sqlx-postgres-0.7.3",
-    urls = ["https://crates.io/api/v1/crates/sqlx-postgres/0.7.3/download"],
+    name = "sqlx-postgres-0.7.4.crate",
+    sha256 = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e",
+    strip_prefix = "sqlx-postgres-0.7.4",
+    urls = ["https://crates.io/api/v1/crates/sqlx-postgres/0.7.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sqlx-postgres-0.7.3",
-    srcs = [":sqlx-postgres-0.7.3.crate"],
+    name = "sqlx-postgres-0.7.4",
+    srcs = [":sqlx-postgres-0.7.4.crate"],
     crate = "sqlx_postgres",
-    crate_root = "sqlx-postgres-0.7.3.crate/src/lib.rs",
+    crate_root = "sqlx-postgres-0.7.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bigdecimal",
@@ -14096,7 +14129,7 @@ cargo.rust_library(
         ":atoi-2.0.0",
         ":base64-0.21.7",
         ":bigdecimal-0.3.1",
-        ":bitflags-2.4.2",
+        ":bitflags-2.5.0",
         ":byteorder-1.5.0",
         ":chrono-0.4.35",
         ":crc-3.0.1",
@@ -14119,16 +14152,15 @@ cargo.rust_library(
         ":rust_decimal-1.34.3",
         ":serde-1.0.197",
         ":serde_json-1.0.114",
-        ":sha1-0.10.6",
         ":sha2-0.10.8",
         ":smallvec-1.13.1",
-        ":sqlx-core-0.7.3",
+        ":sqlx-core-0.7.4",
         ":stringprep-0.1.4",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":time-0.3.34",
         ":tracing-0.1.40",
-        ":uuid-1.7.0",
-        ":whoami-1.5.0",
+        ":uuid-1.8.0",
+        ":whoami-1.5.1",
     ],
 )
 
@@ -14303,10 +14335,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":rustversion-1.0.14",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -14390,7 +14422,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":unicode-ident-1.0.12",
     ],
@@ -14398,23 +14430,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.52",
+    actual = ":syn-2.0.53",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.52.crate",
-    sha256 = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07",
-    strip_prefix = "syn-2.0.52",
-    urls = ["https://crates.io/api/v1/crates/syn/2.0.52/download"],
+    name = "syn-2.0.53.crate",
+    sha256 = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032",
+    strip_prefix = "syn-2.0.53",
+    urls = ["https://crates.io/api/v1/crates/syn/2.0.53/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.52",
-    srcs = [":syn-2.0.52.crate"],
+    name = "syn-2.0.53",
+    srcs = [":syn-2.0.53.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.52.crate/src/lib.rs",
+    crate_root = "syn-2.0.53.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -14432,7 +14464,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":unicode-ident-1.0.12",
     ],
@@ -14648,16 +14680,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -14689,16 +14721,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.31"],
+            deps = [":rustix-0.38.32"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -14759,9 +14791,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -14792,17 +14824,17 @@ cargo.rust_binary(
     visibility = [],
     deps = [
         ":async-nats-0.33.0",
-        ":async-recursion-1.0.5",
-        ":async-trait-0.1.77",
+        ":async-recursion-1.1.0",
+        ":async-trait-0.1.78",
         ":axum-0.6.20",
         ":base64-0.21.7",
-        ":blake3-1.5.0",
+        ":blake3-1.5.1",
         ":bollard-0.15.0",
         ":bytes-1.5.0",
         ":chrono-0.4.35",
         ":ciborium-0.2.2",
-        ":clap-4.5.2",
-        ":color-eyre-0.6.2",
+        ":clap-4.5.3",
+        ":color-eyre-0.6.3",
         ":colored-2.1.0",
         ":comfy-table-7.1.0",
         ":config-0.13.4",
@@ -14820,7 +14852,7 @@ cargo.rust_binary(
         ":dyn-clone-1.0.17",
         ":flate2-1.0.28",
         ":futures-0.3.30",
-        ":futures-lite-2.2.0",
+        ":futures-lite-2.3.0",
         ":hex-0.4.3",
         ":http-0.2.12",
         ":hyper-0.14.28",
@@ -14840,10 +14872,10 @@ cargo.rust_binary(
         ":num_cpus-1.16.0",
         ":once_cell-1.19.0",
         ":open-5.1.2",
-        ":opentelemetry-0.21.0",
-        ":opentelemetry-otlp-0.14.0",
-        ":opentelemetry-semantic-conventions-0.13.0",
-        ":opentelemetry_sdk-0.21.2",
+        ":opentelemetry-0.22.0",
+        ":opentelemetry-otlp-0.15.0",
+        ":opentelemetry-semantic-conventions-0.14.0",
+        ":opentelemetry_sdk-0.22.1",
         ":ouroboros-0.18.3",
         ":paste-1.0.14",
         ":pathdiff-0.2.1",
@@ -14853,52 +14885,52 @@ cargo.rust_binary(
         ":postcard-1.0.8",
         ":postgres-types-0.2.6",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":rand-0.8.5",
         ":refinery-0.8.12",
         ":regex-1.10.3",
         ":remain-0.2.13",
-        ":reqwest-0.11.24",
+        ":reqwest-0.11.27",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.22.2",
         ":rustls-pemfile-2.1.1",
-        ":sea-orm-0.12.14",
+        ":sea-orm-0.12.15",
         ":self-replace-1.3.7",
         ":serde-1.0.197",
         ":serde-aux-4.5.0",
         ":serde_json-1.0.114",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.6.1",
-        ":serde_yaml-0.9.32",
+        ":serde_with-3.7.0",
+        ":serde_yaml-0.9.33",
         ":sled-0.34.7",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
         ":strum-0.25.0",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
         ":tar-0.4.40",
         ":tempfile-3.10.1",
         ":test-log-0.2.15",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":tokio-postgres-0.7.10",
         ":tokio-postgres-rustls-0.11.1",
         ":tokio-serde-0.8.0",
-        ":tokio-stream-0.1.14",
-        ":tokio-test-0.4.3",
+        ":tokio-stream-0.1.15",
+        ":tokio-test-0.4.4",
         ":tokio-tungstenite-0.20.1",
         ":tokio-util-0.7.10",
         ":tokio-vsock-0.4.0",
-        ":toml-0.8.10",
+        ":toml-0.8.12",
         ":tower-0.4.13",
         ":tower-http-0.4.4",
         ":tracing-0.1.40",
-        ":tracing-opentelemetry-0.22.0",
+        ":tracing-opentelemetry-0.23.0",
         ":tracing-subscriber-0.3.18",
         ":ulid-1.1.2",
         ":url-2.5.0",
-        ":uuid-1.7.0",
+        ":uuid-1.8.0",
         ":vfs-0.10.0",
         ":vfs-tar-0.4.1",
         ":webpki-roots-0.25.4",
@@ -14909,48 +14941,48 @@ cargo.rust_binary(
 
 alias(
     name = "thiserror",
-    actual = ":thiserror-1.0.57",
+    actual = ":thiserror-1.0.58",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "thiserror-1.0.57.crate",
-    sha256 = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b",
-    strip_prefix = "thiserror-1.0.57",
-    urls = ["https://crates.io/api/v1/crates/thiserror/1.0.57/download"],
+    name = "thiserror-1.0.58.crate",
+    sha256 = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297",
+    strip_prefix = "thiserror-1.0.58",
+    urls = ["https://crates.io/api/v1/crates/thiserror/1.0.58/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-1.0.57",
-    srcs = [":thiserror-1.0.57.crate"],
+    name = "thiserror-1.0.58",
+    srcs = [":thiserror-1.0.58.crate"],
     crate = "thiserror",
-    crate_root = "thiserror-1.0.57.crate/src/lib.rs",
+    crate_root = "thiserror-1.0.58.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":thiserror-impl-1.0.57"],
+    deps = [":thiserror-impl-1.0.58"],
 )
 
 http_archive(
-    name = "thiserror-impl-1.0.57.crate",
-    sha256 = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81",
-    strip_prefix = "thiserror-impl-1.0.57",
-    urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.57/download"],
+    name = "thiserror-impl-1.0.58.crate",
+    sha256 = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7",
+    strip_prefix = "thiserror-impl-1.0.58",
+    urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.58/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-impl-1.0.57",
-    srcs = [":thiserror-impl-1.0.57.crate"],
+    name = "thiserror-impl-1.0.58",
+    srcs = [":thiserror-impl-1.0.58.crate"],
     crate = "thiserror_impl",
-    crate_root = "thiserror-impl-1.0.57.crate/src/lib.rs",
+    crate_root = "thiserror-impl-1.0.58.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -15280,9 +15312,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -15334,7 +15366,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-trait-0.1.78",
         ":byteorder-1.5.0",
         ":bytes-1.5.0",
         ":fallible-iterator-0.2.0",
@@ -15350,7 +15382,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":tokio-1.36.0",
         ":tokio-util-0.7.10",
-        ":whoami-1.5.0",
+        ":whoami-1.5.1",
     ],
 )
 
@@ -15489,23 +15521,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio-stream",
-    actual = ":tokio-stream-0.1.14",
+    actual = ":tokio-stream-0.1.15",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-stream-0.1.14.crate",
-    sha256 = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842",
-    strip_prefix = "tokio-stream-0.1.14",
-    urls = ["https://crates.io/api/v1/crates/tokio-stream/0.1.14/download"],
+    name = "tokio-stream-0.1.15.crate",
+    sha256 = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af",
+    strip_prefix = "tokio-stream-0.1.15",
+    urls = ["https://crates.io/api/v1/crates/tokio-stream/0.1.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-stream-0.1.14",
-    srcs = [":tokio-stream-0.1.14.crate"],
+    name = "tokio-stream-0.1.15",
+    srcs = [":tokio-stream-0.1.15.crate"],
     crate = "tokio_stream",
-    crate_root = "tokio-stream-0.1.14.crate/src/lib.rs",
+    crate_root = "tokio-stream-0.1.15.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -15525,23 +15557,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio-test",
-    actual = ":tokio-test-0.4.3",
+    actual = ":tokio-test-0.4.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-test-0.4.3.crate",
-    sha256 = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719",
-    strip_prefix = "tokio-test-0.4.3",
-    urls = ["https://crates.io/api/v1/crates/tokio-test/0.4.3/download"],
+    name = "tokio-test-0.4.4.crate",
+    sha256 = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7",
+    strip_prefix = "tokio-test-0.4.4",
+    urls = ["https://crates.io/api/v1/crates/tokio-test/0.4.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-test-0.4.3",
-    srcs = [":tokio-test-0.4.3.crate"],
+    name = "tokio-test-0.4.4",
+    srcs = [":tokio-test-0.4.4.crate"],
     crate = "tokio_test",
-    crate_root = "tokio-test-0.4.3.crate/src/lib.rs",
+    crate_root = "tokio-test-0.4.4.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -15549,7 +15581,7 @@ cargo.rust_library(
         ":bytes-1.5.0",
         ":futures-core-0.3.30",
         ":tokio-1.36.0",
-        ":tokio-stream-0.1.14",
+        ":tokio-stream-0.1.15",
     ],
 )
 
@@ -15680,23 +15712,23 @@ cargo.rust_library(
 
 alias(
     name = "toml",
-    actual = ":toml-0.8.10",
+    actual = ":toml-0.8.12",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "toml-0.8.10.crate",
-    sha256 = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
-    strip_prefix = "toml-0.8.10",
-    urls = ["https://crates.io/api/v1/crates/toml/0.8.10/download"],
+    name = "toml-0.8.12.crate",
+    sha256 = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3",
+    strip_prefix = "toml-0.8.12",
+    urls = ["https://crates.io/api/v1/crates/toml/0.8.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml-0.8.10",
-    srcs = [":toml-0.8.10.crate"],
+    name = "toml-0.8.12",
+    srcs = [":toml-0.8.12.crate"],
     crate = "toml",
-    crate_root = "toml-0.8.10.crate/src/lib.rs",
+    crate_root = "toml-0.8.12.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -15708,7 +15740,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":toml_edit-0.22.6",
+        ":toml_edit-0.22.8",
     ],
 )
 
@@ -15732,18 +15764,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "toml_edit-0.22.6.crate",
-    sha256 = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6",
-    strip_prefix = "toml_edit-0.22.6",
-    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.6/download"],
+    name = "toml_edit-0.22.8.crate",
+    sha256 = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd",
+    strip_prefix = "toml_edit-0.22.8",
+    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.22.6",
-    srcs = [":toml_edit-0.22.6.crate"],
+    name = "toml_edit-0.22.8",
+    srcs = [":toml_edit-0.22.8.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.22.6.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "display",
@@ -15761,55 +15793,53 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "tonic-0.9.2.crate",
-    sha256 = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a",
-    strip_prefix = "tonic-0.9.2",
-    urls = ["https://crates.io/api/v1/crates/tonic/0.9.2/download"],
+    name = "tonic-0.11.0.crate",
+    sha256 = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13",
+    strip_prefix = "tonic-0.11.0",
+    urls = ["https://crates.io/api/v1/crates/tonic/0.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tonic-0.9.2",
-    srcs = [":tonic-0.9.2.crate"],
+    name = "tonic-0.11.0",
+    srcs = [":tonic-0.11.0.crate"],
     crate = "tonic",
-    crate_root = "tonic-0.9.2.crate/src/lib.rs",
+    crate_root = "tonic-0.11.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "tonic-0.9.2.crate",
+        "CARGO_MANIFEST_DIR": "tonic-0.11.0.crate",
         "CARGO_PKG_AUTHORS": "Lucio Franco <luciofranco14@gmail.com>",
         "CARGO_PKG_DESCRIPTION": "A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.\n",
         "CARGO_PKG_NAME": "tonic",
         "CARGO_PKG_REPOSITORY": "https://github.com/hyperium/tonic",
-        "CARGO_PKG_VERSION": "0.9.2",
+        "CARGO_PKG_VERSION": "0.11.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "9",
-        "CARGO_PKG_VERSION_PATCH": "2",
+        "CARGO_PKG_VERSION_MINOR": "11",
+        "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
         "channel",
         "codegen",
-        "default",
         "prost",
         "transport",
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.77",
+        ":async-stream-0.3.5",
+        ":async-trait-0.1.78",
         ":axum-0.6.20",
         ":base64-0.21.7",
         ":bytes-1.5.0",
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
-        ":h2-0.3.24",
+        ":h2-0.3.25",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":hyper-0.14.28",
         ":hyper-timeout-0.4.1",
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.5",
-        ":prost-0.11.9",
+        ":prost-0.12.3",
         ":tokio-1.36.0",
-        ":tokio-stream-0.1.14",
+        ":tokio-stream-0.1.15",
         ":tower-0.4.13",
         ":tower-layer-0.3.2",
         ":tower-service-0.3.2",
@@ -15923,7 +15953,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-compression-0.4.6",
-        ":bitflags-2.4.2",
+        ":bitflags-2.5.0",
         ":bytes-1.5.0",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
@@ -16026,9 +16056,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )
 
@@ -16109,33 +16139,33 @@ cargo.rust_library(
 
 alias(
     name = "tracing-opentelemetry",
-    actual = ":tracing-opentelemetry-0.22.0",
+    actual = ":tracing-opentelemetry-0.23.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tracing-opentelemetry-0.22.0.crate",
-    sha256 = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596",
-    strip_prefix = "tracing-opentelemetry-0.22.0",
-    urls = ["https://crates.io/api/v1/crates/tracing-opentelemetry/0.22.0/download"],
+    name = "tracing-opentelemetry-0.23.0.crate",
+    sha256 = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284",
+    strip_prefix = "tracing-opentelemetry-0.23.0",
+    urls = ["https://crates.io/api/v1/crates/tracing-opentelemetry/0.23.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tracing-opentelemetry-0.22.0",
-    srcs = [":tracing-opentelemetry-0.22.0.crate"],
+    name = "tracing-opentelemetry-0.23.0",
+    srcs = [":tracing-opentelemetry-0.23.0.crate"],
     crate = "tracing_opentelemetry",
-    crate_root = "tracing-opentelemetry-0.22.0.crate/src/lib.rs",
+    crate_root = "tracing-opentelemetry-0.23.0.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "tracing-opentelemetry-0.22.0.crate",
+        "CARGO_MANIFEST_DIR": "tracing-opentelemetry-0.23.0.crate",
         "CARGO_PKG_AUTHORS": "Julian Tescher <julian@tescher.me>:Tokio Contributors <team@tokio.rs>",
         "CARGO_PKG_DESCRIPTION": "OpenTelemetry integration for tracing",
         "CARGO_PKG_NAME": "tracing-opentelemetry",
         "CARGO_PKG_REPOSITORY": "https://github.com/tokio-rs/tracing-opentelemetry",
-        "CARGO_PKG_VERSION": "0.22.0",
+        "CARGO_PKG_VERSION": "0.23.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "22",
+        "CARGO_PKG_VERSION_MINOR": "23",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -16147,8 +16177,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":once_cell-1.19.0",
-        ":opentelemetry-0.21.0",
-        ":opentelemetry_sdk-0.21.2",
+        ":opentelemetry-0.22.0",
+        ":opentelemetry_sdk-0.22.1",
         ":smallvec-1.13.1",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
@@ -16304,7 +16334,7 @@ cargo.rust_library(
         ":log-0.4.21",
         ":rand-0.8.5",
         ":sha1-0.10.6",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":url-2.5.0",
         ":utf-8-0.7.6",
     ],
@@ -16550,18 +16580,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "unsafe-libyaml-0.2.10.crate",
-    sha256 = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b",
-    strip_prefix = "unsafe-libyaml-0.2.10",
-    urls = ["https://crates.io/api/v1/crates/unsafe-libyaml/0.2.10/download"],
+    name = "unsafe-libyaml-0.2.11.crate",
+    sha256 = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861",
+    strip_prefix = "unsafe-libyaml-0.2.11",
+    urls = ["https://crates.io/api/v1/crates/unsafe-libyaml/0.2.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "unsafe-libyaml-0.2.10",
-    srcs = [":unsafe-libyaml-0.2.10.crate"],
+    name = "unsafe-libyaml-0.2.11",
+    srcs = [":unsafe-libyaml-0.2.11.crate"],
     crate = "unsafe_libyaml",
-    crate_root = "unsafe-libyaml-0.2.10.crate/src/lib.rs",
+    crate_root = "unsafe-libyaml-0.2.11.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -16687,23 +16717,23 @@ cargo.rust_library(
 
 alias(
     name = "uuid",
-    actual = ":uuid-1.7.0",
+    actual = ":uuid-1.8.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "uuid-1.7.0.crate",
-    sha256 = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a",
-    strip_prefix = "uuid-1.7.0",
-    urls = ["https://crates.io/api/v1/crates/uuid/1.7.0/download"],
+    name = "uuid-1.8.0.crate",
+    sha256 = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0",
+    strip_prefix = "uuid-1.8.0",
+    urls = ["https://crates.io/api/v1/crates/uuid/1.8.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "uuid-1.7.0",
-    srcs = [":uuid-1.7.0.crate"],
+    name = "uuid-1.8.0",
+    srcs = [":uuid-1.8.0.crate"],
     crate = "uuid",
-    crate_root = "uuid-1.7.0.crate/src/lib.rs",
+    crate_root = "uuid-1.8.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -16881,18 +16911,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "whoami-1.5.0.crate",
-    sha256 = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e",
-    strip_prefix = "whoami-1.5.0",
-    urls = ["https://crates.io/api/v1/crates/whoami/1.5.0/download"],
+    name = "whoami-1.5.1.crate",
+    sha256 = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9",
+    strip_prefix = "whoami-1.5.1",
+    urls = ["https://crates.io/api/v1/crates/whoami/1.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "whoami-1.5.0",
-    srcs = [":whoami-1.5.0.crate"],
+    name = "whoami-1.5.1",
+    srcs = [":whoami-1.5.1.crate"],
     crate = "whoami",
-    crate_root = "whoami-1.5.0.crate/src/lib.rs",
+    crate_root = "whoami-1.5.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -17384,7 +17414,7 @@ cargo.rust_library(
         ":ring-0.17.5",
         ":signature-2.2.0",
         ":spki-0.7.3",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":zeroize-1.7.0",
     ],
 )
@@ -17416,7 +17446,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":rustix-0.38.31"],
+    deps = [":rustix-0.38.32"],
 )
 
 alias(
@@ -17443,7 +17473,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
         ":tokio-1.36.0",
         ":yrs-0.17.4",
     ],
@@ -17467,18 +17497,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "yansi-1.0.0.crate",
-    sha256 = "6c2861d76f58ec8fc95708b9b1e417f7b12fd72ad33c01fa6886707092dea0d3",
-    strip_prefix = "yansi-1.0.0",
-    urls = ["https://crates.io/api/v1/crates/yansi/1.0.0/download"],
+    name = "yansi-1.0.1.crate",
+    sha256 = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049",
+    strip_prefix = "yansi-1.0.1",
+    urls = ["https://crates.io/api/v1/crates/yansi/1.0.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "yansi-1.0.0",
-    srcs = [":yansi-1.0.0.crate"],
+    name = "yansi-1.0.1",
+    srcs = [":yansi-1.0.1.crate"],
     crate = "yansi",
-    crate_root = "yansi-1.0.0.crate/src/lib.rs",
+    crate_root = "yansi-1.0.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -17516,7 +17546,7 @@ cargo.rust_library(
         ":serde_json-1.0.114",
         ":smallstr-0.3.0",
         ":smallvec-1.13.1",
-        ":thiserror-1.0.57",
+        ":thiserror-1.0.58",
     ],
 )
 
@@ -17590,8 +17620,8 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.78",
+        ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.52",
+        ":syn-2.0.53",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arrayref"
@@ -217,13 +217,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -245,18 +245,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -288,16 +288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
-]
-
-[[package]]
-name = "atomic-write-file"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8204db279bf648d64fe845bd8840f78b39c8132ed4d6a4194c3b10d4b4cfb0b"
-dependencies = [
- "nix 0.28.0",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -422,10 +412,10 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -502,9 +492,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 dependencies = [
  "serde",
 ]
@@ -534,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -591,7 +581,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.6.1",
+ "serde_with 3.7.0",
 ]
 
 [[package]]
@@ -614,15 +604,15 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "syn_derive",
 ]
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -814,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -837,14 +827,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -872,9 +862,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -1206,7 +1196,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
  "parking_lot 0.12.1",
@@ -1301,7 +1291,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1349,7 +1339,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1371,7 +1361,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1724,7 +1714,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1953,9 +1943,9 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -1972,7 +1962,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2101,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2209,6 +2199,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2442,8 +2438,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.52",
- "toml 0.8.10",
+ "syn 2.0.53",
+ "toml 0.8.12",
  "unicode-xid",
 ]
 
@@ -2518,7 +2514,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2576,6 +2572,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2671,7 +2676,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -2744,7 +2749,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2909,20 +2914,8 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -3107,13 +3100,12 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.5",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3123,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3142,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3154,18 +3146,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
-dependencies = [
- "opentelemetry",
-]
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3254,11 +3243,11 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3267,12 +3256,12 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3469,7 +3458,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3605,10 +3594,10 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3720,9 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3735,16 +3724,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "version_check",
- "yansi 1.0.0",
+ "yansi 1.0.1",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes 1.5.0",
  "prost-derive",
@@ -3752,15 +3741,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3789,7 +3778,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "memchr",
  "unicase",
 ]
@@ -3911,7 +3900,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -3984,12 +3973,12 @@ dependencies = [
  "log",
  "regex",
  "serde",
- "siphasher 1.0.0",
+ "siphasher 1.0.1",
  "thiserror",
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.10",
+ "toml 0.8.12",
  "url",
  "walkdir",
 ]
@@ -4004,7 +3993,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4059,7 +4048,7 @@ checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4073,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
@@ -4266,11 +4255,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4413,18 +4402,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "sea-orm"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6632f499b80cc6aaa781b302e4c9fae663e0e3dcf2640e9d80034d5b10731efe"
+checksum = "c8814e37dc25de54398ee62228323657520b7f29713b8e238649385dbe473ee0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4450,15 +4439,15 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec13bfb4c4aef208f68dbea970dd40d13830c868aa8dcb4e106b956e6bb4f2fa"
+checksum = "5e115c6b078e013aa963cc2d38c196c2c40b05f03d0ac872fe06b6e0d5265603"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.52",
+ "syn 2.0.53",
  "unicode-ident",
 ]
 
@@ -4596,7 +4585,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4622,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
@@ -4638,7 +4627,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4690,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -4702,7 +4691,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.1",
+ "serde_with_macros 3.7.0",
  "time",
 ]
 
@@ -4715,26 +4704,26 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
  "indexmap 2.2.5",
  "itoa",
@@ -4846,9 +4835,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skeptic"
@@ -4965,9 +4954,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4978,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash 0.8.11",
  "atoi",
@@ -4990,7 +4979,6 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
- "dotenvy",
  "either",
  "event-listener",
  "futures-channel",
@@ -5026,9 +5014,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5039,14 +5027,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
- "atomic-write-file",
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -5066,14 +5053,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "bytes 1.5.0",
  "chrono",
@@ -5113,14 +5100,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "chrono",
  "crc",
@@ -5144,7 +5131,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -5158,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -5243,11 +5229,11 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5282,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5300,7 +5286,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5402,7 +5388,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5428,7 +5414,7 @@ dependencies = [
  "bytes 1.5.0",
  "chrono",
  "ciborium",
- "clap 4.5.2",
+ "clap 4.5.3",
  "color-eyre",
  "colored",
  "comfy-table",
@@ -5497,13 +5483,13 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_url_params",
- "serde_with 3.6.1",
+ "serde_with 3.7.0",
  "serde_yaml",
  "sled",
  "sodiumoxide",
  "stream-cancel",
  "strum",
- "syn 2.0.52",
+ "syn 2.0.53",
  "tar",
  "tempfile",
  "test-log",
@@ -5517,7 +5503,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tokio-vsock",
- "toml 0.8.10",
+ "toml 0.8.12",
  "tower",
  "tower-http",
  "tracing",
@@ -5535,22 +5521,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5665,7 +5651,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5756,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5768,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
  "bytes 1.5.0",
@@ -5831,14 +5817,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -5863,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -5876,16 +5862,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes 1.5.0",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -5930,7 +5915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bytes 1.5.0",
  "futures-core",
  "futures-util",
@@ -5977,7 +5962,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6013,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -6026,7 +6011,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "web-time 0.2.4",
+ "web-time",
 ]
 
 [[package]]
@@ -6106,7 +6091,7 @@ dependencies = [
  "getrandom 0.2.12",
  "rand 0.8.5",
  "serde",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -6165,9 +6150,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6213,9 +6198,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
@@ -6334,7 +6319,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -6368,7 +6353,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6384,16 +6369,6 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6417,9 +6392,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
@@ -6685,9 +6660,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2861d76f58ec8fc95708b9b1e417f7b12fd72ad33c01fa6886707092dea0d3"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yrs"
@@ -6721,7 +6696,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6741,5 +6716,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -85,10 +85,10 @@ nkeys = "0.4.0"
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 open = "5.0.0"
-opentelemetry = { version = "0.21.0", features = ["trace"] }
-opentelemetry-otlp = "0.14.0"
-opentelemetry-semantic-conventions = "0.13.0"
-opentelemetry_sdk = { version = "0.21.1", features = ["rt-tokio"] }
+opentelemetry = { version = "0.22.0", features = ["trace"] }
+opentelemetry-otlp = "0.15.0"
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 ouroboros = "0.18.1"
 paste = "1.0.12"
 pathdiff = "0.2.1"
@@ -163,7 +163,7 @@ tower-http = { version = "0.4", features = [
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.22.0"
+tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",


### PR DESCRIPTION
https://github.com/tokio-rs/tracing-opentelemetry/pull/86 fixes some Mutex poisoining issues we're seeing (only in our test harness). Upgrading the various opentelemetry crates so we no longer have to deal with this panic.