### PR TITLE
feat(web): Show "set by socket" option on dropdown for maps and arrays.

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -95,6 +95,7 @@ export interface PropertyEditorProp {
   isReadonly: boolean;
   documentation?: string;
   validationFormat?: string;
+  defaultCanBeSetBySocket: boolean;
 }
 
 export interface PropertyEditorSchema {


### PR DESCRIPTION
<img width="408" alt="image" src="https://github.com/systeminit/si/assets/6564471/cad3b433-8dcd-419d-b998-08b768c32ae4">

This resets the value of a map, array or object back to the default function for the schema variant, as the x button does for text fields (string, number)