### PR TITLE
Improved Visualizer

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceViz.vue
+++ b/app/web/src/components/Workspace/WorkspaceViz.vue
@@ -6,6 +6,8 @@
       type="dropdown"
       class="flex-1"
       :options="schemaVariantOptions"
+      placeholder="--- None ---"
+      placeholderSelectable
     />
 
     <WorkspaceVizSchemaVariant

--- a/app/web/src/components/Workspace/WorkspaceViz.vue
+++ b/app/web/src/components/Workspace/WorkspaceViz.vue
@@ -3,5 +3,20 @@
 </template>
 
 <script lang="ts" setup>
+import { useRouter } from "vue-router";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import { useWorkspacesStore } from "@/store/workspaces.store";
 import WorkspaceVizSchemaVariant from "./WorkspaceVizSchemaVariant.vue";
+
+const featureFlagsStore = useFeatureFlagsStore();
+const workspacesStore = useWorkspacesStore();
+const workspacePk = workspacesStore.getAutoSelectedWorkspacePk();
+
+const router = useRouter();
+if (!featureFlagsStore.FEAT_GRAPHVIZ) {
+  router.replace({
+    name: "workspace-single",
+    params: { workspacePk },
+  });
+}
 </script>

--- a/app/web/src/components/Workspace/WorkspaceViz.vue
+++ b/app/web/src/components/Workspace/WorkspaceViz.vue
@@ -1,35 +1,7 @@
 <template>
-  <Stack class="h-full w-full my-4 mx-4">
-    <VormInput
-      v-model="selectedSchemaVariant"
-      label="Schema Variants"
-      type="dropdown"
-      class="flex-1"
-      :options="schemaVariantOptions"
-      placeholder="--- None ---"
-      placeholderSelectable
-    />
-
-    <WorkspaceVizSchemaVariant
-      :key="selectedSchemaVariant"
-      :schemaVariantId="selectedSchemaVariant"
-    />
-  </Stack>
+  <WorkspaceVizSchemaVariant />
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from "vue";
-import { VormInput, Stack } from "@si/vue-lib/design-system";
-import { useComponentsStore } from "@/store/components.store";
 import WorkspaceVizSchemaVariant from "./WorkspaceVizSchemaVariant.vue";
-
-const componentStore = useComponentsStore();
-
-const selectedSchemaVariant = ref();
-const schemaVariantOptions = computed(() =>
-  componentStore.schemaVariants.map((sv) => ({
-    label: sv.schemaName + (sv.builtin ? " (builtin)" : ""),
-    value: sv.id,
-  })),
-);
 </script>

--- a/app/web/src/components/Workspace/WorkspaceViz.vue
+++ b/app/web/src/components/Workspace/WorkspaceViz.vue
@@ -1,5 +1,5 @@
 <template>
