### PR TITLE
feat: add target for cypress e2e tests into BUCK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ vendor/automerge
 /support/dev/k8s/**/web-htpasswd
 /tmp/
 deploy/docker-compose.env.yml
+app/web/cypress/downloads/
 app/web/cypress/screenshots/
 app/web/cypress/videos/
 bin/si/src/version.txt

--- a/app/web/BUCK
+++ b/app/web/BUCK
@@ -2,6 +2,7 @@ load(
     "@prelude-si//:macros.bzl",
     "docker_image",
     "eslint",
+    "e2e_test",
     "export_file",
     "package_node_modules",
     "shellcheck",
@@ -166,4 +167,8 @@ pnpm_task_test(
     ],
     path = "app/web",
     visibility = ["PUBLIC"],
+)
+
+e2e_test(
+    name = "e2e-test",
 )

--- a/app/web/cypress/e2e/authentication/login.cy.ts
+++ b/app/web/cypress/e2e/authentication/login.cy.ts
@@ -1,15 +1,23 @@
-Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
+const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
+Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
   describe("login", () => {
     beforeEach(() => {
       cy.visit("/");
     });
 
     it("log_in", () => {
-      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
-      cy.visit("/");
-      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
+      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
       // check that you're on head i.e. that you were redirected correctly
-      cy.url().should("contain", "head");
+      cy.wait(4000)
+      cy.url().should("contain", SI_WORKSPACE_ID);
     });
 
   });

--- a/app/web/cypress/e2e/authentication/logout.cy.ts
+++ b/app/web/cypress/e2e/authentication/logout.cy.ts
@@ -1,21 +1,27 @@
-Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const AUTH_PORTAL_URL = Cypress.env('VITE_AUTH_PORTAL_URL') || import.meta.env.VITE_AUTH_PORTAL_URL;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
+Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
   describe("logout", () => {
     beforeEach(() => {
       cy.visit("/");
-      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
     });
 
     it("log_out", () => {
       cy.visit("/");
-      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
-      cy.contains('Create change set', { timeout: 10000 }).should('be.visible').click();
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
+      cy.contains('Create change set', { timeout: 10000 }).should('be.visible');
+      cy.get('.modal-close-button').should('exist').click();
       cy.get('[aria-label="Profile"]').should('exist').click();
       cy.get('#dropdown-menu-item-1').should('exist').should('be.visible').click({ force: true });
 
       // There is a bug currently where you log out of the product & it just logs you out to the dashboard page
       // of the UI in auth portal
-      cy.url().should("contain", import.meta.env.VITE_AUTH_PORTAL_URL + '/dashboard');
-
+      cy.url().should("contain", AUTH_PORTAL_URL + '/dashboard');
     });
   });
 });

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -1,38 +1,48 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
+const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
+Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
   describe('component', () => {
     beforeEach(function () {
-      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      //cy.setupVariables();
+      cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
     });
 
     it('create', () => {
-      cy.visit('/')
-      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
       
-      cy.get('#vorm-input-3').clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3').clear().type(UUID);
 
-      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', UUID);
 
       cy.contains('Create change set', { timeout: 30000 }).click();
 
       // Give time to redirect onto the new changeset
       cy.url().should('not.include', 'head', { timeout: 10000 });
 
-      // Find the AWS Credential
-      cy.get('div[class="tree-node"]', { timeout: 30000 }).contains('AWS Credential').should('be.visible').as('awsCred')
+      // Find the AWS Region
+      cy.get('div[class="tree-node"]', { timeout: 30000 }).contains('Region').as('region');
 
       // Find the canvas to get a location to drag to
       cy.get('canvas').first().as('konvaStage');
 
       // drag to the canvas
-      cy.dragTo('@awsCred', '@konvaStage');
+      cy.dragTo('@region', '@konvaStage');
+
+      cy.wait(5000);
 
       //check to make sure a component has been added to the outliner
-      cy.get('[class="component-outline-node"]', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible');
+      cy.get('[class="component-outline-node"]', { timeout: 30000 }).contains('Region', { timeout: 30000 }).should('be.visible');
 
       // Click the button to destroy changeset
       cy.get('nav.navbar button.vbutton.--variant-ghost.--size-sm.--tone-action')
@@ -46,7 +56,6 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
       .click();
 
-    })
-  })
-
+    });
+  });
 });

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -1,20 +1,27 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
-Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VITE_SI_CYPRESS_MULTIPLIER : 1, () => {
+const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
+const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
+Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
   describe('component', () => {
     beforeEach(function () {
-      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+      cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
     });
 
     it('delete', () => {
-      cy.visit('/')
-      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
       
-      cy.get('#vorm-input-3').clear().type(import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3').clear().type(UUID);
 
-      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+      cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', UUID);
 
       cy.contains('Create change set', { timeout: 30000 }).click();
 
@@ -22,7 +29,7 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       cy.url().should('not.include', 'head', { timeout: 10000 });
 
       // Find the AWS Credential
-      cy.get('div[class="tree-node"]', { timeout: 30000 }).contains('AWS Credential').should('be.visible').as('awsCred')
+      cy.get('div[class="tree-node"]', { timeout: 30000 }).contains('AWS Credential').as('awsCred');
 
       // Find the canvas to get a location to drag to
       cy.get('canvas').first().as('konvaStage');
@@ -31,8 +38,8 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       cy.dragTo('@awsCred', '@konvaStage');
 
       // Check to make sure a component has been added to the outliner
-      cy.get('[class="component-outline-node"]', { timeout: 30000 }).
-        contains('AWS Credential', { timeout: 30000 })
+      cy.get('[class="component-outline-node"]', { timeout: 30000 })
+        .contains('AWS Credential', { timeout: 30000 })
         .should('be.visible')
         .rightclick();
 
@@ -43,7 +50,7 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
         .click();
 
-      //check to make sure a component has been added to the outliner
+      // Check to make sure a component has been added to the outliner
       cy.get('[class="component-outline-node"]', { timeout: 30000 }).contains('AWS Credential', { timeout: 30000 }).should('be.visible');
 
       // Click the button to destroy changeset
@@ -58,6 +65,6 @@ Cypress._.times(import.meta.env.VITE_SI_CYPRESS_MULTIPLIER ? import.meta.env.VIT
       cy.get('button.vbutton.--variant-solid.--size-md.--tone-destructive')
         .click();
 
-    })
-  })
+    });
+  });
 });

