### PR TITLE
Update Rust dependencies since merging `new-engine` into `main` (ENG-2428)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -91,6 +91,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -183,25 +189,24 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
+checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
 dependencies = [
- "base64 0.21.7",
- "bytes 1.5.0",
+ "base64 0.22.0",
+ "bytes 1.6.0",
  "futures",
- "http",
  "memchr",
- "nkeys 0.3.2",
+ "nkeys",
  "nuid",
  "once_cell",
+ "portable-atomic",
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls 0.21.10",
- "rustls-native-certs",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -209,9 +214,9 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-retry",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tracing",
+ "tryhard",
  "url",
 ]
 
@@ -223,7 +228,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -245,18 +250,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -265,7 +270,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -302,24 +307,13 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc"
 dependencies = [
- "http",
+ "http 0.2.12",
  "log",
  "rustls 0.21.10",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -340,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "aws-creds"
@@ -379,11 +373,11 @@ dependencies = [
  "axum-macros",
  "base64 0.21.7",
  "bitflags 1.3.2",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -412,10 +406,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -431,14 +425,14 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -468,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +479,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "smallvec",
 ]
 
@@ -562,19 +562,22 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bollard-stubs",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
- "hyperlocal",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal-next",
  "log",
  "pin-project-lite",
  "serde",
@@ -585,15 +588,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
 name = "bollard-stubs"
-version = "1.43.0-rc.2"
+version = "1.44.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
 dependencies = [
  "serde",
  "serde_repr",
@@ -602,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -612,15 +616,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "syn_derive",
 ]
 
@@ -711,9 +715,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -722,7 +726,7 @@ dependencies = [
 name = "bytes-lines-codec"
 version = "0.1.0"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures",
  "serde",
  "tokio",
@@ -742,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -788,9 +792,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -825,25 +829,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.4.0",
+ "half",
 ]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -864,14 +857,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -948,24 +941,23 @@ checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
  "console",
  "crossterm 0.27.0",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "unicode-width",
 ]
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
- "async-trait",
  "lazy_static",
  "nom",
  "pathdiff",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "yaml-rust",
 ]
 
@@ -982,7 +974,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "toml 0.8.12",
+ "toml",
  "tracing",
 ]
 
@@ -1040,8 +1032,8 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "log",
  "mime",
@@ -1064,8 +1056,8 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "log",
  "mime",
@@ -1114,7 +1106,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 name = "council"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "council-server",
  "si-std",
@@ -1134,7 +1126,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-settings",
- "strum",
+ "strum 0.26.2",
  "telemetry",
  "telemetry-nats",
  "thiserror",
@@ -1177,25 +1169,25 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "futures",
+ "is-terminal",
  "itertools 0.10.5",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1205,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -1329,27 +1321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ct-codecs"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,14 +1350,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "cyclone"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "cyclone-server",
  "telemetry-application",
@@ -1399,14 +1370,14 @@ name = "cyclone-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "buck2-resources",
  "cyclone-core",
  "cyclone-server",
  "futures",
  "futures-lite",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "remain",
  "serde",
