### PR TITLE
feat: add xvfb into ci-base

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         containerd.io \
         docker-buildx-plugin \
         docker-compose-plugin \
+        xvfb \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Adding a virtual framebuffer/a display server implementing X11 within the ci-base as there are no FE packages in there at the minute.

I imagine this might not be the final change here as we will probably need chrome or some additional browser packages for cypress.

Will work forward as needed.

Not adding into the nix flake as any normal developer machine will have this dep already satisfied