### PR TITLE
fix(dal): make sure you can manually override maps and arrays

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2106,23 +2106,11 @@ impl AttributeValue {
         Ok(())
     }
 
-    pub async fn list_input_sockets_sources_for_id(
+    pub async fn list_input_socket_sources_for_id(
         ctx: &DalContext,
         av_id: AttributeValueId,
     ) -> AttributeValueResult<Vec<InputSocketId>> {
         let prototype_id = Self::prototype_id(ctx, av_id).await?;
-
-        let apa_ids = AttributePrototypeArgument::list_ids_for_prototype(ctx, prototype_id).await?;
-
-        let mut input_socket_ids = Vec::<InputSocketId>::new();
-        for apa_id in apa_ids {
-            let maybe_value_source =
-                AttributePrototypeArgument::value_source_by_id(ctx, apa_id).await?;
-            if let Some(ValueSource::InputSocket(socket_id)) = maybe_value_source {
-                input_socket_ids.push(socket_id);
-            }
-        }
-
-        Ok(input_socket_ids)
+        Ok(AttributePrototype::list_input_socket_sources_for_id(ctx, prototype_id).await?)
     }
 }

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -93,87 +93,82 @@ impl DependentValueGraph {
                 .await?
                 .into();
 
-            // Gather dependents from prototype arguments
-            {
-                // Gather the Attribute Prototype Arguments that take the thing the
-                // current value is for (prop, or socket) as an input
-                let relevant_apas = {
-                    let workspace_snapshot = ctx.workspace_snapshot()?;
+            // Gather the Attribute Prototype Arguments that take the thing the
+            // current value is for (prop, or socket) as an input
+            let relevant_apas = {
+                let workspace_snapshot = ctx.workspace_snapshot()?;
 
-                    let attribute_prototype_argument_idxs = workspace_snapshot
-                        .incoming_sources_for_edge_weight_kind(
-                            data_source_id,
-                            EdgeWeightKindDiscriminants::PrototypeArgumentValue,
-                        )
-                        .await?;
+                let attribute_prototype_argument_idxs = workspace_snapshot
+                    .incoming_sources_for_edge_weight_kind(
+                        data_source_id,
+                        EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+                    )
+                    .await?;
 
-                    let mut relevant_apas = vec![];
-                    for apa_idx in attribute_prototype_argument_idxs {
-                        let apa = workspace_snapshot
-                            .get_node_weight(apa_idx)
-                            .await?
-                            .get_attribute_prototype_argument_node_weight()?;
+                let mut relevant_apas = vec![];
+                for apa_idx in attribute_prototype_argument_idxs {
+                    let apa = workspace_snapshot
+                        .get_node_weight(apa_idx)
+                        .await?
+                        .get_attribute_prototype_argument_node_weight()?;
 
-                        match apa.targets() {
-                            // If there are no targets, this is a schema-level attribute prototype argument
-                            None => relevant_apas.push(apa),
-                            Some(targets) => {
-                                if targets.source_component_id == current_component_id {
-                                    let source_component =
-                                        Component::get_by_id(ctx, targets.source_component_id)
-                                            .await
-                                            .map_err(|e| {
-                                                AttributeValueError::Component(e.to_string())
-                                            })?;
-                                    let destination_component =
-                                        Component::get_by_id(ctx, targets.destination_component_id)
-                                            .await
-                                            .map_err(|e| {
-                                                AttributeValueError::Component(e.to_string())
-                                            })?;
+                    match apa.targets() {
+                        // If there are no targets, this is a schema-level attribute prototype argument
+                        None => relevant_apas.push(apa),
+                        Some(targets) => {
+                            if targets.source_component_id == current_component_id {
+                                let source_component =
+                                    Component::get_by_id(ctx, targets.source_component_id)
+                                        .await
+                                        .map_err(|e| {
+                                            AttributeValueError::Component(e.to_string())
+                                        })?;
+                                let destination_component =
+                                    Component::get_by_id(ctx, targets.destination_component_id)
+                                        .await
+                                        .map_err(|e| {
+                                            AttributeValueError::Component(e.to_string())
+                                        })?;
 
-                                    // Both "deleted" and not deleted Components can feed data into
-                                    // "deleted" Components. **ONLY** not deleted Components can feed
-                                    // data into not deleted Components.
-                                    if destination_component.to_delete()
-                                        || (!destination_component.to_delete()
-                                            && !source_component.to_delete())
-                                    {
-                                        relevant_apas.push(apa)
-                                    }
+                                // Both "deleted" and not deleted Components can feed data into
+                                // "deleted" Components. **ONLY** not deleted Components can feed
+                                // data into not deleted Components.
+                                if destination_component.to_delete()
+                                    || (!destination_component.to_delete()
+                                        && !source_component.to_delete())
+                                {
+                                    relevant_apas.push(apa)
                                 }
                             }
                         }
                     }
-                    relevant_apas
-                };
+                }
+                relevant_apas
+            };
 
-                // Find the values that are set by the prototype for the relevant
-                // AttributePrototypeArguments, and declare that these values depend
-                // on the value of the current value
-                for apa in relevant_apas {
-                    let prototype_id = AttributePrototypeArgument::prototype_id_for_argument_id(
-                        ctx,
-                        apa.id().into(),
-                    )
-                    .await?;
+            // Find the values that are set by the prototype for the relevant
+            // AttributePrototypeArguments, and declare that these values depend
+            // on the value of the current value
+            for apa in relevant_apas {
+                let prototype_id =
+                    AttributePrototypeArgument::prototype_id_for_argument_id(ctx, apa.id().into())
+                        .await?;
 
-                    let attribute_value_ids =
-                        AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
+                let attribute_value_ids =
+                    AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
 
-                    for attribute_value_id in attribute_value_ids {
-                        let filter_component_id = match apa.targets() {
-                            None => current_component_id,
-                            Some(targets) => targets.destination_component_id,
-                        };
-                        let component_id =
-                            AttributeValue::component_id(ctx, attribute_value_id).await?;
+                for attribute_value_id in attribute_value_ids {
+                    let filter_component_id = match apa.targets() {
+                        None => current_component_id,
+                        Some(targets) => targets.destination_component_id,
+                    };
+                    let component_id =
+                        AttributeValue::component_id(ctx, attribute_value_id).await?;
 
-                        if component_id == filter_component_id {
-                            work_queue.push_back(attribute_value_id);
-                            dependent_value_graph
-                                .value_depends_on(attribute_value_id, current_attribute_value_id);
-                        }
+                    if component_id == filter_component_id {
+                        work_queue.push_back(attribute_value_id);
+                        dependent_value_graph
+                            .value_depends_on(attribute_value_id, current_attribute_value_id);
                     }
                 }
             }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -24,12 +24,12 @@ use crate::workspace_snapshot::edge_weight::{EdgeWeight, EdgeWeightKind};
 use crate::workspace_snapshot::edge_weight::{EdgeWeightError, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
-use crate::AttributeValueId;
 use crate::{
     label_list::ToLabelList, pk, property_editor::schema::WidgetKind, AttributePrototype,
     AttributePrototypeId, DalContext, Func, FuncBackendResponseType, FuncId, SchemaVariantId,
     Timestamp, TransactionsError,
 };
+use crate::{AttributeValueId, InputSocketId};
 
 pub const PROP_VERSION: PropContentDiscriminants = PropContentDiscriminants::V1;
 
@@ -760,6 +760,11 @@ impl Prop {
             .await?
             .id()
             .into())
+    }
+
+    pub async fn input_socket_sources(&self, ctx: &DalContext) -> PropResult<Vec<InputSocketId>> {
+        let prototype_id = Self::prototype_id(ctx, self.id).await?;
+        Ok(AttributePrototype::list_input_socket_sources_for_id(ctx, prototype_id).await?)
     }
 
     pub async fn set_default_value<T: Serialize>(

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -135,7 +135,7 @@ impl PropertyEditorValues {
                 let child_property_editor_value_id = PropertyEditorValueId::from(child_av_id);
 
                 let sockets_for_av =
-                    AttributeValue::list_input_sockets_sources_for_id(ctx, child_av_id).await?;
+                    AttributeValue::list_input_socket_sources_for_id(ctx, child_av_id).await?;
 
                 let is_from_external_source = sockets_for_av
                     .iter()

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -621,7 +621,7 @@ impl SchemaVariant {
     /// [`AttributePrototypeArgument`](crate::attribute::prototype::argument::AttributePrototypeArgument)
     /// for the /root/si/color [`Prop`](crate::Prop). If a prototype already
     /// exists pointing to a function other than
-    /// [`IntrinsicFunc::SetString`](`crate::func::intrinsics::IntrinsicFunc::SetString`)
+    /// [`IntrinsicFunc::SetString`](crate::func::intrinsics::IntrinsicFunc::SetString)
     /// we will remove that edge and replace it with one pointing to
     /// `SetString`.
     pub async fn set_color(
@@ -642,7 +642,7 @@ impl SchemaVariant {
     /// [`AttributePrototypeArgument`](crate::attribute::prototype::argument::AttributePrototypeArgument)
     /// for the /root/si/type [`Prop`](crate::Prop). If a prototype already
     /// exists pointing to a function other than
-    /// [`IntrinsicFunc::SetString`](`crate::func::intrinsics::IntrinsicFunc::SetString`)
+    /// [`IntrinsicFunc::SetString`](crate::func::intrinsics::IntrinsicFunc::SetString)
     /// we will remove that edge and replace it with one pointing to
     /// `SetString`.
     pub async fn set_type(
@@ -663,7 +663,7 @@ impl SchemaVariant {
     /// [`AttributePrototypeArgument`](crate::attribute::prototype::argument::AttributePrototypeArgument)
     /// for the /root/si/type [`Prop`](crate::Prop). If a prototype already
     /// exists pointing to a function other than
-    /// [`IntrinsicFunc::SetString`](`crate::func::intrinsics::IntrinsicFunc::SetString`)
+    /// [`IntrinsicFunc::SetString`](crate::func::intrinsics::IntrinsicFunc::SetString)
     /// we will remove that edge and replace it with one pointing to
     /// `SetString`.
     pub async fn get_type(&self, ctx: &DalContext) -> SchemaVariantResult<Option<ComponentType>> {

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -42,7 +42,7 @@ pub enum EdgeWeightKind {
     Ordinal,
     /// Used to link an attribute value to the prop that it is for.
     Prop,
-    /// An edge from a [`socket`](crate::socket) or an [`AttributeValue`](`crate::AttributeValue`)
+    /// An edge from a [`socket`](crate::socket), [`AttributeValue`](crate::AttributeValue) or [`Prop`](crate::Prop)
     /// to an [`AttributePrototype`](crate::AttributePrototype). The optional [`String`] is used for
     /// maps, arrays and relevant container types to indicate which element the prototype is for.
     Prototype(Option<String>),

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -3,7 +3,7 @@ use dal::property_editor::schema::{
 };
 use dal::property_editor::values::{PropertyEditorValue, PropertyEditorValues};
 use dal::property_editor::{PropertyEditorPropId, PropertyEditorValueId};
-use dal::{AttributeValue, Component, ComponentId, DalContext, Func, Schema, SchemaVariant};
+use dal::{AttributeValue, Component, ComponentId, DalContext, Schema, SchemaVariant};
 use dal_test::test;
 use dal_test::test_harness::{
     commit_and_update_snapshot, connect_components_with_socket_names,


### PR DESCRIPTION
Previously, the rebaser was skipping any unordered children of ordered containers.

Since an attribute value for a map has an ordering node connection, when computing its children, the rebaser was only considering those edges to those nodes as updates. Since when we do an override we’re binding an attributePrototype directly to the attribute value, without the ordering connection, the rebaser was skipping it.

But this was working fine for string attribute values, for instance, since they are considered unordered containers (they’re not containers at all, but since they don’t have the ordering node that’s how we treat them).
 
This PR also fixes an issue in which adding an ordered node to a fresh graph fails, which was forcing unit tests to be more complex than they needed to be