@@ -1427,7 +1398,7 @@ dependencies = [
 name = "cyclone-core"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "nix 0.27.1",
  "remain",
  "serde",
@@ -1447,13 +1418,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytes-lines-codec",
  "chrono",
  "cyclone-core",
  "derive_builder",
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "remain",
  "serde",
@@ -1478,7 +1449,7 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "blake3",
  "buck2-resources",
  "chrono",
@@ -1504,8 +1475,6 @@ dependencies = [
  "postgres-types",
  "pretty_assertions_sorted",
  "rand 0.8.5",
- "rebaser-core",
- "rebaser-server",
  "refinery",
  "regex",
  "remain",
@@ -1524,7 +1493,7 @@ dependencies = [
  "si-std",
  "sled",
  "sodiumoxide",
- "strum",
+ "strum 0.26.2",
  "telemetry",
  "telemetry-nats",
  "tempfile",
@@ -1580,36 +1549,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1623,18 +1568,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1643,9 +1577,9 @@ version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1760,33 +1694,33 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1858,13 +1792,13 @@ dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "containers-api 0.9.0",
  "docker-api-stubs",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "paste",
  "serde",
@@ -1954,14 +1888,14 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.23"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2017,15 +1951,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "3.1.15"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
 dependencies = [
- "num-bigint",
- "num-traits",
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2097,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff"
@@ -2113,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "filetime"
@@ -2258,7 +2199,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "futures-core",
  "futures-io",
  "parking",
@@ -2273,7 +2214,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2316,6 +2257,15 @@ dependencies = [
  "futures",
  "memchr",
  "pin-project 0.4.30",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -2386,7 +2336,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2406,24 +2356,18 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.2.5",
+ "http 0.2.12",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -2519,15 +2463,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -2604,7 +2539,18 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.6.0",
  "fnv",
  "itoa",
 ]
@@ -2615,8 +2561,31 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.5.0",
- "http",
+ "bytes 1.6.0",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes 1.6.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2644,13 +2613,13 @@ version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2663,17 +2632,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2682,10 +2702,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2695,9 +2735,24 @@ source = "git+https://github.com/fnichol/hyperlocal.git?branch=pub-unix-stream#6
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "pin-project 1.1.5",
  "tokio",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2749,8 +2804,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.53",
- "toml 0.8.12",
+ "syn 2.0.55",
+ "toml",
  "unicode-xid",
 ]
 
@@ -2789,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2813,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inherent"
@@ -2825,21 +2880,22 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "inquire"
-version = "0.6.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "crossterm 0.25.0",
  "dyn-clone",
- "lazy_static",
+ "fuzzy-matcher",
+ "fxhash",
  "newline-converter",
- "thiserror",
+ "once_cell",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2866,6 +2922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2907,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -3066,7 +3133,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3087,9 +3154,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -3157,7 +3224,7 @@ dependencies = [
 name = "module-index"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "module-index-server",
  "si-std",
@@ -3189,12 +3256,12 @@ version = "0.1.0"
 dependencies = [
  "auth-api-client",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "buck2-resources",
  "chrono",
  "derive_builder",
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "jwt-simple",
  "module-index-client",
  "refinery",
@@ -3250,10 +3317,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -3329,7 +3396,7 @@ version = "0.1.0"
 dependencies = [
  "async-nats",
  "async-trait",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures",
  "pin-project-lite",
  "tokio",
@@ -3341,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "newline-converter"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -3369,22 +3436,6 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nkeys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
-dependencies = [
- "byteorder",
- "data-encoding",
- "ed25519 2.2.3",
- "ed25519-dalek",
- "getrandom 0.2.12",
- "log",
- "rand 0.8.5",
- "signatory",
 ]
 
 [[package]]
@@ -3502,7 +3553,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3530,12 +3581,12 @@ dependencies = [
  "serde",
  "serde_json",
  "si-hash",
- "strum",
+ "strum 0.26.2",
  "tar",
  "tempfile",
  "thiserror",
  "tokio",
- "vfs",
+ "vfs 0.12.0",
  "vfs-tar",
 ]
 
@@ -3591,7 +3642,7 @@ checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -3717,7 +3768,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3731,7 +3782,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3868,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
 ]
@@ -3928,7 +3979,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3947,7 +3998,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pinga"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "pinga-server",
  "si-std",
@@ -4013,9 +4064,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"
@@ -4053,7 +4104,7 @@ checksum = "4d0ade207138f12695cb4be3b590283f1cf764c5c4909f39966c4b4b0dba7c1e"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "containers-api 0.8.0",
  "flate2",
@@ -4108,7 +4159,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4119,7 +4170,7 @@ checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -4135,7 +4186,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "fallible-iterator",
  "postgres-derive",
@@ -4235,7 +4286,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -4246,7 +4297,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "prost-derive",
 ]
 
@@ -4260,7 +4311,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4416,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -4438,7 +4489,7 @@ dependencies = [
 name = "rebaser"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "rebaser-server",
  "telemetry-application",
@@ -4540,7 +4591,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.12",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -4555,19 +4606,19 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4587,7 +4638,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4598,9 +4649,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "remain"
@@ -4610,7 +4661,7 @@ checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4624,20 +4675,20 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
- "bytes 1.5.0",
- "encoding_rs",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -4646,21 +4697,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.22.3",
  "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.1",
  "winreg",
 ]
 
@@ -4697,7 +4748,7 @@ checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
@@ -4758,21 +4809,21 @@ dependencies = [
  "aws-creds",
  "aws-region",
  "base64 0.21.7",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "cfg-if",
  "futures",
  "hex",
  "hmac",
- "http",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "log",
  "maybe-async",
  "md5",
  "percent-encoding",
  "quick-xml",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4787,13 +4838,13 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
  "borsh",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "num-traits",
  "rand 0.8.5",
  "rkyv",
@@ -4843,9 +4894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
@@ -4863,6 +4914,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4888,9 +4952,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -4963,7 +5027,7 @@ dependencies = [
 name = "sdf"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "nats-multiplexer",
  "sdf-server",
@@ -4979,7 +5043,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "buck2-resources",
  "chrono",
  "convert_case 0.6.0",
@@ -4988,7 +5052,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "futures-lite",
- "hyper",
+ "hyper 0.14.28",
  "module-index-client",
  "names",
  "nats-multiplexer",
@@ -5014,7 +5078,7 @@ dependencies = [
  "si-settings",
  "si-std",
  "sodiumoxide",
- "strum",
+ "strum 0.26.2",
  "telemetry",
  "telemetry-http",
  "thiserror",
@@ -5041,7 +5105,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5064,7 +5128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.25.0",
  "thiserror",
  "time",
  "tracing",
@@ -5082,7 +5146,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.53",
+ "syn 2.0.55",
  "unicode-ident",
 ]
 
@@ -5203,16 +5267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5220,16 +5274,16 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -5262,7 +5316,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5322,7 +5376,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5336,10 +5390,10 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.8",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5348,19 +5402,19 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
- "darling 0.20.8",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -5402,13 +5456,13 @@ dependencies = [
 name = "si"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "derive_builder",
  "serde_json",
  "si-cli",
  "si-posthog",
- "strum",
+ "strum 0.26.2",
  "telemetry-application",
  "tokio",
  "tokio-util",
@@ -5430,7 +5484,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "color-eyre",
  "colored",
  "comfy-table",
@@ -5457,14 +5511,14 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.8.12",
+ "toml",
 ]
 
 [[package]]
 name = "si-crypto"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "ciborium",
  "remain",
  "serde",
@@ -5482,9 +5536,9 @@ name = "si-data-nats"
 version = "0.1.0"
 dependencies = [
  "async-nats",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures",
- "nkeys 0.4.0",
+ "nkeys",
  "remain",
  "serde",
  "serde_json",
@@ -5499,8 +5553,8 @@ dependencies = [
 name = "si-data-pg"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
- "bytes 1.5.0",
+ "base64 0.22.0",
+ "bytes 1.6.0",
  "deadpool",
  "deadpool-postgres",
  "futures",
@@ -5508,7 +5562,7 @@ dependencies = [
  "ouroboros 0.18.3",
  "refinery",
  "remain",
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "rustls-pemfile 2.1.1",
  "serde",
  "si-std",
@@ -5517,7 +5571,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5525,7 +5579,7 @@ name = "si-events"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "postgres-types",
  "remain",
  "serde",
@@ -5551,7 +5605,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "buck2-resources",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "criterion",
  "futures",
@@ -5568,7 +5622,7 @@ dependencies = [
  "si-events",
  "si-std",
  "sled",
- "strum",
+ "strum 0.26.2",
  "telemetry",
  "tempfile",
  "thiserror",
@@ -5582,17 +5636,17 @@ dependencies = [
 name = "si-pkg"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "chrono",
  "derive_builder",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "object-tree",
  "petgraph",
  "remain",
  "serde",
  "serde_json",
  "si-hash",
- "strum",
+ "strum 0.26.2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5609,7 +5663,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.26.2",
  "telemetry",
  "thiserror",
  "tokio",
@@ -5654,7 +5708,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5784,9 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -5869,7 +5923,7 @@ dependencies = [
  "atoi",
  "bigdecimal",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5882,7 +5936,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "memchr",
  "once_cell",
@@ -5903,7 +5957,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5956,7 +6010,7 @@ dependencies = [
  "bigdecimal",
  "bitflags 2.5.0",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "crc",
  "digest",
@@ -6113,8 +6167,14 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -6127,7 +6187,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6162,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6180,7 +6253,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6188,27 +6261,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "tagptr"
@@ -6277,8 +6329,8 @@ name = "telemetry-http"
 version = "0.1.0"
 dependencies = [
  "axum",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "remain",
  "telemetry",
  "tower-http",
@@ -6301,7 +6353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -6334,16 +6386,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6363,7 +6406,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6443,12 +6486,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "libc",
  "mio",
  "num_cpus",
@@ -6478,7 +6521,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6489,7 +6532,7 @@ checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fallible-iterator",
  "futures-channel",
  "futures-util",
@@ -6513,22 +6556,11 @@ version = "0.11.1"
 source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#b8de7acc8067a3ec4b7e99ba6ea654fae8e28fe4"
 dependencies = [
  "ring",
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.25.0",
  "x509-certificate",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project 1.1.5",
- "rand 0.8.5",
- "tokio",
 ]
 
 [[package]]
@@ -6547,18 +6579,18 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-serde"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "educe",
  "futures-core",
  "futures-sink",
@@ -6586,7 +6618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -6610,7 +6642,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -6626,20 +6658,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures",
  "libc",
  "tokio",
  "vsock",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6651,7 +6674,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -6669,18 +6692,18 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6697,11 +6720,11 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.21.7",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
@@ -6743,11 +6766,11 @@ checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "bitflags 2.5.0",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "pin-project-lite",
  "tokio",
@@ -6789,7 +6812,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6885,15 +6908,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7049,7 +7083,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "veritech"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "si-std",
  "telemetry-application",
@@ -7062,7 +7096,7 @@ dependencies = [
 name = "veritech-client"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "cyclone-core",
  "futures",
  "indoc",
@@ -7124,6 +7158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
 
 [[package]]
+name = "vfs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654cd097e182a71dbf899178e6b5662c2157dd0b8afd5975de18008f6fc173d1"
+dependencies = [
+ "filetime",
+]
+
+[[package]]
 name = "vfs-tar"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7132,7 +7175,7 @@ dependencies = [
  "memmap2",
  "stable_deref_trait",
  "tar-parser2",
- "vfs",
+ "vfs 0.10.0",
 ]
 
 [[package]]
@@ -7212,7 +7255,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -7246,7 +7289,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7282,6 +7325,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -7510,7 +7562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
 dependencies = [
  "bcder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "der",
  "hex",
@@ -7598,7 +7650,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -7618,5 +7670,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,47 +58,47 @@ members = [
 ]
 
 [workspace.dependencies]
-async-nats = { version = "0.33.0", features = ["service"] }
-async-recursion = "1.0.4"
-async-trait = "0.1.68"
-axum = { version = "0.6.18", features = [
+async-nats = { version = "0.34.0", features = ["service"] }
+async-recursion = "1.0.5"
+async-trait = "0.1.79"
+axum = { version = "0.6.20", features = [
     "macros",
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
-base64 = "0.21.0"
-blake3 = "1.3.3"
-bollard = "0.15.0"
-bytes = "1.4.0"
-chrono = { version = "0.4.24", features = ["serde"] }
-ciborium = "0.2.1"
-clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = "0.6.2"
-colored = "2.0.4"
-comfy-table = { version = "7.0.1", features = [
+base64 = "0.22.0"
+blake3 = "1.5.1"
+bollard = "0.16.1"
+bytes = "1.6.0"
+chrono = { version = "0.4.37", features = ["serde"] }
+ciborium = "0.2.2"
+clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
+color-eyre = "0.6.3"
+colored = "2.1.0"
+comfy-table = { version = "7.1.0", features = [
     "crossterm",
     "tty",
     "custom_styling",
 ] }
-config = { version = "0.13.4", default-features = false, features = ["toml"] }
-console = "0.15.7"
+config = { version = "0.14.0", default-features = false, features = ["toml"] }
+console = "0.15.8"
 convert_case = "0.6.0"
-criterion = { version = "0.3", features = [ "async_tokio" ] }
-crossbeam-channel = "0.5.8"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+crossbeam-channel = "0.5.12"
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.12.1"
-derive_builder = "0.12.0"
+derive_builder = "0.20.0"
 derive_more = "0.99.17"
 diff = "0.1.13"
 directories = "5.0.1"
 docker-api = "0.14.0"
-dyn-clone = "1.0.11"
-flate2 = "1.0.26"
-futures = "0.3.28"
-futures-lite = "2.1.0"
+dyn-clone = "1.0.17"
+flate2 = "1.0.28"
+futures = "0.3.30"
+futures-lite = "2.3.0"
 hex = "0.4.3"
-http = "0.2.9" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
-hyper = { version = "0.14.26", features = [
+http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
+hyper = { version = "0.14.28", features = [
     "client",
     "http1",
     "runtime",
@@ -107,54 +107,54 @@ hyper = { version = "0.14.26", features = [
 hyperlocal = { version = "0.8.0", default-features = false, features = [
     "client",
 ] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
-iftree = "1.0.4"
-indicatif = "0.17.5"
-indexmap = "2.2.2"
-indoc = "2.0.1"
-inquire = "0.6.2"
-itertools = "0.12.0"
-jwt-simple = { version = "0.12.6", default-features = false, features = [
+iftree = "1.0.5"
+indicatif = "0.17.8"
+indexmap = "2.2.6"
+indoc = "2.0.5"
+inquire = "0.7.4"
+itertools = "0.12.1"
+jwt-simple = { version = "0.12.9", default-features = false, features = [
     "pure-rust",
 ] }
 lazy_static = "1.4.0"
-moka = { version = "0.12.5", features = [ "future" ] }
+moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }
 nkeys = "0.4.0"
-num_cpus = "1.15.0"
-once_cell = "1.17.1"
-open = "5.0.0"
+num_cpus = "1.16.0"
+once_cell = "1.19.0"
+open = "5.1.2"
 opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
-ouroboros = "0.18.1"
-paste = "1.0.12"
+ouroboros = "0.18.3"
+paste = "1.0.14"
 pathdiff = "0.2.1"
-petgraph = { version = "0.6.3", features = ["serde-1"] }
-pin-project-lite = "0.2.9"
-podman-api = "0.10"
+petgraph = { version = "0.6.4", features = ["serde-1"] }
+pin-project-lite = "0.2.13"
+podman-api = "0.10.0"
 postcard = { version = "1.0.8", features = ["use-std"] }
-postgres-types = { version = "0.2.5", features = ["derive"] }
-pretty_assertions_sorted = "1.2.1"
-proc-macro2 = "1.0.56"
-quote = "1.0.27"
+postgres-types = { version = "0.2.6", features = ["derive"] }
+pretty_assertions_sorted = "1.2.3"
+proc-macro2 = "1.0.79"
+quote = "1.0.35"
 rand = "0.8.5"
-refinery = { version = "0.8.9", features = ["tokio-postgres"] }
-regex = "1.8.1"
-remain = "0.2.8"
-reqwest = { version = "0.11.17", default-features = false, features = [
+refinery = { version = "0.8.12", features = ["tokio-postgres"] }
+regex = "1.10.4"
+remain = "0.2.13"
+reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls",
     "json",
     "multipart",
 ] }
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
-rustls = { version = "0.22.2" }
-rustls-pemfile = { version = "2.0.0" }
+rustls = { version = "0.22.3" }
+rustls-pemfile = { version = "2.1.1" }
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
 ] }
-sea-orm = { version = "0.12.0", features = [
+sea-orm = { version = "0.12.15", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
@@ -162,60 +162,60 @@ sea-orm = { version = "0.12.0", features = [
     "debug-print",
 ] }
 self-replace = "1.3.7"
-serde = { version = "1.0.160", features = ["derive", "rc"] }
-serde-aux = "4.2.0"
-serde_json = { version = "1.0.96", features = ["preserve_order"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde-aux = "4.5.0"
+serde_json = { version = "1.0.115", features = ["preserve_order"] }
 serde_url_params = "0.2.1"
-serde_with = "3.0.0"
-serde_yaml = "0.9.21"
+serde_with = "3.7.0"
+serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sled = "0.34.7"
 sodiumoxide = "0.2.7"
-stream-cancel = "0.8.1"
-strum = { version = "0.25.0", features = ["derive"] }
-syn = { version = "2.0.15", features = ["full", "extra-traits"] }
-tar = "0.4.38"
-tempfile = "3.5.0"
-test-log = { version = "0.2.11", default-features = false, features = [
+stream-cancel = "0.8.2"
+strum = { version = "0.26.2", features = ["derive"] }
+syn = { version = "2.0.55", features = ["full", "extra-traits"] }
+tar = "0.4.40"
+tempfile = "3.10.1"
+test-log = { version = "0.2.15", default-features = false, features = [
     "trace",
 ] }
-thiserror = "1.0.40"
-tokio = { version = "1.28.0", features = ["full"] }
-tokio-postgres = { version = "0.7.8", features = [
+thiserror = "1.0.58"
+tokio = { version = "1.37.0", features = ["full"] }
+tokio-postgres = { version = "0.7.10", features = [
     "runtime",
     "with-chrono-0_4",
     "with-serde_json-1",
 ] }
-tokio-postgres-rustls = { version = "0.11.0" }
-tokio-serde = { version = "0.8.0", features = ["json"] }
-tokio-stream = { version = "0.1.14", features = ["sync"] }
-tokio-test = "0.4.2"
+tokio-postgres-rustls = { version = "0.11.1" }
+tokio-serde = { version = "0.9.0", features = ["json"] }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
+tokio-test = "0.4.4"
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
-tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
+tokio-util = { version = "0.7.10", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
-toml = { version = "0.8.8" }
+toml = { version = "0.8.12" }
 tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.4", features = [
+tower-http = { version = "0.4.4", features = [
     "compression-br",
     "compression-deflate",
     "compression-gzip",
     "cors",
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
-tracing = { version = "0.1" }
+tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",
     "std",
 ] }
-ulid = { version = "1.0.0", features = ["serde"] }
-url = { version = "2.3.1", features = ["serde"] }
-uuid = { version = "1.3.2", features = ["serde", "v4"] }
-vfs = "0.10.0"
-vfs-tar = { version = "0.4.0", features = ["mmap"] }
-webpki-roots = { version = "0.25.3" }
+ulid = { version = "1.1.2", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
+uuid = { version = "1.8.0", features = ["serde", "v4"] }
+vfs = "0.12.0"
+vfs-tar = { version = "0.4.1", features = ["mmap"] }
+webpki-roots = { version = "0.25.4" }
 y-sync = { version = "0.4.0", features = ["net"] }
-yrs = { version = "0.17.2" }
+yrs = { version = "0.17.4" }
 
 [patch.crates-io]
 # pending a potential merge and release of

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-color-eyre = { version = "0.6.1" }
+color-eyre = { workspace = true }
 cyclone-server = { path = "../../lib/cyclone-server" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }

--- a/bin/si/src/args.rs
+++ b/bin/si/src/args.rs
@@ -1,6 +1,6 @@
 use clap::{builder::PossibleValuesParser, Parser, Subcommand};
 use std::str::FromStr;
-use strum::{Display, EnumString, EnumVariantNames};
+use strum::{Display, EnumString, VariantNames};
 
 const NAME: &str = "si";
 
@@ -192,13 +192,13 @@ impl Args {
     }
 }
 
-#[derive(Clone, Copy, Debug, Display, EnumString, EnumVariantNames)]
+#[derive(Clone, Copy, Debug, Display, EnumString, VariantNames)]
 pub enum Mode {
     #[strum(serialize = "local")]
     Local,
 }
 
-#[derive(Clone, Copy, Debug, Display, EnumString, EnumVariantNames, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, EnumString, VariantNames, PartialEq)]
 pub enum Engine {
     #[strum(serialize = "docker")]
     Docker,

--- a/lib/config-file/Cargo.toml
+++ b/lib/config-file/Cargo.toml
@@ -36,11 +36,13 @@ pathdiff = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-serde_toml = { package = "toml", version = "0.8.8", optional = true }
 serde_yaml = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
+
+# FIXME(nick): we should move directly onto the "toml" crate and use the workspace's version.
+serde_toml = { package = "toml", version = "0.8.12", optional = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -7,6 +7,22 @@ rust-version = "1.64"
 publish = false
 
 [dependencies]
+council-server = { path = "../../lib/council-server" }
+nats-subscriber = { path = "../../lib/nats-subscriber" }
+object-tree = { path = "../../lib/object-tree" }
+si-cbor = { path = "../../lib/si-cbor" }
+si-crypto = { path = "../../lib/si-crypto" }
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-data-pg = { path = "../../lib/si-data-pg" }
+si-events = { path = "../../lib/si-events-rs" }
+si-hash = { path = "../../lib/si-hash" }
+si-layer-cache = { path = "../../lib/si-layer-cache" }
+si-pkg = { path = "../../lib/si-pkg" }
+si-std = { path = "../../lib/si-std" }
+telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
+veritech-client = { path = "../../lib/veritech-client" }
+
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -14,7 +30,6 @@ blake3 = { workspace = true }
 chrono = { workspace = true }
 ciborium = { workspace = true }
 convert_case = { workspace = true }
-council-server = { path = "../../lib/council-server" }
 derive_more = { workspace = true }
 diff = { workspace = true }
 dyn-clone = { workspace = true }
@@ -23,14 +38,11 @@ hex = { workspace = true }
 iftree = { workspace = true }
 itertools = { workspace = true }
 jwt-simple = { workspace = true }
-si-layer-cache = { path = "../../lib/si-layer-cache" }
 lazy_static = { workspace = true }
-nats-subscriber = { path = "../../lib/nats-subscriber" }
-object-tree = { path = "../../lib/object-tree" }
 once_cell = { workspace = true }
 paste = { workspace = true }
 petgraph = { workspace = true }
-postcard = { version = "1.0.8", features = ["alloc"] }
+postcard = { workspace = true }
 postgres-types = { workspace = true }
 rand = { workspace = true }
 refinery = { workspace = true }
@@ -40,32 +52,23 @@ serde = { workspace = true }
 serde-aux = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-si-cbor = { path = "../../lib/si-cbor" }
-si-crypto = { path = "../../lib/si-crypto" }
-si-data-nats = { path = "../../lib/si-data-nats" }
-si-data-pg = { path = "../../lib/si-data-pg" }
-si-events = { path = "../../lib/si-events-rs" }
-si-hash = { path = "../../lib/si-hash" }
-si-pkg = { path = "../../lib/si-pkg" }
-si-std = { path = "../../lib/si-std" }
 sled = { workspace = true }
 sodiumoxide = { workspace = true }
 strum = { workspace = true }
-telemetry = { path = "../../lib/telemetry-rs" }
-telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 ulid = { workspace = true }
 url = { workspace = true }
-veritech-client = { path = "../../lib/veritech-client" }
 
 [dev-dependencies]
 buck2-resources = { path = "../../lib/buck2-resources" }
 dal-test = { path = "../../lib/dal-test" }
+telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
+veritech-client = { path = "../../lib/veritech-client" }
+
 itertools = { workspace = true }
 pretty_assertions_sorted = { workspace = true }
-rebaser-core = { path = "../../lib/rebaser-core" }
-rebaser-server = { path = "../../lib/rebaser-server" }
 tempfile = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use si_data_nats::NatsError;
 use si_data_pg::{PgError, PgPool, PgPoolError};
-use strum::{Display, EnumString, EnumVariantNames};
+use strum::{Display, EnumString, VariantNames};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::time;
@@ -242,7 +242,7 @@ pub fn generate_name() -> String {
     DeserializeFromStr,
     Display,
     EnumString,
-    EnumVariantNames,
+    VariantNames,
     Eq,
     PartialEq,
     SerializeDisplay,

--- a/lib/si-std/Cargo.toml
+++ b/lib/si-std/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 # amongst a potential large number of component crates
 [dependencies]
 remain = { workspace = true }
-serde = { version = "1.0.123", features = ["derive"] }
+serde = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -179,18 +179,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aho-corasick-1.1.2.crate",
-    sha256 = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0",
-    strip_prefix = "aho-corasick-1.1.2",
-    urls = ["https://crates.io/api/v1/crates/aho-corasick/1.1.2/download"],
+    name = "aho-corasick-1.1.3.crate",
+    sha256 = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+    strip_prefix = "aho-corasick-1.1.3",
+    urls = ["https://crates.io/api/v1/crates/aho-corasick/1.1.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aho-corasick-1.1.2",
-    srcs = [":aho-corasick-1.1.2.crate"],
+    name = "aho-corasick-1.1.3",
+    srcs = [":aho-corasick-1.1.3.crate"],
     crate = "aho_corasick",
-    crate_root = "aho-corasick-1.1.2.crate/src/lib.rs",
+    crate_root = "aho-corasick-1.1.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -198,7 +198,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":memchr-2.7.1"],
+    deps = [":memchr-2.7.2"],
 )
 
 http_archive(
@@ -272,6 +272,24 @@ cargo.rust_library(
     crate_root = "allocator-api2-0.2.16.crate/src/lib.rs",
     edition = "2018",
     features = ["alloc"],
+    visibility = [],
+)
+
+http_archive(
+    name = "anes-0.1.6.crate",
+    sha256 = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299",
+    strip_prefix = "anes-0.1.6",
+    urls = ["https://crates.io/api/v1/crates/anes/0.1.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "anes-0.1.6",
+    srcs = [":anes-0.1.6.crate"],
+    crate = "anes",
+    crate_root = "anes-0.1.6.crate/src/lib.rs",
+    edition = "2018",
+    features = ["default"],
     visibility = [],
 )
 
@@ -488,9 +506,9 @@ cargo.rust_library(
         ":brotli-3.5.0",
         ":flate2-1.0.28",
         ":futures-core-0.3.30",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
     ],
 )
 
@@ -514,33 +532,33 @@ cargo.rust_library(
 
 alias(
     name = "async-nats",
-    actual = ":async-nats-0.33.0",
+    actual = ":async-nats-0.34.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-nats-0.33.0.crate",
-    sha256 = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60",
-    strip_prefix = "async-nats-0.33.0",
-    urls = ["https://crates.io/api/v1/crates/async-nats/0.33.0/download"],
+    name = "async-nats-0.34.0.crate",
+    sha256 = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5",
+    strip_prefix = "async-nats-0.34.0",
+    urls = ["https://crates.io/api/v1/crates/async-nats/0.34.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-nats-0.33.0",
-    srcs = [":async-nats-0.33.0.crate"],
+    name = "async-nats-0.34.0",
+    srcs = [":async-nats-0.34.0.crate"],
     crate = "async_nats",
-    crate_root = "async-nats-0.33.0.crate/src/lib.rs",
+    crate_root = "async-nats-0.34.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "async-nats-0.33.0.crate",
+        "CARGO_MANIFEST_DIR": "async-nats-0.34.0.crate",
         "CARGO_PKG_AUTHORS": "Tomasz Pietrek <tomasz@nats.io>:Casper Beyer <caspervonb@pm.me>",
         "CARGO_PKG_DESCRIPTION": "A async Rust NATS client",
         "CARGO_PKG_NAME": "async-nats",
         "CARGO_PKG_REPOSITORY": "https://github.com/nats-io/nats.rs",
-        "CARGO_PKG_VERSION": "0.33.0",
+        "CARGO_PKG_VERSION": "0.34.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "33",
+        "CARGO_PKG_VERSION_MINOR": "34",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -550,31 +568,30 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":base64-0.21.7",
-        ":bytes-1.5.0",
+        ":base64-0.22.0",
+        ":bytes-1.6.0",
         ":futures-0.3.30",
-        ":http-0.2.12",
-        ":memchr-2.7.1",
-        ":nkeys-0.3.2",
+        ":memchr-2.7.2",
+        ":nkeys-0.4.0",
         ":nuid-0.5.0",
         ":once_cell-1.19.0",
+        ":portable-atomic-1.6.0",
         ":rand-0.8.5",
-        ":regex-1.10.3",
+        ":regex-1.10.4",
         ":ring-0.17.5",
-        ":rustls-0.21.10",
-        ":rustls-native-certs-0.6.3",
-        ":rustls-pemfile-1.0.4",
-        ":rustls-webpki-0.101.7",
+        ":rustls-native-certs-0.7.0",
+        ":rustls-pemfile-2.1.1",
+        ":rustls-webpki-0.102.2",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_nanos-0.1.3",
         ":serde_repr-0.1.18",
         ":thiserror-1.0.58",
         ":time-0.3.34",
-        ":tokio-1.36.0",
-        ":tokio-retry-0.3.0",
-        ":tokio-rustls-0.24.1",
+        ":tokio-1.37.0",
+        ":tokio-rustls-0.25.0",
         ":tracing-0.1.40",
+        ":tryhard-0.5.1",
         ":url-2.5.0",
     ],
 )
@@ -604,7 +621,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -649,36 +666,36 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "async-trait",
-    actual = ":async-trait-0.1.78",
+    actual = ":async-trait-0.1.79",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-trait-0.1.78.crate",
-    sha256 = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85",
-    strip_prefix = "async-trait-0.1.78",
-    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.78/download"],
+    name = "async-trait-0.1.79.crate",
+    sha256 = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681",
+    strip_prefix = "async-trait-0.1.79",
+    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.79/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-trait-0.1.78",
-    srcs = [":async-trait-0.1.78.crate"],
+    name = "async-trait-0.1.79",
+    srcs = [":async-trait-0.1.79.crate"],
     crate = "async_trait",
-    crate_root = "async-trait-0.1.78.crate/src/lib.rs",
+    crate_root = "async-trait-0.1.79.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -699,10 +716,10 @@ cargo.rust_library(
     features = ["default"],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":pin-project-lite-0.2.13",
     ],
 )
@@ -790,62 +807,25 @@ cargo.rust_library(
         ":http-0.2.12",
         ":log-0.4.21",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":url-2.5.0",
         ":webpki-roots-0.25.4",
     ],
 )
 
 http_archive(
-    name = "atty-0.2.14.crate",
-    sha256 = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
-    strip_prefix = "atty-0.2.14",
-    urls = ["https://crates.io/api/v1/crates/atty/0.2.14/download"],
+    name = "autocfg-1.2.0.crate",
+    sha256 = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80",
+    strip_prefix = "autocfg-1.2.0",
+    urls = ["https://crates.io/api/v1/crates/autocfg/1.2.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "atty-0.2.14",
-    srcs = [":atty-0.2.14.crate"],
-    crate = "atty",
-    crate_root = "atty-0.2.14.crate/src/lib.rs",
-    edition = "2015",
-    platform = {
-        "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
-        ),
-        "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
-        ),
-        "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
-        ),
-        "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
-        ),
-        "windows-gnu": dict(
-            deps = [":winapi-0.3.9"],
-        ),
-        "windows-msvc": dict(
-            deps = [":winapi-0.3.9"],
-        ),
-    },
-    visibility = [],
-)
-
-http_archive(
-    name = "autocfg-1.1.0.crate",
-    sha256 = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-    strip_prefix = "autocfg-1.1.0",
-    urls = ["https://crates.io/api/v1/crates/autocfg/1.1.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "autocfg-1.1.0",
-    srcs = [":autocfg-1.1.0.crate"],
+    name = "autocfg-1.2.0",
+    srcs = [":autocfg-1.2.0.crate"],
     crate = "autocfg",
-    crate_root = "autocfg-1.1.0.crate/src/lib.rs",
+    crate_root = "autocfg-1.2.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
 )
@@ -921,30 +901,30 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":axum-core-0.3.4",
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
         ":bitflags-1.3.2",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":hyper-0.14.28",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":matchit-0.7.3",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":mime-0.3.17",
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.13",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.2",
@@ -968,8 +948,8 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
-        ":bytes-1.5.0",
+        ":async-trait-0.1.79",
+        ":bytes-1.6.0",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":http-body-0.4.6",
@@ -1000,24 +980,24 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 http_archive(
-    name = "backtrace-0.3.69.crate",
-    sha256 = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837",
-    strip_prefix = "backtrace-0.3.69",
-    urls = ["https://crates.io/api/v1/crates/backtrace/0.3.69/download"],
+    name = "backtrace-0.3.71.crate",
+    sha256 = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d",
+    strip_prefix = "backtrace-0.3.71",
+    urls = ["https://crates.io/api/v1/crates/backtrace/0.3.71/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "backtrace-0.3.69",
-    srcs = [":backtrace-0.3.69.crate"],
+    name = "backtrace-0.3.71",
+    srcs = [":backtrace-0.3.71.crate"],
     crate = "backtrace",
-    crate_root = "backtrace-0.3.69.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "backtrace-0.3.71.crate/src/lib.rs",
+    edition = "2021",
     features = [
         "default",
         "gimli-symbolize",
@@ -1112,12 +1092,6 @@ cargo.rust_library(
     visibility = [],
 )
 
-alias(
-    name = "base64",
-    actual = ":base64-0.21.7",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "base64-0.21.7.crate",
     sha256 = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
@@ -1131,6 +1105,34 @@ cargo.rust_library(
     srcs = [":base64-0.21.7.crate"],
     crate = "base64",
     crate_root = "base64-0.21.7.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "alloc",
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
+alias(
+    name = "base64",
+    actual = ":base64-0.22.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "base64-0.22.0.crate",
+    sha256 = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51",
+    strip_prefix = "base64-0.22.0",
+    urls = ["https://crates.io/api/v1/crates/base64/0.22.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "base64-0.22.0",
+    srcs = [":base64-0.22.0.crate"],
+    crate = "base64",
+    crate_root = "base64-0.22.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -1174,8 +1176,8 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
-        ":smallvec-1.13.1",
+        ":bytes-1.6.0",
+        ":smallvec-1.13.2",
     ],
 )
 
@@ -1500,81 +1502,92 @@ cargo.rust_library(
 
 alias(
     name = "bollard",
-    actual = ":bollard-0.15.0",
+    actual = ":bollard-0.16.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "bollard-0.15.0.crate",
-    sha256 = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6",
-    strip_prefix = "bollard-0.15.0",
-    urls = ["https://crates.io/api/v1/crates/bollard/0.15.0/download"],
+    name = "bollard-0.16.1.crate",
+    sha256 = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c",
+    strip_prefix = "bollard-0.16.1",
+    urls = ["https://crates.io/api/v1/crates/bollard/0.16.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bollard-0.15.0",
-    srcs = [":bollard-0.15.0.crate"],
+    name = "bollard-0.16.1",
+    srcs = [":bollard-0.16.1.crate"],
     crate = "bollard",
-    crate_root = "bollard-0.15.0.crate/src/lib.rs",
+    crate_root = "bollard-0.16.1.crate/src/lib.rs",
     edition = "2021",
+    features = ["default"],
     platform = {
         "linux-arm64": dict(
-            deps = [":hyperlocal-0.8.0"],
+            deps = [":hyperlocal-next-0.9.0"],
         ),
         "linux-x86_64": dict(
-            deps = [":hyperlocal-0.8.0"],
+            deps = [":hyperlocal-next-0.9.0"],
         ),
         "macos-arm64": dict(
-            deps = [":hyperlocal-0.8.0"],
+            deps = [":hyperlocal-next-0.9.0"],
         ),
         "macos-x86_64": dict(
-            deps = [":hyperlocal-0.8.0"],
+            deps = [":hyperlocal-next-0.9.0"],
         ),
         "windows-gnu": dict(
-            deps = [":winapi-0.3.9"],
+            deps = [
+                ":hyper-named-pipe-0.1.0",
+                ":tower-service-0.3.2",
+                ":winapi-0.3.9",
+            ],
         ),
         "windows-msvc": dict(
-            deps = [":winapi-0.3.9"],
+            deps = [
+                ":hyper-named-pipe-0.1.0",
+                ":tower-service-0.3.2",
+                ":winapi-0.3.9",
+            ],
         ),
     },
     visibility = [],
     deps = [
-        ":base64-0.21.7",
-        ":bollard-stubs-1.43.0-rc.2",
-        ":bytes-1.5.0",
+        ":base64-0.22.0",
+        ":bollard-stubs-1.44.0-rc.2",
+        ":bytes-1.6.0",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
         ":hex-0.4.3",
-        ":http-0.2.12",
-        ":hyper-0.14.28",
+        ":http-1.1.0",
+        ":http-body-util-0.1.1",
+        ":hyper-1.2.0",
+        ":hyper-util-0.1.3",
         ":log-0.4.21",
         ":pin-project-lite-0.2.13",
         ":serde-1.0.197",
         ":serde_derive-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_repr-0.1.18",
         ":serde_urlencoded-0.7.1",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":url-2.5.0",
     ],
 )
 
 http_archive(
-    name = "bollard-stubs-1.43.0-rc.2.crate",
-    sha256 = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e",
-    strip_prefix = "bollard-stubs-1.43.0-rc.2",
-    urls = ["https://crates.io/api/v1/crates/bollard-stubs/1.43.0-rc.2/download"],
+    name = "bollard-stubs-1.44.0-rc.2.crate",
+    sha256 = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5",
+    strip_prefix = "bollard-stubs-1.44.0-rc.2",
+    urls = ["https://crates.io/api/v1/crates/bollard-stubs/1.44.0-rc.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bollard-stubs-1.43.0-rc.2",
-    srcs = [":bollard-stubs-1.43.0-rc.2.crate"],
+    name = "bollard-stubs-1.44.0-rc.2",
+    srcs = [":bollard-stubs-1.44.0-rc.2.crate"],
     crate = "bollard_stubs",
-    crate_root = "bollard-stubs-1.43.0-rc.2.crate/src/lib.rs",
+    crate_root = "bollard-stubs-1.44.0-rc.2.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -1655,7 +1668,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":serde-1.0.197",
     ],
 )
@@ -1704,23 +1717,23 @@ cargo.rust_library(
 
 alias(
     name = "bytes",
-    actual = ":bytes-1.5.0",
+    actual = ":bytes-1.6.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "bytes-1.5.0.crate",
-    sha256 = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223",
-    strip_prefix = "bytes-1.5.0",
-    urls = ["https://crates.io/api/v1/crates/bytes/1.5.0/download"],
+    name = "bytes-1.6.0.crate",
+    sha256 = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9",
+    strip_prefix = "bytes-1.6.0",
+    urls = ["https://crates.io/api/v1/crates/bytes/1.6.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bytes-1.5.0",
-    srcs = [":bytes-1.5.0.crate"],
+    name = "bytes-1.6.0",
+    srcs = [":bytes-1.6.0.crate"],
     crate = "bytes",
-    crate_root = "bytes-1.5.0.crate/src/lib.rs",
+    crate_root = "bytes-1.6.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -1784,23 +1797,23 @@ cargo.rust_library(
 
 alias(
     name = "chrono",
-    actual = ":chrono-0.4.35",
+    actual = ":chrono-0.4.37",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "chrono-0.4.35.crate",
-    sha256 = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a",
-    strip_prefix = "chrono-0.4.35",
-    urls = ["https://crates.io/api/v1/crates/chrono/0.4.35/download"],
+    name = "chrono-0.4.37.crate",
+    sha256 = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e",
+    strip_prefix = "chrono-0.4.37",
+    urls = ["https://crates.io/api/v1/crates/chrono/0.4.37/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "chrono-0.4.35",
-    srcs = [":chrono-0.4.35.crate"],
+    name = "chrono-0.4.37",
+    srcs = [":chrono-0.4.37.crate"],
     crate = "chrono",
-    crate_root = "chrono-0.4.35.crate/src/lib.rs",
+    crate_root = "chrono-0.4.37.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -1919,47 +1932,25 @@ cargo.rust_library(
     ],
 )
 
-http_archive(
-    name = "clap-2.34.0.crate",
-    sha256 = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c",
-    strip_prefix = "clap-2.34.0",
-    urls = ["https://crates.io/api/v1/crates/clap/2.34.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "clap-2.34.0",
-    srcs = [":clap-2.34.0.crate"],
-    crate = "clap",
-    crate_root = "clap-2.34.0.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [
-        ":bitflags-1.3.2",
-        ":textwrap-0.11.0",
-        ":unicode-width-0.1.11",
-    ],
-)
-
 alias(
     name = "clap",
-    actual = ":clap-4.5.3",
+    actual = ":clap-4.5.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.3.crate",
-    sha256 = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813",
-    strip_prefix = "clap-4.5.3",
-    urls = ["https://crates.io/api/v1/crates/clap/4.5.3/download"],
+    name = "clap-4.5.4.crate",
+    sha256 = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0",
+    strip_prefix = "clap-4.5.4",
+    urls = ["https://crates.io/api/v1/crates/clap/4.5.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.3",
-    srcs = [":clap-4.5.3.crate"],
+    name = "clap-4.5.4",
+    srcs = [":clap-4.5.4.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.3.crate/src/lib.rs",
+    crate_root = "clap-4.5.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -1976,7 +1967,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":clap_builder-4.5.2",
-        ":clap_derive-4.5.3",
+        ":clap_derive-4.5.4",
     ],
 )
 
@@ -2015,18 +2006,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "clap_derive-4.5.3.crate",
-    sha256 = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f",
-    strip_prefix = "clap_derive-4.5.3",
-    urls = ["https://crates.io/api/v1/crates/clap_derive/4.5.3/download"],
+    name = "clap_derive-4.5.4.crate",
+    sha256 = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64",
+    strip_prefix = "clap_derive-4.5.4",
+    urls = ["https://crates.io/api/v1/crates/clap_derive/4.5.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_derive-4.5.3",
-    srcs = [":clap_derive-4.5.3.crate"],
+    name = "clap_derive-4.5.4",
+    srcs = [":clap_derive-4.5.4.crate"],
     crate = "clap_derive",
-    crate_root = "clap_derive-4.5.3.crate/src/lib.rs",
+    crate_root = "clap_derive-4.5.4.crate/src/lib.rs",
     edition = "2021",
     features = ["default"],
     proc_macro = True,
@@ -2035,7 +2026,7 @@ cargo.rust_library(
         ":heck-0.5.0",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -2139,7 +2130,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":backtrace-0.3.69",
+        ":backtrace-0.3.71",
         ":color-spantrace-0.2.1",
         ":eyre-0.6.12",
         ":indenter-0.3.3",
@@ -2279,33 +2270,32 @@ cargo.rust_library(
 
 alias(
     name = "config",
-    actual = ":config-0.13.4",
+    actual = ":config-0.14.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "config-0.13.4.crate",
-    sha256 = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca",
-    strip_prefix = "config-0.13.4",
-    urls = ["https://crates.io/api/v1/crates/config/0.13.4/download"],
+    name = "config-0.14.0.crate",
+    sha256 = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be",
+    strip_prefix = "config-0.14.0",
+    urls = ["https://crates.io/api/v1/crates/config/0.14.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "config-0.13.4",
-    srcs = [":config-0.13.4.crate"],
+    name = "config-0.14.0",
+    srcs = [":config-0.14.0.crate"],
     crate = "config",
-    crate_root = "config-0.13.4.crate/src/lib.rs",
+    crate_root = "config-0.14.0.crate/src/lib.rs",
     edition = "2018",
     features = ["toml"],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
         ":lazy_static-1.4.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
         ":serde-1.0.197",
-        ":toml-0.5.11",
+        ":toml-0.8.12",
     ],
 )
 
@@ -2465,7 +2455,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -2475,10 +2465,10 @@ cargo.rust_library(
         ":paste-1.0.14",
         ":pin-project-1.1.5",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":tar-0.4.40",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":url-2.5.0",
     ],
 )
@@ -2517,7 +2507,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -2527,10 +2517,10 @@ cargo.rust_library(
         ":paste-1.0.14",
         ":pin-project-1.1.5",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":tar-0.4.40",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":url-2.5.0",
     ],
 )
@@ -2706,34 +2696,34 @@ cargo.rust_library(
 
 alias(
     name = "criterion",
-    actual = ":criterion-0.3.6",
+    actual = ":criterion-0.5.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "criterion-0.3.6.crate",
-    sha256 = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f",
-    strip_prefix = "criterion-0.3.6",
-    urls = ["https://crates.io/api/v1/crates/criterion/0.3.6/download"],
+    name = "criterion-0.5.1.crate",
+    sha256 = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f",
+    strip_prefix = "criterion-0.5.1",
+    urls = ["https://crates.io/api/v1/crates/criterion/0.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "criterion-0.3.6",
-    srcs = [":criterion-0.3.6.crate"],
+    name = "criterion-0.5.1",
+    srcs = [":criterion-0.5.1.crate"],
     crate = "criterion",
-    crate_root = "criterion-0.3.6.crate/src/lib.rs",
+    crate_root = "criterion-0.5.1.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "criterion-0.3.6.crate",
+        "CARGO_MANIFEST_DIR": "criterion-0.5.1.crate",
         "CARGO_PKG_AUTHORS": "Jorge Aparicio <japaricious@gmail.com>:Brook Heisler <brookheisler@gmail.com>",
         "CARGO_PKG_DESCRIPTION": "Statistics-driven micro-benchmarking library",
         "CARGO_PKG_NAME": "criterion",
         "CARGO_PKG_REPOSITORY": "https://github.com/bheisler/criterion.rs",
-        "CARGO_PKG_VERSION": "0.3.6",
+        "CARGO_PKG_VERSION": "0.5.1",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "6",
+        "CARGO_PKG_VERSION_MINOR": "5",
+        "CARGO_PKG_VERSION_PATCH": "1",
     },
     features = [
         "async",
@@ -2741,46 +2731,48 @@ cargo.rust_library(
         "cargo_bench_support",
         "default",
         "futures",
+        "plotters",
+        "rayon",
         "tokio",
     ],
     visibility = [],
     deps = [
-        ":atty-0.2.14",
+        ":anes-0.1.6",
         ":cast-0.3.0",
-        ":clap-2.34.0",
-        ":criterion-plot-0.4.5",
-        ":csv-1.3.0",
+        ":ciborium-0.2.2",
+        ":clap-4.5.4",
+        ":criterion-plot-0.5.0",
         ":futures-0.3.30",
+        ":is-terminal-0.4.12",
         ":itertools-0.10.5",
-        ":lazy_static-1.4.0",
         ":num-traits-0.2.18",
+        ":once_cell-1.19.0",
         ":oorandom-11.1.3",
         ":plotters-0.3.5",
-        ":rayon-1.9.0",
-        ":regex-1.10.3",
+        ":rayon-1.10.0",
+        ":regex-1.10.4",
         ":serde-1.0.197",
-        ":serde_cbor-0.11.2",
         ":serde_derive-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":tinytemplate-1.2.1",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":walkdir-2.5.0",
     ],
 )
 
 http_archive(
-    name = "criterion-plot-0.4.5.crate",
-    sha256 = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876",
-    strip_prefix = "criterion-plot-0.4.5",
-    urls = ["https://crates.io/api/v1/crates/criterion-plot/0.4.5/download"],
+    name = "criterion-plot-0.5.0.crate",
+    sha256 = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1",
+    strip_prefix = "criterion-plot-0.5.0",
+    urls = ["https://crates.io/api/v1/crates/criterion-plot/0.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "criterion-plot-0.4.5",
-    srcs = [":criterion-plot-0.4.5.crate"],
+    name = "criterion-plot-0.5.0",
+    srcs = [":criterion-plot-0.5.0.crate"],
     crate = "criterion_plot",
-    crate_root = "criterion-plot-0.4.5.crate/src/lib.rs",
+    crate_root = "criterion-plot-0.5.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [
@@ -3174,48 +3166,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "csv-1.3.0.crate",
-    sha256 = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe",
-    strip_prefix = "csv-1.3.0",
-    urls = ["https://crates.io/api/v1/crates/csv/1.3.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "csv-1.3.0",
-    srcs = [":csv-1.3.0.crate"],
-    crate = "csv",
-    crate_root = "csv-1.3.0.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
-    deps = [
-        ":csv-core-0.1.11",
-        ":itoa-1.0.10",
-        ":ryu-1.0.17",
-        ":serde-1.0.197",
-    ],
-)
-
-http_archive(
-    name = "csv-core-0.1.11.crate",
-    sha256 = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70",
-    strip_prefix = "csv-core-0.1.11",
-    urls = ["https://crates.io/api/v1/crates/csv-core/0.1.11/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "csv-core-0.1.11",
-    srcs = [":csv-core-0.1.11.crate"],
-    crate = "csv_core",
-    crate_root = "csv-core-0.1.11.crate/src/lib.rs",
-    edition = "2018",
-    features = ["default"],
-    visibility = [],
-    deps = [":memchr-2.7.1"],
-)
-
-http_archive(
     name = "ct-codecs-1.1.1.crate",
     sha256 = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df",
     strip_prefix = "ct-codecs-1.1.1",
@@ -3295,7 +3245,7 @@ cargo.rust_binary(
     features = ["digest"],
     visibility = [],
     deps = [
-        ":platforms-3.3.0",
+        ":platforms-3.4.0",
         ":rustc_version-0.4.0",
     ],
 )
@@ -3327,32 +3277,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
-    ],
-)
-
-http_archive(
-    name = "darling-0.14.4.crate",
-    sha256 = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850",
-    strip_prefix = "darling-0.14.4",
-    urls = ["https://crates.io/api/v1/crates/darling/0.14.4/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "darling-0.14.4",
-    srcs = [":darling-0.14.4.crate"],
-    crate = "darling",
-    crate_root = "darling-0.14.4.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "default",
-        "suggestions",
-    ],
-    visibility = [],
-    deps = [
-        ":darling_core-0.14.4",
-        ":darling_macro-0.14.4",
+        ":syn-2.0.55",
     ],
 )
 
@@ -3382,35 +3307,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "darling_core-0.14.4.crate",
-    sha256 = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0",
-    strip_prefix = "darling_core-0.14.4",
-    urls = ["https://crates.io/api/v1/crates/darling_core/0.14.4/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "darling_core-0.14.4",
-    srcs = [":darling_core-0.14.4.crate"],
-    crate = "darling_core",
-    crate_root = "darling_core-0.14.4.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "strsim",
-        "suggestions",
-    ],
-    visibility = [],
-    deps = [
-        ":fnv-1.0.7",
-        ":ident_case-1.0.1",
-        ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
-        ":strsim-0.10.0",
-        ":syn-1.0.109",
-    ],
-)
-
-http_archive(
     name = "darling_core-0.20.8.crate",
     sha256 = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f",
     strip_prefix = "darling_core-0.20.8",
@@ -3435,30 +3331,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":strsim-0.10.0",
-        ":syn-2.0.53",
-    ],
-)
-
-http_archive(
-    name = "darling_macro-0.14.4.crate",
-    sha256 = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e",
-    strip_prefix = "darling_macro-0.14.4",
-    urls = ["https://crates.io/api/v1/crates/darling_macro/0.14.4/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "darling_macro-0.14.4",
-    srcs = [":darling_macro-0.14.4.crate"],
-    crate = "darling_macro",
-    crate_root = "darling_macro-0.14.4.crate/src/lib.rs",
-    edition = "2018",
-    proc_macro = True,
-    visibility = [],
-    deps = [
-        ":darling_core-0.14.4",
-        ":quote-1.0.35",
-        ":syn-1.0.109",
+        ":syn-2.0.55",
     ],
 )
 
@@ -3481,7 +3354,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.8",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -3559,10 +3432,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":deadpool-runtime-0.1.3",
         ":num_cpus-1.16.0",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
     ],
 )
 
@@ -3593,7 +3466,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":deadpool-0.10.0",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":tracing-0.1.40",
     ],
@@ -3615,7 +3488,7 @@ cargo.rust_library(
     edition = "2018",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.36.0",
+        "tokio_1": ":tokio-1.37.0",
     },
     visibility = [],
 )
@@ -3701,74 +3574,76 @@ cargo.rust_library(
 
 alias(
     name = "derive_builder",
-    actual = ":derive_builder-0.12.0",
+    actual = ":derive_builder-0.20.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "derive_builder-0.12.0.crate",
-    sha256 = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8",
-    strip_prefix = "derive_builder-0.12.0",
-    urls = ["https://crates.io/api/v1/crates/derive_builder/0.12.0/download"],
+    name = "derive_builder-0.20.0.crate",
+    sha256 = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7",
+    strip_prefix = "derive_builder-0.20.0",
+    urls = ["https://crates.io/api/v1/crates/derive_builder/0.20.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder-0.12.0",
-    srcs = [":derive_builder-0.12.0.crate"],
+    name = "derive_builder-0.20.0",
+    srcs = [":derive_builder-0.20.0.crate"],
     crate = "derive_builder",
-    crate_root = "derive_builder-0.12.0.crate/src/lib.rs",
-    edition = "2015",
+    crate_root = "derive_builder-0.20.0.crate/src/lib.rs",
+    edition = "2018",
     features = [
         "default",
         "std",
     ],
     visibility = [],
-    deps = [":derive_builder_macro-0.12.0"],
+    deps = [":derive_builder_macro-0.20.0"],
 )
 
 http_archive(
-    name = "derive_builder_core-0.12.0.crate",
-    sha256 = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f",
-    strip_prefix = "derive_builder_core-0.12.0",
-    urls = ["https://crates.io/api/v1/crates/derive_builder_core/0.12.0/download"],
+    name = "derive_builder_core-0.20.0.crate",
+    sha256 = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d",
+    strip_prefix = "derive_builder_core-0.20.0",
+    urls = ["https://crates.io/api/v1/crates/derive_builder_core/0.20.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_core-0.12.0",
-    srcs = [":derive_builder_core-0.12.0.crate"],
+    name = "derive_builder_core-0.20.0",
+    srcs = [":derive_builder_core-0.20.0.crate"],
     crate = "derive_builder_core",
-    crate_root = "derive_builder_core-0.12.0.crate/src/lib.rs",
-    edition = "2015",
+    crate_root = "derive_builder_core-0.20.0.crate/src/lib.rs",
+    edition = "2018",
+    features = ["lib_has_std"],
     visibility = [],
     deps = [
-        ":darling-0.14.4",
+        ":darling-0.20.8",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-1.0.109",
+        ":syn-2.0.55",
     ],
 )
 
 http_archive(
-    name = "derive_builder_macro-0.12.0.crate",
-    sha256 = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e",
-    strip_prefix = "derive_builder_macro-0.12.0",
-    urls = ["https://crates.io/api/v1/crates/derive_builder_macro/0.12.0/download"],
+    name = "derive_builder_macro-0.20.0.crate",
+    sha256 = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b",
+    strip_prefix = "derive_builder_macro-0.20.0",
+    urls = ["https://crates.io/api/v1/crates/derive_builder_macro/0.20.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_macro-0.12.0",
-    srcs = [":derive_builder_macro-0.12.0.crate"],
+    name = "derive_builder_macro-0.20.0",
+    srcs = [":derive_builder_macro-0.20.0.crate"],
     crate = "derive_builder_macro",
-    crate_root = "derive_builder_macro-0.12.0.crate/src/lib.rs",
-    edition = "2015",
+    crate_root = "derive_builder_macro-0.20.0.crate/src/lib.rs",
+    edition = "2018",
+    features = ["lib_has_std"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":derive_builder_core-0.12.0",
-        ":syn-1.0.109",
+        ":derive_builder_core-0.20.0",
+        ":syn-2.0.55",
     ],
 )
 
@@ -3989,8 +3864,8 @@ cargo.rust_library(
         ":asynchronous-codec-0.6.2",
         ":base64-0.13.1",
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
-        ":chrono-0.4.35",
+        ":bytes-1.6.0",
+        ":chrono-0.4.37",
         ":containers-api-0.9.0",
         ":docker-api-stubs-0.6.0",
         ":futures-util-0.3.30",
@@ -3999,7 +3874,7 @@ cargo.rust_library(
         ":log-0.4.21",
         ":paste-1.0.14",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":tar-0.4.40",
         ":thiserror-1.0.58",
         ":url-2.5.0",
@@ -4014,9 +3889,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_with-2.3.3",
     ],
 )
@@ -4212,18 +4087,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "educe-0.4.23.crate",
-    sha256 = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f",
-    strip_prefix = "educe-0.4.23",
-    urls = ["https://crates.io/api/v1/crates/educe/0.4.23/download"],
+    name = "educe-0.5.11.crate",
+    sha256 = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8",
+    strip_prefix = "educe-0.5.11",
+    urls = ["https://crates.io/api/v1/crates/educe/0.5.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "educe-0.4.23",
-    srcs = [":educe-0.4.23.crate"],
+    name = "educe-0.5.11",
+    srcs = [":educe-0.5.11.crate"],
     crate = "educe",
-    crate_root = "educe-0.4.23.crate/src/lib.rs",
+    crate_root = "educe-0.5.11.crate/src/lib.rs",
     edition = "2021",
     features = [
         "Debug",
@@ -4232,10 +4107,10 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":enum-ordinalize-3.1.15",
+        ":enum-ordinalize-4.3.0",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-1.0.109",
+        ":syn-2.0.55",
     ],
 )
 
@@ -4369,27 +4244,44 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "enum-ordinalize-3.1.15.crate",
-    sha256 = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee",
-    strip_prefix = "enum-ordinalize-3.1.15",
-    urls = ["https://crates.io/api/v1/crates/enum-ordinalize/3.1.15/download"],
+    name = "enum-ordinalize-4.3.0.crate",
+    sha256 = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5",
+    strip_prefix = "enum-ordinalize-4.3.0",
+    urls = ["https://crates.io/api/v1/crates/enum-ordinalize/4.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "enum-ordinalize-3.1.15",
-    srcs = [":enum-ordinalize-3.1.15.crate"],
+    name = "enum-ordinalize-4.3.0",
+    srcs = [":enum-ordinalize-4.3.0.crate"],
     crate = "enum_ordinalize",
-    crate_root = "enum-ordinalize-3.1.15.crate/src/lib.rs",
+    crate_root = "enum-ordinalize-4.3.0.crate/src/lib.rs",
+    edition = "2021",
+    features = ["derive"],
+    visibility = [],
+    deps = [":enum-ordinalize-derive-4.3.1"],
+)
+
+http_archive(
+    name = "enum-ordinalize-derive-4.3.1.crate",
+    sha256 = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff",
+    strip_prefix = "enum-ordinalize-derive-4.3.1",
+    urls = ["https://crates.io/api/v1/crates/enum-ordinalize-derive/4.3.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "enum-ordinalize-derive-4.3.1",
+    srcs = [":enum-ordinalize-derive-4.3.1.crate"],
+    crate = "enum_ordinalize_derive",
+    crate_root = "enum-ordinalize-derive-4.3.1.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":num-bigint-0.4.4",
-        ":num-traits-0.2.18",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -4559,18 +4451,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "fastrand-2.0.1.crate",
-    sha256 = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
-    strip_prefix = "fastrand-2.0.1",
-    urls = ["https://crates.io/api/v1/crates/fastrand/2.0.1/download"],
+    name = "fastrand-2.0.2.crate",
+    sha256 = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984",
+    strip_prefix = "fastrand-2.0.2",
+    urls = ["https://crates.io/api/v1/crates/fastrand/2.0.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "fastrand-2.0.1",
-    srcs = [":fastrand-2.0.1.crate"],
+    name = "fastrand-2.0.2",
+    srcs = [":fastrand-2.0.2.crate"],
     crate = "fastrand",
-    crate_root = "fastrand-2.0.1.crate/src/lib.rs",
+    crate_root = "fastrand-2.0.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -5011,7 +4903,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":fastrand-2.0.1",
+        ":fastrand-2.0.2",
         ":futures-core-0.3.30",
         ":futures-io-0.3.30",
         ":parking-2.2.0",
@@ -5038,7 +4930,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -5145,7 +5037,7 @@ cargo.rust_library(
         ":futures-macro-0.3.30",
         ":futures-sink-0.3.30",
         ":futures-task-0.3.30",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":pin-project-lite-0.2.13",
         ":pin-utils-0.1.0",
         ":slab-0.4.9",
@@ -5171,9 +5063,27 @@ cargo.rust_library(
     deps = [
         ":bytes-0.5.6",
         ":futures-0.3.30",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":pin-project-0.4.30",
     ],
+)
+
+http_archive(
+    name = "fuzzy-matcher-0.3.7.crate",
+    sha256 = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94",
+    strip_prefix = "fuzzy-matcher-0.3.7",
+    urls = ["https://crates.io/api/v1/crates/fuzzy-matcher/0.3.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "fuzzy-matcher-0.3.7",
+    srcs = [":fuzzy-matcher-0.3.7.crate"],
+    crate = "fuzzy_matcher",
+    crate_root = "fuzzy-matcher-0.3.7.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":thread_local-1.1.8"],
 )
 
 http_archive(
@@ -5354,11 +5264,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":aho-corasick-1.1.2",
+        ":aho-corasick-1.1.3",
         ":bstr-1.9.1",
         ":log-0.4.21",
         ":regex-automata-0.4.6",
-        ":regex-syntax-0.8.2",
+        ":regex-syntax-0.8.3",
     ],
 )
 
@@ -5401,35 +5311,18 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":fnv-1.0.7",
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":http-0.2.12",
-        ":indexmap-2.2.5",
+        ":indexmap-2.2.6",
         ":slab-0.4.9",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":tracing-0.1.40",
     ],
-)
-
-http_archive(
-    name = "half-1.8.3.crate",
-    sha256 = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403",
-    strip_prefix = "half-1.8.3",
-    urls = ["https://crates.io/api/v1/crates/half/1.8.3/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "half-1.8.3",
-    srcs = [":half-1.8.3.crate"],
-    crate = "half",
-    crate_root = "half-1.8.3.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
 )
 
 http_archive(
@@ -5860,9 +5753,35 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":fnv-1.0.7",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
+    ],
+)
+
+http_archive(
+    name = "http-1.1.0.crate",
+    sha256 = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258",
+    strip_prefix = "http-1.1.0",
+    urls = ["https://crates.io/api/v1/crates/http/1.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "http-1.1.0",
+    srcs = [":http-1.1.0.crate"],
+    crate = "http",
+    crate_root = "http-1.1.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.6.0",
+        ":fnv-1.0.7",
+        ":itoa-1.0.11",
     ],
 )
 
@@ -5882,8 +5801,53 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":http-0.2.12",
+        ":pin-project-lite-0.2.13",
+    ],
+)
+
+http_archive(
+    name = "http-body-1.0.0.crate",
+    sha256 = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643",
+    strip_prefix = "http-body-1.0.0",
+    urls = ["https://crates.io/api/v1/crates/http-body/1.0.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "http-body-1.0.0",
+    srcs = [":http-body-1.0.0.crate"],
+    crate = "http_body",
+    crate_root = "http-body-1.0.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":bytes-1.6.0",
+        ":http-1.1.0",
+    ],
+)
+
+http_archive(
+    name = "http-body-util-0.1.1.crate",
+    sha256 = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d",
+    strip_prefix = "http-body-util-0.1.1",
+    urls = ["https://crates.io/api/v1/crates/http-body-util/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "http-body-util-0.1.1",
+    srcs = [":http-body-util-0.1.1.crate"],
+    crate = "http_body_util",
+    crate_root = "http-body-util-0.1.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":bytes-1.6.0",
+        ":futures-core-0.3.30",
+        ":http-1.1.0",
+        ":http-body-1.0.0",
         ":pin-project-lite-0.2.13",
     ],
 )
@@ -5978,7 +5942,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-channel-0.3.30",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
@@ -5987,13 +5951,74 @@ cargo.rust_library(
         ":http-body-0.4.6",
         ":httparse-1.8.0",
         ":httpdate-1.0.3",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":pin-project-lite-0.2.13",
         ":socket2-0.5.6",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tower-service-0.3.2",
         ":tracing-0.1.40",
         ":want-0.3.1",
+    ],
+)
+
+http_archive(
+    name = "hyper-1.2.0.crate",
+    sha256 = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a",
+    strip_prefix = "hyper-1.2.0",
+    urls = ["https://crates.io/api/v1/crates/hyper/1.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-1.2.0",
+    srcs = [":hyper-1.2.0.crate"],
+    crate = "hyper",
+    crate_root = "hyper-1.2.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "default",
+        "http1",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.6.0",
+        ":futures-channel-0.3.30",
+        ":futures-util-0.3.30",
+        ":http-1.1.0",
+        ":http-body-1.0.0",
+        ":httparse-1.8.0",
+        ":itoa-1.0.11",
+        ":pin-project-lite-0.2.13",
+        ":smallvec-1.13.2",
+        ":tokio-1.37.0",
+        ":want-0.3.1",
+    ],
+)
+
+http_archive(
+    name = "hyper-named-pipe-0.1.0.crate",
+    sha256 = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278",
+    strip_prefix = "hyper-named-pipe-0.1.0",
+    urls = ["https://crates.io/api/v1/crates/hyper-named-pipe/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-named-pipe-0.1.0",
+    srcs = [":hyper-named-pipe-0.1.0.crate"],
+    crate = "hyper_named_pipe",
+    crate_root = "hyper-named-pipe-0.1.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":hex-0.4.3",
+        ":hyper-1.2.0",
+        ":hyper-util-0.1.3",
+        ":pin-project-lite-0.2.13",
+        ":tokio-1.37.0",
+        ":tower-service-0.3.2",
+        ":winapi-0.3.9",
     ],
 )
 
@@ -6017,8 +6042,38 @@ cargo.rust_library(
         ":http-0.2.12",
         ":hyper-0.14.28",
         ":rustls-0.21.10",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-rustls-0.24.1",
+    ],
+)
+
+http_archive(
+    name = "hyper-rustls-0.26.0.crate",
+    sha256 = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c",
+    strip_prefix = "hyper-rustls-0.26.0",
+    urls = ["https://crates.io/api/v1/crates/hyper-rustls/0.26.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-rustls-0.26.0",
+    srcs = [":hyper-rustls-0.26.0.crate"],
+    crate = "hyper_rustls",
+    crate_root = "hyper-rustls-0.26.0.crate/src/lib.rs",
+    edition = "2021",
+    named_deps = {
+        "pki_types": ":rustls-pki-types-1.4.1",
+    },
+    visibility = [],
+    deps = [
+        ":futures-util-0.3.30",
+        ":http-1.1.0",
+        ":hyper-1.2.0",
+        ":hyper-util-0.1.3",
+        ":rustls-0.22.3",
+        ":tokio-1.37.0",
+        ":tokio-rustls-0.25.0",
+        ":tower-service-0.3.2",
     ],
 )
 
@@ -6040,8 +6095,46 @@ cargo.rust_library(
     deps = [
         ":hyper-0.14.28",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-io-timeout-1.2.0",
+    ],
+)
+
+http_archive(
+    name = "hyper-util-0.1.3.crate",
+    sha256 = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa",
+    strip_prefix = "hyper-util-0.1.3",
+    urls = ["https://crates.io/api/v1/crates/hyper-util/0.1.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-util-0.1.3",
+    srcs = [":hyper-util-0.1.3.crate"],
+    crate = "hyper_util",
+    crate_root = "hyper-util-0.1.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "client-legacy",
+        "default",
+        "http1",
+        "tokio",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.6.0",
+        ":futures-channel-0.3.30",
+        ":futures-util-0.3.30",
+        ":http-1.1.0",
+        ":http-body-1.0.0",
+        ":hyper-1.2.0",
+        ":pin-project-lite-0.2.13",
+        ":socket2-0.5.6",
+        ":tokio-1.37.0",
+        ":tower-0.4.13",
+        ":tower-service-0.3.2",
+        ":tracing-0.1.40",
     ],
 )
 
@@ -6068,7 +6161,40 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-0.14.28",
         ":pin-project-1.1.5",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
+    ],
+)
+
+http_archive(
+    name = "hyperlocal-next-0.9.0.crate",
+    sha256 = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc",
+    strip_prefix = "hyperlocal-next-0.9.0",
+    urls = ["https://crates.io/api/v1/crates/hyperlocal-next/0.9.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyperlocal-next-0.9.0",
+    srcs = [":hyperlocal-next-0.9.0.crate"],
+    crate = "hyperlocal_next",
+    crate_root = "hyperlocal-next-0.9.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "default",
+        "http-body-util",
+        "hyper-util",
+        "tower-service",
+    ],
+    visibility = [],
+    deps = [
+        ":hex-0.4.3",
+        ":http-body-util-0.1.1",
+        ":hyper-1.2.0",
+        ":hyper-util-0.1.3",
+        ":pin-project-lite-0.2.13",
+        ":tokio-1.37.0",
+        ":tower-service-0.3.2",
     ],
 )
 
@@ -6174,7 +6300,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":serde-1.0.197",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
         ":toml-0.8.12",
         ":unicode-xid-0.2.4",
     ],
@@ -6207,7 +6333,7 @@ cargo.rust_library(
         ":crossbeam-deque-0.8.5",
         ":globset-0.4.14",
         ":log-0.4.21",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":regex-automata-0.4.6",
         ":same-file-1.0.6",
         ":walkdir-2.5.0",
@@ -6261,23 +6387,23 @@ cargo.rust_library(
 
 alias(
     name = "indexmap",
-    actual = ":indexmap-2.2.5",
+    actual = ":indexmap-2.2.6",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "indexmap-2.2.5.crate",
-    sha256 = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4",
-    strip_prefix = "indexmap-2.2.5",
-    urls = ["https://crates.io/api/v1/crates/indexmap/2.2.5/download"],
+    name = "indexmap-2.2.6.crate",
+    sha256 = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26",
+    strip_prefix = "indexmap-2.2.6",
+    urls = ["https://crates.io/api/v1/crates/indexmap/2.2.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "indexmap-2.2.5",
-    srcs = [":indexmap-2.2.5.crate"],
+    name = "indexmap-2.2.6",
+    srcs = [":indexmap-2.2.6.crate"],
     crate = "indexmap",
-    crate_root = "indexmap-2.2.5.crate/src/lib.rs",
+    crate_root = "indexmap-2.2.6.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -6328,23 +6454,23 @@ cargo.rust_library(
 
 alias(
     name = "indoc",
-    actual = ":indoc-2.0.4",
+    actual = ":indoc-2.0.5",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "indoc-2.0.4.crate",
-    sha256 = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
-    strip_prefix = "indoc-2.0.4",
-    urls = ["https://crates.io/api/v1/crates/indoc/2.0.4/download"],
+    name = "indoc-2.0.5.crate",
+    sha256 = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5",
+    strip_prefix = "indoc-2.0.5",
+    urls = ["https://crates.io/api/v1/crates/indoc/2.0.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "indoc-2.0.4",
-    srcs = [":indoc-2.0.4.crate"],
+    name = "indoc-2.0.5",
+    srcs = [":indoc-2.0.5.crate"],
     crate = "indoc",
-    crate_root = "indoc-2.0.4.crate/src/lib.rs",
+    crate_root = "indoc-2.0.5.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
@@ -6369,43 +6495,47 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "inquire",
-    actual = ":inquire-0.6.2",
+    actual = ":inquire-0.7.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "inquire-0.6.2.crate",
-    sha256 = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b",
-    strip_prefix = "inquire-0.6.2",
-    urls = ["https://crates.io/api/v1/crates/inquire/0.6.2/download"],
+    name = "inquire-0.7.4.crate",
+    sha256 = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b",
+    strip_prefix = "inquire-0.7.4",
+    urls = ["https://crates.io/api/v1/crates/inquire/0.7.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "inquire-0.6.2",
-    srcs = [":inquire-0.6.2.crate"],
+    name = "inquire-0.7.4",
+    srcs = [":inquire-0.7.4.crate"],
     crate = "inquire",
-    crate_root = "inquire-0.6.2.crate/src/lib.rs",
+    crate_root = "inquire-0.7.4.crate/src/lib.rs",
     edition = "2018",
     features = [
         "crossterm",
         "default",
+        "fuzzy",
+        "fuzzy-matcher",
         "macros",
+        "one-liners",
     ],
     visibility = [],
     deps = [
-        ":bitflags-1.3.2",
+        ":bitflags-2.5.0",
         ":crossterm-0.25.0",
         ":dyn-clone-1.0.17",
-        ":lazy_static-1.4.0",
-        ":newline-converter-0.2.2",
-        ":thiserror-1.0.58",
+        ":fuzzy-matcher-0.3.7",
+        ":fxhash-0.2.1",
+        ":newline-converter-0.3.0",
+        ":once_cell-1.19.0",
         ":unicode-segmentation-1.11.0",
         ":unicode-width-0.1.11",
     ],
@@ -6466,6 +6596,43 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [":once_cell-1.19.0"],
+)
+
+http_archive(
+    name = "is-terminal-0.4.12.crate",
+    sha256 = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b",
+    strip_prefix = "is-terminal-0.4.12",
+    urls = ["https://crates.io/api/v1/crates/is-terminal/0.4.12/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "is-terminal-0.4.12",
+    srcs = [":is-terminal-0.4.12.crate"],
+    crate = "is_terminal",
+    crate_root = "is-terminal-0.4.12.crate/src/lib.rs",
+    edition = "2018",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "windows-gnu": dict(
+            deps = [":windows-sys-0.52.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":windows-sys-0.52.0"],
+        ),
+    },
+    visibility = [],
 )
 
 http_archive(
@@ -6561,18 +6728,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "itoa-1.0.10.crate",
-    sha256 = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c",
-    strip_prefix = "itoa-1.0.10",
-    urls = ["https://crates.io/api/v1/crates/itoa/1.0.10/download"],
+    name = "itoa-1.0.11.crate",
+    sha256 = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+    strip_prefix = "itoa-1.0.11",
+    urls = ["https://crates.io/api/v1/crates/itoa/1.0.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "itoa-1.0.10",
-    srcs = [":itoa-1.0.10.crate"],
+    name = "itoa-1.0.11",
+    srcs = [":itoa-1.0.11.crate"],
     crate = "itoa",
-    crate_root = "itoa-1.0.10.crate/src/lib.rs",
+    crate_root = "itoa-1.0.11.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -6637,7 +6804,7 @@ cargo.rust_library(
         ":p384-0.13.0",
         ":rand-0.8.5",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":thiserror-1.0.58",
         ":zeroize-1.7.0",
     ],
@@ -7411,7 +7578,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -7462,18 +7629,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "memchr-2.7.1.crate",
-    sha256 = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149",
-    strip_prefix = "memchr-2.7.1",
-    urls = ["https://crates.io/api/v1/crates/memchr/2.7.1/download"],
+    name = "memchr-2.7.2.crate",
+    sha256 = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d",
+    strip_prefix = "memchr-2.7.2",
+    urls = ["https://crates.io/api/v1/crates/memchr/2.7.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "memchr-2.7.1",
-    srcs = [":memchr-2.7.1.crate"],
+    name = "memchr-2.7.2",
+    srcs = [":memchr-2.7.2.crate"],
     crate = "memchr",
-    crate_root = "memchr-2.7.1.crate/src/lib.rs",
+    crate_root = "memchr-2.7.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -7706,7 +7873,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-lock-2.8.0",
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":crossbeam-channel-0.5.12",
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.19",
@@ -7714,7 +7881,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":parking_lot-0.12.1",
         ":quanta-0.12.2",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":tagptr-0.2.0",
         ":thiserror-1.0.58",
         ":triomphe-0.1.11",
@@ -7739,13 +7906,13 @@ cargo.rust_library(
     features = ["default"],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":encoding_rs-0.8.33",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":httparse-1.8.0",
         ":log-0.4.21",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":mime-0.3.17",
         ":spin-0.9.8",
         ":version_check-0.9.4",
@@ -7817,18 +7984,18 @@ buildscript_run(
 )
 
 http_archive(
-    name = "newline-converter-0.2.2.crate",
-    sha256 = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f",
-    strip_prefix = "newline-converter-0.2.2",
-    urls = ["https://crates.io/api/v1/crates/newline-converter/0.2.2/download"],
+    name = "newline-converter-0.3.0.crate",
+    sha256 = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f",
+    strip_prefix = "newline-converter-0.3.0",
+    urls = ["https://crates.io/api/v1/crates/newline-converter/0.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "newline-converter-0.2.2",
-    srcs = [":newline-converter-0.2.2.crate"],
+    name = "newline-converter-0.3.0",
+    srcs = [":newline-converter-0.3.0.crate"],
     crate = "newline_converter",
-    crate_root = "newline-converter-0.2.2.crate/src/lib.rs",
+    crate_root = "newline-converter-0.3.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":unicode-segmentation-1.11.0"],
@@ -7945,32 +8112,6 @@ cargo.rust_library(
     ],
 )
 
-http_archive(
-    name = "nkeys-0.3.2.crate",
-    sha256 = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47",
-    strip_prefix = "nkeys-0.3.2",
-    urls = ["https://crates.io/api/v1/crates/nkeys/0.3.2/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "nkeys-0.3.2",
-    srcs = [":nkeys-0.3.2.crate"],
-    crate = "nkeys",
-    crate_root = "nkeys-0.3.2.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
-    deps = [
-        ":byteorder-1.5.0",
-        ":data-encoding-2.5.0",
-        ":ed25519-2.2.3",
-        ":ed25519-dalek-2.1.1",
-        ":log-0.4.21",
-        ":rand-0.8.5",
-        ":signatory-0.27.1",
-    ],
-)
-
 alias(
     name = "nkeys",
     actual = ":nkeys-0.4.0",
@@ -8024,7 +8165,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":minimal-lexical-0.2.1",
     ],
 )
@@ -8113,7 +8254,7 @@ cargo.rust_binary(
         "std",
     ],
     visibility = [],
-    deps = [":autocfg-1.1.0"],
+    deps = [":autocfg-1.2.0"],
 )
 
 buildscript_run(
@@ -8158,7 +8299,7 @@ cargo.rust_library(
         ":num-iter-0.1.44",
         ":num-traits-0.2.18",
         ":rand-0.8.5",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":zeroize-1.7.0",
     ],
 )
@@ -8292,7 +8433,7 @@ cargo.rust_binary(
         "std",
     ],
     visibility = [],
-    deps = [":autocfg-1.1.0"],
+    deps = [":autocfg-1.2.0"],
 )
 
 buildscript_run(
@@ -8388,9 +8529,10 @@ cargo.rust_library(
         "pe",
         "read_core",
         "unaligned",
+        "xcoff",
     ],
     visibility = [],
-    deps = [":memchr-2.7.1"],
+    deps = [":memchr-2.7.2"],
 )
 
 alias(
@@ -8586,7 +8728,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":futures-core-0.3.30",
         ":http-0.2.12",
         ":opentelemetry-0.22.0",
@@ -8595,7 +8737,7 @@ cargo.rust_library(
         ":opentelemetry_sdk-0.22.1",
         ":prost-0.12.3",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tonic-0.11.0",
     ],
 )
@@ -8699,7 +8841,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":crossbeam-channel-0.5.12",
         ":futures-channel-0.3.30",
         ":futures-executor-0.3.30",
@@ -8711,7 +8853,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
     ],
 )
@@ -8895,7 +9037,7 @@ cargo.rust_library(
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -8922,7 +9064,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.79",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -9137,7 +9279,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":instant-0.1.12",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
     ],
 )
 
@@ -9178,7 +9320,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
     ],
 )
 
@@ -9327,7 +9469,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":fixedbitset-0.4.2",
-        ":indexmap-2.2.5",
+        ":indexmap-2.2.6",
         ":serde-1.0.197",
         ":serde_derive-1.0.197",
     ],
@@ -9452,7 +9594,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -9569,18 +9711,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "platforms-3.3.0.crate",
-    sha256 = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c",
-    strip_prefix = "platforms-3.3.0",
-    urls = ["https://crates.io/api/v1/crates/platforms/3.3.0/download"],
+    name = "platforms-3.4.0.crate",
+    sha256 = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7",
+    strip_prefix = "platforms-3.4.0",
+    urls = ["https://crates.io/api/v1/crates/platforms/3.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "platforms-3.3.0",
-    srcs = [":platforms-3.3.0.crate"],
+    name = "platforms-3.4.0",
+    srcs = [":platforms-3.4.0.crate"],
     crate = "platforms",
-    crate_root = "platforms-3.3.0.crate/src/lib.rs",
+    crate_root = "platforms-3.4.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -9680,8 +9822,8 @@ cargo.rust_library(
     deps = [
         ":base64-0.13.1",
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
-        ":chrono-0.4.35",
+        ":bytes-1.6.0",
+        ":chrono-0.4.37",
         ":containers-api-0.8.0",
         ":flate2-1.0.28",
         ":futures-util-0.3.30",
@@ -9690,10 +9832,10 @@ cargo.rust_library(
         ":paste-1.0.14",
         ":podman-api-stubs-0.9.0",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":tar-0.4.40",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":url-2.5.0",
     ],
 )
@@ -9714,9 +9856,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
     ],
 )
 
@@ -9845,7 +9987,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -9868,11 +10010,11 @@ cargo.rust_library(
     deps = [
         ":base64-0.21.7",
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":fallible-iterator-0.2.0",
         ":hmac-0.12.1",
         ":md-5-0.10.6",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":rand-0.8.5",
         ":sha2-0.10.8",
         ":stringprep-0.1.4",
@@ -9909,13 +10051,13 @@ cargo.rust_library(
         "with-serde_json-1",
     ],
     named_deps = {
-        "chrono_04": ":chrono-0.4.35",
+        "chrono_04": ":chrono-0.4.37",
         "serde_1": ":serde-1.0.197",
-        "serde_json_1": ":serde_json-1.0.114",
+        "serde_json_1": ":serde_json-1.0.115",
     },
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":fallible-iterator-0.2.0",
         ":postgres-derive-0.4.5",
         ":postgres-protocol-0.6.6",
@@ -10184,7 +10326,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
         ":yansi-1.0.1",
     ],
 )
@@ -10210,7 +10352,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":prost-derive-0.12.3",
     ],
 )
@@ -10236,7 +10378,7 @@ cargo.rust_library(
         ":itertools-0.11.0",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -10318,7 +10460,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":serde-1.0.197",
     ],
 )
@@ -10573,18 +10715,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rayon-1.9.0.crate",
-    sha256 = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd",
-    strip_prefix = "rayon-1.9.0",
-    urls = ["https://crates.io/api/v1/crates/rayon/1.9.0/download"],
+    name = "rayon-1.10.0.crate",
+    sha256 = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa",
+    strip_prefix = "rayon-1.10.0",
+    urls = ["https://crates.io/api/v1/crates/rayon/1.10.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rayon-1.9.0",
-    srcs = [":rayon-1.9.0.crate"],
+    name = "rayon-1.10.0",
+    srcs = [":rayon-1.10.0.crate"],
     crate = "rayon",
-    crate_root = "rayon-1.9.0.crate/src/lib.rs",
+    crate_root = "rayon-1.10.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -10666,15 +10808,15 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":cfg-if-1.0.0",
         ":log-0.4.21",
-        ":regex-1.10.3",
+        ":regex-1.10.4",
         ":serde-1.0.197",
         ":siphasher-1.0.1",
         ":thiserror-1.0.58",
         ":time-0.3.34",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":toml-0.8.12",
         ":url-2.5.0",
@@ -10702,30 +10844,30 @@ cargo.rust_library(
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":refinery-core-0.8.12",
-        ":regex-1.10.3",
-        ":syn-2.0.53",
+        ":regex-1.10.4",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "regex",
-    actual = ":regex-1.10.3",
+    actual = ":regex-1.10.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "regex-1.10.3.crate",
-    sha256 = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15",
-    strip_prefix = "regex-1.10.3",
-    urls = ["https://crates.io/api/v1/crates/regex/1.10.3/download"],
+    name = "regex-1.10.4.crate",
+    sha256 = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c",
+    strip_prefix = "regex-1.10.4",
+    urls = ["https://crates.io/api/v1/crates/regex/1.10.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-1.10.3",
-    srcs = [":regex-1.10.3.crate"],
+    name = "regex-1.10.4",
+    srcs = [":regex-1.10.4.crate"],
     crate = "regex",
-    crate_root = "regex-1.10.3.crate/src/lib.rs",
+    crate_root = "regex-1.10.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -10748,10 +10890,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":aho-corasick-1.1.2",
-        ":memchr-2.7.1",
+        ":aho-corasick-1.1.3",
+        ":memchr-2.7.2",
         ":regex-automata-0.4.6",
-        ":regex-syntax-0.8.2",
+        ":regex-syntax-0.8.3",
     ],
 )
 
@@ -10820,9 +10962,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":aho-corasick-1.1.2",
-        ":memchr-2.7.1",
-        ":regex-syntax-0.8.2",
+        ":aho-corasick-1.1.3",
+        ":memchr-2.7.2",
+        ":regex-syntax-0.8.3",
     ],
 )
 
@@ -10855,18 +10997,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "regex-syntax-0.8.2.crate",
-    sha256 = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
-    strip_prefix = "regex-syntax-0.8.2",
-    urls = ["https://crates.io/api/v1/crates/regex-syntax/0.8.2/download"],
+    name = "regex-syntax-0.8.3.crate",
+    sha256 = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56",
+    strip_prefix = "regex-syntax-0.8.3",
+    urls = ["https://crates.io/api/v1/crates/regex-syntax/0.8.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-syntax-0.8.2",
-    srcs = [":regex-syntax-0.8.2.crate"],
+    name = "regex-syntax-0.8.3",
+    srcs = [":regex-syntax-0.8.3.crate"],
     crate = "regex_syntax",
-    crate_root = "regex-syntax-0.8.2.crate/src/lib.rs",
+    crate_root = "regex-syntax-0.8.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -10908,166 +11050,165 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.11.27",
+    actual = ":reqwest-0.12.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.11.27.crate",
-    sha256 = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62",
-    strip_prefix = "reqwest-0.11.27",
-    urls = ["https://crates.io/api/v1/crates/reqwest/0.11.27/download"],
+    name = "reqwest-0.12.2.crate",
+    sha256 = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338",
+    strip_prefix = "reqwest-0.12.2",
+    urls = ["https://crates.io/api/v1/crates/reqwest/0.12.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.11.27",
-    srcs = [":reqwest-0.11.27.crate"],
+    name = "reqwest-0.12.2",
+    srcs = [":reqwest-0.12.2.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.11.27.crate/src/lib.rs",
+    crate_root = "reqwest-0.12.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "__rustls",
         "__tls",
-        "hyper-rustls",
         "json",
-        "mime_guess",
         "multipart",
-        "rustls",
+        "rustls-pki-types",
         "rustls-tls",
         "rustls-tls-webpki-roots",
-        "serde_json",
-        "tokio-rustls",
-        "webpki-roots",
     ],
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":system-configuration-0.5.1",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":system-configuration-0.5.1",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
             ],
         ),
         "windows-gnu": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
                 ":winreg-0.50.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":encoding_rs-0.8.33",
-                ":h2-0.3.25",
-                ":http-body-0.4.6",
-                ":hyper-0.14.28",
-                ":hyper-rustls-0.24.2",
+                ":http-body-1.0.0",
+                ":http-body-util-0.1.1",
+                ":hyper-1.2.0",
+                ":hyper-rustls-0.26.0",
+                ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
                 ":log-0.4.21",
                 ":mime-0.3.17",
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.13",
-                ":rustls-0.21.10",
+                ":rustls-0.22.3",
                 ":rustls-pemfile-1.0.4",
-                ":tokio-1.36.0",
-                ":tokio-rustls-0.24.1",
-                ":webpki-roots-0.25.4",
+                ":rustls-pki-types-1.4.1",
+                ":tokio-1.37.0",
+                ":tokio-rustls-0.25.0",
+                ":webpki-roots-0.26.1",
                 ":winreg-0.50.0",
             ],
         ),
@@ -11075,13 +11216,13 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.21.7",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
-        ":http-0.2.12",
+        ":http-1.1.0",
         ":mime_guess-2.0.4",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-0.1.2",
         ":tower-service-0.3.2",
@@ -11930,11 +12071,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":cfg-if-1.0.0",
         ":futures-0.3.30",
         ":hex-0.4.3",
@@ -11951,11 +12092,11 @@ cargo.rust_library(
         ":rustls-native-certs-0.6.3",
         ":serde-1.0.197",
         ":serde_derive-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sha2-0.10.8",
         ":thiserror-1.0.58",
         ":time-0.3.34",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.15",
         ":url-2.5.0",
@@ -11963,21 +12104,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rust_decimal-1.34.3.crate",
-    sha256 = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df",
-    strip_prefix = "rust_decimal-1.34.3",
-    urls = ["https://crates.io/api/v1/crates/rust_decimal/1.34.3/download"],
+    name = "rust_decimal-1.35.0.crate",
+    sha256 = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a",
+    strip_prefix = "rust_decimal-1.35.0",
+    urls = ["https://crates.io/api/v1/crates/rust_decimal/1.35.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rust_decimal-1.34.3",
-    srcs = [":rust_decimal-1.34.3.crate"],
+    name = "rust_decimal-1.35.0",
+    srcs = [":rust_decimal-1.35.0.crate"],
     crate = "rust_decimal",
-    crate_root = "rust_decimal-1.34.3.crate/src/lib.rs",
+    crate_root = "rust_decimal-1.35.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "OUT_DIR": "$(location :rust_decimal-1.34.3-build-script-run[out_dir])",
+        "OUT_DIR": "$(location :rust_decimal-1.35.0-build-script-run[out_dir])",
     },
     features = [
         "default",
@@ -11994,10 +12135,10 @@ cargo.rust_library(
 )
 
 cargo.rust_binary(
-    name = "rust_decimal-1.34.3-build-script-build",
-    srcs = [":rust_decimal-1.34.3.crate"],
+    name = "rust_decimal-1.35.0-build-script-build",
+    srcs = [":rust_decimal-1.35.0.crate"],
     crate = "build_script_build",
-    crate_root = "rust_decimal-1.34.3.crate/build.rs",
+    crate_root = "rust_decimal-1.35.0.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -12009,16 +12150,16 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rust_decimal-1.34.3-build-script-run",
+    name = "rust_decimal-1.35.0-build-script-run",
     package_name = "rust_decimal",
-    buildscript_rule = ":rust_decimal-1.34.3-build-script-build",
+    buildscript_rule = ":rust_decimal-1.35.0-build-script-build",
     features = [
         "default",
         "maths",
         "serde",
         "std",
     ],
-    version = "1.34.3",
+    version = "1.35.0",
 )
 
 http_archive(
@@ -12191,23 +12332,23 @@ cargo.rust_library(
 
 alias(
     name = "rustls",
-    actual = ":rustls-0.22.2",
+    actual = ":rustls-0.22.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-0.22.2.crate",
-    sha256 = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41",
-    strip_prefix = "rustls-0.22.2",
-    urls = ["https://crates.io/api/v1/crates/rustls/0.22.2/download"],
+    name = "rustls-0.22.3.crate",
+    sha256 = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c",
+    strip_prefix = "rustls-0.22.3",
+    urls = ["https://crates.io/api/v1/crates/rustls/0.22.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.22.2",
-    srcs = [":rustls-0.22.2.crate"],
+    name = "rustls-0.22.3",
+    srcs = [":rustls-0.22.3.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.22.2.crate/src/lib.rs",
+    crate_root = "rustls-0.22.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -12217,7 +12358,7 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.3.1",
+        "pki_types": ":rustls-pki-types-1.4.1",
     },
     visibility = [],
     deps = [
@@ -12268,6 +12409,47 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "rustls-native-certs-0.7.0.crate",
+    sha256 = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792",
+    strip_prefix = "rustls-native-certs-0.7.0",
+    urls = ["https://crates.io/api/v1/crates/rustls-native-certs/0.7.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustls-native-certs-0.7.0",
+    srcs = [":rustls-native-certs-0.7.0.crate"],
+    crate = "rustls_native_certs",
+    crate_root = "rustls-native-certs-0.7.0.crate/src/lib.rs",
+    edition = "2021",
+    named_deps = {
+        "pki_types": ":rustls-pki-types-1.4.1",
+    },
+    platform = {
+        "linux-arm64": dict(
+            deps = [":openssl-probe-0.1.5"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":openssl-probe-0.1.5"],
+        ),
+        "macos-arm64": dict(
+            deps = [":security-framework-2.9.2"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":security-framework-2.9.2"],
+        ),
+        "windows-gnu": dict(
+            deps = [":schannel-0.1.23"],
+        ),
+        "windows-msvc": dict(
+            deps = [":schannel-0.1.23"],
+        ),
+    },
+    visibility = [],
+    deps = [":rustls-pemfile-2.1.1"],
+)
+
+http_archive(
     name = "rustls-pemfile-1.0.4.crate",
     sha256 = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c",
     strip_prefix = "rustls-pemfile-1.0.4",
@@ -12310,25 +12492,25 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.3.1",
+        "pki_types": ":rustls-pki-types-1.4.1",
     },
     visibility = [],
     deps = [":base64-0.21.7"],
 )
 
 http_archive(
-    name = "rustls-pki-types-1.3.1.crate",
-    sha256 = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8",
-    strip_prefix = "rustls-pki-types-1.3.1",
-    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.3.1/download"],
+    name = "rustls-pki-types-1.4.1.crate",
+    sha256 = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247",
+    strip_prefix = "rustls-pki-types-1.4.1",
+    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.4.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pki-types-1.3.1",
-    srcs = [":rustls-pki-types-1.3.1.crate"],
+    name = "rustls-pki-types-1.4.1",
+    srcs = [":rustls-pki-types-1.4.1.crate"],
     crate = "rustls_pki_types",
-    crate_root = "rustls-pki-types-1.3.1.crate/src/lib.rs",
+    crate_root = "rustls-pki-types-1.4.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12380,11 +12562,12 @@ cargo.rust_library(
     edition = "2021",
     features = [
         "alloc",
+        "default",
         "ring",
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.3.1",
+        "pki_types": ":rustls-pki-types-1.4.1",
     },
     visibility = [],
     deps = [
@@ -12549,7 +12732,7 @@ cargo.rust_library(
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -12600,18 +12783,18 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":futures-0.3.30",
         ":log-0.4.21",
         ":ouroboros-0.17.2",
-        ":rust_decimal-1.34.3",
+        ":rust_decimal-1.35.0",
         ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
         ":thiserror-1.0.58",
@@ -12651,7 +12834,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -12695,12 +12878,12 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":derivative-2.2.0",
         ":inherent-1.0.11",
         ":ordered-float-3.9.2",
-        ":rust_decimal-1.34.3",
-        ":serde_json-1.0.114",
+        ":rust_decimal-1.35.0",
+        ":serde_json-1.0.115",
         ":time-0.3.34",
         ":uuid-1.8.0",
     ],
@@ -12741,10 +12924,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.35",
-        ":rust_decimal-1.34.3",
+        ":chrono-0.4.37",
+        ":rust_decimal-1.35.0",
         ":sea-query-0.30.7",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sqlx-0.7.4",
         ":time-0.3.34",
         ":uuid-1.8.0",
@@ -13005,34 +13188,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
-    ],
-)
-
-http_archive(
-    name = "serde_cbor-0.11.2.crate",
-    sha256 = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5",
-    strip_prefix = "serde_cbor-0.11.2",
-    urls = ["https://crates.io/api/v1/crates/serde_cbor/0.11.2/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "serde_cbor-0.11.2",
-    srcs = [":serde_cbor-0.11.2.crate"],
-    crate = "serde_cbor",
-    crate_root = "serde_cbor-0.11.2.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "default",
-        "std",
-    ],
-    visibility = [],
-    deps = [
-        ":half-1.8.3",
-        ":serde-1.0.197",
+        ":serde_json-1.0.115",
     ],
 )
 
@@ -13056,29 +13214,29 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "serde_json",
-    actual = ":serde_json-1.0.114",
+    actual = ":serde_json-1.0.115",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_json-1.0.114.crate",
-    sha256 = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0",
-    strip_prefix = "serde_json-1.0.114",
-    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.114/download"],
+    name = "serde_json-1.0.115.crate",
+    sha256 = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd",
+    strip_prefix = "serde_json-1.0.115",
+    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.115/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_json-1.0.114",
-    srcs = [":serde_json-1.0.114.crate"],
+    name = "serde_json-1.0.115",
+    srcs = [":serde_json-1.0.115.crate"],
     crate = "serde_json",
-    crate_root = "serde_json-1.0.114.crate/src/lib.rs",
+    crate_root = "serde_json-1.0.115.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13091,8 +13249,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.2.5",
-        ":itoa-1.0.10",
+        ":indexmap-2.2.6",
+        ":itoa-1.0.11",
         ":ryu-1.0.17",
         ":serde-1.0.197",
     ],
@@ -13132,7 +13290,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":serde-1.0.197",
     ],
 )
@@ -13156,7 +13314,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -13223,7 +13381,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":form_urlencoded-1.2.1",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":ryu-1.0.17",
         ":serde-1.0.197",
     ],
@@ -13250,7 +13408,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "chrono_0_4": ":chrono-0.4.35",
+        "chrono_0_4": ":chrono-0.4.37",
         "indexmap_1": ":indexmap-1.9.3",
         "time_0_3": ":time-0.3.34",
     },
@@ -13259,7 +13417,7 @@ cargo.rust_library(
         ":base64-0.13.1",
         ":hex-0.4.3",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_with_macros-2.3.3",
     ],
 )
@@ -13291,9 +13449,9 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "chrono_0_4": ":chrono-0.4.35",
+        "chrono_0_4": ":chrono-0.4.37",
         "indexmap_1": ":indexmap-1.9.3",
-        "indexmap_2": ":indexmap-2.2.5",
+        "indexmap_2": ":indexmap-2.2.6",
         "time_0_3": ":time-0.3.34",
     },
     visibility = [],
@@ -13302,7 +13460,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":serde-1.0.197",
         ":serde_derive-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_with_macros-3.7.0",
     ],
 )
@@ -13327,7 +13485,7 @@ cargo.rust_library(
         ":darling-0.20.8",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -13351,34 +13509,34 @@ cargo.rust_library(
         ":darling-0.20.8",
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
 alias(
     name = "serde_yaml",
-    actual = ":serde_yaml-0.9.33",
+    actual = ":serde_yaml-0.9.34+deprecated",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_yaml-0.9.33.crate",
-    sha256 = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9",
-    strip_prefix = "serde_yaml-0.9.33",
-    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.33/download"],
+    name = "serde_yaml-0.9.34+deprecated.crate",
+    sha256 = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47",
+    strip_prefix = "serde_yaml-0.9.34+deprecated",
+    urls = ["https://crates.io/api/v1/crates/serde_yaml/0.9.34+deprecated/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_yaml-0.9.33",
-    srcs = [":serde_yaml-0.9.33.crate"],
+    name = "serde_yaml-0.9.34+deprecated",
+    srcs = [":serde_yaml-0.9.34+deprecated.crate"],
     crate = "serde_yaml",
-    crate_root = "serde_yaml-0.9.33.crate/src/lib.rs",
+    crate_root = "serde_yaml-0.9.34+deprecated.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
-        ":indexmap-2.2.5",
-        ":itoa-1.0.10",
+        ":indexmap-2.2.6",
+        ":itoa-1.0.11",
         ":ryu-1.0.17",
         ":serde-1.0.197",
         ":unsafe-libyaml-0.2.11",
@@ -13783,22 +13941,22 @@ cargo.rust_library(
     edition = "2018",
     features = ["union"],
     visibility = [],
-    deps = [":smallvec-1.13.1"],
+    deps = [":smallvec-1.13.2"],
 )
 
 http_archive(
-    name = "smallvec-1.13.1.crate",
-    sha256 = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7",
-    strip_prefix = "smallvec-1.13.1",
-    urls = ["https://crates.io/api/v1/crates/smallvec/1.13.1/download"],
+    name = "smallvec-1.13.2.crate",
+    sha256 = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+    strip_prefix = "smallvec-1.13.2",
+    urls = ["https://crates.io/api/v1/crates/smallvec/1.13.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "smallvec-1.13.1",
-    srcs = [":smallvec-1.13.1.crate"],
+    name = "smallvec-1.13.2",
+    srcs = [":smallvec-1.13.2.crate"],
     crate = "smallvec",
-    crate_root = "smallvec-1.13.1.crate/src/lib.rs",
+    crate_root = "smallvec-1.13.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "const_generics",
@@ -14054,8 +14212,8 @@ cargo.rust_library(
         ":atoi-2.0.0",
         ":bigdecimal-0.3.1",
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
-        ":chrono-0.4.35",
+        ":bytes-1.6.0",
+        ":chrono-0.4.37",
         ":crc-3.0.1",
         ":crossbeam-queue-0.3.11",
         ":either-1.10.0",
@@ -14067,23 +14225,23 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":hashlink-0.8.4",
         ":hex-0.4.3",
-        ":indexmap-2.2.5",
+        ":indexmap-2.2.6",
         ":log-0.4.21",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":once_cell-1.19.0",
         ":paste-1.0.14",
         ":percent-encoding-2.3.1",
-        ":rust_decimal-1.34.3",
+        ":rust_decimal-1.35.0",
         ":rustls-0.21.10",
         ":rustls-pemfile-1.0.4",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sha2-0.10.8",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":sqlformat-0.2.3",
         ":thiserror-1.0.58",
         ":time-0.3.34",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
         ":tracing-0.1.40",
         ":url-2.5.0",
@@ -14131,7 +14289,7 @@ cargo.rust_library(
         ":bigdecimal-0.3.1",
         ":bitflags-2.5.0",
         ":byteorder-1.5.0",
-        ":chrono-0.4.35",
+        ":chrono-0.4.37",
         ":crc-3.0.1",
         ":dotenvy-0.15.7",
         ":futures-channel-0.3.30",
@@ -14142,18 +14300,18 @@ cargo.rust_library(
         ":hkdf-0.12.4",
         ":hmac-0.12.1",
         ":home-0.5.9",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":log-0.4.21",
         ":md-5-0.10.6",
-        ":memchr-2.7.1",
+        ":memchr-2.7.2",
         ":num-bigint-0.4.4",
         ":once_cell-1.19.0",
         ":rand-0.8.5",
-        ":rust_decimal-1.34.3",
+        ":rust_decimal-1.35.0",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sha2-0.10.8",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":sqlx-core-0.7.4",
         ":stringprep-0.1.4",
         ":thiserror-1.0.58",
@@ -14227,7 +14385,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-1.1.5",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
     ],
 )
 
@@ -14287,12 +14445,6 @@ cargo.rust_library(
     visibility = [],
 )
 
-alias(
-    name = "strum",
-    actual = ":strum-0.25.0",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "strum-0.25.0.crate",
     sha256 = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125",
@@ -14309,12 +14461,39 @@ cargo.rust_library(
     edition = "2018",
     features = [
         "default",
+        "std",
+    ],
+    visibility = [],
+)
+
+alias(
+    name = "strum",
+    actual = ":strum-0.26.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "strum-0.26.2.crate",
+    sha256 = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29",
+    strip_prefix = "strum-0.26.2",
+    urls = ["https://crates.io/api/v1/crates/strum/0.26.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "strum-0.26.2",
+    srcs = [":strum-0.26.2.crate"],
+    crate = "strum",
+    crate_root = "strum-0.26.2.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
         "derive",
         "std",
         "strum_macros",
     ],
     visibility = [],
-    deps = [":strum_macros-0.25.3"],
+    deps = [":strum_macros-0.26.2"],
 )
 
 http_archive(
@@ -14338,7 +14517,32 @@ cargo.rust_library(
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
         ":rustversion-1.0.14",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
+    ],
+)
+
+http_archive(
+    name = "strum_macros-0.26.2.crate",
+    sha256 = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946",
+    strip_prefix = "strum_macros-0.26.2",
+    urls = ["https://crates.io/api/v1/crates/strum_macros/0.26.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "strum_macros-0.26.2",
+    srcs = [":strum_macros-0.26.2.crate"],
+    crate = "strum_macros",
+    crate_root = "strum_macros-0.26.2.crate/src/lib.rs",
+    edition = "2018",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":heck-0.4.1",
+        ":proc-macro2-1.0.79",
+        ":quote-1.0.35",
+        ":rustversion-1.0.14",
+        ":syn-2.0.55",
     ],
 )
 
@@ -14430,23 +14634,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.53",
+    actual = ":syn-2.0.55",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.53.crate",
-    sha256 = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032",
-    strip_prefix = "syn-2.0.53",
-    urls = ["https://crates.io/api/v1/crates/syn/2.0.53/download"],
+    name = "syn-2.0.55.crate",
+    sha256 = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0",
+    strip_prefix = "syn-2.0.55",
+    urls = ["https://crates.io/api/v1/crates/syn/2.0.55/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.53",
-    srcs = [":syn-2.0.53.crate"],
+    name = "syn-2.0.55",
+    srcs = [":syn-2.0.55.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.53.crate/src/lib.rs",
+    crate_root = "syn-2.0.55.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -14485,88 +14689,6 @@ cargo.rust_library(
     crate_root = "sync_wrapper-0.1.2.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-)
-
-http_archive(
-    name = "system-configuration-0.5.1.crate",
-    sha256 = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7",
-    strip_prefix = "system-configuration-0.5.1",
-    urls = ["https://crates.io/api/v1/crates/system-configuration/0.5.1/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "system-configuration-0.5.1",
-    srcs = [":system-configuration-0.5.1.crate"],
-    crate = "system_configuration",
-    crate_root = "system-configuration-0.5.1.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
-    deps = [
-        ":bitflags-1.3.2",
-        ":core-foundation-0.9.4",
-        ":system-configuration-sys-0.5.0",
-    ],
-)
-
-http_archive(
-    name = "system-configuration-sys-0.5.0.crate",
-    sha256 = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9",
-    strip_prefix = "system-configuration-sys-0.5.0",
-    urls = ["https://crates.io/api/v1/crates/system-configuration-sys/0.5.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "system-configuration-sys-0.5.0",
-    srcs = [":system-configuration-sys-0.5.0.crate"],
-    crate = "system_configuration_sys",
-    crate_root = "system-configuration-sys-0.5.0.crate/src/lib.rs",
-    edition = "2021",
-    env = {
-        "CARGO_MANIFEST_DIR": "system-configuration-sys-0.5.0.crate",
-        "CARGO_PKG_AUTHORS": "Mullvad VPN",
-        "CARGO_PKG_DESCRIPTION": "Low level bindings to SystemConfiguration framework for macOS",
-        "CARGO_PKG_NAME": "system-configuration-sys",
-        "CARGO_PKG_REPOSITORY": "https://github.com/mullvad/system-configuration-rs",
-        "CARGO_PKG_VERSION": "0.5.0",
-        "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "5",
-        "CARGO_PKG_VERSION_PATCH": "0",
-    },
-    rustc_flags = ["@$(location :system-configuration-sys-0.5.0-build-script-run[rustc_flags])"],
-    visibility = [],
-    deps = [
-        ":core-foundation-sys-0.8.6",
-        ":libc-0.2.153",
-    ],
-)
-
-cargo.rust_binary(
-    name = "system-configuration-sys-0.5.0-build-script-build",
-    srcs = [":system-configuration-sys-0.5.0.crate"],
-    crate = "build_script_build",
-    crate_root = "system-configuration-sys-0.5.0.crate/build.rs",
-    edition = "2021",
-    env = {
-        "CARGO_MANIFEST_DIR": "system-configuration-sys-0.5.0.crate",
-        "CARGO_PKG_AUTHORS": "Mullvad VPN",
-        "CARGO_PKG_DESCRIPTION": "Low level bindings to SystemConfiguration framework for macOS",
-        "CARGO_PKG_NAME": "system-configuration-sys",
-        "CARGO_PKG_REPOSITORY": "https://github.com/mullvad/system-configuration-rs",
-        "CARGO_PKG_VERSION": "0.5.0",
-        "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "5",
-        "CARGO_PKG_VERSION_PATCH": "0",
-    },
-    visibility = [],
-)
-
-buildscript_run(
-    name = "system-configuration-sys-0.5.0-build-script-run",
-    package_name = "system-configuration-sys",
-    buildscript_rule = ":system-configuration-sys-0.5.0-build-script-build",
-    version = "0.5.0",
 )
 
 http_archive(
@@ -14701,7 +14823,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":fastrand-2.0.1",
+        ":fastrand-2.0.2",
     ],
 )
 
@@ -14793,26 +14915,8 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
-)
-
-http_archive(
-    name = "textwrap-0.11.0.crate",
-    sha256 = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
-    strip_prefix = "textwrap-0.11.0",
-    urls = ["https://crates.io/api/v1/crates/textwrap/0.11.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "textwrap-0.11.0",
-    srcs = [":textwrap-0.11.0.crate"],
-    crate = "textwrap",
-    crate_root = "textwrap-0.11.0.crate/src/lib.rs",
-    edition = "2015",
-    visibility = [],
-    deps = [":unicode-width-0.1.11"],
 )
 
 cargo.rust_binary(
@@ -14823,28 +14927,28 @@ cargo.rust_binary(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-nats-0.33.0",
+        ":async-nats-0.34.0",
         ":async-recursion-1.1.0",
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":axum-0.6.20",
-        ":base64-0.21.7",
+        ":base64-0.22.0",
         ":blake3-1.5.1",
-        ":bollard-0.15.0",
-        ":bytes-1.5.0",
-        ":chrono-0.4.35",
+        ":bollard-0.16.1",
+        ":bytes-1.6.0",
+        ":chrono-0.4.37",
         ":ciborium-0.2.2",
-        ":clap-4.5.3",
+        ":clap-4.5.4",
         ":color-eyre-0.6.3",
         ":colored-2.1.0",
         ":comfy-table-7.1.0",
-        ":config-0.13.4",
+        ":config-0.14.0",
         ":console-0.15.8",
         ":convert_case-0.6.0",
-        ":criterion-0.3.6",
+        ":criterion-0.5.1",
         ":crossbeam-channel-0.5.12",
         ":deadpool-0.10.0",
         ":deadpool-postgres-0.12.1",
-        ":derive_builder-0.12.0",
+        ":derive_builder-0.20.0",
         ":derive_more-0.99.17",
         ":diff-0.1.13",
         ":directories-5.0.1",
@@ -14858,10 +14962,10 @@ cargo.rust_binary(
         ":hyper-0.14.28",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.5",
-        ":indexmap-2.2.5",
+        ":indexmap-2.2.6",
         ":indicatif-0.17.8",
-        ":indoc-2.0.4",
-        ":inquire-0.6.2",
+        ":indoc-2.0.5",
+        ":inquire-0.7.4",
         ":itertools-0.12.1",
         ":jwt-simple-0.12.9",
         ":lazy_static-1.4.0",
@@ -14889,34 +14993,34 @@ cargo.rust_binary(
         ":quote-1.0.35",
         ":rand-0.8.5",
         ":refinery-0.8.12",
-        ":regex-1.10.3",
+        ":regex-1.10.4",
         ":remain-0.2.13",
-        ":reqwest-0.11.27",
+        ":reqwest-0.12.2",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
-        ":rustls-0.22.2",
+        ":rustls-0.22.3",
         ":rustls-pemfile-2.1.1",
         ":sea-orm-0.12.15",
         ":self-replace-1.3.7",
         ":serde-1.0.197",
         ":serde-aux-4.5.0",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":serde_url_params-0.2.1",
         ":serde_with-3.7.0",
-        ":serde_yaml-0.9.33",
+        ":serde_yaml-0.9.34+deprecated",
         ":sled-0.34.7",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
-        ":strum-0.25.0",
-        ":syn-2.0.53",
+        ":strum-0.26.2",
+        ":syn-2.0.55",
         ":tar-0.4.40",
         ":tempfile-3.10.1",
         ":test-log-0.2.15",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":tokio-postgres-rustls-0.11.1",
-        ":tokio-serde-0.8.0",
+        ":tokio-serde-0.9.0",
         ":tokio-stream-0.1.15",
         ":tokio-test-0.4.4",
         ":tokio-tungstenite-0.20.1",
@@ -14931,7 +15035,7 @@ cargo.rust_binary(
         ":ulid-1.1.2",
         ":url-2.5.0",
         ":uuid-1.8.0",
-        ":vfs-0.10.0",
+        ":vfs-0.12.0",
         ":vfs-tar-0.4.1",
         ":webpki-roots-0.25.4",
         ":y-sync-0.4.0",
@@ -14982,7 +15086,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -15034,7 +15138,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":deranged-0.3.11",
-        ":itoa-1.0.10",
+        ":itoa-1.0.11",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
         ":serde-1.0.197",
@@ -15126,7 +15230,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
     ],
 )
 
@@ -15172,23 +15276,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.36.0",
+    actual = ":tokio-1.37.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.36.0.crate",
-    sha256 = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931",
-    strip_prefix = "tokio-1.36.0",
-    urls = ["https://crates.io/api/v1/crates/tokio/1.36.0/download"],
+    name = "tokio-1.37.0.crate",
+    sha256 = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787",
+    strip_prefix = "tokio-1.37.0",
+    urls = ["https://crates.io/api/v1/crates/tokio/1.37.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.36.0",
-    srcs = [":tokio-1.36.0.crate"],
+    name = "tokio-1.37.0",
+    srcs = [":tokio-1.37.0.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.36.0.crate/src/lib.rs",
+    crate_root = "tokio-1.37.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -15264,7 +15368,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":mio-0.8.11",
         ":num_cpus-1.16.0",
         ":parking_lot-0.12.1",
@@ -15291,7 +15395,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
     ],
 )
 
@@ -15314,7 +15418,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -15366,9 +15470,9 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":fallible-iterator-0.2.0",
         ":futures-channel-0.3.30",
         ":futures-util-0.3.30",
@@ -15380,7 +15484,7 @@ cargo.rust_library(
         ":postgres-protocol-0.6.6",
         ":postgres-types-0.2.6",
         ":rand-0.8.5",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":whoami-1.5.1",
     ],
@@ -15401,33 +15505,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ring-0.17.5",
-        ":rustls-0.22.2",
-        ":tokio-1.36.0",
+        ":rustls-0.22.3",
+        ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":tokio-rustls-0.25.0",
         ":x509-certificate-0.23.1",
-    ],
-)
-
-http_archive(
-    name = "tokio-retry-0.3.0.crate",
-    sha256 = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f",
-    strip_prefix = "tokio-retry-0.3.0",
-    urls = ["https://crates.io/api/v1/crates/tokio-retry/0.3.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "tokio-retry-0.3.0",
-    srcs = [":tokio-retry-0.3.0.crate"],
-    crate = "tokio_retry",
-    crate_root = "tokio-retry-0.3.0.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [
-        ":pin-project-1.1.5",
-        ":rand-0.8.5",
-        ":tokio-1.36.0",
     ],
 )
 
@@ -15453,7 +15535,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.10",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
     ],
 )
 
@@ -15471,36 +15553,42 @@ cargo.rust_library(
     crate = "tokio_rustls",
     crate_root = "tokio-rustls-0.25.0.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "default",
+        "logging",
+        "ring",
+        "tls12",
+    ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.3.1",
+        "pki_types": ":rustls-pki-types-1.4.1",
     },
     visibility = [],
     deps = [
-        ":rustls-0.22.2",
-        ":tokio-1.36.0",
+        ":rustls-0.22.3",
+        ":tokio-1.37.0",
     ],
 )
 
 alias(
     name = "tokio-serde",
-    actual = ":tokio-serde-0.8.0",
+    actual = ":tokio-serde-0.9.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-serde-0.8.0.crate",
-    sha256 = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466",
-    strip_prefix = "tokio-serde-0.8.0",
-    urls = ["https://crates.io/api/v1/crates/tokio-serde/0.8.0/download"],
+    name = "tokio-serde-0.9.0.crate",
+    sha256 = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b",
+    strip_prefix = "tokio-serde-0.9.0",
+    urls = ["https://crates.io/api/v1/crates/tokio-serde/0.9.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-serde-0.8.0",
-    srcs = [":tokio-serde-0.8.0.crate"],
+    name = "tokio-serde-0.9.0",
+    srcs = [":tokio-serde-0.9.0.crate"],
     crate = "tokio_serde",
-    crate_root = "tokio-serde-0.8.0.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "tokio-serde-0.9.0.crate/src/lib.rs",
+    edition = "2021",
     features = [
         "educe",
         "json",
@@ -15509,13 +15597,13 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
-        ":educe-0.4.23",
+        ":bytes-1.6.0",
+        ":educe-0.5.11",
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":pin-project-1.1.5",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
     ],
 )
 
@@ -15550,7 +15638,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
     ],
 )
@@ -15578,9 +15666,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-core-0.3.30",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
     ],
 )
@@ -15615,7 +15703,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":log-0.4.21",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tungstenite-0.20.1",
     ],
 )
@@ -15651,12 +15739,12 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tracing-0.1.40",
     ],
 )
@@ -15683,31 +15771,12 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-0.3.30",
         ":libc-0.2.153",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":vsock-0.3.0",
     ],
-)
-
-http_archive(
-    name = "toml-0.5.11.crate",
-    sha256 = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234",
-    strip_prefix = "toml-0.5.11",
-    urls = ["https://crates.io/api/v1/crates/toml/0.5.11/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "toml-0.5.11",
-    srcs = [":toml-0.5.11.crate"],
-    crate = "toml",
-    crate_root = "toml-0.5.11.crate/src/lib.rs",
-    edition = "2018",
-    features = ["default"],
-    visibility = [],
-    deps = [":serde-1.0.197"],
 )
 
 alias(
@@ -15740,7 +15809,7 @@ cargo.rust_library(
         ":serde-1.0.197",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":toml_edit-0.22.8",
+        ":toml_edit-0.22.9",
     ],
 )
 
@@ -15764,18 +15833,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "toml_edit-0.22.8.crate",
-    sha256 = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd",
-    strip_prefix = "toml_edit-0.22.8",
-    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.8/download"],
+    name = "toml_edit-0.22.9.crate",
+    sha256 = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4",
+    strip_prefix = "toml_edit-0.22.9",
+    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.9/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.22.8",
-    srcs = [":toml_edit-0.22.8.crate"],
+    name = "toml_edit-0.22.9",
+    srcs = [":toml_edit-0.22.9.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.22.8.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.9.crate/src/lib.rs",
     edition = "2021",
     features = [
         "display",
@@ -15784,7 +15853,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.2.5",
+        ":indexmap-2.2.6",
         ":serde-1.0.197",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
@@ -15826,10 +15895,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.78",
+        ":async-trait-0.1.79",
         ":axum-0.6.20",
         ":base64-0.21.7",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":h2-0.3.25",
         ":http-0.2.12",
         ":http-body-0.4.6",
@@ -15838,7 +15907,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.5",
         ":prost-0.12.3",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
         ":tower-0.4.13",
         ":tower-layer-0.3.2",
@@ -15910,7 +15979,7 @@ cargo.rust_library(
         ":pin-project-lite-0.2.13",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":tower-layer-0.3.2",
         ":tower-service-0.3.2",
@@ -15954,14 +16023,14 @@ cargo.rust_library(
     deps = [
         ":async-compression-0.4.6",
         ":bitflags-2.5.0",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
         ":pin-project-lite-0.2.13",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":tower-layer-0.3.2",
         ":tower-service-0.3.2",
@@ -16058,7 +16127,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )
 
@@ -16179,7 +16248,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":opentelemetry-0.22.0",
         ":opentelemetry_sdk-0.22.1",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
         ":tracing-log-0.2.0",
@@ -16255,11 +16324,11 @@ cargo.rust_library(
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
-        ":regex-1.10.3",
+        ":regex-1.10.4",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":sharded-slab-0.1.7",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":thread_local-1.1.8",
         ":tracing-0.1.40",
         ":tracing-core-0.1.32",
@@ -16303,6 +16372,28 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "tryhard-0.5.1.crate",
+    sha256 = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d",
+    strip_prefix = "tryhard-0.5.1",
+    urls = ["https://crates.io/api/v1/crates/tryhard/0.5.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tryhard-0.5.1",
+    srcs = [":tryhard-0.5.1.crate"],
+    crate = "tryhard",
+    crate_root = "tryhard-0.5.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":futures-0.3.30",
+        ":pin-project-lite-0.2.13",
+        ":tokio-1.37.0",
+    ],
+)
+
+http_archive(
     name = "tungstenite-0.20.1.crate",
     sha256 = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9",
     strip_prefix = "tungstenite-0.20.1",
@@ -16327,7 +16418,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":byteorder-1.5.0",
-        ":bytes-1.5.0",
+        ":bytes-1.6.0",
         ":data-encoding-2.5.0",
         ":http-0.2.12",
         ":httparse-1.8.0",
@@ -16766,12 +16857,6 @@ cargo.rust_library(
     visibility = [],
 )
 
-alias(
-    name = "vfs",
-    actual = ":vfs-0.10.0",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "vfs-0.10.0.crate",
     sha256 = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d",
@@ -16787,6 +16872,30 @@ cargo.rust_library(
     crate_root = "vfs-0.10.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
+)
+
+alias(
+    name = "vfs",
+    actual = ":vfs-0.12.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "vfs-0.12.0.crate",
+    sha256 = "654cd097e182a71dbf899178e6b5662c2157dd0b8afd5975de18008f6fc173d1",
+    strip_prefix = "vfs-0.12.0",
+    urls = ["https://crates.io/api/v1/crates/vfs/0.12.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "vfs-0.12.0",
+    srcs = [":vfs-0.12.0.crate"],
+    crate = "vfs",
+    crate_root = "vfs-0.12.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":filetime-0.2.23"],
 )
 
 alias(
@@ -16911,6 +17020,26 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "webpki-roots-0.26.1.crate",
+    sha256 = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009",
+    strip_prefix = "webpki-roots-0.26.1",
+    urls = ["https://crates.io/api/v1/crates/webpki-roots/0.26.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "webpki-roots-0.26.1",
+    srcs = [":webpki-roots-0.26.1.crate"],
+    crate = "webpki_roots",
+    crate_root = "webpki-roots-0.26.1.crate/src/lib.rs",
+    edition = "2018",
+    named_deps = {
+        "pki_types": ":rustls-pki-types-1.4.1",
+    },
+    visibility = [],
+)
+
+http_archive(
     name = "whoami-1.5.1.crate",
     sha256 = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9",
     strip_prefix = "whoami-1.5.1",
@@ -16952,7 +17081,6 @@ cargo.rust_library(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwinbase",
         "minwindef",
         "ntstatus",
         "processenv",
@@ -16991,7 +17119,6 @@ cargo.rust_binary(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwinbase",
         "minwindef",
         "ntstatus",
         "processenv",
@@ -17019,7 +17146,6 @@ buildscript_run(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwinbase",
         "minwindef",
         "ntstatus",
         "processenv",
@@ -17365,7 +17491,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":memchr-2.7.1"],
+    deps = [":memchr-2.7.2"],
 )
 
 http_archive(
@@ -17406,8 +17532,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bcder-0.7.4",
-        ":bytes-1.5.0",
-        ":chrono-0.4.35",
+        ":bytes-1.6.0",
+        ":chrono-0.4.37",
         ":der-0.7.8",
         ":hex-0.4.3",
         ":pem-3.0.3",
@@ -17474,7 +17600,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":thiserror-1.0.58",
-        ":tokio-1.36.0",
+        ":tokio-1.37.0",
         ":yrs-0.17.4",
     ],
 )
@@ -17543,9 +17669,9 @@ cargo.rust_library(
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
         ":serde-1.0.197",
-        ":serde_json-1.0.114",
+        ":serde_json-1.0.115",
         ":smallstr-0.3.0",
-        ":smallvec-1.13.1",
+        ":smallvec-1.13.2",
         ":thiserror-1.0.58",
     ],
 )
@@ -17622,6 +17748,6 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.79",
         ":quote-1.0.35",
-        ":syn-2.0.53",
+        ":syn-2.0.55",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -91,6 +91,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -183,25 +189,24 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
+checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
 dependencies = [
- "base64 0.21.7",
- "bytes 1.5.0",
+ "base64 0.22.0",
+ "bytes 1.6.0",
  "futures",
- "http",
  "memchr",
- "nkeys 0.3.2",
+ "nkeys",
  "nuid",
  "once_cell",
+ "portable-atomic",
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls 0.21.10",
- "rustls-native-certs",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -209,9 +214,9 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-retry",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tracing",
+ "tryhard",
  "url",
 ]
 
@@ -223,7 +228,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -245,18 +250,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -265,7 +270,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -302,31 +307,20 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc"
 dependencies = [
- "http",
+ "http 0.2.12",
  "log",
  "rustls 0.21.10",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "aws-creds"
@@ -363,11 +357,11 @@ dependencies = [
  "axum-macros",
  "base64 0.21.7",
  "bitflags 1.3.2",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -396,10 +390,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -415,14 +409,14 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -452,6 +446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,7 +463,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "smallvec",
 ]
 
@@ -546,19 +546,22 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "bollard-stubs",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
- "hyperlocal",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal-next",
  "log",
  "pin-project-lite",
  "serde",
@@ -569,15 +572,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
 name = "bollard-stubs"
-version = "1.43.0-rc.2"
+version = "1.44.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
 dependencies = [
  "serde",
  "serde_repr",
@@ -586,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -596,15 +600,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "syn_derive",
 ]
 
@@ -687,9 +691,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -705,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -751,9 +755,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -788,25 +792,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.4.0",
+ "half",
 ]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -827,14 +820,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -911,23 +904,22 @@ checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
  "console",
  "crossterm 0.27.0",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "unicode-width",
 ]
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
- "async-trait",
  "lazy_static",
  "nom",
  "pathdiff",
  "serde",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -984,8 +976,8 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "log",
  "mime",
@@ -1008,8 +1000,8 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "log",
  "mime",
@@ -1089,25 +1081,25 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "futures",
+ "is-terminal",
  "itertools 0.10.5",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1117,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -1241,27 +1233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ct-codecs"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,17 +1262,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1310,22 +1271,8 @@ version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1339,18 +1286,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1359,9 +1295,9 @@ version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1449,33 +1385,33 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1547,13 +1483,13 @@ dependencies = [
  "asynchronous-codec",
  "base64 0.13.1",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "containers-api 0.9.0",
  "docker-api-stubs",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "paste",
  "serde",
@@ -1643,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.23"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1706,15 +1642,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "3.1.15"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
 dependencies = [
- "num-bigint",
- "num-traits",
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1786,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff"
@@ -1802,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "filetime"
@@ -1947,7 +1890,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "futures-core",
  "futures-io",
  "parking",
@@ -1962,7 +1905,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2005,6 +1948,15 @@ dependencies = [
  "futures",
  "memchr",
  "pin-project 0.4.30",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -2075,7 +2027,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2095,24 +2047,18 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.2.5",
+ "http 0.2.12",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -2208,15 +2154,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -2293,7 +2230,18 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.6.0",
  "fnv",
  "itoa",
 ]
@@ -2304,8 +2252,31 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.5.0",
- "http",
+ "bytes 1.6.0",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes 1.6.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2333,13 +2304,13 @@ version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2352,17 +2323,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2371,10 +2393,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2384,9 +2426,24 @@ source = "git+https://github.com/fnichol/hyperlocal.git?branch=pub-unix-stream#6
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "pin-project 1.1.5",
  "tokio",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2438,8 +2495,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.53",
- "toml 0.8.12",
+ "syn 2.0.55",
+ "toml",
  "unicode-xid",
 ]
 
@@ -2478,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2502,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inherent"
@@ -2514,21 +2571,22 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "inquire"
-version = "0.6.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "crossterm 0.25.0",
  "dyn-clone",
- "lazy_static",
+ "fuzzy-matcher",
+ "fxhash",
  "newline-converter",
- "thiserror",
+ "once_cell",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2555,6 +2613,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2596,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -2749,7 +2818,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2770,9 +2839,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -2866,10 +2935,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -2889,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "newline-converter"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2917,22 +2986,6 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nkeys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
-dependencies = [
- "byteorder",
- "data-encoding",
- "ed25519 2.2.3",
- "ed25519-dalek",
- "getrandom 0.2.12",
- "log",
- "rand 0.8.5",
- "signatory",
 ]
 
 [[package]]
@@ -3050,7 +3103,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3121,7 +3174,7 @@ checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -3247,7 +3300,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3261,7 +3314,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3398,7 +3451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
 ]
@@ -3458,7 +3511,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3502,9 +3555,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"
@@ -3542,7 +3595,7 @@ checksum = "4d0ade207138f12695cb4be3b590283f1cf764c5c4909f39966c4b4b0dba7c1e"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "containers-api 0.8.0",
  "flate2",
@@ -3597,7 +3650,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3608,7 +3661,7 @@ checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -3624,7 +3677,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "fallible-iterator",
  "postgres-derive",
@@ -3724,7 +3777,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -3735,7 +3788,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "prost-derive",
 ]
 
@@ -3749,7 +3802,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3905,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -3978,7 +4031,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "toml 0.8.12",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -3993,19 +4046,19 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4025,7 +4078,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4036,9 +4089,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "remain"
@@ -4048,7 +4101,7 @@ checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4062,20 +4115,20 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
- "bytes 1.5.0",
- "encoding_rs",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -4084,21 +4137,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.22.3",
  "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.1",
  "winreg",
 ]
 
@@ -4134,7 +4187,7 @@ checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
@@ -4195,21 +4248,21 @@ dependencies = [
  "aws-creds",
  "aws-region",
  "base64 0.21.7",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "cfg-if",
  "futures",
  "hex",
  "hmac",
- "http",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "log",
  "maybe-async",
  "md5",
  "percent-encoding",
  "quick-xml",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4224,13 +4277,13 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
  "borsh",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "num-traits",
  "rand 0.8.5",
  "rkyv",
@@ -4280,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
@@ -4300,6 +4353,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4325,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -4406,7 +4472,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4429,7 +4495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.25.0",
  "thiserror",
  "time",
  "tracing",
@@ -4447,7 +4513,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.53",
+ "syn 2.0.55",
  "unicode-ident",
 ]
 
@@ -4568,16 +4634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4585,16 +4641,16 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -4627,7 +4683,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4687,7 +4743,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4701,10 +4757,10 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.8",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4713,19 +4769,19 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
- "darling 0.20.8",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -4890,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -4975,7 +5031,7 @@ dependencies = [
  "atoi",
  "bigdecimal",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -4988,7 +5044,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "memchr",
  "once_cell",
@@ -5009,7 +5065,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5062,7 +5118,7 @@ dependencies = [
  "bigdecimal",
  "bitflags 2.5.0",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "crc",
  "digest",
@@ -5219,8 +5275,14 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -5233,7 +5295,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5268,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5286,7 +5361,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5294,27 +5369,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "tagptr"
@@ -5355,7 +5409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5388,16 +5442,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5408,13 +5453,13 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "blake3",
  "bollard",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "ciborium",
- "clap 4.5.3",
+ "clap",
  "color-eyre",
  "colored",
  "comfy-table",
@@ -5435,11 +5480,11 @@ dependencies = [
  "futures",
  "futures-lite",
  "hex",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyperlocal",
  "iftree",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "indicatif",
  "indoc",
  "inquire",
@@ -5449,7 +5494,7 @@ dependencies = [
  "moka",
  "names",
  "nix 0.27.1",
- "nkeys 0.4.0",
+ "nkeys",
  "num_cpus",
  "once_cell",
  "open",
@@ -5475,7 +5520,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rust-s3",
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "rustls-pemfile 2.1.1",
  "sea-orm",
  "self-replace",
@@ -5488,8 +5533,8 @@ dependencies = [
  "sled",
  "sodiumoxide",
  "stream-cancel",
- "strum",
- "syn 2.0.53",
+ "strum 0.26.2",
+ "syn 2.0.55",
  "tar",
  "tempfile",
  "test-log",
@@ -5503,7 +5548,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tokio-vsock",
- "toml 0.8.12",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -5512,9 +5557,9 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
- "vfs",
+ "vfs 0.12.0",
  "vfs-tar",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "y-sync",
  "yrs",
 ]
@@ -5536,7 +5581,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5616,12 +5661,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "libc",
  "mio",
  "num_cpus",
@@ -5651,7 +5696,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5662,7 +5707,7 @@ checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fallible-iterator",
  "futures-channel",
  "futures-util",
@@ -5686,22 +5731,11 @@ version = "0.11.1"
 source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#b8de7acc8067a3ec4b7e99ba6ea654fae8e28fe4"
 dependencies = [
  "ring",
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.25.0",
  "x509-certificate",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project 1.1.5",
- "rand 0.8.5",
- "tokio",
 ]
 
 [[package]]
@@ -5720,18 +5754,18 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.3",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-serde"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "educe",
  "futures-core",
  "futures-sink",
@@ -5759,7 +5793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -5783,7 +5817,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -5799,20 +5833,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures",
  "libc",
  "tokio",
  "vsock",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5824,7 +5849,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -5842,18 +5867,18 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5870,11 +5895,11 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.21.7",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
@@ -5916,11 +5941,11 @@ checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "bitflags 2.5.0",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "pin-project-lite",
  "tokio",
@@ -5962,7 +5987,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6058,15 +6083,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -6231,6 +6267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
 
 [[package]]
+name = "vfs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654cd097e182a71dbf899178e6b5662c2157dd0b8afd5975de18008f6fc173d1"
+dependencies = [
+ "filetime",
+]
+
+[[package]]
 name = "vfs-tar"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6239,7 +6284,7 @@ dependencies = [
  "memmap2",
  "stable_deref_trait",
  "tar-parser2",
- "vfs",
+ "vfs 0.10.0",
 ]
 
 [[package]]
@@ -6319,7 +6364,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -6353,7 +6398,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6389,6 +6434,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -6617,7 +6671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
 dependencies = [
  "bcder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "chrono",
  "der",
  "hex",
@@ -6696,7 +6750,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6716,5 +6770,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -19,47 +19,47 @@ path = "top/main.rs"
 # BEGIN: DEPENDENCIES
 
 [dependencies]
-async-nats = { version = "0.33.0", features = ["service"] }
-async-recursion = "1.0.4"
-async-trait = "0.1.68"
-axum = { version = "0.6.18", features = [
+async-nats = { version = "0.34.0", features = ["service"] }
+async-recursion = "1.0.5"
+async-trait = "0.1.79"
+axum = { version = "0.6.20", features = [
     "macros",
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
-base64 = "0.21.0"
-blake3 = "1.3.3"
-bollard = "0.15.0"
-bytes = "1.4.0"
-chrono = { version = "0.4.24", features = ["serde"] }
-ciborium = "0.2.1"
-clap = { version = "4.2.7", features = ["derive", "color", "env", "wrap_help"] }
-color-eyre = "0.6.2"
-colored = "2.0.4"
-comfy-table = { version = "7.0.1", features = [
+base64 = "0.22.0"
+blake3 = "1.5.1"
+bollard = "0.16.1"
+bytes = "1.6.0"
+chrono = { version = "0.4.37", features = ["serde"] }
+ciborium = "0.2.2"
+clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
+color-eyre = "0.6.3"
+colored = "2.1.0"
+comfy-table = { version = "7.1.0", features = [
     "crossterm",
     "tty",
     "custom_styling",
 ] }
-config = { version = "0.13.4", default-features = false, features = ["toml"] }
-console = "0.15.7"
+config = { version = "0.14.0", default-features = false, features = ["toml"] }
+console = "0.15.8"
 convert_case = "0.6.0"
-criterion = { version = "0.3", features = [ "async_tokio" ] }
-crossbeam-channel = "0.5.8"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+crossbeam-channel = "0.5.12"
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.12.1"
-derive_builder = "0.12.0"
+derive_builder = "0.20.0"
 derive_more = "0.99.17"
 diff = "0.1.13"
 directories = "5.0.1"
 docker-api = "0.14.0"
-dyn-clone = "1.0.11"
-flate2 = "1.0.26"
-futures = "0.3.28"
-futures-lite = "2.1.0"
+dyn-clone = "1.0.17"
+flate2 = "1.0.28"
+futures = "0.3.30"
+futures-lite = "2.3.0"
 hex = "0.4.3"
-http = "0.2.9" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
-hyper = { version = "0.14.26", features = [
+http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
+hyper = { version = "0.14.28", features = [
     "client",
     "http1",
     "runtime",
@@ -68,54 +68,54 @@ hyper = { version = "0.14.26", features = [
 hyperlocal = { version = "0.8.0", default-features = false, features = [
     "client",
 ] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
-iftree = "1.0.4"
-indicatif = "0.17.5"
-indexmap = "2.2.2"
-indoc = "2.0.1"
-inquire = "0.6.2"
-itertools = "0.12.0"
-jwt-simple = { version = "0.12.6", default-features = false, features = [
+iftree = "1.0.5"
+indicatif = "0.17.8"
+indexmap = "2.2.6"
+indoc = "2.0.5"
+inquire = "0.7.4"
+itertools = "0.12.1"
+jwt-simple = { version = "0.12.9", default-features = false, features = [
     "pure-rust",
 ] }
 lazy_static = "1.4.0"
-moka = { version = "0.12.5", features = [ "future" ] }
+moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }
 nkeys = "0.4.0"
-num_cpus = "1.15.0"
-once_cell = "1.17.1"
-open = "5.0.0"
+num_cpus = "1.16.0"
+once_cell = "1.19.0"
+open = "5.1.2"
 opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
-ouroboros = "0.18.1"
-paste = "1.0.12"
+ouroboros = "0.18.3"
+paste = "1.0.14"
 pathdiff = "0.2.1"
-petgraph = { version = "0.6.3", features = ["serde-1"] }
-pin-project-lite = "0.2.9"
-podman-api = "0.10"
+petgraph = { version = "0.6.4", features = ["serde-1"] }
+pin-project-lite = "0.2.13"
+podman-api = "0.10.0"
 postcard = { version = "1.0.8", features = ["use-std"] }
-postgres-types = { version = "0.2.5", features = ["derive"] }
-pretty_assertions_sorted = "1.2.1"
-proc-macro2 = "1.0.56"
-quote = "1.0.27"
+postgres-types = { version = "0.2.6", features = ["derive"] }
+pretty_assertions_sorted = "1.2.3"
+proc-macro2 = "1.0.79"
+quote = "1.0.35"
 rand = "0.8.5"
-refinery = { version = "0.8.9", features = ["tokio-postgres"] }
-regex = "1.8.1"
-remain = "0.2.8"
-reqwest = { version = "0.11.17", default-features = false, features = [
+refinery = { version = "0.8.12", features = ["tokio-postgres"] }
+regex = "1.10.4"
+remain = "0.2.13"
+reqwest = { version = "0.12.2", default-features = false, features = [
     "rustls-tls",
     "json",
     "multipart",
 ] }
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
-rustls = { version = "0.22.2" }
-rustls-pemfile = { version = "2.0.0" }
+rustls = { version = "0.22.3" }
+rustls-pemfile = { version = "2.1.1" }
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
 ] }
-sea-orm = { version = "0.12.0", features = [
+sea-orm = { version = "0.12.15", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
@@ -123,60 +123,60 @@ sea-orm = { version = "0.12.0", features = [
     "debug-print",
 ] }
 self-replace = "1.3.7"
-serde = { version = "1.0.160", features = ["derive", "rc"] }
-serde-aux = "4.2.0"
-serde_json = { version = "1.0.96", features = ["preserve_order"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde-aux = "4.5.0"
+serde_json = { version = "1.0.115", features = ["preserve_order"] }
 serde_url_params = "0.2.1"
-serde_with = "3.0.0"
-serde_yaml = "0.9.21"
+serde_with = "3.7.0"
+serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sled = "0.34.7"
 sodiumoxide = "0.2.7"
-stream-cancel = "0.8.1"
-strum = { version = "0.25.0", features = ["derive"] }
-syn = { version = "2.0.15", features = ["full", "extra-traits"] }
-tar = "0.4.38"
-tempfile = "3.5.0"
-test-log = { version = "0.2.11", default-features = false, features = [
+stream-cancel = "0.8.2"
+strum = { version = "0.26.2", features = ["derive"] }
+syn = { version = "2.0.55", features = ["full", "extra-traits"] }
+tar = "0.4.40"
+tempfile = "3.10.1"
+test-log = { version = "0.2.15", default-features = false, features = [
     "trace",
 ] }
-thiserror = "1.0.40"
-tokio = { version = "1.28.0", features = ["full"] }
-tokio-postgres = { version = "0.7.8", features = [
+thiserror = "1.0.58"
+tokio = { version = "1.37.0", features = ["full"] }
+tokio-postgres = { version = "0.7.10", features = [
     "runtime",
     "with-chrono-0_4",
     "with-serde_json-1",
 ] }
-tokio-postgres-rustls = { version = "0.11.0" }
-tokio-serde = { version = "0.8.0", features = ["json"] }
-tokio-stream = { version = "0.1.14", features = ["sync"] }
-tokio-test = "0.4.2"
+tokio-postgres-rustls = { version = "0.11.1" }
+tokio-serde = { version = "0.9.0", features = ["json"] }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
+tokio-test = "0.4.4"
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
-tokio-util = { version = "0.7.8", features = ["codec", "rt"] }
+tokio-util = { version = "0.7.10", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
-toml = { version = "0.8.8" }
+toml = { version = "0.8.12" }
 tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.4", features = [
+tower-http = { version = "0.4.4", features = [
     "compression-br",
     "compression-deflate",
     "compression-gzip",
     "cors",
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
-tracing = { version = "0.1" }
+tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",
     "std",
 ] }
-ulid = { version = "1.0.0", features = ["serde"] }
-url = { version = "2.3.1", features = ["serde"] }
-uuid = { version = "1.3.2", features = ["serde", "v4"] }
-vfs = "0.10.0"
-vfs-tar = { version = "0.4.0", features = ["mmap"] }
-webpki-roots = { version = "0.25.3" }
+ulid = { version = "1.1.2", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
+uuid = { version = "1.8.0", features = ["serde", "v4"] }
+vfs = "0.12.0"
+vfs-tar = { version = "0.4.1", features = ["mmap"] }
+webpki-roots = { version = "0.25.4" }
 y-sync = { version = "0.4.0", features = ["net"] }
-yrs = { version = "0.17.2" }
+yrs = { version = "0.17.4" }
 
 [patch.crates-io]
 # pending a potential merge and release of


### PR DESCRIPTION
## Description

This PR updates every Rust-based dependency by its major, minor or patch version by default. It also moves the `postcard` version declaration from `dal` to the main `Cargo.toml` since the `alloc` feature is a subset of the `use-std` feature.

<img src="https://media1.giphy.com/media/26u4n5NamL40WyB1u/giphy.gif"/>

## Exceptions

Given the large scope of these changes, this PR does not seek to change any Rust code or fixups barring a small change regarding`EnumVariantNames`. Exceptions to the goal of this PR include the following:

- Hold `rustls`, `webpki-roots`, `tokio-vsock` and `yrs` to their minor versions due to API changes
- Hold `nix` and `ring` to their current versions due to needing buck2-specific changes
- Hold all hyper v1 dependencies to their minor versions due to a longer term effort needed to get us to hyper v1
- Hold `serde_yaml` to its current version due to being unmaintained as of [`0.9.34`](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34)

## Note

As a reminder, the `new-engine` was merged into `main` as of #3113.