--- a/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
+++ b/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
@@ -1,23 +1,26 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const SI_WORKSPACE_URL = Cypress.env('VITE_SI_WORKSPACE_URL') || import.meta.env.VITE_SI_WORKSPACE_URL;
+const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
 describe('web', () => {
-    beforeEach(function () {
-      cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+  beforeEach(function () {
+    cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
+  });
 
+  it('get_summary', () => {
+    // Go to the Synthetic Workspace
+    cy.visit(SI_WORKSPACE_URL + '/w/' + SI_WORKSPACE_ID + '/head');
+    cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
+    cy.intercept('GET', SI_WORKSPACE_URL + '/api/qualification/get_summary?visibility_change_set_pk=00000000000000000000000000', (req) => {
+      // Log the intercepted request URL and response status code
+      cy.log(`Request to ${req.url}`, req.response.statusCode);
+      // Assert that the status code is 200
+      expect(req.response.statusCode).to.eq(200);
     });
-  
-    it('get_summary', () => {
-  
-      // Go to the Synthetic Workspace
-      cy.visit(import.meta.env.VITE_SI_WORKSPACE_URL + '/w/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/head')
-      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
-      cy.intercept('GET', import.meta.env.VITE_SI_WORKSPACE_URL + '/api/qualification/get_summary?visibility_change_set_pk=00000000000000000000000000', (req) => {
-        // Log the intercepted request URL and response status code
-        cy.log(`Request to ${req.url}`, req.response.statusCode);
-        // Assert that the status code is 200
-        expect(req.response.statusCode).to.eq(200);
-      });
-
-    })
-})
+  });
+});

