### PR TITLE
feat: add more deps into ci-base image

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -33,6 +33,12 @@ RUN set -eux; \
         docker-buildx-plugin \
         docker-compose-plugin \
         xvfb \
+        libgtk2.0-0 \
+        libnss3 \
+        libatk-bridge2.0-0 \
+        libgtk-3-0 \
+        libgdm-dev \
+        libasound2 \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Follow on PR to add the rest of the deps in for Cypress tests in CI. 

These will be satisfied locally on dev machines my default (normally)