### PR TITLE
feat(dal,sdf): unset overriden value

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1658,7 +1658,7 @@ impl AttributeValue {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<()> {
-        let prototype_id = AttributeValue::component_prototype_id(&ctx, attribute_value_id)
+        let prototype_id = AttributeValue::component_prototype_id(ctx, attribute_value_id)
             .await?
             .ok_or(AttributeValueError::NoComponentPrototype(
                 attribute_value_id,

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -829,6 +829,26 @@ impl WorkspaceSnapshot {
         )?)
     }
 
+    #[instrument(level = "debug", skip_all)]
+    pub async fn remove_edge_for_ulids(
+        &self,
+        change_set: &ChangeSetPointer,
+        source_node_id: impl Into<Ulid>,
+        target_node_id: impl Into<Ulid>,
+        edge_kind: EdgeWeightKindDiscriminants,
+    ) -> WorkspaceSnapshotResult<()> {
+        let source_node_index = self
+            .working_copy()
+            .await
+            .get_node_index_by_id(source_node_id)?;
+        let target_node_index = self
+            .working_copy()
+            .await
+            .get_node_index_by_id(target_node_id)?;
+        self.remove_edge(change_set, source_node_index, target_node_index, edge_kind)
+            .await
+    }
+
     /// Perform [`Updates`](Update) using [`self`](WorkspaceSnapshot) as the "to rebase" graph and
     /// another [`snapshot`](WorkspaceSnapshot) as the "onto" graph.
     #[instrument(level = "debug", skip_all)]

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -33,6 +33,7 @@ pub mod list_qualifications;
 // pub mod resource_domain_diff;
 pub mod debug;
 pub mod get_code;
+pub mod restore_default_function;
 pub mod set_type;
 
 #[remain::sorted]
@@ -172,6 +173,10 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/delete_property_editor_value",
             post(delete_property_editor_value::delete_property_editor_value),
+        )
+        .route(
+            "/restore_default_function",
+            post(restore_default_function::restore_default_function),
         )
         .route("/set_type", post(set_type::set_type))
         // .route("/refresh", post(refresh::refresh))

--- a/lib/sdf-server/src/server/service/component/restore_default_function.rs
+++ b/lib/sdf-server/src/server/service/component/restore_default_function.rs
@@ -1,9 +1,9 @@
-use axum::{extract::OriginalUri, response::IntoResponse, Json};
+use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use dal::{AttributeValue, AttributeValueId, ChangeSetPointer, Visibility};
 
-use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::extract::{AccessBuilder, HandlerContext};
 
 use super::ComponentResult;
 

--- a/lib/sdf-server/src/server/service/component/restore_default_function.rs
+++ b/lib/sdf-server/src/server/service/component/restore_default_function.rs
@@ -1,17 +1,11 @@
 use axum::{extract::OriginalUri, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
-use dal::{
-    AttributeValue, AttributeValueError, AttributeValueId, ChangeSet, Component, Prop,
-    StandardModel, Visibility,
-};
+use dal::{AttributeValue, AttributeValueId, ChangeSetPointer, Visibility};
 
-use crate::server::{
-    extract::{AccessBuilder, HandlerContext, PosthogClient},
-    tracking::track,
-};
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 
-use super::{ComponentError, ComponentResult};
+use super::ComponentResult;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -24,8 +18,6 @@ pub struct RestoreDefaultFunctionRequest {
 pub async fn restore_default_function(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    PosthogClient(posthog_client): PosthogClient,
-    OriginalUri(original_uri): OriginalUri,
     Json(request): Json<RestoreDefaultFunctionRequest>,
 ) -> ComponentResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
@@ -35,40 +27,40 @@ pub async fn restore_default_function(
     AttributeValue::use_default_prototype(&ctx, request.attribute_value_id).await?;
 
     // Track
-    {
-        let attribute_value = AttributeValue::get_by_id(&ctx, &request.attribute_value_id)
-            .await?
-            .ok_or_else(|| {
-                AttributeValueError::NotFound(request.attribute_value_id, *ctx.visibility())
-            })?;
-        let component = Component::get_by_id(&ctx, &attribute_value.context.component_id())
-            .await?
-            .ok_or_else(|| ComponentError::NotFound(attribute_value.context.component_id()))?;
-
-        let component_schema = component
-            .schema(&ctx)
-            .await?
-            .ok_or(ComponentError::SchemaNotFound)?;
-
-        let prop = Prop::get_by_id(&ctx, &attribute_value.context.prop_id())
-            .await?
-            .ok_or(ComponentError::PropNotFound(
-                attribute_value.context.prop_id(),
-            ))?;
-
-        track(
-            &posthog_client,
-            &ctx,
-            &original_uri,
-            "default_function_restored",
-            serde_json::json!({
-                "component_id": component.id(),
-                "component_schema_name": component_schema.name(),
-                "prop_id": prop.id(),
-                "prop_name": prop.name(),
-            }),
-        );
-    }
+    // {
+    //     let attribute_value = AttributeValue::get_by_id(&ctx, &request.attribute_value_id)
+    //         .await?
+    //         .ok_or_else(|| {
+    //             AttributeValueError::NotFound(request.attribute_value_id, *ctx.visibility())
+    //         })?;
+    //     let component = Component::get_by_id(&ctx, &attribute_value.context.component_id())
+    //         .await?
+    //         .ok_or_else(|| ComponentError::NotFound(attribute_value.context.component_id()))?;
+    //
+    //     let component_schema = component
+    //         .schema(&ctx)
+    //         .await?
+    //         .ok_or(ComponentError::SchemaNotFound)?;
+    //
+    //     let prop = Prop::get_by_id(&ctx, &attribute_value.context.prop_id())
+    //         .await?
+    //         .ok_or(ComponentError::PropNotFound(
+    //             attribute_value.context.prop_id(),
+    //         ))?;
+    //
+    //     track(
+    //         &posthog_client,
+    //         &ctx,
+    //         &original_uri,
+    //         "default_function_restored",
+    //         serde_json::json!({
+    //             "component_id": component.id(),
+    //             "component_schema_name": component_schema.name(),
+    //             "prop_id": prop.id(),
+    //             "prop_name": prop.name(),
+    //         }),
+    //     );
+    // }
 
     ctx.commit().await?;
 


### PR DESCRIPTION
Allow user to revert manually setting a value by detaching the av from its direct prototype, making the av be set by the default prototype for its prop

<img src="https://media2.giphy.com/media/9PeoqWYJ09ROWWg4hF/giphy-downsized-medium.gif"/>