--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -1,31 +1,37 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
+const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+const AUTH_PORTAL_URL = Cypress.env('VITE_AUTH_PORTAL_URL') || import.meta.env.VITE_AUTH_PORTAL_URL;
+const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
+const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+
 describe("workspace", () => {
   beforeEach(() => {
     cy.visit("/");
   });
 
   it("dashboard_redirect", () => {
-    cy.loginToAuth0(import.meta.env.VITE_AUTH0_USERNAME, import.meta.env.VITE_AUTH0_PASSWORD);
+
+    cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
 
     // Go to the Synthetic User's Dashboard
-    cy.visit(import.meta.env.VITE_AUTH_PORTAL_URL + '/dashboard')
-    cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", import.meta.env.VITE_UUID ? import.meta.env.VITE_UUID: "local");
+    cy.visit(AUTH_PORTAL_URL + '/dashboard')
+    cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
 
-    cy.wait(5000)
+    cy.wait(5000);
 
     // Find the URL for the synthetic workspace and go there
-    cy.get('a[href="' + import.meta.env.VITE_AUTH_API_URL + '/workspaces/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/go"]')
+    cy.get('a[href="' + AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go"]')
        .should('be.visible')
        .invoke('removeAttr', 'target')
        .click();
 
-    cy.wait(5000)
+    cy.wait(5000);
 
     // Check that it loaded the workspace + prompted to create a new changeset
     cy.contains('Create change set', { timeout: 10000 }).should('be.visible');
-
   });
-
 });

--- a/app/web/cypress/global.d.ts
+++ b/app/web/cypress/global.d.ts
@@ -24,6 +24,6 @@ declare namespace Cypress {
     */
     sendPosthogEvent(event: string, eventKey: string, eventData: string): Chainable<any>;
 
-    dragTo(sourceElement: string, targetElement: string): void;
+    dragTo(sourceElement: string, targetElement: string, offsetX? :number, offsetY?: number): void;
   }
 }

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -42,26 +42,45 @@ Cypress.Commands.add("getBySelLike", (selector, ...args) => {
 
 // Define the custom Cypress command in your Cypress support/commands.ts file
 // commands.ts
-Cypress.Commands.add('dragTo', (sourceElement: string, targetElement: string) => {
-  cy.get(sourceElement).then(() => {
+Cypress.Commands.add('dragTo', (sourceElement: string, targetElement: string, offsetX?: number, offsetY?: number) => {
+  cy.get(sourceElement).then(($sourceElement) => {
     cy.get(targetElement).then(($targetElement) => {
       const targetOffset = $targetElement.offset();
       const targetWidth = $targetElement.width();
       const targetHeight = $targetElement.height();
 
       // Calculate the coordinates to move to the center of the target element
-      const clientX = targetOffset.left + targetWidth / 2;
-      const clientY = targetOffset.top + targetHeight / 2;
+      let clientX = targetOffset.left + targetWidth / 2;
+      let clientY = targetOffset.top + targetHeight / 2;
+
+      if (offsetX) clientX += offsetX;
+      if (offsetY) clientY += offsetY;
 
       // Trigger a drag and drop action
-      cy.get(sourceElement)
-        .trigger('mousedown', { button: 0 }) // Simulate mouse down event
-        .trigger('mousemove', { clientX: clientX, clientY: clientY }) // Move the object to a new position
-        .trigger('mouseup') // Simulate mouse up event
+      const sourceOffset = $sourceElement.offset();
+      const drag = cy.get(sourceElement)
+        .trigger('mousemove', { clientX: sourceOffset?.left, clientY: sourceOffset?.top, force: true })
+        .trigger('mousedown', { button: 0, force: true }) // Simulate mouse down event
+        .wait(10)
+        .trigger('mousemove', { clientX: clientX, clientY: clientY, force: true }) // Move the object to a new position
+        .wait(10)
+        .trigger('mouseup', { button: 0 }) // Simulate mouse up event
     })
   })
 });
 
-
-
-
+//Cypress.Commands.add('setupVariables', () => {
+//  const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
+//  const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
+//  const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
+//  const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
+//  const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
+//  const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
+//
+//  Cypress.env('SI_CYPRESS_MULTIPLIER', SI_CYPRESS_MULTIPLIER);
+//  Cypress.env('AUTH0_USERNAME', AUTH0_USERNAME);
+//  Cypress.env('AUTH0_PASSWORD', AUTH0_PASSWORD);
+//  Cypress.env('AUTH_API_URL', AUTH_API_URL);
+//  Cypress.env('SI_WORKSPACE_ID', SI_WORKSPACE_ID);
+//  Cypress.env('UUID', UUID);
+//});

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -330,6 +330,7 @@
           <input
             v-model="newValueString"
             spellcheck="false"
+            :class="`${propLabelParts[0]}${propLabelParts[1]}`"
             type="text"
             @blur="onBlur"
             @focus="onFocus"

--- a/app/web/src/store/auth.store.ts
+++ b/app/web/src/store/auth.store.ts
@@ -150,6 +150,9 @@ export const useAuthStore = defineStore("auth", {
         if (errCode === "WORKSPACE_NOT_INITIALIZED") {
           // db is migrated, but workspace does not exist, probably because it has been reset
           const _reconnectReq = await this.AUTH_RECONNECT();
+          // WHAT HAD HAPPENED WAS...
+          // in a local scenario where prd auth portal has a workspace, and local does not, the first attempt this will hit an infinite loop trying to find the workspace, totally stuck
+          // on a second attempt, it appears, the workspace gets created and user exits the loop
           // TODO: react to failure here?
         } else if (
           // db is totally empty and needs migrations to run

--- a/prelude-si/e2e.bzl
+++ b/prelude-si/e2e.bzl
@@ -1,0 +1,80 @@
+load(
+    "//e2e:toolchain.bzl",
+    "E2eToolchainInfo",
+)
+
+E2eTestInfo = provider(fields = {
+    "name": provider_field(typing.Any, default = None),
+})
+
+def e2e_test_impl(ctx: AnalysisContext) -> list[[
+    DefaultInfo,
+    RunInfo,
+    E2eTestInfo,
+]]:
+    if ctx.attrs.pkg_name:
+        name = ctx.attrs.pkg_name
+    else:
+        name = ctx.attrs.name
+
+    if ctx.attrs.web_endpoint:
+        web_endpoint = ctx.attrs.web_endpoint
+    else:
+        web_endpoint = "http://localhost:8080"
+
+    if ctx.attrs.e2e_tests:
+        e2e_tests = ctx.attrs.e2e_tests
+    else:
+        e2e_tests = "cypress/e2e/**"
+
+    test_report = ctx.actions.declare_output("{}".format(name))
+
+    e2e_toolchain = ctx.attrs._e2e_toolchain[E2eToolchainInfo]
+    cmd = cmd_args(
+        "python3",
+        e2e_toolchain.e2e_test[DefaultInfo].default_outputs,
+        "--output",
+        test_report.as_output(),
+        "--tests",
+        e2e_tests,
+        "--web-endpoint",
+        web_endpoint,
+    )
+
+    ctx.actions.run(cmd, category = "e2e_test")
+
+    return [
+        DefaultInfo(
+        ),
+        RunInfo(
+            args = cmd
+        ),
+        E2eTestInfo(
+            name = test_report
+        ),
+    ]
+
+e2e_test = rule(
+    impl = e2e_test_impl,
+    attrs = {
+        "pkg_name": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """package name (default: 'attrs.name').""",
+        ),
+        "web_endpoint": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """web endpoint to test against (default http://localhost:8080)""",
+        ),
+        "e2e_tests": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = """package name (default: 'attrs.name').""",
+        ),
+        "_e2e_toolchain": attrs.toolchain_dep(
+            default = "toolchains//:e2e",
+            providers = [E2eToolchainInfo],
+        ),
+    },
+)

--- a/prelude-si/e2e/BUCK
+++ b/prelude-si/e2e/BUCK
@@ -1,0 +1,8 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "export_file",
+)
+
+export_file(
+    name = "e2e_test.py",
+)

--- a/prelude-si/e2e/e2e_test.py
+++ b/prelude-si/e2e/e2e_test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Runs Cypress E2E Suite against a stack
+"""
+import argparse
+import os
+import sys
+from enum import Enum, EnumMeta
+from typing import Any, Dict, List, Union
+import subprocess
+import urllib.request
+import time
+import shutil
+
+# A slightly more Rust-y feeling enum
+# Thanks to: https://stackoverflow.com/a/65225753
+class MetaEnum(EnumMeta):
+
+    def __contains__(self: type[Any], member: object) -> bool:
+        try:
+            self(member)
+        except ValueError:
+            return False
+        return True
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
+
+
+class PlatformArchitecture(BaseEnum):
+    Aarch64 = "aarch64"
+    X86_64 = "x86_64"
+
+
+class PlatformOS(BaseEnum):
+    Darwin = "darwin"
+    Linux = "linux"
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output for results/logs/recordings",
+    )
+    parser.add_argument(
+        "--tests",
+        help="Path to tests, default is 'cypress/e2e/**'",
+        action="store",
+    )
+    parser.add_argument(
+        "--web-endpoint",
+        help="Endpoint (<scheme><hostname><path>:<port> to test against, defaults to http://localhost:8080",
+        default="http://localhost:8080",
+        action="store",
+    )
+
+    return parser.parse_args()
+
+def clear_directory(directory):
+    try:
+        for root, dirs, files in os.walk(directory, topdown=False):
+            for name in files:
+                file_path = os.path.join(root, name)
+                os.remove(file_path)
+            for name in dirs:
+                dir_path = os.path.join(root, name)
+                os.rmdir(dir_path)
+        print(f"All files and subdirectories in '{directory}' cleared successfully.")
+    except Exception as e:
+        print(f"Error occurred while clearing directory '{directory}': {e}")
+
+def print_last_50_lines(file_path):
+    # Open the file for reading
+    with open(file_path, "r") as file:
+        # Read the last 50 lines using file.readlines() and slicing
+        lines = file.readlines()[-50:]
+
+        # Print the last 50 lines
+        for line in lines:
+            print(line, end="")  # Print each line without adding extra newline
+
+def run_cypress_tests(directory_path, tests, output_file):
+
+    # Get the absolute path of the output file
+    output_file_path = os.path.abspath(os.path.join(os.getcwd(), output_file))
+    
+    clear_directory(output_file_path.rsplit('/', 1)[0])
+
+    # Ensure the directory of the output file exists, create if necessary
+    os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+
+    command = f"ls {output_file_path.rsplit('/', 1)[0]}"
+    process = subprocess.run(command, shell=True)
+
+    # Run the Cypress tests using subprocess and redirect output to the specified file
+    with open(output_file_path, "a") as output:
+        command = f"cd app/web && npx cypress run --spec {tests} --config videosFolder={output_file_path.rsplit('/', 1)[0]}\/videos"
+        process = subprocess.run(command, shell=True, stdout=output, stderr=subprocess.PIPE)
+
+    print_last_50_lines(output_file)
+
+    # Check the exit code
+    if process.returncode != 0:
+        exit(1)
+
+def validate_cypress_install(output_file):
+
+    # Get the absolute path of the output file
+    output_file_path = os.path.abspath(os.path.join(os.getcwd(), output_file))
+    
+    # Ensure the directory of the output file exists, create if necessary
+    os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+
+    # Clear the output file if it already exists
+    if os.path.exists(output_file_path):
+        open(output_file_path, 'w').close()
+
+    # Run the Cypress tests using subprocess and redirect output to the specified file
+    with open(output_file_path, "a") as output:
+        command = f"cd app/web && npx cypress verify"
+        process = subprocess.run(command, shell=True, stdout=output, stderr=subprocess.PIPE)
+
+    # Check the exit code
+    if process.returncode != 0:
+        print_last_50_lines(output_file)
+        exit(1)
+
+def health_check(endpoint, timeout):
+    start_time = time.time()
+    while True:
+        try:
+            response = urllib.request.urlopen(endpoint)
+            if response.getcode() == 200:
+                print("Endpoint is healthy:", endpoint)
+                return 0  # Exit code 0 indicates success
+        except urllib.error.URLError as e:
+            print(f"Error occurred: {e}")
+        
+        if time.time() - start_time >= timeout:
+            print("Timeout reached. Endpoint is not healthy:", endpoint)
+            return 1  # Exit code 1 indicates failure
+        
+        print("Endpoint not yet healthy. Retrying in 5 seconds...")
+        time.sleep(5)
+
+def main() -> int:
+    args = parse_args()
+
+    detect_architecture()
+    detect_os()
+    validate_cypress_install(args.output)
+
+    directory_path = "app/web"
+    tests = args.tests
+
+    health_check(args.web_endpoint, 60)
+    run_cypress_tests(directory_path, tests, args.output)
+
+    return 0
+
+# Possible machine architecture detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_architecture() -> PlatformArchitecture:
+    machine = os.uname().machine
+
+    if (machine == "amd64" or machine == "x86_64" or machine == "x86-64"
+            or machine == "x64"):
+        return PlatformArchitecture.X86_64
+    elif (machine == "arm64" or machine == "aarch64" or machine == "arm64v8"):
+        return PlatformArchitecture.Aarch64
+    else:
+        print(
+            f"xxx Failed to determine architecure or unsupported: {machine}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+# Possible machine operating system detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_os() -> PlatformOS:
+    platform_os = os.uname().sysname
+
+    if (platform_os == "Darwin"):
+        return PlatformOS.Darwin
+    elif (platform_os == "Linux"):
+        return PlatformOS.Linux
+    else:
+        print(
+            f"xxx Failed to determine operating system or unsupported: {platform_os}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prelude-si/e2e/toolchain.bzl
+++ b/prelude-si/e2e/toolchain.bzl
@@ -1,0 +1,24 @@
+E2eToolchainInfo = provider(fields = {
+    "e2e_test": typing.Any,
+})
+
+def e2e_toolchain_impl(ctx) -> list[[DefaultInfo, E2eToolchainInfo]]:
+    """
+    A e2e test execution toolchain.
+    """
+    return [
+        DefaultInfo(),
+        E2eToolchainInfo(
+            e2e_test = ctx.attrs._e2e_test,
+        ),
+    ]
+
+e2e_toolchain = rule(
+    impl = e2e_toolchain_impl,
+    attrs = {
+        "_e2e_test": attrs.dep(
+            default = "prelude-si//e2e:e2e_test.py",
+        ),
+    },
+    is_toolchain_rule = True,
+) 

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -33,6 +33,12 @@ nix_flake_lock = _nix_flake_lock
 nix_omnibus_pkg = _nix_omnibus_pkg
 
 load(
+    "@prelude-si//macros:e2e.bzl",
+    _e2e_test = "e2e_test",
+)
+e2e_test = _e2e_test
+
+load(
     "@prelude-si//macros:pnpm.bzl",
     _eslint = "eslint",
     _ts_test = "ts_test",

--- a/prelude-si/macros/e2e.bzl
+++ b/prelude-si/macros/e2e.bzl
@@ -1,0 +1,15 @@
+load(
+    "@prelude-si//:e2e.bzl",
+    _e2e_test = "e2e_test",
+
+)
+
+def e2e_test(
+        name,
+        visibility = ["PUBLIC"],
+        **kwargs):
+    _e2e_test(
+        name = name,
+        visibility = visibility,
+        **kwargs
+    )

--- a/prelude-si/tilt.bzl
+++ b/prelude-si/tilt.bzl
@@ -71,7 +71,7 @@ tilt_docker_compose_pull = rule(
     attrs = {
         "docker_compose_file": attrs.string(
             default = "docker-compose.yml",
-            doc = """The Tiltfile to run.""",
+            doc = """The Docker Compose to run.""",
         ),
         "services": attrs.list(
             attrs.string(),
@@ -108,7 +108,7 @@ tilt_docker_compose_stop = rule(
     attrs = {
         "docker_compose_file": attrs.string(
             default = "docker-compose.yml",
-            doc = """The Tiltfile to run.""",
+            doc = """The Docker Compose to run.""",
         ),
         "services": attrs.list(
             attrs.string(),

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -5,6 +5,7 @@ load(
     "system_python_bootstrap_toolchain",
     "system_python_toolchain",
 )
+load("@prelude-si//e2e:toolchain.bzl", "e2e_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude-si//build_context:toolchain.bzl", "build_context_toolchain")
@@ -57,6 +58,11 @@ build_context_toolchain(
 
 docker_toolchain(
     name = "docker",
+    visibility = ["PUBLIC"],
+)
+
+e2e_toolchain(
+    name = "e2e",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This PR adds a new toolchain into our BUCK build system to allow us to execute Cypress end to end tests via BUCK directly.

In a follow up PR, the test will then be executed in CI.

The added target is runnable and buildable, depending on how you would like to execute it.

You can explicitly invoke as follows:
`buck2 run app/web:e2e-test -- --tests 'cypress/e2e/**' --web-endpoint http://localhost:8080`

This will run all our e2e tests against your local stack. These values are the defaults and can be excluded entirely on invocation if you desire, i.e.
`buck2 run app/web:e2e-test`

When executed, the target will check a few things before executing, these are listed below:
- The stack is responsive on the given `--web-endpoint` within 60s
- Cypress installation is valid
- You are on an supported OS / Architecture

During execution, it will then output the log contents and videos from cypress into the BUCK out path, which is usually something in the form of:
`si/buck-out/v2/gen/root/<uuid>/app/web/__e2e-test__/<content here>`

**Variables**
Some variables are required to allow these tests to execute successfully and each test has slightly differing requirements. In the header of each of the cypress typescript test files you will see a block like follows:
```
const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AUTH_API_URL;
const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
```

This basically means, either have the variables in your local shell environment or within the .env files for vite, i.e. `.env.local` usually. I've included some psuedocode in `app/web/cypress/support/commands.ts` as to how we might refactor this to centralise the variables in one place, but I got into a bit of a tizzy with cypress coinage so I may have to come back to this in a follow up PR to implement the new test into CI.