-  <Stack class="h-full w-full">
+  <Stack class="h-full w-full my-4 mx-4">
     <VormInput
       v-model="selectedSchemaVariant"
       label="Schema Variants"

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -114,7 +114,7 @@ let renderer: Sigma;
 function buildClickedNeighbors() {
   state.clickedNeighbors.clear();
   state.clickedNodes.forEach((c: string) => {
-    for (const n in graph.neighbors(c)) {
+    for (const n of graph.neighbors(c)) {
       state.clickedNeighbors.add(n);
     }
   });
@@ -155,7 +155,6 @@ onMounted(async () => {
     await vizStore.LOAD_DATA(schemaVariant.value);
     loading.value = false;
 
-    console.log("COMPONENT NODES", vizStore.nodes);
     if (vizStore.edges.length === 0 && vizStore.nodes.length === 0) {
       return;
     }

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -31,10 +31,12 @@ const props = defineProps<{ schemaVariantId?: string }>();
 
 const getColor = (nodeKind: string, contentKind: string | null) => {
   const kindMap: { [key: string]: string } = {
-    Category: "#2FA",
+    Category: "#c200ff",
     Func: "#F02",
     Ordering: "#ABC",
     Prop: "#0FF",
+    AttributePrototypeArgument: "#103016",
+    FuncArgument: "#40300c",
   };
 
   const contentKindMap: { [key: string]: string } = {

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -7,7 +7,7 @@
         type="dropdown"
         class="flex-1"
         :options="schemaVariantOptions"
-        placeholder="Entire Workspace"
+        placeholder="Dropped Components"
         placeholderSelectable
       />
       <VormInput
@@ -173,7 +173,11 @@ onMounted(async () => {
     }
 
     loading.value = true;
-    await vizStore.LOAD_DATA(schemaVariant.value);
+    if (schemaVariant.value) {
+      await vizStore.LOAD_VARIANTS(schemaVariant.value);
+    } else {
+      await vizStore.LOAD_COMPONENTS();
+    }
     loading.value = false;
 
     if (vizStore.edges.length === 0 && vizStore.nodes.length === 0) {

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -65,6 +65,7 @@ onMounted(async () => {
   const nodes = nodesAndEdges.result.data.nodes;
   const edges = nodesAndEdges.result.data.edges;
 
+
   for (const node of nodes) {
     graph.addNode(node.id, {
       color: getColor(node.nodeKind, node.contentKind),
@@ -90,6 +91,8 @@ onMounted(async () => {
 
   const container = document.getElementById("vizDiv") as HTMLElement;
   // tslint:disable-next-line
-  const _sigma = new Sigma(graph, container);
+  const _sigma = new Sigma(graph, container, {
+    allowInvalidContainer: true,
+  });
 });
 </script>

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -191,7 +191,7 @@ onMounted(async () => {
         }`,
         x: Math.floor(Math.random() * 1000),
         y: Math.floor(Math.random() * 1000),
-        size: size.value,
+        size: node.contentKind === "Root" ? size.value * 2 : size.value, // make Root stand out
         grouping:
           node.nodeKind === "Content" ? node.contentKind : node.contentKind,
       });

--- a/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
+++ b/app/web/src/components/Workspace/WorkspaceVizSchemaVariant.vue
@@ -24,7 +24,7 @@
         >
       </div>
       <div>
-        <VButton @click="toggleLayout"
+        <VButton :disabled="loading" @click="toggleLayout"
           >{{ animate_layout ? "Stop" : "Start" }} Animation</VButton
         >
       </div>
@@ -209,6 +209,7 @@ onMounted(async () => {
     const sensibleSettings = forceAtlas2.inferSettings(graph);
     fa2Layout = new FA2Layout(graph, { settings: sensibleSettings });
     fa2Layout.start();
+    animate_layout.value = true; // override, since we're re-drawing the graph
 
     // Cheap trick: tilt the camera a bit to make labels more readable
     renderer.getCamera().setState({

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -20,7 +20,7 @@
         @click="openWorkspaceDetailsHandler"
       />
       <DropdownMenuItem
-        v-if="showViz()"
+        v-if="showViz"
         icon="diagram"
         label="Visualizer"
         @click="gotoViz"
@@ -34,7 +34,7 @@
 
 <script setup lang="ts">
 import { DropdownMenuItem, Icon } from "@si/vue-lib/design-system";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import WorkspaceImportModal from "@/components/WorkspaceImportModal.vue";
 import WorkspaceExportModal from "@/components/WorkspaceExportModal.vue";
@@ -59,11 +59,11 @@ const openWorkspaceDetailsHandler = () => {
   window.open(`${AUTH_PORTAL_URL}/workspace/${currentWorkspace}`, "_blank");
 };
 
-const showViz = () => {
+const showViz = computed(() => {
   if (!changeSetStore.selectedChangeSetId) return false;
   if (!featureFlagsStore.FEAT_GRAPHVIZ) return false;
   return true;
-};
+});
 
 const gotoViz = () => {
   router.push({

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -19,6 +19,12 @@
         label="Manage Users"
         @click="openWorkspaceDetailsHandler"
       />
+      <DropdownMenuItem
+        v-if="showViz()"
+        icon="diagram"
+        label="Visualizer"
+        @click="gotoViz"
+      />
     </template>
   </NavbarButton>
 
@@ -29,9 +35,12 @@
 <script setup lang="ts">
 import { DropdownMenuItem, Icon } from "@si/vue-lib/design-system";
 import { ref } from "vue";
+import { useRouter, useRoute } from "vue-router";
 import WorkspaceImportModal from "@/components/WorkspaceImportModal.vue";
 import WorkspaceExportModal from "@/components/WorkspaceExportModal.vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import NavbarButton from "./NavbarButton.vue";
 
 const AUTH_PORTAL_URL = import.meta.env.VITE_AUTH_PORTAL_URL;
@@ -39,10 +48,30 @@ const importModalRef = ref<InstanceType<typeof WorkspaceImportModal>>();
 const exportModalRef = ref<InstanceType<typeof WorkspaceExportModal>>();
 
 const workspacesStore = useWorkspacesStore();
+const featureFlagsStore = useFeatureFlagsStore();
+const changeSetStore = useChangeSetsStore();
+const router = useRouter();
+const route = useRoute();
 
 const openWorkspaceDetailsHandler = () => {
   const currentWorkspace = workspacesStore.urlSelectedWorkspaceId;
   if (!currentWorkspace) return;
   window.open(`${AUTH_PORTAL_URL}/workspace/${currentWorkspace}`, "_blank");
+};
+
+const showViz = () => {
+  if (!changeSetStore.selectedChangeSetId) return false;
+  if (!featureFlagsStore.FEAT_GRAPHVIZ) return false;
+  return true;
+};
+
+const gotoViz = () => {
+  router.push({
+    name: "workspace-viz",
+    params: {
+      ...route.params,
+      changeSetId: changeSetStore.selectedChangeSetId,
+    },
+  });
 };
 </script>

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -10,6 +10,7 @@ const FLAG_MAPPING = {
   INVITE_USER: "invite_user",
   MODULES_TAB: "modules_tab",
   INDICATORS_MANUAL_FUNCTION_SOCKET: "indicators_manual_function_socket",
+  FEAT_GRAPHVIZ: "feat-graphviz",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/app/web/src/store/viz.store.ts
+++ b/app/web/src/store/viz.store.ts
@@ -24,10 +24,30 @@ export type ContentKind =
   | "StaticArgumentValue"
   | "ValidationPrototype";
 
+export type EdgeWeightKind =
+  | "Use"
+  | "Action"
+  | "ActionPrototype"
+  | "AuthenticationPrototype"
+  | "Contain"
+  | "FrameContains"
+  | "Ordering"
+  | "Ordinal"
+  | "Prop"
+  | "Prototype"
+  | "PrototypeArgument"
+  | "PrototypeArgumentValue"
+  | "Proxy"
+  | "Root"
+  | "Socket"
+  | "SocketValue"
+  | "Use";
+
 export interface VizResponse {
   edges: {
     from: string;
     to: string;
+    edgeWeightKind: EdgeWeightKind | null;
   }[];
 
   nodes: {

--- a/app/web/src/store/viz.store.ts
+++ b/app/web/src/store/viz.store.ts
@@ -59,15 +59,23 @@ export const useVizStore = addStoreHooks(
       rootNodeId: "",
     });
 
-    async function LOAD_DATA(schemaVariantId: string | null) {
-      function onSuccess(response: VizResponse): void {
-        data.nodes.splice(0, data.nodes.length);
-        data.edges.splice(0, data.edges.length);
-        data.edges.push(...response.edges);
-        data.nodes.push(...response.nodes);
-        data.rootNodeId = response.rootNodeId;
-      }
+    function onSuccess(response: VizResponse): void {
+      data.nodes.splice(0, data.nodes.length);
+      data.edges.splice(0, data.edges.length);
+      data.edges.push(...response.edges);
+      data.nodes.push(...response.nodes);
+      data.rootNodeId = response.rootNodeId;
+    }
 
+    async function LOAD_COMPONENTS() {
+      return new ApiRequest<VizResponse>({
+        url: "/graphviz/components",
+        params: { ...visibility },
+        onSuccess,
+      });
+    }
+
+    async function LOAD_VARIANTS(schemaVariantId: string | null) {
       return schemaVariantId === null
         ? new ApiRequest<VizResponse>({
             url: "/graphviz/nodes_edges",
@@ -81,6 +89,11 @@ export const useVizStore = addStoreHooks(
           });
     }
 
-    return { edges: data.edges, nodes: data.nodes, LOAD_DATA };
+    return {
+      edges: data.edges,
+      nodes: data.nodes,
+      LOAD_VARIANTS,
+      LOAD_COMPONENTS,
+    };
   }),
 );

--- a/app/web/src/store/viz.store.ts
+++ b/app/web/src/store/viz.store.ts
@@ -6,7 +6,13 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import { nilId } from "@/utils/nilId";
 
-export type NodeKind = "Category" | "Content" | "Func" | "Ordering" | "Prop";
+export type NodeKind =
+  | "Category"
+  | "Content"
+  | "Func"
+  | "Ordering"
+  | "Prop"
+  | "Component";
 
 export type ContentKind =
   | "Root"

--- a/app/web/src/store/viz.store.ts
+++ b/app/web/src/store/viz.store.ts
@@ -1,7 +1,6 @@
 import { defineStore } from "pinia";
 import { ApiRequest, addStoreHooks } from "@si/vue-lib/pinia";
 import { reactive } from "vue";
-import { useWorkspacesStore } from "@/store/workspaces.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import { nilId } from "@/utils/nilId";

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -712,6 +712,29 @@ impl WorkspaceSnapshot {
         Ok(())
     }
 
+    pub async fn get_edges_between_nodes(
+        &self,
+        from_node_id: Ulid,
+        to_node_id: Ulid,
+    ) -> WorkspaceSnapshotResult<Vec<EdgeWeight>> {
+        let from_node_index = self.get_node_index_by_id(from_node_id).await?;
+
+        let to_node_index = self.get_node_index_by_id(to_node_id).await?;
+        let edges = self
+            .edges()
+            .await?
+            .into_iter()
+            .filter_map(|(edge, node_from, node_to)| {
+                if node_from == from_node_index && node_to == to_node_index {
+                    Some(edge)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(edges)
+    }
+
     #[instrument(level = "debug", skip_all)]
     pub async fn remove_node_by_id(
         &self,


### PR DESCRIPTION
There are 3 different kinds of things you can view, all rendered as a graph.

1. The default view contains all the components you've placed on the diagram and all the nodes in the system they are connected to. We start at the components and walk the graph from there.
2. The next option contains everything. We walk from every node in the workspace, which includes assets and builtins that are not related to components. Components in the diagram are also included here.
3. The rest of the options are all the builtins themselves. We take a single schema variant and walk only its related nodes. This will never contain a component from the diagram.

I've included a handy refresh button. If you're viewing components, and change the diagram, you can hit that button to reload the page. You can search for specific nodes based on the text of their label. You can hover and click on nodes to focus on just that node and its neighbors. This is a way to focus on a piece of a large graph. And you can stop or start the animation, technically the layout algorithm is continuously optimizing the graph and moving nodes... which can make hovering or clicking on items challenging.