### PR TITLE
feat(si-layer-cache): impl rebaser requests work queue stream

### DIFF
--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -9,7 +9,10 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use ulid::Ulid;
 
 use crate::{
-    activities::{Activity, ActivityPayloadDiscriminants, ActivityPublisher, ActivityStream},
+    activities::{
+        Activity, ActivityPayloadDiscriminants, ActivityPublisher, ActivityStream,
+        RebaserRequestsWorkQueueStream,
+    },
     error::LayerDbResult,
     layer_cache::LayerCache,
     persister::{PersisterClient, PersisterTask},
@@ -167,6 +170,12 @@ where
             None::<std::vec::IntoIter<_>>,
         )
         .await
+    }
+
+    pub async fn subscribe_rebaser_requests_work_queue(
+        &self,
+    ) -> LayerDbResult<RebaserRequestsWorkQueueStream> {
+        RebaserRequestsWorkQueueStream::create(&self.nats_client).await
     }
 }
 

--- a/lib/si-layer-cache/src/error.rs
+++ b/lib/si-layer-cache/src/error.rs
@@ -63,6 +63,8 @@ pub enum LayerDbError {
     SledError(#[from] sled::Error),
     #[error("tokio oneshot recv error: {0}")]
     TokioOneShotRecv(#[from] tokio::sync::oneshot::error::RecvError),
+    #[error("unexpected activity variant; expected={0}, actual={1}")]
+    UnexpectedActivityVariant(String, String),
 }
 
 impl LayerDbError {


### PR DESCRIPTION
This is an initial implementation of a work queue stream of rebaser requests, suitable for use by the rebaser service.

Note that it's not yet clear if additional work queue streams follow this pattern, if the code is extractable into the service-related crates, or if some other code de-duplication is possible. At the moment, the newly added Rust types are doing a *lot* of heavy lifting to ensure correctness of behavior and type safety.

Also note that this NATS Jetstream setup may require further testing and refinement to confirm the desired stream sourcing behavior.

<img src="https://media1.giphy.com/media/5YuhLwDgrgtRVwI7OY/giphy.gif"/>