### PR TITLE
fix(dal): : synchronize graph access in dependent values updates

### DIFF
--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -101,6 +101,16 @@ pub enum WorkspaceSnapshotError {
 
 pub type WorkspaceSnapshotResult<T> = Result<T, WorkspaceSnapshotError>;
 
+/// The workspace graph. The concurrency types used here to give us interior
+/// mutability in the tokio run time are *not* sufficient to prevent data races
+/// when operating on the same graph on different threads, since our graph
+/// operations are not "atomic" and the graph *WILL* end up being read from
+/// different threads while a write operation is still in progress if it is
+/// shared between threads for modification. For example after a node is added
+/// but *before* the edges necessary to place that node in the right spot in the
+/// graph have been added. We need a more general solution here, but for now an
+/// example of synchronization when accessing a snapshot across threads can be
+/// found in [`crate::job::definition::DependentValuesUpdate`].
 #[derive(Debug, Clone)]
 pub struct WorkspaceSnapshot {
     address: Arc<RwLock<WorkspaceSnapshotAddress>>,


### PR DESCRIPTION
The concurrency types used by the WorkspaceSnapshot to provide interior mutability in the tokio run time are *not* sufficient to prevent data races when operating on the same graph on different threads, since our graph operations are not "atomic" and the graph *WILL* end up being read from different threads while a write operation is still in progress if it is shared between threads for modification. For example after a node is added but *before* the edges necessary to place that node in the right spot in the graph.

A more general solution is needed to represent the concept of a "transaction" when mutating the graph, to prevent other readers from seeing incomplete graphs from in-progress write operations.

For now, we have added a lock to `DependentValuesUpdate` that ensures the portion of the update that gathers the inputs to a function acquires a read lock, (which is released as soon as the function is sent to the executor, so that we don't hold on to it while executing in veritech), while the portion of the update that updates the graph with the execution result acquires a write lock.

<img src="https://media0.giphy.com/media/lS7otnEgehFrnxz7Fw/giphy.gif"/>